### PR TITLE
core: make visit_item_tree non-generic

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2464,11 +2464,15 @@ fn generate_item_tree(
             fn visit_children_item(self: ::core::pin::Pin<&Self>, index: isize, order: sp::TraversalOrder, visitor: sp::ItemVisitorRefMut<'_>)
                 -> sp::VisitChildrenResult
             {
-                return sp::visit_item_tree(self, &sp::VRcMapped::origin(&self.as_ref().self_weak.get().unwrap().upgrade().unwrap()), self.get_item_tree().as_slice(), index, order, visitor, visit_dynamic);
-                #[allow(unused)]
-                fn visit_dynamic(_self: ::core::pin::Pin<&#inner_component_id>, order: sp::TraversalOrder, visitor: sp::ItemVisitorRefMut<'_>, dyn_index: u32) -> sp::VisitChildrenResult  {
-                    _self.visit_dynamic_children(dyn_index, order, visitor)
-                }
+                let item_tree = sp::VRcMapped::origin(&self.as_ref().self_weak.get().unwrap().upgrade().unwrap());
+                sp::visit_item_tree(
+                    &item_tree,
+                    self.get_item_tree().as_slice(),
+                    index,
+                    order,
+                    visitor,
+                    &mut |order, visitor, dyn_index| self.visit_dynamic_children(dyn_index, order, visitor),
+                )
             }
 
             fn get_item_ref(self: ::core::pin::Pin<&Self>, index: u32) -> ::core::pin::Pin<sp::ItemRef<'_>> {

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1343,20 +1343,20 @@ fn visit_internal<State>(
 /// Visit the children within an array of ItemTreeNode
 ///
 /// The dynamic visitor is called for the dynamic nodes, its signature is
-/// `fn(base: &Base, visitor: vtable::VRefMut<ItemVisitorVTable>, dyn_index: usize)`
+/// `fn(order: TraversalOrder, visitor: vtable::VRefMut<ItemVisitorVTable>, dyn_index: u32)`.
+/// It is a `dyn` callback (capturing the component) rather than generic, so this function is
+/// not duplicated per component type.
 ///
 /// FIXME: the design of this use lots of indirection and stack frame in recursive functions
 /// Need to check if the compiler is able to optimize away some of it.
 /// Possibly we should generate code that directly call the visitor instead
-pub fn visit_item_tree<Base>(
-    base: Pin<&Base>,
+pub fn visit_item_tree(
     item_tree: &ItemTreeRc,
     item_tree_array: &[ItemTreeNode],
     index: isize,
     order: TraversalOrder,
     mut visitor: vtable::VRefMut<ItemVisitorVTable>,
-    visit_dynamic: impl Fn(
-        Pin<&Base>,
+    visit_dynamic: &mut dyn FnMut(
         TraversalOrder,
         vtable::VRefMut<ItemVisitorVTable>,
         u32,
@@ -1370,7 +1370,7 @@ pub fn visit_item_tree<Base>(
             }
             ItemTreeNode::DynamicTree { index, .. } => {
                 if let Some(sub_idx) =
-                    visit_dynamic(base, order, visitor.borrow_mut(), *index).aborted_index()
+                    visit_dynamic(order, visitor.borrow_mut(), *index).aborted_index()
                 {
                     VisitChildrenResult::abort(idx, sub_idx)
                 } else {
@@ -1455,14 +1455,14 @@ pub(crate) mod ffi {
             dyn_index: u32,
         ) -> VisitChildrenResult,
     ) -> VisitChildrenResult {
+        let base = VRc::as_pin_ref(item_tree).get_ref() as *const vtable::Dyn as *const c_void;
         crate::item_tree::visit_item_tree(
-            VRc::as_pin_ref(item_tree),
             item_tree,
             item_tree_array.as_slice(),
             index,
             order,
             visitor,
-            |a, b, c, d| visit_dynamic(a.get_ref() as *const vtable::Dyn as *const c_void, b, c, d),
+            &mut |order, visitor, dyn_index| visit_dynamic(base, order, visitor, dyn_index),
         )
     }
 }

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -811,13 +811,12 @@ extern "C" fn visit_children_item(
     let instance_ref = unsafe { InstanceRef::from_pin_ref(component, guard) };
     let comp_rc = instance_ref.self_weak().get().unwrap().upgrade().unwrap();
     i_slint_core::item_tree::visit_item_tree(
-        instance_ref.instance,
         &vtable::VRc::into_dyn(comp_rc),
         get_item_tree(component).as_slice(),
         index,
         order,
         v,
-        |_, order, visitor, index| {
+        &mut |order, visitor, index| {
             if index as usize >= instance_ref.description.repeater.len() {
                 // Do nothing: We are ComponentContainer and Our parent already did all the work!
                 VisitChildrenResult::CONTINUE


### PR DESCRIPTION
visit_item_tree was generic over the component type only to hand it to the visit_dynamic callback for dynamic subtrees, so it was duplicated per component. Take the callback as a `&mut dyn FnMut` that captures the component instead, and drop the type parameter. The generated visit_children_item now passes a closure directly, replacing the forwarding function it used to pass, so there is no extra stack frame on the (recursive) traversal path.

visit_item_tree is now compiled once instead of ~460 KB per large UI. No ABI change (the C entry point keeps its signature); interpreter and FFI callers updated.