### PR TITLE
docs: always show experimental features on website

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -22,8 +22,6 @@ import {
     PYTHON_BASE_URL,
 } from "@slint/common-files/src/utils/site-config";
 
-const experimentalDocs = process.env.SLINT_ENABLE_EXPERIMENTAL_FEATURES === "1";
-
 // Starlight prepends the base path to every sidebar link that is not a full
 // URL (http/https). Strip BASE_PATH so the re-added prefix produces the
 // intended absolute path (e.g. "/docs/../cpp/" -> "../cpp/" -> Starlight
@@ -220,44 +218,40 @@ export default defineConfig({
                                     "guide/backends-and-renderers/backend_winit",
                                 ],
                             },
-                            ...(experimentalDocs
-                                ? [
-                                      {
-                                          label: "Experimental Features",
-                                          collapsed: true,
-                                          items: [
-                                              {
-                                                  label: "Overview",
-                                                  slug: "guide/experimental/overview",
-                                              },
-                                              {
-                                                  label: "FlexboxLayout",
-                                                  slug: "guide/experimental/flexboxlayout",
-                                              },
-                                              {
-                                                  label: "Interface",
-                                                  slug: "guide/experimental/interface",
-                                              },
-                                              {
-                                                  label: "ComponentContainer",
-                                                  slug: "guide/experimental/component-container",
-                                              },
-                                              {
-                                                  label: "Library Modules",
-                                                  slug: "guide/experimental/library-modules",
-                                              },
-                                              {
-                                                  label: "Match Elements",
-                                                  slug: "guide/experimental/match-elements",
-                                              },
-                                              {
-                                                  label: "Deprecated Properties",
-                                                  slug: "guide/experimental/deprecated",
-                                              },
-                                          ],
-                                      },
-                                  ]
-                                : []),
+                            {
+                                label: "Experimental Features",
+                                collapsed: true,
+                                items: [
+                                    {
+                                        label: "Overview",
+                                        slug: "guide/experimental/overview",
+                                    },
+                                    {
+                                        label: "FlexboxLayout",
+                                        slug: "guide/experimental/flexboxlayout",
+                                    },
+                                    {
+                                        label: "Interface",
+                                        slug: "guide/experimental/interface",
+                                    },
+                                    {
+                                        label: "ComponentContainer",
+                                        slug: "guide/experimental/component-container",
+                                    },
+                                    {
+                                        label: "Library Modules",
+                                        slug: "guide/experimental/library-modules",
+                                    },
+                                    {
+                                        label: "Match Elements",
+                                        slug: "guide/experimental/match-elements",
+                                    },
+                                    {
+                                        label: "Deprecated Properties",
+                                        slug: "guide/experimental/deprecated",
+                                    },
+                                ],
+                            },
                         ],
                     },
                     {

--- a/docs/astro/src/content.config.ts
+++ b/docs/astro/src/content.config.ts
@@ -6,7 +6,10 @@ import { docsSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
     docs: defineCollection({
-        loader: glob({ base: "src/content/docs", pattern: "**/[^_]*.{md,mdx}" }),
+        loader: glob({
+            base: "src/content/docs",
+            pattern: "**/[^_]*.{md,mdx}",
+        }),
         schema: docsSchema(),
     }),
 };

--- a/docs/astro/src/content.config.ts
+++ b/docs/astro/src/content.config.ts
@@ -4,16 +4,9 @@ import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
 
-const experimentalDocs = process.env.SLINT_ENABLE_EXPERIMENTAL_FEATURES === "1";
-
-const docsPattern = [
-    "**/[^_]*.{md,mdx}",
-    ...(experimentalDocs ? [] : ["!guide/experimental/**"]),
-];
-
 export const collections = {
     docs: defineCollection({
-        loader: glob({ base: "src/content/docs", pattern: docsPattern }),
+        loader: glob({ base: "src/content/docs", pattern: "**/[^_]*.{md,mdx}" }),
         schema: docsSchema(),
     }),
 };


### PR DESCRIPTION
## Summary

Remove the `SLINT_ENABLE_EXPERIMENTAL_FEATURES` gate from the documentation website so that experimental features are always visible in the sidebar and their content is always loaded.

## Changes

- **`docs/astro/astro.config.mjs`**: Remove conditional sidebar rendering. The "Experimental Features" section is now always displayed.
- **`docs/astro/src/content.config.ts`**: Remove content filtering. Experimental docs are now always loaded.

## Motivation

Previously, both the sidebar section and the content loading were conditional on the `SLINT_ENABLE_EXPERIMENTAL_FEATURES` environment variable. This made it impossible for users to discover experimental features (FlexboxLayout, Match Elements, Interface, etc.) through the documentation website without knowing about the hidden environment variable.

Making these features visible by default helps users discover and provide feedback on new functionality before it becomes stable.
