### PR TITLE
docs: write language-spec paragraph IDs in their MDX-safe escaped form

### DIFF
--- a/docs/astro/src/content/docs/reference/language/exports.md
+++ b/docs/astro/src/content/docs/reference/language/exports.md
@@ -5,16 +5,16 @@ description: Making components in a file available to other files.
 
 ## Placement
 
-Export statements may appear at the top level of a `.slint` source file, interleaved with [component definitions](../file-structure/#sls.file.component.definition-forms). {#sls.export.placement}
+Export statements may appear at the top level of a `.slint` source file, interleaved with [component definitions](../file-structure/#sls.file.component.definition-forms). \{#sls.export.placement}
 
 ## Privacy
 
 Names defined in a `.slint` source file are private to that file by default.
-A name is visible to importers only if it is explicitly exported. {#sls.export.default-private}
+A name is visible to importers only if it is explicitly exported. \{#sls.export.default-private}
 
 ## Form
 
-An export statement has one of the following forms: {#sls.export.forms}
+An export statement has one of the following forms: \{#sls.export.forms}
 
 ```slint no-test
 export component Name { /* ... */ }
@@ -24,20 +24,20 @@ export { Name, ... }
 ## Export at the Declaration Site
 
 The form `export component Name { ... }` defines a component and exports it in a single statement.
-The exported name is the component's own name. {#sls.export.declaration-site}
+The exported name is the component's own name. \{#sls.export.declaration-site}
 
 ## Export Lists
 
 The form `export { Name, ... }` exports one or more names already defined in the current file.
-A trailing comma is permitted. {#sls.export.list}
+A trailing comma is permitted. \{#sls.export.list}
 
 An export list item is either a bare identifier `Name` or a renaming of the form `Name as Other`.
 A renaming exports the locally-defined `Name` under the external name `Other`.
-The local name `Name` remains defined in the current file. {#sls.export.rename}
+The local name `Name` remains defined in the current file. \{#sls.export.rename}
 
-Each identifier on the left of `as`, and each bare identifier, shall refer to a name defined in the current file. {#sls.export.left-must-exist}
+Each identifier on the left of `as`, and each bare identifier, shall refer to a name defined in the current file. \{#sls.export.left-must-exist}
 
 ## Duplicate Exports
 
 A source file shall not export the same external name more than once.
-This includes the combination of any declaration-site export and any export-list entry. {#sls.export.no-duplicates}
+This includes the combination of any declaration-site export and any export-list entry. \{#sls.export.no-duplicates}

--- a/docs/astro/src/content/docs/reference/language/file-structure.md
+++ b/docs/astro/src/content/docs/reference/language/file-structure.md
@@ -5,55 +5,55 @@ description: Top-level structure of a Slint source file and the basic form of co
 
 ## A Slint Source File
 
-A `.slint` source file is a sequence of zero or more *top-level items*, separated only by whitespace and comments. {#sls.file.source-file}
+A `.slint` source file is a sequence of zero or more *top-level items*, separated only by whitespace and comments. \{#sls.file.source-file}
 
-A source file that contains only whitespace and comments is well-formed and defines no components. {#sls.file.source-file.empty}
+A source file that contains only whitespace and comments is well-formed and defines no components. \{#sls.file.source-file.empty}
 
 ## Top-Level Items
 
-A *top-level item* is a *component definition*. {#sls.file.top-level-item}
+A *top-level item* is a *component definition*. \{#sls.file.top-level-item}
 
 ## Component Definitions
 
-A component definition has one of the following two forms: {#sls.file.component.definition-forms}
+A component definition has one of the following two forms: \{#sls.file.component.definition-forms}
 
 ```slint no-test
 component Name { /* component body */ }
 component Name inherits Base { /* component body */ }
 ```
 
-The identifier following the `component` keyword is the *name* of the component. {#sls.file.component.name}
+The identifier following the `component` keyword is the *name* of the component. \{#sls.file.component.name}
 
 The first form defines a component with no explicit base; the second form defines a component that inherits from the element type named by `Base`.
-The identifier `Base` shall resolve to a built-in element or to a component previously defined. {#sls.file.component.inherits}
+The identifier `Base` shall resolve to a built-in element or to a component previously defined. \{#sls.file.component.inherits}
 
-The braces `{` and `}` delimit the *component body*. {#sls.file.component.body-braces}
+The braces `{` and `}` delimit the *component body*. \{#sls.file.component.body-braces}
 
 ## Component Bodies
 
-A component body is a sequence of zero or more *element instantiations*, separated only by whitespace and comments. {#sls.file.component.body}
+A component body is a sequence of zero or more *element instantiations*, separated only by whitespace and comments. \{#sls.file.component.body}
 
-A component body that contains no element instantiations is well-formed. {#sls.file.component.body.empty}
+A component body that contains no element instantiations is well-formed. \{#sls.file.component.body.empty}
 
 ## Element Instantiations
 
-An element instantiation has the form: {#sls.file.element.instantiation-form}
+An element instantiation has the form: \{#sls.file.element.instantiation-form}
 
 ```slint no-test
 TypeName { /* element body */ }
 ```
 
-The identifier `TypeName` shall resolve to a built-in or user-defined component. {#sls.file.element.instantiation-typename}
+The identifier `TypeName` shall resolve to a built-in or user-defined component. \{#sls.file.element.instantiation-typename}
 
 The braces delimit the *element body*.
-An element body is a sequence of zero or more nested element instantiations, separated only by whitespace and comments. {#sls.file.element.body}
+An element body is a sequence of zero or more nested element instantiations, separated only by whitespace and comments. \{#sls.file.element.body}
 
 A nested element instantiation is a *child* of the element instantiation in whose body it appears.
-The child relationship forms a tree rooted at the elements that appear directly in a component body. {#sls.file.element.tree}
+The child relationship forms a tree rooted at the elements that appear directly in a component body. \{#sls.file.element.tree}
 
 ## Example
 
-The following is a complete, well-formed `.slint` source file: {#sls.file.example.intro}
+The following is a complete, well-formed `.slint` source file: \{#sls.file.example.intro}
 
 ```slint
 component Hello {
@@ -66,4 +66,4 @@ component Hello {
 }
 ```
 
-It defines one component, `Hello`, whose body contains two top-level `Rectangle` instantiations; the first of those has one nested `Rectangle` child. {#sls.file.example.description}
+It defines one component, `Hello`, whose body contains two top-level `Rectangle` instantiations; the first of those has one nested `Rectangle` child. \{#sls.file.example.description}

--- a/docs/astro/src/content/docs/reference/language/imports.md
+++ b/docs/astro/src/content/docs/reference/language/imports.md
@@ -14,52 +14,52 @@ Draft content; will be uncommented once imports come into scope.
 
 ## Placement
 
-Import statements may appear at the top level of a `.slint` source file, interleaved with [component definitions](../file-structure/#sls.file.component.definition-forms). {#sls.import.placement}
+Import statements may appear at the top level of a `.slint` source file, interleaved with [component definitions](../file-structure/#sls.file.component.definition-forms). \{#sls.import.placement}
 
 ## Form
 
-An import statement has the form: {#sls.import.forms}
+An import statement has the form: \{#sls.import.forms}
 
 ```slint no-test
 import { Item, ... } from "path";
 ```
 
-It brings named items from the file referenced by `"path"` into the importing file's namespace. {#sls.import.semantics}
+It brings named items from the file referenced by `"path"` into the importing file's namespace. \{#sls.import.semantics}
 
 ## Import Lists
 
 The brace-delimited list contains zero or more *import items* separated by commas.
-A trailing comma is permitted. {#sls.import.list}
+A trailing comma is permitted. \{#sls.import.list}
 
-An import item is either: {#sls.import.item}
+An import item is either: \{#sls.import.item}
 
 - a single [identifier](../lexical-structure/#sls.lex.identifier.classes) `Name`, or
 - a renaming of the form `Name as Other`.
 
-A bare identifier `Name` brings the corresponding exported name from the imported file into the current file's namespace under the same name. {#sls.import.same-name}
+A bare identifier `Name` brings the corresponding exported name from the imported file into the current file's namespace under the same name. \{#sls.import.same-name}
 
 A renaming `Name as Other` brings the corresponding exported name into the current file's namespace under the name `Other` only.
-The original name `Name` is not introduced. {#sls.import.rename}
+The original name `Name` is not introduced. \{#sls.import.rename}
 
-The identifier on the left of `as` shall refer to a name exported by the imported file. {#sls.import.left-must-exist}
+The identifier on the left of `as` shall refer to a name exported by the imported file. \{#sls.import.left-must-exist}
 
 TODO: extend this rule when structs, enums, and globals come into scope of the specification.
 
-An imported name shall refer to a component. {#sls.import.component-only}
+An imported name shall refer to a component. \{#sls.import.component-only}
 
 ## Import Paths
 
 An import path is a double-quoted string literal.
-Backslash escape sequences are recognized as in any other string literal. {#sls.import.path-literal}
+Backslash escape sequences are recognized as in any other string literal. \{#sls.import.path-literal}
 
-If the path begins with the character `@`, it is a *library import*: the remainder of the path is resolved against the compiler's configured library paths. {#sls.import.path-library}
+If the path begins with the character `@`, it is a *library import*: the remainder of the path is resolved against the compiler's configured library paths. \{#sls.import.path-library}
 
 Otherwise, the path is resolved first relative to the directory of the importing source file, then against the compiler's configured include paths.
-The first match in this search order is used. {#sls.import.path-relative}
+The first match in this search order is used. \{#sls.import.path-relative}
 
-The referenced file shall exist and shall be a Slint source file. {#sls.import.path-must-exist}
+The referenced file shall exist and shall be a Slint source file. \{#sls.import.path-must-exist}
 
 ## Name Clashes
 
-Two import items in the same source file shall not introduce the same name. {#sls.import.no-clash}
+Two import items in the same source file shall not introduce the same name. \{#sls.import.no-clash}
 -->

--- a/docs/astro/src/content/docs/reference/language/index.md
+++ b/docs/astro/src/content/docs/reference/language/index.md
@@ -10,18 +10,18 @@ This specification is a work in progress and doesn't yet cover the whole Slint l
 ## Purpose
 
 This document is the normative reference for the `.slint` markup language as accepted by the Slint Compiler.
-It defines what a `.slint` source file is, how its parts fit together, and what constraints implementations and users have to honor. {#sls.meta.purpose}
+It defines what a `.slint` source file is, how its parts fit together, and what constraints implementations and users have to honor. \{#sls.meta.purpose}
 
 The [Reference](../overview/) describes the individual elements, properties, and types that make up the Slint API surface.
-This specification describes the surrounding language itself. {#sls.meta.purpose-vs-reference}
+This specification describes the surrounding language itself. \{#sls.meta.purpose-vs-reference}
 
 ## Conventions
 
 ### Normative Wording
 
 The key words **shall**, **should**, **may**, and **must** are to be interpreted following ISO/IEC Directives Part 2.
-Other prose is informative. {#sls.meta.conventions.normative}
+Other prose is informative. \{#sls.meta.conventions.normative}
 
 ### Code Examples
 
-Code examples are formatted as `slint` fenced code blocks and are informative unless explicitly stated otherwise. {#sls.meta.conventions.examples}
+Code examples are formatted as `slint` fenced code blocks and are informative unless explicitly stated otherwise. \{#sls.meta.conventions.examples}

--- a/docs/astro/src/content/docs/reference/language/lexical-structure.md
+++ b/docs/astro/src/content/docs/reference/language/lexical-structure.md
@@ -5,31 +5,31 @@ description: Identifiers, contextual keywords, and element type names in the Sli
 
 ## Tokens
 
-After whitespace and comments are removed (see [Source Files](../source-files/)), the remaining input is a sequence of tokens. {#sls.lex.tokens}
+After whitespace and comments are removed (see [Source Files](../source-files/)), the remaining input is a sequence of tokens. \{#sls.lex.tokens}
 
 ## Identifiers
 
-An identifier consists of one or more characters drawn from the following classes: {#sls.lex.identifier.classes}
+An identifier consists of one or more characters drawn from the following classes: \{#sls.lex.identifier.classes}
 
 - The first character shall be a Unicode alphanumeric character or `U+005F` (LOW LINE, `_`).
 - Each subsequent character shall be a Unicode alphanumeric character, `U+005F` (LOW LINE, `_`), or `U+002D` (HYPHEN-MINUS, `-`).
 
-A `U+002D` (`-`) shall not appear as the first character of an identifier. {#sls.lex.identifier.no-leading-hyphen}
+A `U+002D` (`-`) shall not appear as the first character of an identifier. \{#sls.lex.identifier.no-leading-hyphen}
 
 ## Identifier Normalization
 
 Two identifiers are considered the same if and only if their *normalized forms* are equal.
-The normalized form of an identifier is obtained by applying the following replacements in order over the characters of the source identifier: {#sls.lex.identifier.normalization}
+The normalized form of an identifier is obtained by applying the following replacements in order over the characters of the source identifier: \{#sls.lex.identifier.normalization}
 
 - The first character, if it is `U+005F` (`_`) or `U+002D` (`-`), is replaced with `U+005F` (`_`).
 - Each subsequent `U+005F` (`_`) is replaced with `U+002D` (`-`).
 - All other characters are left unchanged.
 
-For example, `foo_bar` and `foo-bar` are the same identifier; `_foo_bar` and `-foo-bar` are the same identifier. {#sls.lex.identifier.normalization-example}
+For example, `foo_bar` and `foo-bar` are the same identifier; `_foo_bar` and `-foo-bar` are the same identifier. \{#sls.lex.identifier.normalization-example}
 
-The kebab-case form (with `U+002D`) is the canonical written form. {#sls.lex.identifier.canonical-form}
+The kebab-case form (with `U+002D`) is the canonical written form. \{#sls.lex.identifier.canonical-form}
 
 ## Contextual Keywords
 
 Slint has no globally reserved words.
-Each language construct is introduced by a *contextual keyword*: an identifier that has a special meaning only when it appears in a position where the grammar expects that construct. {#sls.lex.contextual-keywords}
+Each language construct is introduced by a *contextual keyword*: an identifier that has a special meaning only when it appears in a position where the grammar expects that construct. \{#sls.lex.contextual-keywords}

--- a/docs/astro/src/content/docs/reference/language/source-files.md
+++ b/docs/astro/src/content/docs/reference/language/source-files.md
@@ -5,37 +5,37 @@ description: Slint source file extension, encoding, line terminators, whitespace
 
 ## File Extension
 
-Slint source files use the file extension `.slint`. {#sls.source.file-extension}
+Slint source files use the file extension `.slint`. \{#sls.source.file-extension}
 
 ## Encoding
 
-A `.slint` source file shall be encoded as UTF-8. {#sls.source.encoding.utf8}
+A `.slint` source file shall be encoded as UTF-8. \{#sls.source.encoding.utf8}
 
-A UTF-8 byte order mark (`U+FEFF`) may appear at the start of the file and is ignored. {#sls.source.encoding.bom}
+A UTF-8 byte order mark (`U+FEFF`) may appear at the start of the file and is ignored. \{#sls.source.encoding.bom}
 
 ## Line Terminators
 
-The compiler recognizes the character `U+000A` (LINE FEED) and the two-character sequence `U+000D U+000A` (CARRIAGE RETURN, LINE FEED) as equivalent line terminators. {#sls.source.line-terminators}
+The compiler recognizes the character `U+000A` (LINE FEED) and the two-character sequence `U+000D U+000A` (CARRIAGE RETURN, LINE FEED) as equivalent line terminators. \{#sls.source.line-terminators}
 
 A `U+000D` (CARRIAGE RETURN) that is not immediately followed by `U+000A` is not a line terminator.
-Source files should not contain bare carriage returns. {#sls.source.bare-cr}
+Source files should not contain bare carriage returns. \{#sls.source.bare-cr}
 
 ## Whitespace
 
-The whitespace characters are `U+0020` (SPACE), `U+0009` (CHARACTER TABULATION), and the line terminators defined in [Line Terminators](#line-terminators). {#sls.source.whitespace.chars}
+The whitespace characters are `U+0020` (SPACE), `U+0009` (CHARACTER TABULATION), and the line terminators defined in [Line Terminators](#line-terminators). \{#sls.source.whitespace.chars}
 
-Whitespace separates tokens but is otherwise insignificant; any sequence of one or more whitespace characters is equivalent to a single space. {#sls.source.whitespace.collapse}
+Whitespace separates tokens but is otherwise insignificant; any sequence of one or more whitespace characters is equivalent to a single space. \{#sls.source.whitespace.collapse}
 
 ## Comments
 
-A line comment begins with two consecutive solidus characters `//` and extends to the next line terminator. {#sls.source.comment.line}
+A line comment begins with two consecutive solidus characters `//` and extends to the next line terminator. \{#sls.source.comment.line}
 
 A block comment is delimited by `/*` and `*/`.
-Block comments nest: an inner `/*` inside a block comment increments the nesting depth, and the comment terminates only when a matching `*/` returns the nesting depth to zero. {#sls.source.comment.block}
+Block comments nest: an inner `/*` inside a block comment increments the nesting depth, and the comment terminates only when a matching `*/` returns the nesting depth to zero. \{#sls.source.comment.block}
 
-Comments are equivalent to whitespace; they have no other semantic effect. {#sls.source.comment.whitespace-equivalent}
+Comments are equivalent to whitespace; they have no other semantic effect. \{#sls.source.comment.whitespace-equivalent}
 
-The token sequences `///` and `/**` are recognized as ordinary line and block comments, respectively, and carry no special meaning. {#sls.source.comment.no-doc-comments}
+The token sequences `///` and `/**` are recognized as ordinary line and block comments, respectively, and carry no special meaning. \{#sls.source.comment.no-doc-comments}
 
 ```slint
 // A line comment.

--- a/docs/common/src/utils/rehype-sls-ids.mjs
+++ b/docs/common/src/utils/rehype-sls-ids.mjs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 // Assign author-specified paragraph IDs to every `<p>` under `language/`.
-// Each normative paragraph ends with a Pandoc-style marker `{#sls_xxx}`;
-// the plugin strips the marker, sets it as the paragraph's `id`, and
-// appends a visible `[sls_xxx]` badge that doubles as an anchor.
+// Each normative paragraph ends with a Pandoc-style marker, written as
+// `\{#sls_xxx}` in the sources so that the brace also stays literal text in
+// MDX files (where an unescaped `{` starts a JSX expression). The escape is
+// consumed by the markdown parser, so this plugin sees `{#sls_xxx}`; it
+// strips the marker, sets it as the paragraph's `id`, and appends a visible
+// `[sls_xxx]` badge that doubles as an anchor.
 //
 // Cross-file references like `#sls_xxx` are validated by
 // `starlight-links-validator`. A paragraph that loses its marker (e.g.

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -115,7 +115,9 @@ fn check(pages: &[SpecPage], refs: &[TestRef]) -> Vec<String> {
 }
 
 /// Parse a `{#sls.…}` marker at the end of a line, mirroring `ID_MARKER` in
-/// docs/common/src/utils/rehype-sls-ids.mjs.
+/// docs/common/src/utils/rehype-sls-ids.mjs. The sources write the marker in
+/// its MDX-safe escaped form `\{#sls.…}`; the backslash sits before the `{`
+/// found via `rfind`, so both forms parse the same here.
 fn anchor_id(line: &str) -> Option<&str> {
     let t = line.trim_end().strip_suffix('}')?;
     let id = &t[t.rfind("{#")? + 2..];
@@ -317,6 +319,7 @@ tests marked `syntax:` are compiler syntax tests from `{syntax_root}/`.
 #[test]
 fn test_anchor_id() {
     assert_eq!(anchor_id("Some text. {#sls.foo.bar}"), Some("sls.foo.bar"));
+    assert_eq!(anchor_id(r"MDX-escaped. \{#sls.foo.bar}"), Some("sls.foo.bar"));
     assert_eq!(anchor_id("Text. {#sls.a-b_c.d2}  "), Some("sls.a-b_c.d2"));
     assert_eq!(anchor_id("{#sls.x}"), Some("sls.x"));
     assert_eq!(anchor_id("no marker here"), None);


### PR DESCRIPTION
Rewrite the `{#sls.…}` markers as `\{#sls.…}` so the chapters can be converted to .mdx, where an unescaped `{` starts a JSX expression and fails to parse. CommonMark treats `\{` as a punctuation escape, so plain .md files render identically, and both consumers of the marker keep working unchanged: the rehype plugin matches the text after the escape is consumed by the parser, and the traceability generator finds the opening brace via rfind, skipping the backslash.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
