### PR TITLE
Display for PropertyVisibility uses `in`, `out`, `in-out`

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1835,7 +1835,7 @@ impl Expression {
                     true
                 } else {
                     ctx.diag.push_error(
-                        format!("{what} on a {} property", lookup.property_visibility),
+                        format!("{what} on an {} property", lookup.property_visibility),
                         node,
                     );
                     false

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -650,9 +650,9 @@ impl Display for PropertyVisibility {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PropertyVisibility::Private => f.write_str("private"),
-            PropertyVisibility::Input => f.write_str("input"),
-            PropertyVisibility::Output => f.write_str("output"),
-            PropertyVisibility::InOut => f.write_str("input output"),
+            PropertyVisibility::Input => f.write_str("in"),
+            PropertyVisibility::Output => f.write_str("out"),
+            PropertyVisibility::InOut => f.write_str("in-out"),
             PropertyVisibility::Constexpr => f.write_str("constexpr"),
             PropertyVisibility::Public => f.write_str("public"),
             PropertyVisibility::Protected => f.write_str("protected"),

--- a/internal/compiler/tests/syntax/elements/text.slint
+++ b/internal/compiler/tests/syntax/elements/text.slint
@@ -4,7 +4,7 @@
 export component Foo inherits Rectangle {
     Text {
         font-metrics: 42;
-//      >          <error{Cannot assign to output property 'font-metrics'}
+//      >          <error{Cannot assign to out property 'font-metrics'}
 //                    > <^error{Cannot convert float to FontMetrics}
 
     }

--- a/internal/compiler/tests/syntax/fuzzing/6632.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6632.slint
@@ -4,6 +4,6 @@
 export component S{
     t:=TextInput{
         has-focus<=>t.has-focus;
-//      >       <error{Cannot assign to output property 'has-focus'}
+//      >       <error{Cannot assign to out property 'has-focus'}
     }
 }

--- a/internal/compiler/tests/syntax/interfaces/interface_properties.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_properties.slint
@@ -33,7 +33,7 @@ export component ComponentWithMismatchedVisibility {
     implement OutOnlyInterface <=> self;
 
     in-out property <int> count;
-//  >                          <error{Incorrect implementation of 'count' from 'OutOnlyInterface' - expected visibility: 'output'}
+//  >                          <error{Incorrect implementation of 'count' from 'OutOnlyInterface' - expected visibility: 'out'}
 }
 
 export interface InterfaceWithDefaultPropertyValues {

--- a/internal/compiler/tests/syntax/interfaces/uses_errors.slint
+++ b/internal/compiler/tests/syntax/interfaces/uses_errors.slint
@@ -73,7 +73,7 @@ component IncorrectPropertyVisibility {
 
 export component ChildDoesNotImplementInterfaceProperty1 {
     implement ValidInterface <=> impl;
-//                               >  <error{'impl' does not implement 'value' from 'ValidInterface' - expected visibility: 'input output'}
+//                               >  <error{'impl' does not implement 'value' from 'ValidInterface' - expected visibility: 'in-out'}
     impl := IncorrectPropertyVisibility { }
 }
 
@@ -112,7 +112,7 @@ component IncorrectSpeakType {
 
 export component ChildDoesNotImplementInterfaceCallback {
     implement ValidInterface <=> impl;
-//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void', visibility: 'input output'}
+//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void', visibility: 'in-out'}
     impl := IncorrectSpeakType { }
 }
 

--- a/internal/compiler/tests/syntax/lookup/absolute-position.slint
+++ b/internal/compiler/tests/syntax/lookup/absolute-position.slint
@@ -4,14 +4,14 @@
 export component Hello {
     Rectangle {
         absolute-position: {x: 45px, y: 78px};
-//      >               <error{Cannot assign to output property 'absolute-position'}
+//      >               <error{Cannot assign to out property 'absolute-position'}
 
     }
 
     Rectangle {
         init => {
             self.absolute-position.x += 45px;
-//          >                              <error{Self assignment on a output property}
+//          >                              <error{Self assignment on a out property}
         }
     }
 }

--- a/internal/compiler/tests/syntax/lookup/absolute-position.slint
+++ b/internal/compiler/tests/syntax/lookup/absolute-position.slint
@@ -11,7 +11,7 @@ export component Hello {
     Rectangle {
         init => {
             self.absolute-position.x += 45px;
-//          >                              <error{Self assignment on a out property}
+//          >                              <error{Self assignment on an out property}
         }
     }
 }

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -14,7 +14,7 @@ component Compo inherits Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a in property}
+//          >         <error{Assignment on an in property}
             inout1 = 75;
         }
 
@@ -53,7 +53,7 @@ OldCompo := Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a in property}
+//          >         <error{Assignment on an in property}
             inout1 = 75;
         }
     }

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -14,12 +14,12 @@ component Compo inherits Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a input property}
+//          >         <error{Assignment on a in property}
             inout1 = 75;
         }
 
         pressed: true;
