### PR TITLE
navigation: federation — contracts, mount, and capabilities

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -134,6 +134,7 @@ deinit
 delenv
 depfile
 deque
+desugars
 devcode
 devenv
 dfaure
@@ -283,6 +284,7 @@ incididunt
 Inconsolata
 incpath
 inputchip
+interp
 intprop
 intval
 IRAM
@@ -514,6 +516,7 @@ rlib
 Roboto
 RODATA
 rowcol
+rsplit
 rspolib
 rsvg
 rtti
@@ -639,6 +642,7 @@ udivdi
 uintptr
 ullamco
 unfocusable
+ungated
 unhinted
 unicodes
 uninit
@@ -659,6 +663,7 @@ vbus
 vecmodel
 veniam
 venv
+versionable
 verticalbox
 verticallayout
 VGWGPU
@@ -701,9 +706,11 @@ xcent
 xchg
 xcrun
 xfer
+XFILE
 xfixes
 xlib
 xmark
+xmount
 Xrgb
 xshell
 xxaaxx

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -178,6 +178,10 @@ export default defineConfig({
                                         label: "Navigation",
                                         slug: "guide/development/navigation",
                                     },
+                                    {
+                                        label: "Federated Navigation",
+                                        slug: "guide/development/navigation-federation",
+                                    },
                                     "guide/development/best-practices",
                                     "guide/development/third-party-libraries",
                                 ],

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -174,6 +174,10 @@ export default defineConfig({
                                         label: "Drag and Drop",
                                         slug: "guide/development/drag-and-drop",
                                     },
+                                    {
+                                        label: "Navigation",
+                                        slug: "guide/development/navigation",
+                                    },
                                     "guide/development/best-practices",
                                     "guide/development/third-party-libraries",
                                 ],

--- a/docs/astro/src/content/docs/guide/development/navigation-federation.mdx
+++ b/docs/astro/src/content/docs/guide/development/navigation-federation.mdx
@@ -1,0 +1,158 @@
+---
+title: Federated Navigation
+description: Compose an app from independently-authored parts using navigation contracts, mounts, and host capabilities.
+---
+
+Large apps are often built by several teams, each owning a feature and shipping
+on its own release cycle. Federation lets each team declare its screens and the
+contract at its boundary, and lets an integration layer compose them into one
+app, without any team editing another's code.
+
+It builds on the [`navigator`](navigation) construct: each part runs its own
+navigator internally, and the integrator mounts the part at a route.
+
+:::caution[Experimental]
+These constructs are experimental. Build with
+`SLINT_ENABLE_EXPERIMENTAL_FEATURES=1` (or set `enable_experimental` in the
+compiler configuration) to use them.
+:::
+
+## The navigation contract
+
+A contract is an `interface` that declares the routes a part exposes at its
+boundary. It is the only thing the integrator and the part have to agree on.
+
+```slint
+export interface FeatureNav {
+    @version(1)
+    @uri("app://feature") route Main;
+}
+```
+
+- `route Main;` declares an entry route. A route may take parameters, for
+  example `route Details(id: int);`, for deep links that carry data.
+- `@version(n)` versions the contract, so an integrator can tell which revision
+  a part was built against.
+- `@uri("…")` gives a route a stable deep-link address.
+
+A contract may also declare the capabilities the host provides to a mounted
+part:
+
+```slint
+export interface HostServices {
+    callback log(string);
+    callback go-home();
+}
+```
+
+## Implementing a contract
+
+A part `implements` a contract, which checks at compile time that it covers
+every route the contract declares. It declares the capabilities it `needs` from
+its host, and runs its own navigator internally:
+
+```slint
+import { FeatureNav, HostServices } from "contract.slint";
+
+enum MediaRoute { Main, Player }
+
+export component MediaFeature implements FeatureNav inherits Rectangle {
+    needs HostServices;
+    in-out property <MediaRoute> current-route: MediaRoute.Main;
+
+    init => { root.log("media: mounted"); }
+
+    navigator (current-route) {
+        MediaRoute.Main: Library {
+            play => { root.navigate(MediaRoute.Player); }
+            home => { root.go-home(); }
+        }
+        MediaRoute.Player: Player {
+            go-back => { root.back(); }
+        }
+    }
+}
+```
+
+`needs HostServices` makes `log` and `go-home` usable inside the part as if it
+declared them, but leaves them unbound: the integrator binds them at the mount.
+
+## Mounting a part
+
+The integration shell mounts a part at one of its own routes with
+`mount … via Contract`, and binds the capabilities the part needs right there:
+
+```slint
+import { FeatureNav } from "contract.slint";
+import { MediaFeature } from "media.slint";
+
+enum Shell { Home, Media }
+
+export component App inherits Window {
+    in-out property <Shell> current: Shell.Home;
+
+    navigator (current) {
+        Shell.Home: HomeScreen {
+            open-media => { root.navigate(Shell.Media); }
+        }
+        Shell.Media: mount MediaFeature via FeatureNav {
+            log(message) => { debug(message); }
+            go-home => { root.navigate(Shell.Home); }
+        }
+    }
+}
+```
+
+`mount MediaFeature via FeatureNav` instantiates the part directly and checks it
+against the contract at build time. An unbound `needs` capability is a compile
+error at the mount site, so the integration never ships a part missing a service
+it requires.
+
+## External parts
+
+A part built and shipped on its own cycle is not a compile-time dependency.
+Mount it with `mount extern via Contract` and hand it a `ComponentFactory` at
+runtime:
+
+```slint
+export component App inherits Window {
+    in property <component-factory> plugin-factory;
+    // ...
+    navigator (current) {
+        // ...
+        Shell.Plugin: mount extern via FeatureNav {
+            component-factory: root.plugin-factory;
+        }
+    }
+}
+```
+
+The host supplies the factory. Here it loads the part from source at runtime
+with the interpreter, but it could equally be a separately compiled binary:
+
+```rust
+let factory = slint::ComponentFactory::new(|ctx| {
+    let compiler = slint_interpreter::Compiler::new();
+    let def = spin_on::spin_on(
+        compiler.build_from_source(plugin_source, "plugin.slint".into()),
+    )
+    .component("Plugin")
+    .unwrap();
+    def.create_embedded(ctx).ok()
+});
+app.set_plugin_factory(factory);
+```
+
+The external part renders into the mount's slot; the seam is a
+`ComponentContainer`, so nothing about the shell has to be recompiled when the
+part changes.
+
+## Why federation
+
+The contract is the whole coupling surface. Because it is declared structure
+checked by the compiler, an integration team can compose parts it did not write,
+each part can be versioned and deep-linked, and a part can be swapped, at build
+time or at runtime, without either side reaching into the other's internals.
+
+A runnable version lives in `examples/navigation-federated` in the Slint
+repository.

--- a/docs/astro/src/content/docs/guide/development/navigation.mdx
+++ b/docs/astro/src/content/docs/guide/development/navigation.mdx
@@ -1,0 +1,85 @@
+---
+title: Navigation
+description: The convention for moving between screens with an enum route and a current-route property.
+---
+
+Slint has no dedicated navigation element yet. Multi-screen apps are built from a
+small, stable convention: an `enum` of routes, a `current-route` property, and one
+conditional child per route. This page describes that convention.
+
+This is the interim pattern that the visual editor's flow map understands, so
+following it exactly lets tooling read the screens and the transitions between them.
+
+## The convention
+
+The pattern is made of four parts.
+
+1. A user-declared `enum Route` with one value per screen.
+2. A root component with `in-out property <Route> current-route`, set to the initial screen.
+3. One conditional child per route, mapping a route to its screen: `if current-route == Route.Home : HomeScreen { ... }`.
+4. Navigation by assigning the route property: `current-route = Route.Details;`.
+
+```slint
+import { Button, VerticalBox } from "std-widgets.slint";
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits VerticalBox {
+    callback show-details();
+    callback show-settings();
+    Text { text: "Home"; }
+    Button { text: "Go to Details"; clicked => { root.show-details(); } }
+    Button { text: "Open Settings"; clicked => { root.show-settings(); } }
+}
+
+component DetailsScreen inherits VerticalBox {
+    callback back();
+    Text { text: "Details"; }
+    Button { text: "Back to Home"; clicked => { root.back(); } }
+}
+
+component SettingsScreen inherits VerticalBox {
+    callback back();
+    Text { text: "Settings"; }
+    Button { text: "Back to Home"; clicked => { root.back(); } }
+}
+
+export component App inherits Window {
+    // The current screen. Assigning this property navigates.
+    in-out property <Route> current-route: Route.Home;
+
+    // One conditional child per route maps a route to its screen.
+    if current-route == Route.Home : HomeScreen {
+        show-details => { root.current-route = Route.Details; }
+        show-settings => { root.current-route = Route.Settings; }
+    }
+    if current-route == Route.Details : DetailsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+    if current-route == Route.Settings : SettingsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+}
+```
+
+## How it reads
+
+- The `enum Route` is the set of screens.
+- `current-route` is the active screen, and its initializer is the entry screen.
+- Each `if current-route == Route.X : Screen { ... }` is the route-to-screen mapping.
+- Each `current-route = Route.Y;` assignment is a transition from the enclosing screen to `Route.Y`.
+
+Keeping a screen in its own component and wiring its callbacks in the root, next to the
+matching conditional child, keeps each transition close to the screen it starts from.
+
+## Scope
+
+The convention tracks a single `current-route` only. There is no back-stack: returning
+to a previous screen is just another assignment, as in the `back` callbacks above. A
+history stack is a separate concern and is not part of this convention.
+
+A runnable version of this example lives in `examples/navigation` in the Slint repository.

--- a/docs/astro/src/content/docs/guide/development/navigation.mdx
+++ b/docs/astro/src/content/docs/guide/development/navigation.mdx
@@ -1,23 +1,27 @@
 ---
 title: Navigation
-description: The convention for moving between screens with an enum route and a current-route property.
+description: Move between screens with the navigator construct - an enum of routes, a current-route property, and a compiler-checked route table.
 ---
 
-Slint has no dedicated navigation element yet. Multi-screen apps are built from a
-small, stable convention: an `enum` of routes, a `current-route` property, and one
-conditional child per route. This page describes that convention.
+The `navigator` construct declares the screens of a multi-screen app and the
+route between them as one compiler-checked structure. The set of screens is
+static (the compiler resolves it), while the active screen is a value you drive
+at runtime, so tooling can read the whole navigation graph from the source and
+it always matches what runs.
 
-This is the interim pattern that the visual editor's flow map understands, so
-following it exactly lets tooling read the screens and the transitions between them.
+:::caution[Experimental]
+`navigator` is an experimental feature. Build with
+`SLINT_ENABLE_EXPERIMENTAL_FEATURES=1` (or set `enable_experimental` in the
+compiler configuration) to use it.
+:::
 
-## The convention
+## The navigator
 
-The pattern is made of four parts.
+Three pieces make up a navigator:
 
-1. A user-declared `enum Route` with one value per screen.
-2. A root component with `in-out property <Route> current-route`, set to the initial screen.
-3. One conditional child per route, mapping a route to its screen: `if current-route == Route.Home : HomeScreen { ... }`.
-4. Navigation by assigning the route property: `current-route = Route.Details;`.
+1. A user-declared `enum` with one value per screen.
+2. An `in-out property` of that enum type holding the current route.
+3. A `navigator (current-route) { ... }` block that maps each route to its screen.
 
 ```slint
 import { Button, VerticalBox } from "std-widgets.slint";
@@ -37,49 +41,86 @@ component HomeScreen inherits VerticalBox {
 }
 
 component DetailsScreen inherits VerticalBox {
-    callback back();
     Text { text: "Details"; }
-    Button { text: "Back to Home"; clicked => { root.back(); } }
 }
 
 component SettingsScreen inherits VerticalBox {
-    callback back();
     Text { text: "Settings"; }
-    Button { text: "Back to Home"; clicked => { root.back(); } }
 }
 
 export component App inherits Window {
-    // The current screen. Assigning this property navigates.
     in-out property <Route> current-route: Route.Home;
 
-    // One conditional child per route maps a route to its screen.
-    if current-route == Route.Home : HomeScreen {
-        show-details => { root.current-route = Route.Details; }
-        show-settings => { root.current-route = Route.Settings; }
-    }
-    if current-route == Route.Details : DetailsScreen {
-        back => { root.current-route = Route.Home; }
-    }
-    if current-route == Route.Settings : SettingsScreen {
-        back => { root.current-route = Route.Home; }
+    navigator (current-route) {
+        Route.Home: HomeScreen {
+            show-details => { root.navigate(Route.Details); }
+            show-settings => { root.navigate(Route.Settings); }
+        }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
     }
 }
 ```
 
-## How it reads
+{/* cSpell:ignore Detials */}
+The navigator instantiates only the screen for the current route. The route
+enum is a closed set, so `Route.Detials` (a typo) is a compile error rather than
+a screen that silently never shows.
 
-- The `enum Route` is the set of screens.
-- `current-route` is the active screen, and its initializer is the entry screen.
-- Each `if current-route == Route.X : Screen { ... }` is the route-to-screen mapping.
-- Each `current-route = Route.Y;` assignment is a transition from the enclosing screen to `Route.Y`.
+## Navigating
 
-Keeping a screen in its own component and wiring its callbacks in the root, next to the
-matching conditional child, keeps each transition close to the screen it starts from.
+The navigator adds a small history API to the component that declares it:
 
-## Scope
+- `navigate(route)` switches to `route` and pushes the previous one onto a
+  back-stack.
+- `back()` returns to the previous screen, or does nothing at the root.
+- `can-go-back` is `true` while there is somewhere to go back to.
 
-The convention tracks a single `current-route` only. There is no back-stack: returning
-to a previous screen is just another assignment, as in the `back` callbacks above. A
-history stack is a separate concern and is not part of this convention.
+These members belong to the component that declares the `navigator` (`App`
+below), not to the screens. A screen that needs one, such as a Back button that
+disables at the root, takes it as a property that `App` binds when it maps the
+route:
 
