### PR TITLE
software renderer: support aligned dirty regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### General
+
+ - SoftwareRenderer: Fixed the dirty region bounding box including rectangles
+   that were entirely clipped out by the screen bounds.
+
+### Rust
+
+ - SoftwareRenderer: Added `set_dirty_region_alignment` to align dirty regions to a physical pixel grid,
+   for display controllers that require aligned address windows. (#12656)
+
+### C++
+
+ - SoftwareRenderer: Added `set_dirty_region_alignment`. (#12656)
+
 ## [1.17.1] - 2026-07-07
 
  - Fixed a panic/crash on startup when a global reads `Palette.color-scheme` (or accent-color) during its initialization.

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -872,6 +872,17 @@ public:
         cbindgen_private::slint_software_renderer_set_rendering_rotation(
                 inner, static_cast<int>(rotation));
     }
+
+    /// Align dirty regions to the specified physical pixel grid.
+    ///
+    /// Use this for display controllers that require aligned address windows.
+    /// The screen dimensions must be multiples of their corresponding alignment after applying
+    /// RenderingRotation. Values of zero are treated as one.
+    void set_dirty_region_alignment(uint16_t horizontal, uint16_t vertical)
+    {
+        cbindgen_private::slint_software_renderer_set_dirty_region_alignment(inner, horizontal,
+                                                                             vertical);
+    }
 };
 #endif
 

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -362,7 +362,7 @@ mod software_renderer {
     use i_slint_core::SharedVector;
     use i_slint_core::graphics::{IntRect, Rgb8Pixel};
     use i_slint_renderer_software::{
-        PhysicalRegion, RepaintBufferType, Rgb565Pixel, SoftwareRenderer,
+        DirtyRegionAlignment, PhysicalRegion, RepaintBufferType, Rgb565Pixel, SoftwareRenderer,
     };
 
     #[cfg(feature = "experimental")]
@@ -720,6 +720,16 @@ mod software_renderer {
             270 => RenderingRotation::Rotate270,
             _ => RenderingRotation::NoRotation,
         });
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn slint_software_renderer_set_dirty_region_alignment(
+        r: SoftwareRendererOpaque,
+        horizontal: u16,
+        vertical: u16,
+    ) {
+        let renderer = unsafe { &*(r as *const SoftwareRenderer) };
+        renderer.set_dirty_region_alignment(DirtyRegionAlignment::new(horizontal, vertical));
     }
 
     #[unsafe(no_mangle)]

