### PR TITLE
slint-sc: make the safety manual reference a flat list

### DIFF
--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -103,15 +103,9 @@ export default defineConfig({
                     items: [
                         { label: "Overview", slug: "reference" },
                         {
-                            label: "Elements",
-                            items: [
-                                {
-                                    autogenerate: {
-                                        directory:
-                                            "reference/generated/elements",
-                                    },
-                                },
-                            ],
+                            autogenerate: {
+                                directory: "reference/generated",
+                            },
                         },
                     ],
                 },

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -823,7 +823,9 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
-        let group = extract_group(&mut description);
+        // The SC reference is small, so it presents one flat list without
+        // the group subdirectories used by the main docs site.
+        let group = extract_group(&mut description).filter(|_| !cfg.sc_only);
         let draft = strip_annotation(&mut description, "\\draft");
         if draft {
             continue;


### PR DESCRIPTION
The generator placed element pages in per-group subdirectories, but the safety sidebar only listed the elements group, so the Window page was generated but unreachable. Ignore the group in SC mode and autogenerate the sidebar from the whole generated directory.

This will fix the Window not being listed as a supported element.
