### PR TITLE
docs: Fix up association of docs with properties for the Path element

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2403,16 +2403,16 @@ export component Path {
     /// If no view box is defined, the implicit bounding rectangle is used.
     /// \default contain
     in property <ImageFit> fit: contain;
+    /// By default, when a path has a view box defined and the elements render
+    /// outside of it, they are still rendered. When this property is set to `true`, then rendering will be
+    /// clipped at the boundaries of the view box.
     /// \default false
     in property <bool> clip;
-    //!  By default, when a path has a view box defined and the elements render
-    //! outside of it, they are still rendered. When this property is set to `true`, then rendering will be
-    //! clipped at the boundaries of the view box.
+    ///  By default, the fill and stroke of a path is rendered with anti-aliasing, for best quality. Some GPUs
+    ///  have performance issues when rendering with anti-aliasing and animation. Setting the value to `false`
+    ///  might improve the frame-rate at the expense of a smoother looking path.
     /// \default true
     in property <bool> anti-alias: true;
-    //!  By default, the fill and stroke of a path is rendered with anti-aliasing, for best quality. Some GPUs
-    //!  have performance issues when rendering with anti-aliasing and animation. Setting the value to `false`
-    //!  might improve the frame-rate at the expense of a smoother looking path.
     //!
     //! ## Path Using SVG Commands
     //!

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2377,28 +2377,7 @@ export component Path {
     //! If non-zero, the path will be scaled to fit into the specified height.
     //! </SlintProperty>
     //!
-    //! ## Viewbox Properties
-    //! ### viewbox-x
-    //! <SlintProperty propName="viewbox-x" typeName="float"/>
-    //!
-    //! ### viewbox-y
-    //! <SlintProperty propName="viewbox-y" typeName="float"/>
-    //!
-    //! ### viewbox-width
-    //! <SlintProperty propName="viewbox-width" typeName="float"/>
-    //!
-    //! ### viewbox-height
-    //! <SlintProperty propName="viewbox-height" typeName="float"/>
-    //!
-    //! These four properties allow defining the position and size of the viewport of the path in path coordinates.
-    //!
-    //! If the `viewbox-width` or `viewbox-height` is less or equal than zero, the viewbox properties are
-    //! ignored and instead the bounding rectangle of all path elements is used to define the view port.
     in property <string> commands;  // 'fake' hardcoded in typeregister.rs
-    in property <float> viewbox-x;
-    in property <float> viewbox-y;
-    in property <float> viewbox-width;
-    in property <float> viewbox-height;
     /// Defines how the path's view box is scaled to fit the element's width and height.
     /// If no view box is defined, the implicit bounding rectangle is used.
     /// \default contain
@@ -2413,6 +2392,20 @@ export component Path {
     ///  might improve the frame-rate at the expense of a smoother looking path.
     /// \default true
     in property <bool> anti-alias: true;
+    //! ## Viewbox Properties
+    //!
+    //! These four properties allow defining the position and size of the viewport of the path in path coordinates.
+    //!
+    //! If the `viewbox-width` or `viewbox-height` is less or equal than zero, the viewbox properties are
+    //! ignored and instead the bounding rectangle of all path elements is used to define the view port.
+    ///
+    in property <float> viewbox-x;
+    ///
+    in property <float> viewbox-y;
+    ///
+    in property <float> viewbox-width;
+    ///
+    in property <float> viewbox-height;
     //!
     //! ## Path Using SVG Commands
     //!


### PR DESCRIPTION
It was rendered correctly, but we should be using /// instead of pasting verbatim into the mdx with //!.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