--- a/api/rs/slint/tests/dirty_region_alignment.rs
+++ b/api/rs/slint/tests/dirty_region_alignment.rs
@@ -1,0 +1,141 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::rc::Rc;
+
+use slint::Rgb8Pixel;
+use slint::platform::software_renderer::{
+    DirtyRegionAlignment, LineBufferProvider, MinimalSoftwareWindow, PhysicalRegion,
+    RepaintBufferType,
+};
+use slint::platform::{PlatformError, WindowAdapter};
+
+const WIDTH: usize = 16;
+const HEIGHT: usize = 8;
+
+struct TestPlatform(Rc<MinimalSoftwareWindow>);
+
+impl slint::platform::Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        Ok(self.0.clone())
+    }
+}
+
+fn assert_aligned(region: &PhysicalRegion) {
+    for (position, size) in region.iter() {
+        assert_eq!(position.x % 2, 0);
+        assert_eq!(position.y % 2, 0);
+        assert_eq!(size.width % 2, 0);
+        assert_eq!(size.height % 2, 0);
+    }
+}
+
+fn render_frame(window: &MinimalSoftwareWindow, buffer: &mut [Rgb8Pixel]) {
+    assert!(window.draw_if_needed(|renderer| {
+        renderer.set_dirty_region_alignment(DirtyRegionAlignment::new(2, 2));
+        let region = renderer.render(buffer, WIDTH);
+        assert_aligned(&region);
+    }));
+}
+
+struct FrameBuffer<'a>(&'a mut [Rgb8Pixel]);
+
+impl LineBufferProvider for FrameBuffer<'_> {
+    type TargetPixel = Rgb8Pixel;
+
+    fn process_line(
+        &mut self,
+        line: usize,
+        range: core::ops::Range<usize>,
+        render_fn: impl FnOnce(&mut [Self::TargetPixel]),
+    ) {
+        render_fn(&mut self.0[line * WIDTH..][range]);
+    }
+}
+
+fn render_frame_by_line(
+    window: &MinimalSoftwareWindow,
+    buffer: &mut [Rgb8Pixel],
+    switch_to_reused_buffer: bool,
+) {
+    assert!(window.draw_if_needed(|renderer| {
+        if switch_to_reused_buffer {
+            renderer.set_repaint_buffer_type(RepaintBufferType::ReusedBuffer);
+        }
+        let region = renderer.render_by_line(FrameBuffer(buffer));
+        assert_aligned(&region);
+    }));
+}
+
+fn assert_frame(buffer: &[Rgb8Pixel], white_x: usize) {
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let expected = if x == white_x && y == 3 {
+                Rgb8Pixel::new(255, 255, 255)
+            } else if x == 2 && y == 3 {
+                Rgb8Pixel::new(0, 255, 0)
+            } else {
+                Rgb8Pixel::new(0, 0, 0)
+            };
+            assert_eq!(buffer[y * WIDTH + x], expected, "unexpected pixel at ({x}, {y})");
+        }
+    }
+}
+
+#[test]
+fn alignment_preserves_content_in_partial_rendering_modes() {
+    slint::slint! {
+        export component App inherits Window {
+            in property <int> rect-x: 3;
+            background: black;
+            Rectangle {
+                x: 2phx;
+                y: 3phx;
+                width: 1phx;
+                height: 1phx;
+                background: #00ff00;
+            }
+            Rectangle {
+                x: root.rect-x * 1phx;
+                y: 3phx;
+                width: 1phx;
+                height: 1phx;
+                background: white;
+            }
+        }
+    }
+
+    let window = MinimalSoftwareWindow::new(RepaintBufferType::SwappedBuffers);
+    slint::platform::set_platform(Box::new(TestPlatform(window.clone()))).unwrap();
+    let ui = App::new().unwrap();
+    window.set_size(slint::PhysicalSize::new(WIDTH as u32, HEIGHT as u32));
+    ui.show().unwrap();
+
+    let mut buffers = [
+        vec![Rgb8Pixel::new(0x55, 0x55, 0x55); WIDTH * HEIGHT],
+        vec![Rgb8Pixel::new(0xaa, 0xaa, 0xaa); WIDTH * HEIGHT],
+    ];
+
+    render_frame(&window, &mut buffers[0]);
+    assert_frame(&buffers[0], 3);
+
+    window.request_redraw();
+    render_frame(&window, &mut buffers[1]);
+    assert_frame(&buffers[1], 3);
+
+    for (frame, x) in [5, 7, 9, 11].into_iter().enumerate() {
+        ui.set_rect_x(x as i32);
+        let buffer = &mut buffers[frame % 2];
+        render_frame(&window, buffer);
+        assert_frame(buffer, x);
+    }
+
+    ui.set_rect_x(3);
+    let mut line_buffer = vec![Rgb8Pixel::new(0x55, 0x55, 0x55); WIDTH * HEIGHT];
+    render_frame_by_line(&window, &mut line_buffer, true);
+    assert_frame(&line_buffer, 3);
+
+    ui.set_rect_x(5);
+    render_frame_by_line(&window, &mut line_buffer, false);
+    assert_frame(&line_buffer, 5);
+}

