### PR TITLE
slint-sc: prune specification citations that the tests don't cover

### DIFF
--- a/api/slint-sc/tests/cases/component/background_color.slint
+++ b/api/slint-sc/tests/cases/component/background_color.slint
@@ -1,11 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
 
-//#sls.binding.form
-//#sls.expr.color.forms
-
 export component BackgroundColor inherits Window {
     Rectangle {
+        //#sls.binding.form
         background: #123456;
     }
     Rectangle {

--- a/api/slint-sc/tests/cases/component/empty.slint
+++ b/api/slint-sc/tests/cases/component/empty.slint
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
 
 //#sls.file.component.body.empty
-//#sls.file.component.definition-forms
 //#sls.export.declaration-site
 export component Empty inherits Window {}
 /*

--- a/api/slint-sc/tests/cases/component/with_comments.slint
+++ b/api/slint-sc/tests/cases/component/with_comments.slint
@@ -2,16 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
 
 //#sls.source.comment.line
-//#sls.source.comment.block
-//#sls.source.comment.whitespace-equivalent
-
 // A line comment before the component.
 
+//#sls.source.comment.block
 /* A block comment
    spanning multiple lines. */
 
 /* Block comments /* may be nested */ like this. */
 
+//#sls.source.comment.whitespace-equivalent
 export component WithComments inherits Window {
     // Line comment inside a component body.
     Rectangle {

--- a/internal/compiler/tests/syntax/slint-sc/color_literals.slint
+++ b/internal/compiler/tests/syntax/slint-sc/color_literals.slint
@@ -4,11 +4,11 @@
 // Color literals with 3, 4, 6, or 8 hexadecimal digits are accepted as
 // binding expressions; any other number of digits, or non-hexadecimal
 // characters, are an error.
-//#sls.binding.form
 //#sls.expr.color.forms
 
 export component Test inherits Window {
     Rectangle {
+        //#sls.binding.form
         background: #18f;
     }
     Rectangle {

--- a/internal/compiler/tests/syntax/slint-sc/comments.slint
+++ b/internal/compiler/tests/syntax/slint-sc/comments.slint
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // Comments are equivalent to whitespace and carry no semantic effect.
-//#sls.source.comment.line
-//#sls.source.comment.block
-//#sls.source.comment.whitespace-equivalent
-//#sls.source.comment.no-doc-comments
 
+//#sls.source.comment.line
 // A line comment.
 
+//#sls.source.comment.block
 /* A block comment. */
 
 /* Block comments /* may be nested */ like this. */
 
+//#sls.source.comment.no-doc-comments
 /// Triple-slash is an ordinary line comment.
 
 /** Double-star-slash is an ordinary block comment. */
 
+//#sls.source.comment.whitespace-equivalent
 export component Test inherits Window {
     // comment inside component body
     Rectangle {

--- a/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
+++ b/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
@@ -4,15 +4,11 @@
 // Non-exported component declarations are rejected in Slint SC mode.
 // Only one exported component per file is allowed.
 
-//#sls.export.default-private
 component Helper inherits Window { }
 //        >    <error{Component declarations are not supported in Slint SC}
 //>                                  <^<<warning{Component is neither used nor exported}
 
-//#sls.export.declaration-site
-//#sls.file.component.definition-forms
 export component First inherits Window { }
 
-//#sls.export.no-duplicates
 export component Second inherits Window { }
 //               >    <error{Multiple exported components per file are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/element_nesting.slint
+++ b/internal/compiler/tests/syntax/slint-sc/element_nesting.slint
@@ -3,7 +3,6 @@
 
 // Element instantiations form a tree rooted at the component body.
 //#sls.file.element.instantiation-form
-//#sls.file.element.instantiation-typename
 //#sls.file.element.body
 //#sls.file.element.tree
 //#sls.file.component.body

--- a/internal/compiler/tests/syntax/slint-sc/elements.slint
+++ b/internal/compiler/tests/syntax/slint-sc/elements.slint
@@ -3,10 +3,6 @@
 
 // All builtin elements are rejected in Slint SC mode.
 
-//#sls.file.element.instantiation-form
-//#sls.file.element.instantiation-typename
-//#sls.file.element.body
-//#sls.file.element.tree
 export component Test inherits Window {
     width: 100px;
 //  >   <error{The property 'width' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
+++ b/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
@@ -6,12 +6,9 @@
 component Foo inherits Window { }
 //        > <error{Component declarations are not supported in Slint SC}
 
-//#sls.export.forms
-//#sls.export.list
 export { Foo }
 //       >  <error{Export specifiers are not supported in Slint SC}
 
-//#sls.export.rename
 export { Foo as Bar }
 //       >        <error{Export specifiers are not supported in Slint SC}
 

--- a/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
+++ b/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
@@ -3,9 +3,9 @@
 
 // Repeated and conditional elements are rejected in Slint SC mode.
 
-//#sls.file.component.body
 export component Test inherits Window {
 
+    //#sls.file.component.body
     for i in [1, 2, 3]: Rectangle { }
 //  >                               <error{Repeated elements (for-in) are not supported in Slint SC}
 //           >       <^error{Array expressions are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen.slint
@@ -3,7 +3,7 @@
 
 // A `-` shall not appear as the first character of an identifier:
 // component name.
-//#sls.lex.identifier.no-leading-hyphen
 
+//#sls.lex.identifier.no-leading-hyphen
 export component -Foo inherits Window {}
 //               ^error{Syntax error: expected Identifier}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_element_id.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_element_id.slint
@@ -3,9 +3,9 @@
 
 // A `-` shall not appear as the first character of an identifier:
 // element id.
-//#sls.lex.identifier.no-leading-hyphen
 
 export component Foo inherits Window {
+    //#sls.lex.identifier.no-leading-hyphen
     -rect := Rectangle {}
 //  ^error{Parse error}
 }

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_inherits.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_inherits.slint
@@ -3,7 +3,7 @@
 
 // A `-` shall not appear as the first character of an identifier:
 // base type name.
-//#sls.lex.identifier.no-leading-hyphen
 
+//#sls.lex.identifier.no-leading-hyphen
 export component Foo inherits -Window {}
 //                            ^error{Syntax error: expected Identifier}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_property.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_leading_hyphen_property.slint
@@ -3,9 +3,9 @@
 
 // A `-` shall not appear as the first character of an identifier:
 // property name.
-//#sls.lex.identifier.no-leading-hyphen
 
 export component Foo inherits Window {
+    //#sls.lex.identifier.no-leading-hyphen
     property <int> -prop;
 //                 ^error{Syntax error: expected Identifier}
 //                 ^^error{Syntax error: expected ';'}

--- a/internal/compiler/tests/syntax/slint-sc/identifiers.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifiers.slint
@@ -1,10 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Identifier character classes and normalization rules.
-//#sls.lex.identifier.classes
-//#sls.lex.identifier.normalization
-//#sls.lex.contextual-keywords
+// Underscores are accepted in component identifiers.
 
 export component My_Test_Component inherits Window {
 }

--- a/internal/compiler/tests/syntax/slint-sc/inheritance.slint
+++ b/internal/compiler/tests/syntax/slint-sc/inheritance.slint
@@ -6,7 +6,6 @@
 component Base inherits Window { }
 //        >  <error{Component declarations are not supported in Slint SC}
 
-//#sls.file.component.inherits
 export component Test inherits Base {
 //                             >   <error{Inheriting from user-defined components is not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/source_file.slint
+++ b/internal/compiler/tests/syntax/slint-sc/source_file.slint
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // A `.slint` source file is a sequence of top-level items.
-//#sls.source.file-extension
 //#sls.file.source-file
 //#sls.file.top-level-item
-//#sls.file.component.name
-//#sls.file.component.body-braces
-//#sls.export.placement
 
 export component MyComponent inherits Window {
 }

--- a/internal/compiler/tests/syntax/slint-sc/whitespace.slint
+++ b/internal/compiler/tests/syntax/slint-sc/whitespace.slint
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // Whitespace separates tokens but is otherwise insignificant.
-//#sls.lex.tokens
-//#sls.source.whitespace.chars
 //#sls.source.whitespace.collapse
 
 


### PR DESCRIPTION
The //#sls citations were added too liberally: many sat on tests that merely contain the construct without testing the cited paragraph.

Keep a citation only when the test really covers the paragraph: a structural paragraph needs a test exhibiting that structure, and a shall-clause needs its violation tested. The traceability matrix now honestly reports the pruned paragraphs as uncovered.

Removed citations, and why:

- inheritance.slint, file.component.inherits: the test checks that a user-defined base is rejected in SC mode; no test resolves an unknown base name.

- component_declaration.slint, export.default-private: visibility to importers can't be observed because SC has no imports; the tested errors are SC restrictions, not privacy.

- component_declaration.slint, export.declaration-site: nothing there observes that the component was exported. The runtime case component/empty.slint keeps its citation: Empty::new() in the Rust snippet observes that the exported name is the component's name.

- component_declaration.slint, file.component.definition-forms, and case component/empty.slint: only the inherits form appears; the form without a base never does (an SC component must inherit Window).

- component_declaration.slint, export.no-duplicates: the tested error is "multiple exported components", not a duplicated name. The normalization-collision test doesn't carry it either: it duplicates a name only after normalization, never literally.

- identifiers.slint, lex.identifier.classes, lex.identifier.normalization, lex.contextual-keywords: a component named My_Test_Component exercises no character-class boundary, no normalization pair, and no keyword used as an identifier.

- export_specifiers.slint, export.forms, export.list, export.rename: SC rejects export lists outright, so the paragraphs describing how lists work aren't tested. left-must-exist stays: the "'DoesNotExist' not found" error is the violation of that clause.

- elements.slint, the four element-structure paragraphs: that test is about SC rejecting builtin elements and properties; element_nesting.slint covers the structure.

- element_nesting.slint, file.element.instantiation-typename: only resolvable type names appear; no test uses an unknown element type.

- source_file.slint, source.file-extension, file.component.name, file.component.body-braces, export.placement: the file contains only the boilerplate every test shares; nothing targets these rules.

- whitespace.slint, lex.tokens: definitional, any compiling file demonstrates it. source.whitespace.chars: the file contains no tab, so the whitespace character set isn't fully exercised.

- case component/background_color.slint, expr.color.forms: the 4-digit form and case-insensitivity are missing; the syntax test color_literals.slint covers all the forms.

Also move the surviving citations from the top of the file next to the line that tests them, when they don't describe a whole-file property.

