### PR TITLE
Improve `@deprecated` property replacement hints and warning coverage

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/deprecated.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/deprecated.mdx
@@ -12,7 +12,7 @@ This lets a component evolve its public API while giving users a migration path 
 ## Syntax
 
 Prefix a property declaration with `@deprecated`.
-Without an argument, the property must have a two-way binding, and the replacement is derived from its target:
+Without an argument, the property must have a two-way binding whose target is a public property of the same element, and the replacement is derived from that target:
 
 ```slint no-test
 @deprecated in-out property <int> old-prop <=> new-prop;
@@ -50,7 +50,7 @@ export component Example {
 ## Rules
 
 - `@deprecated` can only be applied to property declarations.
-- Without a message, the declaration must use a two-way binding (`<=>`) so the replacement can be derived from its target. Otherwise, the compiler reports an error.
+- Without a message, the declaration must use a two-way binding (`<=>`) whose target is a public property of the same element, so the replacement can be derived and reached by callers. Otherwise, provide an explicit message.
 - The message must be a plain string literal, without any `\{}` expressions.
 - Accessing a deprecated property is only a warning, never an error, so existing code keeps compiling.
 - Accesses from within the declaring component do not warn, since that component still needs to implement the property.

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2400,6 +2400,14 @@ impl Element {
                     &lookup_result.resolved_name,
                     &name_token,
                 );
+            } else if let Some(message) =
+                lookup_result.deprecated.as_ref().filter(|_| !lookup_result.is_local_to_component)
+            {
+                diag.push_property_deprecation_warning_with_message(
+                    &unresolved_name,
+                    message,
+                    &name_token,
+                );
             }
 
             match self.bindings.entry(lookup_result.resolved_name.into()) {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -691,6 +691,18 @@ impl PropertyDeclaration {
             node.clone().into()
         }
     }
+
+    /// True when declared `@deprecated` without a custom message, so the hint in
+    /// [`Self::deprecated`] is derived from the two-way binding target.
+    pub fn has_derived_deprecation(&self) -> bool {
+        self.deprecated.is_some()
+            && self
+                .node
+                .as_ref()
+                .and_then(|n| syntax_nodes::PropertyDeclaration::new(n.clone()))
+                .and_then(|p| p.PropertyDeprecation())
+                .is_some_and(|d| d.child_token(SyntaxKind::StringLiteral).is_none())
+    }
 }
 
 impl From<Type> for PropertyDeclaration {
@@ -1418,19 +1430,22 @@ impl Element {
                 }
                 if let Some(message) = deprecation.child_token(SyntaxKind::StringLiteral) {
                     crate::literals::unescape_string(message.text())
-                } else if let Some(target) = prop_decl
+                } else if let Some(qn) = prop_decl
                     .TwoWayBinding()
                     .and_then(|twb| twb.Expression().QualifiedName())
-                    .and_then(|qn| {
-                        qn.children_with_tokens()
-                            .filter(|t| t.kind() == SyntaxKind::Identifier)
-                            .last()
-                    })
                 {
-                    Some(format_smolstr!(
-                        "Please use '{}' instead",
-                        parser::normalize_identifier(target.as_token().unwrap().text())
-                    ))
+                    // Keep the full target path (e.g. `a-struct.field`), dropping a leading
+                    // `self`/`root`. The resolving pass checks the target is actually reachable.
+                    let mut segments = qn
+                        .children_with_tokens()
+                        .filter(|t| t.kind() == SyntaxKind::Identifier)
+                        .map(|t| parser::normalize_identifier(t.as_token().unwrap().text()))
+                        .peekable();
+                    if segments.peek().is_some_and(|s| matches!(s.as_str(), "self" | "root")) {
+                        segments.next();
+                    }
+                    let path = segments.collect::<Vec<_>>().join(".");
+                    (!path.is_empty()).then(|| format_smolstr!("Please use '{path}' instead"))
                 } else {
                     diag.push_error(
                         "@deprecated without a message requires a two-way binding to derive the replacement from".into(),

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2583,6 +2583,23 @@ fn resolve_two_way_bindings_for_element(
                 }
                 rhs_lookup.is_local_to_component &= lookup_ctx.is_local_element(&nr.element());
 
+                // The derived replacement only helps callers if the target is a public property
+                // of the same element, reached through the same object. Otherwise the hint is
+                // unreachable, so require an explicit message instead.
+                if elem
+                    .borrow()
+                    .property_declarations
+                    .get(prop_name)
+                    .is_some_and(|d| d.has_derived_deprecation())
+                    && !(Rc::ptr_eq(&nr.element(), elem)
+                        && rhs_lookup.property_visibility != PropertyVisibility::Private)
+                {
+                    lookup_ctx.diag.push_error(
+                        "@deprecated without a message derives the replacement from the two-way binding target, which must be a public property of the same element; provide an explicit @deprecated(\"...\") message instead".into(),
+                        &node,
+                    );
+                }
+
                 if !rhs_lookup.is_valid_for_assignment() {
                     match (lhs_lookup.property_visibility, rhs_lookup.property_visibility) {
                         (PropertyVisibility::Input, PropertyVisibility::Input)

--- a/internal/compiler/tests/syntax/lookup/deprecated_two_way.slint
+++ b/internal/compiler/tests/syntax/lookup/deprecated_two_way.slint
@@ -1,0 +1,66 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Without a custom message, the replacement is derived from the two-way binding
+// target, which must be a public property of the same element. This checks the
+// derivation, the reachability errors, and that every access path warns.
+
+component Sub {
+    in-out property <int> inner-property;
+}
+
+component Inner {
+    private property <int> private-prop;
+    in-out property <int> public-prop;
+    in-out property <{ field: int }> a-struct;
+    sub := Sub { }
+
+    callback tapped();
+
+    // Reachable targets: the hint keeps the full path, minus a leading self/root.
+    @deprecated in-out property <int> to-public <=> public-prop;
+    @deprecated in-out property <int> to-self <=> self.public-prop;
+    @deprecated in-out property <int> to-struct <=> a-struct.field;
+
+    // Unreachable targets require an explicit message.
+    @deprecated in-out property <int> to-private <=> private-prop;
+//                                               >               <error{@deprecated without a message derives the replacement from the two-way binding target, which must be a public property of the same element; provide an explicit @deprecated("...") message instead}
+    @deprecated in-out property <int> to-sub <=> sub.inner-property;
+//                                           >                     <error{@deprecated without a message derives the replacement from the two-way binding target, which must be a public property of the same element; provide an explicit @deprecated("...") message instead}
+
+    // An explicit message lifts the requirement on the target.
+    @deprecated("Use 'private-prop' internally") in-out property <int> with-message <=> private-prop;
+}
+
+export component Test {
+    in-out property <int> root-prop;
+
+    // @deprecated also applies to a property of a nested element, relative to it.
+    the-rect := Rectangle {
+        in-out property <int> rn;
+        private property <int> rp;
+        @deprecated in-out property <int> re-ok <=> rn;
+        @deprecated in-out property <int> re-private <=> rp;
+//                                                   >     <error{@deprecated without a message derives the replacement from the two-way binding target, which must be a public property of the same element; provide an explicit @deprecated("...") message instead}
+        // Target on another element (the component root) is not reachable here.
+        @deprecated in-out property <int> re-root <=> root.root-prop;
+//                                                >                 <error{@deprecated without a message derives the replacement from the two-way binding target, which must be a public property of the same element; provide an explicit @deprecated("...") message instead}
+        @deprecated("Use rn") in-out property <int> re-msg <=> rp;
+    }
+
+    inner := Inner {
+        // Every way of accessing a deprecated property from outside warns.
+        to-public: 1;
+//      >       <warning{The property 'to-public' has been deprecated. Please use 'public-prop' instead}
+        tapped => { inner.to-public = 2; }
+//                        >       <warning{The property 'to-public' has been deprecated. Please use 'public-prop' instead}
+    }
+    property <int> a: inner.to-public;
+//                          >       <warning{The property 'to-public' has been deprecated. Please use 'public-prop' instead}
+    property <int> b <=> inner.to-self;
+//                             >     <warning{The property 'to-self' has been deprecated. Please use 'public-prop' instead}
+    property <int> c: inner.to-struct;
+//                          >       <warning{The property 'to-struct' has been deprecated. Please use 'a-struct.field' instead}
+    property <int> d: inner.to-private;
+//                          >        <warning{The property 'to-private' has been deprecated. Please use 'private-prop' instead}
+}

--- a/tests/cases/properties/deprecated.slint
+++ b/tests/cases/properties/deprecated.slint
@@ -1,0 +1,94 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `@deprecated` property keeps working exactly like the property it aliases: it can be
+// read, written, two-way bound, and stays part of the generated public API. The only effect
+// of the annotation is a compile-time warning when accessed from outside the component.
+
+component Inner {
+    in-out property <int> new-prop: 1;
+    in-out property <{ field: int }> a-struct;
+
+    @deprecated in-out property <int> old-prop <=> new-prop;
+    @deprecated in-out property <int> struct-alias <=> a-struct.field;
+
+    // A deprecated property declared on a nested element also works.
+    the-rect := Rectangle {
+        in-out property <int> nested: 7;
+        @deprecated in-out property <int> nested-alias <=> nested;
+    }
+    in-out property <int> nested-alias <=> the-rect.nested-alias;
+}
+
+export component TestCase inherits Window {
+    inner := Inner { }
+
+    // Aliasing a deprecated property is allowed and stays two-way.
+    in-out property <int> old-prop <=> inner.old-prop;
+    in-out property <int> new-prop <=> inner.new-prop;
+    in-out property <int> struct-alias <=> inner.struct-alias;
+    in-out property <int> nested-alias <=> inner.nested-alias;
+
+    // Reading a deprecated property reflects its two-way target.
+    out property <bool> test: old-prop == new-prop && old-prop == 1 && nested-alias == 7;
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+// Writing the target is visible through the deprecated alias.
+instance.set_new_prop(5);
+assert_eq!(instance.get_old_prop(), 5);
+
+// Writing the deprecated property updates the target.
+instance.set_old_prop(8);
+assert_eq!(instance.get_new_prop(), 8);
+
+// The struct-member alias is a normal writable property.
+instance.set_struct_alias(42);
+assert_eq!(instance.get_struct_alias(), 42);
+
+// A deprecated property declared on a nested element works too.
+instance.set_nested_alias(9);
+assert_eq!(instance.get_nested_alias(), 9);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+instance.set_new_prop(5);
+assert_eq(instance.get_old_prop(), 5);
+
+instance.set_old_prop(8);
+assert_eq(instance.get_new_prop(), 8);
+
+instance.set_struct_alias(42);
+assert_eq(instance.get_struct_alias(), 42);
+
+instance.set_nested_alias(9);
+assert_eq(instance.get_nested_alias(), 9);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+
+instance.new_prop = 5;
+assert.equal(instance.old_prop, 5);
+
+instance.old_prop = 8;
+assert.equal(instance.new_prop, 8);
+
+instance.struct_alias = 42;
+assert.equal(instance.struct_alias, 42);
+
+instance.nested_alias = 9;
+assert.equal(instance.nested_alias, 9);
+```
+
+*/

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -98,6 +98,9 @@ fn format_node(
         SyntaxKind::PropertyDeclaration => {
             return format_property_declaration(node, writer, state);
         }
+        SyntaxKind::PropertyDeprecation => {
+            return format_property_deprecation(node, writer, state);
+        }
         SyntaxKind::Binding => {
             return format_binding(node, writer, state);
         }
@@ -584,6 +587,26 @@ fn format_property_declaration(
     if need_newline {
         state.new_line();
     }
+    Ok(())
+}
+
+fn format_property_deprecation(
+    node: &SyntaxNode,
+    writer: &mut impl TokenWriter,
+    state: &mut FormatState,
+) -> Result<(), std::io::Error> {
+    let mut sub = node.children_with_tokens();
+    whitespace_to(&mut sub, SyntaxKind::At, writer, state, "")?;
+    // The "deprecated" keyword and an optional `("message")`.
+    whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?;
+    if node.child_token(SyntaxKind::LParent).is_some() {
+        let _ok = whitespace_to(&mut sub, SyntaxKind::LParent, writer, state, "")?
+            && whitespace_to(&mut sub, SyntaxKind::StringLiteral, writer, state, "")?
+            && whitespace_to(&mut sub, SyntaxKind::RParent, writer, state, "")?;
+    }
+    // Drop the whitespace between the deprecation and the property; the caller
+    // inserts a single space before the following keyword.
+    state.skip_all_whitespace = true;
     Ok(())
 }
 
@@ -2375,6 +2398,32 @@ Main := Window {
 
     pure callback some-fn({x: int}, string);
     in property <int> foo: 42;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn deprecated_property() {
+        assert_formatting(
+            r#"
+component W {
+    in-out property <int> new-prop;
+    @deprecated  in-out    property   <int>   old-prop   <=>   new-prop;
+    @deprecated
+
+        in-out property <int> spaced-prop <=> new-prop;
+    @deprecated (   "Use 'new-prop' instead"   )   in-out property <int> older-prop <=> new-prop;
+    @deprecated("msg")in-out property<int>compact<=>new-prop;
+}
+"#,
+            r#"
+component W {
+    in-out property <int> new-prop;
+    @deprecated in-out property <int> old-prop <=> new-prop;
+    @deprecated in-out property <int> spaced-prop <=> new-prop;
+    @deprecated("Use 'new-prop' instead") in-out property <int> older-prop <=> new-prop;
+    @deprecated("msg") in-out property <int> compact <=> new-prop;
 }
 "#,
         );


### PR DESCRIPTION
improvements to the `@deprecated` property annotation.

When `@deprecated` has no custom message, the replacement in the warning is derived
from the two-way binding target. This makes that derivation correct and complete:

- Derive the full, reachable path: A struct-member alias like `<=> a-struct.field`
  now points at `a-struct.field` instead of the bare `field`, and a leading `self`/`root`
  is stripped.
- Require the target to be reachable: A private target, or one on another element,
  can't be reached by callers, so it's now rejected asking for an explicit
  `@deprecated("...")` message.
- Warn on binding assignment: Setting a deprecated property with a binding in an
  element (the common `ScrollView { viewport-width: ... }` case) now warns, like reading
  or `=`-assigning it already did.

Adds syntax-test coverage for the derivation, the reachability errors (at component and
nested-element level) and every access path, plus a runtime test confirming deprecated
properties still read/write/two-way bind through the generated API. Docs updated.