### PR TITLE
codegen: Re-evaluate repeated bindings when a callback handler changes

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3509,7 +3509,7 @@ fn generate_public_api_for_properties(
                 format!("{}.set_handler(std::forward<Functor>(callback_handler));", access),
             ];
             if let Some(t) = &tracker {
-                on_stmts.push(format!("{t}.mark_dirty();"));
+                on_stmts.push(t.then(|x| format!("{x}.mark_dirty();")));
             }
             declarations.push((
                 Access::Public,
@@ -3656,14 +3656,20 @@ fn access_window_field(ctx: &EvaluationContext) -> String {
     format!("{}->window().window_handle()", ctx.generator_state.global_access)
 }
 
+/// Walks up `parent_level` parent pointers, starting from `self`.
+fn parent_access_path(parent_level: usize) -> MemberAccess {
+    let mut path = MemberAccess::Direct("self".to_string());
+    for _ in 0..parent_level {
+        path = path.and_then(|x| format!("{x}->parent.lock()"));
+    }
+    path
+}
+
 /// Returns the code that can access the given property (but without the set or get)
 fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> MemberAccess {
     match reference {
         llr::MemberReference::Relative { parent_level, local_reference } => {
-            let mut path = MemberAccess::Direct("self".to_string());
-            for _ in 0..*parent_level {
-                path = path.and_then(|x| format!("{x}->parent.lock()"));
-            }
+            let path = parent_access_path(*parent_level);
             if let Some(sub_component) = ctx.parent_sub_component_idx(*parent_level) {
                 let (compo_path, sub_component) = follow_sub_component_path(
                     ctx.compilation_unit,
@@ -3781,17 +3787,17 @@ fn field_name(name: &str) -> SmolStr {
 fn access_callback_tracker_cpp(
     reference: &llr::MemberReference,
     ctx: &EvaluationContext,
-) -> Option<String> {
+) -> Option<MemberAccess> {
     fn in_global(
         g: &llr::GlobalComponent,
         callback_idx: &llr::CallbackIdx,
         self_: &str,
-    ) -> Option<String> {
+    ) -> Option<MemberAccess> {
         if !g.callbacks[*callback_idx].needs_tracker {
             return None;
         }
         let tracker_name = callback_tracker_name(&g.callbacks[*callback_idx].name);
-        Some(format!("{self_}{tracker_name}"))
+        Some(MemberAccess::Direct(format!("{self_}{tracker_name}")))
     }
 
     match reference {
@@ -3808,22 +3814,25 @@ fn access_callback_tracker_cpp(
                 in_global(global, callback_idx, &format!("{global_access}->{global_id}->"))
             }
         }
-        llr::MemberReference::Relative { parent_level: 0, local_reference } => {
-            if let llr::LocalMemberIndex::Callback(callback_idx) = &local_reference.reference {
-                if let Some(current_global) = ctx.current_global() {
-                    return in_global(current_global, callback_idx, "this->");
-                }
-                if local_reference.sub_component_path.is_empty()
-                    && let Some(sc_idx) = ctx.parent_sub_component_idx(0)
-                {
-                    let sc = &ctx.compilation_unit.sub_components[sc_idx];
-                    if sc.callbacks[*callback_idx].needs_tracker {
-                        let tracker_name = callback_tracker_name(&sc.callbacks[*callback_idx].name);
-                        return Some(format!("self->{tracker_name}"));
-                    }
-                }
+        llr::MemberReference::Relative { parent_level, local_reference } => {
+            let llr::LocalMemberIndex::Callback(callback_idx) = &local_reference.reference else {
+                return None;
+            };
+            if let Some(current_global) = ctx.current_global() {
+                return in_global(current_global, callback_idx, "this->");
             }
-            None
+            let sc_idx = ctx.parent_sub_component_idx(*parent_level)?;
+            let (compo_path, sub_component) = follow_sub_component_path(
+                ctx.compilation_unit,
+                sc_idx,
+                &local_reference.sub_component_path,
+            );
+            if !sub_component.callbacks[*callback_idx].needs_tracker {
+                return None;
+            }
+            let tracker_name = callback_tracker_name(&sub_component.callbacks[*callback_idx].name);
+            let path = parent_access_path(*parent_level);
+            Some(path.with_member(format!("->{compo_path}{tracker_name}")))
         }
         _ => None,
     }
@@ -4019,7 +4028,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         Expression::CallBackCall { callback, arguments } => {
             let f = access_member(callback, ctx);
             let tracker_get = access_callback_tracker_cpp(callback, ctx)
-                .map(|t| format!("(void){t}.get(), "))
+                .map(|t| format!("(void)({}), ", t.get_property()))
                 .unwrap_or_default();
             let mut a = arguments.iter().map(|a| compile_expression(a, ctx));
             if expr.ty(ctx) == Type::Void {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -991,24 +991,36 @@ fn handle_property_init(
     }
 }
 
+/// Token stream that walks up `parent_level` parent pointers (`_self.parent.upgrade()...`),
+/// or `None` when `parent_level` is 0 (the member lives on the current component).
+fn parent_access_path(parent_level: usize) -> Option<TokenStream> {
+    (parent_level != 0).then(|| {
+        let mut path = quote!(_self.parent.upgrade());
+        for _ in 1..parent_level {
+            path = quote!(#path.and_then(|x| x.parent.upgrade()));
+        }
+        path
+    })
+}
+
 /// Returns the code to access the change-tracker `Property<()>` for an exported callback.
 /// Returns `None` if the callback doesn't have a tracker.
 fn access_callback_tracker(
     reference: &llr::MemberReference,
     ctx: &EvaluationContext,
-) -> Option<TokenStream> {
+) -> Option<MemberAccess> {
     fn in_global(
         g: &llr::GlobalComponent,
         callback_idx: &llr::CallbackIdx,
         _self: TokenStream,
-    ) -> Option<TokenStream> {
+    ) -> Option<MemberAccess> {
         if !g.callbacks[*callback_idx].needs_tracker {
             return None;
         }
         let tracker_name = callback_tracker_ident(&g.callbacks[*callback_idx].name);
         let global_name = global_inner_name(g);
         let tracker_field = quote!({ *&#global_name::FIELD_OFFSETS.#tracker_name() });
-        Some(quote!(#tracker_field.apply_pin(#_self)))
+        Some(MemberAccess::Direct(quote!(#tracker_field.apply_pin(#_self))))
     }
 
     match reference {
@@ -1027,26 +1039,33 @@ fn access_callback_tracker(
             };
             in_global(global, callback_idx, s)
         }
-        llr::MemberReference::Relative { parent_level: 0, local_reference } => {
-            if let llr::LocalMemberIndex::Callback(callback_idx) = &local_reference.reference {
-                if let Some(current_global) = ctx.current_global() {
-                    return in_global(current_global, callback_idx, quote!(_self));
-                }
-                if local_reference.sub_component_path.is_empty()
-                    && let Some(sc_idx) = ctx.parent_sub_component_idx(0)
-                {
-                    let sc = &ctx.compilation_unit.sub_components[sc_idx];
-                    if sc.callbacks[*callback_idx].needs_tracker {
-                        let tracker_name =
-                            callback_tracker_ident(&sc.callbacks[*callback_idx].name);
-                        let component_id = inner_component_id(sc);
-                        let tracker_field =
-                            access_component_field_offset(&component_id, &tracker_name);
-                        return Some(quote!((#tracker_field).apply_pin(_self)));
-                    }
-                }
+        llr::MemberReference::Relative { parent_level, local_reference } => {
+            let llr::LocalMemberIndex::Callback(callback_idx) = &local_reference.reference else {
+                return None;
+            };
+            if let Some(current_global) = ctx.current_global() {
+                return in_global(current_global, callback_idx, quote!(_self));
             }
-            None
+            let sc_idx = ctx.parent_sub_component_idx(*parent_level)?;
+            let (compo_path, sub_component) = follow_sub_component_path(
+                ctx.compilation_unit,
+                sc_idx,
+                &local_reference.sub_component_path,
+            );
+            if !sub_component.callbacks[*callback_idx].needs_tracker {
+                return None;
+            }
+            let tracker_name = callback_tracker_ident(&sub_component.callbacks[*callback_idx].name);
+            let component_id = inner_component_id(sub_component);
+            let tracker_field = access_component_field_offset(&component_id, &tracker_name);
+
+            let parent_path = parent_access_path(*parent_level);
+            Some(parent_path.map_or_else(
+                || MemberAccess::Direct(quote!((#compo_path #tracker_field).apply_pin(_self))),
+                |parent_path| {
+                    MemberAccess::Option(quote!(#parent_path.as_ref().map(|x| (#compo_path #tracker_field).apply_pin(x.as_pin_ref()))))
+                },
+            ))
         }
         _ => None,
     }
@@ -1079,8 +1098,8 @@ fn public_api(
             ));
             let on_ident = accessor_names::rust_accessor_ident(name, AccessorKind::Handler);
             let args_index = (0..callback_args.len()).map(proc_macro2::Literal::usize_unsuffixed);
-            let tracker_access = access_callback_tracker(&p.prop, ctx);
-            let set_dirty = tracker_access.map(|t| quote!(#t.mark_dirty();));
+            let set_dirty = access_callback_tracker(&p.prop, ctx)
+                .map(|t| t.then(|t| quote!({ #t.mark_dirty(); })));
             property_and_callback_accessors.push(quote!(
                 #[allow(dead_code)]
                 pub fn #on_ident(&self, mut f: impl FnMut(#(#callback_args),*) -> #return_type + 'static) {
@@ -2959,13 +2978,7 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                 return in_global(current_global, &local_reference.reference, quote!(_self));
             }
 
-            let parent_path = (*parent_level != 0).then(|| {
-                let mut path = quote!(_self.parent.upgrade());
-                for _ in 1..*parent_level {
-                    path = quote!(#path.and_then(|x| x.parent.upgrade()));
-                }
-                path
-            });
+            let parent_path = parent_access_path(*parent_level);
 
             match &local_reference.reference {
                 llr::LocalMemberIndex::Property(property_index) => {
@@ -3659,8 +3672,8 @@ fn compile_cast(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
 fn compile_callback_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
     let Expression::CallBackCall { callback, arguments } = expr else { unreachable!() };
     let f = access_member(callback, ctx);
-    let tracker = access_callback_tracker(callback, ctx);
-    let register_dep = tracker.map(|t| quote!(#t.get();));
+    let register_dep =
+        access_callback_tracker(callback, ctx).map(|t| t.then(|t| quote!({ #t.get(); })));
     let a = arguments.iter().map(|a| compile_expression_to_value(a, ctx));
     if expr.ty(ctx) == Type::Void {
         f.then(|f| quote!({ #register_dep #f.call(&(#(#a as _,)*)); }))

--- a/tests/cases/callbacks/callback_change_reevaluation_repeated.slint
+++ b/tests/cases/callbacks/callback_change_reevaluation_repeated.slint
@@ -1,0 +1,77 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test that setting a callback handler from native code triggers re-evaluation
+// of property bindings that invoke that callback from *inside a repeater*.
+// Regression test for https://github.com/slint-ui/slint/issues/12642
+
+export component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+
+    // A root callback invoked from a binding inside the repeater below.
+    pure callback cell-width(int) -> length;
+
+    in-out property <int> clicked-index: -1;
+
+    for idx in 3: TouchArea {
+        x: idx * 30phx;
+        y: 0;
+        width: root.cell-width(idx);
+        height: 100phx;
+        clicked => {
+            root.clicked-index = idx;
+        }
+    }
+
+    out property <bool> test: clicked-index == -1;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+// No handler installed: cell-width returns 0, so no TouchArea is hittable.
+slint_testing::send_mouse_click(&instance, 45., 50.);
+assert_eq(instance.get_clicked_index(), -1);
+
+// Install a handler: the width bindings inside the repeater must re-evaluate.
+instance.on_cell_width([](int) { return 30.; });
+slint_testing::send_mouse_click(&instance, 45., 50.);
+assert_eq(instance.get_clicked_index(), 1);
+slint_testing::send_mouse_click(&instance, 15., 50.);
+assert_eq(instance.get_clicked_index(), 0);
+slint_testing::send_mouse_click(&instance, 75., 50.);
+assert_eq(instance.get_clicked_index(), 2);
+
+// Change the handler: the bindings must re-evaluate again, back to width 0.
+instance.on_cell_width([](int) { return 0.; });
+instance.set_clicked_index(-1);
+slint_testing::send_mouse_click(&instance, 45., 50.);
+assert_eq(instance.get_clicked_index(), -1);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+
+// No handler installed: cell-width returns 0, so no TouchArea is hittable.
+slint_testing::send_mouse_click(&instance, 45., 50.);
+assert_eq!(instance.get_clicked_index(), -1);
+
+// Install a handler: the width bindings inside the repeater must re-evaluate.
+instance.on_cell_width(|_| 30.);
+slint_testing::send_mouse_click(&instance, 45., 50.);
+assert_eq!(instance.get_clicked_index(), 1);
+slint_testing::send_mouse_click(&instance, 15., 50.);
+assert_eq!(instance.get_clicked_index(), 0);
+slint_testing::send_mouse_click(&instance, 75., 50.);
+assert_eq!(instance.get_clicked_index(), 2);
+
+// Change the handler: the bindings must re-evaluate again, back to width 0.
+instance.on_cell_width(|_| 0.);
+instance.set_clicked_index(-1);
+slint_testing::send_mouse_click(&instance, 45., 50.);
+assert_eq!(instance.get_clicked_index(), -1);
+```
+*/


### PR DESCRIPTION
The callback change-tracker was only looked up for callbacks referenced directly from the root or a global (parent_level 0). A binding inside a repeater invokes a root callback through the parent chain, so no dependency was registered and changing the handler did not re-evaluate the repeated element. Handle any parent_level and sub_component_path in both the Rust and C++ generators.

Fixes: #12642