### PR TITLE
docs: fix the paragraph-id highlight selector

### DIFF
--- a/docs/common/src/styles/sls-ids.css
+++ b/docs/common/src/styles/sls-ids.css
@@ -18,8 +18,8 @@
     text-decoration: underline;
 }
 
-/* Highlight the targeted paragraph when navigating via #sls_xxxxxx. */
-p[id^="sls_"]:target {
+/* Highlight the targeted paragraph when navigating via #sls.xxxxxx. */
+p[id^="sls."]:target {
     background-color: var(--sl-color-accent-low);
     border-radius: 2px;
 }


### PR DESCRIPTION
The :target rule matched ids starting with `sls_`, while the ids the
rehype plugin assigns start with `sls.`, so following a paragraph badge
never highlighted its paragraph.

