### PR TITLE
Fix popup shown from a nested sub-component anchor

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5158,26 +5158,26 @@ fn compile_builtin_function_call(
             format!("{}.text_input_focused()", access_window_field(ctx))
         }
         BuiltinFunction::ShowPopupWindow => {
-            // A trailing argument may carry the synthesized `is-open` property reference, resolved in
-            // this call's own frame (see lower_show_popup_window).
-            if let [llr::Expression::NumberLiteral(popup_index), close_policy, llr::Expression::PropertyReference(parent_ref), is_open_args @ ..] =
+            // `owner_ref` is the popup's declaring component (its `popup_id` and scope); `anchor_ref`
+            // is the parent item for positioning. A trailing argument may carry the synthesized
+            // `is-open` property reference, resolved in this call's own frame (see
+            // lower_show_popup_window).
+            if let [llr::Expression::NumberLiteral(popup_index), close_policy, llr::Expression::PropertyReference(owner_ref), llr::Expression::PropertyReference(anchor_ref), is_open_args @ ..] =
                 arguments
             {
                 let mut component_access = MemberAccess::Direct("self".into());
-                let llr::MemberReference::Relative { parent_level, local_reference } = parent_ref else {unreachable!()};
+                let llr::MemberReference::Relative { parent_level, local_reference } = owner_ref else {unreachable!()};
                 for _ in 0..*parent_level {
                     component_access = component_access.and_then(|x| format!("{x}->parent.lock()"));
                 }
 
                 let window = access_window_field(ctx);
-                // The popup is declared in the component of the parent item;
-                // `compo_path` descends the item reference's path.
                 let (compo_path, _) = follow_sub_component_path(
                     ctx.compilation_unit,
                     ctx.parent_sub_component_idx(*parent_level).unwrap(),
                     &local_reference.sub_component_path,
                 );
-                let parent_component = access_item_rc(parent_ref, ctx);
+                let parent_component = access_item_rc(anchor_ref, ctx);
                 ctx.with_reference_scope(*parent_level, &local_reference.sub_component_path, |parent_ctx| {
                 let popup = &ctx.compilation_unit.sub_components[parent_ctx.sub_component]
                     .popup_windows[*popup_index as usize];

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -4149,15 +4149,18 @@ fn compile_builtin_function_call(
             }
         }
         BuiltinFunction::ShowPopupWindow => {
+            // `owner_ref` is the popup's declaring component (its `popup_id` and scope);
+            // `anchor_ref` is the parent item for positioning.
             if let [
                 Expression::NumberLiteral(popup_index),
                 close_policy,
-                Expression::PropertyReference(parent_ref),
+                Expression::PropertyReference(owner_ref),
+                Expression::PropertyReference(anchor_ref),
                 is_open_args @ ..,
             ] = arguments
             {
                 let mut component_access_tokens = MemberAccess::Direct(quote!(_self));
-                let llr::MemberReference::Relative { parent_level, local_reference } = parent_ref
+                let llr::MemberReference::Relative { parent_level, local_reference } = owner_ref
                 else {
                     unreachable!()
                 };
@@ -4172,14 +4175,12 @@ fn compile_builtin_function_call(
                         _ => unreachable!(),
                     };
                 }
-                // The popup is declared in the component of the parent item;
-                // descend the item reference's path with plain field accesses.
                 let (suffix, _) = follow_sub_component_path_fields(
                     ctx.compilation_unit,
                     ctx.parent_sub_component_idx(*parent_level).unwrap(),
                     &local_reference.sub_component_path,
                 );
-                let parent_item = access_item_rc(parent_ref, ctx);
+                let parent_item = access_item_rc(anchor_ref, ctx);
 
                 ctx.with_reference_scope(
                     *parent_level,

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -20,7 +20,7 @@ use crate::langtype::{BuiltinStruct, ConstantExpression, Struct, StructName, Typ
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
 use crate::namedreference::NamedReference;
-use crate::object_tree::{Component, Element, ElementRc, PropertyAnimation};
+use crate::object_tree::{Component, Element, ElementRc, ElementWeak, PropertyAnimation};
 use crate::typeregister::BUILTIN;
 
 pub struct ExpressionLoweringCtxInner<'a> {
@@ -643,21 +643,40 @@ fn lower_restart_timer(args: &[tree_Expression], ctx: &ExpressionLoweringCtx) ->
     }
 }
 
+/// Resolve the component that declares the popup referenced by `e`: a reference to its root,
+/// where the `popup_id` and scope live, and the popup's index in that component. The declaring
+/// component is the parent item's enclosing component, which is not always the parent item
+/// itself (it may be a nested sub-component instance), so this reference must be resolved
+/// separately from the parent item used for positioning.
+fn lower_popup_owner(
+    e: &ElementWeak,
+    ctx: &mut ExpressionLoweringCtx,
+) -> (Rc<Component>, llr_Expression, usize) {
+    let popup_window = e.upgrade().unwrap();
+    let pop_comp = popup_window.borrow().enclosing_component.upgrade().unwrap();
+    let parent_elem = pop_comp.parent_element().unwrap();
+    let parent_component = parent_elem.borrow().enclosing_component.upgrade().unwrap();
+    let owner_ref = lower_expression(
+        &tree_Expression::ElementReference(Rc::downgrade(&parent_component.root_element)),
+        ctx,
+    );
+    let popup_index = parent_component
+        .popup_windows
+        .borrow()
+        .iter()
+        .position(|p| Rc::ptr_eq(&p.component, &pop_comp))
+        .unwrap();
+    (parent_component, owner_ref, popup_index)
+}
+
 fn lower_show_popup_window(
     args: &[tree_Expression],
     ctx: &mut ExpressionLoweringCtx,
 ) -> llr_Expression {
     if let [tree_Expression::ElementReference(e)] = args {
-        let popup_window = e.upgrade().unwrap();
-        let pop_comp = popup_window.borrow().enclosing_component.upgrade().unwrap();
-        let parent_elem = pop_comp.parent_element().unwrap();
-        let parent_component = parent_elem.borrow().enclosing_component.upgrade().unwrap();
+        let (parent_component, owner_ref, popup_index) = lower_popup_owner(e, ctx);
         let popup_list = parent_component.popup_windows.borrow();
-        let (popup_index, popup) = popup_list
-            .iter()
-            .enumerate()
-            .find(|(_, p)| Rc::ptr_eq(&p.component, &pop_comp))
-            .unwrap();
+        let popup = &popup_list[popup_index];
         let item_ref = lower_expression(
             &tree_Expression::ElementReference(Rc::downgrade(&popup.parent_element)),
             ctx,
@@ -666,6 +685,7 @@ fn lower_show_popup_window(
         let mut arguments = vec![
             llr_Expression::NumberLiteral(popup_index as _),
             llr_Expression::EnumerationValue(popup.close_policy.clone()),
+            owner_ref,
             item_ref,
         ];
         // Map `is-open` here, at the show site, so it resolves in the same frame as `item_ref`. The
@@ -688,27 +708,13 @@ fn lower_close_popup_window(
     ctx: &mut ExpressionLoweringCtx,
 ) -> llr_Expression {
     if let [tree_Expression::ElementReference(e)] = args {
-        let popup_window = e.upgrade().unwrap();
-        let pop_comp = popup_window.borrow().enclosing_component.upgrade().unwrap();
-        let parent_elem = pop_comp.parent_element().unwrap();
-        let parent_component = parent_elem.borrow().enclosing_component.upgrade().unwrap();
-        let popup_list = parent_component.popup_windows.borrow();
-        let (popup_index, popup) = popup_list
-            .iter()
-            .enumerate()
-            .find(|(_, p)| Rc::ptr_eq(&p.component, &pop_comp))
-            .unwrap();
-        let item_ref = lower_expression(
-            &tree_Expression::ElementReference(Rc::downgrade(&popup.parent_element)),
-            ctx,
-        );
-
+        let (_, owner_ref, popup_index) = lower_popup_owner(e, ctx);
         llr_Expression::BuiltinFunctionCall {
             function: BuiltinFunction::ClosePopupWindow,
-            arguments: vec![llr_Expression::NumberLiteral(popup_index as _), item_ref],
+            arguments: vec![llr_Expression::NumberLiteral(popup_index as _), owner_ref],
         }
     } else {
-        panic!("invalid arguments to ShowPopupWindow");
+        panic!("invalid arguments to ClosePopupWindow");
     }
 }
 

--- a/tests/cases/elements/popupwindow_anchor_subcomponent.slint
+++ b/tests/cases/elements/popupwindow_anchor_subcomponent.slint
@@ -1,0 +1,100 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A popup declared in a component but anchored to a nested sub-component instance: the
+// popup is the instance's only child (so, once the popup is lowered out, the instance is
+// not inlined and stays a real sub-component). The popup's parent item then descends into
+// that instance, while its `popup_id` and scope belong to the declaring component -- the
+// two must be resolved separately. The popup's position also references the anchoring
+// instance through `parent`.
+
+component Slot inherits Rectangle {
+    callback clicked;
+    ta := TouchArea {
+        clicked => {
+            root.clicked();
+        }
+    }
+}
+
+component Widget inherits Rectangle {
+    out property <bool> is-open <=> p.is-open;
+
+    slot := Slot {
+        x: 20px;
+        y: 30px;
+        width: 40px;
+        height: 10px;
+
+        clicked => {
+            p.show();
+        }
+
+        p := PopupWindow {
+            // `parent` is the `Slot` instance the popup is anchored to.
+            x: parent.width;
+            y: parent.height;
+            width: 15px;
+            height: 15px;
+            close-policy: PopupClosePolicy.no-auto-close;
+
+            TouchArea {
+                clicked => {
+                    p.close();
+                }
+            }
+        }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    out property <bool> popup-open: w.is-open;
+
+    w := Widget {
+        width: 100px;
+        height: 100px;
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_popup_open());
+// Click the Slot (at 20,30 with size 40x10) to open the popup through its callback.
+slint_testing::send_mouse_click(&instance, 40., 35.);
+assert!(instance.get_popup_open());
+// The popup is anchored to the Slot (at 20,30) and positioned at parent.width/parent.height (40,10),
+// so its own touch area sits around (60+, 40+). Click it to close.
+slint_testing::send_mouse_click(&instance, 67., 47.);
+assert!(!instance.get_popup_open());
+// And it can be opened again.
+slint_testing::send_mouse_click(&instance, 40., 35.);
+assert!(instance.get_popup_open());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_popup_open());
+slint_testing::send_mouse_click(&instance, 40., 35.);
+assert(instance.get_popup_open());
+slint_testing::send_mouse_click(&instance, 67., 47.);
+assert(!instance.get_popup_open());
+slint_testing::send_mouse_click(&instance, 40., 35.);
+assert(instance.get_popup_open());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.popup_open, false);
+slintlib.private_api.send_mouse_click(instance, 40., 35.);
+assert.equal(instance.popup_open, true);
+slintlib.private_api.send_mouse_click(instance, 67., 47.);
+assert.equal(instance.popup_open, false);
+slintlib.private_api.send_mouse_click(instance, 40., 35.);
+assert.equal(instance.popup_open, true);
+```
+*/


### PR DESCRIPTION
A popup's id and scope live in the component that declares it, which is not always the parent item used for positioning (the item may be a nested sub-component instance). Reference the declaring component's root separately from that parent item.

This is a regression from commit a2e26abc08 (Resolve popups through the full parent item reference).
