### PR TITLE
ci: reduce the Actions cache churn

### DIFF
--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -169,6 +169,19 @@ jobs:
                 SLINT_LIVE_PREVIEW: 1
               run: cargo test --locked --verbose --all-features --manifest-path tests/Cargo.toml --features slint/live-preview -p test-driver-rust -- --skip=_qt::t
               shell: bash
+            # The linked Skia libraries are plain files in out/skia; the
+            # subdirectories are ninja intermediates from a source build and
+            # .cache holds the downloaded archives. Neither belongs in the
+            # multi-gigabyte rust-cache blob this job saves on master.
+            - name: Trim Skia build intermediates before the cache is saved
+              if: always()
+              shell: bash
+              run: |
+                  for dir in target/*/build/skia-bindings-*/out; do
+                      [ -d "$dir" ] || continue
+                      find "$dir/skia" -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} + 2>/dev/null || true
+                      rm -rf "$dir/.cache"
+                  done
             - name: Upload build timing reports
               if: always()
               uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,6 +332,7 @@ jobs:
             - uses: Swatinem/rust-cache@v2
               with:
                 key: "vsce_1" # increment this to bust the cache if needed
+                save-if: ${{ github.ref == 'refs/heads/master' }}
             - uses: ./.github/actions/install-linux-dependencies
             - uses: actions/setup-node@v7
               with:
@@ -512,6 +513,8 @@ jobs:
                   buildtargets: esp32
                   ldproxy: false
             - uses: Swatinem/rust-cache@v2
+              with:
+                save-if: ${{ github.ref == 'refs/heads/master' }}
             - name: Build and Test Printer demo
               shell: bash
               working-directory: demos/printerdemo_mcu/esp-idf

--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -63,6 +63,7 @@ jobs:
           - uses: Swatinem/rust-cache@v2
             with:
                 key: tests
+                save-if: ${{ github.ref == 'refs/heads/master' }}
           - name: Build & run tests
             run: cargo test -p material-gallery
 

--- a/.github/workflows/material_gallery.yaml
+++ b/.github/workflows/material_gallery.yaml
@@ -84,6 +84,7 @@ jobs:
         if: steps.cache-apk.outputs.cache-hit != 'true' || steps.cache-aab.outputs.cache-hit != 'true'
         with:
           key: android-build
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install xbuild
         if: (steps.cache-apk.outputs.cache-hit != 'true' || steps.cache-aab.outputs.cache-hit != 'true') && steps.xbuild-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/material_wasm_gallery.yaml
+++ b/.github/workflows/material_wasm_gallery.yaml
@@ -40,6 +40,7 @@ jobs:
               if: steps.cache-wasm.outputs.cache-hit != 'true'
               with:
                   key: wasm-build
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
             - name: Build
               if: steps.cache-wasm.outputs.cache-hit != 'true'
               working-directory: ui-libraries/material/examples/gallery


### PR DESCRIPTION
The repository holds over 100 GB of cache entries and GitHub evicts them within hours, so jobs regularly run with no cache at all.

Direct uses of rust-cache default to saving on every branch: each PR saved its own multi-gigabyte copy of the material, vsce, and esp-idf caches. Only save on master, like the setup-rust action already does.

Also delete the Skia ninja intermediates and downloaded archives before the build_and_test cache is saved: the linked libraries are plain files in out/skia, and the rest is dead weight in the largest cache blobs.
