### PR TITLE
docs: show the traceability identifiers only in the safety manual

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -39,7 +39,13 @@ export default defineConfig({
     trailingSlash: SLINT_STARLIGHT_TRAILING_SLASH,
     markdown: {
         gfm: true,
-        rehypePlugins: [rehypeExternalLinksSlint, rehypeNotInSc, rehypeSlsIds],
+        rehypePlugins: [
+            rehypeExternalLinksSlint,
+            rehypeNotInSc,
+            // The traceability identifiers anchor the paragraphs here too, but
+            // only the safety manual displays them.
+            [rehypeSlsIds, { renderBadge: false }],
+        ],
     },
     integrations: [
         sitemap(),

--- a/docs/common/src/utils/rehype-sls-ids.mjs
+++ b/docs/common/src/utils/rehype-sls-ids.mjs
@@ -7,7 +7,10 @@
 // MDX files (where an unescaped `{` starts a JSX expression). The escape is
 // consumed by the markdown parser, so this plugin sees `{#sls.xxx}`; it strips
 // the marker, sets it as the paragraph's `id`, and appends a visible
-// `[sls.xxx]` badge that doubles as an anchor.
+// `[sls.xxx]` badge that doubles as an anchor. The badge is what makes an
+// identifier citable at a glance, which the safety manual needs and the main
+// documentation doesn't: pass `{ renderBadge: false }` there to keep the
+// identifiers as anchors without showing them.
 //
 // The markers are authoring syntax, so no page ever renders one verbatim:
 // where a page carries no identifiers -- the same doc comments feed the main
@@ -61,6 +64,7 @@ function textPreview(node) {
 
 export default function rehypeSlsIds({
     generatedReferenceRequiresIds = false,
+    renderBadge = true,
 } = {}) {
     // Closure-scoped: persists across files in one build, so a duplicate
     // id assigned in two different pages fails the build. The (id ->
@@ -151,6 +155,9 @@ export default function rehypeSlsIds({
             }
 
             node.properties = { ...(node.properties || {}), id };
+            // The identifier stays an anchor either way: the specification
+            // cites paragraphs across chapters with `#sls.…` links.
+            if (!renderBadge) return;
             node.children.push({
                 type: "element",
                 tagName: "a",


### PR DESCRIPTION
The `[sls.…]` badge makes a paragraph's identifier citable at a glance, which the safety manual needs. In the main documentation it's noise: the specification reads there as prose, not as a list of requirements.

Keep assigning the identifiers so that the citations between chapters still resolve, and render the badge only where it's read.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
