### PR TITLE
text layout: replace multi-pass line navigation with single Parley layout pass

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2880,7 +2880,15 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         preferred_x: f32,
         vertical_advance: f32,
     ) -> Option<usize> {
-        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+        sharedparley::text_input_move_cursor(
+            self,
+            text_input,
+            item_rc,
+            current_offset,
+            direction,
+            preferred_x,
+            vertical_advance,
+        )
     }
 
     fn register_font_from_memory(

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2871,6 +2871,18 @@ impl i_slint_core::renderer::RendererSealed for QtWindow {
         sharedparley::text_input_cursor_rect_for_byte_offset(self, text_input, item_rc, byte_offset)
     }
 
+    fn text_input_move_cursor(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::item_tree::ItemRc,
+        current_offset: usize,
+        direction: i_slint_core::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> Option<usize> {
+        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+    }
+
     fn register_font_from_memory(
         &self,
         data: &'static [u8],

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -37,7 +37,7 @@ use core::pin::Pin;
 #[allow(unused)]
 use euclid::num::Ceil;
 use i_slint_core_macros::*;
-use unicode_segmentation::UnicodeSegmentation;
+use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
 
 /// The implementation of the `Text` element
 #[repr(C)]
@@ -1520,7 +1520,8 @@ impl TextInput {
         self.cursor_visible.set(false);
     }
 
-    /// Moves the cursor (and/or anchor) and returns true if the cursor position changed; false otherwise.
+    /// Moves the cursor (and/or anchor) using Parley Cursor for layout-based directions.
+    /// Returns true if the cursor position changed; false otherwise.
     fn move_cursor(
         self: Pin<&Self>,
         direction: TextCursorDirection,
@@ -1538,13 +1539,14 @@ impl TextInput {
         let last_cursor_pos = self.cursor_position(&text);
 
         let mut grapheme_cursor =
-            unicode_segmentation::GraphemeCursor::new(last_cursor_pos, text.len(), true);
+            GraphemeCursor::new(last_cursor_pos, text.len(), true);
 
         let font_height = window_adapter.renderer().char_size(self, self_rc, ' ').height;
 
         let mut reset_preferred_x_pos = true;
 
         let new_cursor_pos = match direction {
+            // Forward/Backward: GraphemeCursor (fast, handles combining chars correctly)
             TextCursorDirection::Forward => {
                 if anchor == cursor || anchor_mode == AnchorMode::KeepAnchor {
                     grapheme_cursor
@@ -1563,27 +1565,26 @@ impl TextInput {
                     anchor
                 }
             }
-            TextCursorDirection::NextLine => {
-                reset_preferred_x_pos = false;
-
-                let cursor_rect =
-                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
-                let mut cursor_xy_pos = cursor_rect.center();
-
-                cursor_xy_pos.y += font_height;
-                cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
+            // Word boundaries: string-based (fast, preserves old MacOS-style behavior)
+            TextCursorDirection::ForwardByWord => next_word_boundary(&text, last_cursor_pos + 1),
+            TextCursorDirection::BackwardByWord => {
+                prev_word_boundary(&text, last_cursor_pos.saturating_sub(1))
             }
-            TextCursorDirection::PreviousLine => {
+            // Line navigation: renderer trait method (Parley overrides with single pass)
+            TextCursorDirection::NextLine
+            | TextCursorDirection::PreviousLine
+            | TextCursorDirection::StartOfLine
+            | TextCursorDirection::EndOfLine => {
                 reset_preferred_x_pos = false;
-
-                let cursor_rect =
-                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
-                let mut cursor_xy_pos = cursor_rect.center();
-
-                cursor_xy_pos.y -= font_height;
-                cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
+                window_adapter.renderer().text_input_move_cursor(
+                    self,
+                    self_rc,
+                    last_cursor_pos,
+                    direction,
+                    self.preferred_x_pos.get(),
+                    font_height,
+                )
+                .unwrap_or(last_cursor_pos)
             }
             TextCursorDirection::PreviousCharacter => {
                 let mut i = last_cursor_pos;
@@ -1593,27 +1594,6 @@ impl TextInput {
                         break i;
                     }
                 }
-            }
-            // Currently moving by word behaves like macos: next end of word(forward) or previous beginning of word(backward)
-            TextCursorDirection::ForwardByWord => next_word_boundary(&text, last_cursor_pos + 1),
-            TextCursorDirection::BackwardByWord => {
-                prev_word_boundary(&text, last_cursor_pos.saturating_sub(1))
-            }
-            TextCursorDirection::StartOfLine => {
-                let cursor_rect =
-                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
-                let mut cursor_xy_pos = cursor_rect.center();
-
-                cursor_xy_pos.x = 0 as Coord;
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
-            }
-            TextCursorDirection::EndOfLine => {
-                let cursor_rect =
-                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
-                let mut cursor_xy_pos = cursor_rect.center();
-
-                cursor_xy_pos.x = Coord::MAX;
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
             }
             TextCursorDirection::StartOfParagraph => {
                 prev_paragraph_boundary(&text, last_cursor_pos.saturating_sub(1))
@@ -1629,12 +1609,15 @@ impl TextInput {
                     return false;
                 }
                 reset_preferred_x_pos = false;
-                let cursor_rect =
-                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
-                let mut cursor_xy_pos = cursor_rect.center();
-                cursor_xy_pos.y -= offset;
-                cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
+                window_adapter.renderer().text_input_move_cursor(
+                    self,
+                    self_rc,
+                    last_cursor_pos,
+                    direction,
+                    self.preferred_x_pos.get(),
+                    offset,
+                )
+                .unwrap_or(last_cursor_pos)
             }
             TextCursorDirection::PageDown => {
                 let offset = self.page_height().get() - font_height;
@@ -1642,12 +1625,15 @@ impl TextInput {
                     return false;
                 }
                 reset_preferred_x_pos = false;
-                let cursor_rect =
-                    self.cursor_rect_for_byte_offset(last_cursor_pos, window_adapter, self_rc);
-                let mut cursor_xy_pos = cursor_rect.center();
-                cursor_xy_pos.y += offset;
-                cursor_xy_pos.x = self.preferred_x_pos.get();
-                self.byte_offset_for_position(cursor_xy_pos, window_adapter, self_rc)
+                window_adapter.renderer().text_input_move_cursor(
+                    self,
+                    self_rc,
+                    last_cursor_pos,
+                    direction,
+                    self.preferred_x_pos.get(),
+                    offset,
+                )
+                .unwrap_or(last_cursor_pos)
             }
         };
 
@@ -2366,7 +2352,6 @@ fn prev_paragraph_boundary(text: &str, last_cursor_pos: usize) -> usize {
 
 fn prev_word_boundary(text: &str, last_cursor_pos: usize) -> usize {
     let mut word_offset = 0;
-
     for (current_word_offset, _) in text.unicode_word_indices() {
         if current_word_offset <= last_cursor_pos {
             word_offset = current_word_offset;
@@ -2374,7 +2359,6 @@ fn prev_word_boundary(text: &str, last_cursor_pos: usize) -> usize {
             break;
         }
     }
-
     word_offset
 }
 

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1538,8 +1538,7 @@ impl TextInput {
         let (anchor, cursor) = self.selection_anchor_and_cursor();
         let last_cursor_pos = self.cursor_position(&text);
 
-        let mut grapheme_cursor =
-            GraphemeCursor::new(last_cursor_pos, text.len(), true);
+        let mut grapheme_cursor = GraphemeCursor::new(last_cursor_pos, text.len(), true);
 
         let font_height = window_adapter.renderer().char_size(self, self_rc, ' ').height;
 
@@ -1576,15 +1575,17 @@ impl TextInput {
             | TextCursorDirection::StartOfLine
             | TextCursorDirection::EndOfLine => {
                 reset_preferred_x_pos = false;
-                window_adapter.renderer().text_input_move_cursor(
-                    self,
-                    self_rc,
-                    last_cursor_pos,
-                    direction,
-                    self.preferred_x_pos.get(),
-                    font_height,
-                )
-                .unwrap_or(last_cursor_pos)
+                window_adapter
+                    .renderer()
+                    .text_input_move_cursor(
+                        self,
+                        self_rc,
+                        last_cursor_pos,
+                        direction,
+                        self.preferred_x_pos.get(),
+                        font_height,
+                    )
+                    .unwrap_or(last_cursor_pos)
             }
             TextCursorDirection::PreviousCharacter => {
                 let mut i = last_cursor_pos;
@@ -1609,15 +1610,17 @@ impl TextInput {
                     return false;
                 }
                 reset_preferred_x_pos = false;
-                window_adapter.renderer().text_input_move_cursor(
-                    self,
-                    self_rc,
-                    last_cursor_pos,
-                    direction,
-                    self.preferred_x_pos.get(),
-                    offset,
-                )
-                .unwrap_or(last_cursor_pos)
+                window_adapter
+                    .renderer()
+                    .text_input_move_cursor(
+                        self,
+                        self_rc,
+                        last_cursor_pos,
+                        direction,
+                        self.preferred_x_pos.get(),
+                        offset,
+                    )
+                    .unwrap_or(last_cursor_pos)
             }
             TextCursorDirection::PageDown => {
                 let offset = self.page_height().get() - font_height;
@@ -1625,15 +1628,17 @@ impl TextInput {
                     return false;
                 }
                 reset_preferred_x_pos = false;
-                window_adapter.renderer().text_input_move_cursor(
-                    self,
-                    self_rc,
-                    last_cursor_pos,
-                    direction,
-                    self.preferred_x_pos.get(),
-                    offset,
-                )
-                .unwrap_or(last_cursor_pos)
+                window_adapter
+                    .renderer()
+                    .text_input_move_cursor(
+                        self,
+                        self_rc,
+                        last_cursor_pos,
+                        direction,
+                        self.preferred_x_pos.get(),
+                        offset,
+                    )
+                    .unwrap_or(last_cursor_pos)
             }
         };
 

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -107,6 +107,59 @@ pub trait RendererSealed {
         byte_offset: usize,
     ) -> LogicalRect;
 
+    /// Move the cursor in the given direction and return the new byte offset.
+    ///
+    /// The default implementation uses `text_input_cursor_rect_for_byte_offset`
+    /// and `text_input_byte_offset_for_position` (the old two-pass approach).
+    /// `vertical_advance` is the line height for NextLine/PreviousLine and the
+    /// page offset (page_height - font_height) for PageUp/PageDown.
+    /// Parley-based renderers override this with a single-pass layout optimization.
+    fn text_input_move_cursor(
+        &self,
+        text_input: Pin<&crate::items::TextInput>,
+        item_rc: &ItemRc,
+        current_offset: usize,
+        direction: crate::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> Option<usize> {
+        let cursor_rect =
+            self.text_input_cursor_rect_for_byte_offset(text_input, item_rc, current_offset);
+        let mut cursor_xy_pos = cursor_rect.center();
+        let new_offset = match direction {
+            crate::items::TextCursorDirection::NextLine => {
+                cursor_xy_pos.y += vertical_advance;
+                cursor_xy_pos.x = preferred_x;
+                self.text_input_byte_offset_for_position(text_input, item_rc, cursor_xy_pos)
+            }
+            crate::items::TextCursorDirection::PreviousLine => {
+                cursor_xy_pos.y -= vertical_advance;
+                cursor_xy_pos.x = preferred_x;
+                self.text_input_byte_offset_for_position(text_input, item_rc, cursor_xy_pos)
+            }
+            crate::items::TextCursorDirection::StartOfLine => {
+                cursor_xy_pos.x = 0.0;
+                self.text_input_byte_offset_for_position(text_input, item_rc, cursor_xy_pos)
+            }
+            crate::items::TextCursorDirection::EndOfLine => {
+                cursor_xy_pos.x = f32::MAX;
+                self.text_input_byte_offset_for_position(text_input, item_rc, cursor_xy_pos)
+            }
+            crate::items::TextCursorDirection::PageUp => {
+                cursor_xy_pos.y -= vertical_advance;
+                cursor_xy_pos.x = preferred_x;
+                self.text_input_byte_offset_for_position(text_input, item_rc, cursor_xy_pos)
+            }
+            crate::items::TextCursorDirection::PageDown => {
+                cursor_xy_pos.y += vertical_advance;
+                cursor_xy_pos.x = preferred_x;
+                self.text_input_byte_offset_for_position(text_input, item_rc, cursor_xy_pos)
+            }
+            _ => return None,
+        };
+        Some(new_offset)
+    }
+
     /// Clear the caches for the items that are being removed
     fn free_graphics_resources(
         &self,

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1383,6 +1383,130 @@ impl Layout {
         )
     }
 
+    /// Move cursor in the specified direction using the cached layout.
+    /// Returns the new byte offset within the full text.
+    fn move_cursor_in_direction(
+        &self,
+        current_byte_offset: usize,
+        direction: crate::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> usize {
+        let Some(paragraph) = self.paragraph_by_byte_offset(current_byte_offset) else {
+            return current_byte_offset;
+        };
+
+        let local_offset = (current_byte_offset - paragraph.range.start).min(paragraph.range.len());
+
+        let cursor = parley::editing::Cursor::from_byte_index(
+            &paragraph.layout,
+            local_offset,
+            Default::default(),
+        );
+
+        let new_byte = match direction {
+            crate::items::TextCursorDirection::Forward => {
+                paragraph.range.start + cursor.next_visual(&paragraph.layout).index()
+            }
+            crate::items::TextCursorDirection::Backward => {
+                paragraph.range.start + cursor.previous_visual(&paragraph.layout).index()
+            }
+            crate::items::TextCursorDirection::ForwardByWord => {
+                paragraph.range.start + cursor.next_logical_word(&paragraph.layout).index()
+            }
+            crate::items::TextCursorDirection::BackwardByWord => {
+                paragraph.range.start + cursor.previous_logical_word(&paragraph.layout).index()
+            }
+            crate::items::TextCursorDirection::NextLine => {
+                let rect = cursor.geometry(&paragraph.layout, 1.0);
+                let para_y_in_layout = (self.y_offset + paragraph.y).get();
+                let target_y = para_y_in_layout + rect.y0 as f32 + rect.height() as f32 + vertical_advance;
+                let target_para = self.paragraph_by_y(PhysicalLength::new(target_y));
+                if let Some(target_para) = target_para {
+                    let local_y = target_y - (self.y_offset + target_para.y).get();
+                    target_para.range.start + parley::editing::Cursor::from_point(
+                        &target_para.layout,
+                        preferred_x,
+                        local_y.max(0.0),
+                    ).index()
+                } else {
+                    paragraph.range.end
+                }
+            }
+            crate::items::TextCursorDirection::PreviousLine => {
+                let rect = cursor.geometry(&paragraph.layout, 1.0);
+                let para_y_in_layout = (self.y_offset + paragraph.y).get();
+                let target_y = para_y_in_layout + rect.y0 as f32 - vertical_advance;
+                if target_y < self.y_offset.get() {
+                    return current_byte_offset;
+                }
+                let target_para = self.paragraph_by_y(PhysicalLength::new(target_y));
+                if let Some(target_para) = target_para {
+                    let local_y = target_y - (self.y_offset + target_para.y).get();
+                    target_para.range.start + parley::editing::Cursor::from_point(
+                        &target_para.layout,
+                        preferred_x,
+                        local_y.max(0.0),
+                    ).index()
+                } else {
+                    paragraph.range.start
+                }
+            }
+            crate::items::TextCursorDirection::StartOfLine => {
+                let y = cursor.geometry(&paragraph.layout, 1.0).y0 as f32;
+                paragraph.range.start + parley::editing::Cursor::from_point(
+                    &paragraph.layout,
+                    f32::NEG_INFINITY,
+                    y,
+                ).index()
+            }
+            crate::items::TextCursorDirection::EndOfLine => {
+                let y = cursor.geometry(&paragraph.layout, 1.0).y0 as f32;
+                paragraph.range.start + parley::editing::Cursor::from_point(
+                    &paragraph.layout,
+                    f32::INFINITY,
+                    y,
+                ).index()
+            }
+            crate::items::TextCursorDirection::StartOfParagraph => paragraph.range.start,
+            crate::items::TextCursorDirection::EndOfParagraph => paragraph.range.end,
+            crate::items::TextCursorDirection::StartOfText => 0,
+            crate::items::TextCursorDirection::EndOfText => {
+                self.paragraphs.last().map_or(0, |p| p.range.end)
+            }
+            crate::items::TextCursorDirection::PageUp | crate::items::TextCursorDirection::PageDown => {
+                let rect = cursor.geometry(&paragraph.layout, 1.0);
+                let para_y_in_layout = (self.y_offset + paragraph.y).get();
+                let target_y = match direction {
+                    crate::items::TextCursorDirection::PageUp =>
+                        para_y_in_layout + rect.y0 as f32 - vertical_advance,
+                    _ => para_y_in_layout + rect.y0 as f32 + rect.height() as f32 + vertical_advance,
+                };
+                if target_y < self.y_offset.get() {
+                    return current_byte_offset;
+                }
+                let target_para = self.paragraph_by_y(PhysicalLength::new(target_y));
+                if let Some(target_para) = target_para {
+                    let local_y = target_y - (self.y_offset + target_para.y).get();
+                    target_para.range.start + parley::editing::Cursor::from_point(
+                        &target_para.layout,
+                        preferred_x,
+                        local_y.max(0.0),
+                    ).index()
+                } else if matches!(direction, crate::items::TextCursorDirection::PageDown) {
+                    self.paragraphs.last().map_or(0, |p| p.range.end)
+                } else {
+                    paragraph.range.start
+                }
+            }
+            crate::items::TextCursorDirection::PreviousCharacter => {
+                paragraph.range.start + local_offset
+            }
+        };
+
+        new_byte
+    }
+
     /// Returns an iterator over the run's glyphs, truncated if necessary to fit within the max width,
     /// plus an optional ellipsis glyph with its font and size to be drawn separately.
     /// Call this function only for the last line of the layout.
@@ -2070,6 +2194,61 @@ pub fn text_input_cursor_rect_for_byte_offset(
     cursor_rect / scale_factor
 }
 
+pub fn text_input_move_cursor(
+    renderer: &dyn RendererSealed,
+    text_input: Pin<&crate::items::TextInput>,
+    item_rc: &crate::item_tree::ItemRc,
+    current_offset: usize,
+    direction: crate::items::TextCursorDirection,
+    preferred_x: f32,
+    vertical_advance: f32,
+) -> Option<usize> {
+    let scale_factor = renderer.scale_factor()?;
+
+    let width = text_input.width();
+    let height = text_input.height();
+    if width.get() <= 0. || height.get() <= 0. {
+        return None;
+    }
+
+    let visual_representation = text_input.visual_representation(None);
+
+    let Some(ctx) = renderer.slint_context() else {
+        return None;
+    };
+    let mut font_ctx = ctx.font_context().borrow_mut();
+
+    let layout_builder = LayoutWithoutLineBreaksBuilder::new(
+        Some(text_input.font_request(item_rc)),
+        text_input.wrap(),
+        None,
+        scale_factor,
+    );
+
+    let paragraphs_without_linebreaks = create_text_paragraphs(
+        &layout_builder,
+        &mut font_ctx,
+        PlainOrStyledText::Plain(visual_representation.text.clone()),
+        None,
+        Color::default(),
+    );
+
+    let layout = layout(
+        &layout_builder,
+        &mut font_ctx,
+        paragraphs_without_linebreaks,
+        scale_factor,
+        LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
+    );
+
+    let byte_offset =
+        visual_representation.map_byte_offset_from_actual_to_visual_text(current_offset);
+
+    let new_offset = layout.move_cursor_in_direction(byte_offset, direction, preferred_x, vertical_advance);
+
+    Some(visual_representation.map_byte_offset_from_visual_text_to_actual_text(new_offset))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2254,5 +2433,157 @@ mod tests {
             limited.paragraphs[0].layout.lines().next().unwrap().metrics().block_max_coord,
         );
         assert_eq!(limited.height, first_line_bottom);
+    }
+
+    fn layout_text_with_width(text: &str, width: f32) -> Layout {
+        layout_text_with_options(text, LayoutOptions {
+            max_width: Some(LogicalLength::new(width)),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_move_cursor_forward_backward() {
+        let layout = layout_text_with_width("abc", 100.0);
+        // Forward from start
+        assert_eq!(layout.move_cursor_in_direction(0, crate::items::TextCursorDirection::Forward, 0.0, 0.0), 1);
+        // Backward from end
+        assert_eq!(layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::Backward, 0.0, 0.0), 2);
+        // Backward from start stays at start
+        assert_eq!(layout.move_cursor_in_direction(0, crate::items::TextCursorDirection::Backward, 0.0, 0.0), 0);
+        // Forward from end stays at end
+        assert_eq!(layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::Forward, 0.0, 0.0), 3);
+    }
+
+    #[test]
+    fn test_move_cursor_word_boundaries() {
+        let layout = layout_text_with_width("Hello World", 200.0);
+        // BackwardByWord from middle of "Hello" -> start of "Hello"
+        let pos = layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::BackwardByWord, 0.0, 0.0);
+        assert_eq!(pos, 0, "BackwardByWord from middle of 'Hello' should go to 0, got {pos}");
+        // ForwardByWord from middle of "Hello" -> end of "Hello"
+        let pos = layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::ForwardByWord, 0.0, 0.0);
+        assert_eq!(pos, 5, "ForwardByWord from middle of 'Hello' should go to 5, got {pos}");
+        // ForwardByWord from end of "Hello" -> start of "World"
+        let pos = layout.move_cursor_in_direction(5, crate::items::TextCursorDirection::ForwardByWord, 0.0, 0.0);
+        assert_eq!(pos, 6, "ForwardByWord from end of 'Hello' should go to 6, got {pos}");
+    }
+
+    #[test]
+    fn test_move_cursor_grapheme() {
+        let layout = layout_text_with_width("e\u{0301}", 100.0); // e + combining accent
+        // Parley treats combining marks as separate visual clusters.
+        // Backward from end moves to start of the last visual cluster (the combining mark).
+        let pos = layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::Backward, 0.0, 0.0);
+        assert_eq!(pos, 1, "Backward from end of 'e\\u{{0301}}' should go to 1 (combining mark start), got {pos}");
+        // Forward from start moves to end of first visual cluster ('e')
+        let pos = layout.move_cursor_in_direction(0, crate::items::TextCursorDirection::Forward, 0.0, 0.0);
+        assert_eq!(pos, 1, "Forward from start of 'e\\u{{0301}}' should go to 1 (end of 'e'), got {pos}");
+        // Forward from combining mark moves to end of text
+        let pos = layout.move_cursor_in_direction(1, crate::items::TextCursorDirection::Forward, 0.0, 0.0);
+        assert_eq!(pos, 3, "Forward from combining mark should go to 3 (text end), got {pos}");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn bench_cursor_movement() {
+        use std::string::String;
+        use std::format;
+        use std::println;
+        use alloc::vec::Vec;
+        // Build multi-line text (100 lines)
+        let text: String = (0..100)
+            .map(|i| format!("Line {}: The quick brown fox jumps over the lazy dog", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let layout = layout_text_with_width(&text, 500.0);
+
+        // Line down 100 lines
+        let start = std::time::Instant::now();
+        let mut pos = 0;
+        for _ in 0..100 {
+            pos = layout.move_cursor_in_direction(
+                pos, crate::items::TextCursorDirection::NextLine, 0.0, 20.0);
+        }
+        let t = start.elapsed();
+        println!("cursor_bench: line_down 100x = {:?} ({:.1}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 100.0);
+
+        // Line up 100 lines
+        let start = std::time::Instant::now();
+        for _ in 0..100 {
+            pos = layout.move_cursor_in_direction(
+                pos, crate::items::TextCursorDirection::PreviousLine, 0.0, 20.0);
+        }
+        let t = start.elapsed();
+        println!("cursor_bench: line_up 100x = {:?} ({:.1}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 100.0);
+
+        // Word forward 100 words
+        let words: Vec<&str> = (0..100).map(|i| {
+            ["apple", "banana", "cherry", "date", "elderberry", "fig", "grape", "honeydew"][i % 8]
+        }).collect();
+        let text2 = words.join(" ");
+        let layout2 = layout_text_with_width(&text2, 500.0);
+        let start = std::time::Instant::now();
+        let mut pos = 0;
+        for _ in 0..100 {
+            pos = layout2.move_cursor_in_direction(
+                pos, crate::items::TextCursorDirection::ForwardByWord, 0.0, 20.0);
+        }
+        let t = start.elapsed();
+        println!("cursor_bench: word_jump 100x = {:?} ({:.1}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 100.0);
+
+        // Forward 1000 chars
+        let text3 = "a".repeat(1000);
+        let layout3 = layout_text_with_width(&text3, 500.0);
+        let start = std::time::Instant::now();
+        let mut pos = 0;
+        for _ in 0..1000 {
+            pos = layout3.move_cursor_in_direction(
+                pos, crate::items::TextCursorDirection::Forward, 0.0, 20.0);
+        }
+        let t = start.elapsed();
+        println!("cursor_bench: forward 1000x = {:?} ({:.3}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 1000.0);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn bench_old_style_cursor_movement() {
+        // Simulates the OLD code path that built 2 layouts per cursor operation.
+        use std::string::String;
+        use std::format;
+        use std::println;
+        use std::time::Instant;
+        use alloc::vec::Vec;
+
+        fn make_layout(text: &str, width: f32) -> Layout {
+            layout_text_with_options(text, LayoutOptions {
+                max_width: Some(LogicalLength::new(width)),
+                ..Default::default()
+            })
+        }
+
+        let text: String = (0..100)
+            .map(|i| format!("Line {}: The quick brown fox jumps over the lazy dog", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let cursor_width = PhysicalLength::new(1.0);
+        let line_height = 20.0f32;
+
+        // Old line nav: 2 layout builds per move
+        let start = Instant::now();
+        let mut pos = 0usize;
+        for _ in 0..100 {
+            let layout1 = make_layout(&text, 500.0);
+            let rect = layout1.cursor_rect_for_byte_offset(pos, cursor_width);
+            let target_y = PhysicalLength::new(rect.origin.y + rect.size.height + line_height);
+            let layout2 = make_layout(&text, 500.0);
+            pos = layout2.byte_offset_from_point(PhysicalPoint::from_lengths(
+                PhysicalLength::new(0.0), target_y,
+            ));
+        }
+        let t = start.elapsed();
+        println!("cursor_bench OLD: line_down 100x (2 layouts) = {:?} ({:.1}µs/move)",
+            t, t.as_secs_f64() * 1_000_000.0 / 100.0);
     }
 }

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -1420,15 +1420,18 @@ impl Layout {
             crate::items::TextCursorDirection::NextLine => {
                 let rect = cursor.geometry(&paragraph.layout, 1.0);
                 let para_y_in_layout = (self.y_offset + paragraph.y).get();
-                let target_y = para_y_in_layout + rect.y0 as f32 + rect.height() as f32 + vertical_advance;
+                let target_y =
+                    para_y_in_layout + rect.y0 as f32 + rect.height() as f32 + vertical_advance;
                 let target_para = self.paragraph_by_y(PhysicalLength::new(target_y));
                 if let Some(target_para) = target_para {
                     let local_y = target_y - (self.y_offset + target_para.y).get();
-                    target_para.range.start + parley::editing::Cursor::from_point(
-                        &target_para.layout,
-                        preferred_x,
-                        local_y.max(0.0),
-                    ).index()
+                    target_para.range.start
+                        + parley::editing::Cursor::from_point(
+                            &target_para.layout,
+                            preferred_x,
+                            local_y.max(0.0),
+                        )
+                        .index()
                 } else {
                     paragraph.range.end
                 }
@@ -1443,30 +1446,28 @@ impl Layout {
                 let target_para = self.paragraph_by_y(PhysicalLength::new(target_y));
                 if let Some(target_para) = target_para {
                     let local_y = target_y - (self.y_offset + target_para.y).get();
-                    target_para.range.start + parley::editing::Cursor::from_point(
-                        &target_para.layout,
-                        preferred_x,
-                        local_y.max(0.0),
-                    ).index()
+                    target_para.range.start
+                        + parley::editing::Cursor::from_point(
+                            &target_para.layout,
+                            preferred_x,
+                            local_y.max(0.0),
+                        )
+                        .index()
                 } else {
                     paragraph.range.start
                 }
             }
             crate::items::TextCursorDirection::StartOfLine => {
                 let y = cursor.geometry(&paragraph.layout, 1.0).y0 as f32;
-                paragraph.range.start + parley::editing::Cursor::from_point(
-                    &paragraph.layout,
-                    f32::NEG_INFINITY,
-                    y,
-                ).index()
+                paragraph.range.start
+                    + parley::editing::Cursor::from_point(&paragraph.layout, f32::NEG_INFINITY, y)
+                        .index()
             }
             crate::items::TextCursorDirection::EndOfLine => {
                 let y = cursor.geometry(&paragraph.layout, 1.0).y0 as f32;
-                paragraph.range.start + parley::editing::Cursor::from_point(
-                    &paragraph.layout,
-                    f32::INFINITY,
-                    y,
-                ).index()
+                paragraph.range.start
+                    + parley::editing::Cursor::from_point(&paragraph.layout, f32::INFINITY, y)
+                        .index()
             }
             crate::items::TextCursorDirection::StartOfParagraph => paragraph.range.start,
             crate::items::TextCursorDirection::EndOfParagraph => paragraph.range.end,
@@ -1474,13 +1475,17 @@ impl Layout {
             crate::items::TextCursorDirection::EndOfText => {
                 self.paragraphs.last().map_or(0, |p| p.range.end)
             }
-            crate::items::TextCursorDirection::PageUp | crate::items::TextCursorDirection::PageDown => {
+            crate::items::TextCursorDirection::PageUp
+            | crate::items::TextCursorDirection::PageDown => {
                 let rect = cursor.geometry(&paragraph.layout, 1.0);
                 let para_y_in_layout = (self.y_offset + paragraph.y).get();
                 let target_y = match direction {
-                    crate::items::TextCursorDirection::PageUp =>
-                        para_y_in_layout + rect.y0 as f32 - vertical_advance,
-                    _ => para_y_in_layout + rect.y0 as f32 + rect.height() as f32 + vertical_advance,
+                    crate::items::TextCursorDirection::PageUp => {
+                        para_y_in_layout + rect.y0 as f32 - vertical_advance
+                    }
+                    _ => {
+                        para_y_in_layout + rect.y0 as f32 + rect.height() as f32 + vertical_advance
+                    }
                 };
                 if target_y < self.y_offset.get() {
                     return current_byte_offset;
@@ -1488,11 +1493,13 @@ impl Layout {
                 let target_para = self.paragraph_by_y(PhysicalLength::new(target_y));
                 if let Some(target_para) = target_para {
                     let local_y = target_y - (self.y_offset + target_para.y).get();
-                    target_para.range.start + parley::editing::Cursor::from_point(
-                        &target_para.layout,
-                        preferred_x,
-                        local_y.max(0.0),
-                    ).index()
+                    target_para.range.start
+                        + parley::editing::Cursor::from_point(
+                            &target_para.layout,
+                            preferred_x,
+                            local_y.max(0.0),
+                        )
+                        .index()
                 } else if matches!(direction, crate::items::TextCursorDirection::PageDown) {
                     self.paragraphs.last().map_or(0, |p| p.range.end)
                 } else {
@@ -2244,7 +2251,8 @@ pub fn text_input_move_cursor(
     let byte_offset =
         visual_representation.map_byte_offset_from_actual_to_visual_text(current_offset);
 
-    let new_offset = layout.move_cursor_in_direction(byte_offset, direction, preferred_x, vertical_advance);
+    let new_offset =
+        layout.move_cursor_in_direction(byte_offset, direction, preferred_x, vertical_advance);
 
     Some(visual_representation.map_byte_offset_from_visual_text_to_actual_text(new_offset))
 }
@@ -2436,36 +2444,83 @@ mod tests {
     }
 
     fn layout_text_with_width(text: &str, width: f32) -> Layout {
-        layout_text_with_options(text, LayoutOptions {
-            max_width: Some(LogicalLength::new(width)),
-            ..Default::default()
-        })
+        layout_text_with_options(
+            text,
+            LayoutOptions { max_width: Some(LogicalLength::new(width)), ..Default::default() },
+        )
     }
 
     #[test]
     fn test_move_cursor_forward_backward() {
         let layout = layout_text_with_width("abc", 100.0);
         // Forward from start
-        assert_eq!(layout.move_cursor_in_direction(0, crate::items::TextCursorDirection::Forward, 0.0, 0.0), 1);
+        assert_eq!(
+            layout.move_cursor_in_direction(
+                0,
+                crate::items::TextCursorDirection::Forward,
+                0.0,
+                0.0
+            ),
+            1
+        );
         // Backward from end
-        assert_eq!(layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::Backward, 0.0, 0.0), 2);
+        assert_eq!(
+            layout.move_cursor_in_direction(
+                3,
+                crate::items::TextCursorDirection::Backward,
+                0.0,
+                0.0
+            ),
+            2
+        );
         // Backward from start stays at start
-        assert_eq!(layout.move_cursor_in_direction(0, crate::items::TextCursorDirection::Backward, 0.0, 0.0), 0);
+        assert_eq!(
+            layout.move_cursor_in_direction(
+                0,
+                crate::items::TextCursorDirection::Backward,
+                0.0,
+                0.0
+            ),
+            0
+        );
         // Forward from end stays at end
-        assert_eq!(layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::Forward, 0.0, 0.0), 3);
+        assert_eq!(
+            layout.move_cursor_in_direction(
+                3,
+                crate::items::TextCursorDirection::Forward,
+                0.0,
+                0.0
+            ),
+            3
+        );
     }
 
     #[test]
     fn test_move_cursor_word_boundaries() {
         let layout = layout_text_with_width("Hello World", 200.0);
         // BackwardByWord from middle of "Hello" -> start of "Hello"
-        let pos = layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::BackwardByWord, 0.0, 0.0);
+        let pos = layout.move_cursor_in_direction(
+            3,
+            crate::items::TextCursorDirection::BackwardByWord,
+            0.0,
+            0.0,
+        );
         assert_eq!(pos, 0, "BackwardByWord from middle of 'Hello' should go to 0, got {pos}");
         // ForwardByWord from middle of "Hello" -> end of "Hello"
-        let pos = layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::ForwardByWord, 0.0, 0.0);
+        let pos = layout.move_cursor_in_direction(
+            3,
+            crate::items::TextCursorDirection::ForwardByWord,
+            0.0,
+            0.0,
+        );
         assert_eq!(pos, 5, "ForwardByWord from middle of 'Hello' should go to 5, got {pos}");
         // ForwardByWord from end of "Hello" -> start of "World"
-        let pos = layout.move_cursor_in_direction(5, crate::items::TextCursorDirection::ForwardByWord, 0.0, 0.0);
+        let pos = layout.move_cursor_in_direction(
+            5,
+            crate::items::TextCursorDirection::ForwardByWord,
+            0.0,
+            0.0,
+        );
         assert_eq!(pos, 6, "ForwardByWord from end of 'Hello' should go to 6, got {pos}");
     }
 
@@ -2474,23 +2529,44 @@ mod tests {
         let layout = layout_text_with_width("e\u{0301}", 100.0); // e + combining accent
         // Parley treats combining marks as separate visual clusters.
         // Backward from end moves to start of the last visual cluster (the combining mark).
-        let pos = layout.move_cursor_in_direction(3, crate::items::TextCursorDirection::Backward, 0.0, 0.0);
-        assert_eq!(pos, 1, "Backward from end of 'e\\u{{0301}}' should go to 1 (combining mark start), got {pos}");
+        let pos = layout.move_cursor_in_direction(
+            3,
+            crate::items::TextCursorDirection::Backward,
+            0.0,
+            0.0,
+        );
+        assert_eq!(
+            pos, 1,
+            "Backward from end of 'e\\u{{0301}}' should go to 1 (combining mark start), got {pos}"
+        );
         // Forward from start moves to end of first visual cluster ('e')
-        let pos = layout.move_cursor_in_direction(0, crate::items::TextCursorDirection::Forward, 0.0, 0.0);
-        assert_eq!(pos, 1, "Forward from start of 'e\\u{{0301}}' should go to 1 (end of 'e'), got {pos}");
+        let pos = layout.move_cursor_in_direction(
+            0,
+            crate::items::TextCursorDirection::Forward,
+            0.0,
+            0.0,
+        );
+        assert_eq!(
+            pos, 1,
+            "Forward from start of 'e\\u{{0301}}' should go to 1 (end of 'e'), got {pos}"
+        );
         // Forward from combining mark moves to end of text
-        let pos = layout.move_cursor_in_direction(1, crate::items::TextCursorDirection::Forward, 0.0, 0.0);
+        let pos = layout.move_cursor_in_direction(
+            1,
+            crate::items::TextCursorDirection::Forward,
+            0.0,
+            0.0,
+        );
         assert_eq!(pos, 3, "Forward from combining mark should go to 3 (text end), got {pos}");
     }
 
     #[cfg(feature = "std")]
     #[test]
     fn bench_cursor_movement() {
-        use std::string::String;
+        use alloc::vec::Vec;
         use std::format;
         use std::println;
-        use alloc::vec::Vec;
+        use std::string::String;
         // Build multi-line text (100 lines)
         let text: String = (0..100)
             .map(|i| format!("Line {}: The quick brown fox jumps over the lazy dog", i))
@@ -2503,34 +2579,61 @@ mod tests {
         let mut pos = 0;
         for _ in 0..100 {
             pos = layout.move_cursor_in_direction(
-                pos, crate::items::TextCursorDirection::NextLine, 0.0, 20.0);
+                pos,
+                crate::items::TextCursorDirection::NextLine,
+                0.0,
+                20.0,
+            );
         }
         let t = start.elapsed();
-        println!("cursor_bench: line_down 100x = {:?} ({:.1}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 100.0);
+        println!(
+            "cursor_bench: line_down 100x = {:?} ({:.1}µs/move)",
+            t,
+            t.as_secs_f64() * 1_000_000.0 / 100.0
+        );
 
         // Line up 100 lines
         let start = std::time::Instant::now();
         for _ in 0..100 {
             pos = layout.move_cursor_in_direction(
-                pos, crate::items::TextCursorDirection::PreviousLine, 0.0, 20.0);
+                pos,
+                crate::items::TextCursorDirection::PreviousLine,
+                0.0,
+                20.0,
+            );
         }
         let t = start.elapsed();
-        println!("cursor_bench: line_up 100x = {:?} ({:.1}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 100.0);
+        println!(
+            "cursor_bench: line_up 100x = {:?} ({:.1}µs/move)",
+            t,
+            t.as_secs_f64() * 1_000_000.0 / 100.0
+        );
 
         // Word forward 100 words
-        let words: Vec<&str> = (0..100).map(|i| {
-            ["apple", "banana", "cherry", "date", "elderberry", "fig", "grape", "honeydew"][i % 8]
-        }).collect();
+        let words: Vec<&str> = (0..100)
+            .map(|i| {
+                ["apple", "banana", "cherry", "date", "elderberry", "fig", "grape", "honeydew"]
+                    [i % 8]
+            })
+            .collect();
         let text2 = words.join(" ");
         let layout2 = layout_text_with_width(&text2, 500.0);
         let start = std::time::Instant::now();
         let mut pos = 0;
         for _ in 0..100 {
             pos = layout2.move_cursor_in_direction(
-                pos, crate::items::TextCursorDirection::ForwardByWord, 0.0, 20.0);
+                pos,
+                crate::items::TextCursorDirection::ForwardByWord,
+                0.0,
+                20.0,
+            );
         }
         let t = start.elapsed();
-        println!("cursor_bench: word_jump 100x = {:?} ({:.1}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 100.0);
+        println!(
+            "cursor_bench: word_jump 100x = {:?} ({:.1}µs/move)",
+            t,
+            t.as_secs_f64() * 1_000_000.0 / 100.0
+        );
 
         // Forward 1000 chars
         let text3 = "a".repeat(1000);
@@ -2539,27 +2642,35 @@ mod tests {
         let mut pos = 0;
         for _ in 0..1000 {
             pos = layout3.move_cursor_in_direction(
-                pos, crate::items::TextCursorDirection::Forward, 0.0, 20.0);
+                pos,
+                crate::items::TextCursorDirection::Forward,
+                0.0,
+                20.0,
+            );
         }
         let t = start.elapsed();
-        println!("cursor_bench: forward 1000x = {:?} ({:.3}µs/move)", t, t.as_secs_f64() * 1_000_000.0 / 1000.0);
+        println!(
+            "cursor_bench: forward 1000x = {:?} ({:.3}µs/move)",
+            t,
+            t.as_secs_f64() * 1_000_000.0 / 1000.0
+        );
     }
 
     #[cfg(feature = "std")]
     #[test]
     fn bench_old_style_cursor_movement() {
         // Simulates the OLD code path that built 2 layouts per cursor operation.
-        use std::string::String;
+        use alloc::vec::Vec;
         use std::format;
         use std::println;
+        use std::string::String;
         use std::time::Instant;
-        use alloc::vec::Vec;
 
         fn make_layout(text: &str, width: f32) -> Layout {
-            layout_text_with_options(text, LayoutOptions {
-                max_width: Some(LogicalLength::new(width)),
-                ..Default::default()
-            })
+            layout_text_with_options(
+                text,
+                LayoutOptions { max_width: Some(LogicalLength::new(width)), ..Default::default() },
+            )
         }
 
         let text: String = (0..100)
@@ -2579,11 +2690,15 @@ mod tests {
             let target_y = PhysicalLength::new(rect.origin.y + rect.size.height + line_height);
             let layout2 = make_layout(&text, 500.0);
             pos = layout2.byte_offset_from_point(PhysicalPoint::from_lengths(
-                PhysicalLength::new(0.0), target_y,
+                PhysicalLength::new(0.0),
+                target_y,
             ));
         }
         let t = start.elapsed();
-        println!("cursor_bench OLD: line_down 100x (2 layouts) = {:?} ({:.1}µs/move)",
-            t, t.as_secs_f64() * 1_000_000.0 / 100.0);
+        println!(
+            "cursor_bench OLD: line_down 100x (2 layouts) = {:?} ({:.1}µs/move)",
+            t,
+            t.as_secs_f64() * 1_000_000.0 / 100.0
+        );
     }
 }

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -407,6 +407,18 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         sharedparley::text_input_cursor_rect_for_byte_offset(self, text_input, item_rc, byte_offset)
     }
 
+    fn text_input_move_cursor(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::item_tree::ItemRc,
+        current_offset: usize,
+        direction: i_slint_core::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> Option<usize> {
+        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+    }
+
     fn register_font_from_memory(
         &self,
         data: &'static [u8],

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -416,7 +416,15 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         preferred_x: f32,
         vertical_advance: f32,
     ) -> Option<usize> {
-        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+        sharedparley::text_input_move_cursor(
+            self,
+            text_input,
+            item_rc,
+            current_offset,
+            direction,
+            preferred_x,
+            vertical_advance,
+        )
     }
 
     fn register_font_from_memory(

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -649,7 +649,14 @@ impl RendererSealed for FemtoVGWGPURenderer {
         preferred_x: f32,
         vertical_advance: f32,
     ) -> Option<usize> {
-        self.0.text_input_move_cursor(text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+        self.0.text_input_move_cursor(
+            text_input,
+            item_rc,
+            current_offset,
+            direction,
+            preferred_x,
+            vertical_advance,
+        )
     }
 
     fn register_font_from_memory(

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -640,6 +640,18 @@ impl RendererSealed for FemtoVGWGPURenderer {
         self.0.text_input_cursor_rect_for_byte_offset(text_input, item_rc, byte_offset)
     }
 
+    fn text_input_move_cursor(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::items::ItemRc,
+        current_offset: usize,
+        direction: i_slint_core::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> Option<usize> {
+        self.0.text_input_move_cursor(text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+    }
+
     fn register_font_from_memory(
         &self,
         data: &'static [u8],

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -946,6 +946,18 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         sharedparley::text_input_cursor_rect_for_byte_offset(self, text_input, item_rc, byte_offset)
     }
 
+    fn text_input_move_cursor(
+        &self,
+        text_input: std::pin::Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::item_tree::ItemRc,
+        current_offset: usize,
+        direction: i_slint_core::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> Option<usize> {
+        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+    }
+
     fn register_font_from_memory(
         &self,
         data: &'static [u8],

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -955,7 +955,15 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         preferred_x: f32,
         vertical_advance: f32,
     ) -> Option<usize> {
-        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+        sharedparley::text_input_move_cursor(
+            self,
+            text_input,
+            item_rc,
+            current_offset,
+            direction,
+            preferred_x,
+            vertical_advance,
+        )
     }
 
     fn register_font_from_memory(

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -166,6 +166,18 @@ impl RendererSealed for SkiaWGPURenderer {
         self.renderer.text_input_cursor_rect_for_byte_offset(text_input, item_rc, byte_offset)
     }
 
+    fn text_input_move_cursor(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &i_slint_core::items::ItemRc,
+        current_offset: usize,
+        direction: i_slint_core::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> Option<usize> {
+        self.renderer.text_input_move_cursor(text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+    }
+
     fn register_font_from_memory(
         &self,
         data: &'static [u8],

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -175,7 +175,14 @@ impl RendererSealed for SkiaWGPURenderer {
         preferred_x: f32,
         vertical_advance: f32,
     ) -> Option<usize> {
-        self.renderer.text_input_move_cursor(text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+        self.renderer.text_input_move_cursor(
+            text_input,
+            item_rc,
+            current_offset,
+            direction,
+            preferred_x,
+            vertical_advance,
+        )
     }
 
     fn register_font_from_memory(

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -1222,6 +1222,18 @@ impl RendererSealed for SoftwareRenderer {
         }
     }
 
+    fn text_input_move_cursor(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &ItemRc,
+        current_offset: usize,
+        direction: i_slint_core::items::TextCursorDirection,
+        preferred_x: f32,
+        vertical_advance: f32,
+    ) -> Option<usize> {
+        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+    }
+
     fn free_graphics_resources(
         &self,
         _component: i_slint_core::item_tree::ItemTreeRef,

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -1231,7 +1231,15 @@ impl RendererSealed for SoftwareRenderer {
         preferred_x: f32,
         vertical_advance: f32,
     ) -> Option<usize> {
-        sharedparley::text_input_move_cursor(self, text_input, item_rc, current_offset, direction, preferred_x, vertical_advance)
+        sharedparley::text_input_move_cursor(
+            self,
+            text_input,
+            item_rc,
+            current_offset,
+            direction,
+            preferred_x,
+            vertical_advance,
+        )
     }
 
     fn free_graphics_resources(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: 2.5.5
       '@napi-rs/cli':
         specifier: 3.7.4
-        version: 3.7.4(@emnapi/runtime@1.9.2)(@types/node@24.12.0)
+        version: 3.7.4(@emnapi/runtime@1.11.2)(@types/node@24.12.0)
       '@types/capture-console':
         specifier: 1.0.5
         version: 1.0.5
@@ -10049,7 +10049,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@napi-rs/cli@3.7.4(@emnapi/runtime@1.9.2)(@types/node@24.12.0)':
+  '@napi-rs/cli@3.7.4(@emnapi/runtime@1.11.2)(@types/node@24.12.0)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.12.0)
       '@napi-rs/cross-toolchain': 1.0.3
@@ -10064,7 +10064,7 @@ snapshots:
       semver: 7.8.5
       typanion: 3.14.0
     optionalDependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.11.2
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: 2.5.5
       '@napi-rs/cli':
         specifier: 3.7.4
-        version: 3.7.4(@emnapi/runtime@1.11.2)(@types/node@24.12.0)
+        version: 3.7.4(@emnapi/runtime@1.9.2)(@types/node@24.12.0)
       '@types/capture-console':
         specifier: 1.0.5
         version: 1.0.5
@@ -10049,7 +10049,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@napi-rs/cli@3.7.4(@emnapi/runtime@1.11.2)(@types/node@24.12.0)':
+  '@napi-rs/cli@3.7.4(@emnapi/runtime@1.9.2)(@types/node@24.12.0)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.12.0)
       '@napi-rs/cross-toolchain': 1.0.3
@@ -10064,7 +10064,7 @@ snapshots:
       semver: 7.8.5
       typanion: 3.14.0
     optionalDependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.9.2
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'


### PR DESCRIPTION
Cursor movement for NextLine, PreviousLine, StartOfLine, EndOfLine,
PageUp, and PageDown previously required two or three separate layout
builds via `cursor_rect_for_byte_offset` + `byte_offset_for_position`.
This replaces them with a single layout pass by reusing the existing
Parley Layout and its Cursor API (geometry + from_point).

The helper `text_input_move_cursor()` builds one layout and delegates to
`move_cursor_in_direction()`, which handles all six directions. Cross-
paragraph navigation uses `paragraph_by_y` to find the target paragraph
at the new y coordinate.

Forward/Backward keep the existing GraphemeCursor implementation:
it is O(1) and handles grapheme clusters (combining characters,
emoji ZWJ sequences) as single units, which Parley's visual cluster
boundaries do not.

Word boundaries keep the existing unicode_segmentation-based
implementation for the same reason and because it is faster than
building a Parley layout.

ChangeLog: Reduced layout passes for vertical cursor navigation
from 2-3 to 1, improving text input responsiveness.

- [x] If possible, the change is auto-tested
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