-//      >     <error{Cannot assign to output property 'pressed'}
+//      >     <error{Cannot assign to out property 'pressed'}
 
     }
 
@@ -29,13 +29,13 @@ component Compo inherits Rectangle {
             priv2: 55;
             output1: 55;
             input1: 12;
-//          >    <error{'input1' cannot be set in a state because it is input}
+//          >    <error{'input1' cannot be set in a state because it is in}
             inout1: 78;
         }
     ]
 
     animate input1 {}
-//          >     <error{Cannot animate input property 'input1'}
+//          >     <error{Cannot animate in property 'input1'}
 }
 
 OldCompo := Rectangle {
@@ -53,7 +53,7 @@ OldCompo := Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a input property}
+//          >         <error{Assignment on a in property}
             inout1 = 75;
         }
     }
@@ -66,12 +66,12 @@ export component Foo inherits Rectangle {
         priv2: 55;
 //      >   <error{Cannot assign to private property 'priv2'}
         output1: 855;
-//      >     <error{Cannot assign to output property 'output1'}
+//      >     <error{Cannot assign to out property 'output1'}
         input1: 12;
         inout1: 78;
 
         animate output1 {}
-//              >      <error{Cannot animate output property 'output1'}
+//              >      <error{Cannot animate out property 'output1'}
 
         animate priv2 {}
 //              >    <error{Cannot animate private property 'priv2'}
@@ -84,7 +84,7 @@ export component Foo inherits Rectangle {
         priv2: 55;
 //      >   <error{Cannot assign to private property 'priv2'}
         output1: 585;
-//      >     <error{Cannot assign to output property 'output1'}
+//      >     <error{Cannot assign to out property 'output1'}
         input1: 12;
         inout1: 78;
     }
@@ -98,7 +98,7 @@ export component Foo inherits Rectangle {
 //          >      <error{'c1.priv2' cannot be set in a state because it is private}
 
             c2.output1: 55;
-//          >        <error{'c2.output1' cannot be set in a state because it is output}
+//          >        <error{'c2.output1' cannot be set in a state because it is out}
         }
     ]
 

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -12,7 +12,7 @@ global Glo {
     foo(x) => {
         out1 = 42;
         in1 = 55;
-//      >      <error{Assignment on a in property}
+//      >      <error{Assignment on an in property}
     }
 }
 
@@ -29,11 +29,11 @@ component Compo inherits Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a in property}
+//          >         <error{Assignment on an in property}
             inout1 = 75;
 
             self.pressed-x = 42px;
-//          >                   <error{Assignment on a out property}
+//          >                   <error{Assignment on an out property}
         }
     }
 
@@ -53,7 +53,7 @@ OldCompo := Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a in property}
+//          >         <error{Assignment on an in property}
             inout1 = 75;
             pressed-x = 45px;
 //          >              <warning{Assignment on an output property is deprecated}
