### PR TITLE
compiler: Add @deprecated annotation for property declarations

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -250,6 +250,10 @@ export default defineConfig({
                                                   label: "Match Elements",
                                                   slug: "guide/experimental/match-elements",
                                               },
+                                              {
+                                                  label: "Deprecated Properties",
+                                                  slug: "guide/experimental/deprecated",
+                                              },
                                           ],
                                       },
                                   ]

--- a/docs/astro/src/content/docs/guide/experimental/deprecated.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/deprecated.mdx
@@ -1,0 +1,56 @@
+---
+title: Deprecated Properties
+description: Experimental @deprecated annotation for property declarations.
+---
+
+The `@deprecated` annotation marks a property declaration as deprecated.
+Whenever the property is accessed from outside the component that declares it, the compiler emits a warning that points to the replacement.
+This lets a component evolve its public API while giving users a migration path instead of a hard break.
+
+> **Note**: `@deprecated` is experimental and subject to change.
+
+## Syntax
+
+Prefix a property declaration with `@deprecated`.
+Without an argument, the property must have a two-way binding, and the replacement is derived from its target:
+
+```slint no-test
+@deprecated in-out property <int> old-prop <=> new-prop;
+```
+
+An access to `old-prop` then warns with `Please use 'new-prop' instead`.
+
+Pass a string literal to provide a custom message when there is no single replacement property:
+
+```slint no-test
+@deprecated("Compute it from 'new-prop' instead") in-out property <int> older-prop: 42;
+```
+
+## Example
+
+```slint
+component Inner {
+    in-out property <int> new-prop;
+    @deprecated in-out property <int> old-prop <=> new-prop;
+
+    // No warning: accesses within the declaring component are fine.
+    in-out property <int> internal: old-prop;
+}
+
+export component Example {
+    inner := Inner {
+        new-prop: 42;
+    }
+
+    // Warning: The property 'old-prop' has been deprecated. Please use 'new-prop' instead
+    property <int> value: inner.old-prop;
+}
+```
+
+## Rules
+
+- `@deprecated` can only be applied to property declarations.
+- Without a message, the declaration must use a two-way binding (`<=>`) so the replacement can be derived from its target. Otherwise, the compiler reports an error.
+- The message must be a plain string literal, without any `\{}` expressions.
+- Accessing a deprecated property is only a warning, never an error, so existing code keeps compiling.
+- Accesses from within the declaring component do not warn, since that component still needs to implement the property.

--- a/editors/kate/slint.ksyntaxhighlighter.xml
+++ b/editors/kate/slint.ksyntaxhighlighter.xml
@@ -44,6 +44,7 @@
       <item>pure</item>
       <item>@tr</item>
       <item>@children</item>
