### PR TITLE
Add Image::load_from_data to load an encoded image from memory

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -641,6 +641,7 @@ fn gen_corelib(
                 "slint_image_path",
                 "slint_image_load_from_path",
                 "slint_image_load_from_embedded_data",
+                "slint_image_load_from_data",
                 "slint_image_from_embedded_textures",
                 "slint_image_compare_equal",
                 "slint_image_set_nine_slice_edges",

--- a/api/cpp/include/private/slint_image.h
+++ b/api/cpp/include/private/slint_image.h
@@ -130,6 +130,26 @@ public:
         cbindgen_private::types::slint_image_load_from_path(&file_path, &img.data);
         return img;
     }
+
+    /// Load an image from a buffer in memory that holds an encoded image, such as the content of a
+    /// PNG, JPEG, or SVG file.
+    ///
+    /// \a format is the lowercase file extension of the encoded data (for example "png", "jpg", or
+    /// "svg"). When left empty, the format is guessed from the data. SVG data is only recognized by
+    /// this guess when it begins with an `<?xml` or `<svg` tag; otherwise pass "svg" explicitly.
+    ///
+    /// The data only needs to remain valid for the duration of this call.
+    ///
+    /// Returns a default constructed (empty) Image if the data could not be decoded.
+    [[nodiscard]] static Image load_from_data(std::span<const uint8_t> data,
+                                              std::string_view format = {})
+    {
+        cbindgen_private::types::Image img(cbindgen_private::types::Image::ImageInner_None());
+        cbindgen_private::types::slint_image_load_from_data(
+                private_api::make_slice(data.data(), data.size()),
+                private_api::string_to_slice(format), &img);
+        return Image(img);
+    }
 #endif
 
     /// Constructs a new Image from an existing OpenGL texture. The texture remains borrowed by

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -4,6 +4,8 @@
 #include <ranges>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
+#include <vector>
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch_all.hpp"
 
@@ -205,6 +207,27 @@ TEST_CASE("Image")
         auto actual_path = img.path();
         REQUIRE(actual_path.has_value());
         REQUIRE(*actual_path == SOURCE_DIR "/../../../logo/slint-logo-square-light-128x128.png");
