### PR TITLE
docs: mark what holds for Slint SC alone

### DIFF
--- a/docs/astro/src/content/docs/reference/language/geometry.mdx
+++ b/docs/astro/src/content/docs/reference/language/geometry.mdx
@@ -4,6 +4,7 @@ description: Position and size of elements.
 ---
 
 import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
+import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
 
 ## Properties
 
@@ -12,12 +13,15 @@ Every element has the four geometry properties `x`, `y`, `width`, and `height`, 
 `x` and `y` are the offsets from the element's parent's top-left corner to the element's top-left corner.
 `width` and `height` are the element's size, extending to the right and downwards from that corner. \{#sls.geom.relative}
 
-The `x` and `y` properties of the root element are meaningless and shall not be used.
+The `x` and `y` properties of the root element are meaningless and shall not be used. \{#sls.geom.window.root}
+
+<OnlyInSC>
 Binding a geometry property of the root element is an error. \{#sls.geom.window}
+</OnlyInSC>
 
 <NotInSC>
-In the full Slint language, only binding `x` or `y` of the root element is deprecated;
-the window size can be set through `width` and `height`.
+Binding `x` or `y` of the root element is deprecated.
+The window size can be set through `width` and `height`.
 </NotInSC>
 
 ## Defaults

--- a/docs/common/src/components/OnlyInSC.astro
+++ b/docs/common/src/components/OnlyInSC.astro
@@ -1,0 +1,20 @@
+---
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// The counterpart of NotInSC: documentation that holds for Slint SC alone.
+// The safety manual shows it; every other site omits it, because there it
+// would be wrong -- a rule the certified compiler enforces is often only a
+// deprecation in the full language.
+//
+// The specification chapters are synced into the safety manual verbatim, so
+// both sites import this from the same path and the component has to tell
+// them apart itself: the safety manual sets SLINT_SC_SAFETY_MANUAL in its
+// dev and build scripts.
+//
+// Unlike NotInSC, what this encloses is normative: the paragraphs carry
+// `{#sls.…}` identifiers and the traceability matrix lists them.
+const inSafetyManual = process.env.SLINT_SC_SAFETY_MANUAL === "1";
+---
+
+{inSafetyManual && <slot />}

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -911,6 +911,12 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
                 "import NotInSC from '@slint/common-files/src/components/NotInSC.astro';"
             )?;
         }
+        if all_text.contains("<OnlyInSC>") {
+            writeln!(
+                file,
+                "import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';"
+            )?;
+        }
         if all_text.contains("<Tabs ") || all_text.contains("<TabItem ") {
             writeln!(file, "import {{ Tabs, TabItem }} from '@astrojs/starlight/components';")?;
         }

--- a/knip.json
+++ b/knip.json
@@ -87,7 +87,6 @@
         "src/components/HeaderPythonDocs.astro",
         "src/components/HeaderSlintDocs.astro",
         "src/components/HeaderVersioned.astro",
-        "src/components/NotInSC.astro",
         "src/components/ThemeSelect.astro",
         "src/components/VersionSelector.astro",
         "src/components/ThreeCardGrid.astro",


### PR DESCRIPTION
The geometry chapter told every reader that binding a geometry property of the root element is an error. That's true of Slint SC, whose compiler rejects the property outright, but in the full language it's only deprecated -- so the main documentation stated a rule and then corrected itself two lines later.

`<NotInSC>` can only take text away from the safety manual, so add its counterpart: `<OnlyInSC>` keeps text out of every other site. What it encloses is normative, identifiers and all, unlike `<NotInSC>`.

Knip resolves both components now that chapters import them, so it no longer needs to be told they're used.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