@@ -90,7 +90,7 @@ export component Foo inherits Rectangle {
             c1.priv2 = 78;
 //             >   <error{The property 'priv2' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             c1.output1 = c1.input1;
-//          >                    <error{Assignment on a out property}
+//          >                    <error{Assignment on an out property}
             c1.input1 = 75;
             c1.inout1 = 75;
 
@@ -99,15 +99,15 @@ export component Foo inherits Rectangle {
             c2.priv2 = 78;
 //             >   <error{The property 'priv2' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             c2.output1 = c1.inout2;
-//          >                    <error{Assignment on a out property}
+//          >                    <error{Assignment on an out property}
             c2.input1 = 75;
             c2.inout1 = 75;
 
             input_model[42] += 12;
-//          >                   <error{Self assignment on a in property}
+//          >                   <error{Self assignment on an in property}
 
             Glo.out1 = Glo.in1;
-//          >                <error{Assignment on a out property}
+//          >                <error{Assignment on an out property}
             Glo.inout1 = Glo.priv1;
 //                           >   <error{The property 'priv1' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             Glo.priv2 = Glo.out1;

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -12,7 +12,7 @@ global Glo {
     foo(x) => {
         out1 = 42;
         in1 = 55;
-//      >      <error{Assignment on a input property}
+//      >      <error{Assignment on a in property}
     }
 }
 
@@ -29,11 +29,11 @@ component Compo inherits Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a input property}
+//          >         <error{Assignment on a in property}
             inout1 = 75;
 
             self.pressed-x = 42px;
-//          >                   <error{Assignment on a output property}
+//          >                   <error{Assignment on a out property}
         }
     }
 
@@ -53,7 +53,7 @@ OldCompo := Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on a input property}
+//          >         <error{Assignment on a in property}
             inout1 = 75;
             pressed-x = 45px;
 //          >              <warning{Assignment on an output property is deprecated}
@@ -90,7 +90,7 @@ export component Foo inherits Rectangle {
             c1.priv2 = 78;
 //             >   <error{The property 'priv2' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             c1.output1 = c1.input1;
-//          >                    <error{Assignment on a output property}
+//          >                    <error{Assignment on a out property}
             c1.input1 = 75;
             c1.inout1 = 75;
 
@@ -99,15 +99,15 @@ export component Foo inherits Rectangle {
             c2.priv2 = 78;
 //             >   <error{The property 'priv2' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             c2.output1 = c1.inout2;
-//          >                    <error{Assignment on a output property}
+//          >                    <error{Assignment on a out property}
             c2.input1 = 75;
             c2.inout1 = 75;
 
             input_model[42] += 12;
-//          >                   <error{Self assignment on a input property}
+//          >                   <error{Self assignment on a in property}
 
             Glo.out1 = Glo.in1;
-//          >                <error{Assignment on a output property}
+//          >                <error{Assignment on a out property}
             Glo.inout1 = Glo.priv1;
 //                           >   <error{The property 'priv1' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             Glo.priv2 = Glo.out1;

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -18,9 +18,9 @@ export component C1 {
     // pressed is "output" in Button
     out <=> b.pressed;  // ok  (but then there should be no other assignment?)
     in <=> b.pressed; // Error
-//  >               <error{Cannot link to a output property}
+//  >               <error{Cannot link to a out property}
     inout <=> b.pressed;
-//  >                  <error{Cannot link to a output property}
+//  >                  <error{Cannot link to a out property}
     priv <=> b.pressed; // makes assignment forbidden
 
 
@@ -28,7 +28,7 @@ export component C1 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on a input property}
+//          >      <error{Assignment on a in property}
             out = !out;
 //          >        <error{Cannot modify a property that is linked to a read-only property}
             inout = !inout;
@@ -38,7 +38,7 @@ export component C1 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a output property}
+//          >                          <error{Assignment on a out property}
 
         }
     }