+    }
+
+    {
+        std::ifstream file(SOURCE_DIR "/redpixel.png", std::ios::binary);
+        std::vector<uint8_t> data((std::istreambuf_iterator<char>(file)),
+                                  std::istreambuf_iterator<char>());
+        auto from_data = Image::load_from_data(data);
+        auto size = from_data.size();
+        REQUIRE(size.width == 1);
+        REQUIRE(size.height == 1);
+        REQUIRE(!from_data.path().has_value());
+    }
+
+    {
+        static constexpr unsigned char svg[] =
+                R"(<svg xmlns="http://www.w3.org/2000/svg" width="16" height="8"></svg>)";
+        // The format is guessed from the leading `<svg` tag.
+        auto from_data = Image::load_from_data(std::span(svg, sizeof(svg) - 1));
+        auto size = from_data.size();
+        REQUIRE(size.width == 16);
+        REQUIRE(size.height == 8);
     }
 #endif
 

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -596,7 +596,10 @@ impl ImageInner {
         #[cfg(not(target_arch = "wasm32"))]
         {
             #[cfg(feature = "svg")]
-            if format.as_slice() == b"svg" || format.as_slice() == b"svgz" {
+            if format.as_slice() == b"svg"
+                || format.as_slice() == b"svgz"
+                || (format.is_empty() && (data.starts_with(b"<?xml") || data.starts_with(b"<svg")))
+            {
                 return Some(ImageInner::Svg(vtable::VRc::new(
                     svg::load_from_data(data.as_slice(), cache_key).map_or_else(
                         |svg_err| {
@@ -1016,6 +1019,25 @@ impl Image {
         }
     }
 
+    /// Creates a new Image from a buffer in memory holding the content of an encoded image file,
+    /// such as a PNG, JPEG or SVG.
+    ///
+    /// `format` is the lowercase file extension of the encoded data (for example `"png"`, `"jpg"`
+    /// or `"svg"`). Pass `None` to guess the format from the data; SVG is only recognized by this
+    /// guess when the data begins with an `<?xml` or `<svg` tag, otherwise pass `Some("svg")`.
+    ///
+    /// The supported formats are the same as for [`Self::load_from_path`].
+    #[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]
+    pub fn load_from_data(data: &[u8], format: Option<&str>) -> Result<Self, LoadImageError> {
+        ImageInner::load_from_data_with_cache_key(
+            ImageCacheKey::Invalid,
+            Slice::from_slice(data),
+            Slice::from_slice(format.unwrap_or_default().as_bytes()),
+        )
+        .map(Image)
+        .ok_or(LoadImageError(()))
+    }
+
     /// Sets the nine-slice edges of the image.
     ///
     /// [Nine-slice scaling](https://en.wikipedia.org/wiki/9-slice_scaling) is a method for scaling
@@ -1253,6 +1275,40 @@ fn test_image_invalid_svg() {
     let invalid_svg = r#"AaBbCcDd"#;
     let result = Image::load_from_svg_data(invalid_svg.as_bytes());
     assert!(result.is_err());
+}
+
+#[cfg(feature = "svg")]
+#[test]
+// memchr's manually aligned SIMD loads are a false positive under -Zmiri-symbolic-alignment-check
+#[cfg_attr(miri, ignore)]
+fn test_image_load_from_data_svg() {
+    let simple_svg = r#"<svg width="320" height="200" xmlns="http://www.w3.org/2000/svg"></svg>"#;
+    // The leading `<svg` tag lets the format be guessed.
+    let guessed = Image::load_from_data(simple_svg.as_bytes(), None).unwrap();
+    assert_eq!(guessed.size(), [320, 200].into());
+    // An explicit format hint works too.
+    let hinted = Image::load_from_data(simple_svg.as_bytes(), Some("svg")).unwrap();
+    assert_eq!(hinted.size(), [320, 200].into());
+}
+
+#[cfg(feature = "image-decoders")]
+#[test]
+#[cfg_attr(miri, ignore)]
+fn test_image_load_from_data_png() {
+    let mut png = std::io::Cursor::new(std::vec::Vec::new());
+    image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(2, 3, image::Rgb([0, 255, 0])))
+        .write_to(&mut png, image::ImageFormat::Png)
+        .unwrap();
+    let png = png.into_inner();
+
+    // The PNG magic bytes let the format be guessed.
+    let guessed = Image::load_from_data(&png, None).unwrap();
+    assert_eq!(guessed.size(), [2, 3].into());
+    // An explicit format hint works too.
+    let hinted = Image::load_from_data(&png, Some("png")).unwrap();
+    assert_eq!(hinted.size(), [2, 3].into());
+
+    assert!(Image::load_from_data(b"not an image", None).is_err());
 }
 
 /// The result of the fit function
@@ -1556,6 +1612,20 @@ pub(crate) mod ffi {
         image: *mut Image,
     ) {
         unsafe { core::ptr::write(image, super::load_image_from_embedded_data(data, format)) };
+    }
+
+    /// Unlike `slint_image_load_from_embedded_data`, this does not go through the image cache,
+    /// so `data` does not have to be `'static`.
+    #[cfg(all(feature = "std", feature = "image-decoders"))]
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slint_image_load_from_data(
+        data: Slice<'_, u8>,
+        format: Slice<'_, u8>,
+        image: *mut Image,
+    ) {
+        let format = core::str::from_utf8(format.as_slice()).ok();
+        let loaded = super::Image::load_from_data(data.as_slice(), format).unwrap_or_default();
+        unsafe { core::ptr::write(image, loaded) };
     }
 
     #[unsafe(no_mangle)]


### PR DESCRIPTION
Add a public API in both C++ and Rust to decode an encoded image (SVG, PNG, JPEG, ...) held in a memory buffer, wrapping the same decoders that generated code already uses for embedded images.

C++ previously only exposed load_from_path and the pixel-buffer constructors; Rust only had load_from_svg_data for the SVG case.

Also sniff SVG in the format-guessing path so load_from_data works without passing an explicit "svg" extension.

https://github.com/slint-ui/slint/issues/2624#issuecomment-5044952288