### PR TITLE
FlexboxLayout: apply the flex-shrink default of 1 to static cells too

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -862,7 +862,8 @@ fn flexbox_layout_data(
                     .flex_shrink
                     .as_ref()
                     .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
-                    .unwrap_or(llr_Expression::NumberLiteral(0.0)),
+                    // CSS default, same as the interpreter and the repeated-cell path
+                    .unwrap_or(llr_Expression::NumberLiteral(1.0)),
                 basis: li
                     .flex_basis
                     .as_ref()

--- a/tests/cases/layout/flexbox_flex_grow.slint
+++ b/tests/cases/layout/flexbox_flex_grow.slint
@@ -143,6 +143,49 @@ component TestFlexDefaults inherits Rectangle {
     out property <bool> test: test_r1 && test_r2;
 }
 
+// Test 6: flex-shrink defaults to 1 (CSS), so items shrink without setting it
+component TestFlexShrinkDefault inherits Rectangle {
+    width: 200px;
+    height: 50px;
+    FlexboxLayout {
+        flex-wrap: no-wrap;
+        r1 := Rectangle {
+            flex-basis: 150px;
+            height: 50px;
+            background: red;
+        }
+        r2 := Rectangle {
+            flex-basis: 150px;
+            height: 50px;
+            background: green;
+        }
+    }
+    FlexboxLayout {
+        y: 50px;
+        flex-wrap: no-wrap;
+        // flex-shrink: 0 opts out, so these overflow instead
+        n1 := Rectangle {
+            flex-basis: 150px;
+            flex-shrink: 0;
+            height: 50px;
+            background: red;
+        }
+        n2 := Rectangle {
+            flex-basis: 150px;
+            flex-shrink: 0;
+            height: 50px;
+            background: green;
+        }
+    }
+
+    // Same as test 3, but relying on the default flex-shrink
+    out property <bool> test_r1: r1.width == 100px;
+    out property <bool> test_r2: r2.width == 100px;
+    out property <bool> test_n1: n1.width == 150px;
+    out property <bool> test_n2: n2.width == 150px;
+    out property <bool> test: test_r1 && test_r2 && test_n1 && test_n2;
+}
+
 export component TestCase inherits Window {
     width: 400px;
     height: 400px;
@@ -153,9 +196,10 @@ export component TestCase inherits Window {
         t3 := TestFlexShrinkRow { }
         t4 := TestFlexBasis { }
         t5 := TestFlexDefaults { }
+        t6 := TestFlexShrinkDefault { }
     }
 
-    out property <bool> test: t1.test && t2.test && t3.test && t4.test && t5.test;
+    out property <bool> test: t1.test && t2.test && t3.test && t4.test && t5.test && t6.test;
 }
 
 /*


### PR DESCRIPTION
Commit facc6b30bbe6 ("Change flex-shrink default from 0 to 1 to match CSS") was
incomplete: it updated the runtime default, the interpreter, the docs and
the repeated-cell lowering, but not the static-cell lowering in
flexbox_layout_data(). Generated Rust/C++ code therefore still defaulted
to 0, so a static flex child never shrank while a repeated one in the
same layout did, and the interpreter disagreed with both.