+      <item>@deprecated</item>
       <item>@image-url</item>
       <item>@linear-gradient</item>
       <item>@radial-gradient</item>

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -129,8 +129,15 @@ module.exports = grammar({
         choice(seq($.imperative_block, optional(";")), seq($.expression, ";")),
       ),
 
+    property_deprecation: ($) =>
+      seq(
+        "@deprecated",
+        optional(seq("(", field("message", $.string_value), ")")),
+      ),
+
     property: ($) =>
       seq(
+        field("deprecation", optional($.property_deprecation)),
         field("visibility", optional($.property_visibility)),
         "property",
         seq(
@@ -146,6 +153,7 @@ module.exports = grammar({
 
     binding_alias: ($) =>
       seq(
+        field("deprecation", optional($.property_deprecation)),
         field("visibility", optional($.property_visibility)),
         optional("property"),
         field("name", $.simple_identifier),

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -440,10 +440,23 @@ impl BuildDiagnostics {
         new_property: &str,
         source: &dyn Spanned,
     ) {
+        self.push_property_deprecation_warning_with_message(
+            old_property,
+            &format!("Please use '{new_property}' instead"),
+            source,
+        )
+    }
+
+    /// Same as [`Self::push_property_deprecation_warning`], but with a free-form message shown
+    /// after "The property 'xxx' has been deprecated."
+    pub fn push_property_deprecation_warning_with_message(
+        &mut self,
+        old_property: &str,
+        message: &str,
+        source: &dyn Spanned,
+    ) {
         self.push_diagnostic_with_span(
-            format!(
-                "The property '{old_property}' has been deprecated. Please use '{new_property}' instead"
-            ),
+            format!("The property '{old_property}' has been deprecated. {message}"),
             source.to_source_location(),
             crate::diagnostics::DiagnosticLevel::Warning,
         )

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -515,6 +515,7 @@ impl ElementType {
                         },
                         #[cfg(feature = "slint-sc")]
                         is_slint_sc: p.slint_sc,
+                        deprecated: None,
                     },
                 }
             }
@@ -537,6 +538,7 @@ impl ElementType {
                     builtin_function: None,
                     #[cfg(feature = "slint-sc")]
                     is_slint_sc: false,
+                    deprecated: None,
                 }
             }
             _ => PropertyLookupResult::invalid(Cow::Borrowed(name)),
@@ -932,6 +934,11 @@ pub struct PropertyLookupResult<'a> {
     /// (`\sc` marker in its doc comment in builtins.slint).
     #[cfg(feature = "slint-sc")]
     pub is_slint_sc: bool,
+
+    /// Some if the property was declared with `@deprecated`: the hint message shown after
+    /// "The property 'xxx' has been deprecated." in the warning.
+    /// (Only set for properties declared in a component; builtin aliases use `resolved_name` instead.)
+    pub deprecated: Option<SmolStr>,
 }
 
 impl<'a> PropertyLookupResult<'a> {
@@ -961,6 +968,7 @@ impl<'a> PropertyLookupResult<'a> {
             builtin_function: None,
             #[cfg(feature = "slint-sc")]
             is_slint_sc: false,
+            deprecated: None,
         }
     }
 }

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -16,7 +16,7 @@ use crate::object_tree::{ElementRc, PropertyVisibility};
 use crate::parser::NodeOrToken;
 use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
-use smol_str::{SmolStr, ToSmolStr};
+use smol_str::{SmolStr, ToSmolStr, format_smolstr};
 use std::cell::RefCell;
 
 pub use i_slint_common::color_parsing::named_colors;
@@ -117,8 +117,9 @@ impl<'a> LookupCtx<'a> {
 pub enum LookupResult {
     Expression {
         expression: Expression,
-        /// When set, this is deprecated, and the string is the new name
-        deprecated: Option<String>,
+        /// When set, this is deprecated, and the string is the hint message shown after
+        /// "The property 'xxx' has been deprecated." (e.g. "Please use 'yyy' instead")
+        deprecated: Option<SmolStr>,
     },
     Enumeration(Rc<Enumeration>),
     Namespace(BuiltinNamespace),
@@ -524,7 +525,15 @@ impl LookupObject for ElementRc {
                 || lookup_result.property_visibility != PropertyVisibility::Private)
         {
             let deprecated = (lookup_result.resolved_name != name.as_str())
-                .then(|| lookup_result.resolved_name.to_string())
+                .then(|| format_smolstr!("Please use '{}' instead", lookup_result.resolved_name))
+                .or_else(|| {
+                    // Only warn about `@deprecated` properties when accessed from outside the
+                    // component that declares them
+                    lookup_result
+                        .deprecated
+                        .clone()
+                        .filter(|_| !lookup_result.is_local_to_component)
+                })
                 .or_else(|| check_extra_deprecated(self, ctx, name));
             Some(expression_from_reference(
                 NamedReference::new(self, lookup_result.resolved_name.to_smolstr()),
@@ -537,13 +546,17 @@ impl LookupObject for ElementRc {
     }
 }
 
+/// Returns the deprecation hint message for some hardcoded deprecated properties
 pub fn check_extra_deprecated(
     elem: &ElementRc,
     ctx: &LookupCtx<'_>,
     name: &SmolStr,
-) -> Option<String> {
+) -> Option<SmolStr> {
     if crate::typeregister::DEPRECATED_ROTATION_ORIGIN_PROPERTIES.iter().any(|(p, _)| p == name) {
-        return Some(format!("transform-origin.{}", &name[name.len() - 1..]));
+        return Some(format_smolstr!(
+            "Please use 'transform-origin.{}' instead",
+            &name[name.len() - 1..]
+        ));
     }
     let borrow = elem.borrow();
     (!ctx.type_register.expose_internal_types
@@ -557,13 +570,13 @@ pub fn check_extra_deprecated(
             .and_then(|x| x.node.source_file())
             .is_none_or(|x| x.path().starts_with("builtin:"))
         && !name.starts_with("layout-"))
-    .then(|| format!("Palette.{name}"))
+    .then(|| format_smolstr!("Please use 'Palette.{name}' instead"))
 }
 
 fn expression_from_reference(
     n: NamedReference,
     ty: &Type,
-    deprecated: Option<String>,
+    deprecated: Option<SmolStr>,
 ) -> LookupResult {
     match ty {
         Type::Callback { .. } => Callable::Callback(n).into(),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -675,6 +675,10 @@ pub struct PropertyDeclaration {
     /// Whether the declaration shadows a builtin element member of the same name
     /// (diagnosed by the check_builtin_shadowing pass)
     pub shadows_builtin: bool,
+    /// Some if the property was declared with `@deprecated`. The string is the hint shown after
+    /// "The property 'xxx' has been deprecated." in the warning: either derived from the two-way
+    /// binding target, or the custom message given as argument to `@deprecated("...")`.
+    pub deprecated: Option<SmolStr>,
 }
 
 impl PropertyDeclaration {
@@ -1408,6 +1412,34 @@ impl Element {
                 }
             }
 
+            let deprecated = prop_decl.PropertyDeprecation().and_then(|deprecation| {
+                if reject_experimental_feature(diag, tr, "@deprecated", &deprecation) {
+                    return None;
+                }
+                if let Some(message) = deprecation.child_token(SyntaxKind::StringLiteral) {
+                    crate::literals::unescape_string(message.text())
+                } else if let Some(target) = prop_decl
+                    .TwoWayBinding()
+                    .and_then(|twb| twb.Expression().QualifiedName())
+                    .and_then(|qn| {
+                        qn.children_with_tokens()
+                            .filter(|t| t.kind() == SyntaxKind::Identifier)
+                            .last()
+                    })
+                {
+                    Some(format_smolstr!(
+                        "Please use '{}' instead",
+                        parser::normalize_identifier(target.as_token().unwrap().text())
+                    ))
+                } else {
+                    diag.push_error(
+                        "@deprecated without a message requires a two-way binding to derive the replacement from".into(),
+                        &deprecation,
+                    );
+                    None
+                }
+            });
+
             // Use the name as declared, not the resolved name: when the declaration
             // shadows a builtin member, the resolved name may be a native alias.
             r.property_declarations.insert(
@@ -1417,6 +1449,7 @@ impl Element {
                     node: Some(prop_decl.clone().into()),
                     visibility,
                     shadows_builtin,
+                    deprecated,
                     ..Default::default()
                 },
             );
@@ -2282,6 +2315,7 @@ impl Element {
                 builtin_function: None,
                 #[cfg(feature = "slint-sc")]
                 is_slint_sc: false,
+                deprecated: p.deprecated.clone(),
             },
         )
     }

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -373,7 +373,10 @@ declare_syntax! {
         ReturnType -> [Type],
         CallbackConnection -> [ *DeclaredIdentifier, ?CodeBlock, ?Expression ],
         /// Declaration of a property.
-        PropertyDeclaration-> [ ?Type , DeclaredIdentifier, ?BindingExpression, ?TwoWayBinding ],
+        PropertyDeclaration-> [ ?PropertyDeprecation, ?Type , DeclaredIdentifier, ?BindingExpression, ?TwoWayBinding ],
+        /// `@deprecated` or `@deprecated("message")` prefixing a PropertyDeclaration.
+        /// The optional message is a StringLiteral token child.
+        PropertyDeprecation -> [],
         /// QualifiedName are the properties name
         PropertyAnimation-> [ *QualifiedName, *Binding ],
         /// `changed xxx => {...}`  where `xxx` is the DeclaredIdentifier

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -49,6 +49,7 @@ pub fn parse_element(p: &mut impl Parser) -> bool {
 /// animate someProp { }
 /// animate * { }
 /// @children
+/// @deprecated property alias <=> two.way;
 /// double_binding <=> element.property;
 /// public pure function foo() {}
 /// changed foo => {}
@@ -157,6 +158,10 @@ pub fn parse_element_content(p: &mut impl Parser) {
                 }
             },
             SyntaxKind::At => {
+                if p.nth(1).as_str() == "deprecated" {
+                    parse_property_declaration(&mut *p);
+                    continue;
+                }
                 let checkpoint = p.checkpoint();
                 p.consume();
                 if p.peek().as_str() == "children" {
@@ -535,14 +540,40 @@ fn parse_callback_declaration(p: &mut impl Parser) {
 /// property<string> text: "Something";
 /// property<string> text <=> two.way;
 /// property alias <=> two.way;
+/// @deprecated property alias <=> two.way;
+/// @deprecated("Use 'two.way' instead") in-out property <string> text <=> two.way;
 /// ```
 fn parse_property_declaration(p: &mut impl Parser) {
     let checkpoint = p.checkpoint();
+    let has_deprecation = p.peek().kind() == SyntaxKind::At;
+    if has_deprecation {
+        let mut p = p.start_node(SyntaxKind::PropertyDeprecation);
+        p.consume(); // "@"
+        debug_assert_eq!(p.peek().as_str(), "deprecated");
+        p.consume(); // "deprecated"
+        if p.test(SyntaxKind::LParent) {
+            let peek = p.peek();
+            if peek.kind() != SyntaxKind::StringLiteral
+                || !peek.as_str().starts_with('"')
+                || !peek.as_str().ends_with('"')
+            {
+                p.error("@deprecated message must be a plain string literal, without any '\\{}' expressions");
+                p.until(SyntaxKind::RParent);
+            } else {
+                p.expect(SyntaxKind::StringLiteral);
+                p.expect(SyntaxKind::RParent);
+            }
+        }
+    }
     while matches!(p.peek().as_str(), "in" | "out" | "in-out" | "in_out" | "private") {
         p.consume();
     }
     if p.peek().as_str() != "property" {
-        p.error("Expected 'property' keyword");
+        if has_deprecation {
+            p.error("@deprecated can only be applied to property declarations");
+        } else {
+            p.error("Expected 'property' keyword");
+        }
         return;
     }
     let mut p = p.start_node_at(checkpoint, SyntaxKind::PropertyDeclaration);

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -2087,6 +2087,7 @@ fn lower_dialog_layout(
                                         visibility: PropertyVisibility::InOut,
                                         pure: None,
                                         shadows_builtin: false,
+                                        deprecated: None,
                                     });
                             }
                         }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2224,7 +2224,7 @@ fn lookup_qualified_name_node(
     };
 
     if let Some(depr) = result.deprecated() {
-        ctx.diag.push_property_deprecation_warning(&first_str, depr, &first);
+        ctx.diag.push_property_deprecation_warning_with_message(&first_str, depr, &first);
     }
 
     match result {
@@ -2317,10 +2317,19 @@ fn continue_lookup_within_element(
                 &lookup_result.resolved_name,
                 &second,
             );
+        } else if let Some(message) =
+            lookup_result.deprecated.as_ref().filter(|_| !local_to_component)
+        {
+            // `@deprecated` properties only warn when accessed from outside the declaring component
+            ctx.diag.push_property_deprecation_warning_with_message(&prop_name, message, &second);
         } else if let Some(deprecated) =
             crate::lookup::check_extra_deprecated(elem, ctx, &prop_name)
         {
-            ctx.diag.push_property_deprecation_warning(&prop_name, &deprecated, &second);
+            ctx.diag.push_property_deprecation_warning_with_message(
+                &prop_name,
+                &deprecated,
+                &second,
+            );
         }
         let prop = Expression::PropertyReference(NamedReference::new(
             elem,

--- a/internal/compiler/tests/syntax/lookup/deprecated_declaration_errors.slint
+++ b/internal/compiler/tests/syntax/lookup/deprecated_declaration_errors.slint
@@ -1,0 +1,8 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test {
+    // Without a message, the replacement must be derivable from a two-way binding:
+    @deprecated in-out property <int> stand-alone;
+//  >          <error{@deprecated without a message requires a two-way binding to derive the replacement from}
+}

--- a/internal/compiler/tests/syntax/lookup/deprecated_declared_property.slint
+++ b/internal/compiler/tests/syntax/lookup/deprecated_declared_property.slint
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Inner {
+    in-out property <int> new-prop;
+    @deprecated in-out property <int> old-prop <=> new-prop;
+    @deprecated("Compute it from 'new-prop' instead") in-out property <int> older-prop: 42;
+
+    // No warning for accesses within the declaring component:
+    in-out property <int> internal: old-prop + self.older-prop;
+}
+
+export component Derived inherits Inner {
+    // Accessing a deprecated property from the base component warns:
+    in-out property <int> xx: self.old-prop;
+//                                 >      <warning{The property 'old-prop' has been deprecated. Please use 'new-prop' instead}
+}
+
+export component Test {
+    inner := Inner {
+        new-prop: 42;
+    }
+
+    property <int> qualified: inner.old-prop;
+//                                  >      <warning{The property 'old-prop' has been deprecated. Please use 'new-prop' instead}
+    property <int> custom-message: inner.older-prop;
+//                                       >        <warning{The property 'older-prop' has been deprecated. Compute it from 'new-prop' instead}
+    property <int> two-way <=> inner.old-prop;
+//                                   >      <warning{The property 'old-prop' has been deprecated. Please use 'new-prop' instead}
+}

--- a/internal/compiler/tests/syntax/parse_error/deprecated_parse_errors.slint
+++ b/internal/compiler/tests/syntax/parse_error/deprecated_parse_errors.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Test {
+    // The message must be a plain string literal:
+    @deprecated("foo \{42}") in-out property <int> template-message <=> other;
+//              >     <error{@deprecated message must be a plain string literal, without any '\{}' expressions}
+    in-out property <int> other;
+
+    // Only properties can be deprecated:
+    @deprecated callback foo();
+//              >      <error{@deprecated can only be applied to property declarations}
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -549,6 +549,7 @@ impl Snapshotter {
                     visibility: v.visibility,
                     pure: v.pure,
                     shadows_builtin: v.shadows_builtin,
+                    deprecated: v.deprecated.clone(),
                 };
                 (k.clone(), decl)
             })

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -371,6 +371,7 @@ pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResul
             property_visibility: visibility,
             declared_pure: None,
             builtin_function,
+            deprecated: None,
         };
     }
 
@@ -392,6 +393,7 @@ pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResul
                         builtin_function: None,
                         #[cfg(feature = "slint-sc")]
                         is_slint_sc: false,
+                        deprecated: None,
                     };
                 }
             }


### PR DESCRIPTION
Properties declared in .slint components can now be marked as deprecated:

    @deprecated in-out property <length> viewport-width <=> content-width;
    @deprecated("Use content-width instead") in-out property <length> viewport-width <=> content-width;

Accessing such a property from outside the declaring component emits a deprecation warning. Without a custom message, the replacement is derived from the two-way binding target.

The feature is experimental (requires SLINT_ENABLE_EXPERIMENTAL_FEATURES), except for the builtin widget library, which will use it to deprecate the viewport-* properties of ScrollView and friends in favor of content-* (#1443).

The deprecation hint in the lookup results now carries the full warning message instead of just the replacement name, so that custom messages fit through the same path; the emitted warning text for existing deprecations is unchanged.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
