### PR TITLE
FlexboxLayout: re-measure width-for-height cells of a repeated instance (v2)

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2960,10 +2960,25 @@ fn generate_flexbox_layout_item_info_decl(
                 )
             })
             .unwrap_or_default();
+        // Mirror of `v_constrained` for the other axis: a width-for-height
+        // instance (e.g. a wrapping column FlexboxLayout) must not read
+        // self.height. Use the unbounded constrained horizontal info.
+        let h_constrained = root_sc
+            .layout_info_h_constrained_for_repeated
+            .as_ref()
+            .map(|e| {
+                let h = compile_expression(&e.borrow(), ctx);
+                format!(
+                    "if (o == slint::cbindgen_private::Orientation::Horizontal && !child_index.has_value()) {{ \
+                         info.constraint = {h}; return info; }} "
+                )
+            })
+            .unwrap_or_default();
         format!(
             "[[maybe_unused]] auto self = this; \
              auto info = {compiled}; \
              {v_constrained}\
+             {h_constrained}\
              info.constraint = layout_item_info(o, child_index).constraint; \
              return info;"
         )
@@ -3001,6 +3016,26 @@ fn generate_flexbox_layout_item_info_decl(
             .to_owned(),
     };
 
+    // Mirror of `at_cross_width_body`: a FlexboxLayout calls this with the
+    // height it assigned so a width-for-height instance resolves to the width
+    // it really needs. The expression reads the `flex_cross_height` parameter.
+    let at_cross_height_body = match (
+        &for_repeated_compiled,
+        root_sc.layout_info_h_at_cross_height_for_repeated.as_ref(),
+    ) {
+        (Some(compiled), Some(e)) => {
+            let h = compile_expression(&e.borrow(), ctx);
+            format!(
+                "[[maybe_unused]] auto self = this; \
+                 auto info = {compiled}; \
+                 info.constraint = {h}; \
+                 return info;"
+            )
+        }
+        _ => "return flexbox_layout_item_info(slint::cbindgen_private::Orientation::Horizontal, std::nullopt);"
+            .to_owned(),
+    };
+
     vec![
         Declaration::Function(Function {
             name: "flexbox_layout_item_info".into(),
@@ -3014,6 +3049,14 @@ fn generate_flexbox_layout_item_info_decl(
                 "([[maybe_unused]] float flex_cross_width) const -> slint::cbindgen_private::FlexboxLayoutItemInfo"
                     .to_owned(),
             statements: Some(vec![at_cross_width_body]),
+            ..Function::default()
+        }),
+        Declaration::Function(Function {
+            name: "flexbox_layout_item_info_at_cross_height".into(),
+            signature:
+                "([[maybe_unused]] float flex_cross_height) const -> slint::cbindgen_private::FlexboxLayoutItemInfo"
+                    .to_owned(),
+            statements: Some(vec![at_cross_height_body]),
             ..Function::default()
         }),
     ]
@@ -4634,8 +4677,15 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                                      return {{ w, h }}; }} \
                                  cursor += len; }}\n"
                             ));
-                            // No width-for-height accessor on a repeated instance: keep its default.
-                            h_steps.push_str(&format!("cursor += self->repeater_{i}.len();\n"));
+                            h_steps.push_str(&format!(
+                                "{{ auto len = self->repeater_{i}.len(); \
+                                 if (index >= cursor && index < cursor + len) {{ \
+                                     if (auto *sub_comp = self->repeater_{i}.typed_instance_at(index - cursor)) {{ \
+                                         auto li = sub_comp->flexbox_layout_item_info_at_cross_height(h).constraint; \
+                                         return {{ {BOUNDED}, h }}; }} \
+                                     return {{ w, h }}; }} \
+                                 cursor += len; }}\n"
+                            ));
                         }
                     }
                 }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2802,6 +2802,37 @@ fn generate_repeated_component(
                                 self.layout_item_info(sp::Orientation::Vertical, sp::None).constraint;
                         }
                     });