--- a/api/rs/slint/tests/dirty_region_alignment_rotated.rs
+++ b/api/rs/slint/tests/dirty_region_alignment_rotated.rs
@@ -1,0 +1,104 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::rc::Rc;
+
+use slint::Rgb8Pixel;
+use slint::platform::software_renderer::{
+    DirtyRegionAlignment, MinimalSoftwareWindow, PhysicalRegion, RenderingRotation,
+    RepaintBufferType,
+};
+use slint::platform::{PlatformError, WindowAdapter};
+
+// Window size; with Rotate90 the buffer is HEIGHT pixels wide and WIDTH lines tall.
+const WIDTH: usize = 16;
+const HEIGHT: usize = 8;
+
+struct TestPlatform(Rc<MinimalSoftwareWindow>);
+
+impl slint::platform::Platform for TestPlatform {
+    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+        Ok(self.0.clone())
+    }
+}
+
+// The 4×2 alignment applies to the panel (buffer) axes, which are the window axes swapped.
+// Using different values per axis catches an accidental axis swap in the implementation.
+fn assert_aligned(region: &PhysicalRegion) {
+    for (position, size) in region.iter() {
+        assert_eq!(position.x % 4, 0);
+        assert_eq!(position.y % 2, 0);
+        assert_eq!(size.width % 4, 0);
+        assert_eq!(size.height % 2, 0);
+    }
+}
+
+fn render_frame(window: &MinimalSoftwareWindow, buffer: &mut [Rgb8Pixel]) {
+    assert!(window.draw_if_needed(|renderer| {
+        renderer.set_rendering_rotation(RenderingRotation::Rotate90);
+        renderer.set_dirty_region_alignment(DirtyRegionAlignment::new(4, 2));
+        let region = renderer.render(buffer, HEIGHT);
+        assert_aligned(&region);
+    }));
+}
+
+// Rotate90 maps the window pixel (x, y) to the buffer pixel (HEIGHT - 1 - y, x).
+fn buffer_index(x: usize, y: usize) -> usize {
+    x * HEIGHT + (HEIGHT - 1 - y)
+}
+
+fn assert_frame(buffer: &[Rgb8Pixel], white_x: usize) {
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let expected = if x == white_x && y == 3 {
+                Rgb8Pixel::new(255, 255, 255)
+            } else if x == 2 && y == 3 {
+                Rgb8Pixel::new(0, 255, 0)
+            } else {
+                Rgb8Pixel::new(0, 0, 0)
+            };
+            assert_eq!(buffer[buffer_index(x, y)], expected, "unexpected pixel at ({x}, {y})");
+        }
+    }
+}
+
+#[test]
+fn alignment_uses_panel_axes_when_rotated() {
+    slint::slint! {
+        export component App inherits Window {
+            in property <int> rect-x: 3;
+            background: black;
+            Rectangle {
+                x: 2phx;
+                y: 3phx;
+                width: 1phx;
+                height: 1phx;
+                background: #00ff00;
+            }
+            Rectangle {
+                x: root.rect-x * 1phx;
+                y: 3phx;
+                width: 1phx;
+                height: 1phx;
+                background: white;
+            }
+        }
+    }
+
+    let window = MinimalSoftwareWindow::new(RepaintBufferType::ReusedBuffer);
+    slint::platform::set_platform(Box::new(TestPlatform(window.clone()))).unwrap();
+    let ui = App::new().unwrap();
+    window.set_size(slint::PhysicalSize::new(WIDTH as u32, HEIGHT as u32));
+    ui.show().unwrap();
+
+    let mut buffer = vec![Rgb8Pixel::new(0x55, 0x55, 0x55); WIDTH * HEIGHT];
+
+    render_frame(&window, &mut buffer);
+    assert_frame(&buffer, 3);
+
+    for x in [5, 7, 9, 11] {
+        ui.set_rect_x(x as i32);
+        render_frame(&window, &mut buffer);
+        assert_frame(&buffer, x);
+    }
+}

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -50,7 +50,7 @@ use i_slint_core::partial_renderer::{DirtyRegion, PartialRenderingState};
 use i_slint_core::renderer::RendererSealed;
 use i_slint_core::textlayout::{AbstractFont, FontMetrics, TextParagraphLayout};
 use i_slint_core::window::{WindowAdapter, WindowInner};
-use i_slint_core::{Brush, Color, ImageInner, StaticTextures};
+use i_slint_core::{Brush, Color, Coord, ImageInner, StaticTextures};
 #[allow(unused)]
 use num_traits::Float;
 use num_traits::NumCast;
@@ -299,13 +299,101 @@ impl PhysicalRegion {
     }
 }
 
