### PR TITLE
Node: Use the testing backend in the unit tests to fix flacky tests

### DIFF
--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -12,7 +12,10 @@ import {
     language,
     CompileError,
     StyledText,
+    private_api,
 } from "../dist/index.js";
+
+private_api.initTesting();
 
 const dirname = path.dirname(
     fileURLToPath(import.meta.url).replace("build", "__test__"),

--- a/api/node/__test__/compiler.spec.mts
+++ b/api/node/__test__/compiler.spec.mts
@@ -8,6 +8,8 @@ import { test, expect } from "vitest";
 import { private_api } from "../dist/index.js";
 import * as napi from "../binding.cjs";
 
+private_api.initTesting();
+
 test("get/set include paths", () => {
     const compiler = new private_api.ComponentCompiler();
 

--- a/api/node/__test__/data_transfer.spec.mts
+++ b/api/node/__test__/data_transfer.spec.mts
@@ -5,6 +5,8 @@ import { test, expect } from "vitest";
 
 import { DataTransfer, loadSource, private_api } from "../dist/index.js";
 
+private_api.initTesting();
+
 test("default DataTransfer is empty", () => {
     const dt = new DataTransfer();
     expect(dt.hasPlainText).toBe(false);

--- a/api/node/__test__/globals.spec.mts
+++ b/api/node/__test__/globals.spec.mts
@@ -5,6 +5,8 @@ import { test, expect } from "vitest";
 
 import { private_api } from "../dist/index.js";
 
+private_api.initTesting();
+
 test("get/set global properties", () => {
     const compiler = new private_api.ComponentCompiler();
     const definition = compiler.buildFromSource(

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -15,6 +15,8 @@ import {
     type Model,
 } from "../dist/index.js";
 
+private_api.initTesting();
+
 const filename = fileURLToPath(import.meta.url).replace("build", "__test__");
 const dirname = path.dirname(filename);
 

--- a/api/node/__test__/window.spec.mts
+++ b/api/node/__test__/window.spec.mts
@@ -5,6 +5,8 @@ import { test, expect } from "vitest";
 
 import { private_api, Window } from "../dist/index.js";
 
+private_api.initTesting();
+
 test("Window constructor", () => {
     let thrownError: any;
     try {


### PR DESCRIPTION
The specs that instantiate a component without calling initTesting() go through the default backend selector, which tries winit and falls back to linuxkms. Under the headless CI display a worker occasionally fails to reach winit and drops to linuxkms, which has no renderer, so create() fails intermittently.

Install the testing backend up front, like models and gc already do, so these specs no longer depend on the display. The eventloop specs keep the real backend since they exercise the integrated event loop.
