### PR TITLE
ci: bound every apt-get call with a timeout so a stuck runner can't hang

### DIFF
--- a/.github/actions/install-linux-dependencies/action.yaml
+++ b/.github/actions/install-linux-dependencies/action.yaml
@@ -21,14 +21,15 @@ runs:
     steps:
         - name: Install Linux dependencies
           if: runner.os == 'Linux'
-          run: |
-              sudo apt-get update
-              sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev libinput-dev libgbm-dev libfontconfig-dev libseat-dev libsystemd-dev ${{ inputs.extra-packages }}
           shell: bash
+          run: |
+              # Bound apt so a stuck dpkg lock or mirror stall fails in minutes instead of hanging the job.
+              sudo timeout 300 apt-get update
+              sudo timeout 300 apt-get install -y libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libudev-dev libinput-dev libgbm-dev libfontconfig-dev libseat-dev libsystemd-dev ${{ inputs.extra-packages }}
         - name: Install C++ compiler
           if: ${{ (runner.os == 'Linux') && (inputs.force-gcc-10 == 'true') }}
+          shell: bash
           run: |
-              sudo apt-get install gcc-10 g++-10
+              sudo timeout 300 apt-get install -y gcc-10 g++-10
               echo "CC=gcc-10" >> $GITHUB_ENV
               echo "CXX=g++-10" >> $GITHUB_ENV
-          shell: bash

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -111,7 +111,7 @@ jobs:
                   cache: true
             - name: Install ffmpeg, alsa, gstreamer and libunwind (Linux)
               if: runner.os == 'Linux'
-              run: sudo apt-get install clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+              run: sudo timeout 300 apt-get install clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
             - name: Setup headless display
               if: runner.os != 'macOS'
               uses: pyvista/setup-headless-display-action@v4

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -56,7 +56,7 @@ jobs:
                   toolchain: nightly
                   target: aarch64-linux-android
             - name: Install apt dependencies
-              run: sudo apt-get install doxygen
+              run: sudo timeout 300 apt-get install doxygen
             - name: "Install Node dependencies"
               run: pnpm i --frozen-lockfile
             - name: Test Cpp docs converter
@@ -138,7 +138,7 @@ jobs:
             - name: Install MS fonts for comic sans needed by one of the screenshots in the docs
               run: |
                   echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-                  sudo apt-get install ttf-mscorefonts-installer -y
+                  sudo timeout 300 apt-get install ttf-mscorefonts-installer -y
             - uses: ./.github/actions/setup-rust
               with:
                   toolchain: stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,8 +205,8 @@ jobs:
             - name: Install 32-bit build dependencies
               run: |
                   sudo dpkg --add-architecture i386
-                  sudo apt-get update
-                  sudo apt-get install -y gcc-multilib g++-multilib libfontconfig-dev:i386
+                  sudo timeout 300 apt-get update
+                  sudo timeout 300 apt-get install -y gcc-multilib g++-multilib libfontconfig-dev:i386
             - uses: ./.github/actions/setup-rust
               with:
                   target: i686-unknown-linux-gnu
@@ -506,7 +506,7 @@ jobs:
                   cd $IDF_PYTHON_ENV_PATH
                   bin/pip install pydantic==2.11.10
             - uses: actions/checkout@v7
-            - run: apt-get update && apt-get install -y libfontconfig1-dev
+            - run: timeout 300 apt-get update && timeout 300 apt-get install -y libfontconfig1-dev
             - uses: dtolnay/rust-toolchain@stable
             - uses: esp-rs/xtensa-toolchain@v1.7
               with:
@@ -709,9 +709,9 @@ jobs:
             - uses: actions/checkout@v7
             - uses: ./.github/actions/install-linux-dependencies
             - name: Install ffmpeg and alsa (Linux)
-              run: sudo apt-get install clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config
+              run: sudo timeout 300 apt-get install clang libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev libavdevice-dev libasound2-dev pkg-config
             - name: Install gstreamer and libunwind (Linux)
-              run: sudo apt-get install libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+              run: sudo timeout 300 apt-get install libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
             - uses: ./.github/actions/setup-rust
             - name: Run Clippy
               run: ./scripts/run_clippy.sh
@@ -762,7 +762,7 @@ jobs:
             # provides the unversioned tool names. nasm assembles aws-lc-sys' x86 assembly
             # (pulled in via rustls/aws-lc-rs, e.g. by the servo example and live-preview).
             - name: Install LLVM tools and nasm
-              run: sudo apt-get update && sudo apt-get install -y llvm nasm
+              run: sudo timeout 300 apt-get update && sudo timeout 300 apt-get install -y llvm nasm
             - uses: baptiste0928/cargo-install@v3
               with:
                   crate: cargo-xwin
