### PR TITLE
slint-sc: omit uncertified features from the safety manual

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -12,6 +12,7 @@ import {
 } from "@slint/common-files/src/utils/starlight-site-defaults";
 import { rehypeExternalLinksSlint } from "@slint/common-files/src/utils/rehype-external-links-preset";
 import rehypeSlsIds from "@slint/common-files/src/utils/rehype-sls-ids.mjs";
+import rehypeNotInSc from "@slint/common-files/src/utils/rehype-not-in-sc.mjs";
 import { slintStarlightSocial } from "@slint/common-files/src/utils/starlight-social";
 import {
     BASE_PATH,
@@ -38,7 +39,7 @@ export default defineConfig({
     trailingSlash: SLINT_STARLIGHT_TRAILING_SLASH,
     markdown: {
         gfm: true,
-        rehypePlugins: [rehypeExternalLinksSlint, rehypeSlsIds],
+        rehypePlugins: [rehypeExternalLinksSlint, rehypeNotInSc, rehypeSlsIds],
     },
     integrations: [
         sitemap(),

--- a/docs/common/src/utils/rehype-not-in-sc.mjs
+++ b/docs/common/src/utils/rehype-not-in-sc.mjs
@@ -1,0 +1,124 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// `<NotInSC>` … `</NotInSC>` marks documentation of a feature that isn't part
+// of the safety-certified surface. The safety manual drops what the tags
+// enclose, every other site keeps it, and neither renders the tags: they are
+// authoring syntax.
+//
+// The tags work in hand-written pages and in the reference generated from the
+// doc comments of internal/compiler/builtins.slint alike, which is why this
+// lives here rather than in the generator: only the specification chapters'
+// own source can mark passages of the specification.
+//
+// Markdown and MDX deliver the tags in three different shapes:
+//   - MDX parses them as one `mdxJsxFlowElement` named `NotInSC` whose
+//     children are the enclosed content;
+//   - Markdown with no blank line inside makes the whole region a single raw
+//     HTML node, tags and text together;
+//   - Markdown with paragraphs inside makes the tags two raw nodes of their
+//     own, with the enclosed nodes between them.
+//
+// An unbalanced tag would omit the wrong content, so it fails the build.
+
+const OPEN = "<NotInSC>";
+const CLOSE = "</NotInSC>";
+const TAG_NAME = "NotInSC";
+
+/** The tag a raw markdown node consists of, if it is nothing else. */
+function rawTag(node) {
+    if (node?.type !== "raw" && node?.type !== "html") return undefined;
+    const value = node.value.trim();
+    return value === OPEN || value === CLOSE ? value : undefined;
+}
+
+/** Whether a raw markdown node holds a whole region, tags and content. */
+function isSelfContainedRegion(node) {
+    if (node?.type !== "raw" && node?.type !== "html") return false;
+    const value = node.value.trim();
+    return value.startsWith(OPEN) && value.endsWith(CLOSE);
+}
+
+/** The region's content, with the tags removed. */
+function regionContent(node) {
+    return node.value.trim().slice(OPEN.length, -CLOSE.length).trim();
+}
+
+/**
+ * Mark content of a region that this site keeps, so that the rest of the
+ * pipeline can tell it apart: it documents a feature outside the certified
+ * subset, and states no requirement of the specification.
+ */
+function markNotInSc(node) {
+    node.data = { ...node.data, notInSc: true };
+    for (const child of node.children ?? []) markNotInSc(child);
+    return node;
+}
+
+/**
+ * @param {{ omit?: boolean }} options `omit` drops what the tags enclose,
+ * for the site that documents the certified subset only.
+ */
+export default function rehypeNotInSc({ omit = false } = {}) {
+    return (tree, file) => {
+        const sourcePath = file?.path ?? "";
+        visit(tree);
+
+        function visit(parent) {
+            if (!parent.children) return;
+            const children = [];
+            // Nodes of an open region, kept only when this site includes them.
+            let enclosed;
+
+            for (const node of parent.children) {
+                if (
+                    node.type === "mdxJsxFlowElement" &&
+                    node.name === TAG_NAME
+                ) {
+                    if (!omit) children.push(...node.children.map(markNotInSc));
+                    continue;
+                }
+                if (isSelfContainedRegion(node)) {
+                    if (!omit)
+                        children.push(
+                            markNotInSc({
+                                ...node,
+                                value: regionContent(node),
+                            }),
+                        );
+                    continue;
+                }
+                const tag = rawTag(node);
+                if (tag === OPEN) {
+                    if (enclosed) {
+                        throw new Error(unbalanced(sourcePath, OPEN));
+                    }
+                    enclosed = [];
+                    continue;
+                }
+                if (tag === CLOSE) {
+                    if (!enclosed) {
+                        throw new Error(unbalanced(sourcePath, CLOSE));
+                    }
+                    if (!omit) children.push(...enclosed.map(markNotInSc));
+                    enclosed = undefined;
+                    continue;
+                }
+                (enclosed ?? children).push(node);
+                visit(node);
+            }
+
+            if (enclosed) {
+                throw new Error(unbalanced(sourcePath, OPEN));
+            }
+            parent.children = children;
+        }
+    };
+}
+
+function unbalanced(sourcePath, tag) {
+    return (
+        `rehype-not-in-sc: unbalanced \`${tag}\` in ${sourcePath}\n` +
+        "Each `<NotInSC>` shall be closed by a `</NotInSC>` of its own."
+    );
+}

--- a/docs/common/src/utils/rehype-sls-ids.mjs
+++ b/docs/common/src/utils/rehype-sls-ids.mjs
@@ -102,6 +102,9 @@ export default function rehypeSlsIds({
 
         walk(tree, (node, depth) => {
             if (node.tagName !== "p") return;
+            // A feature outside the certified subset states no requirement, so
+            // it carries no identifier. See rehype-not-in-sc.mjs.
+            if (node.data?.notInSc) return;
             const last = node.children.at(-1);
             const match =
                 last?.type === "text" ? last.value.match(ID_MARKER) : null;

--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -15,6 +15,7 @@ import {
     SAFETY_DOCS_BASE_PATH,
 } from "./src/safety-site-config.mjs";
 import rehypeSlsIds from "@slint/common-files/src/utils/rehype-sls-ids.mjs";
+import rehypeNotInSc from "@slint/common-files/src/utils/rehype-not-in-sc.mjs";
 
 const _safetyOrigin = String(SAFETY_DOCS_BASE_URL).replace(/\/+$/, "");
 const _safetyAtRoot = SAFETY_DOCS_BASE_PATH === "/";
@@ -35,6 +36,9 @@ export default defineConfig({
         // every paragraph of it carries a traceability id.
         rehypePlugins: [
             rehypeExternalLinksSlint,
+            // Before the identifiers are assigned: paragraphs this site omits
+            // state no requirement and carry none.
+            [rehypeNotInSc, { omit: true }],
             [rehypeSlsIds, { generatedReferenceRequiresIds: true }],
         ],
     },

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -220,19 +220,11 @@ pub fn extract_enum_docs(
 
     if sc_only {
         enums.retain(|_, e| crate::element_docs::is_sc_covered(&e.description));
-        for e in enums.values_mut() {
-            e.description = crate::element_docs::strip_sc(&e.description);
-            for v in &mut e.values {
-                v.description = crate::element_docs::strip_sc(&v.description);
-            }
-        }
-    } else {
-        // Even outside SC mode, the marker should never leak into output.
-        for e in enums.values_mut() {
-            e.description = crate::element_docs::strip_sc(&e.description);
-            for v in &mut e.values {
-                v.description = crate::element_docs::strip_sc(&v.description);
-            }
+    }
+    for e in enums.values_mut() {
+        e.description = crate::element_docs::strip_sc(&e.description);
+        for v in &mut e.values {
+            v.description = crate::element_docs::strip_sc(&v.description);
         }
     }
 

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -164,6 +164,9 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
     };
     let mut in_comment = false;
     let mut in_fence = false;
+    // `<NotInSC>` regions aren't published in the safety manual, so whatever
+    // they enclose states no requirement. See rehype-not-in-sc.mjs.
+    let mut in_not_in_sc = false;
     let mut frontmatter_delimiters = 0;
     for (i, line) in text.lines().enumerate() {
         let t = line.trim();
@@ -188,6 +191,17 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
             continue;
         }
         if in_fence {
+            continue;
+        }
+        if t == "<NotInSC>" {
+            in_not_in_sc = true;
+            continue;
+        }
+        if t == "</NotInSC>" {
+            in_not_in_sc = false;
+            continue;
+        }
+        if in_not_in_sc {
             continue;
         }
         if t.starts_with("<!--") {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -146,7 +146,9 @@ component BasicBorderRectangle inherits Rectangle {
 /// By default, a `Rectangle` is just an empty item that shows nothing. By setting a color or configuring a border,
 /// it's then possible to draw a rectangle on the screen. \{#sls.meta.rectangle.purpose}
 ///
-/// When not part of a layout, its width and height default to 100% of the parent element. \{#sls.ref.rectangle.default-size}
+/// <NotInSC>
+/// When not part of a layout, its width and height default to 100% of the parent element.
+/// </NotInSC>
 ///
 /// ```slint playground imageAlt="rectangle example"
 /// export component ExampleRectangle inherits Window {
@@ -1582,11 +1584,15 @@ component WindowItem {
 
 /// `Window` is the root of the tree of elements that are visible on the screen. \{#sls.meta.window.purpose}
 ///
+/// <NotInSC>
 /// The `Window` geometry will be restricted by its layout constraints: Setting the `width` will result in a fixed width,
 /// and the window manager will respect the `min-width` and `max-width` so the window can't be resized bigger
-/// or smaller. The initial width can be controlled with the `preferred-width` property. The same applies to the `Window`s height. \{#sls.ref.window.geometry-constraints}
+/// or smaller. The initial width can be controlled with the `preferred-width` property. The same applies to the `Window`s height.
+/// </NotInSC>
 ///
-/// Use the <Link type="MenuBar" /> element to declare a menu bar for the window. \{#sls.meta.window.menu-bar}
+/// <NotInSC>
+/// Use the <Link type="MenuBar" /> element to declare a menu bar for the window.
+/// </NotInSC>
 /// \group:window
 /// \sc
 export component Window inherits WindowItem {

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -206,7 +206,15 @@ fn clean_builtin_doc(raw: &str) -> String {
         if trimmed.starts_with('\\') {
             continue;
         }
-        if trimmed.starts_with('<') && trimmed.ends_with("/>") {
+        // A line that is nothing but a tag is markup for the documentation
+        // site, not prose. That covers `<Link … />` as well as the
+        // `<NotInSC>` … `</NotInSC>` pair marking what the safety-certified
+        // subset leaves out, whose text the tooltip keeps: it documents the
+        // full language.
+        // TODO: once the LSP serves Slint SC development too, it should tell
+        // the reader that a feature inside `<NotInSC>` is unavailable there
+        // instead of presenting it like the rest.
+        if trimmed.starts_with('<') && trimmed.ends_with('>') && !trimmed[1..].contains('<') {
             continue;
         }
         if !result.is_empty() {


### PR DESCRIPTION
Members are opted into the certified surface one by one, but an element description was all or nothing: a single `\sc` on the element emitted the whole prose. The Window page therefore documented how its geometry is constrained by `min-width`, `max-width` and `preferred-width` -- properties the certified surface doesn't include.

Wrap such passages in `<NotInSC>` … `</NotInSC>`. The safety manual drops what they enclose, the main documentation keeps it, and neither renders the tags. Unbalanced tags are an error, since they would omit the wrong lines. The identifier of the omitted paragraph goes with it: it described a requirement the manual no longer states.

The tag wraps whole lines, so it applies to examples and sections as well as to prose, and it doesn't collide with the `\sc` scanners, which accept a following `-`.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