@@ -61,7 +61,7 @@ export component C1 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on a input property}
+//          >      <error{Assignment on a in property}
             out = !out;
             inout = !inout;
             priv = !priv;
@@ -71,7 +71,7 @@ export component C1 {
 //          >                          <error{Cannot modify a property that is linked to a read-only property}
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a output property}
+//          >                          <error{Assignment on a out property}
 
         }
     }
@@ -93,7 +93,7 @@ export component C3 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on a input property}
+//          >      <error{Assignment on a in property}
             out = !out;
             inout = !inout;
             priv = !priv;
@@ -102,7 +102,7 @@ export component C3 {
             self.checked = !self.checked;
 //          >                          <error{Cannot modify a property that is linked to a read-only property}
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a output property}
+//          >                          <error{Assignment on a out property}
         }
     }
 }
@@ -136,7 +136,7 @@ export component C6 {
     }
     Button {
         checked <=> in;
-//      >             <error{Cannot link to a input property}
+//      >             <error{Cannot link to a in property}
         clicked => { self.checked = !self.checked; }
     }
     Button {
@@ -155,7 +155,7 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a output property}
+//          >                          <error{Assignment on a out property}
         }
     }
     Button {
@@ -168,18 +168,18 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a output property}
+//          >                          <error{Assignment on a out property}
         }
     }
     Button { checked <=> b2.pressed;  }
-//           >                     <error{Cannot link to a output property}
+//           >                     <error{Cannot link to a out property}
 
     b3 := Button {
         clicked => {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a output property}
+//          >                          <error{Assignment on a out property}
         }
     }
     Button {
@@ -222,9 +222,9 @@ export component C9 {
 
     out property <bool> out <=> in1;
     in property <bool> in <=> in2;
-//                        >      <error{Cannot link to a input property}
+//                        >      <error{Cannot link to a in property}
     in-out property <bool> inout <=> in3;
-//                               >      <error{Cannot link to a input property}
+//                               >      <error{Cannot link to a in property}
     property <bool> priv <=> in4;
 
     Button {
@@ -232,7 +232,7 @@ export component C9 {
             out = !out;
 //          >        <error{Cannot modify a property that is linked to a read-only property}
             in = !in;
-//          >      <error{Assignment on a input property}
+//          >      <error{Assignment on a in property}
             inout = !inout;
             priv = !priv;
 //          >          <error{Cannot modify a property that is linked to a read-only property}
@@ -261,7 +261,7 @@ export component C10 {
             inout4 = !inout4;
             out = !out;
             in = !in;
-//          >      <error{Assignment on a input property}
+//          >      <error{Assignment on a in property}
             inout = !inout;
             priv = !priv;
         }
@@ -288,7 +288,7 @@ export component C11 {
             priv4 = !priv4;
             out = !out;
             in = !in;
-//          >      <error{Assignment on a input property}
+//          >      <error{Assignment on a in property}
             inout = !inout;
             priv = !priv;
         }
@@ -297,7 +297,7 @@ export component C11 {
 
 export component C12 {
     in property <bool> in1 <=> btn.pressed;
-//                         >              <error{Cannot link to a output property}
+//                         >              <error{Cannot link to a out property}
     in property <bool> in2 <=> btn.checked;
 //                         >              <warning{Linking input properties to input output properties is deprecated}
     in property <bool> in3 <=> btn.enabled;
@@ -338,24 +338,24 @@ export component C13 {
 //           >      <error{Cannot assign to private property 'internal'}
 
     Button { pressed <=> self.pressed; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
     Button { pressed <=> self.checked; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
     Button { pressed <=> self.enabled; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
     Button { pressed <=> self.accessible-checked; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
     Button { pressed <=> self.internal; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
 //                            >      <^error{The property 'internal' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
     Button { pressed <=> out; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
     Button { pressed <=> in; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
     Button { pressed <=> inout; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
     Button { pressed <=> priv; }
-//           >     <error{Cannot assign to output property 'pressed'}
+//           >     <error{Cannot assign to out property 'pressed'}
 
 }
 
@@ -363,10 +363,10 @@ export Legacy1 := Rectangle {
 //             ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     b1:= Button {}
     in property in1 <=> b1.pressed;
-//                  >             <warning{Link to a output property is deprecated}
+//                  >             <warning{Link to a out property is deprecated}
     out property out1 <=> b1.pressed;
     in-out property inout1 <=> b1.pressed;
-//                         >             <warning{Link to a output property is deprecated}
+//                         >             <warning{Link to a out property is deprecated}
 
 
     property <bool> p1;

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -28,7 +28,7 @@ export component C1 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on a in property}
+//          >      <error{Assignment on an in property}
             out = !out;
 //          >        <error{Cannot modify a property that is linked to a read-only property}
             inout = !inout;
@@ -38,7 +38,7 @@ export component C1 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a out property}
+//          >                          <error{Assignment on an out property}
 
         }
     }
@@ -61,7 +61,7 @@ export component C1 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on a in property}
+//          >      <error{Assignment on an in property}
             out = !out;
             inout = !inout;
             priv = !priv;
@@ -71,7 +71,7 @@ export component C1 {
 //          >                          <error{Cannot modify a property that is linked to a read-only property}
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a out property}
+//          >                          <error{Assignment on an out property}
 
         }
     }
@@ -93,7 +93,7 @@ export component C3 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on a in property}
+//          >      <error{Assignment on an in property}
             out = !out;
             inout = !inout;
             priv = !priv;
@@ -102,7 +102,7 @@ export component C3 {
             self.checked = !self.checked;
 //          >                          <error{Cannot modify a property that is linked to a read-only property}
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a out property}
+//          >                          <error{Assignment on an out property}
         }
     }
 }
@@ -155,7 +155,7 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a out property}
+//          >                          <error{Assignment on an out property}
         }
     }
     Button {
@@ -168,7 +168,7 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a out property}
+//          >                          <error{Assignment on an out property}
         }
     }
     Button { checked <=> b2.pressed;  }
