### PR TITLE
android: fix hold-to-repeat backspace in text inputs

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -203,8 +203,10 @@ class SlintInputView extends View {
 
     public void setText(String text, int cursorPosition, int anchorPosition, int preeditStart, int preeditEnd,
             int inputType) {
-        boolean restart = mInputType != inputType || !mText.equals(text) || mCursorPosition != cursorPosition
-                || mAnchorPosition != anchorPosition;
+        boolean typeChanged = mInputType != inputType;
+        boolean textChanged = !mText.equals(text);
+        boolean selectionChanged = mCursorPosition != cursorPosition || mAnchorPosition != anchorPosition;
+
         mText = text;
         mCursorPosition = cursorPosition;
         mAnchorPosition = anchorPosition;
@@ -212,12 +214,29 @@ class SlintInputView extends View {
         mPreeditEnd = preeditEnd;
         mInputType = inputType;
 
-        if (restart) {
+        if (typeChanged) {
             mEditable = new SlintEditable();
             Selection.setSelection(mEditable, cursorPosition, anchorPosition);
             InputMethodManager imm = (InputMethodManager) this.getContext()
                     .getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.restartInput(this);
+        } else if (textChanged || selectionChanged) {
+            InputMethodManager imm = (InputMethodManager) this.getContext()
+                    .getSystemService(Context.INPUT_METHOD_SERVICE);
+            mInBatch += 1;
+            try {
+                if (textChanged) {
+                    mEditable.replace(0, mEditable.length(), text);
+                }
+                if (Selection.getSelectionStart(mEditable) != cursorPosition
+                        || Selection.getSelectionEnd(mEditable) != anchorPosition) {
+                    Selection.setSelection(mEditable, cursorPosition, anchorPosition);
+                }
+            } finally {
+                mInBatch -= 1;
+                mPending = false;
+            }
+            imm.updateSelection(this, cursorPosition, anchorPosition, preeditStart, preeditEnd);
         }
     }
 


### PR DESCRIPTION
Holding backspace in a text input on Android only deletes one character
instead of repeating. Same thing breaks key-repeat for other keys too.

The cause is in SlintInputView.setText(): it had one restart flag that
was true on any change (text, cursor, or input type) and always called
imm.restartInput(). But every keystroke round-trips through Rust and
calls setText() again, so restartInput() tears down the input connection
mid-repeat and the platform's repeat timer never fires again.

So I split the flag up and only call restartInput() when the input type
actually changes. For text/cursor changes I update the existing mEditable
in place and use updateSelection() instead, that keeps the IME session
alive. The in-place update reuses the existing mInBatch guard so the
InputConnection callbacks don't loop back into Rust.

Tested by hand on a physical device (Android 14). There's no Java/IME
test harness in the android-activity backend and CI only does
cargo apk build, so I couldn't add an automated test. Checked that:

- holding backspace deletes continuously (was stopping after 1 char)
- key-repeat works for other keys
- typing, cursor movement and selection still behave
- switching between fields with different input types still resets the IME