-A runnable version of this example lives in `examples/navigation` in the Slint repository.
+```slint
+component DetailsScreen inherits VerticalBox {
+    in property <bool> can-go-back;
+    callback go-back();
+    Text { text: "Details"; }
+    Button {
+        text: "Back";
+        enabled: can-go-back;
+        clicked => { root.go-back(); }
+    }
+}
+
+// ...in App, binding the navigator members next to the route:
+navigator (current-route) {
+    Route.Home: HomeScreen {
+        show-details => { root.navigate(Route.Details); }
+    }
+    Route.Details: DetailsScreen {
+        can-go-back: root.can-go-back;
+        go-back => { root.back(); }
+    }
+}
+```
+
+Assigning `current-route` directly still switches the screen, but it does not
+touch the history. Use `navigate()` and `back()` when you want a back-stack.
+
+For navigation bars that work by position rather than by route (a tab bar, a
+segmented control), the navigator also exposes an integer view: `current-route-index`
+is the ordinal of the active route, and `navigate-index(i)` navigates to the
+route at position `i`. A presentation widget can bind to these without knowing
+the route enum.
+
+## Why a construct
+
+Because the route table is declared structure and the destinations come from a
+compiler-known enum, the navigation graph is fully derivable from source. The
+visual editor's flow map reads the screens and the transitions between them
+straight from the navigator, references are checked at compile time, and the
+tool never disagrees with the running app.
+
+A runnable version of this example lives in `examples/navigation` in the Slint
+repository.

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -9283,6 +9283,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "navigation-federated"
+version = "1.18.0"
+dependencies = [
+ "slint",
+]
+
+[[package]]
 name = "navigation-std"
 version = "1.18.0"
 dependencies = [

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -9276,6 +9276,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
+name = "navigation"
+version = "1.18.0"
+dependencies = [
+ "slint",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -9283,6 +9283,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "navigation-std"
+version = "1.18.0"
+dependencies = [
+ "slint",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6023,6 +6023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
+name = "generativity"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7155,6 +7161,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "i-slint-backend-qt"
+version = "1.18.0"
+dependencies = [
+ "const-field-offset",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "vtable",
+]
+
+[[package]]
 name = "i-slint-backend-selector"
 version = "1.18.0"
 dependencies = [
@@ -7162,6 +7179,7 @@ dependencies = [
  "cfg_aliases",
  "i-slint-backend-android-activity",
  "i-slint-backend-linuxkms",
+ "i-slint-backend-qt",
  "i-slint-backend-testing",
  "i-slint-backend-winit",
  "i-slint-common",
@@ -9287,6 +9305,8 @@ name = "navigation-federated"
 version = "1.18.0"
 dependencies = [
  "slint",
+ "slint-interpreter",
+ "spin_on",
 ]
 
 [[package]]
@@ -14200,6 +14220,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "slint-interpreter"
+version = "1.18.0"
+dependencies = [
+ "derive_more",
+ "generativity",
+ "i-slint-backend-selector",
+ "i-slint-backend-winit",
+ "i-slint-common",
+ "i-slint-compiler",
+ "i-slint-core",
+ "i-slint-core-macros",
+ "itertools 0.14.0",
+ "lyon_path",
+ "once_cell",
+ "smol_str 0.3.6",
+ "unicode-segmentation",
+ "vtable",
+ "web-sys",
+]
+
+[[package]]
 name = "slint-macros"
 version = "1.18.0"
 dependencies = [
@@ -15011,7 +15052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   'mcu-board-support',
   'memory',
   'navigation',
+  'navigation-federated',
   'navigation-std',
   'native-gestures',
   'opengl_texture',

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   'mcu-board-support',
   'memory',
   'navigation',
+  'navigation-std',
   'native-gestures',
   'opengl_texture',
   'opengl_underlay',

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   'maps',
   'mcu-board-support',
   'memory',
+  'navigation',
   'native-gestures',
   'opengl_texture',
   'opengl_underlay',

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,7 @@ These examples demonstrate specialized features or integrations:
 | Example | Description |
 | --- | --- |
 | [fancy_demo](./fancy_demo/) | Custom widget implementations built from scratch (buttons, sliders, checkboxes, MDI windows) |
+| [navigation](./navigation/) | Multi-screen navigation using the `enum Route` + `current-route` convention |
 | [fancy-switches](./fancy-switches/) | Fancy toggle switch animations |
 | [dial](./dial/) | Rotary dial control |
 | [speedometer](./speedometer/) | Animated speedometer gauge |

--- a/examples/navigation-federated/Cargo.toml
+++ b/examples/navigation-federated/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "navigation-federated"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+publish = false
+license = "MIT"
+rust-version.workspace = true
+
+[[bin]]
+path = "main.rs"
+name = "navigation-federated"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }

--- a/examples/navigation-federated/Cargo.toml
+++ b/examples/navigation-federated/Cargo.toml
@@ -16,3 +16,5 @@ name = "navigation-federated"
 
 [dependencies]
 slint = { path = "../../api/rs/slint" }
+slint-interpreter = { path = "../../internal/interpreter" }
+spin_on = { version = "0.1" }

--- a/examples/navigation-federated/README.md
+++ b/examples/navigation-federated/README.md
@@ -9,14 +9,23 @@ team assembles.
 
 | File | Owner | Role |
 | --- | --- | --- |
-| `ui/contract.slint` | platform team | the `FeatureNav` navigation contract + `HostServices` capabilities |
+| `ui/contract.slint` | platform team | the `FeatureNav` contract (`@version` / `@uri`) + `HostServices` capabilities |
 | `ui/media.slint` | Media team | `MediaFeature implements FeatureNav`, `needs HostServices`, its own navigator |
 | `ui/settings.slint` | Settings team | `SettingsFeature`, same contract |
-| `ui/app.slint` | integration team | mounts both features at shell routes and binds the capabilities |
+| `ui/app.slint` | integration team | mounts each feature at a shell route and binds the capabilities |
+| `main.rs` | integration team | supplies the external plugin as a `ComponentFactory` |
 
-The features conform to a shared contract and declare what they `needs`; the
-shell `mount`s each `via FeatureNav` and binds the host services. No team edits
-another team's file.
+The example shows every federation seam:
+
+- **build-time mount** — `mount MediaFeature via FeatureNav { ... }` instantiates a
+  compile-time feature and binds the capabilities it `needs`.
+- **external mount** — `mount extern via FeatureNav { component-factory: ... }` mounts
+  a plugin delivered at runtime. `main.rs` builds it via `slint_interpreter` and passes
+  it in as a `slint::ComponentFactory`; it could equally be shipped as its own binary.
+- **versioned, deep-linkable contract** — `@version(1)` and `@uri("app://feature")` on
+  the contract's routes.
+
+No team edits another team's file.
 
 ## Experimental features
 

--- a/examples/navigation-federated/README.md
+++ b/examples/navigation-federated/README.md
@@ -1,0 +1,34 @@
+# Navigation (federated, multi-team)
+
+A multi-screen app composed from **independently-authored feature modules** using
+the experimental `navigator` federation seams. It mirrors how separate teams,
+each on their own release cycle, plug features into one app that an integration
+team assembles.
+
+## Who owns what
+
+| File | Owner | Role |
+| --- | --- | --- |
+| `ui/contract.slint` | platform team | the `FeatureNav` navigation contract + `HostServices` capabilities |
+| `ui/media.slint` | Media team | `MediaFeature implements FeatureNav`, `needs HostServices`, its own navigator |
+| `ui/settings.slint` | Settings team | `SettingsFeature`, same contract |
+| `ui/app.slint` | integration team | mounts both features at shell routes and binds the capabilities |
+
+The features conform to a shared contract and declare what they `needs`; the
+shell `mount`s each `via FeatureNav` and binds the host services. No team edits
+another team's file.
+
+## Experimental features
+
+`navigator` and its federation seams are experimental. `build.rs` enables them
+for the `slint!` macro:
+
+```rust
+println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+```
+
+Run it with:
+
+```sh
+cargo run -p navigation-federated
+```

--- a/examples/navigation-federated/build.rs
+++ b/examples/navigation-federated/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+}

--- a/examples/navigation-federated/main.rs
+++ b/examples/navigation-federated/main.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::slint!(export { App } from "ui/app.slint";);
+
+pub fn main() {
+    App::new().unwrap().run().unwrap();
+}

--- a/examples/navigation-federated/main.rs
+++ b/examples/navigation-federated/main.rs
@@ -3,6 +3,39 @@
 
 slint::slint!(export { App } from "ui/app.slint";);
 
+// The external plugin is an independently-delivered part. Here it is loaded from
+// source at runtime via the interpreter, but it could equally be a separately
+// compiled binary. The shell mounts it through `mount extern via FeatureNav`.
+fn plugin_factory() -> slint::ComponentFactory {
+    slint::ComponentFactory::new(|ctx| {
+        let compiler = slint_interpreter::Compiler::new();
+        let def = spin_on::spin_on(
+            compiler.build_from_source(
+                r#"
+export component Plugin inherits Rectangle {
+    background: #2b2b40;
+    VerticalLayout {
+        alignment: center;
+        Text {
+            text: "External plugin\n(loaded via ComponentFactory)";
+            color: white;
+            horizontal-alignment: center;
+        }
+    }
+}
+"#
+                .into(),
+                std::path::PathBuf::from("plugin.slint"),
+            ),
+        )
+        .component("Plugin")
+        .unwrap();
+        def.create_embedded(ctx).ok()
+    })
+}
+
 pub fn main() {
-    App::new().unwrap().run().unwrap();
+    let app = App::new().unwrap();
+    app.set_plugin_factory(plugin_factory());
+    app.run().unwrap();
 }

--- a/examples/navigation-federated/ui/app.slint
+++ b/examples/navigation-federated/ui/app.slint
@@ -10,14 +10,17 @@ enum Shell {
     Home,
     Media,
     Settings,
+    Plugin,
 }
 
 component HomeScreen inherits VerticalBox {
     callback open-media();
     callback open-settings();
+    callback open-plugin();
     Text { text: "Federated App"; font-size: 26px; horizontal-alignment: center; }
     Button { text: "Open Media"; clicked => { root.open-media(); } }
     Button { text: "Open Settings"; clicked => { root.open-settings(); } }
+    Button { text: "Open Plugin (external)"; clicked => { root.open-plugin(); } }
 }
 
 export component App inherits Window {
@@ -25,12 +28,18 @@ export component App inherits Window {
     preferred-height: 480px;
     title: "Slint Federated Navigation";
 
+    // Supplied by the host (main.rs) as a ComponentFactory, so the plugin is
+    // delivered at runtime rather than as a compile-time dependency.
+    in property <component-factory> plugin-factory;
+
     in-out property <Shell> current: Shell.Home;
 
+    // The navigator must be a direct child of the component that declares it.
     navigator (current) {
         Shell.Home: HomeScreen {
             open-media => { root.navigate(Shell.Media); }
             open-settings => { root.navigate(Shell.Settings); }
+            open-plugin => { root.navigate(Shell.Plugin); }
         }
         Shell.Media: mount MediaFeature via FeatureNav {
             log(message) => { debug(message); }
@@ -40,5 +49,18 @@ export component App inherits Window {
             log(message) => { debug(message); }
             go-home => { root.navigate(Shell.Home); }
         }
+        Shell.Plugin: mount extern via FeatureNav {
+            component-factory: root.plugin-factory;
+        }
+    }
+
+    // Persistent home control, so the external plugin (which has no capability
+    // wiring back to the shell) can still be exited.
+    if root.current != Shell.Home: Button {
+        text: "⌂ Home";
+        width: 96px;
+        x: parent.width - self.width - 8px;
+        y: 8px;
+        clicked => { root.navigate(Shell.Home); }
     }
 }

--- a/examples/navigation-federated/ui/app.slint
+++ b/examples/navigation-federated/ui/app.slint
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { FeatureNav, HostServices } from "contract.slint";
+import { MediaFeature } from "media.slint";
+import { SettingsFeature } from "settings.slint";
+import { Button, VerticalBox } from "std-widgets.slint";
+
+enum Shell {
+    Home,
+    Media,
+    Settings,
+}
+
+component HomeScreen inherits VerticalBox {
+    callback open-media();
+    callback open-settings();
+    Text { text: "Federated App"; font-size: 26px; horizontal-alignment: center; }
+    Button { text: "Open Media"; clicked => { root.open-media(); } }
+    Button { text: "Open Settings"; clicked => { root.open-settings(); } }
+}
+
+export component App inherits Window {
+    preferred-width: 360px;
+    preferred-height: 480px;
+    title: "Slint Federated Navigation";
+
+    in-out property <Shell> current: Shell.Home;
+
+    navigator (current) {
+        Shell.Home: HomeScreen {
+            open-media => { root.navigate(Shell.Media); }
+            open-settings => { root.navigate(Shell.Settings); }
+        }
+        Shell.Media: mount MediaFeature via FeatureNav {
+            log(message) => { debug(message); }
+            go-home => { root.navigate(Shell.Home); }
+        }
+        Shell.Settings: mount SettingsFeature via FeatureNav {
+            log(message) => { debug(message); }
+            go-home => { root.navigate(Shell.Home); }
+        }
+    }
+}

--- a/examples/navigation-federated/ui/contract.slint
+++ b/examples/navigation-federated/ui/contract.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+export interface FeatureNav {
+    route Main;
+}
+
+export interface HostServices {
+    callback log(string);
+    callback go-home();
+}

--- a/examples/navigation-federated/ui/contract.slint
+++ b/examples/navigation-federated/ui/contract.slint
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 export interface FeatureNav {
-    route Main;
+    @version(1)
+    @uri("app://feature") route Main;
 }
 
 export interface HostServices {

--- a/examples/navigation-federated/ui/media.slint
+++ b/examples/navigation-federated/ui/media.slint
@@ -1,0 +1,44 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { FeatureNav, HostServices } from "contract.slint";
+import { Button, VerticalBox } from "std-widgets.slint";
+
+enum MediaRoute {
+    Main,
+    Player,
+}
+
+component Library inherits VerticalBox {
+    callback play();
+    callback home();
+    Text { text: "Media"; font-size: 22px; horizontal-alignment: center; }
+    Button { text: "Play"; clicked => { root.play(); } }
+    Button { text: "Back to home"; clicked => { root.home(); } }
+}
+
+component Player inherits VerticalBox {
+    in property <bool> can-go-back;
+    callback go-back();
+    Text { text: "Now Playing"; font-size: 22px; horizontal-alignment: center; }
+    Button { text: "Stop"; enabled: can-go-back; clicked => { root.go-back(); } }
+}
+
+export component MediaFeature implements FeatureNav inherits Rectangle {
+    needs HostServices;
+
+    in-out property <MediaRoute> current-route: MediaRoute.Main;
+
+    init => { root.log("media: mounted"); }
+
+    navigator (current-route) {
+        MediaRoute.Main: Library {
+            play => { root.navigate(MediaRoute.Player); }
+            home => { root.go-home(); }
+        }
+        MediaRoute.Player: Player {
+            can-go-back: root.can-go-back;
+            go-back => { root.back(); }
+        }
+    }
+}

--- a/examples/navigation-federated/ui/settings.slint
+++ b/examples/navigation-federated/ui/settings.slint
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { FeatureNav, HostServices } from "contract.slint";
+import { Button, CheckBox, VerticalBox } from "std-widgets.slint";
+
+enum SettingsRoute {
+    Main,
+}
+
+component SettingsPage inherits VerticalBox {
+    callback home();
+    Text { text: "Settings"; font-size: 22px; horizontal-alignment: center; }
+    CheckBox { text: "Dark mode"; }
+    Button { text: "Back to home"; clicked => { root.home(); } }
+}
+
+export component SettingsFeature implements FeatureNav inherits Rectangle {
+    needs HostServices;
+
+    in-out property <SettingsRoute> current-route: SettingsRoute.Main;
+
+    init => { root.log("settings: mounted"); }
+
+    navigator (current-route) {
+        SettingsRoute.Main: SettingsPage {
+            home => { root.go-home(); }
+        }
+    }
+}

--- a/examples/navigation-std/Cargo.toml
+++ b/examples/navigation-std/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "navigation-std"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+publish = false
+license = "MIT"
+rust-version.workspace = true
+
+[[bin]]
+path = "main.rs"
+name = "navigation-std"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }

--- a/examples/navigation-std/README.md
+++ b/examples/navigation-std/README.md
@@ -1,0 +1,35 @@
+# Navigation (std-widgets)
+
+A multi-screen app whose navigation chrome is built from **std-widgets**, driving
+the experimental `navigator` construct. It pairs with the Material navigation
+example to show one route model behind different widget libraries.
+
+The chrome is a segmented tab bar assembled from a row of std `Button`s (std-widgets
+has no public tab-bar/segmented control). It binds to the navigator's int-index
+adapter:
+
+- the highlighted segment follows `current-route-index`,
+- clicking a segment navigates by ordinal via `navigate-index(index)`.
+
+## Why the wiring lives in `main.rs`
+
+The navigator's int-index adapter (`current-route-index` / `navigate-index`) is
+synthesized *after* expression resolution, so it cannot be referenced from
+`.slint`. The navigator therefore sits on the root `Window`, where its adapter
+members land on the component's public API, and `main.rs` bridges them to the tab
+bar's `current-index` / `selected(int)`.
+
+## Experimental features
+
+`navigator` is experimental. `build.rs` enables it for the `slint!` macro that
+compiles `navigation.slint`:
+
+```rust
+println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+```
+
+Run it with:
+
+```sh
+cargo run -p navigation-std
+```

--- a/examples/navigation-std/build.rs
+++ b/examples/navigation-std/build.rs
@@ -2,7 +2,5 @@
 // SPDX-License-Identifier: MIT
 
 fn main() {
-    // The navigator is experimental; enable it for the `slint!` macro that
-    // compiles navigation.slint at build time.
     println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
 }

--- a/examples/navigation-std/build.rs
+++ b/examples/navigation-std/build.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    // The navigator is experimental; enable it for the `slint!` macro that
+    // compiles navigation.slint at build time.
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+}

--- a/examples/navigation-std/main.rs
+++ b/examples/navigation-std/main.rs
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::slint!(export { App } from "navigation.slint";);
+
+pub fn main() {
+    let app = App::new().unwrap();
+
+    // Bridge the std-widgets tab bar to the navigator's int-index adapter. The
+    // adapter lives on the root's public API (current-route-index /
+    // navigate-index) but is synthesized too late to reference from .slint, so
+    // the wiring happens here instead.
+    let weak = app.as_weak();
+    app.on_nav_select(move |index| {
+        let app = weak.unwrap();
+        // A tab click navigates by ordinal ...
+        app.invoke_navigate_index(index);
+        // ... and the highlight follows the resulting current route.
+        app.set_nav_index(app.get_current_route_index());
+    });
+
+    // Seed the highlight from the initial route.
+    app.set_nav_index(app.get_current_route_index());
+
+    app.run().unwrap();
+}

--- a/examples/navigation-std/main.rs
+++ b/examples/navigation-std/main.rs
@@ -6,20 +6,13 @@ slint::slint!(export { App } from "navigation.slint";);
 pub fn main() {
     let app = App::new().unwrap();
 
-    // Bridge the std-widgets tab bar to the navigator's int-index adapter. The
-    // adapter lives on the root's public API (current-route-index /
-    // navigate-index) but is synthesized too late to reference from .slint, so
-    // the wiring happens here instead.
     let weak = app.as_weak();
     app.on_nav_select(move |index| {
         let app = weak.unwrap();
-        // A tab click navigates by ordinal ...
         app.invoke_navigate_index(index);
-        // ... and the highlight follows the resulting current route.
         app.set_nav_index(app.get_current_route_index());
     });
 
-    // Seed the highlight from the initial route.
     app.set_nav_index(app.get_current_route_index());
 
     app.run().unwrap();

--- a/examples/navigation-std/navigation.slint
+++ b/examples/navigation-std/navigation.slint
@@ -3,17 +3,12 @@
 
 import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
 
-// The navigation convention: one enum value per screen.
 enum Route {
     Home,
     Details,
     Settings,
 }
 
-// A segmented navigation bar built from std-widgets `Button`s. std-widgets has
-// no public tab-bar/segmented control, so this binds a plain Button row to the
-// navigator's int-index adapter: the highlighted segment follows `current-index`
-// and clicking one asks to navigate by ordinal via `selected`.
 component NavBar inherits HorizontalBox {
     in property <[string]> titles;
     in property <int> current-index;
@@ -21,7 +16,6 @@ component NavBar inherits HorizontalBox {
 
     for title[index] in titles: Button {
         text: title;
-        // Highlight the active segment; purely driven by current-index.
         primary: index == root.current-index;
         clicked => { root.selected(index); }
     }
@@ -59,13 +53,8 @@ export component App inherits Window {
     preferred-height: 300px;
     title: "Slint Navigation (std-widgets)";
 
-    // The current screen. Assigning this property navigates.
     in-out property <Route> current-route: Route.Home;
 
-    // The navigator's int-index adapter (current-route-index / navigate-index)
-    // is synthesized after expression resolution, so it cannot be referenced
-    // from .slint. main.rs bridges it to these two members instead: it writes
-    // the highlighted segment here and reacts to a selection by ordinal.
     in property <int> nav-index;
     callback nav-select(index: int);
 
@@ -79,8 +68,6 @@ export component App inherits Window {
         selected(index) => { root.nav-select(index); }
     }
 
-    // The navigator is a direct child of the root Window, so its adapter
-    // members land on the root's public API where main.rs can reach them.
     navigator (current-route) {
         Route.Home: HomeScreen {
             y: 48px;

--- a/examples/navigation-std/navigation.slint
+++ b/examples/navigation-std/navigation.slint
@@ -1,0 +1,101 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+// A segmented navigation bar built from std-widgets `Button`s. std-widgets has
+// no public tab-bar/segmented control, so this binds a plain Button row to the
+// navigator's int-index adapter: the highlighted segment follows `current-index`
+// and clicking one asks to navigate by ordinal via `selected`.
+component NavBar inherits HorizontalBox {
+    in property <[string]> titles;
+    in property <int> current-index;
+    callback selected(index: int);
+
+    for title[index] in titles: Button {
+        text: title;
+        // Highlight the active segment; purely driven by current-index.
+        primary: index == root.current-index;
+        clicked => { root.selected(index); }
+    }
+}
+
+component HomeScreen inherits VerticalBox {
+    Text {
+        text: "Home";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+component DetailsScreen inherits VerticalBox {
+    Text {
+        text: "Details";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+component SettingsScreen inherits VerticalBox {
+    Text {
+        text: "Settings";
+        font-size: 24px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+export component App inherits Window {
+    preferred-width: 400px;
+    preferred-height: 300px;
+    title: "Slint Navigation (std-widgets)";
+
+    // The current screen. Assigning this property navigates.
+    in-out property <Route> current-route: Route.Home;
+
+    // The navigator's int-index adapter (current-route-index / navigate-index)
+    // is synthesized after expression resolution, so it cannot be referenced
+    // from .slint. main.rs bridges it to these two members instead: it writes
+    // the highlighted segment here and reacts to a selection by ordinal.
+    in property <int> nav-index;
+    callback nav-select(index: int);
+
+    NavBar {
+        x: 0;
+        y: 0;
+        width: root.width;
+        height: 48px;
+        titles: ["Home", "Details", "Settings"];
+        current-index: root.nav-index;
+        selected(index) => { root.nav-select(index); }
+    }
+
+    // The navigator is a direct child of the root Window, so its adapter
+    // members land on the root's public API where main.rs can reach them.
+    navigator (current-route) {
+        Route.Home: HomeScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+        Route.Details: DetailsScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+        Route.Settings: SettingsScreen {
+            y: 48px;
+            width: root.width;
+            height: root.height - 48px;
+        }
+    }
+}

--- a/examples/navigation/Cargo.toml
+++ b/examples/navigation/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "navigation"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+publish = false
+license = "MIT"
+rust-version.workspace = true
+
+[[bin]]
+path = "main.rs"
+name = "navigation"
+
+[dependencies]
+slint = { path = "../../api/rs/slint" }

--- a/examples/navigation/README.md
+++ b/examples/navigation/README.md
@@ -1,17 +1,32 @@
 # Navigation
 
-A minimal multi-screen app that demonstrates the Slint navigation convention using
-only stable language features.
+A minimal multi-screen app built with the experimental `navigator` construct.
 
-The convention:
+```slint
+navigator (current-route) {
+    Route.Home: HomeScreen { }
+    Route.Details: DetailsScreen { }
+    Route.Settings: SettingsScreen { }
+}
+```
 
-- A user-declared `enum Route`, one value per screen.
-- A root component with `in-out property <Route> current-route`.
-- One conditional child per route: `if current-route == Route.Home : HomeScreen { ... }`.
-- Navigation by assigning the route property: `current-route = Route.Details;`.
+- The set of screens is a compiler-resolved route table; the active screen is the
+  `current-route` property you drive at runtime.
+- The navigator adds a history API to the declaring component: `navigate(route)`,
+  `back()`, and `can-go-back`. This example uses them for the back buttons.
 
-The visual editor's flow map understands this shape. See the docs page
-"Navigation" under Guide > App Development for the full description.
+For the std-widgets and Material presentations of the same route model, see the
+`navigation-std` example. The full description is on the docs page "Navigation"
+under Guide > App Development.
+
+## Experimental features
+
+`navigator` is experimental. `build.rs` enables it for the `slint!` macro that
+compiles `navigation.slint`:
+
+```rust
+println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+```
 
 Run it with:
 

--- a/examples/navigation/README.md
+++ b/examples/navigation/README.md
@@ -1,0 +1,20 @@
+# Navigation
+
+A minimal multi-screen app that demonstrates the Slint navigation convention using
+only stable language features.
+
+The convention:
+
+- A user-declared `enum Route`, one value per screen.
+- A root component with `in-out property <Route> current-route`.
+- One conditional child per route: `if current-route == Route.Home : HomeScreen { ... }`.
+- Navigation by assigning the route property: `current-route = Route.Details;`.
+
+The visual editor's flow map understands this shape. See the docs page
+"Navigation" under Guide > App Development for the full description.
+
+Run it with:
+
+```sh
+cargo run -p navigation
+```

--- a/examples/navigation/build.rs
+++ b/examples/navigation/build.rs
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    println!("cargo:rustc-env=SLINT_ENABLE_EXPERIMENTAL_FEATURES=1");
+}

--- a/examples/navigation/main.rs
+++ b/examples/navigation/main.rs
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+slint::slint!(export { App } from "navigation.slint";);
+
+pub fn main() {
+    App::new().unwrap().run().unwrap();
+}

--- a/examples/navigation/navigation.slint
+++ b/examples/navigation/navigation.slint
@@ -3,7 +3,6 @@
 
 import { Button, VerticalBox } from "std-widgets.slint";
 
-// The navigation convention: one enum value per screen.
 enum Route {
     Home,
     Details,
@@ -30,7 +29,8 @@ component HomeScreen inherits VerticalBox {
 }
 
 component DetailsScreen inherits VerticalBox {
-    callback back();
+    in property <bool> can-go-back;
+    callback go-back();
 
     Text {
         text: "Details";
@@ -38,13 +38,15 @@ component DetailsScreen inherits VerticalBox {
         horizontal-alignment: center;
     }
     Button {
-        text: "Back to Home";
-        clicked => { root.back(); }
+        text: "Back";
+        enabled: can-go-back;
+        clicked => { root.go-back(); }
     }
 }
 
 component SettingsScreen inherits VerticalBox {
-    callback back();
+    in property <bool> can-go-back;
+    callback go-back();
 
     Text {
         text: "Settings";
@@ -52,8 +54,9 @@ component SettingsScreen inherits VerticalBox {
         horizontal-alignment: center;
     }
     Button {
-        text: "Back to Home";
-        clicked => { root.back(); }
+        text: "Back";
+        enabled: can-go-back;
+        clicked => { root.go-back(); }
     }
 }
 
@@ -62,18 +65,20 @@ export component App inherits Window {
     preferred-height: 240px;
     title: "Slint Navigation";
 
-    // The current screen. Assigning this property navigates.
     in-out property <Route> current-route: Route.Home;
 
-    // One conditional child per route maps a route to its screen.
-    if current-route == Route.Home : HomeScreen {
-        show-details => { root.current-route = Route.Details; }
-        show-settings => { root.current-route = Route.Settings; }
-    }
-    if current-route == Route.Details : DetailsScreen {
-        back => { root.current-route = Route.Home; }
-    }
-    if current-route == Route.Settings : SettingsScreen {
-        back => { root.current-route = Route.Home; }
+    navigator (current-route) {
+        Route.Home: HomeScreen {
+            show-details => { root.navigate(Route.Details); }
+            show-settings => { root.navigate(Route.Settings); }
+        }
+        Route.Details: DetailsScreen {
+            can-go-back: root.can-go-back;
+            go-back => { root.back(); }
+        }
+        Route.Settings: SettingsScreen {
+            can-go-back: root.can-go-back;
+            go-back => { root.back(); }
+        }
     }
 }

--- a/examples/navigation/navigation.slint
+++ b/examples/navigation/navigation.slint
@@ -1,0 +1,79 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Button, VerticalBox } from "std-widgets.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits VerticalBox {
+    callback show-details();
+    callback show-settings();
+
+    Text {
+        text: "Home";
+        font-size: 24px;
+        horizontal-alignment: center;
+    }
+    Button {
+        text: "Go to Details";
+        clicked => { root.show-details(); }
+    }
+    Button {
+        text: "Open Settings";
+        clicked => { root.show-settings(); }
+    }
+}
+
+component DetailsScreen inherits VerticalBox {
+    callback back();
+
+    Text {
+        text: "Details";
+        font-size: 24px;
+        horizontal-alignment: center;
+    }
+    Button {
+        text: "Back to Home";
+        clicked => { root.back(); }
+    }
+}
+
+component SettingsScreen inherits VerticalBox {
+    callback back();
+
+    Text {
+        text: "Settings";
+        font-size: 24px;
+        horizontal-alignment: center;
+    }
+    Button {
+        text: "Back to Home";
+        clicked => { root.back(); }
+    }
+}
+
+export component App inherits Window {
+    preferred-width: 360px;
+    preferred-height: 240px;
+    title: "Slint Navigation";
+
+    // The current screen. Assigning this property navigates.
+    in-out property <Route> current-route: Route.Home;
+
+    // One conditional child per route maps a route to its screen.
+    if current-route == Route.Home : HomeScreen {
+        show-details => { root.current-route = Route.Details; }
+        show-settings => { root.current-route = Route.Settings; }
+    }
+    if current-route == Route.Details : DetailsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+    if current-route == Route.Settings : SettingsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+}

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2328,8 +2328,10 @@ impl Element {
         // navigate(route) is enum-typed; recover the route enum from a route
         // case (`Route.X`), whose first path segment names the enum.
         let route_ty = routes.iter().find_map(|r| {
-            let name =
-                QualifiedTypeName::from_node(r.route.QualifiedName()?).members.into_iter().next()?;
+            let name = QualifiedTypeName::from_node(r.route.QualifiedName()?)
+                .members
+                .into_iter()
+                .next()?;
             let ty = tr.lookup(&name);
             matches!(ty, Type::Enumeration(_)).then_some(ty)
         });

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1150,6 +1150,16 @@ pub struct NavigatorRoute {
     pub component: ElementRc,
 }
 
+impl Element {
+    /// Read-only view of the resolved `navigator` route table declared on this
+    /// element, in declaration order (empty when there is no `navigator`).
+    /// Provided as an accessor so tooling reads the authoritative table without
+    /// touching the lowering in `from_navigator_node`.
+    pub fn navigator_routes(&self) -> &[NavigatorRoute] {
+        &self.navigator_routes
+    }
+}
+
 pub type ElementRc = Rc<RefCell<Element>>;
 pub type ElementWeak = Weak<RefCell<Element>>;
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -877,11 +877,7 @@ pub struct Element {
 
     /// This element is part of a `for <xxx> in <model>`:
     pub repeated: Option<RepeatedElementInfo>,
-    /// The resolved `navigator` route table declared on this element, in
-    /// declaration order. Each route's destination is also present among
-    /// `children` as a conditional element. Kept here so later passes and the
-    /// LSP can recover the route -> component graph. Empty for elements without
-    /// a `navigator`.
+    /// The resolved `navigator` route table, in declaration order (empty if none).
     pub navigator_routes: Vec<NavigatorRoute>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
@@ -1138,23 +1134,15 @@ pub struct RepeatedElementInfo {
 
 #[derive(Debug, Clone)]
 /// One entry of a `navigator` route table: a route enum value mapped to its
-/// resolved destination. Populated by `from_navigator_node` in declaration
-/// order and kept on the enclosing element for later tooling (LSP graph).
+/// resolved destination component.
 pub struct NavigatorRoute {
-    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled so
-    /// tooling can recover its name and source location.
+    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled.
     pub route: syntax_nodes::Expression,
-    /// The resolved destination element. Its `base_type` is the resolved
-    /// component (guaranteed to be an `ElementType::Component`, else a
-    /// diagnostic was reported and this is `ElementType::Error`).
+    /// The resolved destination component (`ElementType::Error` on failure).
     pub component: ElementRc,
 }
 
 impl Element {
-    /// Read-only view of the resolved `navigator` route table declared on this
-    /// element, in declaration order (empty when there is no `navigator`).
-    /// Provided as an accessor so tooling reads the authoritative table without
-    /// touching the lowering in `from_navigator_node`.
     pub fn navigator_routes(&self) -> &[NavigatorRoute] {
         &self.navigator_routes
     }
@@ -2238,14 +2226,9 @@ impl Element {
         cases
     }
 
-    /// Build the object tree for a `navigator` route table. Mirrors
-    /// `from_match_node`: each `Route.X: XScreen { }` becomes a conditional
-    /// child whose model is `<navigator-expr> == <Route.X>`, so `XScreen` is
-    /// instantiated only when the current route equals `Route.X`.
-    ///
-    /// It also resolves each destination to a component (the closed-set check)
-    /// and records the resolved route -> component mapping on `parent` for
-    /// later tooling (see `Element::navigator_routes`).
+    /// Lower a `navigator`: each `Route.X: XScreen {}` becomes a conditional child
+    /// (`<navigator-expr> == Route.X`), resolved to a component and recorded on
+    /// `parent` as `navigator_routes`.
     fn from_navigator_node(
         node: syntax_nodes::Navigator,
         parent: &ElementRc,
@@ -2254,9 +2237,6 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> Vec<ElementRc> {
-        // Experimental gate first, like `from_match_node`. Without it a
-        // non-experimental compile rejects `navigator` and builds nothing, so
-        // the construct stays invisible to non-experimental compiles.
         if !diag.enable_experimental {
             diag.push_error("navigator is an experimental feature".into(), &node);
             return Vec::new();
@@ -2269,8 +2249,6 @@ impl Element {
             let Some(sub_element) = route.SubElement() else {
                 continue;
             };
-            // Conditional child: shown only when the route matches, exactly as
-            // `from_match_node` builds its cases.
             let rei = RepeatedElementInfo {
                 model: Expression::BinaryExpression {
                     lhs: Box::new(Expression::Uncompiled(expr.clone().into())),
@@ -2290,10 +2268,8 @@ impl Element {
                 diag,
                 tr,
             );
-            // Closed-set check: a destination must resolve to a component.
-            // `ElementType::Error` means `from_sub_element_node` already
-            // reported an unknown name, so we don't double-report.
             match &e.borrow().base_type {
+                // Error: already diagnosed by from_sub_element_node.
                 ElementType::Component(_) | ElementType::Error => {}
                 other => {
                     diag.push_error(
@@ -2308,12 +2284,8 @@ impl Element {
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
             cases.push(e);
         }
-        // Declare the navigator's public members now, before expression
-        // resolution, so widget chrome can bind to them from .slint (e.g.
-        // `current-index <- nav.current-route-index`). The lower_navigator pass
-        // fills in their bodies later, once the route table is resolved. Same
-        // shape as an interface function: the declaration is in scope now, the
-        // implementation comes later.
+        // Declare the public members before expression resolution so .slint chrome
+        // can bind them; lower_navigator fills in their bodies later.
         if !routes.is_empty() {
             Self::declare_navigator_members(parent, &routes, tr);
         }
@@ -2321,12 +2293,10 @@ impl Element {
         cases
     }
 
-    /// Declare the navigator's public members (the surface widget chrome binds
-    /// to) up front. Only the signatures are known here; `lower_navigator`
-    /// supplies the bindings/bodies after the route table is resolved.
+    /// Declare the navigator's public members (signatures only; `lower_navigator`
+    /// fills the bodies once the route table is resolved).
     fn declare_navigator_members(elem: &ElementRc, routes: &[NavigatorRoute], tr: &TypeRegister) {
-        // navigate(route) is enum-typed; recover the route enum from a route
-        // case (`Route.X`), whose first path segment names the enum.
+        // Recover the route enum from a route case (`Route.X`) for navigate(route).
         let route_ty = routes.iter().find_map(|r| {
             let name = QualifiedTypeName::from_node(r.route.QualifiedName()?)
                 .members
@@ -2346,12 +2316,8 @@ impl Element {
                 PropertyDeclaration { property_type, visibility, pure, ..Default::default() },
             );
         };
-        // Read surface for chrome: ordinal of the current route and whether the
-        // back-stack has anything to pop.
         declare("current-route-index", Type::Int32, PropertyVisibility::Output, None);
         declare("can-go-back", Type::Bool, PropertyVisibility::Output, None);
-        // Navigation entry points. navigate-index(int) is the index-based surface
-        // chrome (Material's NavigationBar, a std nav bar) drives.
         declare("back", func(vec![], vec![]), PropertyVisibility::Public, Some(false));
         declare(
             "navigate-index",

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2308,8 +2308,63 @@ impl Element {
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
             cases.push(e);
         }
+        // Declare the navigator's public members now, before expression
+        // resolution, so widget chrome can bind to them from .slint (e.g.
+        // `current-index <- nav.current-route-index`). The lower_navigator pass
+        // fills in their bodies later, once the route table is resolved. Same
+        // shape as an interface function: the declaration is in scope now, the
+        // implementation comes later.
+        if !routes.is_empty() {
+            Self::declare_navigator_members(parent, &routes, tr);
+        }
         parent.borrow_mut().navigator_routes = routes;
         cases
+    }
+
+    /// Declare the navigator's public members (the surface widget chrome binds
+    /// to) up front. Only the signatures are known here; `lower_navigator`
+    /// supplies the bindings/bodies after the route table is resolved.
+    fn declare_navigator_members(elem: &ElementRc, routes: &[NavigatorRoute], tr: &TypeRegister) {
+        // navigate(route) is enum-typed; recover the route enum from a route
+        // case (`Route.X`), whose first path segment names the enum.
+        let route_ty = routes.iter().find_map(|r| {
+            let name =
+                QualifiedTypeName::from_node(r.route.QualifiedName()?).members.into_iter().next()?;
+            let ty = tr.lookup(&name);
+            matches!(ty, Type::Enumeration(_)).then_some(ty)
+        });
+        let func = |args: Vec<Type>, arg_names: Vec<SmolStr>| {
+            Type::Function(Rc::new(Function { return_type: Type::Void, args, arg_names }))
+        };
+
+        let mut e = elem.borrow_mut();
+        let mut declare = |name, property_type, visibility, pure| {
+            e.property_declarations.insert(
+                SmolStr::new_static(name),
+                PropertyDeclaration { property_type, visibility, pure, ..Default::default() },
+            );
+        };
+        // Read surface for chrome: ordinal of the current route and whether the
+        // back-stack has anything to pop.
+        declare("current-route-index", Type::Int32, PropertyVisibility::Output, None);
+        declare("can-go-back", Type::Bool, PropertyVisibility::Output, None);
+        // Navigation entry points. navigate-index(int) is the index-based surface
+        // chrome (Material's NavigationBar, a std nav bar) drives.
+        declare("back", func(vec![], vec![]), PropertyVisibility::Public, Some(false));
+        declare(
+            "navigate-index",
+            func(vec![Type::Int32], vec![SmolStr::new_static("index")]),
+            PropertyVisibility::Public,
+            Some(false),
+        );
+        if let Some(route_ty) = route_ty {
+            declare(
+                "navigate",
+                func(vec![route_ty], vec![SmolStr::new_static("route")]),
+                PropertyVisibility::Public,
+                Some(false),
+            );
+        }
     }
 
     /// Return the type of a property in this element or its base, along with the final name, in case

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -451,6 +451,46 @@ impl InitCode {
     }
 }
 
+/// One `route` member of a navigation contract (an `interface`'s `route`
+/// declarations). Collected in declaration order by `Component::from_node`.
+#[derive(Debug, Clone)]
+pub struct ContractRoute {
+    /// The route name (the `DeclaredIdentifier`, e.g. `Home`).
+    pub name: SmolStr,
+    /// Typed parameters declared with the route (e.g. `id: int`). Parsed and
+    /// typed here; not yet consumed by this slice.
+    pub params: Vec<(SmolStr, Type)>,
+    /// The deep-link URI declared with `@uri("...")`, if any. Metadata only; the
+    /// runtime navigate-payload plumbing is a later slice.
+    pub uri: Option<SmolStr>,
+}
+
+/// A versionable navigation boundary declared as the `route` members of an
+/// `interface`. Reuses the existing `interface`/export machinery so the contract
+/// exports and imports across files like any other interface type. Later slices
+/// (mount / capability) consume this table.
+#[derive(Debug, Clone, Default)]
+pub struct NavigationContract {
+    /// The declared routes, in source order.
+    pub routes: Vec<ContractRoute>,
+    /// The compile-time contract version from `@version(n)`. Absent means the
+    /// default version 1. Metadata only; no conformance checking in this slice.
+    pub version: Option<u32>,
+}
+
+/// A capability a component declares it requires from its host via `needs
+/// <Interface>`: the interface named and the member names (callbacks/
+/// functions) pulled onto the component as unbound members. The federated-mount
+/// verifier requires each member be bound at the integration site.
+#[derive(Debug, Clone)]
+pub struct NeededCapability {
+    /// The capability interface named by the `needs` specifier.
+    pub interface_name: SmolStr,
+    /// The interface members declared unbound on the component, to be bound by
+    /// the host. In interface declaration order.
+    pub members: Vec<SmolStr>,
+}
+
 /// A component is a type in the language which can be instantiated,
 /// Or is materialized for repeated expression.
 #[derive(Default, Debug)]
@@ -495,6 +535,12 @@ pub struct Component {
 
     /// True if this component is imported from an external library.
     pub from_library: Cell<bool>,
+
+    /// The navigation contract declared by an `interface`'s `route` members, if
+    /// any. Kept apart from the interface's property/callback/function members so
+    /// `implements` iteration never sees routes (see object_tree/interfaces.rs).
+    /// Populated in `Component::from_node`; consumed by later navigation slices.
+    pub navigation_contract: RefCell<Option<NavigationContract>>,
 }
 
 impl Component {
@@ -546,7 +592,79 @@ impl Component {
             }
         });
         interfaces::apply_uses_statement(&c.root_element, node.UsesSpecifier(), tr, diag);
+        // An `interface`'s `route` members form a navigation contract. Collected
+        // here, on the Component, rather than into the interface's normal member
+        // lists so `implements` iteration is unaffected. Only reached under the
+        // experimental flag, since `is_interface()` requires the (experimental)
+        // `interface` keyword; misplaced/ungated `route` members are diagnosed in
+        // `Element::from_node`.
+        if c.is_interface() {
+            let routes = node
+                .Element()
+                .RouteDeclaration()
+                .filter_map(|route| {
+                    let name = parser::identifier_text(&route.DeclaredIdentifier())?;
+                    let params = route
+                        .ArgumentDeclaration()
+                        .filter_map(|a| {
+                            Some((
+                                parser::identifier_text(&a.DeclaredIdentifier())?,
+                                type_from_node(a.Type(), diag, tr),
+                            ))
+                        })
+                        .collect();
+                    // `@uri("...")`: unescape the string literal argument. Last
+                    // one wins if repeated. Metadata only in this slice.
+                    let uri = route.AtUri().last().and_then(|attr| {
+                        let raw = attr.text().to_string();
+                        match crate::literals::unescape_string(raw.trim()) {
+                            Some(s) => Some(s),
+                            None => {
+                                diag.push_error(
+                                    "@uri expects a string literal argument".into(),
+                                    &attr,
+                                );
+                                None
+                            }
+                        }
+                    });
+                    Some(ContractRoute { name, params, uri })
+                })
+                .collect::<Vec<_>>();
+            // `@version(n)`: an interface-level integer literal. Last one wins.
+            let version = node.Element().AtVersion().last().and_then(|attr| {
+                let raw = attr.text().to_string();
+                match raw.trim().parse::<u32>() {
+                    Ok(v) => Some(v),
+                    Err(_) => {
+                        diag.push_error(
+                            "@version expects an integer literal argument".into(),
+                            &attr,
+                        );
+                        None
+                    }
+                }
+            });
+            if !routes.is_empty() || version.is_some() {
+                *c.navigation_contract.borrow_mut() = Some(NavigationContract { routes, version });
+            }
+        }
         c
+    }
+
+    /// Read-only view of the navigation contract declared by this component's
+    /// `route` members, if it is an `interface` declaring any. Mirrors
+    /// `Element::navigator_routes` as the authoritative accessor for tooling and
+    /// later navigation slices, kept separate from the interface's members.
+    pub fn navigation_contract(&self) -> Option<NavigationContract> {
+        self.navigation_contract.borrow().clone()
+    }
+
+    /// The capabilities this component declares via `needs` on its root, if any.
+    /// Read by the federated-mount verifier to require each be bound at the mount
+    /// site. Empty when the component needs nothing from its host.
+    pub fn needed_capabilities(&self) -> Vec<NeededCapability> {
+        self.root_element.borrow().needed_capabilities.clone()
     }
 
     /// This component is a global component introduced with the "global" keyword
@@ -879,6 +997,10 @@ pub struct Element {
     pub repeated: Option<RepeatedElementInfo>,
     /// The resolved `navigator` route table, in declaration order.
     pub navigator_routes: Vec<NavigatorRoute>,
+    /// Capabilities this element declares via `needs <Interface>`. Populated
+    /// when the element is a component root; read by the federated-mount verifier
+    /// off the mounted component's root. Empty for elements with no `needs`.
+    pub needed_capabilities: Vec<NeededCapability>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
 
@@ -1137,6 +1259,28 @@ pub struct RepeatedElementInfo {
 pub struct NavigatorRoute {
     pub route: syntax_nodes::Expression,
     pub component: ElementRc,
+    /// Set when this route is a build-time federated mount
+    /// (`mount Impl via Contract`); distinguishes a mounted sub-graph from a
+    /// plain screen for tooling. `None` for a plain route destination.
+    pub mount: Option<FederatedMount>,
+}
+
+/// A route destination that is a federated mount against a named navigation
+/// contract. Metadata only. `impl_name = None` marks an external mount whose
+/// implementation is host-supplied at runtime rather than in this build.
+#[derive(Debug, Clone)]
+pub struct FederatedMount {
+    /// The mounted component's name, or `None` for an external mount.
+    pub impl_name: Option<SmolStr>,
+    pub contract_name: SmolStr,
+    /// The contract's `@version`, if declared. Metadata, not a compat check.
+    pub contract_version: Option<u32>,
+}
+
+impl FederatedMount {
+    pub fn is_external(&self) -> bool {
+        self.impl_name.is_none()
+    }
 }
 
 impl Element {
@@ -1244,6 +1388,22 @@ impl Element {
             tr.empty_type()
         };
         let is_interface = base_type == ElementType::Interface;
+        // `route` members declare a navigation contract; they are experimental
+        // and valid only in an `interface` body. Valid routes are collected onto
+        // the Component in `Component::from_node`; here we only reject misuse.
+        for route in node.RouteDeclaration() {
+            if !diag.enable_experimental && !tr.expose_internal_types {
+                diag.push_error(
+                    "navigation 'route' members are an experimental feature".into(),
+                    &route,
+                );
+            } else if !is_interface {
+                diag.push_error(
+                    "'route' members are only allowed inside an 'interface'".into(),
+                    &route,
+                );
+            }
+        }
         // This isn't truly qualified yet, the enclosing component is added at the end of Component::from_node
         let qualified_id = (!id.is_empty()).then(|| id.clone());
         if let ElementType::Component(c) = &base_type {
@@ -1542,6 +1702,13 @@ impl Element {
         }
 
         interfaces::apply_callbacks(&mut r, &implemented_interface, diag);
+
+        // `needs <Interface>` declares the interface's callbacks/functions as
+        // unbound members on this element, to be bound by the host at the mount
+        // site. Same "declare on the component, bind at instantiation" mechanism
+        // as an interface callback, minus a local body.
+        let needed_interfaces = interfaces::get_needed_interfaces(&r, &node, tr, diag);
+        r.needed_capabilities = interfaces::apply_needs(&mut r, &needed_interfaces, diag);
 
         for func in node.Function() {
             #[cfg(feature = "slint-sc")]
@@ -2013,6 +2180,10 @@ impl Element {
 
         interfaces::apply_default_property_values(&r, &implemented_interface);
         interfaces::validate_function_implementations(&r.borrow(), &implemented_interface, diag);
+        // Checked here, not right after `implements` is resolved above: a
+        // navigator fills its route table while the host element's children are
+        // built (the loop above), so the table is only populated at this point.
+        interfaces::validate_navigation_contract_conformance(&r, &implemented_interface, diag);
 
         r
     }
@@ -2241,9 +2412,18 @@ impl Element {
         let mut cases: Vec<ElementRc> = Vec::new();
         let mut routes: Vec<NavigatorRoute> = Vec::new();
         for route in node.Route() {
-            let Some(sub_element) = route.SubElement() else {
-                continue;
-            };
+            // A destination is a plain sub-element, a local mount, or an external
+            // (cross-process) mount; each desugars to a conditional child.
+            let mount_node = route.MountDestination();
+            let external = mount_node.as_ref().is_some_and(Self::mount_is_external);
+            let (site, sub_element): (SyntaxNode, syntax_nodes::SubElement) =
+                if let Some(mount_node) = &mount_node {
+                    (mount_node.clone().into(), mount_node.SubElement())
+                } else if let Some(sub_element) = route.SubElement() {
+                    (sub_element.clone().into(), sub_element)
+                } else {
+                    continue;
+                };
             let rei = RepeatedElementInfo {
                 model: Expression::BinaryExpression {
                     lhs: Box::new(Expression::Uncompiled(expr.clone().into())),
@@ -2255,27 +2435,46 @@ impl Element {
                 is_conditional_element: true,
                 is_listview: None,
             };
-            let e = Element::from_sub_element_node(
-                sub_element.clone(),
-                parent_type.clone(),
-                component_child_insertion_point,
-                is_in_legacy_component,
-                diag,
-                tr,
-            );
+            // External mounts build a ComponentContainer directly; others resolve
+            // their base name.
+            let e = if external {
+                Self::from_external_mount_node(&sub_element.Element(), tr, diag)
+            } else {
+                Element::from_sub_element_node(
+                    sub_element,
+                    parent_type.clone(),
+                    component_child_insertion_point,
+                    is_in_legacy_component,
+                    diag,
+                    tr,
+                )
+            };
             match &e.borrow().base_type {
                 ElementType::Component(_) | ElementType::Error => {}
+                ElementType::Builtin(b) if external && b.name == "ComponentContainer" => {}
                 other => {
                     diag.push_error(
                         format!(
                             "navigator route destination must be a component, but '{other}' is not"
                         ),
-                        &sub_element,
+                        &site,
                     );
                 }
             }
+            // Integration-site verification. A local mount verifies the mounted
+            // component against the contract and records the edge. An external
+            // mount only records the declared contract edge and checks that a
+            // `component-factory` is supplied; the absent impl is not conformance
+            // checked here. `None` for a plain screen or on failure.
+            let mount = mount_node.and_then(|mount_node| {
+                if external {
+                    Self::verify_external_mount(&mount_node, &e, &parent_type, tr, diag)
+                } else {
+                    Self::verify_federated_mount(&mount_node, &e, &parent_type, tr, diag)
+                }
+            });
             e.borrow_mut().repeated = Some(rei);
-            routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
+            routes.push(NavigatorRoute { route: route.Expression(), component: e.clone(), mount });
             cases.push(e);
         }
         // Members must be declared before expression resolution so chrome can bind them.
@@ -2284,6 +2483,190 @@ impl Element {
         }
         parent.borrow_mut().navigator_routes = routes;
         cases
+    }
+
+    /// Verify a federated mount: the mounted component must satisfy the contract
+    /// named after `via`. Returns the mount edge, or `None` after a diagnostic.
+    fn verify_federated_mount(
+        mount_node: &syntax_nodes::MountDestination,
+        dest: &ElementRc,
+        parent_type: &ElementType,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> Option<FederatedMount> {
+        // `Error` means the name failed to resolve, already reported upstream.
+        let impl_comp = match &dest.borrow().base_type {
+            ElementType::Component(c) => c.clone(),
+            _ => return None,
+        };
+        let (contract_name, contract) =
+            Self::resolve_mount_contract(mount_node, parent_type, tr, diag)?;
+        let impl_name = impl_comp.id.clone();
+        let conforms = interfaces::validate_mount_conformance(
+            &impl_name,
+            &impl_comp.root_element,
+            &contract_name,
+            &contract,
+            mount_node,
+            diag,
+        );
+        let all_bound =
+            Self::verify_mount_capabilities(&impl_name, &impl_comp, dest, mount_node, diag);
+        (conforms && all_bound).then(|| FederatedMount {
+            impl_name: Some(impl_name),
+            contract_name,
+            contract_version: contract.version,
+        })
+    }
+
+    /// True for `mount extern via C { ... }`: the `extern` soft keyword sits as a
+    /// direct token of the MountDestination (a local mount has none).
+    fn mount_is_external(mount_node: &syntax_nodes::MountDestination) -> bool {
+        mount_node.children_with_tokens().any(|n| {
+            n.as_token().is_some_and(|t| t.kind() == SyntaxKind::Identifier && t.text() == "extern")
+        })
+    }
+
+    /// Resolve the contract named after `via` to a navigation-contract interface.
+    /// Shared by local and external mounts.
+    fn resolve_mount_contract(
+        mount_node: &syntax_nodes::MountDestination,
+        parent_type: &ElementType,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> Option<(SmolStr, NavigationContract)> {
+        let Some(contract_node) =
+            mount_node.SubElement().Element().MountVia().map(|via| via.QualifiedName())
+        else {
+            // Missing MountVia means a malformed mount, already diagnosed.
+            return None;
+        };
+        let contract_name = QualifiedTypeName::from_node(contract_node.clone()).to_smolstr();
+        let contract_comp = match parent_type.lookup_type_for_child_element(&contract_name, tr) {
+            Ok(ElementType::Component(c)) if c.is_interface() => c,
+            Ok(_) => {
+                diag.push_error(
+                    format!("mount contract '{contract_name}' is not an interface"),
+                    &contract_node,
+                );
+                return None;
+            }
+            Err(err) => {
+                diag.push_error(err, &contract_node);
+                return None;
+            }
+        };
+        let Some(contract) = contract_comp.navigation_contract().filter(|c| !c.routes.is_empty())
+        else {
+            diag.push_error(
+                format!("'{contract_name}' is not a navigation contract: it declares no routes"),
+                &contract_node,
+            );
+            return None;
+        };
+        Some((contract_name, contract))
+    }
+
+    /// Verify an external cross-process mount at its integration site. Unlike a
+    /// local mount there is no compile-time impl to conformance-check: the contract
+    /// is the declared expectation the host's runtime component must honor. We
+    /// verify only that (1) the boundary contract resolves and (2) a
+    /// `component-factory` is supplied (the runtime transport). Records an external
+    /// edge (`impl_name = None`) so tooling sees the declared boundary.
+    fn verify_external_mount(
+        mount_node: &syntax_nodes::MountDestination,
+        dest: &ElementRc,
+        parent_type: &ElementType,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> Option<FederatedMount> {
+        let (contract_name, contract) =
+            Self::resolve_mount_contract(mount_node, parent_type, tr, diag)?;
+        // The runtime transport: the host sets this ComponentFactory-typed property
+        // at runtime, and the container renders whatever component it produces.
+        // Without it the external seam has nothing to fill the route slot.
+        if !dest.borrow().bindings.contains_key("component-factory") {
+            diag.push_error(
+                format!("external mount via '{contract_name}' requires a 'component-factory'"),
+                mount_node,
+            );
+            return None;
+        }
+        Some(FederatedMount { impl_name: None, contract_name, contract_version: contract.version })
+    }
+
+    /// Build an external mount's destination: a `ComponentContainer` the host fills
+    /// at runtime. No compile-time impl and no base name, so the container is looked
+    /// up directly and the mount block's bindings attached through the normal path.
+    fn from_external_mount_node(
+        element_node: &syntax_nodes::Element,
+        tr: &TypeRegister,
+        diag: &mut BuildDiagnostics,
+    ) -> ElementRc {
+        let base_type = tr.lookup_builtin_element("ComponentContainer").unwrap_or_else(|| {
+            debug_assert!(false, "ComponentContainer builtin missing");
+            ElementType::Error
+        });
+        let r = Element {
+            id: SmolStr::default(),
+            base_type: base_type.clone(),
+            debug: vec![ElementDebugInfo {
+                qualified_id: None,
+                element_hash: 0,
+                type_name: base_type.type_name().unwrap_or_default().to_string(),
+                node: element_node.clone(),
+                layout: None,
+                element_boundary: false,
+            }],
+            ..Default::default()
+        }
+        .make_rc();
+        apply_default_type_properties(&mut r.borrow_mut());
+        // Attach the block's `component-factory` binding through the shared path so
+        // unknown-property and type checks run as they would for a normal body.
+        r.borrow_mut().parse_bindings(
+            element_node.Binding().filter_map(|b| {
+                Some((b.child_token(SyntaxKind::Identifier)?, b.BindingExpression().into()))
+            }),
+            false,
+            diag,
+        );
+        r
+    }
+
+    /// Verify that the mount block binds every capability the mounted module
+    /// declares via `needs`. Each need is a callback/function declared unbound on
+    /// the module's root; the mount block binds it as a handler, which lands as a
+    /// binding on the instantiation `dest`. A need with no binding is a compile
+    /// error at the mount site. Returns true when all needs are bound.
+    fn verify_mount_capabilities(
+        impl_name: &SmolStr,
+        impl_comp: &Rc<Component>,
+        dest: &ElementRc,
+        mount_node: &syntax_nodes::MountDestination,
+        diag: &mut BuildDiagnostics,
+    ) -> bool {
+        let needs = impl_comp.needed_capabilities();
+        if needs.is_empty() {
+            return true;
+        }
+        let dest = dest.borrow();
+        let mut all_bound = true;
+        for cap in &needs {
+            for member in &cap.members {
+                if !dest.bindings.contains_key(member) {
+                    diag.push_error(
+                        format!(
+                            "mount of '{impl_name}' does not bind required capability '{member}' (from '{}')",
+                            cap.interface_name
+                        ),
+                        mount_node,
+                    );
+                    all_bound = false;
+                }
+            }
+        }
+        all_bound
     }
 
     /// Declare the navigator's public members; `lower_navigator` fills the bodies later.

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -877,6 +877,12 @@ pub struct Element {
 
     /// This element is part of a `for <xxx> in <model>`:
     pub repeated: Option<RepeatedElementInfo>,
+    /// The resolved `navigator` route table declared on this element, in
+    /// declaration order. Each route's destination is also present among
+    /// `children` as a conditional element. Kept here so later passes and the
+    /// LSP can recover the route -> component graph. Empty for elements without
+    /// a `navigator`.
+    pub navigator_routes: Vec<NavigatorRoute>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
 
@@ -1128,6 +1134,20 @@ pub struct RepeatedElementInfo {
     pub is_conditional_element: bool,
     /// When the for is the delegate of a ListView
     pub is_listview: Option<ListViewInfo>,
+}
+
+#[derive(Debug, Clone)]
+/// One entry of a `navigator` route table: a route enum value mapped to its
+/// resolved destination. Populated by `from_navigator_node` in declaration
+/// order and kept on the enclosing element for later tooling (LSP graph).
+pub struct NavigatorRoute {
+    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled so
+    /// tooling can recover its name and source location.
+    pub route: syntax_nodes::Expression,
+    /// The resolved destination element. Its `base_type` is the resolved
+    /// component (guaranteed to be an `ElementType::Component`, else a
+    /// diagnostic was reported and this is `ElementType::Error`).
+    pub component: ElementRc,
 }
 
 pub type ElementRc = Rc<RefCell<Element>>;
@@ -1889,6 +1909,23 @@ impl Element {
                     )
                 }
                 r.borrow_mut().children.extend(rep);
+            } else if se.kind() == SyntaxKind::Navigator {
+                let mut sub_child_insertion_point = None;
+                let rep = Element::from_navigator_node(
+                    se.into(),
+                    &r,
+                    &mut sub_child_insertion_point,
+                    is_legacy_syntax,
+                    diag,
+                    tr,
+                );
+                if let Some(ChildrenInsertionPoint { node: se, .. }) = sub_child_insertion_point {
+                    diag.push_error(
+                        "The @children placeholder cannot appear in a navigator".into(),
+                        &se,
+                    )
+                }
+                r.borrow_mut().children.extend(rep);
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
                 #[cfg(feature = "slint-sc")]
                 diag.slint_sc_error("The @children placeholder is", &se);
@@ -2188,6 +2225,80 @@ impl Element {
             e.borrow_mut().repeated = Some(rei);
             cases.push(e);
         }
+        cases
+    }
+
+    /// Build the object tree for a `navigator` route table. Mirrors
+    /// `from_match_node`: each `Route.X: XScreen { }` becomes a conditional
+    /// child whose model is `<navigator-expr> == <Route.X>`, so `XScreen` is
+    /// instantiated only when the current route equals `Route.X`.
+    ///
+    /// It also resolves each destination to a component (the closed-set check)
+    /// and records the resolved route -> component mapping on `parent` for
+    /// later tooling (see `Element::navigator_routes`).
+    fn from_navigator_node(
+        node: syntax_nodes::Navigator,
+        parent: &ElementRc,
+        component_child_insertion_point: &mut Option<ChildrenInsertionPoint>,
+        is_in_legacy_component: bool,
+        diag: &mut BuildDiagnostics,
+        tr: &TypeRegister,
+    ) -> Vec<ElementRc> {
+        // Experimental gate first, like `from_match_node`. Without it a
+        // non-experimental compile rejects `navigator` and builds nothing, so
+        // the construct stays invisible to non-experimental compiles.
+        if !diag.enable_experimental {
+            diag.push_error("navigator is an experimental feature".into(), &node);
+            return Vec::new();
+        }
+        let parent_type = parent.borrow().base_type.clone();
+        let expr = node.Expression();
+        let mut cases: Vec<ElementRc> = Vec::new();
+        let mut routes: Vec<NavigatorRoute> = Vec::new();
+        for route in node.Route() {
+            let Some(sub_element) = route.SubElement() else {
+                continue;
+            };
+            // Conditional child: shown only when the route matches, exactly as
+            // `from_match_node` builds its cases.
+            let rei = RepeatedElementInfo {
+                model: Expression::BinaryExpression {
+                    lhs: Box::new(Expression::Uncompiled(expr.clone().into())),
+                    rhs: Box::new(Expression::Uncompiled(route.Expression().into())),
+                    op: '=',
+                },
+                model_data_id: SmolStr::default(),
+                index_id: SmolStr::default(),
+                is_conditional_element: true,
+                is_listview: None,
+            };
+            let e = Element::from_sub_element_node(
+                sub_element.clone(),
+                parent_type.clone(),
+                component_child_insertion_point,
+                is_in_legacy_component,
+                diag,
+                tr,
+            );
+            // Closed-set check: a destination must resolve to a component.
+            // `ElementType::Error` means `from_sub_element_node` already
+            // reported an unknown name, so we don't double-report.
+            match &e.borrow().base_type {
+                ElementType::Component(_) | ElementType::Error => {}
+                other => {
+                    diag.push_error(
+                        format!(
+                            "navigator route destination must be a component, but '{other}' is not"
+                        ),
+                        &sub_element,
+                    );
+                }
+            }
+            e.borrow_mut().repeated = Some(rei);
+            routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
+            cases.push(e);
+        }
+        parent.borrow_mut().navigator_routes = routes;
         cases
     }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -877,7 +877,7 @@ pub struct Element {
 
     /// This element is part of a `for <xxx> in <model>`:
     pub repeated: Option<RepeatedElementInfo>,
-    /// The resolved `navigator` route table, in declaration order (empty if none).
+    /// The resolved `navigator` route table, in declaration order.
     pub navigator_routes: Vec<NavigatorRoute>,
     /// This element is a placeholder to embed an Component at
     pub is_component_placeholder: bool,
@@ -1133,12 +1133,9 @@ pub struct RepeatedElementInfo {
 }
 
 #[derive(Debug, Clone)]
-/// One entry of a `navigator` route table: a route enum value mapped to its
-/// resolved destination component.
+/// One `navigator` route: an uncompiled route enum value and its resolved component.
 pub struct NavigatorRoute {
-    /// The route enum value expression (e.g. `Route.Home`), kept uncompiled.
     pub route: syntax_nodes::Expression,
-    /// The resolved destination component (`ElementType::Error` on failure).
     pub component: ElementRc,
 }
 
@@ -2226,9 +2223,7 @@ impl Element {
         cases
     }
 
-    /// Lower a `navigator`: each `Route.X: XScreen {}` becomes a conditional child
-    /// (`<navigator-expr> == Route.X`), resolved to a component and recorded on
-    /// `parent` as `navigator_routes`.
+    /// Lower a `navigator`: each route becomes a conditional child and is recorded on `parent`.
     fn from_navigator_node(
         node: syntax_nodes::Navigator,
         parent: &ElementRc,
@@ -2269,7 +2264,6 @@ impl Element {
                 tr,
             );
             match &e.borrow().base_type {
-                // Error: already diagnosed by from_sub_element_node.
                 ElementType::Component(_) | ElementType::Error => {}
                 other => {
                     diag.push_error(
@@ -2284,8 +2278,7 @@ impl Element {
             routes.push(NavigatorRoute { route: route.Expression(), component: e.clone() });
             cases.push(e);
         }
-        // Declare the public members before expression resolution so .slint chrome
-        // can bind them; lower_navigator fills in their bodies later.
+        // Members must be declared before expression resolution so chrome can bind them.
         if !routes.is_empty() {
             Self::declare_navigator_members(parent, &routes, tr);
         }
@@ -2293,10 +2286,9 @@ impl Element {
         cases
     }
 
-    /// Declare the navigator's public members (signatures only; `lower_navigator`
-    /// fills the bodies once the route table is resolved).
+    /// Declare the navigator's public members; `lower_navigator` fills the bodies later.
     fn declare_navigator_members(elem: &ElementRc, routes: &[NavigatorRoute], tr: &TypeRegister) {
-        // Recover the route enum from a route case (`Route.X`) for navigate(route).
+        // Recover the route enum from a route case for navigate(route).
         let route_ty = routes.iter().find_map(|r| {
             let name = QualifiedTypeName::from_node(r.route.QualifiedName()?)
                 .members

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -4,7 +4,7 @@
 //! Module containing interfaces related types and functions.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Display;
 use std::rc::Rc;
 
@@ -16,14 +16,13 @@ use crate::expression_tree::{BindingExpression, Callable, Expression};
 use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
-    Component, Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
-    visit_named_references_in_expression,
+    Component, Element, ElementRc, NavigationContract, NeededCapability, PropertyDeclaration,
+    QualifiedTypeName, find_element_by_id, recurse_elem, visit_named_references_in_expression,
 };
 use crate::parser;
 use crate::parser::{SyntaxKind, syntax_nodes};
 use crate::typeregister::TypeRegister;
 
-/// A parsed [syntax_nodes::UsesIdentifier].
 #[derive(Clone, Debug)]
 struct UsesStatement {
     interface_name: QualifiedTypeName,
@@ -32,18 +31,14 @@ struct UsesStatement {
 }
 
 impl UsesStatement {
-    /// Get the node representing the interface name.
     fn interface_name_node(&self) -> syntax_nodes::QualifiedName {
         self.node.QualifiedName()
     }
 
-    /// Get the node representing the child identifier.
     fn child_id_node(&self) -> syntax_nodes::DeclaredIdentifier {
         self.node.DeclaredIdentifier()
     }
 
-    /// Lookup the interface component for this uses statement. Emits an error if the interface could not be found, or
-    /// was not actually an interface.
     fn lookup_interface(
         &self,
         tr: &TypeRegister,
@@ -124,15 +119,12 @@ fn validate_property_declaration_for_interface(
     }
 }
 
-/// An ImplementsSpecifier and the corresponding interface element.
 pub(super) struct ImplementedInterface {
     implements_specifier: syntax_nodes::ImplementsSpecifier,
     interface: ElementRc,
     interface_name: SmolStr,
 }
 
-/// If the element implements a valid interface, return the corresponding ImplementedInterface. Otherwise return None.
-/// Emits diagnostics if the implements specifier is invalid.
 pub(super) fn get_implemented_interface(
     e: &Element,
     node: &syntax_nodes::Element,
@@ -186,8 +178,6 @@ pub(super) fn get_implemented_interface(
     }
 }
 
-/// Apply the properties declared in the interface to the element, emitting diagnostics if there are any conflicts.
-/// Existing property declarations are permitted, provided they match the declaration from the interface.
 pub(super) fn apply_properties(
     e: &mut Element,
     implemented_interface: &Option<ImplementedInterface>,
@@ -201,7 +191,7 @@ pub(super) fn apply_properties(
 
     for (unresolved_prop_name, prop_decl) in
         interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-            // Functions are expected to be implemented manually, so we don't automatically add them.
+            // Functions are implemented manually, so we don't add them automatically.
             !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
         })
     {
@@ -216,8 +206,6 @@ pub(super) fn apply_properties(
     }
 }
 
-/// Apply the callbacks declared in the interface to the element, emitting diagnostics if there are any conflicts.
-/// Existing callback declarations are permitted, provided they match the declaration from the interface.
 pub(super) fn apply_callbacks(
     e: &mut Element,
     implemented_interface: &Option<ImplementedInterface>,
@@ -229,11 +217,11 @@ pub(super) fn apply_callbacks(
         return;
     };
 
-    for (unresolved_prop_name, prop_decl) in
-        interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-            // Functions are expected to be implemented manually, so we don't automatically add them.
-            matches!(prop_decl.property_type, Type::Callback { .. })
-        })
+    for (unresolved_prop_name, prop_decl) in interface
+        .borrow()
+        .property_declarations
+        .iter()
+        .filter(|(_, prop_decl)| matches!(prop_decl.property_type, Type::Callback { .. }))
     {
         apply_interface_property_declaration(
             e,
@@ -246,8 +234,6 @@ pub(super) fn apply_callbacks(
     }
 }
 
-/// Apply a [PropertyDeclaration] from an interface to the element, emitting diagnostics if there are any conflicts. An
-/// existing declaration with the same name is permitted, provided it matches the declaration from the interface.
 fn apply_interface_property_declaration(
     e: &mut Element,
     unresolved_prop_name: &SmolStr,
@@ -257,9 +243,7 @@ fn apply_interface_property_declaration(
     diag: &mut BuildDiagnostics,
 ) {
     if matches!(prop_decl.property_type, Type::Invalid) {
-        // The interface's own declaration is invalid (e.g. an unknown property type). A diagnostic
-        // was already emitted when the interface was parsed, so there is nothing meaningful to apply
-        // or conflict-check here.
+        // Invalid interface declaration; already diagnosed when the interface was parsed.
         return;
     }
 
@@ -294,13 +278,8 @@ fn apply_interface_property_declaration(
         }
 
         match property_matches_interface(&lookup_result, prop_decl) {
-            Ok(()) => {
-                // The property already exists and matches the interface declaration, so we don't need to do anything.
-                return;
-            }
+            Ok(()) => return,
             Err(error) => {
-                // Attempt to find a node for the existing property for better diagnostics. If the property is not local
-                // to the component, we fall back to pointing at the implements specifier below.
                 if let Some(local_property_node) = find_conflicting_node(e, unresolved_prop_name) {
                     diag.push_error(
                         format!("Conflict with '{}' which {}", interface_name, error),
@@ -325,7 +304,112 @@ fn apply_interface_property_declaration(
     e.property_declarations.insert(unresolved_prop_name.clone(), prop_decl.clone());
 }
 
-/// Apply default property values defined in the interface to the element.
+pub(super) struct NeededInterface {
+    needs_specifier: syntax_nodes::NeedsSpecifier,
+    interface: ElementRc,
+    interface_name: SmolStr,
+}
+
+/// Resolve the `needs` specifiers on `node` to capability interfaces.
+pub(super) fn get_needed_interfaces(
+    e: &Element,
+    node: &syntax_nodes::Element,
+    tr: &TypeRegister,
+    diag: &mut BuildDiagnostics,
+) -> Vec<NeededInterface> {
+    let specifiers: Vec<syntax_nodes::NeedsSpecifier> = node.NeedsSpecifier().collect();
+    if specifiers.is_empty() {
+        return Vec::new();
+    }
+
+    #[cfg(feature = "slint-sc")]
+    for specifier in &specifiers {
+        diag.slint_sc_error("'needs' is", specifier);
+    }
+
+    if !diag.enable_experimental && !tr.expose_internal_types {
+        for specifier in &specifiers {
+            diag.push_error("'needs' is an experimental feature".into(), specifier);
+        }
+        return Vec::new();
+    }
+
+    let mut needed = Vec::new();
+    for needs_specifier in specifiers {
+        let interface_name =
+            QualifiedTypeName::from_node(needs_specifier.QualifiedName()).to_smolstr();
+        match e.base_type.lookup_type_for_child_element(&interface_name, tr) {
+            Ok(ElementType::Component(c)) if c.is_interface() => {
+                c.used.set(true);
+                needed.push(NeededInterface {
+                    needs_specifier,
+                    interface: c.root_element.clone(),
+                    interface_name,
+                });
+            }
+            Ok(_) => diag.push_error(
+                format!("Cannot use '{interface_name}' as a capability. It is not an interface"),
+                &needs_specifier.QualifiedName(),
+            ),
+            Err(err) => diag.push_error(err, &needs_specifier.QualifiedName()),
+        }
+    }
+    needed
+}
+
+/// Declare each needed interface's members as unbound on `e` (the host binds them
+/// at the mount site) and return the recorded needs for the mount verifier.
+pub(super) fn apply_needs(
+    e: &mut Element,
+    needed: &[NeededInterface],
+    diag: &mut BuildDiagnostics,
+) -> Vec<NeededCapability> {
+    let mut capabilities = Vec::new();
+    for NeededInterface { needs_specifier, interface, interface_name } in needed {
+        let mut members = Vec::new();
+        for (name, prop_decl) in interface.borrow().property_declarations.iter().filter(|(_, d)| {
+            matches!(d.property_type, Type::Callback { .. } | Type::Function { .. })
+        }) {
+            if apply_needed_member(e, name, prop_decl, needs_specifier, interface_name, diag) {
+                members.push(name.clone());
+            }
+        }
+        capabilities.push(NeededCapability { interface_name: interface_name.clone(), members });
+    }
+    capabilities
+}
+
+/// Declare one capability member as unbound; false on a name conflict (diagnostic emitted).
+fn apply_needed_member(
+    e: &mut Element,
+    name: &SmolStr,
+    prop_decl: &PropertyDeclaration,
+    needs_specifier: &syntax_nodes::NeedsSpecifier,
+    interface_name: &SmolStr,
+    diag: &mut BuildDiagnostics,
+) -> bool {
+    if matches!(prop_decl.property_type, Type::Invalid) {
+        return false;
+    }
+
+    let lookup_result = e.lookup_property(name);
+    if lookup_result.property_type != Type::Invalid && lookup_result.is_local_to_component {
+        diag.push_error(
+            format!(
+                "Conflict with '{interface_name}' which declares a capability member '{name}' with the same name"
+            ),
+            &needs_specifier.QualifiedName(),
+        );
+        return false;
+    }
+
+    // No declaration of its own: point diagnostics at the `needs` specifier.
+    let mut prop_decl = prop_decl.clone();
+    prop_decl.node = Some(needs_specifier.QualifiedName().into());
+    e.property_declarations.insert(name.clone(), prop_decl);
+    true
+}
+
 pub(super) fn apply_default_property_values(
     e: &ElementRc,
     implemented_interface: &Option<ImplementedInterface>,
@@ -342,7 +426,6 @@ pub(super) fn apply_default_property_values(
         .property_declarations
         .iter()
         .filter(|(_, prop_decl)| {
-            // Only apply default bindings for properties
             !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
         })
         .filter_map(|(property_name, _)| {
@@ -353,15 +436,14 @@ pub(super) fn apply_default_property_values(
                 .map(|binding| (property_name.clone(), binding.clone()))
         })
         .filter(|(property_name, _)| {
-            // Only apply the default binding if there isn't already a binding set on the element.
-            // `need_explicit: false` includes two-way bindings from a `uses { ... }` alias on
-            // a base component — overriding those with an interface default would sever the alias.
+            // `need_explicit: false` also catches two-way `uses` aliases; overriding
+            // those with an interface default would sever the alias.
             !e.borrow().is_binding_set(property_name, false)
         })
         .collect();
 
     for (property_name, binding) in bindings_to_apply {
-        // Remap NamedReferences from the interface's root element to the implementing element
+        // Remap NamedReferences from the interface's root to the implementing element.
         visit_named_references_in_expression(&mut binding.borrow_mut().expression, &mut |nr| {
             if Rc::ptr_eq(&nr.element(), &interface_root) {
                 *nr = NamedReference::new(e, nr.name().clone());
@@ -371,7 +453,6 @@ pub(super) fn apply_default_property_values(
     }
 }
 
-/// Validate that the functions declared in the interface are correctly implemented in the element. Emits diagnostics if not.
 pub(super) fn validate_function_implementations(
     e: &Element,
     implemented_interface: &Option<ImplementedInterface>,
@@ -443,9 +524,8 @@ pub(super) fn validate_function_implementations(
                     function_name, interface_name
                 ),
             ),
-            _ => {
-                // If the implementation is pure but the declaration is not, we allow it.
-            }
+            // A pure implementation of an impure declaration is allowed.
+            _ => {}
         }
 
         if function_property_decl.visibility != found_function.property_visibility {
@@ -493,6 +573,108 @@ pub(super) fn validate_function_implementations(
     }
 }
 
+/// Last `.`-segment of a qualified enum value, e.g. `Home` from `Route.Home`.
+fn navigator_route_name(route: &syntax_nodes::Expression) -> SmolStr {
+    route.text().to_string().rsplit('.').next().unwrap_or_default().trim().into()
+}
+
+/// Route names of the first `navigator` in `root` (one per component by
+/// convention), or `None` if none. Shared by conformance and federated mount.
+fn navigator_route_names(root: &ElementRc) -> Option<HashSet<SmolStr>> {
+    let mut names: Option<HashSet<SmolStr>> = None;
+    recurse_elem(root, &(), &mut |elem, _| {
+        if names.is_none() {
+            let elem = elem.borrow();
+            let routes = elem.navigator_routes();
+            if !routes.is_empty() {
+                names = Some(routes.iter().map(|r| navigator_route_name(&r.route)).collect());
+            }
+        }
+    });
+    names
+}
+
+/// Verify a federated mount: `impl_root` must cover every `contract` route by name.
+pub(super) fn validate_mount_conformance(
+    impl_name: &str,
+    impl_root: &ElementRc,
+    contract_name: &str,
+    contract: &NavigationContract,
+    mount_site: &dyn crate::diagnostics::Spanned,
+    diag: &mut BuildDiagnostics,
+) -> bool {
+    let Some(names) = navigator_route_names(impl_root) else {
+        diag.push_error(
+            format!(
+                "mount of '{impl_name}' does not satisfy contract '{contract_name}': it declares no navigator"
+            ),
+            mount_site,
+        );
+        return false;
+    };
+    // Extra routes are allowed; only missing contract routes are an error.
+    let missing: Vec<&str> =
+        contract.routes.iter().map(|r| r.name.as_str()).filter(|n| !names.contains(*n)).collect();
+    if !missing.is_empty() {
+        diag.push_error(
+            format!(
+                "mount of '{impl_name}' does not satisfy contract '{contract_name}': missing route(s) {}",
+                missing.join(", ")
+            ),
+            mount_site,
+        );
+        return false;
+    }
+    true
+}
+
+/// Verify a component implementing a nav-contract interface covers every contract
+/// route. Only route-name coverage is checked; param-type conformance is deferred.
+pub(super) fn validate_navigation_contract_conformance(
+    root: &ElementRc,
+    implemented_interface: &Option<ImplementedInterface>,
+    diag: &mut BuildDiagnostics,
+) {
+    let Some(ImplementedInterface { interface, implements_specifier, interface_name }) =
+        implemented_interface
+    else {
+        return;
+    };
+
+    // No contract: a plain interface, nothing to conform to.
+    let Some(contract) =
+        interface.borrow().enclosing_component.upgrade().and_then(|c| c.navigation_contract())
+    else {
+        return;
+    };
+    if contract.routes.is_empty() {
+        return;
+    }
+
+    let Some(navigator_route_names) = navigator_route_names(root) else {
+        diag.push_error(
+            format!(
+                "component implements navigation contract '{interface_name}' but declares no navigator"
+            ),
+            &implements_specifier.QualifiedName(),
+        );
+        return;
+    };
+
+    // Extra navigator routes are allowed; only missing contract routes are an error.
+    for route in &contract.routes {
+        if !navigator_route_names.contains(&route.name) {
+            diag.push_error(
+                format!(
+                    "component implements '{interface_name}' but its navigator has no route for '{}'",
+                    route.name
+                ),
+                &implements_specifier.QualifiedName(),
+            );
+        }
+    }
+}
+
 pub(super) fn apply_uses_statement(
     e: &ElementRc,
     uses_specifier: Option<syntax_nodes::UsesSpecifier>,
@@ -527,8 +709,7 @@ pub(super) fn apply_uses_statement(
                 continue;
             }
 
-            // Replace the node with the interface name for better diagnostics later, since the declaration won't have a
-            // node in this element.
+            // No node on this element: point diagnostics at the interface name.
             let mut prop_decl = prop_decl.clone();
             prop_decl.node = Some(uses_statement.interface_name_node().into());
 
@@ -580,15 +761,13 @@ pub(super) fn apply_uses_statement(
     }
 }
 
-/// A valid `uses` statement, containing the looked up interface and child element.
 struct ValidUsesStatement {
     uses_statement: UsesStatement,
     interface: ElementRc,
     child: ElementRc,
 }
 
-/// Gather valid `uses` statements, emitting diagnostics for invalid ones. A valid `uses` statement is one where the
-/// interface can be found, the child element can be found, and the child element implements the interface.
+/// Gather valid `uses` statements (interface and child found, child implements interface).
 fn gather_valid_uses_statements(
     e: &Rc<RefCell<Element>>,
     tr: &TypeRegister,
@@ -621,9 +800,7 @@ fn gather_valid_uses_statements(
     valid_uses_statements
 }
 
-/// Filter out conflicting `uses` statements, emitting diagnostics for each conflict. Two `uses` statements conflict if
-/// they introduce properties/callbacks/functions with the same name. In that case we keep the first one and filter out
-/// the rest.
+/// Drop `uses` statements that conflict on a member name, keeping the first.
 fn filter_conflicting_uses_statements(
     diag: &mut BuildDiagnostics,
     uses_statements: Vec<ValidUsesStatement>,
@@ -664,7 +841,6 @@ fn filter_conflicting_uses_statements(
     valid_uses_statements
 }
 
-/// Check that the given element implements the given interface. Emits a diagnostic if the interface is not implemented.
 fn element_implements_interface(
     element: &ElementRc,
     interface: &ElementRc,
@@ -693,7 +869,6 @@ fn element_implements_interface(
     valid
 }
 
-/// Check that the given property matches the declaration from the interface. Emits a diagnostic if it doesn't match.
 fn property_matches_interface(
     property: &PropertyLookupResult,
     interface_declaration: &PropertyDeclaration,
@@ -724,15 +899,13 @@ fn property_matches_interface(
     }
 }
 
-/// Apply the function from the interface to the element, creating a forwarding bindings to the function on the child
-/// element. Emits diagnostics if there are conflicting functions.
+/// Forward the interface function to the child element's function of the same name.
 fn apply_uses_statement_function_binding(
     e: &ElementRc,
     child: &ElementRc,
     name: &SmolStr,
     func: &Rc<Function>,
 ) -> Option<RefCell<BindingExpression>> {
-    // Create forwarding call expression: child.function_name(arg0, arg1, ...)
     let args_expr: Vec<Expression> = func
         .args
         .iter()
@@ -740,14 +913,12 @@ fn apply_uses_statement_function_binding(
         .map(|(i, ty)| Expression::FunctionParameterReference { index: i, ty: ty.clone() })
         .collect();
 
-    // Use Callable::Function with a NamedReference to the child's function
     let call_expr = Expression::FunctionCall {
         function: Callable::Function(NamedReference::new(child, name.clone())),
         arguments: args_expr,
         source_location: None,
     };
 
-    // The function body is just the forwarding call. CodeBlock handles the return implicitly for the last expression
     let body = Expression::CodeBlock(vec![call_expr]);
     e.borrow_mut().bindings.insert(name.clone(), RefCell::new(BindingExpression::from(body)))
 }

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -352,9 +352,9 @@ declare_syntax! {
         /// `id := Element { ... }`
         SubElement -> [ Element ],
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
-                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *SubElement,
+                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *RouteDeclaration, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
-                     *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder ],
+                     *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder, *AtVersion, ?MountVia, *NeedsSpecifier ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
         RepeatedIndex -> [],
         ConditionalElement -> [ Expression , SubElement],
@@ -366,8 +366,14 @@ declare_syntax! {
         WildcardMatchCase -> [ ?SubElement ],
         /// navigator (current-route) { Route.Home: HomeScreen { } }
         Navigator -> [ Expression, *Route ],
-        /// Route.Home: HomeScreen { }
-        Route -> [ Expression, ?SubElement ],
+        /// Route.Home: HomeScreen { }  or  Route.ModuleA: mount ModuleA via AppNavV1 { }
+        Route -> [ Expression, ?SubElement, ?MountDestination ],
+        /// mount ModuleA via AppNavV1 { open-settings => {} }
+        MountDestination -> [ SubElement ],
+        /// via AppNavV1
+        MountVia -> [ QualifiedName ],
+        /// route Home;  or  route Details(id: int);  with an optional @uri("...") prefix
+        RouteDeclaration -> [ DeclaredIdentifier, *ArgumentDeclaration, *AtUri ],
         CallbackDeclaration -> [ DeclaredIdentifier, *CallbackDeclarationParameter, ?ReturnType, ?TwoWayBinding ],
         // `foo: type` or just `type`
         CallbackDeclarationParameter -> [ ?DeclaredIdentifier, Type],
@@ -478,12 +484,18 @@ declare_syntax! {
         EnumValue -> [],
         /// `@rust-attr(...)`
         AtRustAttr -> [],
+        /// `@version(n)`: the navigation contract version, on an `interface`.
+        AtVersion -> [],
+        /// `@uri("...")`: a route's deep-link URI, on a `route` declaration.
+        AtUri -> [],
         /// `uses { Foo from Bar, Baz from Qux }`
         UsesSpecifier -> [ *UsesIdentifier ],
         /// `Interface.Foo from bar`
         UsesIdentifier -> [QualifiedName, DeclaredIdentifier],
         /// `implements Interface.Foo`
         ImplementsSpecifier -> [ QualifiedName ],
+        /// `needs AppServices;`  a capability the component requires from its host.
+        NeedsSpecifier -> [ QualifiedName ],
     }
 }
 

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -352,7 +352,7 @@ declare_syntax! {
         /// `id := Element { ... }`
         SubElement -> [ Element ],
         Element -> [ ?QualifiedName, *PropertyDeclaration, *Binding, *CallbackConnection,
-                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Function, *SubElement,
+                     *CallbackDeclaration, *ConditionalElement, *MatchElement, *Navigator, *Function, *SubElement,
                      *RepeatedElement, *PropertyAnimation, *PropertyChangedCallback,
                      *TwoWayBinding, *States, *Transitions, ?ChildrenPlaceholder ],
         RepeatedElement -> [ ?DeclaredIdentifier, ?RepeatedIndex, Expression , SubElement],
@@ -364,6 +364,11 @@ declare_syntax! {
         MatchCase -> [ Expression, ?SubElement ],
         /// *: Elem { }
         WildcardMatchCase -> [ ?SubElement ],
+        /// navigator (current-route) { Route.Home: HomeScreen { } }
+        /// The Expression is the current-route binding.
+        Navigator -> [ Expression, *Route ],
+        /// Route.Home: HomeScreen { }
+        Route -> [ Expression, ?SubElement ],
         CallbackDeclaration -> [ DeclaredIdentifier, *CallbackDeclarationParameter, ?ReturnType, ?TwoWayBinding ],
         // `foo: type` or just `type`
         CallbackDeclarationParameter -> [ ?DeclaredIdentifier, Type],

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -365,7 +365,6 @@ declare_syntax! {
         /// *: Elem { }
         WildcardMatchCase -> [ ?SubElement ],
         /// navigator (current-route) { Route.Home: HomeScreen { } }
-        /// The Expression is the current-route binding.
         Navigator -> [ Expression, *Route ],
         /// Route.Home: HomeScreen { }
         Route -> [ Expression, ?SubElement ],

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -54,6 +54,8 @@ pub fn parse_element(p: &mut impl Parser) -> bool {
 /// changed foo => {}
 /// match (foo) { 1: Elem { } }
 /// match bar.property { 1: Elem { } }
+/// navigator (current-route) { Route.Home: Sub { } }
+/// navigator current-route { Route.Home: Sub { } }
 /// ```
 pub fn parse_element_content(p: &mut impl Parser) {
     let mut had_parse_error = false;

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -136,8 +136,6 @@ pub fn parse_element_content(p: &mut impl Parser) {
                         }
                     }
                 }
-                // Experimental: parsed unconditionally like `match`; the experimental
-                // gate is applied at object-tree lowering (see from_match_node).
                 SyntaxKind::Identifier | SyntaxKind::LParent
                     if p.peek().as_str() == "navigator" =>
                 {

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -372,8 +372,7 @@ fn parse_wildcard_case(p: &mut impl Parser) {
 fn parse_navigation(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().as_str(), "navigator");
     let mut p = p.start_node(SyntaxKind::Navigator);
-    p.expect(SyntaxKind::Identifier); // "navigator"
-    // The current-route binding.
+    p.expect(SyntaxKind::Identifier);
     parse_expression(&mut *p);
     if !p.test(SyntaxKind::LBrace) {
         p.error("Expected '{' to start routes");

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -67,7 +67,7 @@ pub fn parse_element_content(p: &mut impl Parser) {
                     had_parse_error |= !parse_sub_element(&mut *p)
                 }
                 SyntaxKind::FatArrow | SyntaxKind::LParent
-                    if !["if", "match"].contains(&p.peek().as_str()) =>
+                    if !["if", "match", "navigator"].contains(&p.peek().as_str()) =>
                 {
                     parse_callback_connection(&mut *p)
                 }
@@ -121,6 +121,33 @@ pub fn parse_element_content(p: &mut impl Parser) {
                             }
                             SyntaxKind::LBrace => {
                                 parse_match_element(&mut *p);
+                                break;
+                            }
+                            SyntaxKind::Eof => {
+                                if !had_parse_error {
+                                    p.error("Error: Expected '{'");
+                                    had_parse_error = true;
+                                }
+                                break;
+                            }
+                            _ => i += 1,
+                        }
+                    }
+                }
+                // Experimental: parsed unconditionally like `match`; the experimental
+                // gate is applied at object-tree lowering (see from_match_node).
+                SyntaxKind::Identifier | SyntaxKind::LParent
+                    if p.peek().as_str() == "navigator" =>
+                {
+                    let mut i = 2;
+                    loop {
+                        match p.nth(i).kind() {
+                            SyntaxKind::FatArrow => {
+                                parse_callback_connection(&mut *p);
+                                break;
+                            }
+                            SyntaxKind::LBrace => {
+                                parse_navigation(&mut *p);
                                 break;
                             }
                             SyntaxKind::Eof => {
@@ -329,6 +356,55 @@ fn parse_wildcard_case(p: &mut impl Parser) {
         if p.peek().kind() == SyntaxKind::Identifier {
             p.error("Remove '{ }' around case element");
             return;
+        }
+        p.expect(SyntaxKind::RBrace);
+        return;
+    }
+    parse_sub_element(&mut *p);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,Navigator
+/// navigator (current-route) { Route.Home: Home { } }
+/// navigator current-route { Route.Home: Home { } Route.Settings: Settings { } }
+/// navigator (current-route) { }
+/// ```
+fn parse_navigation(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "navigator");
+    let mut p = p.start_node(SyntaxKind::Navigator);
+    p.expect(SyntaxKind::Identifier); // "navigator"
+    // The current-route binding.
+    parse_expression(&mut *p);
+    if !p.test(SyntaxKind::LBrace) {
+        p.error("Expected '{' to start routes");
+    }
+    while ![SyntaxKind::RBrace, SyntaxKind::Eof].contains(&p.peek().kind()) {
+        parse_route(&mut *p);
+    }
+    p.expect(SyntaxKind::RBrace);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,Route
+/// Route.Home: Home { }
+/// (Route.Home): Home { }
+/// Route.Home: { }
+/// ```
+fn parse_route(p: &mut impl Parser) {
+    let mut p = p.start_node(SyntaxKind::Route);
+    parse_expression(&mut *p);
+    if !p.test(SyntaxKind::Colon) {
+        p.error("Expected ':' after route");
+        if p.peek().kind() != SyntaxKind::Identifier {
+            p.consume();
+        }
+    }
+    if p.peek().kind() == SyntaxKind::LBrace {
+        // empty route
+        p.expect(SyntaxKind::LBrace);
+        if p.peek().kind() == SyntaxKind::Identifier {
+            p.error("Remove '{ }' around route component");
+            parse_sub_element(&mut *p);
         }
         p.expect(SyntaxKind::RBrace);
         return;

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -92,6 +92,13 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 {
                     parse_function(&mut *p);
                 }
+                // Parsed unconditionally; the experimental gate is applied at lowering.
+                SyntaxKind::Identifier if p.peek().as_str() == "route" => {
+                    parse_route_declaration(&mut *p, None);
+                }
+                SyntaxKind::Identifier if p.peek().as_str() == "needs" => {
+                    parse_needs_specifier(&mut *p);
+                }
                 SyntaxKind::Identifier | SyntaxKind::Star if p.peek().as_str() == "animate" => {
                     parse_property_animation(&mut *p);
                 }
@@ -180,18 +187,34 @@ pub fn parse_element_content(p: &mut impl Parser) {
                     }
                 }
             },
-            SyntaxKind::At => {
-                let checkpoint = p.checkpoint();
-                p.consume();
-                if p.peek().as_str() == "children" {
-                    let mut p =
-                        p.start_node_at(checkpoint.clone(), SyntaxKind::ChildrenPlaceholder);
-                    p.consume()
-                } else {
+            SyntaxKind::At => match p.nth(1).as_str() {
+                "children" => {
+                    let checkpoint = p.checkpoint();
+                    p.consume(); // "@"
+                    let mut p = p.start_node_at(checkpoint, SyntaxKind::ChildrenPlaceholder);
+                    p.consume() // "children"
+                }
+                "version" => {
+                    parse_navigation_attribute(&mut *p, "version", SyntaxKind::AtVersion);
+                }
+                "uri" => {
+                    let checkpoint = p.checkpoint();
+                    parse_navigation_attribute(&mut *p, "uri", SyntaxKind::AtUri);
+                    while p.peek().as_str() == "@" && p.nth(1).as_str() == "uri" {
+                        parse_navigation_attribute(&mut *p, "uri", SyntaxKind::AtUri);
+                    }
+                    if p.peek().as_str() == "route" {
+                        parse_route_declaration(&mut *p, Some(checkpoint));
+                    } else {
+                        p.error("Parse error: Expected 'route' after @uri");
+                    }
+                }
+                _ => {
+                    p.consume(); // "@"
                     p.test(SyntaxKind::Identifier);
                     p.error("Parse error: Expected @children")
                 }
-            }
+            },
             _ => {
                 if !had_parse_error {
                     p.error("Parse error");
@@ -398,6 +421,11 @@ fn parse_route(p: &mut impl Parser) {
             p.consume();
         }
     }
+    // A federated mount destination: `mount Impl via Contract { }`.
+    if p.peek().as_str() == "mount" {
+        parse_mount_destination(&mut *p);
+        return;
+    }
     if p.peek().kind() == SyntaxKind::LBrace {
         // empty route
         p.expect(SyntaxKind::LBrace);
@@ -409,6 +437,67 @@ fn parse_route(p: &mut impl Parser) {
         return;
     }
     parse_sub_element(&mut *p);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,MountDestination
+/// mount ModuleA via AppNavV1 { }
+/// mount M via C {}
+/// mount ModuleA via AppNavV1 { open-settings => {} }
+/// mount ModuleA via AppNavV1 { play-media(url) => { root.x = url; } }
+/// mount extern via AppNavV1 { component-factory: root.f; }
+/// mount extern via C {}
+/// ```
+fn parse_mount_destination(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "mount");
+    let mut p = p.start_node(SyntaxKind::MountDestination);
+    p.expect(SyntaxKind::Identifier); // "mount"
+    // `extern` (soft keyword) marks an external cross-process destination: no
+    // statically-known impl. The destination resolves to a `ComponentContainer`
+    // the host fills at runtime; the Element carries no base name, which is how
+    // object_tree tells an external mount from a local one.
+    let external = p.peek().as_str() == "extern";
+    if external {
+        p.consume(); // "extern"
+    }
+    // The mounted implementation is a normal instantiation `Impl { <bindings> }`,
+    // wrapped as a SubElement so the mount-block bindings flow onto it through the
+    // ordinary binding path (they satisfy the module's capability needs). The
+    // `via <Contract>` clause is nested in a MountVia node inside the Element so
+    // the base name and the trailing bindings stay contiguous. An external mount
+    // omits the base name; its block binds `component-factory` on the container.
+    let mut sub = p.start_node(SyntaxKind::SubElement);
+    let mut el = sub.start_node(SyntaxKind::Element);
+    if !external {
+        parse_qualified_name(&mut *el); // the mounted implementation
+    }
+    {
+        let mut via = el.start_node(SyntaxKind::MountVia);
+        if via.peek().as_str() != "via" {
+            via.error("Expected 'via <Contract>' after 'mount <Impl>'");
+        } else {
+            via.consume(); // "via"
+        }
+        parse_qualified_name(&mut *via); // the navigation contract to satisfy
+    }
+    if !el.expect(SyntaxKind::LBrace) {
+        return;
+    }
+    parse_element_content(&mut *el);
+    el.expect(SyntaxKind::RBrace);
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,NeedsSpecifier
+/// needs AppServices;
+/// needs Fully.Qualified.Services;
+/// ```
+fn parse_needs_specifier(p: &mut impl Parser) {
+    debug_assert_eq!(p.peek().as_str(), "needs");
+    let mut p = p.start_node(SyntaxKind::NeedsSpecifier);
+    p.expect(SyntaxKind::Identifier); // "needs"
+    parse_qualified_name(&mut *p);
+    p.expect(SyntaxKind::Semicolon);
 }
 
 #[cfg_attr(test, parser_test)]
@@ -896,4 +985,78 @@ fn parse_function(p: &mut impl Parser) {
     } else if !p.test(SyntaxKind::Semicolon) {
         p.error("Expected function body or semicolon");
     }
+}
+
+#[cfg_attr(test, parser_test)]
+/// ```test,RouteDeclaration
+/// route Home;
+/// route Details(id: int);
+/// route Details(id: int, name: string);
+/// route Details(id: int,);
+/// ```
+/// The optional `checkpoint` lets a preceding `@uri(...)` attribute be wrapped
+/// into the RouteDeclaration node (mirrors struct/enum + `@rust-attr`).
+fn parse_route_declaration<P: Parser>(p: &mut P, checkpoint: Option<P::Checkpoint>) {
+    debug_assert_eq!(p.peek().as_str(), "route");
+    let mut p = p.start_node_at(checkpoint, SyntaxKind::RouteDeclaration);
+    p.expect(SyntaxKind::Identifier); // "route"
+    {
+        let mut p = p.start_node(SyntaxKind::DeclaredIdentifier);
+        p.expect(SyntaxKind::Identifier);
+    }
+    // Optional typed parameters, reusing the function argument grammar. The
+    // params are parsed and typed but not yet consumed by this slice.
+    if p.test(SyntaxKind::LParent) {
+        while p.peek().kind() != SyntaxKind::RParent {
+            let mut p_arg = p.start_node(SyntaxKind::ArgumentDeclaration);
+            {
+                let mut p = p_arg.start_node(SyntaxKind::DeclaredIdentifier);
+                p.expect(SyntaxKind::Identifier);
+            }
+            p_arg.expect(SyntaxKind::Colon);
+            parse_type(&mut *p_arg);
+            drop(p_arg);
+            if !p.test(SyntaxKind::Comma) {
+                break;
+            }
+        }
+        p.expect(SyntaxKind::RParent);
+    }
+    if !p.test(SyntaxKind::Semicolon) {
+        p.error("Expected ';' after route declaration");
+    }
+}
+
+/// Parse a navigation attribute `@name(<literal>)`, wrapping the argument tokens
+/// in `kind`. Mirrors `parse_rustattr` so the read-out reuses `attr.text()`. The
+/// caller has verified the attribute name at `nth(1)`.
+fn parse_navigation_attribute(p: &mut impl Parser, name: &str, kind: SyntaxKind) -> bool {
+    debug_assert_eq!(p.peek().as_str(), "@");
+    p.consume(); // "@"
+    p.consume(); // attribute name
+    if !p.expect(SyntaxKind::LParent) {
+        return false;
+    }
+    {
+        let mut p = p.start_node(kind);
+        let mut level = 1;
+        loop {
+            match p.peek().kind() {
+                SyntaxKind::LParent => level += 1,
+                SyntaxKind::RParent => {
+                    level -= 1;
+                    if level == 0 {
+                        break;
+                    }
+                }
+                SyntaxKind::Eof => {
+                    p.error(format!("unmatched parentheses in @{name}"));
+                    return false;
+                }
+                _ => {}
+            }
+            p.consume()
+        }
+    }
+    p.expect(SyntaxKind::RParent)
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -35,6 +35,7 @@ mod lower_accessibility;
 mod lower_component_container;
 mod lower_layout;
 mod lower_menus;
+mod lower_navigator;
 mod lower_platform;
 mod lower_popups;
 mod lower_property_to_element;
@@ -120,6 +121,9 @@ pub async fn run_passes(
     lower_tooltips::lower_tooltips(doc, type_loader, diag).await;
     lower_tabwidget::lower_tabwidget(doc, type_loader, diag).await;
     lower_radiogroup::lower_radiogroup(doc, type_loader, diag).await;
+    // Runs after resolve (route models are typed) and before inlining, so the
+    // synthesized navigate/back/can-go-back propagate like any declared member.
+    lower_navigator::lower_navigator(doc, diag);
     lower_menus::lower_menus(doc, type_loader, diag).await;
     lower_component_container::lower_component_container(doc, type_loader, diag);
     collect_subcomponents::collect_subcomponents(doc);

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -74,6 +74,14 @@ fn simplify_expression(
             simplify_single_statement_code_block(expr, ga, cache)
         }
         Expression::FunctionCall { .. } => simplify_function_call(expr, ga, cache),
+        // The lhs of an assignment is a target (lvalue) and must not be folded to
+        // a constant value; only the rhs may be simplified. An assignment is never
+        // a constant itself.
+        Expression::SelfAssignment { rhs, .. } => {
+            // Only fold the rhs; the lhs is an assignment target, not a constant.
+            simplify_expression(rhs, ga, cache);
+            false
+        }
         Expression::ElementReference { .. } => false,
         Expression::LayoutCacheAccess { .. } => false,
         Expression::OrganizeGridLayout { .. } => false,

--- a/internal/compiler/passes/const_propagation.rs
+++ b/internal/compiler/passes/const_propagation.rs
@@ -74,14 +74,6 @@ fn simplify_expression(
             simplify_single_statement_code_block(expr, ga, cache)
         }
         Expression::FunctionCall { .. } => simplify_function_call(expr, ga, cache),
-        // The lhs of an assignment is a target (lvalue) and must not be folded to
-        // a constant value; only the rhs may be simplified. An assignment is never
-        // a constant itself.
-        Expression::SelfAssignment { rhs, .. } => {
-            // Only fold the rhs; the lhs is an assignment target, not a constant.
-            simplify_expression(rhs, ga, cache);
-            false
-        }
         Expression::ElementReference { .. } => false,
         Expression::LayoutCacheAccess { .. } => false,
         Expression::OrganizeGridLayout { .. } => false,

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -399,6 +399,7 @@ fn duplicate_element_with_mapping(
             .map(|x| duplicate_element_with_mapping(x, mapping, root_component, priority_delta))
             .collect(),
         repeated: elem.repeated.clone(),
+        navigator_routes: elem.navigator_routes.clone(),
         is_component_placeholder: elem.is_component_placeholder,
         debug: elem.debug.clone(),
         enclosing_component: Rc::downgrade(root_component),

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -400,6 +400,7 @@ fn duplicate_element_with_mapping(
             .collect(),
         repeated: elem.repeated.clone(),
         navigator_routes: elem.navigator_routes.clone(),
+        needed_capabilities: elem.needed_capabilities.clone(),
         is_component_placeholder: elem.is_component_placeholder,
         debug: elem.debug.clone(),
         enclosing_component: Rc::downgrade(root_component),
@@ -488,6 +489,7 @@ fn duplicate_sub_component(
         private_properties: Default::default(),
         inherits_popup_window: core::cell::Cell::new(false),
         from_library: core::cell::Cell::new(false),
+        navigation_contract: component_to_duplicate.navigation_contract.clone(),
     };
 
     let new_component = Rc::new(new_component);

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,27 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Implement the navigator's public members (declared early by
-//! `from_navigator_node`) and add its private back-stack.
+//! Implement the navigator's public members and add its private back-stack.
 //!
 //! `from_navigator_node` records the resolved route table on the enclosing
 //! element (`Element::navigator_routes`) and declares the public members
 //! (`current-route-index`, `can-go-back`, `navigate`, `navigate-index`, `back`)
-//! up front, so .slint chrome can bind to them. Navigation itself is just
-//! assigning the route property. This pass fills in those members' bodies and
-//! adds, on the same element, the private back-stack that backs them:
+//! up front.
 //!
 //!   navigate(route): push the current route, then switch to `route`
 //!   back():          restore and drop the top of the back-stack (no-op if empty)
 //!   can-go-back:     true while the back-stack is non-empty
-//!
-//! It is expressed entirely by lowering onto the existing property/callback and
-//! `Array*` builtin machinery, so it needs no new `internal/core` items.
-//!
-//! Runs after expression resolution (the route models are typed and the route
-//! property is a resolved reference by then) and before inlining. The construct
-//! is experimental-gated in `from_navigator_node`, so `navigator_routes` is only
-//! ever populated under `enable_experimental`; this pass inherits that gate.
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};
@@ -31,8 +20,6 @@ use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-// Private storage for the back-stack. A single navigator per element is
-// supported, matching the navigation convention.
 const BACK_STACK: &str = "navigator-back-stack";
 
 pub fn lower_navigator(doc: &Document, diag: &mut BuildDiagnostics) {
@@ -46,8 +33,6 @@ pub fn lower_navigator(doc: &Document, diag: &mut BuildDiagnostics) {
 }
 
 fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
-    // The route property and its enum type both come from a route case's model:
-    // resolve turned each case into `<route-property> == Route.X`.
     let model = elem
         .borrow()
         .navigator_routes
@@ -61,8 +46,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
     if !matches!(route_ty, Type::Enumeration(_)) {
         return;
     }
-    // navigate()/back() write the route back, so it must be an assignable
-    // property reference. The convention uses `in-out property <Route>`.
+
     if !matches!(route_ref, Expression::PropertyReference(_)) {
         diag.push_error(
             "the navigator route must be a writable property to support navigate() and back()"
@@ -80,8 +64,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
             ..Default::default()
         },
     );
-    // Initialize to an empty array: an unbound model property is a null model
-    // whose push/remove are silently no-ops.
+
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static(BACK_STACK),
         RefCell::new(Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into()),
@@ -93,7 +76,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         arguments: vec![back_stack()],
         source_location: None,
     };
-    // Index of the top of the stack: `length - 1`.
     let top_index = || Expression::BinaryExpression {
         lhs: Box::new(length()),
         rhs: Box::new(Expression::NumberLiteral(1., Unit::None)),
@@ -111,7 +93,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         node: None,
     };
 
-    // navigate(route): remember the current route, then switch to the argument.
     let navigate_body = Expression::CodeBlock(vec![
         Expression::FunctionCall {
             function: Callable::Builtin(BuiltinFunction::ArrayPush),
@@ -121,8 +102,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         assign_route(Expression::FunctionParameterReference { index: 0, ty: route_ty.clone() }),
     ]);
 
-    // back(): restore the top route, then drop it. The restore reads the top
-    // before the remove, so both use the pre-pop length.
     let back_body = Expression::Condition {
         condition: Box::new(non_empty()),
         true_expr: Box::new(Expression::CodeBlock(vec![
@@ -141,10 +120,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
 
     let can_go_back = non_empty();
 
-    // Int-index adapter for chrome that speaks `current_index: int` /
-    // `index_changed(int)` rather than the route enum. Each route case's
-    // resolved model is `route_ref == Route.X`, so its rhs is that route's enum
-    // value; collected in declaration order these map ordinal <-> route.
     let route_values: Vec<Expression> = elem
         .borrow()
         .navigator_routes
@@ -155,8 +130,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         })
         .collect();
 
-    // current-route-index: ordinal of the current route, else -1. Lowered as an
-    // if-chain `current == route0 ? 0 : current == route1 ? 1 : ... : -1`.
     let current_route_index = route_values.iter().enumerate().rev().fold(
         Expression::NumberLiteral(-1., Unit::None),
         |otherwise, (i, route_value)| Expression::Condition {
@@ -170,8 +143,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
 
-    // navigate-index(index): navigate to the route at that ordinal using the same
-    // push-then-set logic as navigate(); an out-of-range index is a no-op.
     let index_param = || Expression::FunctionParameterReference { index: 0, ty: Type::Int32 };
     let navigate_index_body = route_values.iter().enumerate().rev().fold(
         Expression::CodeBlock(vec![]),
@@ -193,9 +164,6 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
 
-    // The public members were declared early (before resolve) by
-    // `from_navigator_node` so .slint chrome can bind to them; here we only fill
-    // in their bodies/bindings, now that the route table is resolved.
     let mut e = elem.borrow_mut();
     e.bindings.insert(SmolStr::new_static("navigate"), RefCell::new(navigate_body.into()));
     e.bindings.insert(SmolStr::new_static("back"), RefCell::new(back_body.into()));

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,16 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Implement the navigator's public members and add its private back-stack.
+//! Fill in the navigator's public member bodies and add its private back-stack.
 //!
-//! `from_navigator_node` records the resolved route table on the enclosing
-//! element (`Element::navigator_routes`) and declares the public members
-//! (`current-route-index`, `can-go-back`, `navigate`, `navigate-index`, `back`)
-//! up front.
-//!
-//!   navigate(route): push the current route, then switch to `route`
-//!   back():          restore and drop the top of the back-stack (no-op if empty)
-//!   can-go-back:     true while the back-stack is non-empty
+//! Runs after the route table and member signatures are set up by `from_navigator_node`.
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,12 +1,15 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Synthesize the navigator back-stack.
+//! Implement the navigator's public members (declared early by
+//! `from_navigator_node`) and add its private back-stack.
 //!
 //! `from_navigator_node` records the resolved route table on the enclosing
-//! element (`Element::navigator_routes`); navigation itself is just assigning
-//! the route property. This pass adds, on that same element, a back-stack plus
-//! the surface for going back:
+//! element (`Element::navigator_routes`) and declares the public members
+//! (`current-route-index`, `can-go-back`, `navigate`, `navigate-index`, `back`)
+//! up front, so .slint chrome can bind to them. Navigation itself is just
+//! assigning the route property. This pass fills in those members' bodies and
+//! adds, on the same element, the private back-stack that backs them:
 //!
 //!   navigate(route): push the current route, then switch to `route`
 //!   back():          restore and drop the top of the back-stack (no-op if empty)
@@ -22,7 +25,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};
-use crate::langtype::{Function, Type};
+use crate::langtype::Type;
 use crate::object_tree::*;
 use smol_str::SmolStr;
 use std::cell::RefCell;
@@ -194,79 +197,16 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
 
+    // The public members were declared early (before resolve) by
+    // `from_navigator_node` so .slint chrome can bind to them; here we only fill
+    // in their bodies/bindings, now that the route table is resolved.
     let mut e = elem.borrow_mut();
-    e.property_declarations.insert(
-        SmolStr::new_static("navigate"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![route_ty.clone()],
-                arg_names: vec![SmolStr::new_static("route")],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            // Synthesized after check_public_api; opt into the public surface so
-            // callers can invoke it and remove_unused_properties keeps it.
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("navigate"), RefCell::new(navigate_body.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("back"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![],
-                arg_names: vec![],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("back"), RefCell::new(back_body.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("can-go-back"),
-        PropertyDeclaration {
-            property_type: Type::Bool,
-            visibility: PropertyVisibility::Output,
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
-
-    e.property_declarations.insert(
-        SmolStr::new_static("current-route-index"),
-        PropertyDeclaration {
-            property_type: Type::Int32,
-            visibility: PropertyVisibility::Output,
-            expose_in_public_api: true,
-            ..Default::default()
-        },
-    );
     e.bindings.insert(
         SmolStr::new_static("current-route-index"),
         RefCell::new(current_route_index.into()),
-    );
-
-    e.property_declarations.insert(
-        SmolStr::new_static("navigate-index"),
-        PropertyDeclaration {
-            property_type: Type::Function(Rc::new(Function {
-                return_type: Type::Void,
-                args: vec![Type::Int32],
-                arg_names: vec![SmolStr::new_static("index")],
-            })),
-            visibility: PropertyVisibility::Public,
-            pure: Some(false),
-            expose_in_public_api: true,
-            ..Default::default()
-        },
     );
     e.bindings
         .insert(SmolStr::new_static("navigate-index"), RefCell::new(navigate_index_body.into()));

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -1,0 +1,188 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Synthesize the navigator back-stack.
+//!
+//! `from_navigator_node` records the resolved route table on the enclosing
+//! element (`Element::navigator_routes`); navigation itself is just assigning
+//! the route property. This pass adds, on that same element, a back-stack plus
+//! the surface for going back:
+//!
+//!   navigate(route): push the current route, then switch to `route`
+//!   back():          restore and drop the top of the back-stack (no-op if empty)
+//!   can-go-back:     true while the back-stack is non-empty
+//!
+//! It is expressed entirely by lowering onto the existing property/callback and
+//! `Array*` builtin machinery, so it needs no new `internal/core` items.
+//!
+//! Runs after expression resolution (the route models are typed and the route
+//! property is a resolved reference by then) and before inlining. The construct
+//! is experimental-gated in `from_navigator_node`, so `navigator_routes` is only
+//! ever populated under `enable_experimental`; this pass inherits that gate.
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference, Unit};
+use crate::langtype::{Function, Type};
+use crate::object_tree::*;
+use smol_str::SmolStr;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// Private storage for the back-stack. A single navigator per element is
+// supported, matching the navigation convention.
+const BACK_STACK: &str = "navigator-back-stack";
+
+pub fn lower_navigator(doc: &Document, diag: &mut BuildDiagnostics) {
+    doc.visit_all_used_components(|component| {
+        recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+            if !elem.borrow().navigator_routes.is_empty() {
+                lower_one(elem, diag);
+            }
+        })
+    });
+}
+
+fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
+    // The route property and its enum type both come from a route case's model:
+    // resolve turned each case into `<route-property> == Route.X`.
+    let model = elem
+        .borrow()
+        .navigator_routes
+        .first()
+        .and_then(|r| r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()));
+    let Some(Expression::BinaryExpression { lhs: route_ref, .. }) = model else {
+        return;
+    };
+    let route_ref = *route_ref;
+    let route_ty = route_ref.ty();
+    if !matches!(route_ty, Type::Enumeration(_)) {
+        return;
+    }
+    // navigate()/back() write the route back, so it must be an assignable
+    // property reference. The convention uses `in-out property <Route>`.
+    if !matches!(route_ref, Expression::PropertyReference(_)) {
+        diag.push_error(
+            "the navigator route must be a writable property to support navigate() and back()"
+                .into(),
+            &*elem.borrow(),
+        );
+        return;
+    }
+
+    elem.borrow_mut().property_declarations.insert(
+        SmolStr::new_static(BACK_STACK),
+        PropertyDeclaration {
+            property_type: Type::Array(Rc::new(route_ty.clone())),
+            visibility: PropertyVisibility::Private,
+            ..Default::default()
+        },
+    );
+    // Initialize to an empty array: an unbound model property is a null model
+    // whose push/remove are silently no-ops.
+    elem.borrow_mut().bindings.insert(
+        SmolStr::new_static(BACK_STACK),
+        RefCell::new(
+            Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into(),
+        ),
+    );
+
+    let back_stack = || Expression::PropertyReference(NamedReference::new(elem, BACK_STACK.into()));
+    let length = || Expression::FunctionCall {
+        function: Callable::Builtin(BuiltinFunction::ArrayLength),
+        arguments: vec![back_stack()],
+        source_location: None,
+    };
+    // Index of the top of the stack: `length - 1`.
+    let top_index = || Expression::BinaryExpression {
+        lhs: Box::new(length()),
+        rhs: Box::new(Expression::NumberLiteral(1., Unit::None)),
+        op: '-',
+    };
+    let non_empty = || Expression::BinaryExpression {
+        lhs: Box::new(length()),
+        rhs: Box::new(Expression::NumberLiteral(0., Unit::None)),
+        op: '>',
+    };
+    let assign_route = |rhs: Expression| Expression::SelfAssignment {
+        lhs: Box::new(route_ref.clone()),
+        rhs: Box::new(rhs),
+        op: '=',
+        node: None,
+    };
+
+    // navigate(route): remember the current route, then switch to the argument.
+    let navigate_body = Expression::CodeBlock(vec![
+        Expression::FunctionCall {
+            function: Callable::Builtin(BuiltinFunction::ArrayPush),
+            arguments: vec![back_stack(), route_ref.clone()],
+            source_location: None,
+        },
+        assign_route(Expression::FunctionParameterReference { index: 0, ty: route_ty.clone() }),
+    ]);
+
+    // back(): restore the top route, then drop it. The restore reads the top
+    // before the remove, so both use the pre-pop length.
+    let back_body = Expression::Condition {
+        condition: Box::new(non_empty()),
+        true_expr: Box::new(Expression::CodeBlock(vec![
+            assign_route(Expression::ArrayIndex {
+                array: Box::new(back_stack()),
+                index: Box::new(top_index()),
+            }),
+            Expression::FunctionCall {
+                function: Callable::Builtin(BuiltinFunction::ArrayRemove),
+                arguments: vec![back_stack(), top_index()],
+                source_location: None,
+            },
+        ])),
+        false_expr: Box::new(Expression::CodeBlock(vec![])),
+    };
+
+    let can_go_back = non_empty();
+
+    let mut e = elem.borrow_mut();
+    e.property_declarations.insert(
+        SmolStr::new_static("navigate"),
+        PropertyDeclaration {
+            property_type: Type::Function(Rc::new(Function {
+                return_type: Type::Void,
+                args: vec![route_ty.clone()],
+                arg_names: vec![SmolStr::new_static("route")],
+            })),
+            visibility: PropertyVisibility::Public,
+            pure: Some(false),
+            // Synthesized after check_public_api; opt into the public surface so
+            // callers can invoke it and remove_unused_properties keeps it.
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(SmolStr::new_static("navigate"), RefCell::new(navigate_body.into()));
+
+    e.property_declarations.insert(
+        SmolStr::new_static("back"),
+        PropertyDeclaration {
+            property_type: Type::Function(Rc::new(Function {
+                return_type: Type::Void,
+                args: vec![],
+                arg_names: vec![],
+            })),
+            visibility: PropertyVisibility::Public,
+            pure: Some(false),
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(SmolStr::new_static("back"), RefCell::new(back_body.into()));
+
+    e.property_declarations.insert(
+        SmolStr::new_static("can-go-back"),
+        PropertyDeclaration {
+            property_type: Type::Bool,
+            visibility: PropertyVisibility::Output,
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
+}

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -140,6 +140,60 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
 
     let can_go_back = non_empty();
 
+    // Int-index adapter for chrome that speaks `current_index: int` /
+    // `index_changed(int)` rather than the route enum. Each route case's
+    // resolved model is `route_ref == Route.X`, so its rhs is that route's enum
+    // value; collected in declaration order these map ordinal <-> route.
+    let route_values: Vec<Expression> = elem
+        .borrow()
+        .navigator_routes
+        .iter()
+        .filter_map(|r| {
+            match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
+                Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
+                _ => None,
+            }
+        })
+        .collect();
+
+    // current-route-index: ordinal of the current route, else -1. Lowered as an
+    // if-chain `current == route0 ? 0 : current == route1 ? 1 : ... : -1`.
+    let current_route_index = route_values.iter().enumerate().rev().fold(
+        Expression::NumberLiteral(-1., Unit::None),
+        |otherwise, (i, route_value)| Expression::Condition {
+            condition: Box::new(Expression::BinaryExpression {
+                lhs: Box::new(route_ref.clone()),
+                rhs: Box::new(route_value.clone()),
+                op: '=',
+            }),
+            true_expr: Box::new(Expression::NumberLiteral(i as f64, Unit::None)),
+            false_expr: Box::new(otherwise),
+        },
+    );
+
+    // navigate-index(index): navigate to the route at that ordinal using the same
+    // push-then-set logic as navigate(); an out-of-range index is a no-op.
+    let index_param = || Expression::FunctionParameterReference { index: 0, ty: Type::Int32 };
+    let navigate_index_body = route_values.iter().enumerate().rev().fold(
+        Expression::CodeBlock(vec![]),
+        |otherwise, (i, route_value)| Expression::Condition {
+            condition: Box::new(Expression::BinaryExpression {
+                lhs: Box::new(index_param()),
+                rhs: Box::new(Expression::NumberLiteral(i as f64, Unit::None)),
+                op: '=',
+            }),
+            true_expr: Box::new(Expression::CodeBlock(vec![
+                Expression::FunctionCall {
+                    function: Callable::Builtin(BuiltinFunction::ArrayPush),
+                    arguments: vec![back_stack(), route_ref.clone()],
+                    source_location: None,
+                },
+                assign_route(route_value.clone()),
+            ])),
+            false_expr: Box::new(otherwise),
+        },
+    );
+
     let mut e = elem.borrow_mut();
     e.property_declarations.insert(
         SmolStr::new_static("navigate"),
@@ -185,4 +239,35 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         },
     );
     e.bindings.insert(SmolStr::new_static("can-go-back"), RefCell::new(can_go_back.into()));
+
+    e.property_declarations.insert(
+        SmolStr::new_static("current-route-index"),
+        PropertyDeclaration {
+            property_type: Type::Int32,
+            visibility: PropertyVisibility::Output,
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings.insert(
+        SmolStr::new_static("current-route-index"),
+        RefCell::new(current_route_index.into()),
+    );
+
+    e.property_declarations.insert(
+        SmolStr::new_static("navigate-index"),
+        PropertyDeclaration {
+            property_type: Type::Function(Rc::new(Function {
+                return_type: Type::Void,
+                args: vec![Type::Int32],
+                arg_names: vec![SmolStr::new_static("index")],
+            })),
+            visibility: PropertyVisibility::Public,
+            pure: Some(false),
+            expose_in_public_api: true,
+            ..Default::default()
+        },
+    );
+    e.bindings
+        .insert(SmolStr::new_static("navigate-index"), RefCell::new(navigate_index_body.into()));
 }

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -84,9 +84,7 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
     // whose push/remove are silently no-ops.
     elem.borrow_mut().bindings.insert(
         SmolStr::new_static(BACK_STACK),
-        RefCell::new(
-            Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into(),
-        ),
+        RefCell::new(Expression::Array { element_ty: route_ty.clone(), values: vec![] }.into()),
     );
 
     let back_stack = || Expression::PropertyReference(NamedReference::new(elem, BACK_STACK.into()));
@@ -151,11 +149,9 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         .borrow()
         .navigator_routes
         .iter()
-        .filter_map(|r| {
-            match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
-                Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
-                _ => None,
-            }
+        .filter_map(|r| match r.component.borrow().repeated.as_ref().map(|rep| rep.model.clone()) {
+            Some(Expression::BinaryExpression { rhs, .. }) => Some(*rhs),
+            _ => None,
         })
         .collect();
 

--- a/internal/compiler/passes/lower_navigator.rs
+++ b/internal/compiler/passes/lower_navigator.rs
@@ -40,14 +40,17 @@ fn lower_one(elem: &ElementRc, diag: &mut BuildDiagnostics) {
         return;
     }
 
-    if !matches!(route_ref, Expression::PropertyReference(_)) {
+    let Expression::PropertyReference(route_nr) = &route_ref else {
         diag.push_error(
             "the navigator route must be a writable property to support navigate() and back()"
                 .into(),
             &*elem.borrow(),
         );
         return;
-    }
+    };
+    // navigate()/back() assign the route, so mark it set. Otherwise a mounted
+    // module (where the route is internal) classifies it constant and panics.
+    route_nr.mark_as_set();
 
     elem.borrow_mut().property_declarations.insert(
         SmolStr::new_static(BACK_STACK),

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -47,6 +47,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 property_declarations: std::mem::take(&mut original_elem.property_declarations),
                 named_references: Default::default(),
                 repeated: None,
+                navigator_routes: Default::default(),
                 is_component_placeholder: false,
                 debug: original_elem.debug.clone(),
                 enclosing_component: Default::default(),

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -48,6 +48,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 named_references: Default::default(),
                 repeated: None,
                 navigator_routes: Default::default(),
+                needed_capabilities: Default::default(),
                 is_component_placeholder: false,
                 debug: original_elem.debug.clone(),
                 enclosing_component: Default::default(),

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -43,6 +43,7 @@ pub fn ensure_window(
         base_type: std::mem::replace(&mut win_elem_mut.base_type, window_type),
         bindings: Default::default(),
         change_callbacks: Default::default(),
+        needed_capabilities: Default::default(),
         is_component_placeholder: false,
         property_analysis: Default::default(),
         children: std::mem::take(&mut win_elem_mut.children),

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -50,6 +50,7 @@ pub fn ensure_window(
         property_declarations: Default::default(),
         named_references: Default::default(),
         repeated: Default::default(),
+        navigator_routes: Default::default(),
         states: Default::default(),
         transitions: Default::default(),
         child_of_layout: false,

--- a/internal/compiler/tests/syntax/navigation/assignment.slint
+++ b/internal/compiler/tests/syntax/navigation/assignment.slint
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigation edge is an assignment to current-route inside a callback.
+// Several assignment forms are exercised here and all compile cleanly.
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+export component App {
+    in-out property <Route> current-route: Route.Home;
+
+    // Assignment triggered by an element callback.
+    TouchArea {
+        clicked => { root.current-route = Route.Details; }
+    }
+
+    // Assignment inside a declared callback handler.
+    callback open-settings();
+    open-settings => { current-route = Route.Settings; }
+
+    // Assignment inside a function.
+    function go-home() {
+        current-route = Route.Home;
+    }
+}

--- a/internal/compiler/tests/syntax/navigation/basic.slint
+++ b/internal/compiler/tests/syntax/navigation/basic.slint
@@ -1,0 +1,40 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigation convention: enum Route + current-route + conditional
+// children + assignment. This shape is expected to compile cleanly.
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle {
+    callback show-details();
+    TouchArea { clicked => { root.show-details(); } }
+}
+
+component DetailsScreen inherits Rectangle {
+    callback back();
+    TouchArea { clicked => { root.back(); } }
+}
+
+component SettingsScreen inherits Rectangle {
+    callback back();
+    TouchArea { clicked => { root.back(); } }
+}
+
+export component App {
+    in-out property <Route> current-route: Route.Home;
+
+    if current-route == Route.Home : HomeScreen {
+        show-details => { root.current-route = Route.Details; }
+    }
+    if current-route == Route.Details : DetailsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+    if current-route == Route.Settings : SettingsScreen {
+        back => { root.current-route = Route.Home; }
+    }
+}

--- a/internal/compiler/tests/syntax/navigation/initial_route.slint
+++ b/internal/compiler/tests/syntax/navigation/initial_route.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // The current-route initializer picks the entry screen. Any enum value is a
-// valid initial route, and the conditional mapping stays the same.
+// valid initial route; the navigator maps the same set of routes either way.
 
 enum Route {
     Home,
@@ -15,15 +15,19 @@ component Screen inherits Rectangle { }
 export component StartOnDetails {
     in-out property <Route> current-route: Route.Details;
 
-    if current-route == Route.Home : Screen { }
-    if current-route == Route.Details : Screen { }
-    if current-route == Route.Settings : Screen { }
+    navigator (current-route) {
+        Route.Home: Screen { }
+        Route.Details: Screen { }
+        Route.Settings: Screen { }
+    }
 }
 
 export component StartOnSettings {
     in-out property <Route> current-route: Route.Settings;
 
-    if current-route == Route.Home : Screen { }
-    if current-route == Route.Details : Screen { }
-    if current-route == Route.Settings : Screen { }
+    navigator (current-route) {
+        Route.Home: Screen { }
+        Route.Details: Screen { }
+        Route.Settings: Screen { }
+    }
 }

--- a/internal/compiler/tests/syntax/navigation/initial_route.slint
+++ b/internal/compiler/tests/syntax/navigation/initial_route.slint
@@ -1,0 +1,29 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The current-route initializer picks the entry screen. Any enum value is a
+// valid initial route, and the conditional mapping stays the same.
+
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component Screen inherits Rectangle { }
+
+export component StartOnDetails {
+    in-out property <Route> current-route: Route.Details;
+
+    if current-route == Route.Home : Screen { }
+    if current-route == Route.Details : Screen { }
+    if current-route == Route.Settings : Screen { }
+}
+
+export component StartOnSettings {
+    in-out property <Route> current-route: Route.Settings;
+
+    if current-route == Route.Home : Screen { }
+    if current-route == Route.Details : Screen { }
+    if current-route == Route.Settings : Screen { }
+}

--- a/internal/compiler/tests/syntax/navigator/destination_resolution.slint
+++ b/internal/compiler/tests/syntax/navigator/destination_resolution.slint
@@ -1,0 +1,32 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigator destinations form a compiler-checked closed set: each route
+// must resolve to a component.
+
+enum Route {
+    Home,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle { }
+
+export component App inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        // A user-defined component is a valid destination.
+        Route.Home: HomeScreen { }
+        // An unknown name is rejected.
+        Route.Settings: DoesNotExist { }
+//                      >           <error{Unknown element 'DoesNotExist'}
+    }
+}
+
+export component App2 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        // A builtin element is not a component, so it is rejected.
+        Route.Home: Rectangle { }
+//                  >           <error{navigator route destination must be a component, but 'Rectangle' is not}
+    }
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1587,6 +1587,13 @@ impl TypeLoader {
         is_builtin: bool,
         import_stack: &HashSet<PathBuf>,
     ) -> (PathBuf, Document) {
+        // Mirror lib.rs `prepare_for_compile`: the main compile path sets this on the
+        // diagnostics up front, but LSP/live-editor loads reach the type loader with a
+        // fresh BuildDiagnostics that never got the flag. This is the single funnel every
+        // load entry point flows through, so propagate the config here.
+        let enable_experimental = state.borrow().tl.compiler_config.enable_experimental;
+        state.borrow_mut().diag.enable_experimental = enable_experimental;
+
         let dependency_registry =
             Rc::new(RefCell::new(TypeRegister::new(&state.borrow().tl.global_type_registry)));
         dependency_registry.borrow_mut().expose_internal_types =
@@ -1983,6 +1990,59 @@ fn test_dependency_loading() {
     for file in imported_files {
         assert!(loader.get_document(&file).is_none(), "{} is still loaded", file.display());
     }
+}
+
+// The experimental `navigator` compiles through the normal type-loader load
+// path only when the config enables experimental, and is rejected otherwise.
+// Guards the LSP/live-editor load path, which reaches the loader with a fresh
+// BuildDiagnostics that never got the flag from the config.
+#[test]
+fn test_load_navigator_experimental_from_config() {
+    let source = r#"
+enum Route { A, B }
+component A inherits Rectangle { }
+component B inherits Rectangle { }
+export component App inherits Window {
+    in-out property <Route> current-route: Route.A;
+    navigator (current-route) {
+        Route.A: A { }
+        Route.B: B { }
+    }
+}
+"#;
+
+    let load = |enable_experimental: bool| {
+        let mut compiler_config =
+            CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+        compiler_config.style = Some("fluent".into());
+        compiler_config.enable_experimental = enable_experimental;
+
+        let mut build_diagnostics = BuildDiagnostics::default();
+        let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+        assert!(!build_diagnostics.has_errors());
+
+        // The caller-provided diagnostics start without the flag, exactly like
+        // the LSP load path; the loader must derive it from the config.
+        let mut diag = BuildDiagnostics::default();
+        assert!(!diag.enable_experimental);
+        let path = PathBuf::from("/foo/nav.slint");
+        spin_on::spin_on(loader.load_file(&path, &path, source.into(), false, &mut diag));
+        diag
+    };
+
+    let diag = load(true);
+    assert!(diag.enable_experimental, "the config flag must reach the diagnostics");
+    assert!(
+        !diag.iter().any(|d| d.message().contains("experimental")),
+        "navigator rejected with experimental enabled: {:?}",
+        diag.iter().map(|d| d.message().to_string()).collect::<Vec<_>>()
+    );
+
+    let diag = load(false);
+    assert!(
+        diag.iter().any(|d| d.message().contains("navigator is an experimental feature")),
+        "navigator should be rejected when experimental is disabled"
+    );
 }
 
 #[test]

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -391,6 +391,7 @@ impl Snapshotter {
                 root_constraints,
                 root_element,
                 from_library: core::cell::Cell::new(false),
+                navigation_contract: RefCell::new(component.navigation_contract.borrow().clone()),
             }
         });
         self.keep_alive.push((component.clone(), result.clone()));
@@ -2042,6 +2043,746 @@ export component App inherits Window {
     assert!(
         diag.iter().any(|d| d.message().contains("navigator is an experimental feature")),
         "navigator should be rejected when experimental is disabled"
+    );
+}
+
+/// Load `source` under the given experimental flag and return the loaded
+/// document alongside its diagnostics, mirroring the LSP load path.
+#[cfg(test)]
+fn load_source_for_contract_test(
+    source: &str,
+    enable_experimental: bool,
+) -> (TypeLoader, PathBuf, BuildDiagnostics) {
+    let mut compiler_config =
+        CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.enable_experimental = enable_experimental;
+    let mut build_diagnostics = BuildDiagnostics::default();
+    let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+    let mut diag = BuildDiagnostics::default();
+    let path = PathBuf::from("/foo/contract.slint");
+    spin_on::spin_on(loader.load_file(&path, &path, source.into(), false, &mut diag));
+    (loader, path, diag)
+}
+
+#[test]
+fn test_navigation_contract_populated() {
+    // Interface `route` members become a NavigationContract with typed params.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "contract rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let interface = doc
+        .inner_components
+        .iter()
+        .find(|c| c.id == "AppNavV1")
+        .expect("interface component missing");
+    let contract = interface.navigation_contract().expect("navigation contract not populated");
+    assert_eq!(contract.routes.len(), 2);
+    assert_eq!(contract.routes[0].name, "Home");
+    assert!(contract.routes[0].params.is_empty());
+    assert_eq!(contract.routes[1].name, "Details");
+    assert_eq!(contract.routes[1].params.len(), 1);
+    assert_eq!(contract.routes[1].params[0].0, "id");
+    assert_eq!(contract.routes[1].params[0].1.to_string(), "int");
+}
+
+#[test]
+fn test_navigation_contract_attributes() {
+    // `@version(n)` and per-route `@uri("...")` are parsed into contract metadata.
+    let source = r#"
+export interface AppNavV1 {
+    @version(2)
+    @uri("app://home") route Home;
+    @uri("app://details/{id}") route Details(id: int);
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "contract with attributes rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let interface = doc
+        .inner_components
+        .iter()
+        .find(|c| c.id == "AppNavV1")
+        .expect("interface component missing");
+    let contract = interface.navigation_contract().expect("navigation contract not populated");
+    assert_eq!(contract.version, Some(2));
+    assert_eq!(contract.routes.len(), 2);
+    assert_eq!(contract.routes[0].name, "Home");
+    assert_eq!(contract.routes[0].uri.as_deref(), Some("app://home"));
+    assert_eq!(contract.routes[1].name, "Details");
+    assert_eq!(contract.routes[1].uri.as_deref(), Some("app://details/{id}"));
+}
+
+#[test]
+fn test_navigation_contract_default_version() {
+    // Absent `@version` means no explicit version (the documented default is 1).
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "contract rejected: {:?}", diag.to_string_vec());
+    let doc = loader.get_document(&path).unwrap();
+    let interface =
+        doc.inner_components.iter().find(|c| c.id == "AppNavV1").expect("interface missing");
+    let contract = interface.navigation_contract().expect("contract not populated");
+    assert_eq!(contract.version, None);
+}
+
+#[test]
+fn test_navigation_contract_version_non_integer_rejected() {
+    let source = r#"
+export interface AppNavV1 {
+    @version("x")
+    route Home;
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("@version expects an integer literal")),
+        "non-integer @version should be rejected: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_route_outside_interface_rejected() {
+    let source = r#"
+export component App inherits Rectangle {
+    route Home;
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("only allowed inside an 'interface'")),
+        "route outside an interface should be rejected: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_navigation_contract_requires_experimental() {
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, false);
+    assert!(diag.has_errors(), "contract must be rejected without experimental");
+    assert!(
+        diag.iter().any(|d| d.message().contains("experimental")),
+        "expected an experimental-feature diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+    if let Some(doc) = loader.get_document(&path) {
+        assert!(
+            doc.inner_components.iter().all(|c| c.navigation_contract().is_none()),
+            "no contract should be collected without experimental"
+        );
+    }
+}
+
+#[test]
+fn test_navigation_contract_cross_file_import() {
+    // Real files on disk so the importer resolves the relative import.
+    let dir = std::env::temp_dir().join(format!("slint_nav_contract_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let nav_path = dir.join("nav.slint");
+    let main_path = dir.join("main.slint");
+    std::fs::write(
+        &nav_path,
+        r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+"#,
+    )
+    .unwrap();
+    let main_source = r#"
+import { AppNavV1 } from "nav.slint";
+export component App inherits Rectangle { }
+"#;
+    std::fs::write(&main_path, main_source).unwrap();
+
+    let mut compiler_config =
+        CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.enable_experimental = true;
+
+    let mut build_diagnostics = BuildDiagnostics::default();
+    let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+    assert!(!build_diagnostics.has_errors());
+
+    let mut diag = BuildDiagnostics::default();
+    spin_on::spin_on(loader.load_file(
+        &main_path,
+        &main_path,
+        main_source.into(),
+        false,
+        &mut diag,
+    ));
+
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(!diag.has_errors(), "cross-file interface import failed: {:?}", diag.to_string_vec());
+
+    let nav_doc = loader.get_document(&nav_path).expect("exporting document not loaded");
+    let interface = nav_doc
+        .inner_components
+        .iter()
+        .find(|c| c.id == "AppNavV1")
+        .expect("imported interface missing");
+    let contract = interface.navigation_contract().expect("contract missing after import");
+    assert_eq!(contract.routes.len(), 2);
+    assert_eq!(contract.routes[0].name, "Home");
+    assert_eq!(contract.routes[1].name, "Details");
+}
+
+#[test]
+fn test_navigation_contract_conformance_ok() {
+    // Navigator covers every contract route by name (params aren't checked yet).
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+enum Route { Home, Details }
+component HomeScreen inherits Rectangle { }
+component DetailsScreen inherits Rectangle { }
+export component App implements AppNavV1 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "conformant component rejected: {:?}", diag.to_string_vec());
+}
+
+#[test]
+fn test_navigation_contract_conformance_missing_route() {
+    // The navigator omits `Route.Details`, so it does not cover the contract.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details(id: int);
+}
+enum Route { Home, Details }
+component HomeScreen inherits Rectangle { }
+export component App implements AppNavV1 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("its navigator has no route for 'Details'")),
+        "missing route should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_navigation_contract_conformance_no_navigator() {
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+export component App implements AppNavV1 inherits Window { }
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("declares no navigator")),
+        "missing navigator should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_navigation_contract_conformance_extra_routes_allowed() {
+    // A navigator route outside the contract is allowed.
+    let source = r#"
+export interface AppNavV1 {
+    route Home;
+}
+enum Route { Home, Debug }
+component HomeScreen inherits Rectangle { }
+component DebugScreen inherits Rectangle { }
+export component App implements AppNavV1 inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Debug: DebugScreen { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "extra navigator route rejected: {:?}", diag.to_string_vec());
+}
+
+// Shared same-file integrator: `Shell` mounts `ModuleA` (covers `AppNavV1`).
+#[cfg(test)]
+const MOUNT_TEST_SOURCE: &str = r#"
+interface AppNavV1 {
+    route Home;
+    route Details;
+}
+enum ModuleRoute { Home, Details }
+component ModHome inherits Rectangle { }
+component ModDetails inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+        ModuleRoute.Details: ModDetails { }
+    }
+}
+enum ShellRoute { Home, ModuleA }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+
+#[test]
+fn test_federated_mount_resolves_and_records_edge() {
+    // A conforming mount desugars to a direct module instantiation and records an edge.
+    let (loader, path, diag) = load_source_for_contract_test(MOUNT_TEST_SOURCE, true);
+    assert!(!diag.has_errors(), "conforming mount rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let routes = root.navigator_routes();
+    assert_eq!(routes.len(), 2);
+
+    let home = routes.iter().find(|r| r.route.text().to_string().contains("Home")).unwrap();
+    assert!(home.mount.is_none());
+
+    let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    let edge = mounted.mount.as_ref().unwrap();
+    assert!(!edge.is_external(), "a local mount is not external");
+    assert_eq!(edge.impl_name.as_deref(), Some("ModuleA"));
+    assert_eq!(edge.contract_name, "AppNavV1");
+    assert_eq!(
+        mounted.component.borrow().base_type.to_string(),
+        "ModuleA",
+        "mount must desugar to a direct instantiation of the module"
+    );
+}
+
+#[test]
+fn test_federated_mount_non_conforming_rejected() {
+    // ModuleA's navigator omits `Details`, so it does not satisfy `AppNavV1`.
+    let source = r#"
+interface AppNavV1 {
+    route Home;
+    route Details;
+}
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+component ModuleA inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+enum ShellRoute { Home }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d
+            .message()
+            .contains("mount of 'ModuleA' does not satisfy contract 'AppNavV1'")),
+        "non-conforming mount should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_federated_mount_non_contract_rejected() {
+    // `Plain` is an interface with no routes, so it is not a mount boundary.
+    let source = r#"
+interface Plain {
+    in property <int> value;
+}
+component ModuleA inherits Rectangle { }
+enum ShellRoute { Home }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: mount ModuleA via Plain { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains("'Plain' is not a navigation contract")),
+        "non-contract mount should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+// The contract shared by the cross-file mount tests.
+#[cfg(test)]
+const XFILE_CONTRACT_SOURCE: &str = r#"
+export interface AppNavV1 {
+    route Home;
+    route Details;
+}
+"#;
+
+// Contract, module, and integrator each in their own file, wired by relative
+// imports, loaded like the LSP would. `tag` keeps concurrent tests in distinct dirs.
+#[cfg(test)]
+fn load_cross_file_mount_test(
+    tag: &str,
+    module_a_source: &str,
+) -> (TypeLoader, PathBuf, BuildDiagnostics) {
+    let dir = std::env::temp_dir().join(format!("slint_nav_xmount_{}_{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("contract.slint"), XFILE_CONTRACT_SOURCE).unwrap();
+    std::fs::write(dir.join("module-a.slint"), module_a_source).unwrap();
+
+    let main_path = dir.join("main.slint");
+    let main_source = r#"
+import { ModuleA } from "module-a.slint";
+import { AppNavV1 } from "contract.slint";
+enum ShellRoute { Home, ModuleA }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+    std::fs::write(&main_path, main_source).unwrap();
+
+    let mut compiler_config =
+        CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.enable_experimental = true;
+
+    let mut build_diagnostics = BuildDiagnostics::default();
+    let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+    assert!(!build_diagnostics.has_errors());
+
+    let mut diag = BuildDiagnostics::default();
+    spin_on::spin_on(loader.load_file(
+        &main_path,
+        &main_path,
+        main_source.into(),
+        false,
+        &mut diag,
+    ));
+
+    let _ = std::fs::remove_dir_all(&dir);
+    (loader, main_path, diag)
+}
+
+#[test]
+fn test_federated_mount_cross_file_resolves_and_records_edge() {
+    // The imported `ModuleA` is built in its own document, so its routes are
+    // populated before the integrator's mount verification runs.
+    let module_a_source = r#"
+import { AppNavV1 } from "contract.slint";
+enum ModuleRoute { Home, Details }
+component ModHome inherits Rectangle { }
+component ModDetails inherits Rectangle { }
+export component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+        ModuleRoute.Details: ModDetails { }
+    }
+}
+"#;
+    let (loader, path, diag) = load_cross_file_mount_test("ok", module_a_source);
+    assert!(!diag.has_errors(), "cross-file conforming mount rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let routes = root.navigator_routes();
+    assert_eq!(routes.len(), 2);
+
+    let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    let edge = mounted.mount.as_ref().unwrap();
+    assert_eq!(edge.impl_name.as_deref(), Some("ModuleA"));
+    assert_eq!(edge.contract_name, "AppNavV1");
+    assert_eq!(
+        mounted.component.borrow().base_type.to_string(),
+        "ModuleA",
+        "cross-file mount must desugar to a direct instantiation of the imported module"
+    );
+}
+
+#[test]
+fn test_federated_mount_cross_file_non_conforming_rejected() {
+    // `ModuleA` omits `Details` and does not `implements` the contract, so the
+    // conformance error must originate at the integrator's cross-file mount site.
+    let module_a_source = r#"
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+export component ModuleA inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_cross_file_mount_test("bad", module_a_source);
+    assert!(
+        diag.iter().any(|d| d
+            .message()
+            .contains("mount of 'ModuleA' does not satisfy contract 'AppNavV1'")),
+        "cross-file non-conforming mount should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_needs_declares_capability_members() {
+    // `needs <Interface>` declares the interface's callbacks as unbound members
+    // on the component and records them for the mount verifier.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+}
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+export component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    TouchArea { clicked => { root.open-settings(); } }
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "needs declaration rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let module = doc.inner_components.iter().find(|c| c.id == "ModuleA").expect("ModuleA missing");
+    let root = module.root_element.borrow();
+    assert!(root.property_declarations.contains_key("open-settings"));
+    assert!(root.property_declarations.contains_key("play-media"));
+
+    let caps = module.needed_capabilities();
+    assert_eq!(caps.len(), 1);
+    assert_eq!(caps[0].interface_name, "AppServices");
+    assert!(caps[0].members.contains(&"open-settings".into()));
+    assert!(caps[0].members.contains(&"play-media".into()));
+}
+
+#[test]
+fn test_needs_requires_experimental() {
+    // `needs` is experimental-gated exactly like `uses`.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+}
+export component ModuleA inherits Rectangle {
+    needs AppServices;
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, false);
+    assert!(
+        diag.iter().any(|d| d.message().contains("'needs' is an experimental feature")),
+        "needs should be rejected without the experimental flag: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+#[test]
+fn test_mount_binds_needed_capabilities() {
+    // A mount block that binds every needed capability compiles and records the edge.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+    route Details;
+}
+enum ModuleRoute { Home, Details }
+component ModHome inherits Rectangle { }
+component ModDetails inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+        ModuleRoute.Details: ModDetails { }
+    }
+}
+enum ShellRoute { Home, ModuleA }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 {
+            open-settings => { }
+            play-media(url) => { }
+        }
+    }
+}
+"#;
+    let (loader, path, diag) = load_source_for_contract_test(source, true);
+    assert!(!diag.has_errors(), "mount binding all needs rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let mounted =
+        root.navigator_routes().iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    assert_eq!(mounted.mount.as_ref().unwrap().impl_name.as_deref(), Some("ModuleA"));
+    // Mount-block handlers land as bindings on the module instantiation.
+    let dest = mounted.component.borrow();
+    assert!(dest.bindings.contains_key("open-settings"));
+    assert!(dest.bindings.contains_key("play-media"));
+}
+
+#[test]
+fn test_mount_unbound_need_rejected() {
+    // The mount omits `open-settings`, leaving a required capability unbound.
+    let source = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+}
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+enum ShellRoute { Home }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: mount ModuleA via AppNavV1 {
+            play-media(url) => { }
+        }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d.message().contains(
+            "mount of 'ModuleA' does not bind required capability 'open-settings' (from 'AppServices')"
+        )),
+        "unbound need should be a diagnostic: {:?}",
+        diag.to_string_vec()
+    );
+}
+
+// An external mount: `ModuleB` is not in this build; the shell declares the
+// boundary against `AppNavV1` and supplies a ComponentFactory set at runtime.
+#[cfg(test)]
+const EXTERNAL_MOUNT_TEST_SOURCE: &str = r#"
+interface AppNavV1 {
+    route Home;
+}
+enum ShellRoute { Home, ModuleB }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in property <component-factory> module-b-factory;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleB: mount extern via AppNavV1 {
+            component-factory: root.module-b-factory;
+        }
+    }
+}
+"#;
+
+#[test]
+fn test_external_mount_records_external_edge() {
+    // A conforming external mount desugars to a ComponentContainer and records an
+    // external edge (no impl name, the declared contract).
+    let (loader, path, diag) = load_source_for_contract_test(EXTERNAL_MOUNT_TEST_SOURCE, true);
+    assert!(!diag.has_errors(), "external mount rejected: {:?}", diag.to_string_vec());
+
+    let doc = loader.get_document(&path).unwrap();
+    let shell = doc.inner_components.iter().find(|c| c.id == "Shell").expect("Shell missing");
+    let root = shell.root_element.borrow();
+    let routes = root.navigator_routes();
+    assert_eq!(routes.len(), 2);
+
+    let mounted = routes.iter().find(|r| r.mount.is_some()).expect("no mount edge recorded");
+    let edge = mounted.mount.as_ref().unwrap();
+    assert!(edge.is_external(), "the edge must be external");
+    assert_eq!(edge.impl_name, None, "an external mount has no compile-time impl");
+    assert_eq!(edge.contract_name, "AppNavV1");
+    let dest = mounted.component.borrow();
+    assert_eq!(dest.base_type.to_string(), "ComponentContainer");
+    assert!(dest.bindings.contains_key("component-factory"));
+}
+
+#[test]
+fn test_external_mount_missing_factory_rejected() {
+    // An external mount with no component-factory has no runtime transport: a compile error.
+    let source = r#"
+interface AppNavV1 {
+    route Home;
+}
+enum ShellRoute { Home, ModuleB }
+component HomeScreen inherits Rectangle { }
+export component Shell inherits Window {
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleB: mount extern via AppNavV1 { }
+    }
+}
+"#;
+    let (_loader, _path, diag) = load_source_for_contract_test(source, true);
+    assert!(
+        diag.iter().any(|d| d
+            .message()
+            .contains("external mount via 'AppNavV1' requires a 'component-factory'")),
+        "missing factory should be a diagnostic: {:?}",
+        diag.to_string_vec()
     );
 }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -6,7 +6,6 @@ use crate::dynamic_item_tree::{ErasedItemTreeBox, WindowOptions};
 use i_slint_compiler::langtype::Type as LangType;
 use i_slint_core::PathData;
 use i_slint_core::component_factory::ComponentFactory;
-#[cfg(feature = "internal")]
 use i_slint_core::component_factory::FactoryContext;
 use i_slint_core::graphics::euclid::approxeq::ApproxEq as _;
 use i_slint_core::items::*;
@@ -1134,9 +1133,10 @@ impl ComponentDefinition {
         Ok(instance)
     }
 
-    /// Creates a new instance of the component and returns a shared handle to it.
-    #[doc(hidden)]
-    #[cfg(feature = "internal")]
+    /// Instantiate the component for embedding, for use inside a `slint::ComponentFactory::new`
+    /// closure. `ctx` is the `FactoryContext` the closure receives. This fills a
+    /// `ComponentContainer` with a dynamically-loaded component, including a navigator's
+    /// `mount extern via` route.
     pub fn create_embedded(&self, ctx: FactoryContext) -> Result<ComponentInstance, PlatformError> {
         self.create_with_options(WindowOptions::Embed {
             parent_item_tree: ctx.parent_item_tree,

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -444,3 +444,79 @@ export component TestCase inherits Window {
     assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "no-op at root");
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "still root");
 }
+
+// The int-index adapter: `current-route-index` reports the ordinal of the
+// current route in declaration order, and `navigate-index(i)` navigates to the
+// route at that ordinal. This is what int-index chrome (current_index /
+// index_changed) binds to, so it must agree with the route enum both ways.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_index_adapter() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let index = |instance: &crate::ComponentInstance| {
+        i_slint_backend_testing::mock_elapsed_time(100);
+        instance.get_property("current-route-index").unwrap()
+    };
+
+    // Setting the route enum drives current-route-index to the declared ordinal.
+    assert_eq!(index(&instance), Value::from(0.), "Home is ordinal 0");
+    instance.set_property("current-route", route("Details")).unwrap();
+    assert_eq!(index(&instance), Value::from(1.), "Details is ordinal 1");
+    instance.set_property("current-route", route("Settings")).unwrap();
+    assert_eq!(index(&instance), Value::from(2.), "Settings is ordinal 2");
+
+    // navigate-index(i) drives the route enum the other way (and the index with it).
+    instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "navigate-index(2) selects Settings"
+    );
+    assert_eq!(index(&instance), Value::from(2.));
+
+    instance.invoke("navigate-index", &[Value::from(0.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "navigate-index(0) selects Home"
+    );
+    assert_eq!(index(&instance), Value::from(0.));
+
+    // Out-of-range is a no-op: the route (and index) stay put.
+    instance.invoke("navigate-index", &[Value::from(9.)]).unwrap();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "out-of-range navigate-index is a no-op"
+    );
+    assert_eq!(index(&instance), Value::from(0.));
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -370,3 +370,77 @@ export component TestCase inherits Window {
         result.diagnostics().map(|d| d.message().to_owned()).collect::<Vec<_>>()
     );
 }
+
+// The back-stack: `navigate(route)` pushes the current route before switching,
+// `back()` restores the previous route (no-op at the root), and `can-go-back`
+// reflects whether the stack is non-empty. The `active` global still tells us
+// which screen is instantiated, so we assert on the rendered route.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_back_stack() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let rendered = |instance: &crate::ComponentInstance| {
+        i_slint_backend_testing::mock_elapsed_time(100);
+        instance.get_property("active").unwrap()
+    };
+
+    // Root: nothing to go back to.
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("home")));
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "root");
+
+    // navigate(Home -> Details -> Settings): the stack fills up.
+    instance.invoke("navigate", &[route("Details")]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("details")));
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Details");
+
+    instance.invoke("navigate", &[route("Settings")]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("settings")));
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Settings");
+
+    // back() twice unwinds Settings -> Details -> Home.
+    instance.invoke("back", &[]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("details")), "back to Details");
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "one left");
+
+    instance.invoke("back", &[]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "back to Home");
+    assert_eq!(
+        instance.get_property("can-go-back").unwrap(),
+        Value::from(false),
+        "back at the root"
+    );
+
+    // back() at the root is a no-op.
+    instance.invoke("back", &[]).unwrap();
+    assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "no-op at root");
+    assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "still root");
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -279,3 +279,94 @@ export component TestCase {
     instance.invoke("close-a", &[]).unwrap();
     assert_eq!(instance.get_property("a-open").unwrap(), Value::from(false), "a after close");
 }
+
+// The milestone test: a `navigator` renders the destination component for the
+// current route, and re-renders when the route changes. Each destination
+// records its name in a global on `init`, so the observed value tells us which
+// route's screen is currently instantiated. Requires `enable_experimental`,
+// which is only reachable through the `internal` compiler configuration API.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_shows_current_route() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+
+    // The initial route renders its screen.
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("home")),
+        "Route.Home renders HomeScreen"
+    );
+
+    // Switching the current route renders the other screen.
+    instance.set_property("current-route", route("Settings")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings")),
+        "Route.Settings renders SettingsScreen"
+    );
+
+    // And back to the first route.
+    instance.set_property("current-route", route("Home")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("home")),
+        "Route.Home renders HomeScreen again"
+    );
+}
+
+// Without `enable_experimental`, `navigator` is rejected at object-tree
+// lowering with the experimental-feature diagnostic. `Compiler::default()`
+// does not enable experimental features.
+#[test]
+fn navigator_requires_experimental() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::Compiler;
+    let code = r#"
+enum Route { Home }
+component HomeScreen inherits Rectangle { }
+export component TestCase inherits Window {
+    in-out property <Route> current-route: Route.Home;
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+    }
+}
+"#;
+    let compiler = Compiler::default();
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(result.has_errors(), "navigator must be rejected without experimental");
+    assert!(
+        result.diagnostics().any(|d| d.message().contains("navigator is an experimental feature")),
+        "expected the experimental-feature diagnostic, got: {:?}",
+        result.diagnostics().map(|d| d.message().to_owned()).collect::<Vec<_>>()
+    );
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -629,3 +629,141 @@ export component TestCase inherits Window {
         "the navigator renders the Settings screen"
     );
 }
+
+// The presentation-agnostic proof: an int-index chrome that mimics Material's
+// `BaseNavigation` (`items` / `current_index` / `index_changed` / `select`)
+// drives the enum-typed navigator through the int-index adapter, both ways.
+// `IntChrome` copies that contract verbatim (only `select` is public so the test
+// can trigger a "tap"; Material's is protected and fired by item clicks). The
+// two adapter members are consumed exactly as native Material wiring would:
+//   current_index  <- current-route-index   (the bar reflects the route)
+//   index_changed(i) => navigate-index(i)    (a tap navigates)
+// Nothing about the `navigator { Route... }` block is chrome-specific, so std
+// chrome (PR A8) binds the same two members with zero change to the routes.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_int_chrome_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// Mirrors Material's BaseNavigation int API (items/current_index/index_changed/select).
+component IntChrome {
+    in property <[string]> items;
+    in-out property <int> current_index;
+    callback index_changed(index: int);
+    public function select(index: int) {
+        if (index < 0 || index >= root.items.length) {
+            return;
+        }
+        root.current_index = index;
+        root.index_changed(index);
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+
+    // Adapter members are synthesized after expression resolution, so they are a
+    // native/runtime surface, not source-referenceable. The test copies
+    // current-route-index into `chrome-index` and forwards index_changed out, then
+    // binds both to the adapter through the runtime API, as native code does.
+    in property <int> chrome-index;
+    out property <int> chrome-index-out: chrome.current_index;
+    callback chrome-index-changed(index: int);
+
+    chrome := IntChrome {
+        items: ["Home", "Details", "Settings"];
+        current_index: root.chrome-index;              // display <- current-route-index
+        index_changed(i) => { root.chrome-index-changed(i); }  // tap forwarded out
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+    // Simulate an item tap (Material fires select() from a NavigationItem click).
+    public function tap(index: int) { chrome.select(index); }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // The tap binding: index_changed(i) => navigate-index(i). Wired once, exactly
+    // as native Material code binds NavigationBar.index_changed to the adapter.
+    let weak = instance.as_weak();
+    instance
+        .set_callback("chrome-index-changed", move |args| {
+            let i: i32 = args[0].clone().try_into().unwrap();
+            weak.unwrap().invoke("navigate-index", &[Value::from(i as f64)]).unwrap();
+            Value::Void
+        })
+        .unwrap();
+
+    // The display binding: current_index <- current-route-index. Pushed after each
+    // route change (native code does the same via set_bar_index).
+    let mirror = |instance: &crate::ComponentInstance| {
+        let idx = instance.get_property("current-route-index").unwrap();
+        instance.set_property("chrome-index", idx).unwrap();
+        settle();
+    };
+
+    // Display side: moving the route moves the chrome's current_index.
+    mirror(&instance);
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "Home -> 0");
+    instance.set_property("current-route", route("Details")).unwrap();
+    mirror(&instance);
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(1.), "Details -> 1");
+    instance.set_property("current-route", route("Settings")).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("chrome-index-out").unwrap(),
+        Value::from(2.),
+        "Settings -> 2"
+    );
+
+    // Tap side: chrome.select(i) fires index_changed -> navigate-index(i) -> route.
+    instance.invoke("tap", &[Value::from(0.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "bar shows 0");
+
+    instance.invoke("tap", &[Value::from(2.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "tap 2 -> Settings"
+    );
+    assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(2.), "bar shows 2");
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings"))
+    );
+
+    // Out-of-range tap is a no-op in the mimic's guard (same as BaseNavigation.select).
+    instance.invoke("tap", &[Value::from(9.)]).unwrap();
+    mirror(&instance);
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "out-of-range tap is a no-op"
+    );
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -338,6 +338,296 @@ export component TestCase inherits Window {
     );
 }
 
+// A `mount Impl via Contract` route renders the mounted module directly (no
+// ComponentContainer indirection), observed via a global the module's screen writes.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_mount_renders_module() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+interface AppNavV1 {
+    route Home;
+}
+global NavProbe { in-out property <string> active; }
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { init => { NavProbe.active = "module-home"; } }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "shell-home"; } }
+enum ShellRoute { Home, ModuleA }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("ShellRoute".into(), v.into());
+
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("shell-home")),
+        "ShellRoute.Home renders HomeScreen"
+    );
+
+    instance.set_property("current", route("ModuleA")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("module-home")),
+        "ShellRoute.ModuleA mounts and renders ModuleA"
+    );
+}
+
+// A mounted module that `needs` a capability invokes it from its own init; the
+// shell's binding at the mount site runs, proving end-to-end capability wiring.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_mount_binds_capability_end_to_end() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+interface AppServices {
+    callback open-settings();
+    callback play-media(string);
+}
+interface AppNavV1 {
+    route Home;
+}
+global CapProbe { in-out property <string> played; }
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { }
+component ModuleA implements AppNavV1 inherits Rectangle {
+    needs AppServices;
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    // The module invokes a capability it does not implement itself.
+    init => { root.play-media("song.mp3"); }
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+component HomeScreen inherits Rectangle { }
+enum ShellRoute { Home, ModuleA }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    out property <string> played: CapProbe.played;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 {
+            open-settings => { }
+            play-media(url) => { CapProbe.played = url; }
+        }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("played").unwrap(),
+        Value::from(SharedString::from("")),
+        "capability not invoked before the module is mounted"
+    );
+
+    instance
+        .set_property("current", Value::EnumerationValue("ShellRoute".into(), "ModuleA".into()))
+        .unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("played").unwrap(),
+        Value::from(SharedString::from("song.mp3")),
+        "the module's capability call runs the integrator's bound expression"
+    );
+}
+
+// Cross-file counterpart of `navigator_mount_renders_module`: contract and module
+// in their own files. Uses real files so imports resolve; skipped on wasm.
+#[cfg(all(feature = "internal", not(target_arch = "wasm32")))]
+#[test]
+fn navigator_mount_cross_file_renders_module() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+
+    let dir = std::env::temp_dir().join(format!("slint_nav_xmount_interp_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("contract.slint"),
+        r#"
+export interface AppNavV1 {
+    route Home;
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("module-a.slint"),
+        r#"
+import { AppNavV1 } from "contract.slint";
+export global NavProbe { in-out property <string> active; }
+enum ModuleRoute { Home }
+component ModHome inherits Rectangle { init => { NavProbe.active = "module-home"; } }
+export component ModuleA implements AppNavV1 inherits Rectangle {
+    in-out property <ModuleRoute> current-route: ModuleRoute.Home;
+    navigator (current-route) {
+        ModuleRoute.Home: ModHome { }
+    }
+}
+"#,
+    )
+    .unwrap();
+    let main_path = dir.join("main.slint");
+    let code = r#"
+import { ModuleA } from "module-a.slint";
+import { AppNavV1 } from "contract.slint";
+import { NavProbe } from "module-a.slint";
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "shell-home"; } }
+enum ShellRoute { Home, ModuleA }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    out property <string> active: NavProbe.active;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleA: mount ModuleA via AppNavV1 { }
+    }
+}
+"#;
+
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), main_path));
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("ShellRoute".into(), v.into());
+
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("shell-home")),
+        "ShellRoute.Home renders HomeScreen"
+    );
+
+    instance.set_property("current", route("ModuleA")).unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("module-home")),
+        "ShellRoute.ModuleA mounts and renders the imported ModuleA"
+    );
+}
+
+// An external mount: `ModuleB` is separately compiled and delivered through a
+// host-supplied `component-factory`. Since the two compilations share no global,
+// the seam is observed directly: the factory is invoked only once the external
+// route is active.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_external_mount_invokes_host_factory() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, Value};
+    use i_slint_core::component_factory::ComponentFactory;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    // The host module: its own compilation, opaque to the shell at build time.
+    let host_code = r#"
+export component ModuleB inherits Rectangle { background: red; }
+"#;
+    let mut host_compiler = Compiler::default();
+    host_compiler.set_style("fluent".into());
+    let host_result =
+        spin_on::spin_on(host_compiler.build_from_source(host_code.into(), Default::default()));
+    assert!(!host_result.has_errors(), "{:?}", host_result.diagnostics().collect::<Vec<_>>());
+    let host_def = host_result.component("ModuleB").unwrap();
+
+    let code = r#"
+interface AppNavV1 {
+    route Home;
+}
+component HomeScreen inherits Rectangle { }
+enum ShellRoute { Home, ModuleB }
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in property <component-factory> module-b-factory;
+    in-out property <ShellRoute> current: ShellRoute.Home;
+    navigator (current) {
+        ShellRoute.Home: HomeScreen { }
+        ShellRoute.ModuleB: mount extern via AppNavV1 {
+            component-factory: root.module-b-factory;
+        }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    // The factory records when it is invoked and returns an embedded instance.
+    let invoked = Rc::new(Cell::new(false));
+    let invoked_in_factory = invoked.clone();
+    let factory = ComponentFactory::new(move |ctx| {
+        invoked_in_factory.set(true);
+        host_def.create_embedded(ctx).ok()
+    });
+    instance.set_property("module-b-factory", Value::ComponentFactory(factory)).unwrap();
+
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert!(!invoked.get(), "the host factory is not invoked while the external route is inactive");
+
+    // Activating the external route drives the container to build via the factory.
+    instance
+        .set_property("current", Value::EnumerationValue("ShellRoute".into(), "ModuleB".into()))
+        .unwrap();
+    i_slint_backend_testing::mock_elapsed_time(100);
+    assert!(
+        invoked.get(),
+        "activating the external route builds the host component via the factory"
+    );
+}
+
+// Without `enable_experimental`, `navigator` is rejected at object-tree
+// lowering with the experimental-feature diagnostic. `Compiler::default()`
+// does not enable experimental features.
 #[test]
 fn navigator_requires_experimental() {
     i_slint_backend_testing::init_no_event_loop();

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -280,11 +280,8 @@ export component TestCase {
     assert_eq!(instance.get_property("a-open").unwrap(), Value::from(false), "a after close");
 }
 
-// A `navigator` renders the destination component for the
-// current route, and re-renders when the route changes. Each destination
-// records its name in a global on `init`, so the observed value tells us which
-// route's screen is currently instantiated. Requires `enable_experimental`,
-// which is only reachable through the `internal` compiler configuration API.
+// Each destination records its name in `NavProbe.active` on `init`, so `active`
+// tells us which route's screen is currently instantiated.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_shows_current_route() {
@@ -317,7 +314,6 @@ export component TestCase inherits Window {
 
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
 
-    // The initial route renders its screen.
     i_slint_backend_testing::mock_elapsed_time(100);
     assert_eq!(
         instance.get_property("active").unwrap(),
@@ -325,7 +321,6 @@ export component TestCase inherits Window {
         "Route.Home renders HomeScreen"
     );
 
-    // Switching the current route renders the other screen.
     instance.set_property("current-route", route("Settings")).unwrap();
     i_slint_backend_testing::mock_elapsed_time(100);
     assert_eq!(
@@ -334,7 +329,6 @@ export component TestCase inherits Window {
         "Route.Settings renders SettingsScreen"
     );
 
-    // And back to the first route.
     instance.set_property("current-route", route("Home")).unwrap();
     i_slint_backend_testing::mock_elapsed_time(100);
     assert_eq!(
@@ -344,9 +338,6 @@ export component TestCase inherits Window {
     );
 }
 
-// Without `enable_experimental`, `navigator` is rejected at object-tree
-// lowering with the experimental-feature diagnostic. `Compiler::default()`
-// does not enable experimental features.
 #[test]
 fn navigator_requires_experimental() {
     i_slint_backend_testing::init_no_event_loop();
@@ -371,10 +362,6 @@ export component TestCase inherits Window {
     );
 }
 
-// The back-stack: `navigate(route)` pushes the current route before switching,
-// `back()` restores the previous route (no-op at the root), and `can-go-back`
-// reflects whether the stack is non-empty. The `active` global still tells us
-// which screen is instantiated, so we assert on the rendered route.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_back_stack() {
@@ -413,11 +400,9 @@ export component TestCase inherits Window {
         instance.get_property("active").unwrap()
     };
 
-    // Root: nothing to go back to.
     assert_eq!(rendered(&instance), Value::from(SharedString::from("home")));
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "root");
 
-    // navigate(Home -> Details -> Settings): the stack fills up.
     instance.invoke("navigate", &[route("Details")]).unwrap();
     assert_eq!(rendered(&instance), Value::from(SharedString::from("details")));
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Details");
@@ -426,7 +411,6 @@ export component TestCase inherits Window {
     assert_eq!(rendered(&instance), Value::from(SharedString::from("settings")));
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "after Settings");
 
-    // back() twice unwinds Settings -> Details -> Home.
     instance.invoke("back", &[]).unwrap();
     assert_eq!(rendered(&instance), Value::from(SharedString::from("details")), "back to Details");
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(true), "one left");
@@ -439,16 +423,13 @@ export component TestCase inherits Window {
         "back at the root"
     );
 
-    // back() at the root is a no-op.
     instance.invoke("back", &[]).unwrap();
     assert_eq!(rendered(&instance), Value::from(SharedString::from("home")), "no-op at root");
     assert_eq!(instance.get_property("can-go-back").unwrap(), Value::from(false), "still root");
 }
 
-// The int-index adapter: `current-route-index` reports the ordinal of the
-// current route in declaration order, and `navigate-index(i)` navigates to the
-// route at that ordinal. This is what int-index chrome (current_index /
-// index_changed) binds to, so it must agree with the route enum both ways.
+// The int-index adapter (`current-route-index` / `navigate-index`) must agree
+// with the route enum both ways.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_index_adapter() {
@@ -487,14 +468,12 @@ export component TestCase inherits Window {
         instance.get_property("current-route-index").unwrap()
     };
 
-    // Setting the route enum drives current-route-index to the declared ordinal.
     assert_eq!(index(&instance), Value::from(0.), "Home is ordinal 0");
     instance.set_property("current-route", route("Details")).unwrap();
     assert_eq!(index(&instance), Value::from(1.), "Details is ordinal 1");
     instance.set_property("current-route", route("Settings")).unwrap();
     assert_eq!(index(&instance), Value::from(2.), "Settings is ordinal 2");
 
-    // navigate-index(i) drives the route enum the other way (and the index with it).
     instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
     assert_eq!(
         instance.get_property("current-route").unwrap(),
@@ -511,7 +490,6 @@ export component TestCase inherits Window {
     );
     assert_eq!(index(&instance), Value::from(0.));
 
-    // Out-of-range is a no-op: the route (and index) stay put.
     instance.invoke("navigate-index", &[Value::from(9.)]).unwrap();
     assert_eq!(
         instance.get_property("current-route").unwrap(),
@@ -521,14 +499,9 @@ export component TestCase inherits Window {
     assert_eq!(index(&instance), Value::from(0.));
 }
 
-// A std-widgets navigation presentation (a Button-row tab bar) driving
-// the navigator through its int-index adapter. The tab bar is a plain std
-// `Button` row that exposes `current-index` / `selected(int)`; the host bridges
-// those to the navigator's `current-route-index` / `navigate-index` (the adapter
-// is synthesized after resolve, so it is reachable from the host rather than
-// from .slint). This guards that the std presentation compiles with the
-// navigator and that both directions of the binding hold: the highlight source
-// follows the current route, and activating a tab moves the current route.
+// A std-widgets Button-row tab bar driving the navigator through its int-index
+// adapter. The adapter is synthesized after resolve, so the host bridges it to
+// the tab bar's `current-index` / `selected(int)`.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_std_chrome_index_binding() {
@@ -588,9 +561,6 @@ export component TestCase inherits Window {
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
     let settle = || i_slint_backend_testing::mock_elapsed_time(100);
 
-    // The host feeds the tab bar's highlight from the adapter. Setting the route
-    // (as an in-screen action would) moves current-route-index, which is what
-    // the chrome's current-index binds to.
     settle();
     instance.set_property("current-route", route("Details")).unwrap();
     settle();
@@ -609,8 +579,6 @@ export component TestCase inherits Window {
         "the navigator renders the Details screen"
     );
 
-    // Activating a tab: the chrome's `selected(int)` is routed to navigate-index,
-    // which moves the current route (and its rendered screen).
     instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
     settle();
     assert_eq!(
@@ -630,16 +598,8 @@ export component TestCase inherits Window {
     );
 }
 
-// The presentation-agnostic proof: an int-index chrome that mimics Material's
-// `BaseNavigation` (`items` / `current_index` / `index_changed` / `select`)
-// drives the enum-typed navigator through the int-index adapter, both ways.
-// `IntChrome` copies that contract verbatim (only `select` is public so the test
-// can trigger a "tap"; Material's is protected and fired by item clicks). The
-// two adapter members are consumed exactly as native Material wiring would:
-//   current_index  <- current-route-index   (the bar reflects the route)
-//   index_changed(i) => navigate-index(i)    (a tap navigates)
-// Nothing about the `navigator { Route... }` block is chrome-specific, so std
-// chrome binds the same two members with zero change to the routes.
+// An int-index chrome mimicking Material's `BaseNavigation` drives the navigator
+// through the adapter, both ways, bound from the host.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_int_chrome_binding() {
@@ -706,8 +666,7 @@ export component TestCase inherits Window {
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
     let settle = || i_slint_backend_testing::mock_elapsed_time(100);
 
-    // The tap binding: index_changed(i) => navigate-index(i). Wired once, exactly
-    // as native Material code binds NavigationBar.index_changed to the adapter.
+    // index_changed(i) => navigate-index(i), wired as native Material code would.
     let weak = instance.as_weak();
     instance
         .set_callback("chrome-index-changed", move |args| {
@@ -717,15 +676,13 @@ export component TestCase inherits Window {
         })
         .unwrap();
 
-    // The display binding: current_index <- current-route-index. Pushed after each
-    // route change (native code does the same via set_bar_index).
+    // current_index <- current-route-index, pushed after each route change.
     let mirror = |instance: &crate::ComponentInstance| {
         let idx = instance.get_property("current-route-index").unwrap();
         instance.set_property("chrome-index", idx).unwrap();
         settle();
     };
 
-    // Display side: moving the route moves the chrome's current_index.
     mirror(&instance);
     assert_eq!(instance.get_property("chrome-index-out").unwrap(), Value::from(0.), "Home -> 0");
     instance.set_property("current-route", route("Details")).unwrap();
@@ -739,7 +696,6 @@ export component TestCase inherits Window {
         "Settings -> 2"
     );
 
-    // Tap side: chrome.select(i) fires index_changed -> navigate-index(i) -> route.
     instance.invoke("tap", &[Value::from(0.)]).unwrap();
     mirror(&instance);
     assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
@@ -758,7 +714,6 @@ export component TestCase inherits Window {
         Value::from(SharedString::from("settings"))
     );
 
-    // Out-of-range tap is a no-op in the mimic's guard (same as BaseNavigation.select).
     instance.invoke("tap", &[Value::from(9.)]).unwrap();
     mirror(&instance);
     assert_eq!(
@@ -768,15 +723,9 @@ export component TestCase inherits Window {
     );
 }
 
-// The navigator's public members are declared before expression
-// resolution, so widget chrome binds to them INLINE in .slint (not from the
-// host language). This is the same IntChrome contract as
-// navigator_int_chrome_binding, but the two adapter members are wired in .slint:
-//   current-index: root.current-route-index       (the bar reflects the route)
-//   index-changed(i) => root.navigate-index(i)     (a tap navigates)
-// and can-go-back is read in a .slint binding too. If these members did
-// not exist at resolve time, so this binding failed with "does not have a
-// property 'current-route-index'" and had to be done from Rust.
+// The navigator's public members are declared before expression resolution, so
+// chrome can bind them INLINE in .slint (current-route-index, navigate-index,
+// can-go-back) rather than from the host, as navigator_int_chrome_binding does.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_inline_chrome_binding() {
@@ -840,7 +789,6 @@ export component TestCase inherits Window {
     let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
     let settle = || i_slint_backend_testing::mock_elapsed_time(100);
 
-    // Read side, all in .slint: the bar's current-index follows current-route-index.
     settle();
     assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "Home -> 0");
     assert_eq!(instance.get_property("chrome-can-back").unwrap(), Value::from(false), "root");
@@ -857,7 +805,6 @@ export component TestCase inherits Window {
         Value::from(SharedString::from("details"))
     );
 
-    // Write side, all in .slint: tap -> select -> index-changed -> navigate-index.
     instance.invoke("tap", &[Value::from(2.)]).unwrap();
     settle();
     assert_eq!(
@@ -870,20 +817,17 @@ export component TestCase inherits Window {
         instance.get_property("active").unwrap(),
         Value::from(SharedString::from("settings"))
     );
-    // navigate-index pushed the previous route, so can-go-back (bound in .slint) is true.
     assert_eq!(
         instance.get_property("chrome-can-back").unwrap(),
         Value::from(true),
         "can-go-back reflects the push, read in a .slint binding"
     );
 
-    // Another tap moves it back to the first route.
     instance.invoke("tap", &[Value::from(0.)]).unwrap();
     settle();
     assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
     assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "bar shows 0");
 
-    // Out-of-range tap is a no-op (the chrome's own guard).
     instance.invoke("tap", &[Value::from(9.)]).unwrap();
     settle();
     assert_eq!(

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -280,7 +280,7 @@ export component TestCase {
     assert_eq!(instance.get_property("a-open").unwrap(), Value::from(false), "a after close");
 }
 
-// The milestone test: a `navigator` renders the destination component for the
+// A `navigator` renders the destination component for the
 // current route, and re-renders when the route changes. Each destination
 // records its name in a global on `init`, so the observed value tells us which
 // route's screen is currently instantiated. Requires `enable_experimental`,
@@ -521,7 +521,7 @@ export component TestCase inherits Window {
     assert_eq!(index(&instance), Value::from(0.));
 }
 
-// PR A8: a std-widgets navigation presentation (a Button-row tab bar) driving
+// A std-widgets navigation presentation (a Button-row tab bar) driving
 // the navigator through its int-index adapter. The tab bar is a plain std
 // `Button` row that exposes `current-index` / `selected(int)`; the host bridges
 // those to the navigator's `current-route-index` / `navigate-index` (the adapter
@@ -639,7 +639,7 @@ export component TestCase inherits Window {
 //   current_index  <- current-route-index   (the bar reflects the route)
 //   index_changed(i) => navigate-index(i)    (a tap navigates)
 // Nothing about the `navigator { Route... }` block is chrome-specific, so std
-// chrome (PR A8) binds the same two members with zero change to the routes.
+// chrome binds the same two members with zero change to the routes.
 #[cfg(feature = "internal")]
 #[test]
 fn navigator_int_chrome_binding() {
@@ -768,13 +768,13 @@ export component TestCase inherits Window {
     );
 }
 
-// PR #13: the navigator's public members are declared before expression
+// The navigator's public members are declared before expression
 // resolution, so widget chrome binds to them INLINE in .slint (not from the
 // host language). This is the same IntChrome contract as
 // navigator_int_chrome_binding, but the two adapter members are wired in .slint:
 //   current-index: root.current-route-index       (the bar reflects the route)
 //   index-changed(i) => root.navigate-index(i)     (a tap navigates)
-// and can-go-back is read in a .slint binding too. Before #13 these members did
+// and can-go-back is read in a .slint binding too. If these members did
 // not exist at resolve time, so this binding failed with "does not have a
 // property 'current-route-index'" and had to be done from Rust.
 #[cfg(feature = "internal")]
@@ -809,7 +809,7 @@ export component TestCase inherits Window {
     in-out property <Route> current-route: Route.Home;
     out property <string> active: NavProbe.active;
 
-    // The #13 proof: the chrome binds the navigator's synthesized members
+    // The chrome binds the navigator's synthesized members
     // directly in .slint. These mirrors let the test observe the bound values.
     out property <int> chrome-index: chrome.current-index;
     out property <bool> chrome-can-back: root.can-go-back;

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -767,3 +767,128 @@ export component TestCase inherits Window {
         "out-of-range tap is a no-op"
     );
 }
+
+// PR #13: the navigator's public members are declared before expression
+// resolution, so widget chrome binds to them INLINE in .slint (not from the
+// host language). This is the same IntChrome contract as
+// navigator_int_chrome_binding, but the two adapter members are wired in .slint:
+//   current-index: root.current-route-index       (the bar reflects the route)
+//   index-changed(i) => root.navigate-index(i)     (a tap navigates)
+// and can-go-back is read in a .slint binding too. Before #13 these members did
+// not exist at resolve time, so this binding failed with "does not have a
+// property 'current-route-index'" and had to be done from Rust.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_inline_chrome_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// Int-index chrome, same contract as Material's BaseNavigation: the host feeds
+// the highlighted index in, a tap fires index-changed out.
+component IntChrome {
+    in property <[string]> items;
+    in property <int> current-index;
+    callback index-changed(index: int);
+    public function select(index: int) {
+        if (index < 0 || index >= root.items.length) {
+            return;
+        }
+        root.index-changed(index);
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+
+    // The #13 proof: the chrome binds the navigator's synthesized members
+    // directly in .slint. These mirrors let the test observe the bound values.
+    out property <int> chrome-index: chrome.current-index;
+    out property <bool> chrome-can-back: root.can-go-back;
+
+    chrome := IntChrome {
+        items: ["Home", "Details", "Settings"];
+        current-index: root.current-route-index;            // display <- current-route-index
+        index-changed(i) => { root.navigate-index(i); }     // tap -> navigate-index
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+    // Simulate an item tap (Material fires select() from a NavigationItem click).
+    public function tap(index: int) { chrome.select(index); }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // Read side, all in .slint: the bar's current-index follows current-route-index.
+    settle();
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "Home -> 0");
+    assert_eq!(instance.get_property("chrome-can-back").unwrap(), Value::from(false), "root");
+
+    instance.set_property("current-route", route("Details")).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("chrome-index").unwrap(),
+        Value::from(1.),
+        "the bar's current-index reflects the route, bound in .slint"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("details"))
+    );
+
+    // Write side, all in .slint: tap -> select -> index-changed -> navigate-index.
+    instance.invoke("tap", &[Value::from(2.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "a .slint-wired tap navigates by ordinal"
+    );
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(2.), "bar shows 2");
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings"))
+    );
+    // navigate-index pushed the previous route, so can-go-back (bound in .slint) is true.
+    assert_eq!(
+        instance.get_property("chrome-can-back").unwrap(),
+        Value::from(true),
+        "can-go-back reflects the push, read in a .slint binding"
+    );
+
+    // Another tap moves it back to the first route.
+    instance.invoke("tap", &[Value::from(0.)]).unwrap();
+    settle();
+    assert_eq!(instance.get_property("current-route").unwrap(), route("Home"), "tap 0 -> Home");
+    assert_eq!(instance.get_property("chrome-index").unwrap(), Value::from(0.), "bar shows 0");
+
+    // Out-of-range tap is a no-op (the chrome's own guard).
+    instance.invoke("tap", &[Value::from(9.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Home"),
+        "out-of-range tap is a no-op"
+    );
+}

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -520,3 +520,112 @@ export component TestCase inherits Window {
     );
     assert_eq!(index(&instance), Value::from(0.));
 }
+
+// PR A8: a std-widgets navigation presentation (a Button-row tab bar) driving
+// the navigator through its int-index adapter. The tab bar is a plain std
+// `Button` row that exposes `current-index` / `selected(int)`; the host bridges
+// those to the navigator's `current-route-index` / `navigate-index` (the adapter
+// is synthesized after resolve, so it is reachable from the host rather than
+// from .slint). This guards that the std presentation compiles with the
+// navigator and that both directions of the binding hold: the highlight source
+// follows the current route, and activating a tab moves the current route.
+#[cfg(feature = "internal")]
+#[test]
+fn navigator_std_chrome_index_binding() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, SharedString, Value};
+    let code = r#"
+import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+enum Route { Home, Details, Settings }
+global NavProbe { in-out property <string> active; }
+component HomeScreen inherits Rectangle { init => { NavProbe.active = "home"; } }
+component DetailsScreen inherits Rectangle { init => { NavProbe.active = "details"; } }
+component SettingsScreen inherits Rectangle { init => { NavProbe.active = "settings"; } }
+
+// The std presentation: a Button row whose active segment follows current-index.
+component NavBar inherits HorizontalBox {
+    in property <[string]> titles;
+    in property <int> current-index;
+    callback selected(index: int);
+    for title[index] in titles: Button {
+        text: title;
+        primary: index == root.current-index;
+        clicked => { root.selected(index); }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    in-out property <Route> current-route: Route.Home;
+    out property <string> active: NavProbe.active;
+    // The chrome inputs the host bridges to the navigator adapter.
+    in property <int> nav-index;
+    callback nav-select(index: int);
+
+    NavBar {
+        titles: ["Home", "Details", "Settings"];
+        current-index: root.nav-index;
+        selected(index) => { root.nav-select(index); }
+    }
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+"#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let definition = result.component("TestCase").unwrap();
+    let instance = definition.create().unwrap();
+    let _ = instance.window();
+
+    let route = |v: &str| Value::EnumerationValue("Route".into(), v.into());
+    let settle = || i_slint_backend_testing::mock_elapsed_time(100);
+
+    // The host feeds the tab bar's highlight from the adapter. Setting the route
+    // (as an in-screen action would) moves current-route-index, which is what
+    // the chrome's current-index binds to.
+    settle();
+    instance.set_property("current-route", route("Details")).unwrap();
+    settle();
+    let highlight = instance.get_property("current-route-index").unwrap();
+    assert_eq!(highlight, Value::from(1.), "highlight source follows the current route");
+    instance.set_property("nav-index", highlight).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("nav-index").unwrap(),
+        Value::from(1.),
+        "the tab bar's current-index reflects the current route"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("details")),
+        "the navigator renders the Details screen"
+    );
+
+    // Activating a tab: the chrome's `selected(int)` is routed to navigate-index,
+    // which moves the current route (and its rendered screen).
+    instance.invoke("navigate-index", &[Value::from(2.)]).unwrap();
+    settle();
+    assert_eq!(
+        instance.get_property("current-route").unwrap(),
+        route("Settings"),
+        "activating the Settings tab navigates by ordinal"
+    );
+    assert_eq!(
+        instance.get_property("current-route-index").unwrap(),
+        Value::from(2.),
+        "the highlight source moves with the activated tab"
+    );
+    assert_eq!(
+        instance.get_property("active").unwrap(),
+        Value::from(SharedString::from("settings")),
+        "the navigator renders the Settings screen"
+    );
+}

--- a/tests/cases/navigation/basic.slint
+++ b/tests/cases/navigation/basic.slint
@@ -1,0 +1,129 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The navigator's public members (navigate, back, can-go-back, navigate-index,
+// current-route-index) are exercised from every language binding. Driving by the
+// integer adapter keeps the assertions int/bool; one navigate(enum) call checks
+// the enum-argument path.
+
+export enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle { }
+component DetailsScreen inherits Rectangle { }
+component SettingsScreen inherits Rectangle { }
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    in-out property <Route> current-route: Route.Home;
+
+    navigator (current-route) {
+        Route.Home: HomeScreen { }
+        Route.Details: DetailsScreen { }
+        Route.Settings: SettingsScreen { }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_current_route_index(), 0);
+assert!(!instance.get_can_go_back());
+
+instance.invoke_navigate_index(1);
+assert_eq!(instance.get_current_route_index(), 1);
+assert!(instance.get_can_go_back());
+
+instance.invoke_navigate_index(2);
+assert_eq!(instance.get_current_route_index(), 2);
+
+instance.invoke_back();
+assert_eq!(instance.get_current_route_index(), 1);
+
+instance.invoke_back();
+assert_eq!(instance.get_current_route_index(), 0);
+assert!(!instance.get_can_go_back());
+
+instance.invoke_navigate(Route::Settings);
+assert_eq!(instance.get_current_route_index(), 2);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_current_route_index(), 0);
+assert(!instance.get_can_go_back());
+
+instance.invoke_navigate_index(1);
+assert_eq(instance.get_current_route_index(), 1);
+assert(instance.get_can_go_back());
+
+instance.invoke_navigate_index(2);
+assert_eq(instance.get_current_route_index(), 2);
+
+instance.invoke_back();
+assert_eq(instance.get_current_route_index(), 1);
+
+instance.invoke_back();
+assert_eq(instance.get_current_route_index(), 0);
+assert(!instance.get_can_go_back());
+
+instance.invoke_navigate(Route::Settings);
+assert_eq(instance.get_current_route_index(), 2);
+```
+
+```js
+var instance = new slint.TestCase();
+
+assert.equal(instance.current_route_index, 0);
+assert(!instance.can_go_back);
+
+instance.navigate_index(1);
+assert.equal(instance.current_route_index, 1);
+assert(instance.can_go_back);
+
+instance.navigate_index(2);
+assert.equal(instance.current_route_index, 2);
+
+instance.back();
+assert.equal(instance.current_route_index, 1);
+
+instance.back();
+assert.equal(instance.current_route_index, 0);
+assert(!instance.can_go_back);
+
+instance.navigate("Settings");
+assert.equal(instance.current_route_index, 2);
+```
+
+```python
+instance = TestCase()
+
+assert instance.current_route_index == 0
+assert not instance.can_go_back
+
+instance.navigate_index(1)
+assert instance.current_route_index == 1
+assert instance.can_go_back
+
+instance.navigate_index(2)
+assert instance.current_route_index == 2
+
+instance.back()
+assert instance.current_route_index == 1
+
+instance.back()
+assert instance.current_route_index == 0
+assert not instance.can_go_back
+
+instance.navigate(Route.Settings)
+assert instance.current_route_index == 2
+```
+*/

--- a/tests/cases/navigation/basic.slint
+++ b/tests/cases/navigation/basic.slint
@@ -1,11 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// The navigator's public members (navigate, back, can-go-back, navigate-index,
-// current-route-index) are exercised from every language binding. Driving by the
-// integer adapter keeps the assertions int/bool; one navigate(enum) call checks
-// the enum-argument path.
-
 export enum Route {
     Home,
     Details,

--- a/tests/cases/navigation/internal_route.slint
+++ b/tests/cases/navigation/internal_route.slint
@@ -1,0 +1,72 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A navigator inside a non-root component: its route property is internal, and
+// navigate()/back() must still be able to write it. Regression for the route
+// being wrongly classified constant (which panicked "Constant property being
+// changed" the first time navigate() ran).
+
+enum Route { Main, Detail }
+
+component Screen inherits Rectangle { }
+
+component Feature inherits Rectangle {
+    in-out property <Route> route: Route.Main;
+    public function push() { root.navigate(Route.Detail); }
+    public function pop() { root.back(); }
+    navigator (route) {
+        Route.Main: Screen { }
+        Route.Detail: Screen { }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    feature := Feature { }
+
+    out property <int> index: feature.current-route-index;
+
+    public function push() { feature.push(); }
+    public function pop() { feature.pop(); }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_index(), 0);
+instance.invoke_push();
+assert_eq!(instance.get_index(), 1);
+instance.invoke_pop();
+assert_eq!(instance.get_index(), 0);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_index(), 0);
+instance.invoke_push();
+assert_eq(instance.get_index(), 1);
+instance.invoke_pop();
+assert_eq(instance.get_index(), 0);
+```
+
+```js
+var instance = new slint.TestCase();
+assert.equal(instance.index, 0);
+instance.push();
+assert.equal(instance.index, 1);
+instance.pop();
+assert.equal(instance.index, 0);
+```
+
+```python
+instance = TestCase()
+assert instance.index == 0
+instance.push()
+assert instance.index == 1
+instance.pop()
+assert instance.index == 0
+```
+*/

--- a/tests/cases/navigation/mount.slint
+++ b/tests/cases/navigation/mount.slint
@@ -1,0 +1,66 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export interface FeatureNav {
+    route Main;
+}
+
+enum InnerRoute { Main, Detail }
+
+component InnerMain inherits Rectangle { callback go(); }
+component InnerDetail inherits Rectangle { callback go-back(); }
+
+component Feature implements FeatureNav inherits Rectangle {
+    in-out property <InnerRoute> current-route: InnerRoute.Main;
+    navigator (current-route) {
+        InnerRoute.Main: InnerMain { go => { root.navigate(InnerRoute.Detail); } }
+        InnerRoute.Detail: InnerDetail { go-back => { root.back(); } }
+    }
+}
+
+enum Shell { Home, Feature }
+
+component HomeScreen inherits Rectangle { }
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    in-out property <Shell> current: Shell.Home;
+
+    navigator (current) {
+        Shell.Home: HomeScreen { }
+        Shell.Feature: mount Feature via FeatureNav { }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_current_route_index(), 0);
+instance.invoke_navigate_index(1);
+assert_eq!(instance.get_current_route_index(), 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_current_route_index(), 0);
+instance.invoke_navigate_index(1);
+assert_eq(instance.get_current_route_index(), 1);
+```
+
+```js
+var instance = new slint.TestCase();
+assert.equal(instance.current_route_index, 0);
+instance.navigate_index(1);
+assert.equal(instance.current_route_index, 1);
+```
+
+```python
+instance = TestCase()
+assert instance.current_route_index == 0
+instance.navigate_index(1)
+assert instance.current_route_index == 1
+```
+*/

--- a/tests/driver/rust/tests/navigation.rs
+++ b/tests/driver/rust/tests/navigation.rs
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// NOTE: The files under tests/driver/rust/tests/ are generated and validated against this template.
+// Do not edit them directly, instead edit the template.rs file!
+
+// needs to be crate-level
+#![deny(rust_2024_compatibility)]
+
+include!(concat!(env!("OUT_DIR"), "/navigation.rs"));

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -708,12 +708,14 @@ export component App inherits Window {
             if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
         let url = Url::from_file_path(path).unwrap();
 
-        // The type-loader load path does not derive the experimental flag from
-        // the compiler config, so set it on the diagnostics to compile the
-        // experimental `navigator`.
+        // The normal load path derives the experimental flag from the compiler
+        // config (enabled by empty_document_cache_experimental), so a default
+        // BuildDiagnostics is enough to compile the experimental `navigator`.
         let mut diag = BuildDiagnostics::default();
-        diag.enable_experimental = true;
+        assert!(!diag.enable_experimental, "the diag must start without the flag");
         let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
+        // Proof the load path propagated the config flag onto the diagnostics.
+        assert!(diag.enable_experimental, "load path did not propagate enable_experimental");
         assert!(
             !diag.has_errors(),
             "unexpected errors: {:?}",

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -82,33 +82,22 @@ impl CompilerConfiguration {
     }
 }
 
-/// One resolved entry of a `navigator` route table: which destination
-/// component a route enum value maps to, plus where that component is declared.
+/// One resolved entry of a `navigator` route table.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NavigatorRouteEntry {
     /// The route enum value name, e.g. `Home` for `Route.Home`.
     pub route_name: String,
-    /// The destination component's name. Empty when the destination did not
-    /// resolve to a component (a diagnostic was already reported).
+    /// Empty when the destination did not resolve to a component.
     pub destination_component: String,
-    /// Where the destination component is declared. `None` when it did not
-    /// resolve or has no source node.
     pub destination_uri: Option<Url>,
-    /// Byte offset of the destination component's declaration.
     pub destination_offset: Option<TextSize>,
 }
 
-/// The authoritative route table for one `navigator`: the component that
-/// declares it (the entry/root) and its resolved routes, in declaration order.
-/// This is the compiler-resolved route -> destination mapping. It is not the
-/// screen-to-screen edge graph, which the flow-map derives separately.
+/// The resolved route table for one `navigator`: the declaring component and its routes.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NavigatorTable {
-    /// The component that declares the `navigator`.
     pub entry_component: String,
-    /// Where that component is declared.
     pub entry_uri: Option<Url>,
-    /// Byte offset of the entry component's declaration.
     pub entry_offset: Option<TextSize>,
     /// The resolved routes, in declaration order.
     pub routes: Vec<NavigatorRouteEntry>,
@@ -514,19 +503,11 @@ impl DocumentCache {
         self.type_loader.all_files_to_watch()
     }
 
-    /// Return the navigator route tables declared in `text_document_uri`.
+    /// Return the resolved navigator route tables declared in `text_document_uri`.
     ///
-    /// For every component that contains a `navigator`, this yields its
-    /// entry/root and the compiler-resolved route table: each route enum value
-    /// mapped to its destination component and that component's location. This
-    /// is the authoritative route -> screen mapping only. It is not the
-    /// screen-to-screen edge graph, which the flow-map derives separately from
-    /// assignment detection.
-    ///
-    /// Reuses the `inner_components` walk that `element_at_document_and_offset`
-    /// relies on, so it sees the same un-inlined object tree.
+    /// Walks `inner_components` so it sees the same un-inlined object tree as
+    /// `element_at_document_and_offset`.
     pub fn navigator_tables(&self, text_document_uri: &Url) -> Vec<NavigatorTable> {
-        // Location of a component's declaration, from its source node.
         fn component_location(
             node: &Option<syntax_nodes::Component>,
         ) -> (Option<Url>, Option<TextSize>) {
@@ -537,8 +518,7 @@ impl DocumentCache {
             }
         }
 
-        // Collect elements holding a navigator route table. A navigator is
-        // usually on the root element, but may be nested, so walk children too.
+        // A navigator may be nested below the root, so walk children too.
         fn collect(element: &ElementRc, out: &mut Vec<ElementRc>) {
             let elem = element.borrow();
             if !elem.navigator_routes().is_empty() {
@@ -568,8 +548,6 @@ impl DocumentCache {
                     .navigator_routes()
                     .iter()
                     .map(|route| {
-                        // The last segment of the qualified enum value, e.g.
-                        // `Home` from `Route.Home`.
                         let route_name = route
                             .route
                             .text()
@@ -687,8 +665,6 @@ mod tests {
     fn test_navigator_tables() {
         use i_slint_compiler::diagnostics::BuildDiagnostics;
 
-        // A component that declares a navigator over two routes, each resolving
-        // to a component in the same document.
         let content = r#"
 enum Route { A, B }
 component A inherits Rectangle { }
@@ -708,13 +684,11 @@ export component App inherits Window {
             if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
         let url = Url::from_file_path(path).unwrap();
 
-        // The normal load path derives the experimental flag from the compiler
-        // config (enabled by empty_document_cache_experimental), so a default
-        // BuildDiagnostics is enough to compile the experimental `navigator`.
+        // The load path derives the experimental flag from the compiler config,
+        // so a default BuildDiagnostics compiles the experimental `navigator`.
         let mut diag = BuildDiagnostics::default();
         assert!(!diag.enable_experimental, "the diag must start without the flag");
         let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
-        // Proof the load path propagated the config flag onto the diagnostics.
         assert!(diag.enable_experimental, "load path did not propagate enable_experimental");
         assert!(
             !diag.has_errors(),
@@ -728,7 +702,6 @@ export component App inherits Window {
         assert_eq!(table.entry_component, "App");
         assert_eq!(table.entry_uri.as_ref(), Some(&url));
 
-        // The authoritative route table: Route.A -> A, Route.B -> B, in order.
         let routes: Vec<(&str, &str)> = table
             .routes
             .iter()
@@ -736,7 +709,6 @@ export component App inherits Window {
             .collect();
         assert_eq!(routes, vec![("A", "A"), ("B", "B")]);
 
-        // Destinations point at real declarations in this document.
         for route in &table.routes {
             assert_eq!(route.destination_uri.as_ref(), Some(&url));
             assert!(route.destination_offset.is_some(), "missing offset for {}", route.route_name);

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -4,7 +4,8 @@
 //! Data structures common between LSP and previewer
 
 use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile};
-use i_slint_compiler::object_tree::Document;
+use i_slint_compiler::langtype::ElementType;
+use i_slint_compiler::object_tree::{Document, ElementRc};
 use i_slint_compiler::parser::{TextSize, syntax_nodes};
 use i_slint_compiler::typeloader::TypeLoader;
 use i_slint_compiler::typeregister::TypeRegister;
@@ -79,6 +80,38 @@ impl CompilerConfiguration {
 
         (result, self.open_import_callback)
     }
+}
+
+/// One resolved entry of a `navigator` route table: which destination
+/// component a route enum value maps to, plus where that component is declared.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavigatorRouteEntry {
+    /// The route enum value name, e.g. `Home` for `Route.Home`.
+    pub route_name: String,
+    /// The destination component's name. Empty when the destination did not
+    /// resolve to a component (a diagnostic was already reported).
+    pub destination_component: String,
+    /// Where the destination component is declared. `None` when it did not
+    /// resolve or has no source node.
+    pub destination_uri: Option<Url>,
+    /// Byte offset of the destination component's declaration.
+    pub destination_offset: Option<TextSize>,
+}
+
+/// The authoritative route table for one `navigator`: the component that
+/// declares it (the entry/root) and its resolved routes, in declaration order.
+/// This is the compiler-resolved route -> destination mapping. It is not the
+/// screen-to-screen edge graph, which the flow-map derives separately.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavigatorTable {
+    /// The component that declares the `navigator`.
+    pub entry_component: String,
+    /// Where that component is declared.
+    pub entry_uri: Option<Url>,
+    /// Byte offset of the entry component's declaration.
+    pub entry_offset: Option<TextSize>,
+    /// The resolved routes, in declaration order.
+    pub routes: Vec<NavigatorRouteEntry>,
 }
 
 /// A cache of loaded documents
@@ -480,6 +513,96 @@ impl DocumentCache {
     pub fn all_paths_to_watch(&self) -> HashSet<PathBuf> {
         self.type_loader.all_files_to_watch()
     }
+
+    /// Return the navigator route tables declared in `text_document_uri`.
+    ///
+    /// For every component that contains a `navigator`, this yields its
+    /// entry/root and the compiler-resolved route table: each route enum value
+    /// mapped to its destination component and that component's location. This
+    /// is the authoritative route -> screen mapping only. It is not the
+    /// screen-to-screen edge graph, which the flow-map derives separately from
+    /// assignment detection.
+    ///
+    /// Reuses the `inner_components` walk that `element_at_document_and_offset`
+    /// relies on, so it sees the same un-inlined object tree.
+    pub fn navigator_tables(&self, text_document_uri: &Url) -> Vec<NavigatorTable> {
+        // Location of a component's declaration, from its source node.
+        fn component_location(
+            node: &Option<syntax_nodes::Component>,
+        ) -> (Option<Url>, Option<TextSize>) {
+            let Some(node) = node else { return (None, None) };
+            match file_to_uri(node.source_file.path()) {
+                Some(uri) => (Some(uri), Some(node.text_range().start())),
+                None => (None, None),
+            }
+        }
+
+        // Collect elements holding a navigator route table. A navigator is
+        // usually on the root element, but may be nested, so walk children too.
+        fn collect(element: &ElementRc, out: &mut Vec<ElementRc>) {
+            let elem = element.borrow();
+            if !elem.navigator_routes().is_empty() {
+                out.push(element.clone());
+            }
+            for child in &elem.children {
+                collect(child, out);
+            }
+        }
+
+        let Some(document) = self.get_document(text_document_uri) else {
+            return Vec::new();
+        };
+
+        let mut tables = Vec::new();
+        for component in &document.inner_components {
+            let mut navigator_elements = Vec::new();
+            collect(&component.root_element, &mut navigator_elements);
+            if navigator_elements.is_empty() {
+                continue;
+            }
+
+            let (entry_uri, entry_offset) = component_location(&component.node);
+            for element in &navigator_elements {
+                let element = element.borrow();
+                let routes = element
+                    .navigator_routes()
+                    .iter()
+                    .map(|route| {
+                        // The last segment of the qualified enum value, e.g.
+                        // `Home` from `Route.Home`.
+                        let route_name = route
+                            .route
+                            .text()
+                            .to_string()
+                            .rsplit('.')
+                            .next()
+                            .unwrap_or_default()
+                            .trim()
+                            .to_string();
+                        let destination = route.component.borrow();
+                        let (destination_component, dest_node) = match &destination.base_type {
+                            ElementType::Component(c) => (c.id.to_string(), c.node.clone()),
+                            _ => (String::new(), None),
+                        };
+                        let (destination_uri, destination_offset) = component_location(&dest_node);
+                        NavigatorRouteEntry {
+                            route_name,
+                            destination_component,
+                            destination_uri,
+                            destination_offset,
+                        }
+                    })
+                    .collect();
+                tables.push(NavigatorTable {
+                    entry_component: component.id.to_string(),
+                    entry_uri: entry_uri.clone(),
+                    entry_offset,
+                    routes,
+                });
+            }
+        }
+        tables
+    }
 }
 
 #[cfg(test)]
@@ -558,5 +681,63 @@ mod tests {
         assert_eq!(base_type_at_position(&dc, &url, 27, 4), Some("VerticalBox".to_string()));
         assert_eq!(base_type_at_position(&dc, &url, 28, 8), Some("Text".to_string()));
         assert_eq!(base_type_at_position(&dc, &url, 51, 4), Some("VerticalBox".to_string()));
+    }
+
+    #[test]
+    fn test_navigator_tables() {
+        use i_slint_compiler::diagnostics::BuildDiagnostics;
+
+        // A component that declares a navigator over two routes, each resolving
+        // to a component in the same document.
+        let content = r#"
+enum Route { A, B }
+component A inherits Rectangle { }
+component B inherits Rectangle { }
+export component App inherits Window {
+    in-out property <Route> current-route: Route.A;
+    navigator (current-route) {
+        Route.A: A { }
+        Route.B: B { }
+    }
+}
+"#;
+
+        let mut dc = crate::language::test::empty_document_cache_experimental();
+        spin_on::spin_on(dc.preload_builtins());
+        let path =
+            if cfg!(target_family = "windows") { "c://foo/nav.slint" } else { "/foo/nav.slint" };
+        let url = Url::from_file_path(path).unwrap();
+
+        // The type-loader load path does not derive the experimental flag from
+        // the compiler config, so set it on the diagnostics to compile the
+        // experimental `navigator`.
+        let mut diag = BuildDiagnostics::default();
+        diag.enable_experimental = true;
+        let _ = spin_on::spin_on(dc.load_url(&url, Some(1), content.to_string(), &mut diag));
+        assert!(
+            !diag.has_errors(),
+            "unexpected errors: {:?}",
+            diag.iter().map(|d| d.message().to_string()).collect::<Vec<_>>()
+        );
+
+        let tables = dc.navigator_tables(&url);
+        assert_eq!(tables.len(), 1, "expected exactly one navigator table");
+        let table = &tables[0];
+        assert_eq!(table.entry_component, "App");
+        assert_eq!(table.entry_uri.as_ref(), Some(&url));
+
+        // The authoritative route table: Route.A -> A, Route.B -> B, in order.
+        let routes: Vec<(&str, &str)> = table
+            .routes
+            .iter()
+            .map(|r| (r.route_name.as_str(), r.destination_component.as_str()))
+            .collect();
+        assert_eq!(routes, vec![("A", "A"), ("B", "B")]);
+
+        // Destinations point at real declarations in this document.
+        for route in &table.routes {
+            assert_eq!(route.destination_uri.as_ref(), Some(&url));
+            assert!(route.destination_offset.is_some(), "missing offset for {}", route.route_name);
+        }
     }
 }

--- a/tools/lsp/language/test.rs
+++ b/tools/lsp/language/test.rs
@@ -49,6 +49,17 @@ pub fn empty_document_cache() -> common::DocumentCache {
     common::DocumentCache::new(config)
 }
 
+/// Create an empty `DocumentCache` with experimental features enabled, so
+/// experimental constructs like `navigator` compile in tests.
+pub fn empty_document_cache_experimental() -> common::DocumentCache {
+    let config = crate::common::document_cache::CompilerConfiguration {
+        style: Some("fluent".to_string()),
+        enable_experimental: true,
+        ..Default::default()
+    };
+    common::DocumentCache::new(config)
+}
+
 /// Create a `DocumentCache` with one document loaded into it.
 pub fn loaded_document_cache(
     content: String,

--- a/ui-libraries/material/Cargo.toml
+++ b/ui-libraries/material/Cargo.toml
@@ -11,7 +11,7 @@
 # artifacts are reused. Developers working on the material library can load
 # both workspaces at once via `rust-analyzer.linkedProjects`.
 [workspace]
-members = ['examples/gallery']
+members = ['examples/gallery', 'examples/navigation']
 
 resolver = "3"
 

--- a/ui-libraries/material/examples/navigation/Cargo.toml
+++ b/ui-libraries/material/examples/navigation/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+# PR A8b: proves Material's navigation chrome binds to the experimental
+# `navigator` construct. `navigator` is experimental, so the compile is enabled
+# via build.rs (see there); no change to Material's int-based API is required.
+[package]
+name = "material-navigation"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+publish = false
+license.workspace = true
+
+[[bin]]
+path = "src/main.rs"
+name = "material-navigation"
+
+[dependencies]
+slint = { path = "../../../../api/rs/slint", features = ["renderer-skia"] }
+
+[build-dependencies]
+slint-build = { path = "../../../../api/rs/build" }

--- a/ui-libraries/material/examples/navigation/Cargo.toml
+++ b/ui-libraries/material/examples/navigation/Cargo.toml
@@ -1,9 +1,6 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: MIT
 
-# PR A8b: proves Material's navigation chrome binds to the experimental
-# `navigator` construct. `navigator` is experimental, so the compile is enabled
-# via build.rs (see there); no change to Material's int-based API is required.
 [package]
 name = "material-navigation"
 version.workspace = true

--- a/ui-libraries/material/examples/navigation/build.rs
+++ b/ui-libraries/material/examples/navigation/build.rs
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    // The `navigator` construct is experimental. slint-build has no typed setter
+    // for it, but `CompilerConfiguration::new()` reads this env var, and the
+    // compile runs in this same build-script process, so setting it here enables
+    // experimental for exactly this crate's `.slint` compile. Edition 2024 makes
+    // `set_var` unsafe; it is sound here because the build script is still
+    // single-threaded when this runs.
+    unsafe {
+        std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
+    }
+    slint_build::compile("ui/app.slint").expect("Slint build failed");
+}

--- a/ui-libraries/material/examples/navigation/build.rs
+++ b/ui-libraries/material/examples/navigation/build.rs
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 fn main() {
-    // The `navigator` construct is experimental. slint-build has no typed setter
-    // for it, but `CompilerConfiguration::new()` reads this env var, and the
-    // compile runs in this same build-script process, so setting it here enables
-    // experimental for exactly this crate's `.slint` compile. Edition 2024 makes
-    // `set_var` unsafe; it is sound here because the build script is still
-    // single-threaded when this runs.
     unsafe {
         std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
     }

--- a/ui-libraries/material/examples/navigation/src/main.rs
+++ b/ui-libraries/material/examples/navigation/src/main.rs
@@ -1,21 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-// PR A8b acceptance: ONE route model (the `navigator { Route... }` block in
-// app.slint) drives Material's int-index chrome through the adapter. Material's
-// `BaseNavigation` int API is untouched; the binding lives here, in the two
-// lines that connect the bar to `navigate-index` / `current-route-index`.
-
 slint::include_modules!();
 
 fn main() -> Result<(), slint::PlatformError> {
     let app = App::new()?;
 
-    // Bind Material's chrome to the navigator adapter:
-    //   index_changed(i) => navigate-index(i)   (the tap navigates)
-    //   current_index    <- current-route-index (the bar reflects the route)
-    // Both bar taps and in-screen buttons funnel through `request-index`, so
-    // every navigation goes through the adapter and the bar stays in sync.
     let weak = app.as_weak();
     app.on_request_index(move |index| {
         let app = weak.unwrap();
@@ -23,7 +13,6 @@ fn main() -> Result<(), slint::PlatformError> {
         app.set_bar_index(app.get_current_route_index());
     });
 
-    // Initial sync: the bar starts on whatever route the navigator starts on.
     app.set_bar_index(app.get_current_route_index());
 
     app.run()

--- a/ui-libraries/material/examples/navigation/src/main.rs
+++ b/ui-libraries/material/examples/navigation/src/main.rs
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// PR A8b acceptance: ONE route model (the `navigator { Route... }` block in
+// app.slint) drives Material's int-index chrome through the adapter. Material's
+// `BaseNavigation` int API is untouched; the binding lives here, in the two
+// lines that connect the bar to `navigate-index` / `current-route-index`.
+
+slint::include_modules!();
+
+fn main() -> Result<(), slint::PlatformError> {
+    let app = App::new()?;
+
+    // Bind Material's chrome to the navigator adapter:
+    //   index_changed(i) => navigate-index(i)   (the tap navigates)
+    //   current_index    <- current-route-index (the bar reflects the route)
+    // Both bar taps and in-screen buttons funnel through `request-index`, so
+    // every navigation goes through the adapter and the bar stays in sync.
+    let weak = app.as_weak();
+    app.on_request_index(move |index| {
+        let app = weak.unwrap();
+        app.invoke_navigate_index(index);
+        app.set_bar_index(app.get_current_route_index());
+    });
+
+    // Initial sync: the bar starts on whatever route the navigator starts on.
+    app.set_bar_index(app.get_current_route_index());
+
+    app.run()
+}

--- a/ui-libraries/material/examples/navigation/ui/app.slint
+++ b/ui-libraries/material/examples/navigation/ui/app.slint
@@ -1,0 +1,92 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// PR A8b: bind Material's int-index navigation chrome to the `navigator`
+// construct through its adapter. Material's `NavigationBar` (int `current_index`
+// / `index_changed`) is unchanged; only what feeds it changes. The SAME
+// `navigator { Route... }` block would drive std-widgets chrome (PR A8) with no
+// change to the route declarations, because both bind the same two adapter
+// members: `current-route-index` and `navigate-index`.
+
+import { MaterialWindow, NavigationBar, FilledButton, MaterialText } from "../../../src/material.slint";
+
+// The navigation convention: one enum value per screen.
+enum Route {
+    Home,
+    Details,
+    Settings,
+}
+
+component HomeScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px; // leave room for the pinned NavigationBar
+        MaterialText { text: "Home"; horizontal-alignment: center; }
+        FilledButton { text: "Go to Details"; clicked => { root.go(1); } }
+        FilledButton { text: "Open Settings"; clicked => { root.go(2); } }
+    }
+}
+
+component DetailsScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px;
+        MaterialText { text: "Details"; horizontal-alignment: center; }
+        FilledButton { text: "Back to Home"; clicked => { root.go(0); } }
+    }
+}
+
+component SettingsScreen inherits Rectangle {
+    callback go(index: int);
+    VerticalLayout {
+        alignment: center;
+        spacing: 12px;
+        padding-bottom: 96px;
+        MaterialText { text: "Settings"; horizontal-alignment: center; }
+        FilledButton { text: "Back to Home"; clicked => { root.go(0); } }
+    }
+}
+
+export component App inherits MaterialWindow {
+    preferred-width: 400px;
+    preferred-height: 640px;
+    title: "Slint Navigation - Material";
+
+    // The navigator's route property (the adapter's enum target).
+    in-out property <Route> current-route: Route.Home;
+
+    // Mirror of the adapter's `current-route-index`. Rust keeps this in sync
+    // after every navigation; the bar's `current_index` binds to it below.
+    in-out property <int> bar-index;
+
+    // Every navigation request funnels here so Rust routes it through the
+    // adapter's `navigate-index`. Bar taps and in-screen buttons both call it.
+    callback request-index(index: int);
+
+    // The route model: one destination per route, in declaration order. This is
+    // the presentation-agnostic surface; swapping the chrome below never touches it.
+    navigator (current-route) {
+        Route.Home: HomeScreen { go(i) => { root.request-index(i); } }
+        Route.Details: DetailsScreen { go(i) => { root.request-index(i); } }
+        Route.Settings: SettingsScreen { go(i) => { root.request-index(i); } }
+    }
+
+    // Material's int-index chrome, one item per route in declaration order.
+    NavigationBar {
+        y: root.height - self.height;
+        width: 100%;
+        items: [
+            { text: "Home" },
+            { text: "Details" },
+            { text: "Settings" },
+        ];
+        // Display: the bar reflects the current route (via current-route-index).
+        current_index: root.bar-index;
+        // Tap: navigating the bar navigates the route (via navigate-index).
+        index_changed(i) => { root.request-index(i); }
+    }
+}

--- a/ui-libraries/material/examples/navigation/ui/app.slint
+++ b/ui-libraries/material/examples/navigation/ui/app.slint
@@ -1,16 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-// PR A8b: bind Material's int-index navigation chrome to the `navigator`
-// construct through its adapter. Material's `NavigationBar` (int `current_index`
-// / `index_changed`) is unchanged; only what feeds it changes. The SAME
-// `navigator { Route... }` block would drive std-widgets chrome (PR A8) with no
-// change to the route declarations, because both bind the same two adapter
-// members: `current-route-index` and `navigate-index`.
-
 import { MaterialWindow, NavigationBar, FilledButton, MaterialText } from "../../../src/material.slint";
 
-// The navigation convention: one enum value per screen.
 enum Route {
     Home,
     Details,
@@ -22,7 +14,7 @@ component HomeScreen inherits Rectangle {
     VerticalLayout {
         alignment: center;
         spacing: 12px;
-        padding-bottom: 96px; // leave room for the pinned NavigationBar
+        padding-bottom: 96px;
         MaterialText { text: "Home"; horizontal-alignment: center; }
         FilledButton { text: "Go to Details"; clicked => { root.go(1); } }
         FilledButton { text: "Open Settings"; clicked => { root.go(2); } }
@@ -56,26 +48,18 @@ export component App inherits MaterialWindow {
     preferred-height: 640px;
     title: "Slint Navigation - Material";
 
-    // The navigator's route property (the adapter's enum target).
     in-out property <Route> current-route: Route.Home;
 
-    // Mirror of the adapter's `current-route-index`. Rust keeps this in sync
-    // after every navigation; the bar's `current_index` binds to it below.
     in-out property <int> bar-index;
 
-    // Every navigation request funnels here so Rust routes it through the
-    // adapter's `navigate-index`. Bar taps and in-screen buttons both call it.
     callback request-index(index: int);
 
-    // The route model: one destination per route, in declaration order. This is
-    // the presentation-agnostic surface; swapping the chrome below never touches it.
     navigator (current-route) {
         Route.Home: HomeScreen { go(i) => { root.request-index(i); } }
         Route.Details: DetailsScreen { go(i) => { root.request-index(i); } }
         Route.Settings: SettingsScreen { go(i) => { root.request-index(i); } }
     }
 
-    // Material's int-index chrome, one item per route in declaration order.
     NavigationBar {
         y: root.height - self.height;
         width: 100%;
@@ -84,9 +68,7 @@ export component App inherits MaterialWindow {
             { text: "Details" },
             { text: "Settings" },
         ];
-        // Display: the bar reflects the current route (via current-route-index).
         current_index: root.bar-index;
-        // Tap: navigating the bar navigates the route (via navigate-index).
         index_changed(i) => { root.request-index(i); }
     }
 }


### PR DESCRIPTION
Adds the **federation** seams to the `navigator` construct to allow an app to be assembled from independently-authored, independently-released parts, composed by an integration layer without editing any part's internals.

## Multi-team composition

A **navigation contract** (an `interface` of routes) is the boundary. A part
`implements` the contract and declares the capabilities it `needs`; the
integration shell `mount`s each part at a route and binds those needs.

Runnable: **`examples/navigation-federated`** models this with separate owners.

| File | Owner | Role |
| --- | --- | --- |
| `ui/contract.slint` | platform | the `FeatureNav` contract + `HostServices` |
| `ui/media.slint` | Media team | `MediaFeature implements FeatureNav`, `needs HostServices` |
| `ui/settings.slint` | Settings team | `SettingsFeature`, same contract |
| `ui/app.slint` | integration | mounts both features, binds the capabilities |

```slint
// contract (shared, owned by the platform team)
export interface FeatureNav { route Main; }
export interface HostServices { callback log(string); callback go-home(); }

// a feature (Media team): conforms + states what it needs, runs its own navigator
export component MediaFeature implements FeatureNav inherits Rectangle {
    needs HostServices;
    in-out property <MediaRoute> current-route: MediaRoute.Main;
    navigator (current-route) { MediaRoute.Main: MediaPage { home => { root.go-home(); } } }
}

// the integration shell composes features without editing them
export component App inherits Window {
    navigator (current) {
        Shell.Home:     HomeScreen { }
        Shell.Media:    mount MediaFeature via FeatureNav {
            log(message) => { debug(message); }
            go-home => { root.navigate(Shell.Home); }
        }
        Shell.Settings: mount SettingsFeature via FeatureNav { }
    }
}
```

## What's in it

- **Contracts** — an `interface` carries a navigation contract; route attributes
  `@version(n)` / `@uri("…")` make it versioned and deep-linkable; conformance via
  `implements`.
- **Build-time mount** — `mount Impl via Contract`, a direct instantiation checked
  against the contract.
- **Capabilities** — `needs Capability`, bound by the integrator at the mount site.
- **Cross-process mount** — `mount extern via Contract { component-factory: … }`
  via `ComponentContainer` + `ComponentFactory`, for parts shipped as their own binary.
  `examples/navigation-federated` demonstrates it end to end: the host builds the plugin
  in `main.rs` and passes it in as a `slint::ComponentFactory`.
- **Public factory API** — `slint_interpreter::ComponentDefinition::create_embedded` is now
  public (it was `#[doc(hidden)]` + `#[cfg(feature = "internal")]`, though the
  `ComponentContainer` docs already showed it as the public pattern), so a real app can
  supply the factory for an external mount without reaching into internal API.
- **A compiler fix** — the navigator now marks its route property as set (navigate()/
  back() assign it). A mounted module's route is internal, so it was wrongly classified
  constant: the generators emitted `set_constant()` and the first `navigate()` panicked
  "Constant property being changed". Regression: `tests/cases/navigation/internal_route.slint`
  drives navigate()/back() on an internal route (Rust/C++/JS/Python).
- **Docs** — a new *Federated Navigation* guide at
  `docs/astro/src/content/docs/guide/development/navigation-federation.mdx`.

## Notes

- **Experimental:** `SLINT_ENABLE_EXPERIMENTAL_FEATURES=1`.
- **Tests:** interpreter tests for build-time mount, capability binding,
  cross-file mount, and the external factory seam; the cross-language mount case,
  plus `internal_route.slint` exercising navigate()/back() on an internal route.