@@ -830,7 +830,7 @@ jobs:
                   wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
                   chmod +x /tmp/llvm.sh
                   sudo /tmp/llvm.sh 20
-                  sudo apt-get install --assume-yes libclang-20-dev
+                  sudo timeout 300 apt-get install --assume-yes libclang-20-dev
                   rm -f /tmp/llvm.sh
             - name: C++ Build
               run: |
@@ -1057,7 +1057,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7
             - name: Install system dependencies
-              run: sudo apt-get update && sudo apt-get install -y libfontconfig-dev
+              run: sudo timeout 300 apt-get update && sudo timeout 300 apt-get install -y libfontconfig-dev
             - uses: ./.github/actions/setup-rust
               with:
                   toolchain: nightly

--- a/.github/workflows/cpp_package.yaml
+++ b/.github/workflows/cpp_package.yaml
@@ -100,7 +100,7 @@ jobs:
               with:
                   target: ${{ matrix.target }}
             - name: Install GNU Arm Embedded Toolchain
-              run: sudo apt-get update && sudo apt-get install gcc-arm-none-eabi
+              run: sudo timeout 300 apt-get update && sudo timeout 300 apt-get install gcc-arm-none-eabi
             - name: Prepare licenses
               run: bash -x ../../scripts/prepare_binary_package.sh ${{ runner.workspace }}/cppbuild
               working-directory: api/cpp/

--- a/.github/workflows/crater.yaml
+++ b/.github/workflows/crater.yaml
@@ -997,8 +997,9 @@ jobs:
             - name: Prepare slint-compiler
               run: |
                   chmod +x slint-compiler-bin/slint-compiler
-                  sudo apt-get update -qq
-                  sudo apt-get install -y --no-install-recommends libfontconfig1 libfreetype6
+                  # Bound apt so a stuck dpkg lock or mirror stall fails in minutes instead of hanging the job.
+                  sudo timeout 300 apt-get update -qq
+                  sudo timeout 300 apt-get install -y --no-install-recommends libfontconfig1 libfreetype6
             - name: Checkout the repo
               run: |
                   cd $HOME

--- a/.github/workflows/material.yaml
+++ b/.github/workflows/material.yaml
@@ -55,8 +55,8 @@ jobs:
           - name: Install Linux dependencies
             if: runner.os == 'Linux'
             run: |
-              sudo apt-get update
-              sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig-dev
+              sudo timeout 300 apt-get update
+              sudo timeout 300 apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig-dev
             shell: bash
           - name: Install Rust
             uses: dtolnay/rust-toolchain@stable
@@ -83,8 +83,8 @@ jobs:
         uses: actions/checkout@v7
       - name: Install Linux dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig-dev
+          sudo timeout 300 apt-get update
+          sudo timeout 300 apt-get install libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig-dev
         shell: bash
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/screenshots.yaml
+++ b/.github/workflows/screenshots.yaml
@@ -18,7 +18,7 @@ jobs:
             - uses: ./.github/actions/setup-rust
             - uses: ./.github/actions/install-linux-dependencies
             - name: Install optipng
-              run: sudo apt-get update && sudo apt-get install --no-install-recommends -y optipng
+              run: sudo timeout 300 apt-get update && sudo timeout 300 apt-get install --no-install-recommends -y optipng
             - name: Build the viewer
               run: cargo build -p slint-viewer
             - name: Regenerate the screenshot and open a pull request if it changed

--- a/.github/workflows/upload_esp_idf_component.yaml
+++ b/.github/workflows/upload_esp_idf_component.yaml
@@ -23,7 +23,7 @@ jobs:
         container: espressif/idf:latest
         steps:
             - uses: actions/checkout@v7
-            - run: apt-get update && apt-get install -y yq
+            - run: timeout 300 apt-get update && timeout 300 apt-get install -y yq
             - name: Make subsequent git calls work
               run: git config --global --add safe.directory '*'
             - name: Extract Version and determine name

--- a/.github/workflows/upload_pypi.yaml
+++ b/.github/workflows/upload_pypi.yaml
@@ -185,8 +185,8 @@ jobs:
             # extension's direct DT_NEEDED libraries; apt pulls the rest.
             - name: Install runtime system libraries
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y \
+                  sudo timeout 300 apt-get update
+                  sudo timeout 300 apt-get install -y \
                     libxkbcommon-x11-0 libxkbcommon0 libgbm1 libinput10 \
                     libfontconfig1 libfreetype6
             - uses: actions/download-artifact@v8


### PR DESCRIPTION
apt on GitHub-hosted runners occasionally blocks on the dpkg lock (held by unattended-upgrades) or stalls on a mirror, hanging the job until its multi-hour default. This has wedged crater runs for hours. Wrap every apt-get call in a 5 minute timeout: in the shared install-linux-dependencies action, in crater's Prepare step, and in the direct apt-get calls across the other workflows.
