### PR TITLE
Android: target API 36 in the slint-viewer

### DIFF
--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -764,7 +764,7 @@ jobs:
             - uses: actions/checkout@v7
             - uses: ./.github/actions/install-linux-dependencies
             - name: Install Android API platforms
-              run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-30" "platforms;android-35" "build-tools;35.0.1"
+              run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-30" "platforms;android-36" "build-tools;36.0.0"
             - name: Cache cargo-apk, cargo-ndk and resvg
               id: cargo-tools-cache
               uses: actions/cache@v6
@@ -816,7 +816,7 @@ jobs:
               uses: gradle/actions/setup-gradle@v6
               with:
                   # Installs Gradle on PATH; the AAB project has no wrapper jar.
-                  gradle-version: "8.10.2"
+                  gradle-version: "8.11.1"
             - name: Build slint-viewer AAB
               env:
                   ANDROID_KEYSTORE_PATH: ${{ env.CARGO_APK_RELEASE_KEYSTORE }}

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -138,7 +138,7 @@ avahi-sys = "LGPL-3.0-or-later"
 [package.metadata.android]
 package = "dev.slint.viewer"
 min_sdk_version = 26
-target_sdk_version = 35
+target_sdk_version = 36
 
 [package.metadata.android.application]
 label = "Slint Viewer"

--- a/tools/viewer/android/app/build.gradle.kts
+++ b/tools/viewer/android/app/build.gradle.kts
@@ -17,13 +17,13 @@ val (major, minor, patch) = slintVersion.substringBefore('-').split('.').map(Str
 // and the cargo-apk APK match.
 android {
     namespace = "dev.slint.viewer"
-    compileSdk = 35
-    buildToolsVersion = "35.0.1"
+    compileSdk = 36
+    buildToolsVersion = "36.0.0"
 
     defaultConfig {
         applicationId = "dev.slint.viewer"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = System.getenv("SLINT_BUILD_NUMBER")?.toIntOrNull()
             ?: (major * 10000 + minor * 100 + patch)
         versionName = slintVersion

--- a/tools/viewer/android/build-aab.sh
+++ b/tools/viewer/android/build-aab.sh
@@ -14,7 +14,7 @@
 #   ANDROID_KEYSTORE_ALIAS     alias of the signing key in the keystore
 #
 # Requires: cargo-ndk; Android SDK + NDK with ANDROID_HOME / ANDROID_NDK_HOME
-# set; gradle 8.9+ on PATH (AGP 8.7); JDK 17; the three Android rust targets
+# set; gradle 8.11.1+ on PATH (AGP 8.10); JDK 17; the three Android rust targets
 # (rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android).
 #
 # Output: app/build/outputs/bundle/release/slint-viewer.aab

--- a/tools/viewer/android/build.gradle.kts
+++ b/tools/viewer/android/build.gradle.kts
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 plugins {
-    id("com.android.application") version "8.7.0" apply false
+    id("com.android.application") version "8.10.1" apply false
 }

--- a/tools/viewer/android/gradle/wrapper/gradle-wrapper.properties
+++ b/tools/viewer/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Google Play requires app updates to target Android 16 (API 36) from 31 August 2026. Bump compileSdk/targetSdk and build-tools accordingly, and update AGP to 8.10.1 and Gradle to 8.11.1, the minimum versions supporting compileSdk 36.
