### PR TITLE
Interfaces: `implement` validates, it does not copy implementations

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -36,7 +36,8 @@ An interface can be exported with `export interface`.
 ## Implementing an interface
 
 A component declares that it implements an interface with an `implement I <=> self;` statement in its body.
-The component must provide an implementation of the functions listed in the interface, with matching types and signatures.
+The component must declare or inherit every property, callback, and function listed in the interface, matching
+type, visibility, and purity. The compiler validates this; it does not add the members for you.
 
 An `implement` statement's target must be `self` or the id of a child element (see delegation below), and the statement
 is only allowed directly in a component's root element, not in a nested child element. `root` and `parent` are not valid
@@ -46,7 +47,7 @@ targets: since `implement` is root-only, `root` and `self` refer to the same ele
 export component MyText {
     implement TextInterface <=> self;
 
-    text <=> input.text;
+    in-out property <string> text <=> input.text;
 
     input := TextInput {
         text: "Hello";
@@ -57,6 +58,8 @@ export component MyText {
     }
 }
 ```
+
+If a member is missing or doesn't match the interface, the compiler reports it as an error.
 
 A component can combine `implement` with `inherits`:
 
@@ -95,6 +98,9 @@ interface Counter {
 component CounterButton {
     // It is not necessary for CounterButton to `implement Counter <=> self;`
     // implement Counter <=> self;
+
+    in-out property <int> value;
+    callback increment();
 
     preferred-width: 100%;
     preferred-height: 100%;

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1409,7 +1409,6 @@ impl Element {
                 interfaces::disallow_implement_in_non_root(&node, tr, diag);
                 (Vec::new(), Vec::new())
             };
-        interfaces::apply_properties(&mut r, &implemented_interfaces, diag);
 
         for (prop_name, csn, source) in property_bindings {
             match r.bindings.entry(prop_name.clone()) {
@@ -1540,8 +1539,6 @@ impl Element {
                 },
             );
         }
-
-        interfaces::apply_callbacks(&mut r, &implemented_interfaces, diag);
 
         for func in node.Function() {
             #[cfg(feature = "slint-sc")]
@@ -1994,6 +1991,7 @@ impl Element {
             }
         }
 
+        interfaces::validate_properties_and_callbacks(&r.borrow(), &implemented_interfaces, diag);
         interfaces::validate_function_implementations(&r.borrow(), &implemented_interfaces, diag);
         interfaces::apply_child_implement_statements(&r, child_implements, diag);
 

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -224,22 +224,21 @@ pub(super) fn disallow_implement_in_non_root(
     }
 }
 
-pub(super) fn apply_properties(
-    element: &mut Element,
+pub(super) fn validate_properties_and_callbacks(
+    element: &Element,
     implemented_interfaces: &[ImplementedInterface],
     diagnostics: &mut BuildDiagnostics,
 ) {
     for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
-        for (unresolved_prop_name, prop_decl) in
-            interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-                // Functions are expected to be implemented manually, so we don't automatically add them.
-                !matches!(prop_decl.property_type, Type::Function { .. } | Type::Callback { .. })
+        for (member_name, member_declaration) in
+            interface.borrow().property_declarations.iter().filter(|(_, property_declaration)| {
+                !matches!(property_declaration.property_type, Type::Function { .. })
             })
         {
-            apply_interface_property_declaration(
+            validate_interface_member_implementation(
                 element,
-                unresolved_prop_name,
-                prop_decl,
+                member_name,
+                member_declaration,
                 node,
                 interface_name,
                 diagnostics,
@@ -248,104 +247,59 @@ pub(super) fn apply_properties(
     }
 }
 
-pub(super) fn apply_callbacks(
-    element: &mut Element,
-    implemented_interfaces: &[ImplementedInterface],
-    diagnostics: &mut BuildDiagnostics,
-) {
-    for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
-        for (unresolved_prop_name, prop_decl) in
-            interface.borrow().property_declarations.iter().filter(|(_, prop_decl)| {
-                // Functions are expected to be implemented manually, so we don't automatically add them.
-                matches!(prop_decl.property_type, Type::Callback { .. })
-            })
-        {
-            apply_interface_property_declaration(
-                element,
-                unresolved_prop_name,
-                prop_decl,
-                node,
-                interface_name,
-                diagnostics,
-            );
-        }
-    }
-}
-
-fn apply_interface_property_declaration(
-    element: &mut Element,
-    unresolved_prop_name: &SmolStr,
-    prop_declaration: &PropertyDeclaration,
-    node: &syntax_nodes::ImplementStatement,
+fn validate_interface_member_implementation(
+    element: &Element,
+    member_name: &SmolStr,
+    interface_member: &PropertyDeclaration,
+    implement_node: &syntax_nodes::ImplementStatement,
     interface_name: &SmolStr,
     diagnostics: &mut BuildDiagnostics,
 ) {
-    if matches!(prop_declaration.property_type, Type::Invalid) {
+    if matches!(interface_member.property_type, Type::Invalid) {
         // The interface's own declaration is invalid (e.g. an unknown property type). A diagnostic
-        // was already emitted when the interface was parsed, so there is nothing meaningful to apply
-        // or conflict-check here.
+        // was already emitted when the interface was parsed, so there is nothing meaningful to
+        // validate here.
         return;
     }
 
-    let lookup_result = element.lookup_property(unresolved_prop_name);
-
-    fn find_conflicting_node(
-        e: &mut Element,
-        unresolved_prop_name: &SmolStr,
-    ) -> Option<parser::SyntaxNode> {
-        e.property_declarations.get(unresolved_prop_name).and_then(|decl| decl.node.clone())
-    }
-
-    if lookup_result.property_type != Type::Invalid {
-        if lookup_result.is_local_to_component {
-            let property_type_name = match prop_declaration.property_type {
-                Type::Callback { .. } => "callback",
-                Type::Function { .. } => "function",
-                _ => "property",
-            };
-
-            let local_property_node = find_conflicting_node(element, unresolved_prop_name)
-                .expect("Expected local property to have a syntax node");
-
-            diagnostics.push_error(
-                format!(
-                    "Conflict with '{}' which declares a {} with the same name",
-                    interface_name, property_type_name
-                ),
-                &local_property_node,
-            );
-            return;
-        }
-
-        match property_matches_interface(&lookup_result, prop_declaration) {
-            Ok(()) => {
-                return;
-            }
-            Err(error) => {
-                if let Some(local_property_node) =
-                    find_conflicting_node(element, unresolved_prop_name)
-                {
-                    diagnostics.push_error(
-                        format!("Conflict with '{}' which {}", interface_name, error),
-                        &local_property_node,
-                    );
-                    return;
-                }
-            }
-        }
-    }
-
-    if let Err(message) = validate_property_declaration_for_interface(
-        InterfaceUseMode::Implements,
-        &lookup_result,
-        &element.base_type,
-        &interface_name,
-    ) {
-        diagnostics.push_error(message, &node.QualifiedName());
+    let lookup_result = element.lookup_property(member_name);
+    if lookup_result.property_type == Type::Invalid {
+        diagnostics.push_error(
+            format!("Missing '{}' from '{}'", member_name, interface_name),
+            &implement_node.QualifiedName(),
+        );
         return;
     }
 
-    element.property_declarations.insert(unresolved_prop_name.clone(), prop_declaration.clone());
+    let Err(conflict) = property_matches_interface(&lookup_result, interface_member) else {
+        return;
+    };
+
+    if !lookup_result.is_local_to_component {
+        if let Err(message) = validate_property_declaration_for_interface(
+            InterfaceUseMode::Implements,
+            &lookup_result,
+            &element.base_type,
+            &interface_name,
+        ) {
+            diagnostics.push_error(message, &implement_node.QualifiedName());
+        }
+        return;
+    }
+
+    let error = format!(
+        "Incorrect implementation of '{}' from '{}' - {}",
+        member_name, interface_name, conflict
+    );
+    let source = element
+        .property_declarations
+        .get(member_name)
+        .and_then(|declaration| declaration.node.clone())
+        .map_or_else(
+            || parser::NodeOrToken::Node(implement_node.QualifiedName().into()),
+            parser::NodeOrToken::Node,
+        );
+    diagnostics.push_error(error, &source);
 }
 
 pub(super) fn validate_function_implementations(

--- a/internal/compiler/tests/syntax/interfaces/callbacks.slint
+++ b/internal/compiler/tests/syntax/interfaces/callbacks.slint
@@ -9,12 +9,13 @@ export component InverterDuplicate {
     implement Inverter <=> self;
 
     callback invert(bool) -> bool;
-//  >                            <error{Conflict with 'Inverter' which declares a callback with the same name}
+//  >                            <error{Incorrect implementation of 'invert' from 'Inverter' - expected purity declaration: 'true'}
 }
 
 export component InverterAliases {
     implement Inverter <=> self;
 
+    pure callback invert(bool) -> bool;
     pure callback invert-alias <=> invert;
 }
 
@@ -31,4 +32,16 @@ interface Clickable {
 export component MyClicker inherits TouchArea {
     implement Clickable <=> self;
 //            >        <error{Cannot implement interface 'Clickable' because 'moved' conflicts with an existing callback in 'TouchArea'}
+}
+
+export component InverterMissingCallback {
+    implement Inverter <=> self;
+//            >       <error{Missing 'invert' from 'Inverter'}
+}
+
+export component InverterImpure {
+    implement Inverter <=> self;
+
+    callback invert(bool) -> bool;
+//  >                            <error{Incorrect implementation of 'invert' from 'Inverter' - expected purity declaration: 'true'}
 }

--- a/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
+++ b/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
@@ -33,8 +33,8 @@ export component IncorrectImpl {
 
 export component DerivedImplementsInterfaceIncorrectly inherits IncorrectImpl {
     implement ValidInterface <=> self;
-//            >             <error{Cannot implement interface 'ValidInterface' because 'value' conflicts with an existing property in 'IncorrectImpl'}
-//            >             <^error{Cannot implement interface 'ValidInterface' because 'speak' conflicts with an existing callback in 'IncorrectImpl'}
+//            >             <error{Cannot implement interface 'ValidInterface' because 'speak' conflicts with an existing callback in 'IncorrectImpl'}
+//            >             <^error{Cannot implement interface 'ValidInterface' because 'value' conflicts with an existing property in 'IncorrectImpl'}
 //            >             <^^error{Incorrect arguments for implementation of 'reset' from interface 'ValidInterface'. Expected () but got (float)}
 }
 
@@ -42,9 +42,7 @@ export component ComponentDeclaresInterfaceAPI {
     implement ValidInterface <=> self;
 
     in-out property <int> value: 24;
-//  >                              <error{Conflict with 'ValidInterface' which declares a property with the same name}
     callback speak();
-//  >               <error{Conflict with 'ValidInterface' which declares a callback with the same name}
     public function reset() {
         self.value = 0;
     }
@@ -55,9 +53,7 @@ export component ComponentDeclaresInterfaceAPIWithTwoWayBinding {
 
     in-out property <int> other: 32;
     in-out property <int> value <=> self.other;
-//  >                                         <error{Conflict with 'ValidInterface' which declares a property with the same name}
     callback speak();
-//  >               <error{Conflict with 'ValidInterface' which declares a callback with the same name}
     public function reset() {
         self.value = 0;
     }
@@ -67,9 +63,9 @@ export component ComponentDeclaresInterfaceAPIIncorrectly {
     implement ValidInterface <=> self;
 
     in-out property <float> value;
-//  >                            <error{Conflict with 'ValidInterface' which declares a property with the same name}
+//  >                            <error{Incorrect implementation of 'value' from 'ValidInterface' - expected type: 'int'}
     callback speak(string);
-//  >                     <error{Conflict with 'ValidInterface' which declares a callback with the same name}
+//  >                     <error{Incorrect implementation of 'speak' from 'ValidInterface' - expected type: 'callback-> void'}
     public function reset(to: float) {
 //  >error{Incorrect arguments for implementation of 'reset' from interface 'ValidInterface'. Expected () but got (float)}
         self.value = to;

--- a/internal/compiler/tests/syntax/interfaces/implement_conflicts.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_conflicts.slint
@@ -19,6 +19,8 @@ export component SelfChildSameInterface {
     implement I <=> child;
 //  >                    <error{'I' is implemented multiple times}
 
+    in-out property <bool> value;
+
     child := ChildA { }
 }
 
@@ -26,18 +28,24 @@ export component SelfSelfSameInterface {
     implement I <=> self;
     implement I <=> self;
 //  >                   <error{'I' is implemented multiple times}
+
+    in-out property <bool> value;
 }
 
 export component SelfSelfMemberConflict {
     implement I <=> self;
     implement J <=> self;
 //            ><error{'value' occurs in 'J' and 'I'}
+
+    in-out property <bool> value;
 }
 
 export component SelfChildMemberConflict {
     implement I <=> self;
     implement J <=> child;
 //            ><error{'value' occurs in 'J' and 'I'}
+
+    in-out property <bool> value;
 
     child := ChildA { }
 }

--- a/internal/compiler/tests/syntax/interfaces/interface_functions.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_functions.slint
@@ -34,6 +34,9 @@ export interface InvalidFunctionVisibility {
 export component CalculatorImpl {
     implement Calculator <=> self;
 
+    in-out property <int> value;
+    callback notify();
+
     pure public function add(a: int, b: int) -> int {
         return a + b;
     }
@@ -54,6 +57,9 @@ export component MyCalculator inherits Rectangle {
 export component OverrideImpl {
     implement Calculator <=> self;
 
+    in-out property <int> value;
+    callback notify();
+
     public function add(a: int, b: int) -> int {
 //  >error{Implementation of pure function 'add' from interface 'Calculator' cannot be impure}
         return a + b;
@@ -71,6 +77,8 @@ export component OverrideBase {
     }
     in property <string> format;
     callback reset();
+    in-out property <int> value;
+    callback notify();
 
     @children
 }
@@ -85,6 +93,9 @@ export component OverrideInherited inherits OverrideBase {
 export component IncorrectImpl {
     implement Calculator <=> self;
 //            >         <error{Missing implementation of function 'add'}
+
+    in-out property <int> value;
+    callback notify();
 
     // Missing add() function
     public function format(fmt: string, value: int) {
@@ -107,6 +118,8 @@ export component IncorrectBase {
     }
     protected function reset() {
     }
+    in-out property <int> value;
+    callback notify();
     @children
 }
 

--- a/internal/compiler/tests/syntax/interfaces/interface_properties.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_properties.slint
@@ -14,13 +14,6 @@ export interface ValidInterfacePropertyDeclarations {
     in_out property <angle> in-out-underscore-property;
 }
 
-export component ComponentWithDuplicateProperty {
-    implement ValidInterfacePropertyDeclarations <=> self;
-
-    out property <string> out-property;
-//  >                                 <error{Conflict with 'ValidInterfacePropertyDeclarations' which declares a property with the same name}
-}
-
 export interface Background {
     in-out property <color> background;
     callback clip();
@@ -30,6 +23,17 @@ export component MyComponent inherits Rectangle {
     implement Background <=> self;
 //            >         <error{Cannot implement interface 'Background' because 'background' conflicts with an existing property in 'Rectangle'}
 //            >         <^error{Cannot implement interface 'Background' because 'clip' conflicts with an existing property in 'Rectangle'}
+}
+
+export interface OutOnlyInterface {
+    out property <int> count;
+}
+
+export component ComponentWithMismatchedVisibility {
+    implement OutOnlyInterface <=> self;
+
+    in-out property <int> count;
+//  >                          <error{Incorrect implementation of 'count' from 'OutOnlyInterface' - expected visibility: 'output'}
 }
 
 export interface InterfaceWithDefaultPropertyValues {

--- a/internal/compiler/tests/syntax/interfaces/interface_uses1.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_uses1.slint
@@ -5,10 +5,6 @@ interface InterfaceI {
     out property <bool> test;
 }
 
-component Base {
-    implement InterfaceI <=> self;
-}
-
 export component InvalidUses {
     implement InterfaceI;
 //                      ^error{Syntax error: expected '<=>'}

--- a/internal/compiler/tests/syntax/interfaces/interface_uses2.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_uses2.slint
@@ -7,6 +7,8 @@ interface InterfaceI {
 
 component Base {
     implement InterfaceI <=> self;
+
+    out property <bool> test;
 }
 
 export component AnotherInvalidUses {

--- a/internal/compiler/tests/syntax/interfaces/interface_uses3.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_uses3.slint
@@ -5,11 +5,7 @@ interface InterfaceI {
     out property <bool> test;
 }
 
-component Base {
-    implement InterfaceI <=> self;
-}
-
 export component InvalidUses {
-    implement InterfaceI <=>;
-//                          ^error{Syntax error: expected Identifier}
+    implement InterfaceI <=> ;
+//                           ^error{Syntax error: expected Identifier}
 }

--- a/internal/compiler/tests/syntax/interfaces/interfaces.slint
+++ b/internal/compiler/tests/syntax/interfaces/interfaces.slint
@@ -12,7 +12,7 @@ interface LineEditInterface {
 export component LineEditBase {
     implement LineEditInterface <=> self;
 
-    text <=> text-input.text;
+    in-out property <string> text <=> text-input.text;
     color <=> text-input.color;
 //  >   <error{Unknown property color}
     text-input := TextInput { }
@@ -25,6 +25,7 @@ interface Inverter {
 export component InverterImpl {
     implement Inverter <=> self;
 
+    pure callback invert(bool) -> bool;
     invert(b) => {
         return !b;
     }
@@ -32,6 +33,7 @@ export component InverterImpl {
 
 export component LineEditBase2 inherits Rectangle {
     implement LineEditInterface <=> self;
+//            >                <error{Missing 'text' from 'LineEditInterface'}
 }
 
 export component MyLineEdit {

--- a/internal/compiler/tests/syntax/interfaces/uses_errors.slint
+++ b/internal/compiler/tests/syntax/interfaces/uses_errors.slint
@@ -170,6 +170,8 @@ export component ChildDoesNotImplementInterface5 {
 component ValidBase {
     implement ValidInterface <=> self;
 
+    in-out property <int> value;
+    callback speak();
     public pure function reset() {
     }
 }
@@ -214,6 +216,8 @@ interface InterfaceA {
 component AImpl {
     implement InterfaceA <=> self;
 
+    in property <bool> test;
+    callback test-callback();
     pure public function test-function() {
     }
 }
@@ -227,6 +231,8 @@ interface InterfaceB {
 component BImpl {
     implement InterfaceB <=> self;
 
+    out property <bool> test;
+    callback test-callback(string);
     pure public function test-function(i: int) -> int {
         return i;
     }

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -6,18 +6,19 @@ import { LineEditInterface } from "std-widget-interfaces.slint";
 export component LineEditBase inherits Rectangle {
     implement LineEditInterface <=> self;
 
-    font-size <=> text-input.font-size;
-    font-family <=> text-input.font-family;
-    font-italic <=> text-input.font-italic;
-    text <=> text-input.text;
-    enabled <=> text-input.enabled;
-    has-focus: text-input.has-focus;
+    in property <length> font-size <=> text-input.font-size;
+    in property <string> font-family <=> text-input.font-family;
+    in property <bool> font-italic <=> text-input.font-italic;
+    in-out property <string> text <=> text-input.text;
+    in property <bool> enabled <=> text-input.enabled;
+    out property <bool> has-focus: text-input.has-focus;
+
     // When true, the password input shows as plain text.
     // Cleared automatically on focus loss.
     in-out property <bool> password-revealed: false;
-    horizontal-alignment <=> text-input.horizontal-alignment;
-    read-only <=> text-input.read-only;
-    input-method-hints <=> text-input.input-method-hints;
+    in property <TextHorizontalAlignment> horizontal-alignment <=> text-input.horizontal-alignment;
+    in property <bool> read-only <=> text-input.read-only;
+    in property <InputMethodHints> input-method-hints <=> text-input.input-method-hints;
 
     changed has-focus => {
         if !self.has-focus {
@@ -31,6 +32,14 @@ export component LineEditBase inherits Rectangle {
     in property <color> selection-background-color <=> text-input.selection-background-color;
     in property <color> selection-foreground-color <=> text-input.selection-foreground-color;
     in property <length> margin;
+
+    in property <InputType> input-type;
+    in property <string> placeholder-text;
+
+    callback accepted(text: string);
+    callback edited(text: string);
+    callback key-pressed(event: KeyEvent) -> EventResult;
+    callback key-released(event: KeyEvent) -> EventResult;
 
     public function set-selection-offsets(start: int, end: int) {
         text-input.set-selection-offsets(start, end);

--- a/tests/cases/imports/external_interfaces.slint
+++ b/tests/cases/imports/external_interfaces.slint
@@ -9,7 +9,7 @@ import { ExportedInterface } from "export_interfaces.slint";
 
 component Base {
     implement ExportedInterface <=> self;
-    value: 2.71;
+    in-out property <float> value: 2.71;
 }
 
 export component TestCase {

--- a/tests/cases/imports/property_bindings.slint
+++ b/tests/cases/imports/property_bindings.slint
@@ -15,8 +15,9 @@ import { ComboBoxInterface } from "export_interfaces.slint";
 
 component ComboBoxBase {
     implement ComboBoxInterface <=> self;
-    current-value: root.model[root.current-index];
-    model: ["Kiwi", "Mango"];
+    in property <[string]> model: ["Kiwi", "Mango"];
+    in-out property <int> current-index;
+    in-out property <string> current-value: root.model[root.current-index];
 }
 
 export component TestCase {

--- a/tests/cases/interfaces/callbacks.slint
+++ b/tests/cases/interfaces/callbacks.slint
@@ -15,6 +15,9 @@ interface Speaker {
 component SpeakerImpl {
     implement Speaker <=> self;
 
+    callback add-message(string);
+    pure callback speak() -> string;
+
     property <string> message;
 
     add-message(text) => {
@@ -33,6 +36,10 @@ component SpeakerImpl {
 export component TestCase {
     implement Speaker <=> speaker;
     implement TestInterface <=> self;
+
+    pure callback invert(bool) -> bool;
+    pure callback double(int) -> int;
+    pure callback sum(int, int) -> int;
 
     invert(b) => {
         return !b;

--- a/tests/cases/interfaces/component_overrides_defaults.slint
+++ b/tests/cases/interfaces/component_overrides_defaults.slint
@@ -14,13 +14,18 @@ interface InterfaceWithDefaults {
 export component TestCase {
     implement InterfaceWithDefaults <=> self;
 
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    callback checked();
+
     out property <bool> test: self.text == "" && !self.enabled && self.precision == 0 && self.confidence == 0.5;
 
     public pure function length(text: string) -> int {
         text.character-count
     }
 
-    confidence: 0.5;
+    in property <float> confidence: 0.5;
 }
 
 /*

--- a/tests/cases/interfaces/derived_implements_defaults.slint
+++ b/tests/cases/interfaces/derived_implements_defaults.slint
@@ -14,8 +14,13 @@ interface InterfaceWithDefaults {
 component Base {
     implement InterfaceWithDefaults <=> self;
 
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    callback checked();
+
     // Base provides its own default value
-    confidence: 0.5;
+    in property <float> confidence: 0.5;
 
     public pure function length(text: string) -> int {
         text.character-count

--- a/tests/cases/interfaces/implements.slint
+++ b/tests/cases/interfaces/implements.slint
@@ -10,7 +10,7 @@ interface TextInterface {
 export component TestCase {
     implement TextInterface <=> self;
 
-    text <=> text-input.text;
+    in-out property <string> text <=> text-input.text;
 
     text-input := TextInput {
         text: "Hello TextInterface";

--- a/tests/cases/interfaces/implements_defaults.slint
+++ b/tests/cases/interfaces/implements_defaults.slint
@@ -14,7 +14,11 @@ interface InterfaceWithDefaults {
 export component TestCase {
     implement InterfaceWithDefaults <=> self;
 
-    confidence: 0.5;
+    in-out property <string> text;
+    out property <bool> enabled;
+    in property <int> precision;
+    in property <float> confidence: 0.5;
+    callback checked();
 
     out property <bool> test: self.text == "" && !self.enabled && self.precision == 0 && self.confidence == 0.5;
 

--- a/tests/cases/interfaces/implements_inherits.slint
+++ b/tests/cases/interfaces/implements_inherits.slint
@@ -8,7 +8,7 @@ interface TestInterface {
 export component TestCase inherits Rectangle {
     implement TestInterface <=> self;
 
-    test: true;
+    in-out property <bool> test: true;
     background: Colors.lightblue;
 }
 

--- a/tests/cases/interfaces/implements_inherits_aliased_property.slint
+++ b/tests/cases/interfaces/implements_inherits_aliased_property.slint
@@ -15,7 +15,7 @@ interface I {
 
 component Sink {
     implement I <=> self;
-    value: true;
+    in-out property <bool> value: true;
 }
 
 component Base {

--- a/tests/cases/interfaces/uses.slint
+++ b/tests/cases/interfaces/uses.slint
@@ -9,7 +9,7 @@ interface TestInterface {
 component TestBase {
     implement TestInterface <=> self;
 
-    test: true;
+    in-out property <bool> test: true;
     pure public function double(i: int) -> int {
         return i * 2;
     }

--- a/tests/helper_components/export_interfaces.slint
+++ b/tests/helper_components/export_interfaces.slint
@@ -7,7 +7,7 @@ export interface ExportedInterface {
 
 export component ExportedBase {
     implement ExportedInterface <=> self;
-    value: 2.71;
+    in-out property <float> value: 2.71;
 }
 
 export interface ComboBoxInterface {


### PR DESCRIPTION
`implement I <=> self;` no longer copies an interface's property/callback/function declarations onto the component. Instead it validates that the component declares or inherits every member, with matching type, visibility, and (for callbacks/functions) purity, via `validate_properties_and_callbacks` and `validate_function_implementations` in `object_tree/interfaces.rs`. Both validators now run in `object_tree.rs` after all of a component's own property, callback, and function declarations are registered, so a locally declared member of the same name is found rather than misreported as missing; a same-named but wrong-kind local declaration (e.g. a `callback` where the interface expects a `property`) is now reported as a kind conflict instead.

Migrates every self-implementing component across the runtime test cases, compiler syntax tests, shipped widgets, and interface.mdx to explicitly declare the members their interfaces require, and updates the affected diagnostic wording to match the new validate-only semantics.

Where possible we have re-used the existing error messages as we intend to improve these in a future PR.

Relates to #1870.