### PR TITLE
binding-analysis: fix panic on a repeated flexbox cell bound to an outer property

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -702,8 +702,9 @@ impl FlexboxLayout {
         match self.direction.as_ref() {
             None => Some(FlexboxLayoutDirection::Row),
             Some(nr) => nr.element().borrow().bindings.get(nr.name()).and_then(|binding| {
+                let binding = binding.borrow();
                 if let crate::expression_tree::Expression::EnumerationValue(ev) =
-                    &binding.borrow().expression
+                    binding.expression.ignore_debug_hooks()
                 {
                     match ev.enumeration.values[ev.value].as_str() {
                         "row" => Some(FlexboxLayoutDirection::Row),

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -106,6 +106,18 @@ impl PropertyPath {
         if element.borrow().enclosing_component.upgrade().unwrap().is_global() {
             return second.clone();
         }
+        fn check_that_element_is_in_the_component(
+            e: &ElementRc,
+            c: &Rc<crate::object_tree::Component>,
+        ) -> bool {
+            let enclosing = e.borrow().enclosing_component.upgrade().unwrap();
+            Rc::ptr_eq(c, &enclosing)
+                || enclosing
+                    .parent_element
+                    .borrow()
+                    .upgrade()
+                    .is_some_and(|e| check_that_element_is_in_the_component(&e, c))
+        }
         let mut elements = self.elements.clone();
         loop {
             let enclosing = element.borrow().enclosing_component.upgrade().unwrap();
@@ -115,32 +127,27 @@ impl PropertyPath {
                 break;
             }
 
-            if let Some(last) = elements.pop() {
-                #[cfg(debug_assertions)]
-                fn check_that_element_is_in_the_component(
-                    e: &ElementRc,
-                    c: &Rc<crate::object_tree::Component>,
-                ) -> bool {
-                    let enclosing = e.borrow().enclosing_component.upgrade().unwrap();
-                    Rc::ptr_eq(c, &enclosing)
-                        || enclosing
-                            .parent_element
-                            .borrow()
-                            .upgrade()
-                            .is_some_and(|e| check_that_element_is_in_the_component(&e, c))
-                }
-                #[cfg(debug_assertions)]
+            let Some(last) = elements.last() else {
+                break;
+            };
+            let last_component = last.borrow().base_type.as_component().clone();
+            if !check_that_element_is_in_the_component(&element, &last_component) {
+                // `element` is not inside `last`'s sub-component. The reverse holds
+                // instead — `last`'s component is enclosed by `element`'s — meaning
+                // `second` is rooted in an enclosing scope (e.g. a repeated cell's
+                // input bound to an outer property). There is no descent prefix to
+                // lift it through, so return it unchanged. Neither containment
+                // holding is a malformed path (asserted in debug builds).
                 debug_assert!(
                     check_that_element_is_in_the_component(
-                        &element,
-                        last.borrow().base_type.as_component()
+                        &last_component.root_element,
+                        &enclosing
                     ),
                     "The element is not in the component pointed at by the path ({self:?} / {second:?})"
                 );
-                element = last.0;
-            } else {
-                break;
+                return second.clone();
             }
+            element = elements.pop().unwrap().0;
         }
         if second.elements.is_empty() {
             debug_assert!(elements.last().is_none_or(|x| *x != ByAddress(second.prop.element())));

--- a/tests/cases/layout/flexbox_repeated_cell_outer_property.slint
+++ b/tests/cases/layout/flexbox_repeated_cell_outer_property.slint
@@ -1,0 +1,59 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test: a *repeated* cell in a FlexboxLayout whose layout-info depends
+// on an input property that is bound to an *outer* property used to panic the
+// compiler in `binding_analysis` ("The element is not in the component pointed at
+// by the path").
+//
+// The `flex-direction` here is set at runtime, so binding-analysis cannot tell
+// which axis is the cross axis and conservatively analyzes both. The vertical
+// cross-axis analysis descends into the repeated instance and follows its input up
+// to the outer property, and `PropertyPath::relative()` then tried to lift that
+// outer reference through the descent path.
+//
+// The assertions are font-independent (fixed sizes), so they hold on nodejs too.
+
+component Card {
+    in property <length> boxh;
+    VerticalLayout { Rectangle { height: root.boxh; } }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 400px;
+
+    // Runtime direction: `axis_relation` is `Unknown`, so both cross-axes are
+    // analyzed. `horizontal` defaults to false, so the resolved direction is column.
+    in property <bool> horizontal: false;
+    property <length> outer-h: 40px;
+
+    FlexboxLayout {
+        width: 100px; height: 300px;
+        flex-direction: horizontal ? FlexboxLayoutDirection.row : FlexboxLayoutDirection.column;
+        for i in [0, 1]: Card { boxh: outer-h; }
+        anchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    out property <length> anchor-y: anchor.y;
+    // Two 40px cells stack above the anchor (column): no compile panic, laid out.
+    out property <bool> test: anchor-y >= 79px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test(), "anchor_y={}", instance.get_anchor_y());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
binding-analysis: fix panic on a repeated flexbox cell bound to an outer property

PropertyPath::relative() assumed a referenced property could always be lifted
through the descent path. It cannot when a repeated FlexboxLayout cell's
layout-info depends on an input bound to an outer property: the flexbox
cross-axis analysis descends into the instance and follows the input up to the
outer property, which lives in an enclosing component. That tripped a
debug_assert (and built a wrong path in release).

Return the reference unchanged when it points into an enclosing component, like
the existing global-property case.

```
component Card {
    in property <length> boxh;
    VerticalLayout { Rectangle { height: root.boxh; } }
}

export component TestCase inherits Window {
    property <length> outer-h: 40px;
    FlexboxLayout {
        flex-direction: [...a runtime expression...];
        for i in [0, 1]: Card { boxh: outer-h; }
    [...]
```

---

binding-analysis: look through debug hooks when reading the flex direction

compile_time_direction() matched the raw binding expression, so under
inject-debug-hooks (--all-features) a constant `flex-direction: column` is
wrapped in a DebugHook and misread as a runtime direction: axis_relation then
returns Unknown and binding-analysis conservatively analyzes both cross-axes
instead of one. Skip the wrapper like the neighboring layout-info lookup
already does, so layout analysis matches with and without debug hooks.