### PR TITLE
slint-sc: support bindings with a color literal expression

### DIFF
--- a/api/slint-sc/tests/cases/component/background_color.slint
+++ b/api/slint-sc/tests/cases/component/background_color.slint
@@ -1,0 +1,22 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+//#sls.binding.form
+//#sls.expr.color.forms
+
+export component BackgroundColor inherits Window {
+    Rectangle {
+        background: #123456;
+    }
+    Rectangle {
+        background: #18f;
+        Rectangle {
+            background: #1188ff88;
+        }
+    }
+}
+/*
+```rust
+let _ = BackgroundColor::new();
+```
+*/

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -288,6 +288,10 @@ export default defineConfig({
                                         label: "Exports",
                                         slug: "reference/language/exports",
                                     },
+                                    {
+                                        label: "Bindings",
+                                        slug: "reference/language/bindings",
+                                    },
                                 ],
                             },
                             {

--- a/docs/astro/src/content/docs/reference/language/bindings.md
+++ b/docs/astro/src/content/docs/reference/language/bindings.md
@@ -1,0 +1,38 @@
+---
+title: Bindings
+description: Assigning expressions to properties.
+---
+
+## Form
+
+A binding assigns an expression to a property of the element in whose body it appears.
+It has the form of a property name, followed by `:`, an expression, and `;`. {#sls.binding.form}
+
+```slint
+export component Example inherits Window {
+    Rectangle {
+        background: #2a6e3f;
+    }
+}
+```
+
+The name shall refer to a property of the enclosing element. {#sls.binding.target-must-exist}
+
+## Expressions
+
+This revision of the specification covers a single expression form: the color literal. {#sls.expr.forms}
+
+### Color Literals
+
+A color literal consists of `#` followed by 3, 4, 6, or 8 hexadecimal digits:
+`#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa`.
+The digits are case-insensitive.
+Any other number of digits is an error. {#sls.expr.color.forms}
+
+The digits specify the red, green, blue, and alpha channels, in this order.
+When the alpha channel is absent, the color is fully opaque. {#sls.expr.color.channels}
+
+In the 3- and 4-digit forms, each digit specifies a channel with the digit duplicated:
+`#18f` is the same color as `#1188ff`. {#sls.expr.color.short-forms}
+
+A color literal evaluates to a value of type `color`. {#sls.expr.color.type}

--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -164,6 +164,10 @@ export default defineConfig({
                             label: "Exports",
                             slug: "language/exports",
                         },
+                        {
+                            label: "Bindings",
+                            slug: "language/bindings",
+                        },
                     ],
                 },
             ],

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -389,6 +389,10 @@ pub struct BuiltinPropertyInfo {
     pub property_visibility: PropertyVisibility,
     /// Raw `///` doc comment from builtins.slint, if any.
     pub docs: Option<String>,
+    /// Whether the property is part of the Slint SC subset
+    /// (`\sc` marker in its doc comment). Set by [`Self::set_docs`].
+    #[cfg(feature = "slint-sc")]
+    pub slint_sc: bool,
     /// True when a component may declare a member of the same name, shadowing this one
     /// (`//-shadowable` annotation in builtins.slint).
     /// Members added to a builtin element after its initial release should be marked
@@ -406,7 +410,19 @@ impl BuiltinPropertyInfo {
             property_visibility: PropertyVisibility::InOut,
             docs: None,
             shadowable: false,
+            #[cfg(feature = "slint-sc")]
+            slint_sc: false,
         }
+    }
+
+    /// Set the doc comment, deriving the Slint SC subset flag from its
+    /// `\sc` marker.
+    pub fn set_docs(&mut self, docs: Option<String>) {
+        #[cfg(feature = "slint-sc")]
+        {
+            self.slint_sc = docs.as_deref().is_some_and(crate::load_builtins::has_sc_marker);
+        }
+        self.docs = docs;
     }
 
     pub fn is_native_output(&self) -> bool {
@@ -422,6 +438,8 @@ impl From<BuiltinFunction> for BuiltinPropertyInfo {
             property_visibility: PropertyVisibility::Public,
             docs: None,
             shadowable: false,
+            #[cfg(feature = "slint-sc")]
+            slint_sc: false,
         }
     }
 }
@@ -489,6 +507,8 @@ impl ElementType {
                             BuiltinPropertyDefault::BuiltinFunction(f) => Some(f.clone()),
                             _ => None,
                         },
+                        #[cfg(feature = "slint-sc")]
+                        is_slint_sc: p.slint_sc,
                     },
                 }
             }
@@ -509,6 +529,8 @@ impl ElementType {
                     is_in_direct_base: false,
                     is_shadowable: false,
                     builtin_function: None,
+                    #[cfg(feature = "slint-sc")]
+                    is_slint_sc: false,
                 }
             }
             _ => PropertyLookupResult::invalid(Cow::Borrowed(name)),
@@ -899,6 +921,11 @@ pub struct PropertyLookupResult<'a> {
 
     /// If the property is a builtin function
     pub builtin_function: Option<BuiltinFunction>,
+
+    /// Whether the property is part of the Slint SC subset
+    /// (`\sc` marker in its doc comment in builtins.slint).
+    #[cfg(feature = "slint-sc")]
+    pub is_slint_sc: bool,
 }
 
 impl<'a> PropertyLookupResult<'a> {
@@ -926,6 +953,8 @@ impl<'a> PropertyLookupResult<'a> {
             is_in_direct_base: false,
             is_shadowable: false,
             builtin_function: None,
+            #[cfg(feature = "slint-sc")]
+            is_slint_sc: false,
         }
     }
 }

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -96,7 +96,7 @@ pub(crate) fn load_builtins(
                         }
                     }
 
