### PR TITLE
core: don't reference the glibc-internal _nl_msg_cat_cntr symbol on musl

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -335,6 +335,7 @@ libglx
 libgstreamer
 libgstrtspserver
 Libinput
+libintl
 libloading
 libm
 librsvg

--- a/internal/core/translations.rs
+++ b/internal/core/translations.rs
@@ -281,7 +281,9 @@ fn global_translation_property() -> usize {
 }
 
 pub fn mark_all_translations_dirty() {
-    #[cfg(all(feature = "gettext-rs", target_family = "unix"))]
+    // _nl_msg_cat_cntr is defined by glibc and the standalone GNU libintl, but not by musl,
+    // which provides its own gettext implementation without that cache counter.
+    #[cfg(all(feature = "gettext-rs", target_family = "unix", not(target_env = "musl")))]
     {
         // SAFETY: This trick from https://www.gnu.org/software/gettext/manual/html_node/gettext-grok.html
         // is merely incrementing a generational counter that will invalidate gettext's internal cache for translations.


### PR DESCRIPTION
Skip the counter increment on musl. In the worst case, a runtime language change won't invalidate gettext's translation cache, which is the fallback behavior the code already accepts.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
