### PR TITLE
llr: fix use-count underflow when inlining a function that reads a parent-set binding

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -387,6 +387,7 @@ mimxrt
 minmax
 MIPI
 mipidsi
+miscompile
 modalnavigationdrawer
 modelprop
 MOSI

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -194,15 +194,17 @@ fn inline_simple_expressions_in_expression(
     ctx: &EvaluationContext,
     counter: &mut usize,
 ) {
-    // Inline a call to a function that is called exactly once: move its body to
-    // the call site. Because it is the only call, the use counts of everything
-    // in the body are preserved by the move, so no adjustment is needed.
+    // Inline a call to a function that is called exactly once: move its body to the call site.
     if let Expression::FunctionCall { function, .. } = expr {
         let inline_target = ctx.function_info(function).and_then(|(f, map)| {
             if f.use_count.get() != 1 || !body_is_inline_safe(&f.code.borrow(), &map) {
                 return None;
             }
             f.use_count.set(0);
+            // count_property_use counts the body in the function's context; re-home the use
+            // counts to the call site, where a reference can resolve to a parent-set binding
+            // (e.g. `height: 100%`) that is invisible in the function and so under-counted.
+            adjust_use_count(&f.code.borrow(), &map.map_context(ctx), -1);
             // Take the body out so it isn't also inlined in place when
             // `for_each_expression` reaches it, which would double-count uses.
             let body = f.code.replace(Expression::CodeBlock(Vec::new()));
@@ -217,6 +219,8 @@ fn inline_simple_expressions_in_expression(
             let uid = *counter;
             *counter += 1;
             map.map_expression(&mut body);
+            // Re-count in the call-site context (see above).
+            adjust_use_count(&body, ctx, 1);
             substitute_function_parameters(&mut body, uid, &arg_types);
             *expr = if arguments.is_empty() {
                 body

--- a/tests/cases/crashes/inlined_function_parent_binding.slint
+++ b/tests/cases/crashes/inlined_function_parent_binding.slint
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The LLR optimizer used to panic ("We use a property and its count is zero"), or
+// miscompile in release, when a component's public function reads a property more
+// than once that is bound from the parent (here via `height: 100%`). The function
+// is inlined into its single cross-component caller, and those reads only become
+// eligible to inline the parent's binding after the move, which the use-count
+// bookkeeping did not account for.
+
+component Child inherits Rectangle {
+    out property <length> read1;
+    out property <length> read2;
+    public function do-read() {
+        read1 = self.height;
+        read2 = self.height;
+    }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    c := Child {
+        height: 100%;
+    }
+    init => {
+        c.do-read();
+    }
+    out property <bool> test: c.read1 == 200px && c.read2 == 200px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
The inline pass moves a single-call function's body to the call site. Its references were counted by count_property_use in the function's own context, but after the move they are evaluated in the call-site context, where a reference can resolve to a binding that is only visible there (a property set on the instance by the parent, e.g. `height: 100%`). Those references then inline that binding without its use count ever being raised for them, so the count reaches zero while references remain - a debug_assert panic, or in release an underflow that clears the binding early and miscompiles.

Re-home the body's use-count contribution from the function context to the call-site context when inlining.

Found by the crater run compiling sanyexieai/me_chat.
