### PR TITLE
compiler: implement Display for langtype::Function

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -130,30 +130,11 @@ impl Display for Type {
             Type::InferredProperty => write!(f, "?"),
             Type::InferredCallback => write!(f, "callback"),
             Type::Callback(callback) => {
-                write!(f, "callback")?;
-                if !callback.args.is_empty() {
-                    write!(f, "(")?;
-                    for (i, arg) in callback.args.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ",")?;
-                        }
-                        write!(f, "{arg}")?;
-                    }
-                    write!(f, ")")?
-                }
-                write!(f, "-> {}", callback.return_type)?;
-                Ok(())
+                write!(f, "callback{}", callback)
             }
             Type::ComponentFactory => write!(f, "component-factory"),
             Type::Function(function) => {
-                write!(f, "function(")?;
-                for (i, arg) in function.args.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ",")?;
-                    }
-                    write!(f, "{arg}")?;
-                }
-                write!(f, ") -> {}", function.return_type)
+                write!(f, "function{}", function)
             }
             Type::Float32 => write!(f, "float"),
             Type::Int32 => write!(f, "int"),
@@ -980,6 +961,19 @@ pub struct Function {
     /// The optional names of the arguments (empty string means not set).
     /// The names are not technically part of the type, but it is good to have them available for auto-completion
     pub arg_names: Vec<SmolStr>,
+}
+
+impl Display for Function {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "(")?;
+        for (i, arg) in self.args.iter().enumerate() {
+            if i > 0 {
+                write!(formatter, ", ")?;
+            }
+            write!(formatter, "{arg}")?;
+        }
+        write!(formatter, ") -> {}", self.return_type)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
+++ b/internal/compiler/tests/syntax/interfaces/component_declares_interface_api.slint
@@ -65,7 +65,7 @@ export component ComponentDeclaresInterfaceAPIIncorrectly {
     in-out property <float> value;
 //  >                            <error{Incorrect implementation of 'value' from 'ValidInterface' - expected type: 'int'}
     callback speak(string);
-//  >                     <error{Incorrect implementation of 'speak' from 'ValidInterface' - expected type: 'callback-> void'}
+//  >                     <error{Incorrect implementation of 'speak' from 'ValidInterface' - expected type: 'callback() -> void'}
     public function reset(to: float) {
 //  >error{Incorrect arguments for implementation of 'reset' from interface 'ValidInterface'. Expected () but got (float)}
         self.value = to;

--- a/internal/compiler/tests/syntax/interfaces/uses_errors.slint
+++ b/internal/compiler/tests/syntax/interfaces/uses_errors.slint
@@ -99,7 +99,7 @@ component IncorrectCallbackReturnType {
 
 export component ChildDoesNotImplementInterfaceCallback1 {
     implement ValidInterface <=> impl;
-//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void'}
+//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback() -> void'}
     impl := IncorrectCallbackReturnType { }
 }
 
@@ -112,7 +112,7 @@ component IncorrectSpeakType {
 
 export component ChildDoesNotImplementInterfaceCallback {
     implement ValidInterface <=> impl;
-//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback-> void', visibility: 'in-out'}
+//                               >  <error{'impl' does not implement 'speak' from 'ValidInterface' - expected type: 'callback() -> void', visibility: 'in-out'}
     impl := IncorrectSpeakType { }
 }
 
@@ -140,7 +140,7 @@ export component IncorrectArgTypes {
 
 export component ChildDoesNotImplementInterface3 {
     implement FunctionInterface <=> base;
-//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
+//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int, string) -> bool'}
     base := IncorrectArgTypes { }
 }
 
@@ -152,7 +152,7 @@ export component IncorrectArgNames {
 
 export component ChildDoesNotImplementInterface4 {
     implement FunctionInterface <=> base;
-//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
+//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int, string) -> bool'}
     base := IncorrectArgNames { }
 }
 
@@ -163,7 +163,7 @@ export component IncorrectReturnType {
 
 export component ChildDoesNotImplementInterface5 {
     implement FunctionInterface <=> base;
-//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int,string) -> bool'}
+//                                  >  <error{'base' does not implement 'foo' from 'FunctionInterface' - expected type: 'function(int, string) -> bool'}
     base := IncorrectReturnType { }
 }
 


### PR DESCRIPTION
The `Display` implementation for `langtype::Type` uses two slightly different implementations to display the inner `Function` of `Type::Callback` and `Type::Function`. Add a single `Display` implementation, based on the `Type::Function` version, and use that for both.

In particular this means that a callback is displayed with empty parenthesis when it has no arguments. Previously these were missing.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>