@@ -179,7 +179,7 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on a out property}
+//          >                          <error{Assignment on an out property}
         }
     }
     Button {
@@ -232,7 +232,7 @@ export component C9 {
             out = !out;
 //          >        <error{Cannot modify a property that is linked to a read-only property}
             in = !in;
-//          >      <error{Assignment on a in property}
+//          >      <error{Assignment on an in property}
             inout = !inout;
             priv = !priv;
 //          >          <error{Cannot modify a property that is linked to a read-only property}
@@ -261,7 +261,7 @@ export component C10 {
             inout4 = !inout4;
             out = !out;
             in = !in;
-//          >      <error{Assignment on a in property}
+//          >      <error{Assignment on an in property}
             inout = !inout;
             priv = !priv;
         }
@@ -288,7 +288,7 @@ export component C11 {
             priv4 = !priv4;
             out = !out;
             in = !in;
-//          >      <error{Assignment on a in property}
+//          >      <error{Assignment on an in property}
             inout = !inout;
             priv = !priv;
         }


### PR DESCRIPTION
Use the expected syntax in the `Display` implementation of `PropertyVisibilty`. In particular, this allows us to write diagnostics that either show the exact error or what is needed to fix it rather than the user having to know that:
- input -> `in`;
- output -> `out`;
- input output -> `in-out`.

This relates to [feedback](https://github.com/slint-ui/slint/pull/12498#discussion_r3596786100) on an interfaces PR where we use the existing `Display` implementation. This PR fixes the `Display` implementation for everything before we apply more targeted interface error message improvements in a future PR.

As a little drive by we also change error messages from "Assignment on *a* in property" to "Assignment on *an* in property" as this is more natural to say.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>