+                // Mirror of `v_constrained` for the other axis: a width-for-height
+                // instance (e.g. a wrapping column FlexboxLayout) must not read
+                // self.height. Use the unbounded constrained horizontal info.
+                let h_constrained =
+                    root_sc.layout_info_h_constrained_for_repeated.as_ref().map(|e| {
+                        let h_info = compile_expression(&e.borrow(), &ctx);
+                        quote! {
+                            if matches!(o, sp::Orientation::Horizontal) && child_index.is_none() {
+                                info.constraint = #h_info;
+                                return info;
+                            }
+                        }
+                    });
+                // A FlexboxLayout calls this with the height it assigned, so a
+                // width-for-height instance resolves to the same width as an
+                // equivalent static cell (instead of the unbounded, unwrapped one
+                // that `flexbox_layout_item_info` returns). The expression reads
+                // the `flex_cross_height` local (matches FLEX_CROSS_HEIGHT_LOCAL).
+                let at_cross_height_body = root_sc
+                    .layout_info_h_at_cross_height_for_repeated
+                    .as_ref()
+                    .map(|e| {
+                        let h_info = compile_expression(&e.borrow(), &ctx);
+                        quote! { info.constraint = #h_info; }
+                    })
+                    .unwrap_or_else(|| {
+                        quote! {
+                            info.constraint =
+                                self.layout_item_info(sp::Orientation::Horizontal, sp::None).constraint;
+                        }
+                    });
                 quote! {
                     fn flexbox_layout_item_info(
                         self: ::core::pin::Pin<&Self>,
@@ -2812,6 +2843,7 @@ fn generate_repeated_component(
                         let _self = self.as_ref();
                         let mut info = self.as_ref().flexbox_layout_item_info_for_repeated();
                         #v_constrained
+                        #h_constrained
                         info.constraint = self.layout_item_info(o, child_index).constraint;
                         info
                     }
@@ -2824,6 +2856,17 @@ fn generate_repeated_component(
                         let _self = self.as_ref();
                         let mut info = self.as_ref().flexbox_layout_item_info_for_repeated();
                         #at_cross_width_body
+                        info
+                    }
+                    #[allow(unused_variables)]
+                    fn flexbox_layout_item_info_at_cross_height(
+                        self: ::core::pin::Pin<&Self>,
+                        flex_cross_height: f32,
+                    ) -> sp::FlexboxLayoutItemInfo {
+                        #[allow(unused)]
+                        let _self = self.as_ref();
+                        let mut info = self.as_ref().flexbox_layout_item_info_for_repeated();
+                        #at_cross_height_body
                         info
                     }
                 }
@@ -5453,8 +5496,22 @@ fn generate_solve_flexbox_layout_with_measure(
                             cursor += len;
                         }
                     ));
