### PR TITLE
ci: Pin ruff version to 0.15.8

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -290,7 +290,7 @@ jobs:
               run: uv run pytest
               working-directory: docs/python
             - name: "Lint the Python docs generator"
-              run: uv tool run ruff check
+              run: uv tool run ruff@0.15.8 check
               working-directory: docs/python
             - name: "Type-check the Python docs generator"
               run: uvx ty check

--- a/.github/workflows/python_test_reusable.yaml
+++ b/.github/workflows/python_test_reusable.yaml
@@ -48,10 +48,10 @@ jobs:
               run: uvx ty check
             - name: Run ruff linter
               working-directory: api/python/slint
-              run: uv tool run ruff check
+              run: uv tool run ruff@0.15.8 check
             - name: Run ruff linter
               working-directory: api/python/briefcase
-              run: uv tool run ruff check
+              run: uv tool run ruff@0.15.8 check
             - name: Run python tests
               working-directory: api/python/slint
               run: uv run pytest -s -v


### PR DESCRIPTION
Previously CI ran `uv tool run ruff check` without a version pin, so the resolved ruff version could change between runs and cause unexpected lint failures. Pin it to 0.15.8 for reproducible linting.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
