### PR TITLE
viewer: Fix --auto-reload with relative paths

### DIFF
--- a/internal/live-preview/file_watcher.rs
+++ b/internal/live-preview/file_watcher.rs
@@ -180,6 +180,9 @@ impl<Impl: FileWatcherImpl> FileWatcher<Impl> {
     }
 
     /// Replaces the watched path set with `paths`.
+    ///
+    /// Paths must be absolute: they are compared by value against the paths the backend reports
+    /// for events, which are absolute, and relative paths are never resolved against a base.
     pub fn update_watched_paths<I>(&mut self, paths: I) -> Result<(), Impl::Error>
     where
         I: IntoIterator<Item = PathBuf>,

--- a/internal/live-preview/file_watcher.rs
+++ b/internal/live-preview/file_watcher.rs
@@ -104,6 +104,10 @@ impl FileWatcherImpl for notify::RecommendedWatcher {
 pub struct FileWatcher<Impl: FileWatcherImpl = notify::RecommendedWatcher> {
     tx: mpsc::Sender<WorkerMessage<Impl>>,
 
+    /// Base for resolving relative watch paths, captured at startup so it stays stable if the
+    /// process later changes its working directory.
+    base: PathBuf,
+
     /// Use a worker thread for processing file events and updating watches.
     ///
     /// `notify` already invokes callbacks from backend-managed threads/event loops, but
@@ -167,7 +171,11 @@ impl<Impl: FileWatcherImpl> FileWatcher<Impl> {
         });
 
         match startup_rx.recv() {
-            Ok(Ok(())) => Ok(Self { tx, worker: Some(worker) }),
+            Ok(Ok(())) => Ok(Self {
+                tx,
+                worker: Some(worker),
+                base: std::env::current_dir().unwrap_or_default(),
+            }),
             Ok(Err(err)) => {
                 let _ = worker.join();
                 Err(err)
@@ -181,15 +189,18 @@ impl<Impl: FileWatcherImpl> FileWatcher<Impl> {
 
     /// Replaces the watched path set with `paths`.
     ///
-    /// Paths must be absolute: they are compared by value against the paths the backend reports
-    /// for events, which are absolute, and relative paths are never resolved against a base.
+    /// Relative paths are resolved against the working directory captured at watcher startup,
+    /// so that they compare equal to the absolute paths the backend reports for events.
     pub fn update_watched_paths<I>(&mut self, paths: I) -> Result<(), Impl::Error>
     where
         I: IntoIterator<Item = PathBuf>,
     {
         let watched_files = paths
             .into_iter()
-            .map(|path| i_slint_compiler::pathutils::clean_path(&path))
+            .map(|path| {
+                let path = i_slint_compiler::pathutils::join(&self.base, &path).unwrap_or(path);
+                i_slint_compiler::pathutils::clean_path(&path)
+            })
             .collect::<HashSet<_>>();
 
         let (response_tx, response_rx) = mpsc::sync_channel(1);

--- a/internal/live-preview/live_component.rs
+++ b/internal/live-preview/live_component.rs
@@ -30,7 +30,6 @@ pub struct LiveReloadingComponent {
     callbacks: RefCell<HashMap<String, Rc<dyn Fn(&[Value]) -> Value + 'static>>>,
     post_reload_hook: Option<Box<dyn Fn(&ComponentInstance)>>,
     extra_watch_paths: Vec<PathBuf>,
-    working_directory: PathBuf,
 }
 
 impl LiveReloadingComponent {
@@ -41,10 +40,6 @@ impl LiveReloadingComponent {
         component_name: Option<String>,
     ) -> Result<Rc<RefCell<Self>>, PlatformError> {
         compiler.set_embed_resources(i_slint_compiler::EmbedResourcesKind::ListAllResources);
-
-        // Base for the compiler's relative watch paths; captured once so it stays stable across
-        // reloads.
-        let working_directory = std::env::current_dir().unwrap_or_default();
 
         let self_rc = Rc::<RefCell<Self>>::new_cyclic(move |self_weak| {
             let watcher = Watcher::new(self_weak.clone());
@@ -59,7 +54,6 @@ impl LiveReloadingComponent {
                 callbacks: Default::default(),
                 post_reload_hook: None,
                 extra_watch_paths: Vec::new(),
-                working_directory,
             })
         });
 
@@ -127,16 +121,11 @@ impl LiveReloadingComponent {
         else {
             unreachable!("Compiler returned Pending")
         };
-        let base = &self.working_directory;
         Watcher::update_watched_paths(
             &self.watcher,
             std::iter::once(self.file_name.clone())
                 .chain(result.watch_paths(i_slint_core::InternalToken).iter().cloned())
-                .chain(self.extra_watch_paths.iter().cloned())
-                // Resolve relative paths so they match the absolute paths the OS reports; the
-                // compiler keeps them relative for diagnostics. `join` leaves absolute paths and
-                // URLs untouched.
-                .map(|path| i_slint_compiler::pathutils::join(base, &path).unwrap_or(path)),
+                .chain(self.extra_watch_paths.iter().cloned()),
         );
         result
     }

--- a/internal/live-preview/live_component.rs
+++ b/internal/live-preview/live_component.rs
@@ -30,6 +30,7 @@ pub struct LiveReloadingComponent {
     callbacks: RefCell<HashMap<String, Rc<dyn Fn(&[Value]) -> Value + 'static>>>,
     post_reload_hook: Option<Box<dyn Fn(&ComponentInstance)>>,
     extra_watch_paths: Vec<PathBuf>,
+    working_directory: PathBuf,
 }
 
 impl LiveReloadingComponent {
@@ -40,6 +41,10 @@ impl LiveReloadingComponent {
         component_name: Option<String>,
     ) -> Result<Rc<RefCell<Self>>, PlatformError> {
         compiler.set_embed_resources(i_slint_compiler::EmbedResourcesKind::ListAllResources);
+
+        // Base for the compiler's relative watch paths; captured once so it stays stable across
+        // reloads.
+        let working_directory = std::env::current_dir().unwrap_or_default();
 
         let self_rc = Rc::<RefCell<Self>>::new_cyclic(move |self_weak| {
             let watcher = Watcher::new(self_weak.clone());
@@ -54,6 +59,7 @@ impl LiveReloadingComponent {
                 callbacks: Default::default(),
                 post_reload_hook: None,
                 extra_watch_paths: Vec::new(),
+                working_directory,
             })
         });
 
@@ -121,11 +127,16 @@ impl LiveReloadingComponent {
         else {
             unreachable!("Compiler returned Pending")
         };
+        let base = &self.working_directory;
         Watcher::update_watched_paths(
             &self.watcher,
             std::iter::once(self.file_name.clone())
                 .chain(result.watch_paths(i_slint_core::InternalToken).iter().cloned())
-                .chain(self.extra_watch_paths.iter().cloned()),
+                .chain(self.extra_watch_paths.iter().cloned())
+                // Resolve relative paths so they match the absolute paths the OS reports; the
+                // compiler keeps them relative for diagnostics. `join` leaves absolute paths and
+                // URLs untouched.
+                .map(|path| i_slint_compiler::pathutils::join(base, &path).unwrap_or(path)),
         );
         result
     }

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -377,16 +377,8 @@ fn init_dialog(instance: &ComponentInstance) {
 }
 
 fn watchable_path(path: &Path) -> Option<PathBuf> {
-    // Filter out `-` for stdin
-    (path != Path::new("-")).then(|| {
-        if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            std::env::current_dir()
-                .map(|current_dir| current_dir.join(path))
-                .unwrap_or_else(|_| path.to_path_buf())
-        }
-    })
+    // Filter out `-` for stdin; the file watcher resolves relative paths.
+    (path != Path::new("-")).then(|| path.to_path_buf())
 }
 
 /// Exit with an error if the component has no window to display (e.g. a `SystemTrayIcon` root).


### PR DESCRIPTION
The file watcher compares the watched paths against the absolute paths the OS reports for file changes, but the compiler keeps them relative, so nothing ever matched and the preview never reloaded.

Resolve the watched paths against the working directory before watching, while keeping the relative paths for the compiler so diagnostics stay relative.

Fixes: #12572
