### PR TITLE
compiler: Fix property usage counting and global property animation handling

### DIFF
--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -851,15 +851,14 @@ impl<'a, T> EvaluationContext<'a, T> {
             r: &'_ LocalMemberIndex,
             map: ContextMap,
         ) -> PropertyInfoResult<'a> {
-            let binding = g.init_values.get(r).map(|b| (b, map.clone()));
-            let animation = g.animations.get(r).map(|a| (a, map));
+            let binding = g.init_values.get(r).map(|b| (b, map));
             match r {
                 LocalMemberIndex::Property(index) => {
                     let property_decl = &g.properties[*index];
                     PropertyInfoResult {
                         analysis: Some(&g.prop_analysis[*index]),
                         binding,
-                        animation,
+                        animation: None,
                         ty: property_decl.ty.clone(),
                         use_count: Some(&property_decl.use_count),
                     }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -138,8 +138,6 @@ pub struct GlobalComponent {
     pub functions: TiVec<FunctionIdx, Function>,
     /// One entry per property
     pub init_values: BTreeMap<LocalMemberIndex, BindingExpression>,
-    /// The animation for properties which are animated
-    pub animations: BTreeMap<LocalMemberIndex, Expression>,
     // maps property to its changed callback
     pub change_callbacks: BTreeMap<PropertyIdx, MutExpression>,
     pub const_properties: TiVec<PropertyIdx, bool>,

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -1080,7 +1080,6 @@ fn lower_global(
     GlobalComponent {
         name: global.root_element.borrow().id.clone(),
         init_values: BTreeMap::new(),
-        animations: BTreeMap::new(),
         properties,
         callbacks,
         functions,
@@ -1108,13 +1107,9 @@ fn lower_global_expressions(
 
     for (prop, binding) in &global.root_element.borrow().bindings {
         assert!(binding.borrow().two_way_bindings.is_empty());
+        assert!(binding.borrow().animation.is_none());
         let expression =
             super::lower_expression::lower_expression(&binding.borrow().expression, &mut ctx);
-        let animation = binding
-            .borrow()
-            .animation
-            .as_ref()
-            .map(|a| super::lower_expression::lower_animation(a, &mut ctx));
 
         let nr = NamedReference::new(&global.root_element, prop.clone());
         let member_index = match &ctx.state.global_properties[&nr] {
@@ -1127,15 +1122,12 @@ fn lower_global_expressions(
             MemberReference::Global { member, .. } => member.clone(),
             _ => unreachable!(),
         };
-        if let Some(Animation::Static(animation)) = animation.as_ref() {
-            lowered.animations.insert(member_index.clone(), animation.clone());
-        }
         let is_constant = binding.borrow().analysis.as_ref().is_some_and(|a| a.is_const);
         lowered.init_values.insert(
             member_index,
             BindingExpression {
                 expression: expression.into(),
-                animation,
+                animation: None,
                 kind: if is_constant { BindingKind::Constant } else { BindingKind::Normal },
                 use_count: 0.into(),
             },

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -113,6 +113,12 @@ pub fn count_property_use(root: &CompilationUnit) {
             }
         }
 
+        // 8. animations (`animate x { … }`): `remove_unused` keeps and remaps these,
+        // so the properties they read must be counted too.
+        for anim in sc.animations.values() {
+            anim.visit_property_references(ctx, &mut visit_property);
+        }
+
         // Function bodies are visited on demand from visit_property when a call to
         // them is found, so that an unreachable function keeps nothing alive.
 

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -85,7 +85,6 @@ pub fn remove_unused(root: &mut CompilationUnit) {
     }
     for (idx, g) in root.globals.iter_mut_enumerated() {
         g.init_values.retain(|x, _| mappings.glob_mappings[idx].keep(x));
-        g.animations.retain(|x, _| mappings.glob_mappings[idx].keep(x));
     }
 
     macro_rules! remap_index {
@@ -438,7 +437,6 @@ mod visitor {
             callbacks: _,
             functions,
             init_values,
-            animations,
             change_callbacks,
             const_properties: _,
             public_properties,
@@ -462,15 +460,6 @@ mod visitor {
             .map(|(mut k, mut v)| {
                 visit_member_index(&mut k, &scope, state, visitor);
                 visit_binding_expression(&mut v, &scope, state, visitor);
-                (k, v)
-            })
-            .collect();
-
-        *animations = std::mem::take(animations)
-            .into_iter()
-            .map(|(mut k, mut v)| {
-                visit_member_index(&mut k, &scope, state, visitor);
-                visit_expression(&mut v, &scope, state, visitor);
                 (k, v)
             })
             .collect();

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -327,20 +327,6 @@ impl PrettyPrinter<'_> {
                 _ => unreachable!(),
             }
         }
-        for (p, animation) in &global.animations {
-            self.indent()?;
-            match p {
-                LocalMemberIndex::Property(p) => {
-                    writeln!(
-                        self.writer,
-                        "animate {} {{ {} }}",
-                        global.properties[*p].name,
-                        DisplayExpression(animation, &ctx),
-                    )?;
-                }
-                _ => unreachable!(),
-            }
-        }
 
         for (p, e) in &global.change_callbacks {
             self.indent()?;

--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -28,13 +28,12 @@ impl PropertySets {
             &e2.borrow().enclosing_component,
         );
         if !same_component {
-            let can_merge_across_components =
-                (e1.borrow().enclosing_component.upgrade().unwrap().is_global()
-                    && !e2.borrow().change_callbacks.contains_key(p2.name()))
-                    || (e2.borrow().enclosing_component.upgrade().unwrap().is_global()
-                        && !e1.borrow().change_callbacks.contains_key(p1.name()));
-            if !can_merge_across_components {
-                // We can only merge aliases if they are in the same Component. (unless one of them is global if the other one don't have change event)
+            let one_is_global = e1.borrow().enclosing_component.upgrade().unwrap().is_global()
+                || e2.borrow().enclosing_component.upgrade().unwrap().is_global();
+            if !one_is_global {
+                // We can only merge aliases across components if one of them is a global.
+                // (A property carrying a `changed` handler or an animation is then kept out
+                // of the global by the master-selection loop below, not here.)
                 // TODO: actually we could still merge two alias in a component pointing to the same
                 // property in a parent component
                 return;
@@ -148,8 +147,26 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             for candidate in set_iter {
                 best = best_property(best.clone(), candidate.clone());
             }
+            let best_is_global =
+                best.element().borrow().enclosing_component.upgrade().unwrap().is_global();
             for x in set.iter() {
                 if *x != best {
+                    // Keep a property with a `changed` handler or an animation in its own
+                    // component rather than aliasing it onto a global (a singleton it can't
+                    // reach); the replacement below leaves it two-way bound to `best`.
+                    let elem = x.element();
+                    let elem = elem.borrow();
+                    let carries_local_state = elem.change_callbacks.contains_key(x.name())
+                        || elem
+                            .bindings
+                            .get(x.name())
+                            .is_some_and(|b| b.borrow().animation.is_some());
+                    if best_is_global
+                        && !elem.enclosing_component.upgrade().unwrap().is_global()
+                        && carries_local_state
+                    {
+                        continue;
+                    }
                     aliases_to_remove.insert(x.clone(), best.clone());
                 }
             }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -2029,29 +2029,14 @@ fn eval_assignment(lhs: &Expression, op: char, rhs: Value, local_context: &mut E
 
             match enclosing_component {
                 ComponentInstance::InstanceRef(enclosing_component) => {
-                    if op == '=' {
-                        store_property(enclosing_component, &element, nr.name(), rhs).unwrap();
-                        return;
-                    }
-
-                    let component = element.borrow().enclosing_component.upgrade().unwrap();
-                    if element.borrow().id == component.root_element.borrow().id
-                        && let Some(x) =
-                            enclosing_component.description.custom_properties.get(nr.name())
-                    {
-                        unsafe {
-                            let p =
-                                Pin::new_unchecked(&*enclosing_component.as_ptr().add(x.offset));
-                            x.prop.set(p, eval(x.prop.get(p).unwrap()), None).unwrap();
-                        }
-                        return;
-                    }
-                    let item_info =
-                        &enclosing_component.description.items[element.borrow().id.as_str()];
-                    let item =
-                        unsafe { item_info.item_from_item_tree(enclosing_component.as_ptr()) };
-                    let p = &item_info.rtti.properties[nr.name().as_str()];
-                    p.set(item, eval(p.get(item)), None).unwrap();
+                    // Go through `store_property` (also for compound assignments) so the
+                    // property's animation is applied, instead of setting it directly.
+                    let value = if op == '=' {
+                        rhs
+                    } else {
+                        eval(load_property(enclosing_component, &element, nr.name()).unwrap())
+                    };
+                    store_property(enclosing_component, &element, nr.name(), value).unwrap();
                 }
                 ComponentInstance::GlobalComponent(global) => {
                     let val = if op == '=' {

--- a/tests/cases/bindings/two_way_changed_global.slint
+++ b/tests/cases/bindings/two_way_changed_global.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A property carrying a `changed` handler, two-way bound through an intermediate
+// to a global. The handler runs in the component's context, so it must not be
+// hoisted onto the global (a singleton) when the alias set is collapsed.
+
+export global Glob {
+    in-out property <string> text;
+}
+
+export component TestCase {
+    in-out property <string> intermediate <=> Glob.text;
+    in-out property <string> alias <=> intermediate;
+    out property <int> change-count: 0;
+    changed alias => { change-count += 1; }
+
+    out property <bool> test: alias == "" && change-count == 0;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(instance.get_change_count(), 0);
+instance.global::<Glob<'_>>().set_text("hello".into());
+assert_eq!(instance.get_alias(), "hello");
+slint_testing::mock_elapsed_time(1);
+assert_eq!(instance.get_change_count(), 1);
+instance.set_alias("world".into());
+assert_eq!(instance.global::<Glob<'_>>().get_text(), "world");
+slint_testing::mock_elapsed_time(1);
+assert_eq!(instance.get_change_count(), 2);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+assert_eq(instance.get_change_count(), 0);
+instance.global<Glob>().set_text("hello");
+assert_eq(instance.get_alias(), "hello");
+slint_testing::mock_elapsed_time(1);
+assert_eq(instance.get_change_count(), 1);
+instance.set_alias("world");
+assert_eq(instance.global<Glob>().get_text(), "world");
+slint_testing::mock_elapsed_time(1);
+assert_eq(instance.get_change_count(), 2);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert(instance.test);
+assert.equal(instance.change_count, 0);
+instance.Glob.text = "hello";
+assert.equal(instance.alias, "hello");
+slintlib.private_api.mock_elapsed_time(1);
+assert.equal(instance.change_count, 1);
+instance.alias = "world";
+assert.equal(instance.Glob.text, "world");
+slintlib.private_api.mock_elapsed_time(1);
+assert.equal(instance.change_count, 2);
+```
+*/

--- a/tests/cases/bindings/two_way_global_animation_local.slint
+++ b/tests/cases/bindings/two_way_global_animation_local.slint
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `aliased` is two-way bound to a global and animated, but the animation's
+// duration reads a component-local property. The animation cannot move onto
+// the global (it would reference component state a singleton can't reach), so
+// `aliased` stays a real component property, two-way bound to the global.
+
+export global Glob {
+    in-out property <int> val: 8;
+}
+
+export component TestCase inherits Window {
+    in property <duration> dur: 200ms;
+    property <int> aliased <=> Glob.val;
+    animate aliased { duration: dur; }
+    out property <int> observed: aliased;
+    public function bump() { aliased += 100; }
+    out property <bool> test: observed == 8;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_observed(), 8);
+instance.invoke_bump();
+// Halfway through the 200ms animation (linear).
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_observed(), 58);
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_observed(), 108);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_observed(), 8);
+instance.invoke_bump();
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_observed(), 58);
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_observed(), 108);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert.equal(instance.observed, 8);
+instance.bump();
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.observed, 58);
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.observed, 108);
+```
+*/

--- a/tests/cases/issues/issue_9961_animation_alias_to_global.slint
+++ b/tests/cases/issues/issue_9961_animation_alias_to_global.slint
@@ -5,9 +5,15 @@ export global GlobalInfo {
     in-out property <int> animated: 8;
 }
 
+// The animation stays on the component property `animated`, not on the global.
+// Setting the global directly updates the value immediately, but setting the
+// component property runs the animation. The global and `observed` (which reads
+// the component property) stay in sync through the two-way binding.
 export component TestCase inherits Window {
     property <int> animated <=> GlobalInfo.animated;
     animate animated { duration: 300ms; }
+    out property <int> observed: animated;
+    public function set-animated(v: int) { animated = v; }
 }
 
 /*
@@ -15,36 +21,59 @@ export component TestCase inherits Window {
 ```rust
 let instance = TestCase::new().unwrap();
 let global = instance.global::<GlobalInfo<'_>>();
+assert_eq!(instance.get_observed(), 8);
 assert_eq!(global.get_animated(), 8);
+// Setting the global directly is not animated.
 global.set_animated(108);
-assert_eq!(global.get_animated(), 8);
+assert_eq!(instance.get_observed(), 108);
+assert_eq!(global.get_animated(), 108);
+// Setting the aliased component property animates it (108 -> 8).
+instance.invoke_set_animated(8);
+assert_eq!(instance.get_observed(), 108);
+assert_eq!(global.get_animated(), 108);
 slint_testing::mock_elapsed_time(150);
+assert_eq!(instance.get_observed(), 58);
 assert_eq!(global.get_animated(), 58);
 slint_testing::mock_elapsed_time(150);
-assert_eq!(global.get_animated(), 108);
+assert_eq!(instance.get_observed(), 8);
+assert_eq!(global.get_animated(), 8);
 ```
 
 ```cpp
 auto handle = TestCase::create();
 const TestCase &instance = *handle;
+assert_eq(instance.get_observed(), 8);
 assert_eq(instance.global<GlobalInfo>().get_animated(), 8);
 instance.global<GlobalInfo>().set_animated(108);
-assert_eq(instance.global<GlobalInfo>().get_animated(), 8);
+assert_eq(instance.get_observed(), 108);
+assert_eq(instance.global<GlobalInfo>().get_animated(), 108);
+instance.invoke_set_animated(8);
+assert_eq(instance.get_observed(), 108);
+assert_eq(instance.global<GlobalInfo>().get_animated(), 108);
 slint_testing::mock_elapsed_time(150);
+assert_eq(instance.get_observed(), 58);
 assert_eq(instance.global<GlobalInfo>().get_animated(), 58);
 slint_testing::mock_elapsed_time(150);
-assert_eq(instance.global<GlobalInfo>().get_animated(), 108);
+assert_eq(instance.get_observed(), 8);
+assert_eq(instance.global<GlobalInfo>().get_animated(), 8);
 ```
 
 ```js
 var instance = new slint.TestCase();
+assert.equal(instance.observed, 8);
 assert.equal(instance.GlobalInfo.animated, 8);
 instance.GlobalInfo.animated = 108;
-assert.equal(instance.GlobalInfo.animated, 8);
+assert.equal(instance.observed, 108);
+assert.equal(instance.GlobalInfo.animated, 108);
+instance.set_animated(8);
+assert.equal(instance.observed, 108);
+assert.equal(instance.GlobalInfo.animated, 108);
 slintlib.private_api.mock_elapsed_time(150);
+assert.equal(instance.observed, 58);
 assert.equal(instance.GlobalInfo.animated, 58);
 slintlib.private_api.mock_elapsed_time(150);
-assert.equal(instance.GlobalInfo.animated, 108);
+assert.equal(instance.observed, 8);
+assert.equal(instance.GlobalInfo.animated, 8);
 ```
 
 */

--- a/tests/cases/properties/animation_compound_assignment.slint
+++ b/tests/cases/properties/animation_compound_assignment.slint
@@ -1,0 +1,78 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A compound assignment (`+=`, `-=`, `*=`, `/=`) to an animated property runs
+// the animation, the same as a plain assignment. This must behave the same
+// across all generators. Values are chosen so each linear midpoint is an integer.
+export component TestCase inherits Window {
+    property <int> added: 8;
+    property <int> subbed: 108;
+    property <int> mulled: 10;
+    property <int> divided: 200;
+    animate added { duration: 200ms; }
+    animate subbed { duration: 200ms; }
+    animate mulled { duration: 200ms; }
+    animate divided { duration: 200ms; }
+    out property <int> added-obs: added;
+    out property <int> subbed-obs: subbed;
+    out property <int> mulled-obs: mulled;
+    out property <int> divided-obs: divided;
+    public function go() {
+        added += 100;    // 8 -> 108
+        subbed -= 100;   // 108 -> 8
+        mulled *= 10;    // 10 -> 100
+        divided /= 2;    // 200 -> 100
+    }
+    out property <bool> test: added-obs == 8 && subbed-obs == 108
+        && mulled-obs == 10 && divided-obs == 200;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+instance.invoke_go();
+// Halfway through the 200ms animation (linear): each is at its midpoint.
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_added_obs(), 58);
+assert_eq!(instance.get_subbed_obs(), 58);
+assert_eq!(instance.get_mulled_obs(), 55);
+assert_eq!(instance.get_divided_obs(), 150);
+// Animation complete: each reached its target.
+slint_testing::mock_elapsed_time(100);
+assert_eq!(instance.get_added_obs(), 108);
+assert_eq!(instance.get_subbed_obs(), 8);
+assert_eq!(instance.get_mulled_obs(), 100);
+assert_eq!(instance.get_divided_obs(), 100);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+instance.invoke_go();
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_added_obs(), 58);
+assert_eq(instance.get_subbed_obs(), 58);
+assert_eq(instance.get_mulled_obs(), 55);
+assert_eq(instance.get_divided_obs(), 150);
+slint_testing::mock_elapsed_time(100);
+assert_eq(instance.get_added_obs(), 108);
+assert_eq(instance.get_subbed_obs(), 8);
+assert_eq(instance.get_mulled_obs(), 100);
+assert_eq(instance.get_divided_obs(), 100);
+```
+
+```js
+let instance = new slint.TestCase({});
+instance.go();
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.added_obs, 58);
+assert.equal(instance.subbed_obs, 58);
+assert.equal(instance.mulled_obs, 55);
+assert.equal(instance.divided_obs, 150);
+slintlib.private_api.mock_elapsed_time(100);
+assert.equal(instance.added_obs, 108);
+assert.equal(instance.subbed_obs, 8);
+assert.equal(instance.mulled_obs, 100);
+assert.equal(instance.divided_obs, 100);
+```
+*/

--- a/tests/cases/properties/animation_prop_inlined.slint
+++ b/tests/cases/properties/animation_prop_inlined.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `Animated` accepts `@children`, so instantiating it with a child element
+// forces the instances to be inlined even in the default codegen path. After
+// inlining, `delay` is read only by the (standalone) `x` animation, whose
+// triggering assignment lives in `animate()`. The animation must keep `delay`
+// alive; two instances stop it being folded into a single reader.
+component Animated {
+    in property <duration> delay;
+    out property <length> xpos: r.x;
+    public function animate() { r.x += 500px; }
+    r := Rectangle {
+        x: 0px;
+        animate x { duration: 200ms; delay: delay; }
+        @children
+    }
+}
+
+export component TestCase {
+    in property <int> value: 100;
+    out property <length> a-x: a.xpos;
+    public function do-animate() { a.animate(); }
+    HorizontalLayout {
+        a := Animated { delay: value * 1ms; Rectangle {} }
+        Animated { delay: value * 1ms; Rectangle {} }
+    }
+    out property <bool> test: a-x == 0px;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_a_x(), 0.);
+instance.invoke_do_animate();
+// Still within the delay (value = 100ms): x has not started moving.
+slint_testing::mock_elapsed_time(50);
+assert_eq!(instance.get_a_x(), 0.);
+// Past delay + duration: x reached its target.
+slint_testing::mock_elapsed_time(100 + 200);
+assert_eq!(instance.get_a_x(), 500.);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_a_x(), 0.);
+instance.invoke_do_animate();
+slint_testing::mock_elapsed_time(50);
+assert_eq(instance.get_a_x(), 0.);
+slint_testing::mock_elapsed_time(100 + 200);
+assert_eq(instance.get_a_x(), 500.);
+```
+
+```js
+let instance = new slint.TestCase({});
+assert.equal(instance.a_x, 0);
+instance.do_animate();
+slintlib.private_api.mock_elapsed_time(50);
+assert.equal(instance.a_x, 0);
+slintlib.private_api.mock_elapsed_time(100 + 200);
+assert.equal(instance.a_x, 500);
+```
+*/


### PR DESCRIPTION
When a property that has a `changed` handler or an `animate` block is two-way
bound to a global, `remove_aliases` used to collapse it onto the global. For
animations that meant the animation ended up on the global (a singleton), which
could also make it reference component-local state it can't reach and panic
during lowering. Such a property is now kept in its component, two-way bound to
the global; the handler/animation stays with it. The alias policy is also
consolidated into the master-selection loop, so `add_link` no longer needs its
own `changed`-handler exception.

This also fixes a separate LLR panic where a property read only by an animation
(whose trigger was unreachable) was counted as unused and removed while the
animation still referenced it.

⚠ **Behavior change:** animating a property that is aliased to a global no                
longer animates when set through the global.
The animation now only runs when the *component* property is set. 
This partially reverts the global-property animation support from #11944 (that LLR
support is removed as dead code; the #9961 test is kept and updated to the new
behavior).