-                    // No width-for-height accessor on a repeated instance: keep its default.
-                    h_steps.push(quote!(cursor += _self.#repeater_id.len();));
+                    h_steps.push(quote!(
+                        {
+                            let len = _self.#repeater_id.len();
+                            if index >= cursor && index < cursor + len {
+                                if let Some(sub_comp) = _self.#repeater_id.instance_at(index - cursor) {
+                                    return (sub_comp
+                                        .as_pin_ref()
+                                        .flexbox_layout_item_info_at_cross_height(h)
+                                        .constraint
+                                        .preferred_bounded(), h);
+                                }
+                                return (w, h);
+                            }
+                            cursor += len;
+                        }
+                    ));
                 }
             }
         }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -261,8 +261,9 @@ pub enum Expression {
     /// `(h_info, v_info)` at the default constraint (matching `data`'s cells);
     /// it provides the preferred size returned when taffy asks for a dimension
     /// without a known cross-axis size (mirroring the plain `solve_flexbox_layout`
-    /// measure). A repeater cell (the `Right` case) is measured by calling
-    /// `flexbox_layout_item_info_at_cross_width` on the instance taffy asks for.
+    /// measure). A repeater cell (the `Right` case) is measured by calling the
+    /// matching cross-axis accessor (`flexbox_layout_item_info_at_cross_width` or
+    /// `_at_cross_height`) on the instance taffy asks for.
     SolveFlexboxLayoutWithMeasure {
         /// The `FlexboxLayoutData` (built inline with the cell arrays, so its
         /// temporaries live for the duration of the solve call).

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -532,6 +532,18 @@ pub struct SubComponent {
     /// which a column FlexboxLayout calls with its real container width so a
     /// repeated cell wraps to the same height as an equivalent static cell.
     pub layout_info_v_at_cross_width_for_repeated: Option<MutExpression>,
+    /// Horizontal counterpart of `layout_info_v_constrained_for_repeated`:
+    /// computed with an unbounded height constraint so a width-for-height
+    /// instance (e.g. a wrapping column FlexboxLayout) doesn't read
+    /// `self.height` and recurse through the parent flex cache. `Some` only
+    /// when the element carries a `layoutinfo-h-with-constraint`.
+    pub layout_info_h_constrained_for_repeated: Option<MutExpression>,
+    /// Same as `layout_info_h_constrained_for_repeated`, but measured at the
+    /// height passed in the `flex_cross_height` local. Drives the generated
+    /// `flexbox_layout_item_info_at_cross_height` method, which a FlexboxLayout
+    /// calls with the height it assigned so a repeated cell resolves to the
+    /// same width as an equivalent static cell.
+    pub layout_info_h_at_cross_height_for_repeated: Option<MutExpression>,
     /// True when this is a repeated Row in a GridLayout, meaning layout_item_info
     /// needs to be able to return layout info for individual children
     pub is_repeated_row: bool,
@@ -729,6 +741,12 @@ impl CompilationUnit {
                 visitor(e, ctx);
             }
             if let Some(e) = &sc.layout_info_v_at_cross_width_for_repeated {
+                visitor(e, ctx);
+            }
+            if let Some(e) = &sc.layout_info_h_constrained_for_repeated {
+                visitor(e, ctx);
+            }
+            if let Some(e) = &sc.layout_info_h_at_cross_height_for_repeated {
                 visitor(e, ctx);
             }
             for e in sc.accessible_prop.values() {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1994,3 +1994,65 @@ pub fn get_layout_info_v_at_cross_width_for_repeated(
     };
     Some(get_layout_info(element, ctx, constraints, Orientation::Vertical, Some(width_constraint)))
 }
+
+/// Horizontal `LayoutInfo` for a repeated element, computed with an unbounded
+/// height constraint. Routes through the element's
+/// `layoutinfo-h-with-constraint` (via [`get_layout_info`]), so a
+/// width-for-height instance in a FlexboxLayout computes its width from that
+/// height instead of reading `self.height` — which would cycle through the
+/// parent flex's layout cache. Returns `None` when the element has no
+/// constrained horizontal layout-info (nothing to break).
+pub fn get_layout_info_h_constrained_for_repeated(
+    ctx: &mut ExpressionLoweringCtx,
+    element: &ElementRc,
+    constraints: &crate::layout::LayoutConstraints,
+) -> Option<llr_Expression> {
+    if element.borrow().inherited_layout_info_h_with_constraint().is_none() {
+        return None;
+    }
+    // Unbounded, the same default static width-for-height cells use: the
+    // natural, unwrapped width. A flex re-measures at the height it really
+    // assigns via `get_layout_info_h_at_cross_height_for_repeated`.
+    let height_constraint = crate::expression_tree::Expression::NumberLiteral(
+        f32::MAX as f64,
+        crate::expression_tree::Unit::Px,
+    );
+    Some(get_layout_info(
+        element,
+        ctx,
+        constraints,
+        Orientation::Horizontal,
+        Some(height_constraint),
+    ))
+}
+
+/// Name of the local that carries the cross-axis (assigned) height into the
+/// generated `flexbox_layout_item_info_at_cross_height` method body.
+pub const FLEX_CROSS_HEIGHT_LOCAL: &str = "flex_cross_height";
+
+/// Like [`get_layout_info_h_constrained_for_repeated`], but measures at the
+/// height passed in the [`FLEX_CROSS_HEIGHT_LOCAL`] local instead of leaving it
+/// unbounded. A FlexboxLayout supplies the height it assigned at solve time, so
+/// a repeated width-for-height instance gets the same width as an equivalent
+/// static cell. Returns `None` when the element has no constrained horizontal
+/// layout-info.
+pub fn get_layout_info_h_at_cross_height_for_repeated(
+    ctx: &mut ExpressionLoweringCtx,
+    element: &ElementRc,
+    constraints: &crate::layout::LayoutConstraints,
+) -> Option<llr_Expression> {
+    if element.borrow().inherited_layout_info_h_with_constraint().is_none() {
+        return None;
+    }
+    let height_constraint = crate::expression_tree::Expression::ReadLocalVariable {
+        name: FLEX_CROSS_HEIGHT_LOCAL.into(),
+        ty: Type::LogicalLength,
+    };
+    Some(get_layout_info(
+        element,
+        ctx,
+        constraints,
+        Orientation::Horizontal,
+        Some(height_constraint),
+    ))
+}

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -320,6 +320,8 @@ fn lower_sub_component(
         flexbox_layout_item_info_for_repeated: None,
         layout_info_v_constrained_for_repeated: None,
         layout_info_v_at_cross_width_for_repeated: None,
+        layout_info_h_constrained_for_repeated: None,
+        layout_info_h_at_cross_height_for_repeated: None,
         is_repeated_row: component
             .root_element
             .borrow()
@@ -698,10 +700,16 @@ fn lower_sub_component(
                 root_elem,
                 &component.root_constraints.borrow(),
             );
+        let h_constrained =
+            super::lower_layout_expression::get_layout_info_h_constrained_for_repeated(
+                &mut ctx,
+                root_elem,
+                &component.root_constraints.borrow(),
+            );
         // Generate the flex item-info accessor when the element sets flex
-        // properties, or when it needs the constrained-vertical fix (a
-        // height-for-width instance in a column flex).
-        if has_flex_binding || v_constrained.is_some() {
+        // properties, or when it needs one of the constrained-axis fixes (a
+        // height-for-width instance in a column flex, or a width-for-height one).
+        if has_flex_binding || v_constrained.is_some() || h_constrained.is_some() {
             sub_component.flexbox_layout_item_info_for_repeated = Some(
                 super::lower_layout_expression::get_flexbox_layout_item_info_for_repeated(
                     &mut ctx, root_elem,
@@ -712,6 +720,14 @@ fn lower_sub_component(
         sub_component.layout_info_v_constrained_for_repeated = v_constrained.map(Into::into);
         sub_component.layout_info_v_at_cross_width_for_repeated =
             super::lower_layout_expression::get_layout_info_v_at_cross_width_for_repeated(
+                &mut ctx,
+                root_elem,
+                &component.root_constraints.borrow(),
+            )
+            .map(Into::into);
+        sub_component.layout_info_h_constrained_for_repeated = h_constrained.map(Into::into);
+        sub_component.layout_info_h_at_cross_height_for_repeated =
+            super::lower_layout_expression::get_layout_info_h_at_cross_height_for_repeated(
                 &mut ctx,
                 root_elem,
                 &component.root_constraints.borrow(),

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -82,6 +82,12 @@ pub fn count_property_use(root: &CompilationUnit) {
         if let Some(e) = &sc.layout_info_v_at_cross_width_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }
+        if let Some(e) = &sc.layout_info_h_constrained_for_repeated {
+            e.borrow().visit_property_references(ctx, &mut visit_property);
+        }
+        if let Some(e) = &sc.layout_info_h_at_cross_height_for_repeated {
+            e.borrow().visit_property_references(ctx, &mut visit_property);
+        }
         for child in &sc.grid_layout_children {
             child.layout_info_h.borrow().visit_property_references(ctx, &mut visit_property);
             child.layout_info_v.borrow().visit_property_references(ctx, &mut visit_property);

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -309,6 +309,8 @@ mod visitor {
             flexbox_layout_item_info_for_repeated,
             layout_info_v_constrained_for_repeated,
             layout_info_v_at_cross_width_for_repeated,
+            layout_info_h_constrained_for_repeated,
+            layout_info_h_at_cross_height_for_repeated,
             is_repeated_row: _,
             grid_layout_children,
             accessible_prop,
@@ -406,6 +408,12 @@ mod visitor {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some(e) = layout_info_v_at_cross_width_for_repeated {
+            visit_expression(e.get_mut(), &scope, state, visitor);
+        }
+        if let Some(e) = layout_info_h_constrained_for_repeated {
+            visit_expression(e.get_mut(), &scope, state, visitor);
+        }
+        if let Some(e) = layout_info_h_at_cross_height_for_repeated {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         for child in grid_layout_children {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3680,6 +3680,42 @@ impl std::iter::IntoIterator for Exports {
     }
 }
 
+/// Re-declare the constrained layout-info functions on an injected wrapper, forwarding
+/// to the element that carries them.
+///
+/// `inherited_layout_info_*_with_constraint` walks the base-type chain, but the element
+/// declaring those functions is now the wrapper's *child*, so without this the wrapper
+/// reports "not height-for-width / width-for-height" and the layout falls back to reading
+/// the cell's own width/height — which the parent layout is still computing (binding loop).
+///
+/// The function must be re-declared rather than the `NamedReference` copied: callers
+/// assert it points at the component's root element, which the wrapper now is.
+fn forward_layout_info_with_constraint(new_root: &ElementRc, old_root: &ElementRc) {
+    let span = old_root.borrow().to_source_location();
+    let forward_to = |nr: NamedReference| Expression::FunctionCall {
+        function: Callable::Function(NamedReference::new(old_root, nr.name().clone())),
+        arguments: vec![Expression::FunctionParameterReference {
+            index: 0,
+            ty: Type::LogicalLength,
+        }],
+        source_location: None,
+    };
+    if let Some(nr) = old_root.borrow().inherited_layout_info_v_with_constraint() {
+        crate::passes::lower_layout::synthesize_layoutinfo_v_with_constraint_on(
+            new_root,
+            span.clone(),
+            forward_to(nr),
+        );
+    }
+    if let Some(nr) = old_root.borrow().inherited_layout_info_h_with_constraint() {
+        crate::passes::lower_layout::synthesize_layoutinfo_h_with_constraint_on(
+            new_root,
+            span,
+            forward_to(nr),
+        );
+    }
+}
+
 /// This function replace the root element of a repeated element. the previous root becomes the only
 /// child of the new root element.
 /// Note that no reference to the base component must exist outside of repeated_element.base_type
@@ -3766,6 +3802,7 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
         Some((li_h.clone(), li_v.clone()))
     });
     new_root.borrow_mut().layout_info_prop = layout_info_prop;
+    forward_layout_info_with_constraint(&new_root, old_root);
 
     // Replace the repeated component's element with our shadow element. That requires a bit of reference counting
     // surgery and relies on nobody having a strong reference left to the component, which we take out of the Rc.

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -34,7 +34,7 @@ mod key_bindings;
 mod lower_absolute_coordinates;
 mod lower_accessibility;
 mod lower_component_container;
-mod lower_layout;
+pub(crate) mod lower_layout;
 mod lower_menus;
 mod lower_platform;
 mod lower_popups;

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -21,7 +21,7 @@ use std::rc::Rc;
 /// Add a `pure function layoutinfo-v-with-constraint(width: length) -> LayoutInfo`
 /// to `elem` with the given `body`. The body reads
 /// `FunctionParameterReference { index: 0 }` for the width.
-fn synthesize_layoutinfo_v_with_constraint_on(
+pub(crate) fn synthesize_layoutinfo_v_with_constraint_on(
     elem: &ElementRc,
     span: crate::diagnostics::SourceLocation,
     body: Expression,
@@ -137,7 +137,7 @@ fn rewrite_layoutinfo_v_for_constraint(expr: &mut Expression, width_param: &Expr
 }
 
 /// Mirror of [`synthesize_layoutinfo_v_with_constraint_on`] for the horizontal axis.
-fn synthesize_layoutinfo_h_with_constraint_on(
+pub(crate) fn synthesize_layoutinfo_h_with_constraint_on(
     elem: &ElementRc,
     span: crate::diagnostics::SourceLocation,
     body: Expression,

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -79,6 +79,18 @@ pub trait RepeatedItemTree:
         self.flexbox_layout_item_info(Orientation::Vertical, None)
     }
 
+    /// Horizontal flexbox info measured at the given cross-axis (assigned)
+    /// height. A FlexboxLayout calls this so a width-for-height instance
+    /// resolves to the width it really needs at that height. The default
+    /// ignores the height (non-width-for-height cells); the generated code
+    /// overrides it for width-for-height instances.
+    fn flexbox_layout_item_info_at_cross_height(
+        self: Pin<&Self>,
+        _flex_cross_height: f32,
+    ) -> crate::layout::FlexboxLayoutItemInfo {
+        self.flexbox_layout_item_info(Orientation::Horizontal, None)
+    }
+
     /// Fills in the grid layout input data for this ItemTree if it is in a grid layout.
     /// This will be a single GridLayoutInputData if the repeated item is a single cell,
     /// or multiple GridLayoutInputData if the repeated item is a full Row.

--- a/tests/cases/layout/flexbox_repeated_wrapped_constrained_cell.slint
+++ b/tests/cases/layout/flexbox_repeated_wrapped_constrained_cell.slint
@@ -1,0 +1,179 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A conditional `opacity`/`visible`/… binding on a repeated FlexboxLayout cell
+// injects a wrapper (Opacity/Clip/…) as the new repeated root. The wrapper must
+// keep reporting the cell as height-for-width / width-for-height, otherwise the
+// flex skips the constrained re-measure and falls back to reading the cell's own
+// width/height — which the parent flex is still computing, so the layout either
+// panics with "Recursion detected" or overflows the stack.
+//
+// `inherited_layout_info_*_with_constraint` walks the base-type chain, and after
+// the injection the element carrying those functions is the wrapper's *child*,
+// so they have to be re-declared on the wrapper.
+
+// A wrapping column flex is width-for-height: 4 boxes of 30px stack into a single
+// 40px column when tall enough, and into two 80px columns at 70px tall.
+component WrapCol {
+    FlexboxLayout {
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px;
+        padding: 0px;
+        align-content: start;
+        Rectangle { width: 40px; height: 30px; background: red; }
+        Rectangle { width: 40px; height: 30px; background: green; }
+        Rectangle { width: 40px; height: 30px; background: blue; }
+        Rectangle { width: 40px; height: 30px; background: yellow; }
+    }
+}
+
+// A word-wrapping Text is height-for-width.
+component Card inherits Rectangle {
+    in property <string> label;
+    VerticalLayout {
+        Text { text: root.label; wrap: word-wrap; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 1000px;
+    height: 600px;
+
+    in-out property <bool> cond: true;
+    property <string> long: "A really long card text that will almost certainly need to wrap onto two or more lines when the flex space is tight";
+
+    // Single-line reference, so the height assertions stay font-independent
+    // (the nodejs backend has no test fonts).
+    refLine := Text { x: -3000px; text: "Short"; wrap: no-wrap; }
+    out property <length> line-height: refLine.height;
+
+    // --- width-for-height cells in a wrapping column flex ---
+    // Each flex is 70px tall: the WrapCol fills the first column on its own and
+    // the anchor is pushed to the second, so `anchor.x` is the solved WrapCol width.
+
+    // Static reference, no repeater, no wrapper.
+    FlexboxLayout {
+        x: 0; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        WrapCol { min-height: 70px; max-height: 70px; }
+        wStatic := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // Repeated cell wrapped by Opacity.
+    FlexboxLayout {
+        x: 300px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        for x in [1]: WrapCol { min-height: 70px; max-height: 70px; opacity: cond ? 1.0 : 0.4; }
+        wOpacity := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // Repeated cell wrapped by Clip (via `visible`).
+    FlexboxLayout {
+        x: 600px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        for x in [1]: WrapCol { min-height: 70px; max-height: 70px; visible: cond; }
+        wVisible := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // --- height-for-width cells in a wrapping row flex ---
+    // The card takes line 1 and the 150px-wide anchor is pushed to line 2, so
+    // `anchor.y` is the solved card height.
+
+    // Static reference, no repeater, no wrapper.
+    FlexboxLayout {
+        x: 0; y: 100px; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        Card { label: long; flex-shrink: 0; flex-basis: 150px; }
+        hStatic := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // Repeated cell wrapped by Opacity.
+    FlexboxLayout {
+        x: 200px; y: 100px; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        for s in [long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; opacity: cond ? 1.0 : 0.4; }
+        hOpacity := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // Repeated cell wrapped by Clip (via `visible`).
+    FlexboxLayout {
+        x: 400px; y: 100px; width: 150px; height: 400px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: start;
+        for s in [long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; visible: cond; }
+        hVisible := Rectangle { width: 150px; height: 5px; }
+    }
+
+    // `x`/`y` are relative to the enclosing flexbox, so they are the solved
+    // cell width/height directly.
+    out property <length> w-static: wStatic.x;
+    out property <length> h-static: hStatic.y;
+
+    // The reference cells really did wrap, otherwise the equalities below would
+    // hold trivially.
+    out property <bool> w-wrapped: w-static > 60px;
+    out property <bool> h-wrapped: h-static > line-height * 1.5;
+
+    out property <bool> w-opacity-ok: abs(wOpacity.x - w-static) < 1px;
+    out property <bool> w-visible-ok: abs(wVisible.x - w-static) < 1px;
+    out property <bool> h-opacity-ok: abs(hOpacity.y - h-static) < 1px;
+    out property <bool> h-visible-ok: abs(hVisible.y - h-static) < 1px;
+
+    out property <bool> test: w-wrapped && h-wrapped
+        && w-opacity-ok && w-visible-ok && h-opacity-ok && h-visible-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_w_wrapped(), "width-for-height reference cell did not wrap");
+assert!(instance.get_h_wrapped(), "height-for-width reference card did not wrap");
+assert!(instance.get_w_opacity_ok(), "opacity-wrapped repeated width-for-height cell not re-measured");
+assert!(instance.get_w_visible_ok(), "visible-wrapped repeated width-for-height cell not re-measured");
+assert!(instance.get_h_opacity_ok(), "opacity-wrapped repeated height-for-width cell not re-measured");
+assert!(instance.get_h_visible_ok(), "visible-wrapped repeated height-for-width cell not re-measured");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_w_wrapped());
+assert(instance.get_h_wrapped());
+assert(instance.get_w_opacity_ok());
+assert(instance.get_w_visible_ok());
+assert(instance.get_h_opacity_ok());
+assert(instance.get_h_visible_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.w_opacity_ok);
+assert(instance.w_visible_ok);
+assert(instance.h_opacity_ok);
+assert(instance.h_visible_ok);
+```
+*/

--- a/tests/cases/layout/flexbox_repeater_column_width_for_height.slint
+++ b/tests/cases/layout/flexbox_repeater_column_width_for_height.slint
@@ -1,0 +1,192 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Mirror of flexbox_repeater_row_height_for_width.slint for the other axis. In
+// a wrapping column FlexboxLayout, a cell's width is its measured width at the
+// height the solve assigned it, so a width-for-height cell must go through the
+// measure callback. A repeated instance used to instead panic with "Recursion
+// detected" (its horizontal info read self.height, set by the parent flex cache
+// it was feeding) and, once that resolved, keep its unwrapped width. Cover both
+// a repeated cell and a static cell sharing a flexbox with a repeater — the
+// presence of a repeater must not disable the callback for anyone.
+
+// A wrapping column flex is width-for-height: its 4 boxes of 30px stack into a
+// single 40px column when tall enough, and into two 80px columns at 70px tall.
+component WrapCol {
+    FlexboxLayout {
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px;
+        padding: 0px;
+        align-content: start;
+        Rectangle { width: 40px; height: 30px; background: red; }
+        Rectangle { width: 40px; height: 30px; background: green; }
+        Rectangle { width: 40px; height: 30px; background: blue; }
+        Rectangle { width: 40px; height: 30px; background: yellow; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 2200px;
+    height: 100px;
+
+    property <[int]> empty-model: [];
+
+    // Each flex is 70px tall and wraps: the WrapCol fills the first column on
+    // its own, the anchor is pushed to the second column, so `anchor.x` is the
+    // solved width of the WrapCol. The cell height comes from min/max-height
+    // rather than `height`, which would be a definite binding the cell could
+    // read back — the flex must be the one assigning it.
+
+    // A: repeated width-for-height cell.
+    FlexboxLayout {
+        x: 0; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        for x in [1]: WrapCol { min-height: 70px; max-height: 70px; }
+        aAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // B: static reference, no repeater in the flexbox.
+    FlexboxLayout {
+        x: 300px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        WrapCol { min-height: 70px; max-height: 70px; }
+        bAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // C: static width-for-height cell sharing a flexbox with a (non-w4h)
+    // repeater declared after it.
+    FlexboxLayout {
+        x: 600px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        WrapCol { min-height: 70px; max-height: 70px; }
+        cAnchor := Rectangle { width: 5px; height: 5px; }
+        for x in [1]: Rectangle { width: 0px; height: 0px; }
+    }
+
+    // D: repeater declared before the static cell, so the static cell's flat
+    // cell index is offset by the repeater's instance count.
+    FlexboxLayout {
+        x: 900px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        for x in [1, 2]: Rectangle { width: 0px; height: 0px; }
+        WrapCol { min-height: 70px; max-height: 70px; }
+        dAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // E: two repeated w4h cells. Each fills a column and wraps, so the second is
+    // measured at `index - cursor == 1` and the anchor lands at twice the cell
+    // width — this exercises the multi-instance walk.
+    FlexboxLayout {
+        x: 1200px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        for x in [1, 2]: WrapCol { min-height: 70px; max-height: 70px; }
+        eAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // F: `if`-conditional w4h cell, lowered as a repeater with one instance
+    // (covers Conditional::typed_instance_at).
+    FlexboxLayout {
+        x: 1500px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        if true: WrapCol { min-height: 70px; max-height: 70px; }
+        fAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // G: an empty repeater before a static w4h cell: `cursor += 0` must not
+    // shift the cell's flat cell index.
+    FlexboxLayout {
+        x: 1800px; y: 0; width: 300px; height: 70px;
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px; padding: 0px;
+        align-content: start;
+        cross-axis-alignment: stretch;
+        for x in empty-model: Rectangle { width: 0px; height: 0px; }
+        WrapCol { min-height: 70px; max-height: 70px; }
+        gAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    out property <length> repeated-w: aAnchor.x;
+    out property <length> static-w: bAnchor.x;
+    out property <length> mixed-w: cAnchor.x;
+    out property <length> offset-w: dAnchor.x;
+    out property <length> multi-w: eAnchor.x;
+    out property <length> cond-w: fAnchor.x;
+    out property <length> empty-w: gAnchor.x;
+
+    // The reference cell really did wrap into two columns (80px, not 40px),
+    // otherwise the equalities below would hold trivially.
+    out property <bool> wrapped: static-w > 60px;
+
+    out property <bool> repeated-ok: abs(repeated-w - static-w) < 1px;
+    out property <bool> mixed-ok: abs(mixed-w - static-w) < 1px;
+    out property <bool> offset-ok: abs(offset-w - static-w) < 1px;
+    // Two wrapped cells side by side, so the anchor is at twice the single width.
+    out property <bool> multi-ok: abs(multi-w - 2 * static-w) < 1px;
+    out property <bool> cond-ok: abs(cond-w - static-w) < 1px;
+    out property <bool> empty-ok: abs(empty-w - static-w) < 1px;
+
+    out property <bool> test: wrapped && repeated-ok && mixed-ok && offset-ok
+        && multi-ok && cond-ok && empty-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_wrapped(), "reference cell did not wrap");
+assert!(instance.get_repeated_ok(), "repeated width-for-height cell not re-measured");
+assert!(instance.get_mixed_ok(), "static width-for-height cell not re-measured next to a repeater");
+assert!(instance.get_offset_ok(), "static width-for-height cell after a repeater not re-measured");
+assert!(instance.get_multi_ok(), "second repeated width-for-height instance not re-measured");
+assert!(instance.get_cond_ok(), "conditional width-for-height cell not re-measured");
+assert!(instance.get_empty_ok(), "empty repeater shifted the static width-for-height cell index");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_wrapped());
+assert(instance.get_repeated_ok());
+assert(instance.get_mixed_ok());
+assert(instance.get_offset_ok());
+assert(instance.get_multi_ok());
+assert(instance.get_cond_ok());
+assert(instance.get_empty_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.wrapped);
+assert(instance.repeated_ok);
+assert(instance.mixed_ok);
+assert(instance.offset_ok);
+assert(instance.multi_ok);
+assert(instance.cond_ok);
+assert(instance.empty_ok);
+```
+*/

--- a/tests/cases/layout/flexbox_repeater_component_with_wrap.slint
+++ b/tests/cases/layout/flexbox_repeater_component_with_wrap.slint
@@ -14,15 +14,6 @@
 //     repeated cell is now re-measured at the container width (see the `matched`
 //     assertion, which is what actually catches this second bug).
 
-// TODO: This regresses under debug hooks (and, more generally, whenever a repeated component in
-// a height-for-width flexbox gets wrapped by opacity/layer/transform lowering — e.g. `opacity:`
-// on the repeated Card). `inject_element_as_repeated_element` splices the wrapper in as the new
-// sub-component root *after* the `layoutinfo-*-with-constraint` routing was wired to the old
-// root, so the height-for-width path is lost and the layout recurses again. The grid variant of
-// this same bug is fixed (grid_layout_cell is re-homed to the wrapper); the flexbox with-constraint
-// re-homing needs deeper work in the routing and is not yet implemented.
-//ignore: interpreter-debug-hooks
-
 component Card inherits Rectangle {
     in property <string> label;
     in property <length> pad: 5px;

--- a/tests/cases/layout/flexbox_repeater_row_height_for_width.slint
+++ b/tests/cases/layout/flexbox_repeater_row_height_for_width.slint
@@ -7,13 +7,12 @@
 // flexbox with a repeater — the presence of a repeater must not disable the
 // callback for anyone.
 
-// TODO: This regresses under debug hooks (and, more generally, whenever a repeated component in
-// a height-for-width flexbox gets wrapped by opacity/layer/transform lowering — e.g. `opacity:`
-// on the repeated Card). `inject_element_as_repeated_element` splices the wrapper in as the new
-// sub-component root *after* the `layoutinfo-*-with-constraint` routing was wired to the old
-// root, so the height-for-width path is lost and the layout recurses again. Same known
-// limitation as flexbox_repeater_component_with_wrap; the flexbox with-constraint re-homing
-// needs deeper work in the routing and is not yet implemented.
+// TODO: still fails under debug hooks, but no longer for a layout reason: with a
+// wrapper on every element, binding analysis hits the `PropertyPath::relative`
+// debug_assert ("element is not in the component pointed at by the path") on the
+// repeated Card's `label`, which reads the outer `root.long` through the model.
+// Unrelated to the flexbox measurement; plain `opacity:` on a repeated cell works
+// (see flexbox_repeated_wrapped_constrained_cell.slint).
 //ignore: interpreter-debug-hooks
 
 component Card inherits Rectangle {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -4,6 +4,7 @@
 
 set -eu
 unset CDPATH
+export RUSTFLAGS='-D warnings'
 
 usage() {
   echo "Usage: $0 <rust|cpp|interpreter|python|nodejs> [<filter>] [<cargo test args>...]" >&2
@@ -52,8 +53,18 @@ if [ "$driver" = "rust" ] && [ -n "$filter" ]; then
   fi
 fi
 
+# Match CI, which runs the whole tests workspace with --all-features. That matters:
+# - interpreter: `inject-debug-hooks` runs every test a second time with debug hooks
+#   injected, and that second run catches failures the plain run does not.
+# - rust: `build-time` (generate code rather than expand the macro; shows warnings and
+#   lets you read the generated code) and `deterministic-output` (compile each testcase
+#   twice and compare).
+# Note that --all-features therefore never exercises the `slint!` macro path; for that,
+# run the rust driver by hand without --all-features.
+features_flag="--all-features"
+
 # The integration tests are their own workspace; select it explicitly so the
 # script works regardless of the current directory.
 manifest="$(cd "$(dirname "$0")" && pwd)/Cargo.toml"
 
-SLINT_TEST_FILTER="$filter" cargo test --manifest-path "$manifest" -p "test-driver-$driver" $test_bin_flag "$@"
+SLINT_TEST_FILTER="$filter" cargo test --manifest-path "$manifest" -p "test-driver-$driver" $features_flag $test_bin_flag "$@"


### PR DESCRIPTION
FlexboxLayout: re-measure width-for-height cells of a repeated instance

Reading the horizontal layout-info of a repeated width-for-height cell (e.g. a
wrapping column FlexboxLayout) panicked with "Recursion detected": its width
query read self.height while the parent flex cache it was feeding was still
being computed. The measure callback's h_steps repeater arm only advanced the
cursor and fell through to the precomputed default width, as there was no way to
re-measure a repeated instance at an assigned height; just returning that
default would leave the cell its unwrapped width.

Mirror the existing height-for-width fix onto the horizontal axis: add
layout_info_h_{constrained,at_cross_height}_for_repeated on the LLR
SubComponent and a flexbox_layout_item_info_at_cross_height accessor, called
from the h_steps arm. That arm now returns a measured width for every repeated
cell in range (as v_steps already did), not only width-for-height ones.

This is a code-generator bug (Rust/C++); the interpreter measures repeated cells
correctly, so it does not reproduce in slint-viewer.

---

FlexboxLayout: keep the constrained layout-info on a wrapped repeated cell

A conditional opacity/visible/... binding on a repeated flex cell injects a
wrapper as the new repeated root. The wrapper did not take over
layout_info_{h,v}_with_constraint, so the cell stopped reporting as
height-for-width / width-for-height: inherited_*_with_constraint() walks the
base-type chain, but the real layout root is now the wrapper's child. The flex
then skipped the constrained re-measure and read the cell's own width/height,
which the parent flex is still computing — "Recursion detected" for
width-for-height, a stack overflow for height-for-width.

Re-declare both functions on the wrapper, forwarding to the child. Copying the
NamedReference does not work: callers assert it points at the component's root
element, which the wrapper now is.

This also fixes flexbox_repeater_component_with_wrap under debug hooks, so drop
its ignore. flexbox_repeater_row_height_for_width keeps one, for an unrelated
binding-analysis assert.

---

tests/run_tests.sh: use --all-features to match CI

This makes it much easier to reproduce (and avoid in the first place)
test failures on CI.

In my recent case, a test only failed on CI and not locally
because --all-features includes --feature inject-debug-hooks
which wraps all elements, and this triggered a flexboxlayout bug
(in parent commit).