+/// Aligns software-renderer dirty regions to a physical pixel grid.
+///
+/// Some display controllers require the origin and size of address windows to be multiples of a
+/// fixed number of pixels.
+/// The default alignment of one pixel on each axis preserves the renderer's existing behavior.
+///
+/// The physical screen width must be a multiple of the horizontal alignment, and the physical
+/// screen height must be a multiple of the vertical alignment.
+/// This applies after [`RenderingRotation`] transforms the screen.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct DirtyRegionAlignment {
+    horizontal: u16,
+    vertical: u16,
+}
+
+impl Default for DirtyRegionAlignment {
+    fn default() -> Self {
+        Self { horizontal: 1, vertical: 1 }
+    }
+}
+
+impl DirtyRegionAlignment {
+    /// Creates a physical dirty-region alignment.
+    ///
+    /// Values of zero are treated as one.
+    pub fn new(horizontal: u16, vertical: u16) -> Self {
+        Self { horizontal: horizontal.max(1), vertical: vertical.max(1) }
+    }
+
+    /// Returns the horizontal alignment in physical pixels.
+    pub fn horizontal(self) -> u16 {
+        self.horizontal
+    }
+
+    /// Returns the vertical alignment in physical pixels.
+    pub fn vertical(self) -> u16 {
+        self.vertical
+    }
+}
+
+fn expand_dirty_region_for_alignment(
+    dirty_region: &DirtyRegion,
+    factor: ScaleFactor,
+    rotation: RenderingRotation,
+    alignment: DirtyRegionAlignment,
+) -> DirtyRegion {
+    let (horizontal, vertical) = if rotation.is_transpose() {
+        (alignment.vertical(), alignment.horizontal())
+    } else {
+        (alignment.horizontal(), alignment.vertical())
+    };
+    let factor = factor.get();
+    // Inflating by the full alignment is deliberately more than the `alignment - 1` pixels that
+    // snapping can add on each side: it stays a superset after the logical-to-physical rounding
+    // and is cheaper than inverse-mapping the snapped physical region back to logical space.
+    let horizontal = (horizontal as f32 / factor).ceil() as Coord;
+    let vertical = (vertical as f32 / factor).ceil() as Coord;
+    let mut expanded = DirtyRegion::default();
+    for dirty_box in dirty_region.iter() {
+        expanded.add_box(dirty_box.inflate(horizontal, vertical));
+    }
+    expanded
+}
+
+fn snap_interval_to_grid(min: i16, max: i16, granularity: u16, limit: i16) -> (i16, i16) {
+    let granularity = granularity as i32;
+    let min = min as i32;
+    let max = max as i32;
+    let limit = limit as i32;
+    let snapped_min = min.div_euclid(granularity) * granularity;
+    // The clamp can leave the extent unaligned when the screen size is not a multiple of the
+    // granularity; that configuration is rejected by the debug_assert in to_physical_region,
+    // and this is the release-mode fallback for it.
+    let snapped_max = ((max + granularity - 1).div_euclid(granularity) * granularity).min(limit);
+    (snapped_min as i16, snapped_max as i16)
+}
+
 fn to_physical_region(
     dirty_region: &DirtyRegion,
     factor: ScaleFactor,
     rotation: RotationInfo,
     size: PhysicalSize,
+    alignment: DirtyRegionAlignment,
 ) -> PhysicalRegion {
     let screen_rect = PhysicalRect::from_size(size);
+    let panel_size = size.transformed(rotation);
+    debug_assert!(
+        panel_size.width <= 0 || panel_size.width as i32 % alignment.horizontal() as i32 == 0,
+        "the screen width must be a multiple of the horizontal dirty-region alignment"
+    );
+    debug_assert!(
+        panel_size.height <= 0 || panel_size.height as i32 % alignment.vertical() as i32 == 0,
+        "the screen height must be a multiple of the vertical dirty-region alignment"
+    );
+
     let mut physical_region = PhysicalRegion::default();
     for dirty_box in dirty_region.iter() {
         let Some(rect) =
@@ -313,12 +401,28 @@ fn to_physical_region(
         else {
             continue;
         };
-        let physical_box = rect.transformed(rotation).to_box2d();
-        if physical_box.is_empty() {
+        let mut aligned_box = rect.transformed(rotation).to_box2d();
+        if alignment.horizontal() > 1 {
+            (aligned_box.min.x, aligned_box.max.x) = snap_interval_to_grid(
+                aligned_box.min.x,
+                aligned_box.max.x,
+                alignment.horizontal(),
+                panel_size.width,
+            );
+        }
+        if alignment.vertical() > 1 {
+            (aligned_box.min.y, aligned_box.max.y) = snap_interval_to_grid(
+                aligned_box.min.y,
+                aligned_box.max.y,
+                alignment.vertical(),
+                panel_size.height,
+            );
+        }
+        if aligned_box.is_empty() {
             continue;
         }
         debug_assert!(physical_region.count < PHYSICAL_REGION_MAX_SIZE);
-        physical_region.rectangles[physical_region.count] = physical_box;
+        physical_region.rectangles[physical_region.count] = aligned_box;
         physical_region.count += 1;
     }
     physical_region
@@ -360,6 +464,55 @@ fn region_iter() {
 }
 
 #[test]
+fn dirty_region_alignment_snaps_minimal_region() {
+    use i_slint_core::lengths::LogicalRect;
+
+    let factor = ScaleFactor::new(1.0);
+    let size = euclid::size2(64, 64);
+    let rotation = RotationInfo { orientation: RenderingRotation::NoRotation, screen_size: size };
+    let mut dirty_region = DirtyRegion::default();
+    dirty_region.add_rect(LogicalRect::new(euclid::point2(3.0, 5.0), euclid::size2(7.0, 9.0)));
+
+    let aligned =
+        to_physical_region(&dirty_region, factor, rotation, size, DirtyRegionAlignment::new(2, 2));
+    assert_eq!(aligned.count, 1);
+    assert_eq!(aligned.rectangles[0].min, euclid::point2(2, 4));
+    assert_eq!(aligned.rectangles[0].max, euclid::point2(10, 14));
+
+    let unaligned = to_physical_region(&dirty_region, factor, rotation, size, Default::default());
+    assert_eq!(unaligned.count, 1);
+    assert_eq!(unaligned.rectangles[0].min, euclid::point2(3, 5));
+    assert_eq!(unaligned.rectangles[0].max, euclid::point2(10, 14));
+}
+
+#[test]
+fn dirty_region_alignment_uses_rotated_panel_axes() {
+    use i_slint_core::lengths::LogicalRect;
+
+    let factor = ScaleFactor::new(1.0);
+    let size = euclid::size2(80, 40);
+    let rotation = RotationInfo { orientation: RenderingRotation::Rotate90, screen_size: size };
+    let alignment = DirtyRegionAlignment::new(4, 8);
+    let mut dirty_region = DirtyRegion::default();
+    dirty_region.add_rect(LogicalRect::new(euclid::point2(70.0, 30.0), euclid::size2(7.0, 7.0)));
+
+    let aligned = to_physical_region(&dirty_region, factor, rotation, size, alignment);
+    assert_eq!(aligned.count, 1);
+    assert_eq!(aligned.rectangles[0].min, euclid::point2(0, 64));
+    assert_eq!(aligned.rectangles[0].max, euclid::point2(12, 80));
+
+    let expanded = expand_dirty_region_for_alignment(
+        &dirty_region,
+        factor,
+        RenderingRotation::Rotate90,
+        alignment,
+    );
+    let expanded_box = expanded.iter().next().unwrap();
+    assert_eq!(expanded_box.min, euclid::point2(62.0, 26.0));
+    assert_eq!(expanded_box.max, euclid::point2(85.0, 41.0));
+}
+
+#[test]
 fn physical_region_count_excludes_clipped_rectangles() {
     use i_slint_core::lengths::LogicalRect;
 
@@ -371,7 +524,7 @@ fn physical_region_count_excludes_clipped_rectangles() {
         .add_rect(LogicalRect::new(euclid::point2(100.0, 100.0), euclid::size2(10.0, 10.0)));
     dirty_region.add_rect(LogicalRect::new(euclid::point2(3.0, 5.0), euclid::size2(7.0, 9.0)));
 
-    let physical = to_physical_region(&dirty_region, factor, rotation, size);
+    let physical = to_physical_region(&dirty_region, factor, rotation, size, Default::default());
     assert_eq!(physical.count, 1);
     assert_eq!(physical.rectangles[0].min, euclid::point2(3, 5));
     assert_eq!(physical.rectangles[0].max, euclid::point2(10, 14));
@@ -481,6 +634,7 @@ impl<'a, T: TargetPixel> target_pixel_buffer::TargetPixelBuffer for TargetPixelS
 ///     in one single buffer
 pub struct SoftwareRenderer {
     repaint_buffer_type: Cell<RepaintBufferType>,
+    dirty_region_alignment: Cell<DirtyRegionAlignment>,
     /// This is the area which was dirty on the previous frame.
     /// Only used if repaint_buffer_type == RepaintBufferType::SwappedBuffers
     prev_frame_dirty: Cell<DirtyRegion>,
@@ -497,6 +651,7 @@ impl Default for SoftwareRenderer {
         Self {
             partial_rendering_state: Default::default(),
             prev_frame_dirty: Default::default(),
+            dirty_region_alignment: Default::default(),
             maybe_window_adapter: Default::default(),
             rotation: Default::default(),
             rendering_metrics_collector: RenderingMetricsCollector::new("software"),
@@ -542,6 +697,20 @@ impl SoftwareRenderer {
     /// Returns the kind of buffer that must be passed to  [`Self::render`]
     pub fn repaint_buffer_type(&self) -> RepaintBufferType {
         self.repaint_buffer_type.get()
+    }
+
+    /// Aligns dirty regions to the specified physical pixel grid.
+    ///
+    /// Use this for display controllers that require aligned address windows.
+    /// The screen dimensions must be multiples of their corresponding alignment after applying
+    /// [`RenderingRotation`].
+    pub fn set_dirty_region_alignment(&self, alignment: DirtyRegionAlignment) {
+        self.dirty_region_alignment.set(alignment);
+    }
+
+    /// Returns the physical pixel alignment for dirty regions.
+    pub fn dirty_region_alignment(&self) -> DirtyRegionAlignment {
+        self.dirty_region_alignment.get()
     }
 
     /// Set how the window need to be rotated in the buffer.
@@ -687,9 +856,8 @@ impl SoftwareRenderer {
                     }
                 }
 
-                let rotation = RotationInfo { orientation: rotation, screen_size: size };
                 let dirty_region =
-                    to_physical_region(&renderer.dirty_region, factor, rotation, size);
+                    self.align_dirty_region(&mut renderer.dirty_region, factor, size);
 
                 renderer.actual_renderer.processor.dirty_region = dirty_region.clone();
                 if !renderer
@@ -732,6 +900,36 @@ impl SoftwareRenderer {
                 dirty_region
             })
             .unwrap_or_default()
+    }
+
+    /// Converts the logical dirty region to the physical region to render, applying the
+    /// configured [`DirtyRegionAlignment`], and expands the logical dirty region in place so
+    /// that the partial renderer repaints every pixel the alignment added.
+    ///
+    /// For `SwappedBuffers`, `prev_frame_dirty` intentionally keeps the unexpanded region:
+    /// the next frame starts from a superset of it and re-applies the expansion.
+    fn align_dirty_region(
+        &self,
+        dirty_region: &mut DirtyRegion,
+        factor: ScaleFactor,
+        size: PhysicalSize,
+    ) -> PhysicalRegion {
+        let alignment = self.dirty_region_alignment.get();
+        let rotation = self.rotation.get();
+        let physical_region = to_physical_region(
+            dirty_region,
+            factor,
+            RotationInfo { orientation: rotation, screen_size: size },
+            size,
+            alignment,
+        );
+        if alignment != DirtyRegionAlignment::default()
+            && self.repaint_buffer_type.get() != RepaintBufferType::NewBuffer
+        {
+            *dirty_region =
+                expand_dirty_region_for_alignment(dirty_region, factor, rotation, alignment);
+        }
+        physical_region
     }
 
     fn measure_frame_rendered(&self, renderer: &mut dyn ItemRenderer) {
@@ -1573,9 +1771,8 @@ fn prepare_scene(
             }
         }
 
-        let rotation =
-            RotationInfo { orientation: software_renderer.rotation.get(), screen_size: size };
-        dirty_region = to_physical_region(&renderer.dirty_region, factor, rotation, size);
+        dirty_region =
+            software_renderer.align_dirty_region(&mut renderer.dirty_region, factor, size);
 
         let partial = software_renderer.repaint_buffer_type.get() != RepaintBufferType::NewBuffer;
         for (component, origin) in components {

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -299,6 +299,31 @@ impl PhysicalRegion {
     }
 }
 
+fn to_physical_region(
+    dirty_region: &DirtyRegion,
+    factor: ScaleFactor,
+    rotation: RotationInfo,
+    size: PhysicalSize,
+) -> PhysicalRegion {
+    let screen_rect = PhysicalRect::from_size(size);
+    let mut physical_region = PhysicalRegion::default();
+    for dirty_box in dirty_region.iter() {
+        let Some(rect) =
+            (dirty_box.cast() * factor).to_rect().round_out().cast().intersection(&screen_rect)
+        else {
+            continue;
+        };
+        let physical_box = rect.transformed(rotation).to_box2d();
+        if physical_box.is_empty() {
+            continue;
+        }
+        debug_assert!(physical_region.count < PHYSICAL_REGION_MAX_SIZE);
+        physical_region.rectangles[physical_region.count] = physical_box;
+        physical_region.count += 1;
+    }
+    physical_region
+}
+
 #[test]
 fn region_iter() {
     let mut region = PhysicalRegion::default();
@@ -332,6 +357,24 @@ fn region_iter() {
     assert_eq!(iter.next(), Some(r(0, 10, 10, 5)));
     assert_eq!(iter.next(), Some(r(6, 15, 3, 7)));
     assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn physical_region_count_excludes_clipped_rectangles() {
+    use i_slint_core::lengths::LogicalRect;
+
+    let factor = ScaleFactor::new(1.0);
+    let size = euclid::size2(64, 64);
+    let rotation = RotationInfo { orientation: RenderingRotation::NoRotation, screen_size: size };
+    let mut dirty_region = DirtyRegion::default();
+    dirty_region
+        .add_rect(LogicalRect::new(euclid::point2(100.0, 100.0), euclid::size2(10.0, 10.0)));
+    dirty_region.add_rect(LogicalRect::new(euclid::point2(3.0, 5.0), euclid::size2(7.0, 9.0)));
+
+    let physical = to_physical_region(&dirty_region, factor, rotation, size);
+    assert_eq!(physical.count, 1);
+    assert_eq!(physical.rectangles[0].min, euclid::point2(3, 5));
+    assert_eq!(physical.rectangles[0].max, euclid::point2(10, 14));
 }
 
 /// Computes what are the x ranges that intersects the region for specified y line.
@@ -645,21 +688,8 @@ impl SoftwareRenderer {
                 }
 
                 let rotation = RotationInfo { orientation: rotation, screen_size: size };
-                let screen_rect = PhysicalRect::from_size(size);
-                let mut i = renderer.dirty_region.iter().filter_map(|r| {
-                    (r.cast() * factor)
-                        .to_rect()
-                        .round_out()
-                        .cast()
-                        .intersection(&screen_rect)?
-                        .transformed(rotation)
-                        .into()
-                });
-                let dirty_region = PhysicalRegion {
-                    rectangles: core::array::from_fn(|_| i.next().unwrap_or_default().to_box2d()),
-                    count: renderer.dirty_region.iter().count(),
-                };
-                drop(i);
+                let dirty_region =
+                    to_physical_region(&renderer.dirty_region, factor, rotation, size);
 
                 renderer.actual_renderer.processor.dirty_region = dirty_region.clone();
                 if !renderer
@@ -1545,21 +1575,7 @@ fn prepare_scene(
 
         let rotation =
             RotationInfo { orientation: software_renderer.rotation.get(), screen_size: size };
-        let screen_rect = PhysicalRect::from_size(size);
-        let mut i = renderer.dirty_region.iter().filter_map(|r| {
-            (r.cast() * factor)
-                .to_rect()
-                .round_out()
-                .cast()
-                .intersection(&screen_rect)?
-                .transformed(rotation)
-                .into()
-        });
-        dirty_region = PhysicalRegion {
-            rectangles: core::array::from_fn(|_| i.next().unwrap_or_default().to_box2d()),
-            count: renderer.dirty_region.iter().count(),
-        };
-        drop(i);
+        dirty_region = to_physical_region(&renderer.dirty_region, factor, rotation, size);
 
         let partial = software_renderer.repaint_buffer_type.get() != RepaintBufferType::NewBuffer;
         for (component, origin) in components {


### PR DESCRIPTION
Some display controllers cannot program arbitrary GRAM address windows: the CO5300, SH8601A, RM67162 and RM690B0 require both the start coordinate and the extent of the address window to be even on each axis. The CO5300 spec states it per axis, in §7.5.21 CASET (2Ah) and §7.5.22 RASET (2Bh): "The SC[9:0] and EC[9:0]-SC[9:0]+1 must can be divisible by 2" ([datasheet](https://files.waveshare.com/wiki/common/Co5300_Datasheet.pdf)). Packed transports impose their own granularity: an eight-pixel horizontal grid for byte-addressed e-paper, and eight vertical pixels per byte for page-addressed monochrome OLEDs such as the SSD1306.

With `render()` into a full framebuffer, a platform can round the returned rectangles outward itself: after `render()` the buffer holds a complete frame in all three `RepaintBufferType` modes, so the added pixels are valid. What it cannot do is get this right by accident. The easy mistake is rounding only the start coordinate and leaving the extent odd, and the platform has to redo the panel-axis mapping that the renderer already does for `RenderingRotation`.

With `render_by_line()` there is no way to fix it up at all. `process_line` hands out only the dirty span of each line, so the pixels a widened address window needs were never rendered. That is the e-paper, SSD1306 and SPI-streaming case.

This repository already has a board with the constraint: `waveshare_esp32_s3_touch_amoled_1_8` (SH8601) discards the returned region and pushes every pixel of the frame through `embedded_graphics::draw_iter`, so it gets no partial rendering at all.

This PR adds an opt-in per-axis alignment grid to the software renderer. The default of 1×1 keeps the existing behavior. Screen dimensions must be multiples of the configured alignment, checked with a `debug_assert`; in release builds the block at the far edge is clipped to the screen.

The PR is two commits:

**Commit 1** is a standalone fix. `to_physical_region` clipped each rectangle to the screen but still counted the ones that ended up empty. `bounding_rect()` is unaffected, because `Box2D::union` skips empty boxes, but `Scene::new` takes its start line from `iter_box()`, which does not: the scene starts at line 0 instead of the first dirty line, retains and sorts items for a line that is never rendered, and trips the `debug_assert_eq!` comparing `current_line` with the bounding rectangle's origin. The commit also removes the duplication @ogoffart pointed at: the region conversion and the `RepaintBufferType` handling above it were copied between `render_buffer_impl` and `prepare_scene`, and both now go through `SoftwareRenderer::compute_frame_dirty_region`.

**Commit 2** is the alignment feature:

- Add `DirtyRegionAlignment` and `SoftwareRenderer::set_dirty_region_alignment()` / `dirty_region_alignment()` to the Rust API
- Expand the logical dirty region before partial rendering so the pixels added by alignment are actually repainted, in both the `render()` and `render_by_line()` paths
- Snap the resulting physical region to the grid in panel coordinates, that is after `RenderingRotation`, so rotated screens align on the panel's native axes
- Expose the setting in the C++ platform API as `SoftwareRenderer::set_dirty_region_alignment(horizontal, vertical)`
- Unit tests for grid snapping, rotated panel axes, a fractional scale factor and a non-power-of-two grid. End-to-end tests that render into garbage-initialized buffers and check the expanded pixels, covering line-buffer, reused-buffer and swapped-buffers modes, `Rotate90` with an asymmetric 4×2 grid that would catch an axis swap, and the block at the far edge of the panel. The line-buffer test also asserts that the `range` handed to `process_line` is aligned, which is what the streaming displays consume.

## Testing

Verified on physical hardware with a CO5300-driven Waveshare ESP32-S3-Touch-AMOLED-2.16 (480×480 AMOLED, QSPI, RGB565 partial uploads from a PSRAM framebuffer) using a 2×2 alignment: https://github.com/okhsunrog/waveshare-esp32s3-amoled-2-16. Both the full-frame and aligned partial-frame upload paths render correctly on the panel; an odd start or odd extent on either axis does not.