-                    info.docs = docs::doc_comment(&p);
+                    info.set_docs(docs::doc_comment(&p));
                     info.shadowable = has_shadowable_annotation(&p);
 
                     if let Some(e) = p.BindingExpression() {
@@ -128,7 +128,7 @@ pub(crate) fn load_builtins(
                             .map(|a| a.DeclaredIdentifier().and_then(|x| identifier_text(&x)).unwrap_or_default())
                             .collect()
                     })));
-                    info.docs = docs::doc_comment(&s);
+                    info.set_docs(docs::doc_comment(&s));
                     info.shadowable = has_shadowable_annotation(&s);
                     (identifier_text(&s.DeclaredIdentifier()).unwrap(), info)
                 }))
@@ -184,7 +184,7 @@ pub(crate) fn load_builtins(
             let mut info = BuiltinPropertyInfo::new(Type::Function(
                 Function { return_type, args, arg_names }.into(),
             ));
-            info.docs = docs::doc_comment(&f);
+            info.set_docs(docs::doc_comment(&f));
             info.shadowable = has_shadowable_annotation(&f);
             (name, info)
         }));
@@ -343,7 +343,7 @@ fn parse_annotation(key: &str, node: &SyntaxNode) -> Option<Option<SmolStr>> {
 /// Check for standalone `\sc` marker in a doc string, ensuring it is not
 /// followed by an alphanumeric or underscore character (avoids matching
 /// `\score`, `\scale`, etc.).
-fn has_sc_marker(doc: &str) -> bool {
+pub(crate) fn has_sc_marker(doc: &str) -> bool {
     doc.match_indices("\\sc").any(|(start, _)| {
         let end = start + 3;
         match doc.as_bytes().get(end).copied() {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2247,6 +2247,8 @@ impl Element {
                 is_in_direct_base: false,
                 is_shadowable: false,
                 builtin_function: None,
+                #[cfg(feature = "slint-sc")]
+                is_slint_sc: false,
             },
         )
     }
@@ -2258,10 +2260,12 @@ impl Element {
         diag: &mut BuildDiagnostics,
     ) {
         for (name_token, b) in bindings {
-            #[cfg(feature = "slint-sc")]
-            diag.slint_sc_error("Bindings are", &name_token);
             let unresolved_name = crate::parser::normalize_identifier(name_token.text());
             let lookup_result = self.lookup_property(&unresolved_name);
+            #[cfg(feature = "slint-sc")]
+            if lookup_result.is_valid() && !lookup_result.is_slint_sc {
+                diag.slint_sc_error(&format!("The property '{unresolved_name}' is"), &name_token);
+            }
             if !lookup_result.property_type.is_property_type() {
                 match lookup_result.property_type {
                         Type::Invalid => {

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -569,8 +569,6 @@ impl Expression {
                             });
                     }
                     SyntaxKind::ColorLiteral => {
-                        #[cfg(feature = "slint-sc")]
-                        ctx.diag.slint_sc_error("Color literals are", &token);
                         return i_slint_common::color_parsing::parse_color_literal(token.text())
                             .map(|i| Expression::Cast {
                                 from: Box::new(Expression::NumberLiteral(i as _, Unit::None)),

--- a/internal/compiler/tests/syntax/slint-sc/animations.slint
+++ b/internal/compiler/tests/syntax/slint-sc/animations.slint
@@ -9,6 +9,6 @@ export component Test inherits Window {
 //                   > <^error{The type 'int' is not supported in Slint SC}
     animate val { duration: 100ms; }
 //  >                              <error{Animations are not supported in Slint SC}
-//                >      <^error{Bindings are not supported in Slint SC}
+//                >      <^error{The property 'duration' is not supported in Slint SC}
 //                          >   <^^error{Number literals are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/bindings.slint
@@ -1,16 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Bindings are rejected in Slint SC mode.
+// Bindings are only allowed on properties in the Slint SC subset, and the
+// expression can only be a color literal.
 
 export component Test inherits Window {
-    width: 100px;
-//  >   <error{Bindings are not supported in Slint SC}
-//         >   <^error{Number literals are not supported in Slint SC}
-    height: 50px;
-//  >    <error{Bindings are not supported in Slint SC}
-//          >  <^error{Number literals are not supported in Slint SC}
-    background: red;
-//  >        <error{Bindings are not supported in Slint SC}
-//              > <^error{Identifier references are not supported in Slint SC}
+    background: #123456;
+//  >        <error{The property 'background' is not supported in Slint SC}
+    Rectangle {
+        width: 100px;
+//      >   <error{The property 'width' is not supported in Slint SC}
+//             >   <^error{Number literals are not supported in Slint SC}
+        //#sls.expr.forms
+        background: red;
+//                  > <error{Identifier references are not supported in Slint SC}
+        //#sls.binding.target-must-exist
+        foo: #123456;
+//      > <error{Unknown property foo in Rectangle}
+    }
 }

--- a/internal/compiler/tests/syntax/slint-sc/color_literals.slint
+++ b/internal/compiler/tests/syntax/slint-sc/color_literals.slint
@@ -1,0 +1,75 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Color literals with 3, 4, 6, or 8 hexadecimal digits are accepted as
+// binding expressions; any other number of digits, or non-hexadecimal
+// characters, are an error.
+//#sls.binding.form
+//#sls.expr.color.forms
+
+export component Test inherits Window {
+    Rectangle {
+        background: #18f;
+    }
+    Rectangle {
+        background: #18f8;
+    }
+    Rectangle {
+        background: #1188ff;
+    }
+    Rectangle {
+        background: #1188FF88;
+    }
+    Rectangle {
+        background: #;
+//                  ^error{Invalid color literal}
+    }
+    Rectangle {
+        background: #1;
+//                  ><error{Invalid color literal}
+    }
+    Rectangle {
+        background: #12;
+//                  > <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #12345;
+//                  >    <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #1234567;
+//                  >      <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #123456789;
+//                  >        <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #1234567890;
+//                  >         <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #12345678901;
+//                  >          <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #123456789012;
+//                  >           <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #1234567890123456;
+//                  >               <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #12345678901234567890;
+//                  >                   <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #xyz;
+//                  >  <error{Invalid color literal}
+    }
+    Rectangle {
+        background: #12g4;
+//                  >   <error{Invalid color literal}
+    }
+}

--- a/internal/compiler/tests/syntax/slint-sc/dialog.slint
+++ b/internal/compiler/tests/syntax/slint-sc/dialog.slint
@@ -7,6 +7,6 @@ export component Test inherits Dialog {
 //                             >     <error{The builtin element 'Dialog' is not supported in Slint SC}
     Text { text: "hello"; }
 //  >   <error{The builtin element 'Text' is not supported in Slint SC}
-//         >  <^error{Bindings are not supported in Slint SC}
+//         >  <^error{The property 'text' is not supported in Slint SC}
 //               >     <^^error{String literals are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/elements.slint
+++ b/internal/compiler/tests/syntax/slint-sc/elements.slint
@@ -9,44 +9,43 @@
 //#sls.file.element.tree
 export component Test inherits Window {
     width: 100px;
-//  >   <error{Bindings are not supported in Slint SC}
+//  >   <error{The property 'width' is not supported in Slint SC}
 //         >   <^error{Number literals are not supported in Slint SC}
     height: 100px;
-//  >    <error{Bindings are not supported in Slint SC}
+//  >    <error{The property 'height' is not supported in Slint SC}
 //          >   <^error{Number literals are not supported in Slint SC}
 
     Rectangle {
         x: 10px;
-//      ^error{Bindings are not supported in Slint SC}
+//      ^error{The property 'x' is not supported in Slint SC}
 //         >  <^error{Number literals are not supported in Slint SC}
         width: 20px;
-//      >   <error{Bindings are not supported in Slint SC}
+//      >   <error{The property 'width' is not supported in Slint SC}
 //             >  <^error{Number literals are not supported in Slint SC}
         height: 20px;
-//      >    <error{Bindings are not supported in Slint SC}
+//      >    <error{The property 'height' is not supported in Slint SC}
 //              >  <^error{Number literals are not supported in Slint SC}
         background: red;
-//      >        <error{Bindings are not supported in Slint SC}
-//                  > <^error{Identifier references are not supported in Slint SC}
+//                  > <error{Identifier references are not supported in Slint SC}
     }
 
     Image {
 //  >    <error{The builtin element 'Image' is not supported in Slint SC}
         source: @image-url("");
-//      >    <error{Bindings are not supported in Slint SC}
+//      >    <error{The property 'source' is not supported in Slint SC}
 //              >            <^error{@image-url() expressions are not supported in Slint SC}
         width: 10px;
-//      >   <error{Bindings are not supported in Slint SC}
+//      >   <error{The property 'width' is not supported in Slint SC}
 //             >  <^error{Number literals are not supported in Slint SC}
         height: 10px;
-//      >    <error{Bindings are not supported in Slint SC}
+//      >    <error{The property 'height' is not supported in Slint SC}
 //              >  <^error{Number literals are not supported in Slint SC}
     }
 
     Text {
 //  >   <error{The builtin element 'Text' is not supported in Slint SC}
         text: "hello";
-//      >  <error{Bindings are not supported in Slint SC}
+//      >  <error{The property 'text' is not supported in Slint SC}
 //            >     <^error{String literals are not supported in Slint SC}
     }
 

--- a/internal/compiler/tests/syntax/slint-sc/expressions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/expressions.slint
@@ -46,7 +46,6 @@ export component Test inherits Window {
     property <color> g: #ff0000;
 //  >                          <error{Property declarations are not supported in Slint SC}
 //            >   <^error{The type 'color' is not supported in Slint SC}
-//                      >     <^^error{Color literals are not supported in Slint SC}
     // unary expressions
     property <int> h: -a;
 //  >                   <error{Property declarations are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/path.slint
+++ b/internal/compiler/tests/syntax/slint-sc/path.slint
@@ -7,10 +7,10 @@ export component Test inherits Window {
     Path {
 //  >   <error{The builtin element 'Path' is not supported in Slint SC}
         width: 100px;
-//      >   <error{Bindings are not supported in Slint SC}
+//      >   <error{The property 'width' is not supported in Slint SC}
 //             >   <^error{Number literals are not supported in Slint SC}
         height: 100px;
-//      >    <error{Bindings are not supported in Slint SC}
+//      >    <error{The property 'height' is not supported in Slint SC}
 //              >   <^error{Number literals are not supported in Slint SC}
     }
 }

--- a/internal/compiler/tests/syntax/slint-sc/timer.slint
+++ b/internal/compiler/tests/syntax/slint-sc/timer.slint
@@ -8,7 +8,7 @@ export component Test inherits Window {
     Timer {
 //  >    <error{The builtin element 'Timer' is not supported in Slint SC}
         interval: 1s;
-//      >      <error{Bindings are not supported in Slint SC}
+//      >      <error{The property 'interval' is not supported in Slint SC}
 //                ><^error{Number literals are not supported in Slint SC}
     }
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -369,6 +369,8 @@ pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResul
             property_visibility: visibility,
             declared_pure: None,
             builtin_function,
+            #[cfg(feature = "slint-sc")]
+            is_slint_sc: false,
         };
     }
 
@@ -388,6 +390,8 @@ pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResul
                         property_visibility: crate::object_tree::PropertyVisibility::InOut,
                         declared_pure: None,
                         builtin_function: None,
+                        #[cfg(feature = "slint-sc")]
+                        is_slint_sc: false,
                     };
                 }
             }


### PR DESCRIPTION
Bindings are now allowed when the target is a property carrying the \sc marker (only Rectangle's background today), checked on the property lookup result: an unknown property keeps only the regular diagnostic, and a property outside the subset reports its name. The subset flag is computed when loading the builtins and stored on BuiltinPropertyInfo, like the element-level flag. Color literals are accepted as expressions; every other expression form is still rejected.

The language specification gains a Bindings chapter covering the binding form and the color literal. The paragraphs about channel order, short forms, and the result type stay uncovered in the traceability matrix: compiling literals can't observe them until the runtime renders or exposes color values.

