### PR TITLE
Added angle-at-percent and position-at-percent to the Path component

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -536,6 +536,7 @@ fn gen_corelib(
         "Callback",
         "slint_property_listener_scope_evaluate",
         "slint_property_listener_scope_is_dirty",
+        "PropertyTracker",
         "PropertyTrackerOpaque",
         "CallbackOpaque",
         "ChangeTracker",
@@ -954,10 +955,7 @@ fn gen_corelib(
         .insert("Flickable".to_owned(), "    inline Flickable(); inline ~Flickable();".into());
     config.export.pre_body.insert("FlickableDataBox".to_owned(), "struct FlickableData;".into());
     config.export.body.insert("Path".to_owned(), "    inline Path(); inline ~Path();".into());
-    config
-        .export
-        .pre_body
-        .insert("PathFittedCacheBox".to_owned(), "struct PathFittedCacheInner;".into());
+    config.export.pre_body.insert("FittedPathBox".to_owned(), "struct FittedPathInner;".into());
     config.export.body.insert(
         "SystemTrayIcon".to_owned(),
         "    inline SystemTrayIcon(); inline ~SystemTrayIcon();".into(),
@@ -1040,6 +1038,7 @@ namespace slint {
         using slint::private_api::WindowAdapterRc;
         using namespace vtable;
         using private_api::Property;
+        using private_api::PropertyTracker;
         using private_api::PathData;
         using private_api::Point;
         struct ItemTreeVTable;

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -953,6 +953,11 @@ fn gen_corelib(
         .body
         .insert("Flickable".to_owned(), "    inline Flickable(); inline ~Flickable();".into());
     config.export.pre_body.insert("FlickableDataBox".to_owned(), "struct FlickableData;".into());
+    config.export.body.insert("Path".to_owned(), "    inline Path(); inline ~Path();".into());
+    config
+        .export
+        .pre_body
+        .insert("PathFittedCacheBox".to_owned(), "struct PathFittedCacheInner;".into());
     config.export.body.insert(
         "SystemTrayIcon".to_owned(),
         "    inline SystemTrayIcon(); inline ~SystemTrayIcon();".into(),

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -601,6 +601,15 @@ cbindgen_private::Flickable::~Flickable()
     slint_flickable_data_free(&data);
 }
 
+cbindgen_private::Path::Path()
+{
+    slint_path_fitted_cache_init(&fitted_cache);
+}
+cbindgen_private::Path::~Path()
+{
+    slint_path_fitted_cache_free(&fitted_cache);
+}
+
 cbindgen_private::SystemTrayIcon::SystemTrayIcon()
 {
     slint_system_tray_icon_data_init(&data);

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -603,11 +603,11 @@ cbindgen_private::Flickable::~Flickable()
 
 cbindgen_private::Path::Path()
 {
-    slint_path_fitted_cache_init(&fitted_cache);
+    slint_path_fitted_cache_init(&fitted_path);
 }
 cbindgen_private::Path::~Path()
 {
-    slint_path_fitted_cache_free(&fitted_cache);
+    slint_path_fitted_cache_free(&fitted_path);
 }
 
 cbindgen_private::SystemTrayIcon::SystemTrayIcon()

--- a/cspell.json
+++ b/cspell.json
@@ -123,6 +123,7 @@
     "combobox",
     "radiobutton",
     "contexte",
+    "cramer",
     "cupertino",
     "datastructures",
     "dealloc",

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2499,6 +2499,12 @@ export component Path {
 
     Close { }
 
+    /// Returns the point at the given percent along the path
+    function point-at-percent(percent: float) -> Point {}
+
+    /// Returns the angle at the given percent along the path
+    function angle-at-percent(percent: float) -> angle {}
+
     //-default_size_binding:expands_to_parent_geometry
 }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2422,6 +2422,22 @@ export component Path {
     ///
     in property <float> viewbox-height;
     //!
+    //! ## Functions
+    //!
+    //! These functions sample the path at a given point along its length, allowing an object to be animated along the path.
+    //! Animating percent between 0 and N traverses the path N times forwards (in the direction the path was defined in).
+    //! Animating percent between N and 0 traverses the path N times backwards.
+    //!
+    //! ### point-at(percent: float) -> Point
+    function point-at(percent: float) -> Point {}
+    //! Returns a point at the given percent along the path in the Path element's coordinate space.
+    //! Returns (0, 0) if the path is empty.
+    //! ### angle-at(percent: float) -> angle
+    function angle-at(percent: float) -> angle {}
+    //! Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given percent.
+    //! The tangent points in the direction the path was defined, so this reflects the path's shape and not
+    //! the object's current direction of travel. Returns 0 if the path is empty.
+    //!
     //! ## Path Using SVG Commands
     //!
     //! SVG is a popular file format for defining scalable graphics, which are often composed of paths. In SVG
@@ -2498,12 +2514,6 @@ export component Path {
     QuadraticTo { }
 
     Close { }
-
-    /// Returns the point at the given percent along the path
-    function point-at-percent(percent: float) -> Point {}
-
-    /// Returns the angle at the given percent along the path
-    function angle-at-percent(percent: float) -> angle {}
 
     //-default_size_binding:expands_to_parent_geometry
 }

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2427,16 +2427,13 @@ export component Path {
     //! These functions sample the path at a given point along its length, allowing an object to be animated along the path.
     //! Animating percent between 0 and N traverses the path N times forwards (in the direction the path was defined in).
     //! Animating percent between N and 0 traverses the path N times backwards.
-    //!
-    //! ### point-at(percent: float) -> Point
+    /// Returns a point at the given percent along the path in the Path element's coordinate space.
+    /// Returns (0, 0) if the path is empty.
     function point-at(percent: float) -> Point {}
-    //! Returns a point at the given percent along the path in the Path element's coordinate space.
-    //! Returns (0, 0) if the path is empty.
-    //! ### angle-at(percent: float) -> angle
+    /// Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given percent.
+    /// The tangent points in the direction the path was defined, so this reflects the path's shape and not
+    /// the object's current direction of travel. Returns 0 if the path is empty.
     function angle-at(percent: float) -> angle {}
-    //! Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given percent.
-    //! The tangent points in the direction the path was defined, so this reflects the path's shape and not
-    //! the object's current direction of travel. Returns 0 if the path is empty.
     //!
     //! ## Path Using SVG Commands
     //!

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2421,18 +2421,17 @@ export component Path {
     in property <float> viewbox-width;
     ///
     in property <float> viewbox-height;
-    //!
-    //! ## Functions
-    //!
-    //! These functions sample the path at a given point along its length, allowing an object to be animated along the path.
-    //! Animating percent between 0 and N traverses the path N times forwards (in the direction the path was defined in).
-    //! Animating percent between N and 0 traverses the path N times backwards.
     /// Returns a point at the given percent along the path in the Path element's coordinate space.
     /// Returns (0, 0) if the path is empty.
+    ///
+    /// If a percent outside the bounds of 0 and 1 is passed, it will be converted to its decimal fraction.
+    /// Ex: 1.5 -> 0.5 and 2.0 -> 1.0. This allows for N iterations of a loop
+    /// by animating percent from 0 to N. If percent is animated from N to 0, it will loop N times backwards.
     function point-at(percent: float) -> Point {}
     /// Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given percent.
     /// The tangent points in the direction the path was defined, so this reflects the path's shape and not
     /// the object's current direction of travel. Returns 0 if the path is empty.
+    /// If a percent outside the bounds of 0 and 1 is passed, the decimal fraction will be passed.
     function angle-at(percent: float) -> angle {}
     //!
     //! ## Path Using SVG Commands

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2424,15 +2424,15 @@ export component Path {
     /// Returns a point at the given percent along the path in the Path element's coordinate space.
     /// Returns (0, 0) if the path is empty.
     ///
-    /// If a percent outside the bounds of 0 and 1 is passed, it will be converted to its decimal fraction.
+    /// If a `t` outside the bounds of 0 and 1 is passed, it will be converted to its decimal fraction.
     /// Ex: 1.5 -> 0.5 and 2.0 -> 1.0. This allows for N iterations of a loop
-    /// by animating percent from 0 to N. If percent is animated from N to 0, it will loop N times backwards.
-    function point-at(percent: float) -> Point {}
-    /// Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given percent.
+    /// by animating t from 0 to N. If `t` is animated from N to 0, it will loop N times backwards.
+    function point-at(t: float) -> Point {}
+    /// Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given `t`.
     /// The tangent points in the direction the path was defined, so this reflects the path's shape and not
     /// the object's current direction of travel. Returns 0 if the path is empty.
-    /// If a percent outside the bounds of 0 and 1 is passed, the decimal fraction will be passed.
-    function angle-at(percent: float) -> angle {}
+    /// If a `t` outside the bounds of 0 and 1 is passed, the decimal fraction will be passed.
+    function angle-at(t: float) -> angle {}
     //!
     //! ## Path Using SVG Commands
     //!

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -139,6 +139,8 @@ pub enum BuiltinFunction {
     /// because `parse_interpolated` takes `StyledText` arguments.
     ColorToStyledText,
     DecimalSeparator,
+    PointAtPercent,
+    AngleAtPercent,
 }
 
 #[derive(Debug, Clone)]
@@ -319,6 +321,8 @@ declare_builtin_function_types!(
     ColorToStyledText: (Type::Color) -> Type::StyledText
     OpenUrl: (Type::String) -> Type::Bool,
     MacosBringAllWindowsToFront: () -> Type::Void,
+    PointAtPercent: (Type::ElementReference, Type::Float32) -> typeregister::logical_point_type().into(),
+    AngleAtPercent: (Type::ElementReference, Type::Float32) -> Type::Angle,
 );
 
 impl Default for BuiltinFunctionTypes {
@@ -435,6 +439,8 @@ impl BuiltinFunction {
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
             BuiltinFunction::MacosBringAllWindowsToFront => false,
+            BuiltinFunction::PointAtPercent => true,
+            BuiltinFunction::AngleAtPercent => true,
         }
     }
 
@@ -529,6 +535,8 @@ impl BuiltinFunction {
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
             BuiltinFunction::MacosBringAllWindowsToFront => false,
+            BuiltinFunction::PointAtPercent => true,
+            BuiltinFunction::AngleAtPercent => true,
         }
     }
 }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -139,8 +139,8 @@ pub enum BuiltinFunction {
     /// because `parse_interpolated` takes `StyledText` arguments.
     ColorToStyledText,
     DecimalSeparator,
-    PointAt,
-    AngleAt,
+    PathPointAt,
+    PathAngleAt,
 }
 
 #[derive(Debug, Clone)]
@@ -321,8 +321,8 @@ declare_builtin_function_types!(
     ColorToStyledText: (Type::Color) -> Type::StyledText
     OpenUrl: (Type::String) -> Type::Bool,
     MacosBringAllWindowsToFront: () -> Type::Void,
-    PointAt: (Type::ElementReference, Type::Float32) -> typeregister::logical_point_type().into(),
-    AngleAt: (Type::ElementReference, Type::Float32) -> Type::Angle,
+    PathPointAt: (Type::ElementReference, Type::Float32) -> typeregister::logical_point_type().into(),
+    PathAngleAt: (Type::ElementReference, Type::Float32) -> Type::Angle,
 );
 
 impl Default for BuiltinFunctionTypes {
@@ -439,8 +439,8 @@ impl BuiltinFunction {
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
             BuiltinFunction::MacosBringAllWindowsToFront => false,
-            BuiltinFunction::PointAt => true,
-            BuiltinFunction::AngleAt => true,
+            BuiltinFunction::PathPointAt => true,
+            BuiltinFunction::PathAngleAt => true,
         }
     }
 
@@ -535,8 +535,8 @@ impl BuiltinFunction {
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
             BuiltinFunction::MacosBringAllWindowsToFront => false,
-            BuiltinFunction::PointAt => true,
-            BuiltinFunction::AngleAt => true,
+            BuiltinFunction::PathPointAt => true,
+            BuiltinFunction::PathAngleAt => true,
         }
     }
 }

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -139,8 +139,8 @@ pub enum BuiltinFunction {
     /// because `parse_interpolated` takes `StyledText` arguments.
     ColorToStyledText,
     DecimalSeparator,
-    PointAtPercent,
-    AngleAtPercent,
+    PointAt,
+    AngleAt,
 }
 
 #[derive(Debug, Clone)]
@@ -321,8 +321,8 @@ declare_builtin_function_types!(
     ColorToStyledText: (Type::Color) -> Type::StyledText
     OpenUrl: (Type::String) -> Type::Bool,
     MacosBringAllWindowsToFront: () -> Type::Void,
-    PointAtPercent: (Type::ElementReference, Type::Float32) -> typeregister::logical_point_type().into(),
-    AngleAtPercent: (Type::ElementReference, Type::Float32) -> Type::Angle,
+    PointAt: (Type::ElementReference, Type::Float32) -> typeregister::logical_point_type().into(),
+    AngleAt: (Type::ElementReference, Type::Float32) -> Type::Angle,
 );
 
 impl Default for BuiltinFunctionTypes {
@@ -439,8 +439,8 @@ impl BuiltinFunction {
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
             BuiltinFunction::MacosBringAllWindowsToFront => false,
-            BuiltinFunction::PointAtPercent => true,
-            BuiltinFunction::AngleAtPercent => true,
+            BuiltinFunction::PointAt => true,
+            BuiltinFunction::AngleAt => true,
         }
     }
 
@@ -535,8 +535,8 @@ impl BuiltinFunction {
             BuiltinFunction::ColorToStyledText => true,
             BuiltinFunction::OpenUrl => false,
             BuiltinFunction::MacosBringAllWindowsToFront => false,
-            BuiltinFunction::PointAtPercent => true,
-            BuiltinFunction::AngleAtPercent => true,
+            BuiltinFunction::PointAt => true,
+            BuiltinFunction::AngleAt => true,
         }
     }
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5531,7 +5531,7 @@ fn compile_builtin_function_call(
             let color = a.next().unwrap();
             format!("slint::private_api::color_to_styled_text({})", color)
         }
-        BuiltinFunction::PointAt => {
+        BuiltinFunction::PathPointAt => {
             if let [llr::Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
@@ -5539,10 +5539,10 @@ fn compile_builtin_function_call(
                     "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at(&{item_rc}, static_cast<float>({percent})))"
                 )
             } else {
-                panic!("internal error: invalid args to PointAt {arguments:?}")
+                panic!("internal error: invalid args to PathPointAt {arguments:?}")
             }
         }
-        BuiltinFunction::AngleAt => {
+        BuiltinFunction::PathAngleAt => {
             if let [llr::Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
@@ -5550,7 +5550,7 @@ fn compile_builtin_function_call(
                     "slint::cbindgen_private::slint_path_angle_at(&{item_rc}, static_cast<float>({percent}))"
                 )
             } else {
-                panic!("internal error: invalid args to AngleAt {arguments:?}")
+                panic!("internal error: invalid args to PathAngleAt {arguments:?}")
             }
         }
     }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5532,22 +5532,22 @@ fn compile_builtin_function_call(
             format!("slint::private_api::color_to_styled_text({})", color)
         }
         BuiltinFunction::PathPointAt => {
-            if let [llr::Expression::PropertyReference(pr), percent] = arguments {
+            if let [llr::Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
-                let percent = compile_expression(percent, ctx);
+                let t = compile_expression(t, ctx);
                 format!(
-                    "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at(&{item_rc}, static_cast<float>({percent})))"
+                    "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at(&{item_rc}, static_cast<float>({t})))"
                 )
             } else {
                 panic!("internal error: invalid args to PathPointAt {arguments:?}")
             }
         }
         BuiltinFunction::PathAngleAt => {
-            if let [llr::Expression::PropertyReference(pr), percent] = arguments {
+            if let [llr::Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
-                let percent = compile_expression(percent, ctx);
+                let t = compile_expression(t, ctx);
                 format!(
-                    "slint::cbindgen_private::slint_path_angle_at(&{item_rc}, static_cast<float>({percent}))"
+                    "slint::cbindgen_private::slint_path_angle_at(&{item_rc}, static_cast<float>({t}))"
                 )
             } else {
                 panic!("internal error: invalid args to PathAngleAt {arguments:?}")

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5531,26 +5531,26 @@ fn compile_builtin_function_call(
             let color = a.next().unwrap();
             format!("slint::private_api::color_to_styled_text({})", color)
         }
-        BuiltinFunction::PointAtPercent => {
+        BuiltinFunction::PointAt => {
             if let [llr::Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
                 format!(
-                    "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at_percent(&{item_rc}, static_cast<float>({percent})))"
+                    "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at(&{item_rc}, static_cast<float>({percent})))"
                 )
             } else {
-                panic!("internal error: invalid args to PointAtPercent {arguments:?}")
+                panic!("internal error: invalid args to PointAt {arguments:?}")
             }
         }
-        BuiltinFunction::AngleAtPercent => {
+        BuiltinFunction::AngleAt => {
             if let [llr::Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
                 format!(
-                    "slint::cbindgen_private::slint_path_angle_at_percent(&{item_rc}, static_cast<float>({percent}))"
+                    "slint::cbindgen_private::slint_path_angle_at(&{item_rc}, static_cast<float>({percent}))"
                 )
             } else {
-                panic!("internal error: invalid args to AngleAtPercent {arguments:?}")
+                panic!("internal error: invalid args to AngleAt {arguments:?}")
             }
         }
     }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5531,6 +5531,28 @@ fn compile_builtin_function_call(
             let color = a.next().unwrap();
             format!("slint::private_api::color_to_styled_text({})", color)
         }
+        BuiltinFunction::PointAtPercent => {
+            if let [llr::Expression::PropertyReference(pr), percent] = arguments {
+                let item_rc = access_item_rc(pr, ctx);
+                let percent = compile_expression(percent, ctx);
+                format!(
+                    "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at_percent(&{item_rc}, static_cast<float>({percent})))"
+                )
+            } else {
+                panic!("internal error: invalid args to PointAtPercent {arguments:?}")
+            }
+        }
+        BuiltinFunction::AngleAtPercent => {
+            if let [llr::Expression::PropertyReference(pr), percent] = arguments {
+                let item_rc = access_item_rc(pr, ctx);
+                let percent = compile_expression(percent, ctx);
+                format!(
+                    "slint::cbindgen_private::slint_path_angle_at_percent(&{item_rc}, static_cast<float>({percent}))"
+                )
+            } else {
+                panic!("internal error: invalid args to AngleAtPercent {arguments:?}")
+            }
+        }
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5019,7 +5019,7 @@ fn compile_builtin_function_call(
             let color = a.next().unwrap();
             quote!(sp::color_to_styled_text(#color))
         }
-        BuiltinFunction::PointAt => {
+        BuiltinFunction::PathPointAt => {
             if let [Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
@@ -5034,10 +5034,10 @@ fn compile_builtin_function_call(
                     )
                 })
             } else {
-                panic!("internal error: invalid args to PointAt {arguments:?}")
+                panic!("internal error: invalid args to PathPointAt {arguments:?}")
             }
         }
-        BuiltinFunction::AngleAt => {
+        BuiltinFunction::PathAngleAt => {
             if let [Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
@@ -5050,7 +5050,7 @@ fn compile_builtin_function_call(
                         .angle_at(&item_rc, #percent as f32)
                 })
             } else {
-                panic!("internal error: invalid args to AngleAt {arguments:?}")
+                panic!("internal error: invalid args to PathAngleAt {arguments:?}")
             }
         }
     }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5019,6 +5019,40 @@ fn compile_builtin_function_call(
             let color = a.next().unwrap();
             quote!(sp::color_to_styled_text(#color))
         }
+        BuiltinFunction::PointAtPercent => {
+            if let [Expression::PropertyReference(pr), percent] = arguments {
+                let item_rc = access_item_rc(pr, ctx);
+                let percent = compile_expression(percent, ctx);
+                quote!({
+                    let item_rc = #item_rc;
+                    sp::logical_position_to_api(
+                        item_rc
+                            .downcast::<sp::Path>()
+                            .unwrap()
+                            .as_pin_ref()
+                            .point_at_percent(&item_rc, #percent as f32),
+                    )
+                })
+            } else {
+                panic!("internal error: invalid args to PointAtPercent {arguments:?}")
+            }
+        }
+        BuiltinFunction::AngleAtPercent => {
+            if let [Expression::PropertyReference(pr), percent] = arguments {
+                let item_rc = access_item_rc(pr, ctx);
+                let percent = compile_expression(percent, ctx);
+                quote!({
+                    let item_rc = #item_rc;
+                    item_rc
+                        .downcast::<sp::Path>()
+                        .unwrap()
+                        .as_pin_ref()
+                        .angle_at_percent(&item_rc, #percent as f32)
+                })
+            } else {
+                panic!("internal error: invalid args to AngleAtPercent {arguments:?}")
+            }
+        }
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5019,7 +5019,7 @@ fn compile_builtin_function_call(
             let color = a.next().unwrap();
             quote!(sp::color_to_styled_text(#color))
         }
-        BuiltinFunction::PointAtPercent => {
+        BuiltinFunction::PointAt => {
             if let [Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
@@ -5030,14 +5030,14 @@ fn compile_builtin_function_call(
                             .downcast::<sp::Path>()
                             .unwrap()
                             .as_pin_ref()
-                            .point_at_percent(&item_rc, #percent as f32),
+                            .point_at(&item_rc, #percent as f32),
                     )
                 })
             } else {
-                panic!("internal error: invalid args to PointAtPercent {arguments:?}")
+                panic!("internal error: invalid args to PointAt {arguments:?}")
             }
         }
-        BuiltinFunction::AngleAtPercent => {
+        BuiltinFunction::AngleAt => {
             if let [Expression::PropertyReference(pr), percent] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let percent = compile_expression(percent, ctx);
@@ -5047,10 +5047,10 @@ fn compile_builtin_function_call(
                         .downcast::<sp::Path>()
                         .unwrap()
                         .as_pin_ref()
-                        .angle_at_percent(&item_rc, #percent as f32)
+                        .angle_at(&item_rc, #percent as f32)
                 })
             } else {
-                panic!("internal error: invalid args to AngleAtPercent {arguments:?}")
+                panic!("internal error: invalid args to AngleAt {arguments:?}")
             }
         }
     }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5020,9 +5020,9 @@ fn compile_builtin_function_call(
             quote!(sp::color_to_styled_text(#color))
         }
         BuiltinFunction::PathPointAt => {
-            if let [Expression::PropertyReference(pr), percent] = arguments {
+            if let [Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
-                let percent = compile_expression(percent, ctx);
+                let t = compile_expression(t, ctx);
                 quote!({
                     let item_rc = #item_rc;
                     sp::logical_position_to_api(
@@ -5030,7 +5030,7 @@ fn compile_builtin_function_call(
                             .downcast::<sp::Path>()
                             .unwrap()
                             .as_pin_ref()
-                            .point_at(&item_rc, #percent as f32),
+                            .point_at(&item_rc, #t as f32),
                     )
                 })
             } else {
@@ -5038,16 +5038,16 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::PathAngleAt => {
-            if let [Expression::PropertyReference(pr), percent] = arguments {
+            if let [Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
-                let percent = compile_expression(percent, ctx);
+                let t = compile_expression(t, ctx);
                 quote!({
                     let item_rc = #item_rc;
                     item_rc
                         .downcast::<sp::Path>()
                         .unwrap()
                         .as_pin_ref()
-                        .angle_at(&item_rc, #percent as f32)
+                        .angle_at(&item_rc, #t as f32)
                 })
             } else {
                 panic!("internal error: invalid args to PathAngleAt {arguments:?}")

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -178,8 +178,8 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ColorToStyledText => ALLOC_COST,
         BuiltinFunction::OpenUrl => isize::MAX,
         BuiltinFunction::MacosBringAllWindowsToFront => isize::MAX,
-        BuiltinFunction::PointAtPercent => PROPERTY_ACCESS_COST,
-        BuiltinFunction::AngleAtPercent => PROPERTY_ACCESS_COST,
+        BuiltinFunction::PointAt => PROPERTY_ACCESS_COST,
+        BuiltinFunction::AngleAt => PROPERTY_ACCESS_COST,
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -178,6 +178,8 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ColorToStyledText => ALLOC_COST,
         BuiltinFunction::OpenUrl => isize::MAX,
         BuiltinFunction::MacosBringAllWindowsToFront => isize::MAX,
+        BuiltinFunction::PointAtPercent => PROPERTY_ACCESS_COST,
+        BuiltinFunction::AngleAtPercent => PROPERTY_ACCESS_COST,
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -178,8 +178,8 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::ColorToStyledText => ALLOC_COST,
         BuiltinFunction::OpenUrl => isize::MAX,
         BuiltinFunction::MacosBringAllWindowsToFront => isize::MAX,
-        BuiltinFunction::PointAt => PROPERTY_ACCESS_COST,
-        BuiltinFunction::AngleAt => PROPERTY_ACCESS_COST,
+        BuiltinFunction::PathPointAt => isize::MAX,
+        BuiltinFunction::PathAngleAt => isize::MAX,
     }
 }
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -621,8 +621,8 @@ impl TypeRegister {
             ElementType::Builtin(b) => {
                 let path = Rc::get_mut(b).unwrap();
                 for (name, func) in [
-                    ("point-at-percent", BuiltinFunction::PointAtPercent),
-                    ("angle-at-percent", BuiltinFunction::AngleAtPercent),
+                    ("point-at-percent", BuiltinFunction::PointAt),
+                    ("angle-at-percent", BuiltinFunction::AngleAt),
                 ] {
                     let existing_docs = path.properties.get(name).and_then(|p| p.docs.clone());
                     let mut info = BuiltinPropertyInfo::from(func);

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -617,6 +617,22 @@ impl TypeRegister {
             _ => unreachable!(),
         }
 
+        match &mut register.elements.get_mut("Path").unwrap() {
+            ElementType::Builtin(b) => {
+                let path = Rc::get_mut(b).unwrap();
+                for (name, func) in [
+                    ("point-at-percent", BuiltinFunction::PointAtPercent),
+                    ("angle-at-percent", BuiltinFunction::AngleAtPercent),
+                ] {
+                    let existing_docs = path.properties.get(name).and_then(|p| p.docs.clone());
+                    let mut info = BuiltinPropertyInfo::from(func);
+                    info.docs = existing_docs;
+                    path.properties.insert(name.into(), info);
+                }
+            }
+            _ => unreachable!(),
+        }
+
         let font_metrics_prop = crate::langtype::BuiltinPropertyInfo {
             property_visibility: PropertyVisibility::Output,
             default_value: BuiltinPropertyDefault::WithElement(|elem| {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -621,8 +621,8 @@ impl TypeRegister {
             ElementType::Builtin(b) => {
                 let path = Rc::get_mut(b).unwrap();
                 for (name, func) in [
-                    ("point-at-percent", BuiltinFunction::PointAt),
-                    ("angle-at-percent", BuiltinFunction::AngleAt),
+                    ("point-at", BuiltinFunction::PathPointAt),
+                    ("angle-at", BuiltinFunction::PathAngleAt),
                 ] {
                     let existing_docs = path.properties.get(name).and_then(|p| p.docs.clone());
                     let mut info = BuiltinPropertyInfo::from(func);

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -297,16 +297,31 @@ impl PathDataIterator {
         builder.build()
     }
 
-    fn sample_at(&self, percent: f32) -> Option<(lyon_path::math::Point, lyon_path::math::Vector)> {
-        use lyon_algorithms::measure::{PathMeasurements, SampleType};
+    /// Builds the lyon path together with its length measurements
+    pub fn to_fitted_path(&self) -> FittedPath {
+        use lyon_algorithms::measure::PathMeasurements;
 
-        let percent = percent.clamp(0., 1.);
         let path = self.to_lyon_path();
         let measurements = PathMeasurements::from_path(&path, PATH_MEASURE_TOLERANCE);
-        if measurements.length() <= 0. {
+        FittedPath { path, measurements }
+    }
+}
+
+/// A path and measurements so they don't need to be recalculated every call to sample
+pub struct FittedPath {
+    path: lyon_path::Path,
+    measurements: lyon_algorithms::measure::PathMeasurements,
+}
+
+impl FittedPath {
+    fn sample_at(&self, percent: f32) -> Option<(lyon_path::math::Point, lyon_path::math::Vector)> {
+        use lyon_algorithms::measure::SampleType;
+
+        let percent = percent.clamp(0., 1.);
+        if self.measurements.length() <= 0. {
             return None;
         }
-        let mut sampler = measurements.create_sampler(&path, SampleType::Normalized);
+        let mut sampler = self.measurements.create_sampler(&self.path, SampleType::Normalized);
         let sample = sampler.sample(percent);
         Some((sample.position(), sample.tangent()))
     }

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -204,6 +204,9 @@ impl<EventIt: Iterator<Item = lyon_path::Event<lyon_path::math::Point, lyon_path
 {
 }
 
+/// The default tolerance used when flattening curves for path length/position measurements.
+const PATH_MEASURE_TOLERANCE: f32 = 0.1;
+
 /// PathDataIterator is a data structure that acts as starting point for iterating
 /// through the low-level events of a path. If the path was constructed from said
 /// events, then it is a very thin abstraction. If the path was created from higher-level
@@ -268,6 +271,55 @@ impl PathDataIterator {
                 fit_style,
             );
         }
+    }
+
+    fn to_lyon_path(&self) -> lyon_path::Path {
+        let mut builder = lyon_path::Path::builder();
+        for event in self.iter() {
+            match event {
+                lyon_path::Event::Begin { at } => {
+                    builder.begin(at);
+                }
+                lyon_path::Event::Line { to, .. } => {
+                    builder.line_to(to);
+                }
+                lyon_path::Event::Quadratic { ctrl, to, .. } => {
+                    builder.quadratic_bezier_to(ctrl, to);
+                }
+                lyon_path::Event::Cubic { ctrl1, ctrl2, to, .. } => {
+                    builder.cubic_bezier_to(ctrl1, ctrl2, to);
+                }
+                lyon_path::Event::End { close, .. } => {
+                    builder.end(close);
+                }
+            }
+        }
+        builder.build()
+    }
+
+    fn sample_at(&self, percent: f32) -> Option<(lyon_path::math::Point, lyon_path::math::Vector)> {
+        use lyon_algorithms::measure::{PathMeasurements, SampleType};
+
+        let percent = percent.clamp(0., 1.);
+        let path = self.to_lyon_path();
+        let measurements = PathMeasurements::from_path(&path, PATH_MEASURE_TOLERANCE);
+        if measurements.length() <= 0. {
+            return None;
+        }
+        let mut sampler = measurements.create_sampler(&path, SampleType::Normalized);
+        let sample = sampler.sample(percent);
+        Some((sample.position(), sample.tangent()))
+    }
+
+    /// Returns the position of the point located at `percent` along the path
+    pub fn position_at(&self, percent: f32) -> Option<lyon_path::math::Point> {
+        self.sample_at(percent).map(|(position, _)| position)
+    }
+
+    /// Returns the angle, in degrees, of the path's tangent at `percent` (0.0..=1.0) along the
+    /// path
+    pub fn angle_at(&self, percent: f32) -> Option<f32> {
+        self.sample_at(percent).map(|(_, tangent)| tangent.angle_from_x_axis().to_degrees())
     }
 }
 

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -7,10 +7,12 @@ This module contains path related types and functions for the run-time library.
 
 use crate::debug_log;
 use crate::items::{ImageFit, PathEvent};
+use crate::lengths::{LogicalPx, LogicalVector};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
 use auto_enums::auto_enum;
 use const_field_offset::FieldOffsets;
+use euclid::Point2D;
 use i_slint_core_macros::*;
 
 #[repr(C)]
@@ -204,9 +206,6 @@ impl<EventIt: Iterator<Item = lyon_path::Event<lyon_path::math::Point, lyon_path
 {
 }
 
-/// The default tolerance used when flattening curves for path length/position measurements.
-const PATH_MEASURE_TOLERANCE: f32 = 0.1;
-
 /// PathDataIterator is a data structure that acts as starting point for iterating
 /// through the low-level events of a path. If the path was constructed from said
 /// events, then it is a very thin abstraction. If the path was created from higher-level
@@ -274,67 +273,47 @@ impl PathDataIterator {
     }
 
     fn to_lyon_path(&self) -> lyon_path::Path {
-        let mut builder = lyon_path::Path::builder();
-        for event in self.iter() {
-            match event {
-                lyon_path::Event::Begin { at } => {
-                    builder.begin(at);
-                }
-                lyon_path::Event::Line { to, .. } => {
-                    builder.line_to(to);
-                }
-                lyon_path::Event::Quadratic { ctrl, to, .. } => {
-                    builder.quadratic_bezier_to(ctrl, to);
-                }
-                lyon_path::Event::Cubic { ctrl1, ctrl2, to, .. } => {
-                    builder.cubic_bezier_to(ctrl1, ctrl2, to);
-                }
-                lyon_path::Event::End { close, .. } => {
-                    builder.end(close);
-                }
-            }
+        match &self.it {
+            LyonPathIteratorVariant::FromPath(path) => path.clone().transformed(&self.transform),
+            LyonPathIteratorVariant::FromEvents(..) => self.iter().collect(),
         }
-        builder.build()
     }
 
     /// Builds the lyon path together with its length measurements
-    pub fn to_fitted_path(&self) -> FittedPath {
+    pub fn to_fitted_path(&self, offset: LogicalVector) -> FittedPath {
         use lyon_algorithms::measure::PathMeasurements;
 
         let path = self.to_lyon_path();
-        let measurements = PathMeasurements::from_path(&path, PATH_MEASURE_TOLERANCE);
-        FittedPath { path, measurements }
+        // the number of path segments is proportional to 1/sqrt(tolerance)
+        // Tolerance is the distance between the curve and the approximation
+        // in the paths element coordinates (without the offset applied yet)
+        let measurements = PathMeasurements::from_path(&path, 1e-3);
+        FittedPath { path, offset, measurements }
     }
 }
 
 /// A path and measurements so they don't need to be recalculated every call to sample
 pub struct FittedPath {
     path: lyon_path::Path,
+    offset: LogicalVector,
     measurements: lyon_algorithms::measure::PathMeasurements,
 }
 
 impl FittedPath {
-    fn sample_at(&self, percent: f32) -> Option<(lyon_path::math::Point, lyon_path::math::Vector)> {
+    /// Samples the fitted path at a given percent. Returns None if the path length is 0
+    pub fn sample_at(&self, percent: f32) -> Option<(Point2D<f32, LogicalPx>, f32)> {
         use lyon_algorithms::measure::SampleType;
 
-        let percent = percent.clamp(0., 1.);
+        // rem_euclid maps 1.0 to 0.0 so if the path isn't closed this would otherwise error
+        let percent = if percent == 1.0 { 1.0 } else { percent.rem_euclid(1.) };
         if self.measurements.length() <= 0. {
             return None;
         }
         let mut sampler = self.measurements.create_sampler(&self.path, SampleType::Normalized);
         let sample = sampler.sample(percent);
-        Some((sample.position(), sample.tangent()))
-    }
-
-    /// Returns the position of the point located at `percent` along the path
-    pub fn position_at(&self, percent: f32) -> Option<lyon_path::math::Point> {
-        self.sample_at(percent).map(|(position, _)| position)
-    }
-
-    /// Returns the angle, in degrees, of the path's tangent at `percent` (0.0..=1.0) along the
-    /// path
-    pub fn angle_at(&self, percent: f32) -> Option<f32> {
-        self.sample_at(percent).map(|(_, tangent)| tangent.angle_from_x_axis().to_degrees())
+        let pos = Point2D::new(sample.position().x, sample.position().y);
+        let angle = sample.tangent().angle_from_x_axis().to_degrees();
+        Some((pos + self.offset, angle))
     }
 }
 

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -439,6 +439,163 @@ impl PathData {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lengths::LogicalLength;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use lyon_path::math::{Point, Transform};
+
+    // Two equivalent representations of the same L-shaped path (Begin, Line, Line, EndOpen):
+    // one built from high-level elements, one from low-level events/coordinates. Used to check
+    // that `PathDataIterator::to_lyon_path` applies `self.transform` the same way regardless of
+    // which `LyonPathIteratorVariant` backs it.
+    fn elements_path() -> PathData {
+        PathData::Elements(
+            [
+                PathElement::MoveTo(PathMoveTo { x: 0., y: 0. }),
+                PathElement::LineTo(PathLineTo { x: 10., y: 0. }),
+                PathElement::LineTo(PathLineTo { x: 10., y: 10. }),
+            ]
+            .as_slice()
+            .into(),
+        )
+    }
+
+    fn events_path() -> PathData {
+        let events: crate::SharedVector<PathEvent> =
+            [PathEvent::Begin, PathEvent::Line, PathEvent::Line, PathEvent::EndOpen]
+                .as_slice()
+                .into();
+        let coordinates: crate::SharedVector<Point> = [
+            Point::new(0., 0.),
+            Point::new(0., 0.),
+            Point::new(10., 0.),
+            Point::new(10., 0.),
+            Point::new(10., 10.),
+        ]
+        .as_slice()
+        .into();
+        PathData::Events(events, coordinates)
+    }
+
+    fn line_path() -> PathData {
+        PathData::Elements(
+            [
+                PathElement::MoveTo(PathMoveTo { x: 0., y: 0. }),
+                PathElement::LineTo(PathLineTo { x: 10., y: 0. }),
+            ]
+            .as_slice()
+            .into(),
+        )
+    }
+
+    fn points_of(path: &lyon_path::Path) -> Vec<Point> {
+        path.iter()
+            .flat_map(|ev| match ev {
+                lyon_path::Event::Begin { at } => vec![at],
+                lyon_path::Event::Line { from, to } => vec![from, to],
+                lyon_path::Event::Quadratic { from, ctrl, to } => vec![from, ctrl, to],
+                lyon_path::Event::Cubic { from, ctrl1, ctrl2, to } => vec![from, ctrl1, ctrl2, to],
+                lyon_path::Event::End { .. } => vec![],
+            })
+            .collect()
+    }
+
+    #[test]
+    fn to_lyon_path_applies_transform_for_elements_variant() {
+        let mut it = elements_path().iter().unwrap();
+        it.transform = Transform::translation(5., 7.);
+        assert_eq!(
+            points_of(&it.to_lyon_path()),
+            vec![
+                Point::new(5., 7.),
+                Point::new(5., 7.),
+                Point::new(15., 7.),
+                Point::new(15., 7.),
+                Point::new(15., 17.),
+            ]
+        );
+    }
+
+    #[test]
+    fn to_lyon_path_applies_transform_for_events_variant() {
+        let mut it = events_path().iter().unwrap();
+        it.transform = Transform::translation(5., 7.);
+        assert_eq!(
+            points_of(&it.to_lyon_path()),
+            vec![
+                Point::new(5., 7.),
+                Point::new(5., 7.),
+                Point::new(15., 7.),
+                Point::new(15., 7.),
+                Point::new(15., 17.),
+            ]
+        );
+    }
+
+    #[test]
+    fn to_lyon_path_transform_stays_consistent_across_variants_after_fit() {
+        let mut elements_it = elements_path().iter().unwrap();
+        let mut events_it = events_path().iter().unwrap();
+
+        // fit() derives a scale+translate transform from the (untransformed) bounding box;
+        // both variants describe the same geometry so they must end up with the same transform.
+        elements_it.fit(100., 50., None, ImageFit::Contain);
+        events_it.fit(100., 50., None, ImageFit::Contain);
+
+        assert_ne!(elements_it.transform, Transform::identity());
+        assert_eq!(elements_it.transform, events_it.transform);
+        assert_eq!(points_of(&elements_it.to_lyon_path()), points_of(&events_it.to_lyon_path()));
+    }
+
+    #[test]
+    fn fitted_path_sample_at_adds_offset_to_position() {
+        let it = line_path().iter().unwrap();
+        let offset = LogicalVector::from_lengths(LogicalLength::new(3.), LogicalLength::new(4.));
+        let fitted = it.to_fitted_path(offset);
+
+        let (start, _) = fitted.sample_at(0.0).unwrap();
+        assert_eq!(start, Point2D::new(3., 4.));
+
+        let (end, _) = fitted.sample_at(1.0).unwrap();
+        assert_eq!(end, Point2D::new(13., 4.));
+    }
+
+    #[test]
+    fn fitted_path_sample_at_wraps_percent_for_open_path() {
+        let it = line_path().iter().unwrap();
+        let fitted = it.to_fitted_path(LogicalVector::default());
+
+        // 1.0 is a special case (sampled directly, not wrapped) and must land on the actual
+        // end of the path, not back at the start the way rem_euclid(1.0, 1.0) == 0.0 would.
+        let (end, _) = fitted.sample_at(1.0).unwrap();
+        assert_eq!(end, Point2D::new(10., 0.));
+
+        let (mid, _) = fitted.sample_at(0.5).unwrap();
+        assert_eq!(mid, Point2D::new(5., 0.));
+
+        // Percentages outside of [0, 1) wrap around via rem_euclid.
+        let (wrapped_up, _) = fitted.sample_at(1.5).unwrap();
+        assert_eq!(wrapped_up, mid);
+        let (wrapped_down, _) = fitted.sample_at(-0.5).unwrap();
+        assert_eq!(wrapped_down, mid);
+    }
+
+    #[test]
+    fn fitted_path_sample_at_returns_none_for_zero_length_path() {
+        let elements = PathData::Elements(
+            [PathElement::MoveTo(PathMoveTo { x: 0., y: 0. })].as_slice().into(),
+        );
+        let it = elements.iter().unwrap();
+        let fitted = it.to_fitted_path(LogicalVector::default());
+
+        assert!(fitted.sample_at(0.0).is_none());
+        assert!(fitted.sample_at(0.5).is_none());
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod ffi {
     #![allow(unsafe_code)]

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -300,12 +300,12 @@ pub struct FittedPath {
 }
 
 impl FittedPath {
-    /// Samples the fitted path at a given percent. Returns None if the path length is 0
-    pub fn sample_at(&self, percent: f32) -> Option<(Point2D<f32, LogicalPx>, f32)> {
+    /// Samples the fitted path at a given `t`. Returns None if the path length is 0
+    pub fn sample_at(&self, t: f32) -> Option<(Point2D<f32, LogicalPx>, f32)> {
         use lyon_algorithms::measure::SampleType;
 
-        let mut rem = percent.rem_euclid(1.);
-        if rem == 0.0 && percent != 0.0 {
+        let mut rem = t.rem_euclid(1.);
+        if rem == 0.0 && t != 0.0 {
             // This makes the path end at the end and not the start
             rem = 1.0;
         }

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -304,13 +304,16 @@ impl FittedPath {
     pub fn sample_at(&self, percent: f32) -> Option<(Point2D<f32, LogicalPx>, f32)> {
         use lyon_algorithms::measure::SampleType;
 
-        // rem_euclid maps 1.0 to 0.0 so if the path isn't closed this would otherwise error
-        let percent = if percent == 1.0 { 1.0 } else { percent.rem_euclid(1.) };
+        let mut rem = percent.rem_euclid(1.);
+        if rem == 0.0 && percent != 0.0 {
+            // This makes the path end at the end and not the start
+            rem = 1.0;
+        }
         if self.measurements.length() <= 0. {
             return None;
         }
         let mut sampler = self.measurements.create_sampler(&self.path, SampleType::Normalized);
-        let sample = sampler.sample(percent);
+        let sample = sampler.sample(rem);
         let pos = Point2D::new(sample.position().x, sample.position().y);
         let angle = sample.tangent().angle_from_x_axis().to_degrees();
         Some((pos + self.offset, angle))

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -11,7 +11,7 @@ Lookup the [`crate::items`] module documentation.
 use super::{
     FillRule, Item, ItemConsts, ItemRc, ItemRendererRef, LineCap, LineJoin, RenderingResult,
 };
-use crate::graphics::{Brush, PathData, PathDataIterator};
+use crate::graphics::{Brush, FittedPath, PathData, PathDataIterator};
 use crate::input::{
     FocusEvent, FocusEventResult, InputEventFilterResult, InputEventResult, InternalKeyEvent,
     KeyEventResult, MouseEvent,
@@ -28,8 +28,10 @@ use crate::lengths::{
 use crate::rtti::*;
 use crate::window::WindowAdapter;
 use crate::{Coord, Property};
+use alloc::boxed::Box;
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
+use core::cell::RefCell;
 use core::pin::Pin;
 use euclid::Point2D;
 use euclid::num::Zero;
@@ -56,6 +58,7 @@ pub struct Path {
     pub clip: Property<bool>,
     pub anti_alias: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
+    fitted_cache: PathFittedCacheBox,
 }
 
 impl Item for Path {
@@ -194,31 +197,96 @@ impl Path {
         (offset, elements_iter).into()
     }
 
+    /// Returns the path and measurements as long as none of the properties are dirty
+    fn cached_fitted_path(self: Pin<&Self>, self_rc: &ItemRc) -> Option<Rc<FittedPath>> {
+        if let Some(new_data) =
+            self.fitted_cache.tracker.as_ref().evaluate_if_dirty(|| self.build_fitted_path(self_rc))
+        {
+            *self.fitted_cache.data.borrow_mut() = new_data.clone();
+            new_data
+        } else {
+            self.fitted_cache.data.borrow().clone()
+        }
+    }
+
+    fn build_fitted_path(self: Pin<&Self>, self_rc: &ItemRc) -> Option<Rc<FittedPath>> {
+        let (_, elements_iter) = self.fitted_path_events(self_rc)?;
+        Some(Rc::new(elements_iter.to_fitted_path()))
+    }
+
     pub fn point_at_percent(
         self: Pin<&Self>,
         self_rc: &ItemRc,
         percent: f32,
     ) -> Point2D<f32, LogicalPx> {
-        if let Some((_, path)) = self.fitted_path_events(self_rc) {
-            let pos = path.position_at(percent);
-            if let Some(pos) = pos { Point2D::new(pos.x, pos.y) } else { Point2D::default() }
-        } else {
-            Point2D::default()
-        }
+        self.cached_fitted_path(self_rc)
+            .and_then(|fitted| fitted.position_at(percent))
+            .map(|pos| Point2D::new(pos.x, pos.y))
+            .unwrap_or_default()
     }
     pub fn angle_at_percent(self: Pin<&Self>, self_rc: &ItemRc, percent: f32) -> f32 {
-        if let Some((_, path)) = self.fitted_path_events(self_rc) {
-            let angle = path.angle_at(percent);
-            angle.unwrap_or(0.0)
-        } else {
-            0.0
-        }
+        self.cached_fitted_path(self_rc).and_then(|fitted| fitted.angle_at(percent)).unwrap_or(0.0)
     }
 }
 
 impl ItemConsts for Path {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<Path, CachedRenderingData> =
         Path::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
+}
+
+pub struct PathFittedCacheInner {
+    data: RefCell<Option<Rc<FittedPath>>>,
+    /// Tracks the properties read while building data to rebuild data when the cache is
+    /// invalidated
+    tracker: Pin<Box<crate::properties::PropertyTracker>>,
+}
+
+impl Default for PathFittedCacheInner {
+    fn default() -> Self {
+        Self { data: Default::default(), tracker: Box::pin(Default::default()) }
+    }
+}
+
+/// Opaque box holding the cached path
+#[repr(C)]
+pub struct PathFittedCacheBox(core::ptr::NonNull<PathFittedCacheInner>);
+
+impl Default for PathFittedCacheBox {
+    fn default() -> Self {
+        PathFittedCacheBox(Box::leak(Box::<PathFittedCacheInner>::default()).into())
+    }
+}
+impl Drop for PathFittedCacheBox {
+    fn drop(&mut self) {
+        // Safety: self.0 was constructed from a Box::leak in PathFittedCacheBox::default
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+    }
+}
+impl core::ops::Deref for PathFittedCacheBox {
+    type Target = PathFittedCacheInner;
+    fn deref(&self) -> &Self::Target {
+        // Safety: initialized in PathFittedCacheBox::default
+        unsafe { self.0.as_ref() }
+    }
+}
+
+/// # Safety
+/// This must be called using a non-null pointer pointing to a chunk of memory big enough to
+/// hold a PathFittedCacheBox
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_path_fitted_cache_init(cache: *mut PathFittedCacheBox) {
+    unsafe { core::ptr::write(cache, PathFittedCacheBox::default()) };
+}
+
+/// # Safety
+/// This must be called using a non-null pointer pointing to an initialized PathFittedCacheBox
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_path_fitted_cache_free(cache: *mut PathFittedCacheBox) {
+    unsafe {
+        core::ptr::drop_in_place(cache);
+    }
 }
 
 #[cfg(feature = "ffi")]

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -229,26 +229,37 @@ impl ItemConsts for Path {
 
 struct FittedPathInner(RefCell<Option<FittedPath>>);
 
-/// Opaque box holding the FittedPath
+/// Opaque box holding the FittedPath, allocated lazily on first use
 #[repr(C)]
-pub struct FittedPathBox(core::ptr::NonNull<FittedPathInner>);
+pub struct FittedPathBox(core::cell::Cell<*mut FittedPathInner>);
 
 impl Default for FittedPathBox {
     fn default() -> Self {
-        FittedPathBox(Box::leak(Box::new(FittedPathInner(Default::default()))).into())
+        FittedPathBox(core::cell::Cell::new(core::ptr::null_mut()))
+    }
+}
+impl FittedPathBox {
+    fn get_or_init(&self) -> &FittedPathInner {
+        if self.0.get().is_null() {
+            self.0.set(Box::leak(Box::new(FittedPathInner(Default::default()))));
+        }
+        // Safety: the pointer is guaranteed non-null above, and was created from a Box::leak
+        unsafe { &*self.0.get() }
     }
 }
 impl Drop for FittedPathBox {
     fn drop(&mut self) {
-        // Safety: self.0 was constructed from a Box::leak in FittedPathBox::default
-        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+        let ptr = self.0.get();
+        if !ptr.is_null() {
+            // Safety: ptr was constructed from a Box::leak in get_or_init
+            drop(unsafe { Box::from_raw(ptr) });
+        }
     }
 }
 impl core::ops::Deref for FittedPathBox {
     type Target = RefCell<Option<FittedPath>>;
     fn deref(&self) -> &Self::Target {
-        // Safety: initialized in FittedPathBox::default
-        unsafe { &self.0.as_ref().0 }
+        &self.get_or_init().0
     }
 }
 

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -58,7 +58,8 @@ pub struct Path {
     pub clip: Property<bool>,
     pub anti_alias: Property<bool>,
     pub cached_rendering_data: CachedRenderingData,
-    fitted_cache: PathFittedCacheBox,
+    fitted_path: FittedPathBox,
+    tracker: crate::properties::PropertyTracker,
 }
 
 impl Item for Path {
@@ -197,35 +198,27 @@ impl Path {
         (offset, elements_iter).into()
     }
 
-    /// Returns the path and measurements as long as none of the properties are dirty
-    fn cached_fitted_path(self: Pin<&Self>, self_rc: &ItemRc) -> Option<Rc<FittedPath>> {
-        if let Some(new_data) =
-            self.fitted_cache.tracker.as_ref().evaluate_if_dirty(|| self.build_fitted_path(self_rc))
-        {
-            *self.fitted_cache.data.borrow_mut() = new_data.clone();
-            new_data
-        } else {
-            self.fitted_cache.data.borrow().clone()
-        }
-    }
-
-    fn build_fitted_path(self: Pin<&Self>, self_rc: &ItemRc) -> Option<Rc<FittedPath>> {
-        let (_, elements_iter) = self.fitted_path_events(self_rc)?;
-        Some(Rc::new(elements_iter.to_fitted_path()))
-    }
-
-    pub fn point_at_percent(
+    fn sample_at(
         self: Pin<&Self>,
         self_rc: &ItemRc,
         percent: f32,
-    ) -> Point2D<f32, LogicalPx> {
-        self.cached_fitted_path(self_rc)
-            .and_then(|fitted| fitted.position_at(percent))
-            .map(|pos| Point2D::new(pos.x, pos.y))
-            .unwrap_or_default()
+    ) -> Option<(Point2D<f32, LogicalPx>, f32)> {
+        if let Some(new_path) =
+            Path::FIELD_OFFSETS.tracker().apply_pin(self).evaluate_if_dirty(|| {
+                let (offset, elements_iter) = self.fitted_path_events(self_rc)?;
+                Some(elements_iter.to_fitted_path(offset))
+            })
+        {
+            *self.fitted_path.borrow_mut() = new_path;
+        }
+        self.fitted_path.borrow().as_ref()?.sample_at(percent)
     }
-    pub fn angle_at_percent(self: Pin<&Self>, self_rc: &ItemRc, percent: f32) -> f32 {
-        self.cached_fitted_path(self_rc).and_then(|fitted| fitted.angle_at(percent)).unwrap_or(0.0)
+
+    pub fn point_at(self: Pin<&Self>, self_rc: &ItemRc, percent: f32) -> Point2D<f32, LogicalPx> {
+        self.sample_at(self_rc, percent).map(|(pos, _)| pos).unwrap_or_default()
+    }
+    pub fn angle_at(self: Pin<&Self>, self_rc: &ItemRc, percent: f32) -> f32 {
+        self.sample_at(self_rc, percent).map(|(_, tangent)| tangent).unwrap_or_default()
     }
 }
 
@@ -234,56 +227,45 @@ impl ItemConsts for Path {
         Path::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
 }
 
-pub struct PathFittedCacheInner {
-    data: RefCell<Option<Rc<FittedPath>>>,
-    /// Tracks the properties read while building data to rebuild data when the cache is
-    /// invalidated
-    tracker: Pin<Box<crate::properties::PropertyTracker>>,
-}
+struct FittedPathInner(RefCell<Option<FittedPath>>);
 
-impl Default for PathFittedCacheInner {
-    fn default() -> Self {
-        Self { data: Default::default(), tracker: Box::pin(Default::default()) }
-    }
-}
-
-/// Opaque box holding the cached path
+/// Opaque box holding the FittedPath
 #[repr(C)]
-pub struct PathFittedCacheBox(core::ptr::NonNull<PathFittedCacheInner>);
+pub struct FittedPathBox(core::ptr::NonNull<FittedPathInner>);
 
-impl Default for PathFittedCacheBox {
+impl Default for FittedPathBox {
     fn default() -> Self {
-        PathFittedCacheBox(Box::leak(Box::<PathFittedCacheInner>::default()).into())
+        FittedPathBox(Box::leak(Box::new(FittedPathInner(Default::default()))).into())
     }
 }
-impl Drop for PathFittedCacheBox {
+impl Drop for FittedPathBox {
     fn drop(&mut self) {
-        // Safety: self.0 was constructed from a Box::leak in PathFittedCacheBox::default
+        // Safety: self.0 was constructed from a Box::leak in FittedPathBox::default
         drop(unsafe { Box::from_raw(self.0.as_ptr()) });
     }
 }
-impl core::ops::Deref for PathFittedCacheBox {
-    type Target = PathFittedCacheInner;
+impl core::ops::Deref for FittedPathBox {
+    type Target = RefCell<Option<FittedPath>>;
     fn deref(&self) -> &Self::Target {
-        // Safety: initialized in PathFittedCacheBox::default
-        unsafe { self.0.as_ref() }
+        // Safety: initialized in FittedPathBox::default
+        unsafe { &self.0.as_ref().0 }
     }
 }
 
 /// # Safety
 /// This must be called using a non-null pointer pointing to a chunk of memory big enough to
-/// hold a PathFittedCacheBox
+/// hold a FittedPathBox
 #[cfg(feature = "ffi")]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_path_fitted_cache_init(cache: *mut PathFittedCacheBox) {
-    unsafe { core::ptr::write(cache, PathFittedCacheBox::default()) };
+pub unsafe extern "C" fn slint_path_fitted_cache_init(cache: *mut FittedPathBox) {
+    unsafe { core::ptr::write(cache, FittedPathBox::default()) };
 }
 
 /// # Safety
-/// This must be called using a non-null pointer pointing to an initialized PathFittedCacheBox
+/// This must be called using a non-null pointer pointing to an initialized FittedPathBox
 #[cfg(feature = "ffi")]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_path_fitted_cache_free(cache: *mut PathFittedCacheBox) {
+pub unsafe extern "C" fn slint_path_fitted_cache_free(cache: *mut FittedPathBox) {
     unsafe {
         core::ptr::drop_in_place(cache);
     }
@@ -291,22 +273,22 @@ pub unsafe extern "C" fn slint_path_fitted_cache_free(cache: *mut PathFittedCach
 
 #[cfg(feature = "ffi")]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_path_point_at_percent(
+pub unsafe extern "C" fn slint_path_point_at(
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
     self_index: u32,
     percent: f32,
 ) -> crate::lengths::LogicalPoint {
     let self_rc = ItemRc::new(self_component.clone(), self_index);
-    self_rc.downcast::<Path>().unwrap().as_pin_ref().point_at_percent(&self_rc, percent)
+    self_rc.downcast::<Path>().unwrap().as_pin_ref().point_at(&self_rc, percent)
 }
 
 #[cfg(feature = "ffi")]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_path_angle_at_percent(
+pub unsafe extern "C" fn slint_path_angle_at(
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
     self_index: u32,
     percent: f32,
 ) -> f32 {
     let self_rc = ItemRc::new(self_component.clone(), self_index);
-    self_rc.downcast::<Path>().unwrap().as_pin_ref().angle_at_percent(&self_rc, percent)
+    self_rc.downcast::<Path>().unwrap().as_pin_ref().angle_at(&self_rc, percent)
 }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -21,7 +21,8 @@ use crate::item_rendering::CachedRenderingData;
 use crate::items::ImageFit;
 use crate::layout::{LayoutInfo, Orientation};
 use crate::lengths::{
-    LogicalBorderRadius, LogicalLength, LogicalRect, LogicalSize, LogicalVector, RectLengths,
+    LogicalBorderRadius, LogicalLength, LogicalPx, LogicalRect, LogicalSize, LogicalVector,
+    RectLengths,
 };
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
@@ -30,6 +31,7 @@ use crate::{Coord, Property};
 use alloc::rc::Rc;
 use const_field_offset::FieldOffsets;
 use core::pin::Pin;
+use euclid::Point2D;
 use euclid::num::Zero;
 use i_slint_core_macros::*;
 
@@ -191,9 +193,52 @@ impl Path {
         );
         (offset, elements_iter).into()
     }
+
+    pub fn point_at_percent(
+        self: Pin<&Self>,
+        self_rc: &ItemRc,
+        percent: f32,
+    ) -> Point2D<f32, LogicalPx> {
+        if let Some((_, path)) = self.fitted_path_events(self_rc) {
+            let pos = path.position_at(percent);
+            if let Some(pos) = pos { Point2D::new(pos.x, pos.y) } else { Point2D::default() }
+        } else {
+            Point2D::default()
+        }
+    }
+    pub fn angle_at_percent(self: Pin<&Self>, self_rc: &ItemRc, percent: f32) -> f32 {
+        if let Some((_, path)) = self.fitted_path_events(self_rc) {
+            let angle = path.angle_at(percent);
+            angle.unwrap_or(0.0)
+        } else {
+            0.0
+        }
+    }
 }
 
 impl ItemConsts for Path {
     const cached_rendering_data_offset: const_field_offset::FieldOffset<Path, CachedRenderingData> =
         Path::FIELD_OFFSETS.cached_rendering_data().as_unpinned_projection();
+}
+
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_path_point_at_percent(
+    self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
+    self_index: u32,
+    percent: f32,
+) -> crate::lengths::LogicalPoint {
+    let self_rc = ItemRc::new(self_component.clone(), self_index);
+    self_rc.downcast::<Path>().unwrap().as_pin_ref().point_at_percent(&self_rc, percent)
+}
+
+#[cfg(feature = "ffi")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_path_angle_at_percent(
+    self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
+    self_index: u32,
+    percent: f32,
+) -> f32 {
+    let self_rc = ItemRc::new(self_component.clone(), self_index);
+    self_rc.downcast::<Path>().unwrap().as_pin_ref().angle_at_percent(&self_rc, percent)
 }

--- a/internal/core/items/path.rs
+++ b/internal/core/items/path.rs
@@ -201,7 +201,7 @@ impl Path {
     fn sample_at(
         self: Pin<&Self>,
         self_rc: &ItemRc,
-        percent: f32,
+        t: f32,
     ) -> Option<(Point2D<f32, LogicalPx>, f32)> {
         if let Some(new_path) =
             Path::FIELD_OFFSETS.tracker().apply_pin(self).evaluate_if_dirty(|| {
@@ -211,14 +211,14 @@ impl Path {
         {
             *self.fitted_path.borrow_mut() = new_path;
         }
-        self.fitted_path.borrow().as_ref()?.sample_at(percent)
+        self.fitted_path.borrow().as_ref()?.sample_at(t)
     }
 
-    pub fn point_at(self: Pin<&Self>, self_rc: &ItemRc, percent: f32) -> Point2D<f32, LogicalPx> {
-        self.sample_at(self_rc, percent).map(|(pos, _)| pos).unwrap_or_default()
+    pub fn point_at(self: Pin<&Self>, self_rc: &ItemRc, t: f32) -> Point2D<f32, LogicalPx> {
+        self.sample_at(self_rc, t).map(|(pos, _)| pos).unwrap_or_default()
     }
-    pub fn angle_at(self: Pin<&Self>, self_rc: &ItemRc, percent: f32) -> f32 {
-        self.sample_at(self_rc, percent).map(|(_, tangent)| tangent).unwrap_or_default()
+    pub fn angle_at(self: Pin<&Self>, self_rc: &ItemRc, t: f32) -> f32 {
+        self.sample_at(self_rc, t).map(|(_, tangent)| tangent).unwrap_or_default()
     }
 }
 
@@ -287,10 +287,10 @@ pub unsafe extern "C" fn slint_path_fitted_cache_free(cache: *mut FittedPathBox)
 pub unsafe extern "C" fn slint_path_point_at(
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
     self_index: u32,
-    percent: f32,
+    t: f32,
 ) -> crate::lengths::LogicalPoint {
     let self_rc = ItemRc::new(self_component.clone(), self_index);
-    self_rc.downcast::<Path>().unwrap().as_pin_ref().point_at(&self_rc, percent)
+    self_rc.downcast::<Path>().unwrap().as_pin_ref().point_at(&self_rc, t)
 }
 
 #[cfg(feature = "ffi")]
@@ -298,8 +298,8 @@ pub unsafe extern "C" fn slint_path_point_at(
 pub unsafe extern "C" fn slint_path_angle_at(
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
     self_index: u32,
-    percent: f32,
+    t: f32,
 ) -> f32 {
     let self_rc = ItemRc::new(self_component.clone(), self_index);
-    self_rc.downcast::<Path>().unwrap().as_pin_ref().angle_at(&self_rc, percent)
+    self_rc.downcast::<Path>().unwrap().as_pin_ref().angle_at(&self_rc, t)
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1943,7 +1943,7 @@ fn call_builtin_function(
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
             Value::StyledText(corelib::styled_text::color_to_styled_text(color))
         }
-        BuiltinFunction::PointAtPercent => {
+        BuiltinFunction::PointAt => {
             let component = local_context.component_instance;
 
             if let Expression::ElementReference(item) = &arguments[0] {
@@ -1969,14 +1969,14 @@ fn call_builtin_function(
                     .downcast::<corelib::items::Path>()
                     .unwrap()
                     .as_pin_ref()
-                    .point_at_percent(&item_rc, percent)
+                    .point_at(&item_rc, percent)
                     .to_untyped()
                     .into()
             } else {
-                panic!("internal error: argument to PointAtPercent must be an element")
+                panic!("internal error: argument to PointAt must be an element")
             }
         }
-        BuiltinFunction::AngleAtPercent => {
+        BuiltinFunction::AngleAt => {
             let component = local_context.component_instance;
 
             if let Expression::ElementReference(item) = &arguments[0] {
@@ -2002,10 +2002,10 @@ fn call_builtin_function(
                     .downcast::<corelib::items::Path>()
                     .unwrap()
                     .as_pin_ref()
-                    .angle_at_percent(&item_rc, percent)
+                    .angle_at(&item_rc, percent)
                     .into()
             } else {
-                panic!("internal error: argument to AngleAtPercent must be an element")
+                panic!("internal error: argument to AngleAt must be an element")
             }
         }
     }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1943,6 +1943,71 @@ fn call_builtin_function(
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
             Value::StyledText(corelib::styled_text::color_to_styled_text(color))
         }
+        BuiltinFunction::PointAtPercent => {
+            let component = local_context.component_instance;
+
+            if let Expression::ElementReference(item) = &arguments[0] {
+                generativity::make_guard!(guard);
+
+                let item = item.upgrade().unwrap();
+                let enclosing_component = enclosing_component_for_element(&item, component, guard);
+                let description = enclosing_component.description;
+
+                let item_info = &description.items[item.borrow().id.as_str()];
+
+                let item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
+
+                let item_rc = corelib::items::ItemRc::new(
+                    vtable::VRc::into_dyn(item_comp),
+                    item_info.item_index(),
+                );
+
+                let percent: f32 =
+                    eval_expression(&arguments[1], local_context).try_into().unwrap();
+
+                item_rc
+                    .downcast::<corelib::items::Path>()
+                    .unwrap()
+                    .as_pin_ref()
+                    .point_at_percent(&item_rc, percent)
+                    .to_untyped()
+                    .into()
+            } else {
+                panic!("internal error: argument to PointAtPercent must be an element")
+            }
+        }
+        BuiltinFunction::AngleAtPercent => {
+            let component = local_context.component_instance;
+
+            if let Expression::ElementReference(item) = &arguments[0] {
+                generativity::make_guard!(guard);
+
+                let item = item.upgrade().unwrap();
+                let enclosing_component = enclosing_component_for_element(&item, component, guard);
+                let description = enclosing_component.description;
+
+                let item_info = &description.items[item.borrow().id.as_str()];
+
+                let item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
+
+                let item_rc = corelib::items::ItemRc::new(
+                    vtable::VRc::into_dyn(item_comp),
+                    item_info.item_index(),
+                );
+
+                let percent: f32 =
+                    eval_expression(&arguments[1], local_context).try_into().unwrap();
+
+                item_rc
+                    .downcast::<corelib::items::Path>()
+                    .unwrap()
+                    .as_pin_ref()
+                    .angle_at_percent(&item_rc, percent)
+                    .into()
+            } else {
+                panic!("internal error: argument to AngleAtPercent must be an element")
+            }
+        }
     }
 }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -3,6 +3,7 @@
 
 use crate::api::{SetPropertyError, Struct, Value};
 use crate::dynamic_item_tree::{CallbackHandler, InstanceRef};
+use core::cell::RefCell;
 use core::ffi::c_void;
 use core::pin::Pin;
 use corelib::graphics::{
@@ -22,12 +23,12 @@ use i_slint_compiler::expression_tree::{
 };
 use i_slint_compiler::langtype::{ConstantExpression, Type};
 use i_slint_compiler::namedreference::NamedReference;
-use i_slint_compiler::object_tree::ElementRc;
+use i_slint_compiler::object_tree::{Element, ElementRc};
 use i_slint_core::api::ToSharedString;
 use i_slint_core::{self as corelib};
 use smol_str::SmolStr;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 pub trait ErasedPropertyInfo {
     fn get(&self, item: Pin<ItemRef>) -> Value;
@@ -1817,20 +1818,7 @@ fn call_builtin_function(
             let component = local_context.component_instance;
 
             if let Expression::ElementReference(item) = &arguments[0] {
-                generativity::make_guard!(guard);
-
-                let item = item.upgrade().unwrap();
-                let enclosing_component = enclosing_component_for_element(&item, component, guard);
-                let description = enclosing_component.description;
-
-                let item_info = &description.items[item.borrow().id.as_str()];
-
-                let item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
-
-                let item_rc = corelib::items::ItemRc::new(
-                    vtable::VRc::into_dyn(item_comp),
-                    item_info.item_index(),
-                );
+                let item_rc = item_rc_for_element(item, component);
 
                 // Map the item's own geometry origin through the ancestor transforms so the
                 // result is the item's absolute position (not its parent's).
@@ -1943,24 +1931,11 @@ fn call_builtin_function(
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
             Value::StyledText(corelib::styled_text::color_to_styled_text(color))
         }
-        BuiltinFunction::PointAt => {
+        BuiltinFunction::PathPointAt => {
             let component = local_context.component_instance;
 
             if let Expression::ElementReference(item) = &arguments[0] {
-                generativity::make_guard!(guard);
-
-                let item = item.upgrade().unwrap();
-                let enclosing_component = enclosing_component_for_element(&item, component, guard);
-                let description = enclosing_component.description;
-
-                let item_info = &description.items[item.borrow().id.as_str()];
-
-                let item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
-
-                let item_rc = corelib::items::ItemRc::new(
-                    vtable::VRc::into_dyn(item_comp),
-                    item_info.item_index(),
-                );
+                let item_rc = item_rc_for_element(item, component);
 
                 let percent: f32 =
                     eval_expression(&arguments[1], local_context).try_into().unwrap();
@@ -1973,27 +1948,14 @@ fn call_builtin_function(
                     .to_untyped()
                     .into()
             } else {
-                panic!("internal error: argument to PointAt must be an element")
+                panic!("internal error: argument to PathPointAt must be an element")
             }
         }
-        BuiltinFunction::AngleAt => {
+        BuiltinFunction::PathAngleAt => {
             let component = local_context.component_instance;
 
             if let Expression::ElementReference(item) = &arguments[0] {
-                generativity::make_guard!(guard);
-
-                let item = item.upgrade().unwrap();
-                let enclosing_component = enclosing_component_for_element(&item, component, guard);
-                let description = enclosing_component.description;
-
-                let item_info = &description.items[item.borrow().id.as_str()];
-
-                let item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
-
-                let item_rc = corelib::items::ItemRc::new(
-                    vtable::VRc::into_dyn(item_comp),
-                    item_info.item_index(),
-                );
+                let item_rc = item_rc_for_element(item, component);
 
                 let percent: f32 =
                     eval_expression(&arguments[1], local_context).try_into().unwrap();
@@ -2005,10 +1967,26 @@ fn call_builtin_function(
                     .angle_at(&item_rc, percent)
                     .into()
             } else {
-                panic!("internal error: argument to AngleAt must be an element")
+                panic!("internal error: argument to PathAngleAt must be an element")
             }
         }
     }
+}
+
+fn item_rc_for_element(
+    item: &Weak<RefCell<Element>>,
+    component: InstanceRef,
+) -> corelib::items::ItemRc {
+    generativity::make_guard!(guard);
+    let item = item.upgrade().unwrap();
+    let enclosing_component = enclosing_component_for_element(&item, component, guard);
+    let description = enclosing_component.description;
+
+    let item_info = &description.items[item.borrow().id.as_str()];
+
+    let item_comp = enclosing_component.self_weak().get().unwrap().upgrade().unwrap();
+
+    corelib::items::ItemRc::new(vtable::VRc::into_dyn(item_comp), item_info.item_index())
 }
 
 fn call_item_member_function(nr: &NamedReference, local_context: &mut EvalLocalContext) -> Value {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1937,8 +1937,7 @@ fn call_builtin_function(
             if let Expression::ElementReference(item) = &arguments[0] {
                 let item_rc = item_rc_for_element(item, component);
 
-                let t: f32 =
-                    eval_expression(&arguments[1], local_context).try_into().unwrap();
+                let t: f32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
 
                 item_rc
                     .downcast::<corelib::items::Path>()
@@ -1957,8 +1956,7 @@ fn call_builtin_function(
             if let Expression::ElementReference(item) = &arguments[0] {
                 let item_rc = item_rc_for_element(item, component);
 
-                let t: f32 =
-                    eval_expression(&arguments[1], local_context).try_into().unwrap();
+                let t: f32 = eval_expression(&arguments[1], local_context).try_into().unwrap();
 
                 item_rc
                     .downcast::<corelib::items::Path>()

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1937,14 +1937,14 @@ fn call_builtin_function(
             if let Expression::ElementReference(item) = &arguments[0] {
                 let item_rc = item_rc_for_element(item, component);
 
-                let percent: f32 =
+                let t: f32 =
                     eval_expression(&arguments[1], local_context).try_into().unwrap();
 
                 item_rc
                     .downcast::<corelib::items::Path>()
                     .unwrap()
                     .as_pin_ref()
-                    .point_at(&item_rc, percent)
+                    .point_at(&item_rc, t)
                     .to_untyped()
                     .into()
             } else {
@@ -1957,14 +1957,14 @@ fn call_builtin_function(
             if let Expression::ElementReference(item) = &arguments[0] {
                 let item_rc = item_rc_for_element(item, component);
 
-                let percent: f32 =
+                let t: f32 =
                     eval_expression(&arguments[1], local_context).try_into().unwrap();
 
                 item_rc
                     .downcast::<corelib::items::Path>()
                     .unwrap()
                     .as_pin_ref()
-                    .angle_at(&item_rc, percent)
+                    .angle_at(&item_rc, t)
                     .into()
             } else {
                 panic!("internal error: argument to PathAngleAt must be an element")

--- a/tests/cases/properties/animation_path.slint
+++ b/tests/cases/properties/animation_path.slint
@@ -6,8 +6,8 @@ export component TestCase inherits Window {
     height: 100px;
 
     // viewbox-x/y is non-zero and the viewbox is stretched non-uniformly relative to the
-    // element (200x100 element vs 25x50 viewbox, via `fit: fill`) so that point-at-percent/
-    // angle-at-percent are exercised in the Path element's own coordinate space rather than
+    // element (200x100 element vs 25x50 viewbox, via `fit: fill`) so that point-at/
+    // angle-at are exercised in the Path element's own coordinate space rather than
     // in raw viewbox coordinates (which would give different, non-round numbers below).
     path := Path {
         width: 200px;
@@ -26,9 +26,24 @@ export component TestCase inherits Window {
         duration: 2000ms;
     }
 
-    out property <float> px: path.point-at-percent(t).x / 1px;
-    out property <float> py: path.point-at-percent(t).y / 1px;
-    out property <angle> angle: path.angle-at-percent(t);
+    out property <float> px: path.point-at(t).x / 1px;
+    out property <float> py: path.point-at(t).y / 1px;
+    out property <angle> angle: path.angle-at(t);
+
+    // testing multi-loop
+    in-out property <float> u: 0;
+    animate u {
+        duration: 4000ms;
+    }
+    out property <float> ux: path.point-at(u).x / 1px;
+    out property <float> uy: path.point-at(u).y / 1px;
+
+    in-out property <float> v: 2;
+    animate v {
+        duration: 4000ms;
+    }
+    out property <float> vx: path.point-at(v).x / 1px;
+    out property <float> vy: path.point-at(v).y / 1px;
 }
 
 /*
@@ -72,6 +87,65 @@ slint_testing::mock_elapsed_time(500);
 assert_eq!(instance.get_px(), 100.0);
 assert_eq!(instance.get_py(), 100.0);
 assert_almost_eq(instance.get_angle(), 0.0);
+
+// Animating u from 0 to 2 traverses the path twice forwards: each 0..1 segment
+// of u must retrace the exact same (x, y) sequence as the first traversal above.
+instance.set_u(2.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_ux(), 0.0);
+assert_eq!(instance.get_uy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_ux(), 0.0);
+assert_eq!(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_ux(), 50.0);
+assert_eq!(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+// u == 1.0 exactly: the true end of the (single) path, not the wrapped start.
+assert_eq!(instance.get_ux(), 100.0);
+assert_eq!(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+// u == 1.25: second forward loop begins, retracing the same points as u == 0.25.
+assert_eq!(instance.get_ux(), 0.0);
+assert_eq!(instance.get_uy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_ux(), 0.0);
+assert_eq!(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_ux(), 50.0);
+assert_eq!(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_ux(), 0.0);
+assert_eq!(instance.get_uy(), 0.0);
+
+// Animating v from 2 down to 0 traverses the path twice backwards: positions
+// mirror the forward trace above, retreating back towards the path's start.
+instance.set_v(0.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_vx(), 50.0);
+assert_eq!(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_vx(), 0.0);
+assert_eq!(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_vx(), 0.0);
+assert_eq!(instance.get_vy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+// v == 1.0 exactly: the true end of the path again, same special case as above.
+assert_eq!(instance.get_vx(), 100.0);
+assert_eq!(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_vx(), 50.0);
+assert_eq!(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_vx(), 0.0);
+assert_eq!(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_vx(), 0.0);
+assert_eq!(instance.get_vy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_vx(), 0.0);
+assert_eq!(instance.get_vy(), 0.0);
 ```
 
 
@@ -111,6 +185,65 @@ slint_testing::mock_elapsed_time(500);
 assert_eq(instance.get_px(), 100.0);
 assert_eq(instance.get_py(), 100.0);
 assert(std::abs(instance.get_angle() - 0.0) < 0.05);
+
+// Animating u from 0 to 2 traverses the path twice forwards: each 0..1 segment
+// of u must retrace the exact same (x, y) sequence as the first traversal above.
+instance.set_u(2.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_ux(), 0.0);
+assert_eq(instance.get_uy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_ux(), 0.0);
+assert_eq(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_ux(), 50.0);
+assert_eq(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+// u == 1.0 exactly: the true end of the (single) path, not the wrapped start.
+assert_eq(instance.get_ux(), 100.0);
+assert_eq(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+// u == 1.25: second forward loop begins, retracing the same points as u == 0.25.
+assert_eq(instance.get_ux(), 0.0);
+assert_eq(instance.get_uy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_ux(), 0.0);
+assert_eq(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_ux(), 50.0);
+assert_eq(instance.get_uy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_ux(), 0.0);
+assert_eq(instance.get_uy(), 0.0);
+
+// Animating v from 2 down to 0 traverses the path twice backwards: positions
+// mirror the forward trace above, retreating back towards the path's start.
+instance.set_v(0.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_vx(), 50.0);
+assert_eq(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_vx(), 0.0);
+assert_eq(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_vx(), 0.0);
+assert_eq(instance.get_vy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+// v == 1.0 exactly: the true end of the path again, same special case as above.
+assert_eq(instance.get_vx(), 100.0);
+assert_eq(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_vx(), 50.0);
+assert_eq(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_vx(), 0.0);
+assert_eq(instance.get_vy(), 100.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_vx(), 0.0);
+assert_eq(instance.get_vy(), 50.0);
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_vx(), 0.0);
+assert_eq(instance.get_vy(), 0.0);
 ```
 
 ```js
@@ -148,6 +281,65 @@ slintlib.private_api.mock_elapsed_time(500);
 assert.equal(instance.px, 100.0);
 assert.equal(instance.py, 100.0);
 assert(Math.abs(instance.angle - 0.0) < 0.05);
+
+// Animating u from 0 to 2 traverses the path twice forwards: each 0..1 segment
+// of u must retrace the exact same (x, y) sequence as the first traversal above.
+instance.u = 2.0;
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.ux, 0.0);
+assert.equal(instance.uy, 50.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.ux, 0.0);
+assert.equal(instance.uy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.ux, 50.0);
+assert.equal(instance.uy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+// u == 1.0 exactly: the true end of the (single) path, not the wrapped start.
+assert.equal(instance.ux, 100.0);
+assert.equal(instance.uy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+// u == 1.25: second forward loop begins, retracing the same points as u == 0.25.
+assert.equal(instance.ux, 0.0);
+assert.equal(instance.uy, 50.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.ux, 0.0);
+assert.equal(instance.uy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.ux, 50.0);
+assert.equal(instance.uy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.ux, 0.0);
+assert.equal(instance.uy, 0.0);
+
+// Animating v from 2 down to 0 traverses the path twice backwards: positions
+// mirror the forward trace above, retreating back towards the path's start.
+instance.v = 0.0;
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.vx, 50.0);
+assert.equal(instance.vy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.vx, 0.0);
+assert.equal(instance.vy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.vx, 0.0);
+assert.equal(instance.vy, 50.0);
+slintlib.private_api.mock_elapsed_time(500);
+// v == 1.0 exactly: the true end of the path again, same special case as above.
+assert.equal(instance.vx, 100.0);
+assert.equal(instance.vy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.vx, 50.0);
+assert.equal(instance.vy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.vx, 0.0);
+assert.equal(instance.vy, 100.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.vx, 0.0);
+assert.equal(instance.vy, 50.0);
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.vx, 0.0);
+assert.equal(instance.vy, 0.0);
 ```
 
 */

--- a/tests/cases/properties/animation_path.slint
+++ b/tests/cases/properties/animation_path.slint
@@ -2,18 +2,23 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component TestCase inherits Window {
-    width: 100px;
+    width: 200px;
     height: 100px;
 
+    // viewbox-x/y is non-zero and the viewbox is stretched non-uniformly relative to the
+    // element (200x100 element vs 25x50 viewbox, via `fit: fill`) so that point-at-percent/
+    // angle-at-percent are exercised in the Path element's own coordinate space rather than
+    // in raw viewbox coordinates (which would give different, non-round numbers below).
     path := Path {
-        width: 100px;
+        width: 200px;
         height: 100px;
-        viewbox-x: 0;
-        viewbox-y: 0;
-        viewbox-width: 100;
-        viewbox-height: 100;
+        viewbox-x: 5;
+        viewbox-y: 3;
+        viewbox-width: 25;
+        viewbox-height: 50;
+        fit: fill;
         stroke-width: 0px;
-        commands: "M0,0 L0,100 L100,100";
+        commands: "M5,3 L5,53 L17.5,53";
     }
 
     in-out property <float> t: 0;
@@ -44,25 +49,25 @@ assert_eq!(instance.get_px(), 0.0);
 assert_eq!(instance.get_py(), 0.0);
 assert_almost_eq(instance.get_angle(), 90.0);
 
-// At 25% expect to be at (0, 50)
+// At 25% expect to be at (0, 50) in element coordinates, not the raw viewbox point (5, 28)
 slint_testing::mock_elapsed_time(500);
 assert_eq!(instance.get_px(), 0.0);
 assert_eq!(instance.get_py(), 50.0);
 assert_almost_eq(instance.get_angle(), 90.0);
 
-// At 50% expect to be at (0, 100)
+// At 50% expect to be at (0, 100) in element coordinates, not the raw viewbox point (5, 53)
 slint_testing::mock_elapsed_time(500);
 assert_eq!(instance.get_px(), 0.0);
 assert_eq!(instance.get_py(), 100.0);
 assert_almost_eq(instance.get_angle(), 90.0);
 
-// At 75% expect to be at (50, 100)
+// At 75% expect to be at (50, 100) in element coordinates, not the raw viewbox point (11.25, 53)
 slint_testing::mock_elapsed_time(500);
 assert_eq!(instance.get_px(), 50.0);
 assert_eq!(instance.get_py(), 100.0);
 assert_almost_eq(instance.get_angle(), 0.0);
 
-// At 100% expect to be at (100, 100)
+// At 100% expect to be at (100, 100) in element coordinates, not the raw viewbox point (17.5, 53)
 slint_testing::mock_elapsed_time(500);
 assert_eq!(instance.get_px(), 100.0);
 assert_eq!(instance.get_py(), 100.0);
@@ -83,25 +88,25 @@ assert_eq(instance.get_px(), 0.0);
 assert_eq(instance.get_py(), 0.0);
 assert(std::abs(instance.get_angle() - 90.0) < 0.05);
 
-// At 25% expect to be at (0, 50)
+// At 25% expect to be at (0, 50) in element coordinates, not the raw viewbox point (5, 28)
 slint_testing::mock_elapsed_time(500);
 assert_eq(instance.get_px(), 0.0);
 assert_eq(instance.get_py(), 50.0);
 assert(std::abs(instance.get_angle() - 90.0) < 0.05);
 
-// At 50% expect to be at (0, 100)
+// At 50% expect to be at (0, 100) in element coordinates, not the raw viewbox point (5, 53)
 slint_testing::mock_elapsed_time(500);
 assert_eq(instance.get_px(), 0.0);
 assert_eq(instance.get_py(), 100.0);
 assert(std::abs(instance.get_angle() - 90.0) < 0.05);
 
-// At 75% expect to be at (50, 100)
+// At 75% expect to be at (50, 100) in element coordinates, not the raw viewbox point (11.25, 53)
 slint_testing::mock_elapsed_time(500);
 assert_eq(instance.get_px(), 50.0);
 assert_eq(instance.get_py(), 100.0);
 assert(std::abs(instance.get_angle() - 0.0) < 0.05);
 
-// At 100% expect to be at (100, 100)
+// At 100% expect to be at (100, 100) in element coordinates, not the raw viewbox point (17.5, 53)
 slint_testing::mock_elapsed_time(500);
 assert_eq(instance.get_px(), 100.0);
 assert_eq(instance.get_py(), 100.0);
@@ -120,25 +125,25 @@ assert.equal(instance.px, 0.0);
 assert.equal(instance.py, 0.0);
 assert(Math.abs(instance.angle - 90.0) < 0.05);
 
-// At 25% expect to be at (0, 50)
+// At 25% expect to be at (0, 50) in element coordinates, not the raw viewbox point (5, 28)
 slintlib.private_api.mock_elapsed_time(500);
 assert.equal(instance.px, 0.0);
 assert.equal(instance.py, 50.0);
 assert(Math.abs(instance.angle - 90.0) < 0.05);
 
-// At 50% expect to be at (0, 100)
+// At 50% expect to be at (0, 100) in element coordinates, not the raw viewbox point (5, 53)
 slintlib.private_api.mock_elapsed_time(500);
 assert.equal(instance.px, 0.0);
 assert.equal(instance.py, 100.0);
 assert(Math.abs(instance.angle - 90.0) < 0.05);
 
-// At 75% expect to be at (50, 100)
+// At 75% expect to be at (50, 100) in element coordinates, not the raw viewbox point (11.25, 53)
 slintlib.private_api.mock_elapsed_time(500);
 assert.equal(instance.px, 50.0);
 assert.equal(instance.py, 100.0);
 assert(Math.abs(instance.angle - 0.0) < 0.05);
 
-// At 100% expect to be at (100, 100)
+// At 100% expect to be at (100, 100) in element coordinates, not the raw viewbox point (17.5, 53)
 slintlib.private_api.mock_elapsed_time(500);
 assert.equal(instance.px, 100.0);
 assert.equal(instance.py, 100.0);

--- a/tests/cases/properties/animation_path.slint
+++ b/tests/cases/properties/animation_path.slint
@@ -1,0 +1,148 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    path := Path {
+        width: 100px;
+        height: 100px;
+        viewbox-x: 0;
+        viewbox-y: 0;
+        viewbox-width: 100;
+        viewbox-height: 100;
+        stroke-width: 0px;
+        commands: "M0,0 L0,100 L100,100";
+    }
+
+    in-out property <float> t: 0;
+    animate t {
+        duration: 2000ms;
+    }
+
+    out property <float> px: path.point-at-percent(t).x / 1px;
+    out property <float> py: path.point-at-percent(t).y / 1px;
+    out property <angle> angle: path.angle-at-percent(t);
+}
+
+/*
+
+```rust
+fn assert_almost_eq(value: f32, expected: f32) {
+    assert!(expected - 0.05 <= value && value <= expected + 0.05, "Expected {value} to be close to {expected} (+-0.05)");
+}
+
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_px(), 0.0);
+assert_eq!(instance.get_py(), 0.0);
+assert_almost_eq(instance.get_angle(), 90.0);
+
+instance.set_t(1.0);
+// no time has elapsed yet
+assert_eq!(instance.get_px(), 0.0);
+assert_eq!(instance.get_py(), 0.0);
+assert_almost_eq(instance.get_angle(), 90.0);
+
+// At 25% expect to be at (0, 50)
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_px(), 0.0);
+assert_eq!(instance.get_py(), 50.0);
+assert_almost_eq(instance.get_angle(), 90.0);
+
+// At 50% expect to be at (0, 100)
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_px(), 0.0);
+assert_eq!(instance.get_py(), 100.0);
+assert_almost_eq(instance.get_angle(), 90.0);
+
+// At 75% expect to be at (50, 100)
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_px(), 50.0);
+assert_eq!(instance.get_py(), 100.0);
+assert_almost_eq(instance.get_angle(), 0.0);
+
+// At 100% expect to be at (100, 100)
+slint_testing::mock_elapsed_time(500);
+assert_eq!(instance.get_px(), 100.0);
+assert_eq!(instance.get_py(), 100.0);
+assert_almost_eq(instance.get_angle(), 0.0);
+```
+
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_px(), 0.0);
+assert_eq(instance.get_py(), 0.0);
+assert(std::abs(instance.get_angle() - 90.0) < 0.05);
+
+instance.set_t(1.0);
+// no time has elapsed yet
+assert_eq(instance.get_px(), 0.0);
+assert_eq(instance.get_py(), 0.0);
+assert(std::abs(instance.get_angle() - 90.0) < 0.05);
+
+// At 25% expect to be at (0, 50)
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_px(), 0.0);
+assert_eq(instance.get_py(), 50.0);
+assert(std::abs(instance.get_angle() - 90.0) < 0.05);
+
+// At 50% expect to be at (0, 100)
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_px(), 0.0);
+assert_eq(instance.get_py(), 100.0);
+assert(std::abs(instance.get_angle() - 90.0) < 0.05);
+
+// At 75% expect to be at (50, 100)
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_px(), 50.0);
+assert_eq(instance.get_py(), 100.0);
+assert(std::abs(instance.get_angle() - 0.0) < 0.05);
+
+// At 100% expect to be at (100, 100)
+slint_testing::mock_elapsed_time(500);
+assert_eq(instance.get_px(), 100.0);
+assert_eq(instance.get_py(), 100.0);
+assert(std::abs(instance.get_angle() - 0.0) < 0.05);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.px, 0.0);
+assert.equal(instance.py, 0.0);
+assert(Math.abs(instance.angle - 90.0) < 0.05);
+
+instance.t = 1.0;
+// no time has elapsed yet
+assert.equal(instance.px, 0.0);
+assert.equal(instance.py, 0.0);
+assert(Math.abs(instance.angle - 90.0) < 0.05);
+
+// At 25% expect to be at (0, 50)
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.px, 0.0);
+assert.equal(instance.py, 50.0);
+assert(Math.abs(instance.angle - 90.0) < 0.05);
+
+// At 50% expect to be at (0, 100)
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.px, 0.0);
+assert.equal(instance.py, 100.0);
+assert(Math.abs(instance.angle - 90.0) < 0.05);
+
+// At 75% expect to be at (50, 100)
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.px, 50.0);
+assert.equal(instance.py, 100.0);
+assert(Math.abs(instance.angle - 0.0) < 0.05);
+
+// At 100% expect to be at (100, 100)
+slintlib.private_api.mock_elapsed_time(500);
+assert.equal(instance.px, 100.0);
+assert.equal(instance.py, 100.0);
+assert(Math.abs(instance.angle - 0.0) < 0.05);
+```
+
+*/

--- a/tests/cases/properties/animation_path.slint
+++ b/tests/cases/properties/animation_path.slint
@@ -115,8 +115,9 @@ slint_testing::mock_elapsed_time(500);
 assert_eq!(instance.get_ux(), 50.0);
 assert_eq!(instance.get_uy(), 100.0);
 slint_testing::mock_elapsed_time(500);
-assert_eq!(instance.get_ux(), 0.0);
-assert_eq!(instance.get_uy(), 0.0);
+// u == 2.0 exactly: end of the double path
+assert_eq!(instance.get_ux(), 100.0);
+assert_eq!(instance.get_uy(), 100.0);
 
 // Animating v from 2 down to 0 traverses the path twice backwards: positions
 // mirror the forward trace above, retreating back towards the path's start.
@@ -213,8 +214,9 @@ slint_testing::mock_elapsed_time(500);
 assert_eq(instance.get_ux(), 50.0);
 assert_eq(instance.get_uy(), 100.0);
 slint_testing::mock_elapsed_time(500);
-assert_eq(instance.get_ux(), 0.0);
-assert_eq(instance.get_uy(), 0.0);
+// u == 2.0 exactly: end of the double path
+assert_eq(instance.get_ux(), 100.0);
+assert_eq(instance.get_uy(), 100.0);
 
 // Animating v from 2 down to 0 traverses the path twice backwards: positions
 // mirror the forward trace above, retreating back towards the path's start.
@@ -309,8 +311,9 @@ slintlib.private_api.mock_elapsed_time(500);
 assert.equal(instance.ux, 50.0);
 assert.equal(instance.uy, 100.0);
 slintlib.private_api.mock_elapsed_time(500);
-assert.equal(instance.ux, 0.0);
-assert.equal(instance.uy, 0.0);
+// u == 2.0 exactly: end of the double path
+assert.equal(instance.ux, 100.0);
+assert.equal(instance.uy, 100.0);
 
 // Animating v from 2 down to 0 traverses the path twice backwards: positions
 // mirror the forward trace above, retreating back towards the path's start.


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
This will allow animation of an object along a path with animating the percent that is passed into these functions.