### PR TITLE
slint-sc: removes untestable meta paragraph from testability matrix

### DIFF
--- a/docs/astro/src/content/docs/reference/language/file-structure.md
+++ b/docs/astro/src/content/docs/reference/language/file-structure.md
@@ -56,14 +56,12 @@ The child relationship forms a tree rooted at the elements that appear directly 
 The following is a complete, well-formed `.slint` source file: {#sls.file.example.intro}
 
 ```slint
-component Hello {
+export component Hello inherits Window {
     Rectangle {
-        Rectangle {
-        }
     }
     Rectangle {
     }
 }
 ```
 
-It defines one component, `Hello`, whose body contains two top-level `Rectangle` instantiations; the first of those has one nested `Rectangle` child. {#sls.file.example.description}
+It exports one component, `Hello`, which inherits from `Window` and whose body contains two top-level `Rectangle` instantiations. {#sls.file.example.description}

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -228,6 +228,13 @@ fn scan_test_refs(
     Ok(())
 }
 
+/// Whether a paragraph is informative rather than a testable requirement:
+/// the document conventions (`sls.meta.…`) and examples. These are excluded
+/// from the matrix; examples are compiled by the doctests test instead.
+fn informative(id: &str) -> bool {
+    id.starts_with("sls.meta.") || id.split('.').any(|s| s == "example")
+}
+
 /// The commit to link test files to on GitHub.
 fn git_head(repo_root: &Path) -> String {
     std::process::Command::new("git")
@@ -253,11 +260,11 @@ fn write_matrix(
     let mut file =
         BufWriter::new(std::fs::File::create(&path).context(format!("error creating {path:?}"))?);
 
-    let total: usize = pages.iter().map(|p| p.anchors.len()).sum();
+    let total = pages.iter().flat_map(|p| &p.anchors).filter(|(id, _)| !informative(id)).count();
     let covered = pages
         .iter()
         .flat_map(|p| &p.anchors)
-        .filter(|(id, _)| tests_by_id.contains_key(id.as_str()))
+        .filter(|(id, _)| !informative(id) && tests_by_id.contains_key(id.as_str()))
         .count();
 
     writeln!(
@@ -273,6 +280,8 @@ shown as a `[sls.…]` badge at the end of the paragraph.
 A test case declares which requirements it verifies by listing their identifiers in `//#sls.…` comments.
 This matrix lists every requirement paragraph with the test cases that declare it.
 Requirements not yet covered by any test are marked ❌.
+Informative paragraphs — the document conventions (`sls.meta.…`) and examples — are not listed;
+the examples are compiled by the doctests test instead.
 
 Tests marked `case:` are executed test cases from `{case_root}/`,
 tests marked `syntax:` are compiler syntax tests from `{syntax_root}/`.
@@ -284,12 +293,16 @@ tests marked `syntax:` are compiler syntax tests from `{syntax_root}/`.
 
     // The index page's title heads the section; the other pages nest under it.
     for page in pages {
-        if page.anchors.is_empty() {
+        let anchors: Vec<&(String, usize)> =
+            page.anchors.iter().filter(|(id, _)| !informative(id)).collect();
+        if page.stem == "index" {
+            writeln!(file, "\n## {}", page.title)?;
+        }
+        if anchors.is_empty() {
             continue;
         }
         // The matrix page is two levels deep, so `../../` is the site root.
         let base = if page.stem == "index" {
-            writeln!(file, "\n## {}", page.title)?;
             "../../language/".to_string()
         } else {
             writeln!(file, "\n### {}", page.title)?;
@@ -297,7 +310,7 @@ tests marked `syntax:` are compiler syntax tests from `{syntax_root}/`.
         };
         writeln!(file, "\n| Paragraph | Tests |")?;
         writeln!(file, "| --- | --- |")?;
-        for (id, _) in &page.anchors {
+        for (id, _) in anchors {
             let tests = match tests_by_id.get(id.as_str()) {
                 Some(files) => files
                     .iter()
@@ -312,6 +325,15 @@ tests marked `syntax:` are compiler syntax tests from `{syntax_root}/`.
         }
     }
     Ok(())
+}
+
+#[test]
+fn test_informative() {
+    assert!(informative("sls.meta.purpose"));
+    assert!(informative("sls.file.example.intro"));
+    assert!(informative("sls.file.example.description"));
+    assert!(!informative("sls.lex.identifier.normalization-example"));
+    assert!(!informative("sls.file.component.body"));
 }
 
 #[test]

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
 name = "doctests"
 version = "1.18.0"
 dependencies = [
+ "i-slint-compiler",
  "slint-interpreter",
  "spin_on",
  "walkdir",

--- a/tests/doctests/Cargo.toml
+++ b/tests/doctests/Cargo.toml
@@ -20,5 +20,6 @@ name = "doctests"
 walkdir = "2"
 
 [dev-dependencies]
+i-slint-compiler = { workspace = true, features = ["slint-sc", "display-diagnostics"] }
 slint-interpreter = { workspace = true, features = ["default", "display-diagnostics"] }
 spin_on = { workspace = true }

--- a/tests/doctests/build.rs
+++ b/tests/doctests/build.rs
@@ -38,6 +38,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         writeln!(tests_file, "\nmod {stem} {{")?;
 
+        // Language Specification examples are additionally compiled in
+        // Slint SC mode, unless the fence carries `no-sc-test`.
+        let language_spec = path
+            .strip_prefix(&prefix)?
+            .starts_with("docs/astro/src/content/docs/reference/language");
+
         let mut lines = file.lines().enumerate();
         while let Some((n, opening)) = lines.next() {
             let trimmed = opening.trim_start();
@@ -88,6 +94,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 snippet.escape_default(),
                 path.to_string_lossy().escape_default()
             )?;
+
+            if language_spec && !info.contains("no-sc-test") {
+                write!(
+                    tests_file,
+                    r##"
+    #[test]
+    fn line_{}_sc() {{
+        crate::do_test_sc("{}", "{}").unwrap();
+    }}
+
+                "##,
+                    n + 1,
+                    snippet.escape_default(),
+                    path.to_string_lossy().escape_default()
+                )?;
+            }
         }
         writeln!(tests_file, "}}")?;
         println!("cargo:rerun-if-changed={}", path.display());

--- a/tests/doctests/main.rs
+++ b/tests/doctests/main.rs
@@ -3,6 +3,15 @@
 
 #![allow(uncommon_codepoints)]
 
+/// Whether a snippet is a fragment that needs wrapping in a component,
+/// as opposed to a complete file with top-level items.
+#[cfg(test)]
+fn must_wrap(snippet: &str) -> bool {
+    !["component ", "global ", "struct ", "enum ", "import ", "export "]
+        .iter()
+        .any(|kw| snippet.contains(kw))
+}
+
 #[cfg(test)]
 fn do_test(snippet: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> {
     // Strip rustdoc-style `# ` prefix from hidden lines
@@ -21,9 +30,7 @@ fn do_test(snippet: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> 
         .join("\n");
     let snippet = snippet.as_str();
 
-    let must_wrap = !snippet.contains("component ") && !snippet.contains("global ");
-
-    let code = if must_wrap {
+    let code = if must_wrap(snippet) {
         format!(
             "import {{
                 Button, CheckBox, ComboBox, DatePickerPopup, LineEdit, Palette, ProgressIndicator,
@@ -64,6 +71,38 @@ fn do_test(snippet: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> 
     if result.has_errors() && !diagnostics.is_empty() {
         return Err(format!("Error when loading {snippet:?} in {path:?}: {diagnostics:?}").into());
     }
+    Ok(())
+}
+
+/// Compile a Language Specification snippet in Slint SC mode.
+/// Snippets that the SC subset doesn't accept yet carry a `no-sc-test`
+/// fence marker and are skipped by the build script.
+#[cfg(test)]
+fn do_test_sc(snippet: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let code = if must_wrap(snippet) {
+        format!("export component Example inherits Window {{\n{snippet}\n}}")
+    } else {
+        snippet.into()
+    };
+
+    let mut diag = i_slint_compiler::diagnostics::BuildDiagnostics::default();
+    let node = i_slint_compiler::parser::parse(code, Some(std::path::Path::new(path)), &mut diag);
+    let config = i_slint_compiler::CompilerConfiguration::new(
+        i_slint_compiler::generator::OutputFormat::SlintSc,
+    );
+    let (doc, diag, loader) =
+        spin_on::spin_on(i_slint_compiler::compile_syntax_node(node, diag, config));
+    if diag.has_errors() {
+        diag.print();
+        return Err(format!("Error when compiling {snippet:?} in {path:?} in Slint SC mode").into());
+    }
+    i_slint_compiler::generator::generate(
+        i_slint_compiler::generator::OutputFormat::SlintSc,
+        &mut std::io::sink(),
+        None,
+        &doc,
+        &loader.compiler_config,
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
... and make sure that all examples for slint-sc are tested with slint-sc