### PR TITLE
Fix Timer.restart() and popup show/close called from another component

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5164,18 +5164,25 @@ fn compile_builtin_function_call(
                 arguments
             {
                 let mut component_access = MemberAccess::Direct("self".into());
-                let llr::MemberReference::Relative { parent_level, .. } = parent_ref else {unreachable!()};
+                let llr::MemberReference::Relative { parent_level, local_reference } = parent_ref else {unreachable!()};
                 for _ in 0..*parent_level {
                     component_access = component_access.and_then(|x| format!("{x}->parent.lock()"));
                 }
 
                 let window = access_window_field(ctx);
-                let current_sub_component = &ctx.compilation_unit.sub_components[ctx.parent_sub_component_idx(*parent_level).unwrap()];
-                let popup = &current_sub_component.popup_windows[*popup_index as usize];
+                // The popup is declared in the component of the parent item;
+                // `compo_path` descends the item reference's path.
+                let (compo_path, _) = follow_sub_component_path(
+                    ctx.compilation_unit,
+                    ctx.parent_sub_component_idx(*parent_level).unwrap(),
+                    &local_reference.sub_component_path,
+                );
+                let parent_component = access_item_rc(parent_ref, ctx);
+                ctx.with_reference_scope(*parent_level, &local_reference.sub_component_path, |parent_ctx| {
+                let popup = &ctx.compilation_unit.sub_components[parent_ctx.sub_component]
+                    .popup_windows[*popup_index as usize];
                 let popup_window_id =
                     ident(&ctx.compilation_unit.sub_components[popup.item_tree.root].name);
-                let parent_component = access_item_rc(parent_ref, ctx);
-                let parent_ctx = ParentScope::new(ctx, None);
                 let popup_ctx = EvaluationContext::new_sub_component(
                     ctx.compilation_unit,
                     popup.item_tree.root,
@@ -5209,17 +5216,25 @@ fn compile_builtin_function_call(
                     }
                     _ => "[](bool) {}".to_string(),
                 };
-                component_access.then(|component_access| format!(
-                    // Use a block statement to create own globals and popup instance
-                    "{window}.close_popup({component_access}->popup_id_{popup_index}); \
-                    {component_access}->popup_id_{popup_index} =  \
-                        {window}.template show_popup<{popup_window_id}>(&*({component_access}),  \
-                                                                        [=](auto self) {{ return {position}; }},  \
-                                                                        {close_policy},  \
-                                                                        {{ {parent_component} }},  \
-                                                                        {window_kind},  \
-                                                                        {is_open_setter})"
-                ))
+                component_access.then(|component_access| {
+                    let compo_ptr = if compo_path.is_empty() {
+                        format!("&*({component_access})")
+                    } else {
+                        format!("&({component_access}->{})", compo_path.trim_end_matches('.'))
+                    };
+                    format!(
+                        // Use a block statement to create own globals and popup instance
+                        "{window}.close_popup({component_access}->{compo_path}popup_id_{popup_index}); \
+                        {component_access}->{compo_path}popup_id_{popup_index} =  \
+                            {window}.template show_popup<{popup_window_id}>({compo_ptr},  \
+                                                                            [=](auto self) {{ return {position}; }},  \
+                                                                            {close_policy},  \
+                                                                            {{ {parent_component} }},  \
+                                                                            {window_kind},  \
+                                                                            {is_open_setter})"
+                    )
+                })
+                })
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")
             }
@@ -5227,12 +5242,17 @@ fn compile_builtin_function_call(
         BuiltinFunction::ClosePopupWindow => {
             if let [llr::Expression::NumberLiteral(popup_index), llr::Expression::PropertyReference(parent_ref)] = arguments {
                 let mut component_access = MemberAccess::Direct("self".into());
-                let llr::MemberReference::Relative { parent_level, .. } = parent_ref else {unreachable!()};
+                let llr::MemberReference::Relative { parent_level, local_reference } = parent_ref else {unreachable!()};
                 for _ in 0..*parent_level {
                     component_access = component_access.and_then(|x| format!("{x}->parent.lock()"));
                 }
+                let (compo_path, _) = follow_sub_component_path(
+                    ctx.compilation_unit,
+                    ctx.parent_sub_component_idx(*parent_level).unwrap(),
+                    &local_reference.sub_component_path,
+                );
 
-                component_access.then(|component_access| format!("{component_access}->globals->window().window_handle().close_popup({component_access}->popup_id_{popup_index})"))
+                component_access.then(|component_access| format!("{component_access}->{compo_path}globals->window().window_handle().close_popup({component_access}->{compo_path}popup_id_{popup_index})"))
             } else {
                 panic!("internal error: invalid args to ClosePopupWindow {arguments:?}")
             }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3685,6 +3685,8 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                         let function_name = ident(&sub_component.functions[*function_index].name);
                         path.with_member(format!("->{compo_path}fn_{function_name}"))
                     }
+                    llr::LocalMemberIndex::Timer(timer_index) => path
+                        .with_member(format!("->{compo_path}timer{}", usize::from(*timer_index))),
                     llr::LocalMemberIndex::Native { item_index, prop_name, .. } => {
                         let item_name = field_name(&sub_component.items[*item_index].name);
                         if prop_name.is_empty()
@@ -5413,8 +5415,9 @@ fn compile_builtin_function_call(
         BuiltinFunction::StartTimer => unreachable!(),
         BuiltinFunction::StopTimer => unreachable!(),
         BuiltinFunction::RestartTimer => {
-            if let [llr::Expression::NumberLiteral(timer_index)] = arguments {
-                format!("const_cast<slint::Timer&>(self->timer{}).restart()", timer_index)
+            if let [llr::Expression::PropertyReference(pr)] = arguments {
+                access_member(pr, ctx)
+                    .then(|x| format!("const_cast<slint::Timer&>({x}).restart()"))
             } else {
                 panic!("internal error: invalid args to RestartTimer {arguments:?}")
             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3186,6 +3186,23 @@ fn follow_sub_component_path<'a>(
     (compo_path, sub_component)
 }
 
+/// Like [`follow_sub_component_path`],
+/// but returns a plain field access suffix (`.sub1.sub2`) instead of a field offset expression.
+fn follow_sub_component_path_fields<'a>(
+    compilation_unit: &'a llr::CompilationUnit,
+    root: llr::SubComponentIdx,
+    sub_component_path: &[llr::SubComponentInstanceIdx],
+) -> (TokenStream, &'a llr::SubComponent) {
+    let mut compo_path = quote!();
+    let mut sub_component = &compilation_unit.sub_components[root];
+    for i in sub_component_path {
+        let sub_component_name = ident(&sub_component.sub_components[*i].name);
+        compo_path = quote!(#compo_path.#sub_component_name);
+        sub_component = &compilation_unit.sub_components[sub_component.sub_components[*i].ty];
+    }
+    (compo_path, sub_component)
+}
+
 fn access_window_adapter_field(ctx: &EvaluationContext) -> TokenStream {
     let global_access = &ctx.generator_state.global_access;
     quote!(&#global_access.window_adapter_impl())
@@ -3209,13 +3226,12 @@ fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> TokenSt
             quote!(#component_access_tokens.parent.upgrade().unwrap().as_pin_ref());
     }
 
-    let mut sub_component =
-        &ctx.compilation_unit.sub_components[ctx.parent_sub_component_idx(*parent_level).unwrap()];
-    for i in &local_reference.sub_component_path {
-        let sub_component_name = ident(&sub_component.sub_components[*i].name);
-        component_access_tokens = quote!(#component_access_tokens . #sub_component_name);
-        sub_component = &ctx.compilation_unit.sub_components[sub_component.sub_components[*i].ty];
-    }
+    let (suffix, sub_component) = follow_sub_component_path_fields(
+        ctx.compilation_unit,
+        ctx.parent_sub_component_idx(*parent_level).unwrap(),
+        &local_reference.sub_component_path,
+    );
+    let component_access_tokens = quote!(#component_access_tokens #suffix);
     let component_rc_tokens = quote!(#component_access_tokens.origin_rc());
     let item_index_in_tree = sub_component.items[*item_index].index_in_tree;
     let item_index_tokens = if item_index_in_tree == 0 {
@@ -4141,7 +4157,8 @@ fn compile_builtin_function_call(
             ] = arguments
             {
                 let mut component_access_tokens = MemberAccess::Direct(quote!(_self));
-                let llr::MemberReference::Relative { parent_level, .. } = parent_ref else {
+                let llr::MemberReference::Relative { parent_level, local_reference } = parent_ref
+                else {
                     unreachable!()
                 };
                 for _ in 0..*parent_level {
@@ -4155,15 +4172,23 @@ fn compile_builtin_function_call(
                         _ => unreachable!(),
                     };
                 }
-
-                let current_sub_component = &ctx.compilation_unit.sub_components
-                    [ctx.parent_sub_component_idx(*parent_level).unwrap()];
-                let popup = &current_sub_component.popup_windows[*popup_index as usize];
-                let popup_window_id =
-                    inner_component_id(&ctx.compilation_unit.sub_components[popup.item_tree.root]);
+                // The popup is declared in the component of the parent item;
+                // descend the item reference's path with plain field accesses.
+                let (suffix, _) = follow_sub_component_path_fields(
+                    ctx.compilation_unit,
+                    ctx.parent_sub_component_idx(*parent_level).unwrap(),
+                    &local_reference.sub_component_path,
+                );
                 let parent_item = access_item_rc(parent_ref, ctx);
 
-                let parent_ctx = ParentScope::new(ctx, None);
+                ctx.with_reference_scope(
+                    *parent_level,
+                    &local_reference.sub_component_path,
+                    |parent_ctx| {
+                let popup = &ctx.compilation_unit.sub_components[parent_ctx.sub_component]
+                    .popup_windows[*popup_index as usize];
+                let popup_window_id =
+                    inner_component_id(&ctx.compilation_unit.sub_components[popup.item_tree.root]);
                 let popup_ctx = EvaluationContext::new_sub_component(
                     ctx.compilation_unit,
                     popup.item_tree.root,
@@ -4194,9 +4219,10 @@ fn compile_builtin_function_call(
                             "ShowPopupWindow is-open argument must be a property reference"
                         )
                     };
-                    access_member(is_open_ref, ctx).then(|p| quote!(#p.set(value);))
+                    access_member(is_open_ref, ctx).then(|p| quote!(#p.set(value)))
                 });
                 component_access_tokens.then(|component_access_tokens| {
+                    let compo = quote!(#component_access_tokens #suffix);
                     // Keep the parent's `is-open` in sync: `show_popup` invokes this setter with `true`
                     // immediately and with `false` from every close path (see window.rs). Passing it
                     // directly into `show_popup` avoids an extra registration call and a second popup
@@ -4218,14 +4244,14 @@ fn compile_builtin_function_call(
                     quote!({
                         let parent_item = #parent_item;
                         // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one
-                        let shared_global = #component_access_tokens.globals.get().unwrap();
+                        let shared_global = #compo.globals.get().unwrap();
                         let window_adapter = shared_global.window_adapter_impl();
                         let window = sp::WindowInner::from_pub(window_adapter.window());
                         let globals = #globals_init;
 
-                        let popup_instance = #popup_window_id::new(#component_access_tokens.self_weak.get().unwrap().clone(), globals).unwrap();
+                        let popup_instance = #popup_window_id::new(#compo.self_weak.get().unwrap().clone(), globals).unwrap();
                         let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);
-                        if let Some(current_id) = #component_access_tokens.#popup_id_name.take() {
+                        if let Some(current_id) = #compo.#popup_id_name.take() {
                             window.close_popup(current_id);
                         }
 
@@ -4243,10 +4269,12 @@ fn compile_builtin_function_call(
                             #window_kind,
                             #is_open_setter,
                         );
-                        #component_access_tokens.#popup_id_name.set(Some(popup_id));
+                        #compo.#popup_id_name.set(Some(popup_id));
                         #popup_window_id::user_init(popup_instance_vrc.clone());
                     })
                 })
+                    },
+                )
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")
             }
@@ -4258,7 +4286,8 @@ fn compile_builtin_function_call(
             ] = arguments
             {
                 let mut component_access_tokens = MemberAccess::Direct(quote!(_self));
-                let llr::MemberReference::Relative { parent_level, .. } = parent_ref else {
+                let llr::MemberReference::Relative { parent_level, local_reference } = parent_ref
+                else {
                     unreachable!()
                 };
                 for _ in 0..*parent_level {
@@ -4272,13 +4301,18 @@ fn compile_builtin_function_call(
                         _ => unreachable!(),
                     };
                 }
+                let (suffix, _) = follow_sub_component_path_fields(
+                    ctx.compilation_unit,
+                    ctx.parent_sub_component_idx(*parent_level).unwrap(),
+                    &local_reference.sub_component_path,
+                );
                 let popup_id_name = internal_popup_id(*popup_index as usize);
                 let current_id_tokens = match component_access_tokens {
                     MemberAccess::Option(token_stream) => quote!(
-                        #token_stream.and_then(|a| a.as_pin_ref().#popup_id_name.take().map(|id| (a.as_pin_ref().globals.get().unwrap().clone(), id)))
+                        #token_stream.and_then(|a| a.as_pin_ref() #suffix.#popup_id_name.take().map(|id| (a.as_pin_ref() #suffix.globals.get().unwrap().clone(), id)))
                     ),
                     MemberAccess::Direct(token_stream) => {
-                        quote!(#token_stream.as_ref().#popup_id_name.take().map(|id|(#token_stream.as_ref().globals.get().unwrap().clone(), id)))
+                        quote!(#token_stream.as_ref() #suffix.#popup_id_name.take().map(|id|(#token_stream.as_ref() #suffix.globals.get().unwrap().clone(), id)))
                     }
                     _ => unreachable!(),
                 };

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2947,7 +2947,9 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                 let fn_id = ident(&format!("fn_{}", g.functions[*function_idx].name));
                 MemberAccess::Direct(quote!(#_self.#fn_id))
             }
-            llr::LocalMemberIndex::Native { .. } => unreachable!(),
+            llr::LocalMemberIndex::Native { .. } | llr::LocalMemberIndex::Timer(_) => {
+                unreachable!()
+            }
         }
     }
 
@@ -3021,6 +3023,22 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                         || MemberAccess::Direct(quote!(#compo_path.#fn_id)),
                         |parent_path| {
                             MemberAccess::OptionFn(parent_path, quote!(|x| #compo_path.#fn_id))
+                        },
+                    )
+                }
+                llr::LocalMemberIndex::Timer(timer_index) => {
+                    let (compo_path, sub_component) = follow_sub_component_path(
+                        ctx.compilation_unit,
+                        ctx.parent_sub_component_idx(*parent_level).unwrap(),
+                        &local_reference.sub_component_path,
+                    );
+                    let component_id = inner_component_id(sub_component);
+                    let timer_ident = format_ident!("timer{}", usize::from(*timer_index));
+                    let timer_field = access_component_field_offset(&component_id, &timer_ident);
+                    parent_path.map_or_else(
+                        || MemberAccess::Direct(quote!((#compo_path #timer_field).apply_pin(_self))),
+                        |parent_path| {
+                            MemberAccess::Option(quote!(#parent_path.as_ref().map(|x| (#compo_path #timer_field).apply_pin(x.as_pin_ref()))))
                         },
                     )
                 }
@@ -4876,9 +4894,8 @@ fn compile_builtin_function_call(
         BuiltinFunction::StartTimer => unreachable!(),
         BuiltinFunction::StopTimer => unreachable!(),
         BuiltinFunction::RestartTimer => {
-            if let [Expression::NumberLiteral(timer_index)] = arguments {
-                let ident = format_ident!("timer{}", *timer_index as usize);
-                quote!(_self.#ident.restart())
+            if let [Expression::PropertyReference(pr)] = arguments {
+                access_member(pr, ctx).then(|timer| quote!(#timer.restart()))
             } else {
                 panic!("internal error: invalid args to RestartTimer {arguments:?}")
             }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -985,7 +985,7 @@ impl<'a, T> EvaluationContext<'a, T> {
                 LocalMemberIndex::Property(property_idx) => &g.properties[*property_idx].ty,
                 LocalMemberIndex::Function(function_idx) => &g.functions[*function_idx].ret_ty,
                 LocalMemberIndex::Callback(callback_idx) => &g.callbacks[*callback_idx].ty,
-                LocalMemberIndex::Native { .. } => unreachable!(),
+                LocalMemberIndex::Native { .. } | LocalMemberIndex::Timer(_) => unreachable!(),
             };
         }
 
@@ -998,6 +998,7 @@ impl<'a, T> EvaluationContext<'a, T> {
             LocalMemberIndex::Property(property_index) => &sc.properties[*property_index].ty,
             LocalMemberIndex::Function(function_index) => &sc.functions[*function_index].ret_ty,
             LocalMemberIndex::Callback(callback_index) => &sc.callbacks[*callback_index].ty,
+            LocalMemberIndex::Timer(_) => unreachable!("a timer reference has no type"),
             LocalMemberIndex::Native { item_index, prop_name, .. } => {
                 if prop_name == "elements" {
                     // The `Path::elements` property is not in the NativeClass
@@ -1024,7 +1025,7 @@ impl<T> TypeResolutionContext for EvaluationContext<'_, T> {
                     LocalMemberIndex::Property(property_idx) => &g.properties[*property_idx].ty,
                     LocalMemberIndex::Function(function_idx) => &g.functions[*function_idx].ret_ty,
                     LocalMemberIndex::Callback(callback_idx) => &g.callbacks[*callback_idx].ty,
-                    LocalMemberIndex::Native { .. } => unreachable!(),
+                    LocalMemberIndex::Native { .. } | LocalMemberIndex::Timer(_) => unreachable!(),
                 }
             }
         }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -953,6 +953,44 @@ impl<'a, T> EvaluationContext<'a, T> {
         }
     }
 
+    /// Resolve the component that a [`MemberReference::Relative`]
+    /// with the given `parent_level` and `sub_component_path` refers to,
+    /// and call `f` with a [`ParentScope`] for it,
+    /// suitable as the parent scope of e.g. a popup declared there.
+    /// Continuation style because the parent chain of a descended sub-component
+    /// borrows from the stack.
+    pub fn with_reference_scope<R>(
+        &self,
+        parent_level: usize,
+        sub_component_path: &[SubComponentInstanceIdx],
+        f: impl FnOnce(ParentScope<'_>) -> R,
+    ) -> R {
+        fn descend<R>(
+            cu: &super::CompilationUnit,
+            sc: SubComponentIdx,
+            parent: Option<&ParentScope<'_>>,
+            path: &[SubComponentInstanceIdx],
+            f: impl FnOnce(ParentScope<'_>) -> R,
+        ) -> R {
+            if let [first, rest @ ..] = path {
+                let ps = ParentScope { sub_component: sc, repeater_index: None, parent };
+                let child = cu.sub_components[sc].sub_components[*first].ty;
+                descend(cu, child, Some(&ps), rest, f)
+            } else {
+                f(ParentScope { sub_component: sc, repeater_index: None, parent })
+            }
+        }
+        let EvaluationScope::SubComponent(mut sc, mut parent) = self.current_scope else {
+            panic!("not in a sub-component scope")
+        };
+        for _ in 0..parent_level {
+            let p = parent.expect("invalid parent reference");
+            sc = p.sub_component;
+            parent = p.parent;
+        }
+        descend(self.compilation_unit, sc, parent, sub_component_path, f)
+    }
+
     pub fn current_sub_component(&self) -> Option<&super::SubComponent> {
         let EvaluationScope::SubComponent(i, _) = self.current_scope else { return None };
         self.compilation_unit.sub_components.get(i)

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -26,6 +26,8 @@ pub struct SubComponentInstanceIdx(usize);
 pub struct ItemInstanceIdx(usize);
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq)]
 pub struct RepeatedElementIdx(usize);
+#[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TimerIdx(usize);
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq)]
 pub struct GridLayoutChildIdx(usize);
 
@@ -174,6 +176,10 @@ pub enum LocalMemberIndex {
     Function(FunctionIdx),
     #[from]
     Callback(CallbackIdx),
+    /// A `Timer` in [`SubComponent::timers`].
+    /// Only valid as the argument of a `RestartTimer` builtin function call.
+    #[from]
+    Timer(TimerIdx),
     Native {
         item_index: ItemInstanceIdx,
         prop_name: SmolStr,
@@ -497,7 +503,7 @@ pub struct SubComponent {
     pub popup_windows: Vec<PopupWindow>,
     /// The MenuItem trees. The index is stored in a Expression::NumberLiteral in the arguments of BuiltinFunction::ShowPopupMenu and BuiltinFunction::SetupMenuBar
     pub menu_item_trees: Vec<ItemTree>,
-    pub timers: Vec<Timer>,
+    pub timers: TiVec<TimerIdx, Timer>,
     pub sub_components: TiVec<SubComponentInstanceIdx, SubComponentInstance>,
     /// The initial value or binding for properties.
     /// This is ordered in the order they must be set.

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -20,7 +20,7 @@ use crate::langtype::{BuiltinStruct, ConstantExpression, Struct, StructName, Typ
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
 use crate::namedreference::NamedReference;
-use crate::object_tree::{Element, ElementRc, PropertyAnimation};
+use crate::object_tree::{Component, Element, ElementRc, PropertyAnimation};
 use crate::typeregister::BUILTIN;
 
 pub struct ExpressionLoweringCtxInner<'a> {
@@ -37,23 +37,30 @@ pub struct ExpressionLoweringCtx<'a> {
 }
 
 impl ExpressionLoweringCtx<'_> {
+    /// How many parent contexts up `enclosing` is, together with its lowering context.
+    fn find_component(
+        &self,
+        enclosing: &Rc<Component>,
+    ) -> (usize, &ExpressionLoweringCtxInner<'_>) {
+        let mut level = 0;
+        let mut map = &self.inner;
+        while !Rc::ptr_eq(enclosing, map.component) {
+            map = map.parent.unwrap_or_else(|| {
+                panic!(
+                    "Could not find component {:?} from component {:?}",
+                    enclosing.id, self.component.id
+                )
+            });
+            level += 1;
+        }
+        (level, map)
+    }
+
     pub fn map_property_reference(&self, from: &NamedReference) -> MemberReference {
         let element = from.element();
         let enclosing = &element.borrow().enclosing_component.upgrade().unwrap();
-        let mut level = 0;
-        let mut map = &self.inner;
-        if !enclosing.is_global() {
-            while !Rc::ptr_eq(enclosing, map.component) {
-                map = map.parent.unwrap_or_else(|| {
-                    panic!(
-                        "Could not find component for property reference {from:?} in component {:?}. Started with enclosing={:?}",
-                        self.component.id,
-                        enclosing.id
-                    )
-                });
-                level += 1;
-            }
-        }
+        let (level, map) =
+            if enclosing.is_global() { (0, &self.inner) } else { self.find_component(enclosing) };
         let mut r = map.mapping.map_property_reference(from, self.state);
         if let MemberReference::Relative { parent_level, .. } = &mut r {
             *parent_level += level;
@@ -279,7 +286,7 @@ fn lower_function_call(
         unreachable!()
     };
     match function {
-        Callable::Builtin(BuiltinFunction::RestartTimer) => lower_restart_timer(arguments),
+        Callable::Builtin(BuiltinFunction::RestartTimer) => lower_restart_timer(arguments, ctx),
         Callable::Builtin(BuiltinFunction::ShowPopupWindow) => {
             lower_show_popup_window(arguments, ctx)
         }
@@ -606,10 +613,14 @@ pub fn repeater_special_property(
     }
 }
 
-fn lower_restart_timer(args: &[tree_Expression]) -> llr_Expression {
+/// Lowers to `RestartTimer(timer_reference)`.
+/// The argument is a `PropertyReference` with a [`LocalMemberIndex::Timer`]
+/// locating the timer in the component that declares it.
+fn lower_restart_timer(args: &[tree_Expression], ctx: &ExpressionLoweringCtx) -> llr_Expression {
     if let [tree_Expression::ElementReference(e)] = args {
         let timer_element = e.upgrade().unwrap();
         let timer_comp = timer_element.borrow().enclosing_component.upgrade().unwrap();
+        let (parent_level, _) = ctx.find_component(&timer_comp);
 
         let timer_list = timer_comp.timers.borrow();
         let timer_index = timer_list
@@ -619,7 +630,13 @@ fn lower_restart_timer(args: &[tree_Expression]) -> llr_Expression {
 
         llr_Expression::BuiltinFunctionCall {
             function: BuiltinFunction::RestartTimer,
-            arguments: vec![llr_Expression::NumberLiteral(timer_index as _)],
+            arguments: vec![llr_Expression::PropertyReference(MemberReference::Relative {
+                parent_level,
+                local_reference: LocalMemberReference {
+                    sub_component_path: Vec::new(),
+                    reference: crate::llr::TimerIdx::from(timer_index).into(),
+                },
+            })],
         }
     } else {
         panic!("invalid arguments to RestartTimer");

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -8,7 +8,7 @@
 
 use crate::expression_tree::{BuiltinFunction, ImageReference};
 use crate::langtype::Type;
-use crate::llr::{CompilationUnit, EvaluationContext, Expression};
+use crate::llr::{CompilationUnit, ContextMap, EvaluationContext, Expression};
 
 const PROPERTY_ACCESS_COST: isize = 1000;
 const ALLOC_COST: isize = 700;
@@ -199,7 +199,7 @@ fn inline_simple_expressions_in_expression(
     // in the body are preserved by the move, so no adjustment is needed.
     if let Expression::FunctionCall { function, .. } = expr {
         let inline_target = ctx.function_info(function).and_then(|(f, map)| {
-            if f.use_count.get() != 1 || !body_is_inline_safe(&f.code.borrow()) {
+            if f.use_count.get() != 1 || !body_is_inline_safe(&f.code.borrow(), &map) {
                 return None;
             }
             f.use_count.set(0);
@@ -282,26 +282,30 @@ fn inline_simple_expressions_in_expression(
     expr.visit_mut(|e| inline_simple_expressions_in_expression(e, ctx, counter));
 }
 
-/// Whether a function body can be moved to its single call site.
+/// Whether a function body can be moved to its single call site through `map`.
 ///
-/// Unsafe when it shows or closes a popup — the popup state lives in the
-/// declaring component and is reached by an upward `parent_level`, so a caller
-/// in an ancestor component cannot reach it — or reads a parameter more than
-/// once: a real call clones each read (`args.N.clone()`), but the inlined body
-/// reads a local that a second read would move.
-fn body_is_inline_safe(exp: &Expression) -> bool {
+/// Unsafe when it references state that only exists in the declaring component
+/// and cannot be remapped by `ContextMap::map_expression`:
+/// popups are reached by an upward `parent_level`,
+/// and `UpdateTimers` refers to the enclosing component implicitly,
+/// so it can only move within the same component.
+/// Also unsafe when it reads a parameter more than once:
+/// a real call clones each read (`args.N.clone()`),
+/// but the inlined body reads a local that a second read would move.
+fn body_is_inline_safe(exp: &Expression, map: &ContextMap) -> bool {
     let mut params = std::collections::HashSet::new();
     let mut safe = true;
     exp.visit_recursive(&mut |e| match e {
         Expression::FunctionParameterReference { index } => safe &= params.insert(*index),
         Expression::BuiltinFunctionCall { function, .. } => {
-            safe &= !matches!(
-                function,
+            safe &= match function {
                 BuiltinFunction::ShowPopupWindow
-                    | BuiltinFunction::ClosePopupWindow
-                    | BuiltinFunction::ShowPopupMenu
-                    | BuiltinFunction::ShowPopupMenuInternal
-            )
+                | BuiltinFunction::ClosePopupWindow
+                | BuiltinFunction::ShowPopupMenu
+                | BuiltinFunction::ShowPopupMenuInternal => false,
+                BuiltinFunction::UpdateTimers => matches!(map, ContextMap::Identity),
+                _ => true,
+            }
         }
         _ => {}
     });

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -286,9 +286,9 @@ fn inline_simple_expressions_in_expression(
 ///
 /// Unsafe when it references state that only exists in the declaring component
 /// and cannot be remapped by `ContextMap::map_expression`:
-/// popups are reached by an upward `parent_level`,
-/// and `UpdateTimers` refers to the enclosing component implicitly,
-/// so it can only move within the same component.
+/// the menu item tree of a popup menu, and `UpdateTimers`,
+/// refer to the enclosing component implicitly,
+/// so they can only move within the same component.
 /// Also unsafe when it reads a parameter more than once:
 /// a real call clones each read (`args.N.clone()`),
 /// but the inlined body reads a local that a second read would move.
@@ -299,11 +299,9 @@ fn body_is_inline_safe(exp: &Expression, map: &ContextMap) -> bool {
         Expression::FunctionParameterReference { index } => safe &= params.insert(*index),
         Expression::BuiltinFunctionCall { function, .. } => {
             safe &= match function {
-                BuiltinFunction::ShowPopupWindow
-                | BuiltinFunction::ClosePopupWindow
-                | BuiltinFunction::ShowPopupMenu
-                | BuiltinFunction::ShowPopupMenuInternal => false,
-                BuiltinFunction::UpdateTimers => matches!(map, ContextMap::Identity),
+                BuiltinFunction::ShowPopupMenu
+                | BuiltinFunction::ShowPopupMenuInternal
+                | BuiltinFunction::UpdateTimers => matches!(map, ContextMap::Identity),
                 _ => true,
             }
         }

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -16,7 +16,7 @@ impl Mapping {
             LocalMemberIndex::Property(p) => self.prop_mapping[*p].is_some(),
             LocalMemberIndex::Callback(c) => self.callback_mapping[*c].is_some(),
             LocalMemberIndex::Function(f) => self.function_mapping[*f].is_some(),
-            LocalMemberIndex::Native { .. } => true,
+            LocalMemberIndex::Native { .. } | LocalMemberIndex::Timer(_) => true,
         }
     }
 }
@@ -609,7 +609,7 @@ mod visitor {
             LocalMemberIndex::Callback(c) => {
                 visitor.visit_callback_idx(c, scope, state);
             }
-            LocalMemberIndex::Native { .. } => {}
+            LocalMemberIndex::Native { .. } | LocalMemberIndex::Timer(_) => {}
         }
     }
 }

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -466,6 +466,9 @@ fn print_local_ref<T>(
                 let i = &sc.items[*item_index];
                 write!(f, "{}.{}", i.name, prop_name)
             }
+            LocalMemberIndex::Timer(timer_index) => {
+                write!(f, "timer#{}", usize::from(*timer_index))
+            }
         }
     }
 }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2984,6 +2984,11 @@ pub fn update_timers(instance: InstanceRef) {
 }
 
 pub fn restart_timer(element: ElementWeak, instance: InstanceRef) {
+    // The calling expression can be in a repeated or conditional child of the
+    // component that declares the timer.
+    let element_rc = element.upgrade().unwrap();
+    generativity::make_guard!(guard);
+    let instance = eval::enclosing_component_for_element(&element_rc, instance, guard);
     let timers = instance.description.original.timers.borrow();
     if let Some((_, offset)) = timers
         .iter()

--- a/tests/cases/elements/popupwindow_show_from_other_component.slint
+++ b/tests/cases/elements/popupwindow_show_from_other_component.slint
@@ -1,0 +1,148 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Showing and closing a popup from a different component than the one that declares it (#12602):
+// `open-it` is inlined into the conditional element,
+// `close-it` into the popup's own item tree,
+// and the child component's functions into the parent.
+// The popup and its id must still be resolved in the declaring component.
+// `Inner` is used twice so it stays a real sub-component;
+// only i1's popup must open.
+
+component Inner {
+    out property <bool> open: p.is-open;
+
+    p := PopupWindow {
+        x: 0;
+        y: 0;
+        width: 40px;
+        height: 40px;
+        close-policy: PopupClosePolicy.no-auto-close;
+
+        Rectangle { }
+    }
+
+    public function open-it() {
+        p.show();
+    }
+
+    public function close-it() {
+        p.close();
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    out property <bool> popup-open: p.is-open;
+
+    p := PopupWindow {
+        x: 0;
+        y: 0;
+        width: 50px;
+        height: 100px;
+        close-policy: PopupClosePolicy.no-auto-close;
+
+        TouchArea {
+            clicked => {
+                root.close-it();
+            }
+        }
+    }
+
+    function open-it() {
+        p.show();
+    }
+
+    function close-it() {
+        p.close();
+    }
+
+    i1 := Inner { }
+    i2 := Inner { }
+
+    out property <bool> open1: i1.open;
+    out property <bool> open2: i2.open;
+
+    public function open-first-inner() {
+        i1.open-it();
+    }
+
+    public function close-first-inner() {
+        i1.close-it();
+    }
+
+    if true: TouchArea {
+        x: 50px;
+        width: 50px;
+        height: 100px;
+        clicked => {
+            root.open-it();
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_popup_open());
+// The conditional touch area opens the popup through the inlined function.
+slint_testing::send_mouse_click(&instance, 75., 50.);
+assert!(instance.get_popup_open());
+// The touch area inside the popup closes it.
+slint_testing::send_mouse_click(&instance, 25., 50.);
+assert!(!instance.get_popup_open());
+// And it can be opened again.
+slint_testing::send_mouse_click(&instance, 75., 50.);
+assert!(instance.get_popup_open());
+// The child component's functions inlined into the parent open and close its popup.
+assert!(!instance.get_open1());
+assert!(!instance.get_open2());
+instance.invoke_open_first_inner();
+assert!(instance.get_open1());
+assert!(!instance.get_open2());
+instance.invoke_close_first_inner();
+assert!(!instance.get_open1());
+assert!(!instance.get_open2());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_popup_open());
+slint_testing::send_mouse_click(&instance, 75., 50.);
+assert(instance.get_popup_open());
+slint_testing::send_mouse_click(&instance, 25., 50.);
+assert(!instance.get_popup_open());
+slint_testing::send_mouse_click(&instance, 75., 50.);
+assert(instance.get_popup_open());
+assert(!instance.get_open1());
+assert(!instance.get_open2());
+instance.invoke_open_first_inner();
+assert(instance.get_open1());
+assert(!instance.get_open2());
+instance.invoke_close_first_inner();
+assert(!instance.get_open1());
+assert(!instance.get_open2());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.popup_open, false);
+slintlib.private_api.send_mouse_click(instance, 75., 50.);
+assert.equal(instance.popup_open, true);
+slintlib.private_api.send_mouse_click(instance, 25., 50.);
+assert.equal(instance.popup_open, false);
+slintlib.private_api.send_mouse_click(instance, 75., 50.);
+assert.equal(instance.popup_open, true);
+assert.equal(instance.open1, false);
+assert.equal(instance.open2, false);
+instance.open_first_inner();
+assert.equal(instance.open1, true);
+assert.equal(instance.open2, false);
+instance.close_first_inner();
+assert.equal(instance.open1, false);
+assert.equal(instance.open2, false);
+```
+*/

--- a/tests/cases/elements/timer_restart_from_other_component.slint
+++ b/tests/cases/elements/timer_restart_from_other_component.slint
@@ -1,0 +1,194 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cspell:ignore tatbt tatbtr tatbtrt tatbtrtct tatbtrtctdt
+
+// `restart()` on a timer declared in a different component than the calling expression (#12602):
+// directly from conditional elements one and two levels below,
+// directly from a repeated element,
+// through a function inlined into the conditional,
+// and through a function of a child component inlined into the parent.
+// `Inner` is used twice so it stays a real sub-component;
+// only i1's timer must be restarted.
+
+component Inner {
+    out property <string> result;
+
+    t := Timer {
+        interval: 100ms;
+        triggered => {
+            root.result += "t";
+            self.stop();
+        }
+    }
+
+    public function restart-it() {
+        t.restart();
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+    out property <string> result;
+    in-out property <bool> cond: true;
+
+    t := Timer {
+        interval: 100ms;
+        triggered => {
+            root.result += "t";
+            self.stop();
+        }
+    }
+
+    function resume() {
+        result += "r";
+        t.restart();
+    }
+
+    i1 := Inner { }
+    i2 := Inner { }
+    out property <string> inner-result: i1.result + "/" + i2.result;
+
+    public function restart-first-inner() {
+        i1.restart-it();
+    }
+
+    if cond: Rectangle {
+        // Direct restart, one level below the timer's component.
+        TouchArea {
+            x: 0;
+            y: 0;
+            width: 50px;
+            height: 50px;
+            clicked => {
+                root.result += "a";
+                t.restart();
+            }
+        }
+
+        // Direct restart, two levels below.
+        if true: TouchArea {
+            x: 50px;
+            y: 0;
+            width: 50px;
+            height: 50px;
+            clicked => {
+                root.result += "b";
+                t.restart();
+            }
+        }
+
+        // The single call site of `resume`, whose inlined body restarts the timer.
+        TouchArea {
+            x: 0;
+            y: 50px;
+            width: 50px;
+            height: 50px;
+            clicked => {
+                root.resume();
+            }
+        }
+    }
+
+    // Direct restart from repeated elements.
+    for i in 2: TouchArea {
+        x: 50px;
+        y: 50px + i * 25px;
+        width: 50px;
+        height: 25px;
+        clicked => {
+            root.result += i == 0 ? "c" : "d";
+            t.restart();
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::mock_elapsed_time(1);
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_result(), "t");
+assert_eq!(instance.get_inner_result(), "t/t");
+// Direct restart from one level below.
+slint_testing::send_mouse_click(&instance, 25., 25.);
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_result(), "tat");
+// Direct restart from two levels below.
+slint_testing::send_mouse_click(&instance, 75., 25.);
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_result(), "tatbt");
+// Through the function inlined into the conditional.
+slint_testing::send_mouse_click(&instance, 25., 75.);
+assert_eq!(instance.get_result(), "tatbtr");
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_result(), "tatbtrt");
+// Direct restart from each repeated element.
+slint_testing::send_mouse_click(&instance, 75., 62.);
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_result(), "tatbtrtct");
+slint_testing::send_mouse_click(&instance, 75., 87.);
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_result(), "tatbtrtctdt");
+// Through the child component's function inlined into the parent.
+instance.invoke_restart_first_inner();
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_inner_result(), "tt/t");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::mock_elapsed_time(1);
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_result(), "t");
+assert_eq(instance.get_inner_result(), "t/t");
+slint_testing::send_mouse_click(&instance, 25., 25.);
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_result(), "tat");
+slint_testing::send_mouse_click(&instance, 75., 25.);
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_result(), "tatbt");
+slint_testing::send_mouse_click(&instance, 25., 75.);
+assert_eq(instance.get_result(), "tatbtr");
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_result(), "tatbtrt");
+slint_testing::send_mouse_click(&instance, 75., 62.);
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_result(), "tatbtrtct");
+slint_testing::send_mouse_click(&instance, 75., 87.);
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_result(), "tatbtrtctdt");
+instance.invoke_restart_first_inner();
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_inner_result(), "tt/t");
+```
+
+```js
+var instance = new slint.TestCase({});
+slintlib.private_api.mock_elapsed_time(1);
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.result, "t");
+assert.equal(instance.inner_result, "t/t");
+slintlib.private_api.send_mouse_click(instance, 25., 25.);
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.result, "tat");
+slintlib.private_api.send_mouse_click(instance, 75., 25.);
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.result, "tatbt");
+slintlib.private_api.send_mouse_click(instance, 25., 75.);
+assert.equal(instance.result, "tatbtr");
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.result, "tatbtrt");
+slintlib.private_api.send_mouse_click(instance, 75., 62.);
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.result, "tatbtrtct");
+slintlib.private_api.send_mouse_click(instance, 75., 87.);
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.result, "tatbtrtctdt");
+instance.restart_first_inner();
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.inner_result, "tt/t");
+```
+*/


### PR DESCRIPTION
The lowered RestartTimer referenced the timer only by an index into the declaring component's timer list, so the generated code looked it up on whatever component the 
expression ended up in. This broke restart() called directly from a repeated or conditional element, and became more visible with #12425 when the function inliner started 
moving such calls into other components (#12602).

The first commit represents the timer as a member reference with a new LocalMemberIndex::Timer, resolved through the regular ContextMap remapping and access_member code 
generation, so it works across parent components and sub-components and needs no inlining restriction.

The second commit does the same for popups: ShowPopupWindow/ClosePopupWindow now honor the full parent item reference (parent level and sub-component path) and compile the 
popup's position in the declaring component's scope, so functions that show or close a popup can be inlined too.

Fixes #12602

