### PR TITLE
slint-sc: cover more specification paragraphs with syntax tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 # With linguist-generated we can mark them as generated so they don't show up in the Github diff.
 # https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
 tests/driver/rust/tests/*.rs linguist-generated
+# These test files must keep their CRLF line terminators; the syntax test driver checks them.
+internal/compiler/tests/syntax/**/crlf-* -text

--- a/.mise/tasks/fix/text/trailing_spaces
+++ b/.mise/tasks/fix/text/trailing_spaces
@@ -14,11 +14,17 @@ else
     SED_INPLACE="sed -i"
 fi
 
+# crlf-* test files must keep their CRLF line terminators, which sed would
+# strip as trailing whitespace.
 if git rev-parse --git-dir >/dev/null 2>&1 ; then
-    git grep -I -l -O"$SED_INPLACE \"s/[[:space:]]*$//\"" -e '' -- ':!*.patch'
+    git grep -I -l -O"$SED_INPLACE \"s/[[:space:]]*$//\"" -e '' -- ':!*.patch' ':!*crlf-*'
 else
     while IFS= read -r -d '' -u 9
     do
+        if [[ "$REPLY" == *crlf-* ]]
+        then
+            continue
+        fi
         if [[ "$(file -bs --mime-type -- "$REPLY")" = text/* ]]
         then
             $SED_INPLACE "s/[[:space:]]*$//" -- "$REPLY"

--- a/internal/compiler/tests/syntax/slint-sc/crlf-line-terminators.slint
+++ b/internal/compiler/tests/syntax/slint-sc/crlf-line-terminators.slint
@@ -1,0 +1,10 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The two copyright lines above end with LF; every line from here on
+// ends with CRLF. Both are equivalent line terminators. The bare CR
+// inside the component body is not a line terminator.
+//#sls.source.line-terminators
+//#sls.source.bare-cr
+
+export component Test inherits Window {}

--- a/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
+++ b/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
@@ -10,3 +10,12 @@ component Foo inherits Window { }
 //#sls.export.list
 export { Foo }
 //       >  <error{Export specifiers are not supported in Slint SC}
+
+//#sls.export.rename
+export { Foo as Bar }
+//       >        <error{Export specifiers are not supported in Slint SC}
+
+//#sls.export.left-must-exist
+export { DoesNotExist }
+//       >           <error{Export specifiers are not supported in Slint SC}
+//       >          <^error{'DoesNotExist' not found}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `-` shall not appear as the first character of an identifier:
+// component name.
+//#sls.lex.identifier.no-leading-hyphen
+
+export component -Foo inherits Window {}
+//               ^error{Syntax error: expected Identifier}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_element_id.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_element_id.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `-` shall not appear as the first character of an identifier:
+// element id.
+//#sls.lex.identifier.no-leading-hyphen
+
+export component Foo inherits Window {
+    -rect := Rectangle {}
+//  ^error{Parse error}
+}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_inherits.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_inherits.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `-` shall not appear as the first character of an identifier:
+// base type name.
+//#sls.lex.identifier.no-leading-hyphen
+
+export component Foo inherits -Window {}
+//                            ^error{Syntax error: expected Identifier}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_property.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_property.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `-` shall not appear as the first character of an identifier:
+// property name.
+//#sls.lex.identifier.no-leading-hyphen
+
+export component Foo inherits Window {
+    property <int> -prop;
+//                 ^error{Syntax error: expected Identifier}
+//                 ^^error{Syntax error: expected ';'}
+//                 ^^^error{Parse error}
+}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_normalization_collision.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_normalization_collision.slint
@@ -1,0 +1,21 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `Foo_Bar` and `Foo-Bar` are the same identifier, so the second component
+// collides with the first, and likewise the element ids `a_b` and `a-b`.
+// The diagnostics print the canonical kebab-case form for both spellings.
+//#sls.lex.identifier.normalization-example
+//#sls.lex.identifier.canonical-form
+
+export component Foo_Bar inherits Window {}
+//               >     <error{Duplicated export 'Foo-Bar'}
+//     >                                  <^warning{Component is neither used nor exported}
+export component Foo-Bar inherits Window {
+//               >     <error{Multiple exported components per file are not supported in Slint SC}
+//               >     <^warning{Component 'Foo-Bar' is replacing a previously defined component with the same name}
+//               >     <^^error{Duplicated export 'Foo-Bar'}
+    a_b := Rectangle {}
+//         >        <error{duplicated element id 'a-b'}
+    a-b := Rectangle {}
+//         >        <error{duplicated element id 'a-b'}
+}

--- a/internal/compiler/tests/syntax/slint-sc/source_file.slint
+++ b/internal/compiler/tests/syntax/slint-sc/source_file.slint
@@ -1,11 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// A source file is a sequence of top-level items.
+// A `.slint` source file is a sequence of top-level items.
+//#sls.source.file-extension
 //#sls.file.source-file
 //#sls.file.top-level-item
 //#sls.file.component.name
 //#sls.file.component.body-braces
+//#sls.export.placement
 
 export component MyComponent inherits Window {
 }

--- a/internal/compiler/tests/syntax/slint-sc/whitespace.slint
+++ b/internal/compiler/tests/syntax/slint-sc/whitespace.slint
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // Whitespace separates tokens but is otherwise insignificant.
+//#sls.lex.tokens
 //#sls.source.whitespace.chars
 //#sls.source.whitespace.collapse
 

--- a/internal/compiler/tests/syntax_tests.rs
+++ b/internal/compiler/tests/syntax_tests.rs
@@ -103,6 +103,12 @@ fn process_file(path: &std::path::Path, update: bool) -> std::io::Result<bool> {
             "{path:?} does not contains BOM while it should"
         )));
     }
+    if path.to_str().unwrap_or("").contains("crlf-") && !source.contains("\r\n") {
+        // make sure that the CRLF line terminators weren't normalized away by some tools
+        return Err(std::io::Error::other(format!(
+            "{path:?} does not contain CRLF line terminators while it should"
+        )));
+    }
     std::panic::catch_unwind(|| process_file_source(path, source, false, update)).unwrap_or_else(
         |err| {
             println!("Panic while processing {}: {:?}", path.display(), err);


### PR DESCRIPTION
Add tests for line terminators (CRLF and bare CR), the leading-hyphen identifier rule in several positions, the normalization example and canonical form (colliding component names and element ids print the kebab-case form), and the export rename and unknown-name rules. Reference the file-extension, export-placement, and token paragraphs from the existing tests that already exercise them. Coverage in the traceability matrix goes from 29 to 39 of 45 paragraphs; the remaining ones describe the document itself or informative examples.

Like the existing bom- check, the syntax test driver refuses crlf-* files that no longer contain CRLF line terminators, and .gitattributes marks them -text so git never converts them.
