### PR TITLE
feat markdown rich

### DIFF
--- a/api/rs/slint/tests/styled_text.rs
+++ b/api/rs/slint/tests/styled_text.rs
@@ -22,10 +22,7 @@ fn styled_text_can_be_created_from_rust_markdown() {
     component.set_text(plain.clone());
     assert_eq!(component.get_text(), plain);
 
-    let error = slint::StyledText::from_markdown("# heading").unwrap_err();
-    let error = error.to_string();
-    assert!(
-        error.starts_with("Markdown headings are not supported"),
-        "unexpected markdown error: {error}"
-    );
+    let _heading = slint::StyledText::from_markdown("# heading").unwrap();
+
+    let _hr = slint::StyledText::from_markdown("---").unwrap();
 }

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -70,6 +70,7 @@ pub enum ParagraphBlock {
         body: alloc::vec::Vec<alloc::vec::Vec<TableCell>>,
         alignments: alloc::vec::Vec<TableAlignment>,
     },
+    CodeBlock { language: Option<alloc::string::String>, text: alloc::string::String },
 }
 
 /// Error returned by markdown styled text parsing
@@ -189,6 +190,7 @@ pub fn rich_text_content(block: &ParagraphBlock) -> Option<&RichText> {
         | ParagraphBlock::BlockQuote { content, .. } => Some(content),
         ParagraphBlock::HorizontalRule => None,
         ParagraphBlock::Table { .. } => None,
+        ParagraphBlock::CodeBlock { .. } => None,
     }
 }
 
@@ -324,7 +326,6 @@ fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String 
         Heading { .. } => "headings",
         // Image { .. } => "images",            // handled inline
         // BlockQuote(_) => "block quotes",     // handled inline
-        CodeBlock(_) => "code blocks",
         // Table(_) => "tables",
         HtmlBlock => "HTML blocks",
         // FootnoteDefinition(_) => "footnotes", // handled inline
@@ -385,7 +386,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
     let mut skip_until_depth: usize = 0;
 
     let mut in_table = false;
-    let mut _table_alignments: Vec<TableAlignment> = Vec::new();
+    let mut table_alignments: Vec<TableAlignment> = Vec::new();
     let mut table_header_rows: Vec<Vec<RichText>> = Vec::new();
     let mut table_body_rows: Vec<Vec<RichText>> = Vec::new();
     let mut table_current_row: Vec<RichText> = Vec::new();
@@ -397,7 +398,13 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
     let mut current_heading_level: Option<u8> = None;
     let mut block_quote_level: u32 = 0;
 
+    let mut code_block_language: Option<alloc::string::String> = None;
+    let mut code_block_text: Option<alloc::string::String> = None;
+
     let mut current_paragraph: Option<ParagraphBlock> = None;
+    let mut footnote_definitions: Vec<(alloc::string::String, alloc::vec::Vec<ParagraphBlock>)> = Vec::new();
+    let mut current_footnote_name: Option<alloc::string::String> = None;
+    let mut footnote_start_index: usize = 0;
 
     for (event, event_range) in parser.into_offset_iter() {
         let indentation = list_state_stack.len().saturating_sub(1) as _;
@@ -472,7 +479,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     columns: table_columns,
                     header,
                     body,
-                    alignments: alloc::vec::Vec::new(),
+                    alignments: core::mem::take(&mut table_alignments),
                 });
                 current_paragraph = None;
                 continue;
@@ -575,9 +582,14 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     pulldown_cmark::Tag::Superscript => Style::Superscript,
                     pulldown_cmark::Tag::Subscript => Style::Subscript,
 
-                    pulldown_cmark::Tag::Table(_) => {
+                    pulldown_cmark::Tag::Table(alignments) => {
                         in_table = true;
-                        _table_alignments = Vec::new();
+                        table_alignments = alignments.iter().map(|a| match a {
+                            pulldown_cmark::Alignment::None => TableAlignment::None,
+                            pulldown_cmark::Alignment::Left => TableAlignment::Left,
+                            pulldown_cmark::Alignment::Center => TableAlignment::Center,
+                            pulldown_cmark::Alignment::Right => TableAlignment::Right,
+                        }).collect();
                         table_header_rows = Vec::new();
                         table_body_rows = Vec::new();
                         table_current_row = Vec::new();
@@ -601,11 +613,33 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                         continue;
                     }
 
-                    pulldown_cmark::Tag::FootnoteDefinition(_) => {
-                        skip_until_depth = 1;
+                    pulldown_cmark::Tag::FootnoteDefinition(name) => {
+                        if let Some(paragraph) = current_paragraph.take() {
+                            paragraphs.push(paragraph);
+                        }
+                        current_footnote_name = Some(name.into());
+                        footnote_start_index = paragraphs.len();
                         continue;
                     }
                     pulldown_cmark::Tag::Image { .. } => {
+                        skip_end_count += 1;
+                        continue;
+                    }
+                    pulldown_cmark::Tag::CodeBlock(kind) => {
+                        if let Some(paragraph) =
+                            current_paragraph.replace(begin_paragraph(indentation, None))
+                        {
+                            paragraphs.push(paragraph);
+                        }
+                        let language = match kind {
+                            pulldown_cmark::CodeBlockKind::Fenced(lang) => {
+                                let l = lang.trim();
+                                if l.is_empty() { None } else { Some(l.into()) }
+                            }
+                            pulldown_cmark::CodeBlockKind::Indented => None,
+                        };
+                        code_block_language = language;
+                        code_block_text = Some(alloc::string::String::new());
                         skip_end_count += 1;
                         continue;
                     }
@@ -635,10 +669,36 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     table_current_cell.text.push_str(&text);
                     continue;
                 }
+                if let Some(ref mut code_text) = code_block_text {
+                    code_text.push_str(&text);
+                    continue;
+                }
                 let paragraph =
                     get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
 
                 substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
+            }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::FootnoteDefinition) => {
+                if let Some(name) = current_footnote_name.take() {
+                    if let Some(paragraph) = current_paragraph.take() {
+                        paragraphs.push(paragraph);
+                    }
+                    let footnote_paras: Vec<ParagraphBlock> =
+                        if footnote_start_index < paragraphs.len() {
+                            paragraphs.drain(footnote_start_index..).collect()
+                        } else {
+                            Vec::new()
+                        };
+                    footnote_definitions.push((name, footnote_paras));
+                }
+            }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::CodeBlock) => {
+                skip_end_count = skip_end_count.saturating_sub(1);
+                if let Some(text) = code_block_text.take() {
+                    let language = code_block_language.take();
+                    paragraphs.push(ParagraphBlock::CodeBlock { language, text });
+                }
+                continue;
             }
             pulldown_cmark::Event::End(_) => {
                 if in_table {
@@ -1009,6 +1069,17 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
         }
     } else if let Some(paragraph) = current_paragraph.take() {
         paragraphs.push(paragraph);
+    }
+
+    if !footnote_definitions.is_empty() {
+        paragraphs.push(ParagraphBlock::HorizontalRule);
+        for (name, content) in footnote_definitions {
+            let ref_text = alloc::format!("[{}] ", name);
+            let mut rt = RichText::default();
+            rt.text = ref_text;
+            paragraphs.push(ParagraphBlock::Text(rt));
+            paragraphs.extend(content);
+        }
     }
 
     (paragraphs, errors)
@@ -1532,10 +1603,21 @@ fn markdown_footnote_reference() {
         "Text with a footnote[^1]\n\n[^1]: The footnote content",
         &[]
     ));
-    assert_eq!(result.len(), 1);
+    assert_eq!(result.len(), 4);
     assert_eq!(result[0], ParagraphBlock::Text(RichText {
         text: "Text with a footnote[1]".into(),
         formatting: alloc::vec![FormattedSpan { range: 20..23, style: Style::Superscript }],
+        links: alloc::vec![],
+    }));
+    assert_eq!(result[1], ParagraphBlock::HorizontalRule);
+    assert_eq!(result[2], ParagraphBlock::Text(RichText {
+        text: "[1] ".into(),
+        formatting: alloc::vec![],
+        links: alloc::vec![],
+    }));
+    assert_eq!(result[3], ParagraphBlock::Text(RichText {
+        text: "The footnote content".into(),
+        formatting: alloc::vec![],
         links: alloc::vec![],
     }));
 }
@@ -1565,6 +1647,53 @@ fn markdown_image() {
             formatting: alloc::vec![],
             links: alloc::vec![],
         })]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_code_block() {
+    let empty: &[&[ParagraphBlock]] = &[];
+    let result = assert_no_errors(parse_interpolated(
+        "Text before\n\n```\ncode block\n```\n\nText after",
+        empty,
+    ));
+    assert!(
+        result.iter().any(|b| matches!(b, ParagraphBlock::CodeBlock { text, .. } if text == "code block\n")),
+        "Expected a CodeBlock with text 'code block\\n', got: {result:?}"
+    );
+    let code_blocks: alloc::vec::Vec<_> = result.iter().filter(|b| matches!(b, ParagraphBlock::CodeBlock { .. })).collect();
+    assert_eq!(code_blocks.len(), 1);
+    if let ParagraphBlock::CodeBlock { language, .. } = &code_blocks[0] {
+        assert_eq!(*language, None);
+    }
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_code_block_with_language() {
+    let empty: &[&[ParagraphBlock]] = &[];
+    let result = assert_no_errors(parse_interpolated(
+        "```rust\nfn main() {}\n```",
+        empty,
+    ));
+    assert!(
+        result.iter().any(|b| matches!(b, ParagraphBlock::CodeBlock { language: Some(lang), text } if lang == "rust" && text.contains("fn main"))),
+        "Expected a CodeBlock with language 'rust' containing 'fn main', got: {result:?}"
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_code_block_indented() {
+    let empty: &[&[ParagraphBlock]] = &[];
+    let result = assert_no_errors(parse_interpolated(
+        "    indented code block",
+        empty,
+    ));
+    assert!(
+        result.iter().any(|b| matches!(b, ParagraphBlock::CodeBlock { .. })),
+        "Expected a CodeBlock, got: {result:?}"
     );
 }
 

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -339,7 +339,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
     );
 
     let mut list_state_stack: alloc::vec::Vec<Option<u64>> = alloc::vec::Vec::new();
-    let mut style_stack: alloc::vec::Vec<(Style, usize)> = alloc::vec::Vec::new();
+    let mut style_stack: alloc::vec::Vec<(Style, usize, bool)> = alloc::vec::Vec::new();
     let mut current_url = None;
     let mut arg_index = 0;
     let mut paragraphs = alloc::vec::Vec::new();
@@ -472,7 +472,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range)
                 else { unreachable!() };
 
-                style_stack.push((style, rt.text.len()));
+                style_stack.push((style, rt.text.len(), false));
             }
             pulldown_cmark::Event::Text(text) => {
                 let paragraph =
@@ -481,7 +481,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
             }
             pulldown_cmark::Event::End(_) => {
-                let (style, start) = if let Some(value) = style_stack.pop() {
+                let (style, start, _from_html) = if let Some(value) = style_stack.pop() {
                     value
                 } else if skip_end_count > 0 {
                     skip_end_count -= 1;
@@ -523,7 +523,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
             }
             pulldown_cmark::Event::InlineHtml(html) => {
                 if html.starts_with("</") {
-                    let (style, start) = if let Some(value) = style_stack.pop() {
+                    let (style, start, from_html) = if let Some(value) = style_stack.pop() {
                         value
                     } else if skip_end_count > 0 {
                         skip_end_count -= 1;
@@ -533,14 +533,28 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                         continue;
                     };
 
-                    let expected_tag = match &style {
-                        Style::Color(_) => "</font>",
-                        Style::Underline => "</u>",
+                    if !from_html {
+                        // The top of the stack is a markdown style, not
+                        // the expected HTML style. Push it back and report
+                        // an error instead of consuming it (issue #11563).
+                        style_stack.push((style, start, from_html));
+                        interleaved_count += 1;
+                        errors.push(StyledTextParseError::new(
+                            E::InterleavedStyles((&*html).into()),
+                            event_range.clone(),
+                        ));
+                        continue;
+                    }
+
+                    let is_valid_close = match &style {
+                        Style::Color(_) => (&*html) == "</font>",
+                        Style::Underline => (&*html) == "</u>",
+                        Style::Strikethrough => matches!(&*html, "</s>" | "</del>"),
+                        Style::Emphasis => matches!(&*html, "</i>" | "</em>"),
+                        Style::Strong => matches!(&*html, "</b>" | "</strong>"),
                         _ => {
-                            // The top of the stack is a markdown style, not
-                            // the expected HTML style. Push it back and report
-                            // an error instead of consuming it (issue #11563).
-                            style_stack.push((style, start));
+                            // HTML-pushed style we don't know how to close
+                            style_stack.push((style, start, from_html));
                             interleaved_count += 1;
                             errors.push(StyledTextParseError::new(
                                 E::InterleavedStyles((&*html).into()),
@@ -550,7 +564,15 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                         }
                     };
 
-                    if (&*html) != expected_tag {
+                    if !is_valid_close {
+                        let expected_tag = match &style {
+                            Style::Color(_) => "</font>",
+                            Style::Underline => "</u>",
+                            Style::Strikethrough => "</s> or </del>",
+                            Style::Emphasis => "</i> or </em>",
+                            Style::Strong => "</b> or </strong>",
+                            _ => unreachable!(),
+                        };
                         errors.push(StyledTextParseError::new(
                             E::ClosingTagMismatch(expected_tag.into(), (&*html).into()),
                             event_range.clone(),
@@ -586,10 +608,37 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                         &event_range,
                                     );
                                     let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
-                                    style_stack.push((Style::Underline, len));
+                                    style_stack.push((Style::Underline, len, true));
                                 }
                                 "font" => {
                                     expecting_color_attribute = true;
+                                }
+                                "s" | "del" => {
+                                    let paragraph = get_or_create_paragraph(
+                                        &mut current_paragraph,
+                                        &mut errors,
+                                        &event_range,
+                                    );
+                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    style_stack.push((Style::Strikethrough, len, true));
+                                }
+                                "i" | "em" => {
+                                    let paragraph = get_or_create_paragraph(
+                                        &mut current_paragraph,
+                                        &mut errors,
+                                        &event_range,
+                                    );
+                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    style_stack.push((Style::Emphasis, len, true));
+                                }
+                                "b" | "strong" => {
+                                    let paragraph = get_or_create_paragraph(
+                                        &mut current_paragraph,
+                                        &mut errors,
+                                        &event_range,
+                                    );
+                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    style_stack.push((Style::Strong, len, true));
                                 }
                                 _ => {
                                     let r = base + span.start()..base + span.end();
@@ -647,7 +696,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                                 &event_range,
                                             );
                                             let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
-                                            style_stack.push((Style::Color(value), len));
+                                            style_stack.push((Style::Color(value), len, true));
                                         }
                                         None => {
                                             let r = base + span.start()..base + span.end();
@@ -663,7 +712,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                                 &event_range,
                                             );
                                             let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
-                                            style_stack.push((Style::Color(0), len));
+                                            style_stack.push((Style::Color(0), len, true));
                                         }
                                     }
                                 }
@@ -833,6 +882,25 @@ new *line*
                 links: alloc::vec::Vec::new()
             })
         ]
+    );
+
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>(
+            "<s>strike</s> <i>italic</i> <b>bold</b> <del>del</del> <em>em</em> <strong>strong</strong>",
+            &[]
+        )),
+        [ParagraphBlock::Text(RichText {
+            text: "strike italic bold del em strong".into(),
+            formatting: alloc::vec![
+                FormattedSpan { range: 0..6, style: Style::Strikethrough },
+                FormattedSpan { range: 7..13, style: Style::Emphasis },
+                FormattedSpan { range: 14..18, style: Style::Strong },
+                FormattedSpan { range: 19..22, style: Style::Strikethrough },
+                FormattedSpan { range: 23..25, style: Style::Emphasis },
+                FormattedSpan { range: 26..32, style: Style::Strong },
+            ],
+            links: alloc::vec![],
+        })]
     );
 
     assert_eq!(

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -788,6 +788,8 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                         Style::Color(_) => (&*html) == "</font>",
                         Style::Underline => (&*html) == "</u>",
                         Style::Strikethrough => matches!(&*html, "</s>" | "</del>"),
+                        Style::Subscript => (&*html) == "</sub>",
+                        Style::Superscript => (&*html) == "</sup>",
                         Style::Emphasis => matches!(&*html, "</i>" | "</em>"),
                         Style::Strong => matches!(&*html, "</b>" | "</strong>"),
                         _ => {
@@ -877,6 +879,24 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                     );
                                     let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
                                     style_stack.push((Style::Strong, len, true));
+                                }
+                                "sub" => {
+                                    let paragraph = get_or_create_paragraph(
+                                        &mut current_paragraph,
+                                        &mut errors,
+                                        &event_range,
+                                    );
+                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    style_stack.push((Style::Subscript, len, true));
+                                }
+                                "sup" => {
+                                    let paragraph = get_or_create_paragraph(
+                                        &mut current_paragraph,
+                                        &mut errors,
+                                        &event_range,
+                                    );
+                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    style_stack.push((Style::Superscript, len, true));
                                 }
                                 _ => {
                                     let r = base + span.start()..base + span.end();
@@ -1694,6 +1714,22 @@ fn markdown_code_block_indented() {
     assert!(
         result.iter().any(|b| matches!(b, ParagraphBlock::CodeBlock { .. })),
         "Expected a CodeBlock, got: {result:?}"
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_html_sub_sup() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("H<sub>2</sub>O and E=mc<sup>2</sup>", &[])),
+        [ParagraphBlock::Text(RichText {
+            text: "H2O and E=mc2".into(),
+            formatting: alloc::vec![
+                FormattedSpan { range: 1..2, style: Style::Subscript },
+                FormattedSpan { range: 12..13, style: Style::Superscript },
+            ],
+            links: alloc::vec![],
+        })]
     );
 }
 

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -323,17 +323,9 @@ fn get_or_create_paragraph<'a>(
 fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String {
     use pulldown_cmark::Tag::*;
     match tag {
-        Heading { .. } => "headings",
-        // Image { .. } => "images",            // handled inline
-        // BlockQuote(_) => "block quotes",     // handled inline
-        // Table(_) => "tables",
         HtmlBlock => "HTML blocks",
-        // FootnoteDefinition(_) => "footnotes", // handled inline
         DefinitionList | DefinitionListTitle | DefinitionListDefinition => "definition lists",
-        // TableHead | TableRow | TableCell => "tables",
         MetadataBlock(_) => "metadata blocks",
-        // Superscript => "superscript",
-        // Subscript => "subscript",
         other => return alloc::format!("{:?}", other.to_end()),
     }
     .into()
@@ -343,10 +335,7 @@ fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String 
 fn unsupported_event_name(event: &pulldown_cmark::Event<'_>) -> alloc::string::String {
     use pulldown_cmark::Event::*;
     match event {
-        Rule => "horizontal rules".into(),
         TaskListMarker(_) => "task lists".into(),
-        // FootnoteReference(_) => "footnote references",   // handled inline
-        // InlineMath(_) | DisplayMath(_) => "math",        // handled inline
         Html(text) => alloc::format!("HTML blocks ({})", text.trim()),
         _ => alloc::format!("{event:?}"),
     }
@@ -760,6 +749,10 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 }
             }
             pulldown_cmark::Event::InlineHtml(html) => {
+                if in_table {
+                    table_current_cell.text.push_str(&html);
+                    continue;
+                }
                 if html.starts_with("</") {
                     let (style, start, from_html) = if let Some(value) = style_stack.pop() {
                         value

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -176,7 +176,7 @@ fn begin_paragraph(indentation: u32, list_item_type: Option<ListItemType>) -> Pa
             let remainder = indentation % 3;
             text.push_str(if remainder == 0 { "• " } else if remainder == 1 { "◦ " } else { "▪ " });
         }
-        Some(ListItemType::Ordered(num)) => text.push_str(&alloc::format!("{}. ", num)),
+        Some(ListItemType::Ordered(num)) => text.push_str(&alloc::format!("{:>3}. ", num)),
         None => {}
     };
     ParagraphBlock::Text(RichText { text, formatting: Default::default(), links: Default::default() })
@@ -1068,17 +1068,17 @@ fn markdown_parsing() {
         )),
         [
             ParagraphBlock::Text(RichText {
-                text: "1. a".into(),
+                text: "  1. a".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
             }),
             ParagraphBlock::Text(RichText {
-                text: "2. b".into(),
+                text: "  2. b".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
             }),
             ParagraphBlock::Text(RichText {
-                text: "3. c".into(),
+                text: "  3. c".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
             })

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -15,6 +15,7 @@ pub enum Style {
     Color(u32),
     Superscript,
     Subscript,
+    Math,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -40,12 +41,35 @@ pub struct RichText {
     pub links: alloc::vec::Vec<(core::ops::Range<usize>, alloc::string::String)>,
 }
 
+/// Column alignment for tables, matching pulldown_cmark::Alignment values.
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum TableAlignment {
+    #[default]
+    None,
+    Left,
+    Center,
+    Right,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TableCell {
+    pub content: RichText,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParagraphBlock {
     Text(RichText),
     /// level is 1-6
     Heading { level: u8, content: RichText },
+    /// level is the nesting depth (1 for `>`, 2 for `>>`, etc.)
+    BlockQuote { level: u8, content: RichText },
     HorizontalRule,
+    Table {
+        columns: usize,
+        header: alloc::vec::Vec<alloc::vec::Vec<TableCell>>,
+        body: alloc::vec::Vec<alloc::vec::Vec<TableCell>>,
+        alignments: alloc::vec::Vec<TableAlignment>,
+    },
 }
 
 /// Error returned by markdown styled text parsing
@@ -160,8 +184,11 @@ fn begin_paragraph(indentation: u32, list_item_type: Option<ListItemType>) -> Pa
 
 pub fn rich_text_content(block: &ParagraphBlock) -> Option<&RichText> {
     match block {
-        ParagraphBlock::Text(content) | ParagraphBlock::Heading { content, .. } => Some(content),
+        ParagraphBlock::Text(content)
+        | ParagraphBlock::Heading { content, .. }
+        | ParagraphBlock::BlockQuote { content, .. } => Some(content),
         ParagraphBlock::HorizontalRule => None,
+        ParagraphBlock::Table { .. } => None,
     }
 }
 
@@ -295,14 +322,14 @@ fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String 
     use pulldown_cmark::Tag::*;
     match tag {
         Heading { .. } => "headings",
-        Image { .. } => "images",
-        BlockQuote(_) => "block quotes",
+        // Image { .. } => "images",            // handled inline
+        // BlockQuote(_) => "block quotes",     // handled inline
         CodeBlock(_) => "code blocks",
-        Table(_) => "tables",
+        // Table(_) => "tables",
         HtmlBlock => "HTML blocks",
-        FootnoteDefinition(_) => "footnotes",
+        // FootnoteDefinition(_) => "footnotes", // handled inline
         DefinitionList | DefinitionListTitle | DefinitionListDefinition => "definition lists",
-        TableHead | TableRow | TableCell => "tables",
+        // TableHead | TableRow | TableCell => "tables",
         MetadataBlock(_) => "metadata blocks",
         // Superscript => "superscript",
         // Subscript => "subscript",
@@ -317,8 +344,8 @@ fn unsupported_event_name(event: &pulldown_cmark::Event<'_>) -> alloc::string::S
     match event {
         Rule => "horizontal rules".into(),
         TaskListMarker(_) => "task lists".into(),
-        FootnoteReference(_) => "footnote references".into(),
-        InlineMath(_) | DisplayMath(_) => "math".into(),
+        // FootnoteReference(_) => "footnote references",   // handled inline
+        // InlineMath(_) | DisplayMath(_) => "math",        // handled inline
         Html(text) => alloc::format!("HTML blocks ({})", text.trim()),
         _ => alloc::format!("{event:?}"),
     }
@@ -333,7 +360,10 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
 
     let parser = pulldown_cmark::Parser::new_ext(
         format_string,
-        pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+        pulldown_cmark::Options::ENABLE_TABLES
+            | pulldown_cmark::Options::ENABLE_FOOTNOTES
+            | pulldown_cmark::Options::ENABLE_MATH
+            | pulldown_cmark::Options::ENABLE_STRIKETHROUGH
             | pulldown_cmark::Options::ENABLE_SUBSCRIPT
             | pulldown_cmark::Options::ENABLE_SUPERSCRIPT,
     );
@@ -349,19 +379,52 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
     // we silently consume it instead of reporting a cascading Pop error.
     let mut skip_end_count: usize = 0;
     let mut interleaved_count: usize = 0;
+    // When > 0, we are inside a tag whose entire sub-tree should be skipped
+    // (e.g. FootnoteDefinition). Every Start/End event increments/decrements
+    // this depth; non-tag events (Text, Code, etc.) are silently consumed.
+    let mut skip_until_depth: usize = 0;
+
+    let mut in_table = false;
+    let mut _table_alignments: Vec<TableAlignment> = Vec::new();
+    let mut table_header_rows: Vec<Vec<RichText>> = Vec::new();
+    let mut table_body_rows: Vec<Vec<RichText>> = Vec::new();
+    let mut table_current_row: Vec<RichText> = Vec::new();
+    let mut table_current_cell: RichText = RichText::default();
+    let mut table_current_cell_style_stack: Vec<(Style, usize)> = Vec::new();
+    let mut in_table_head = false;
+    let mut table_columns = 0;
 
     let mut current_heading_level: Option<u8> = None;
+    let mut block_quote_level: u32 = 0;
 
     let mut current_paragraph: Option<ParagraphBlock> = None;
 
     for (event, event_range) in parser.into_offset_iter() {
         let indentation = list_state_stack.len().saturating_sub(1) as _;
 
+        if skip_until_depth > 0 {
+            match &event {
+                pulldown_cmark::Event::Start(_) => skip_until_depth += 1,
+                pulldown_cmark::Event::End(_) => skip_until_depth -= 1,
+                _ => {}
+            }
+            continue;
+        }
+
         match event {
             pulldown_cmark::Event::SoftBreak | pulldown_cmark::Event::HardBreak => {
                 if let Some(paragraph) =
                     current_paragraph.replace(begin_paragraph(indentation, None))
                 {
+                    if block_quote_level > 0 {
+                        if let ParagraphBlock::Text(content) = paragraph {
+                            paragraphs.push(ParagraphBlock::BlockQuote {
+                                level: block_quote_level as u8,
+                                content,
+                            });
+                            continue;
+                        }
+                    }
                     paragraphs.push(paragraph);
                 }
             }
@@ -372,6 +435,47 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     paragraphs.push(paragraph);
                 }
                 paragraphs.push(ParagraphBlock::HorizontalRule);
+            }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::TableCell) => {
+                table_current_row.push(core::mem::take(&mut table_current_cell));
+                table_current_cell_style_stack.clear();
+                continue;
+            }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::TableRow) => {
+                let row = core::mem::take(&mut table_current_row);
+                table_columns = table_columns.max(row.len());
+                if in_table_head {
+                    table_header_rows.push(row);
+                } else {
+                    table_body_rows.push(row);
+                }
+                continue;
+            }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::TableHead) => {
+                in_table_head = false;
+                if !table_current_row.is_empty() {
+                    table_header_rows.push(core::mem::take(&mut table_current_row));
+                }
+                continue;
+            }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::Table) => {
+                in_table = false;
+
+                let header: Vec<Vec<TableCell>> = table_header_rows.drain(..).map(|row| {
+                    row.into_iter().map(|content| TableCell { content }).collect()
+                }).collect();
+                let body: Vec<Vec<TableCell>> = table_body_rows.drain(..).map(|row| {
+                    row.into_iter().map(|content| TableCell { content }).collect()
+                }).collect();
+
+                paragraphs.push(ParagraphBlock::Table {
+                    columns: table_columns,
+                    header,
+                    body,
+                    alignments: alloc::vec::Vec::new(),
+                });
+                current_paragraph = None;
+                continue;
             }
             pulldown_cmark::Event::End(pulldown_cmark::TagEnd::List(_)) => {
                 if list_state_stack.pop().is_none() {
@@ -389,12 +493,33 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 }
                 current_paragraph = Some(begin_paragraph(indentation, None));
             }
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::BlockQuote(_)) => {
+                if let Some(paragraph) = current_paragraph.take() {
+                    if let ParagraphBlock::Text(content) = paragraph {
+                        paragraphs.push(ParagraphBlock::BlockQuote {
+                            level: block_quote_level as u8,
+                            content,
+                        });
+                    }
+                }
+                block_quote_level = block_quote_level.saturating_sub(1);
+                current_paragraph = None;
+            }
             pulldown_cmark::Event::Start(tag) => {
                 let style = match tag {
                     pulldown_cmark::Tag::Paragraph => {
                         if let Some(paragraph) =
                             current_paragraph.replace(begin_paragraph(indentation, None))
                         {
+                            if block_quote_level > 0 {
+                                if let ParagraphBlock::Text(content) = paragraph {
+                                    paragraphs.push(ParagraphBlock::BlockQuote {
+                                        level: block_quote_level as u8,
+                                        content,
+                                    });
+                                    continue;
+                                }
+                            }
                             paragraphs.push(paragraph);
                         }
                         continue;
@@ -428,15 +553,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     }
 
                     pulldown_cmark::Tag::BlockQuote(_) => {
-                        let mut r = event_range.clone();
-                        if let Some(pos) = format_string[r.clone()].find('>') {
-                            r.start += pos;
-                        }
-                        errors.push(StyledTextParseError::new(
-                            E::UnsupportedMarkdown(unsupported_tag_name(&tag)),
-                            r,
-                        ));
-                        skip_end_count += 1;
+                        block_quote_level += 1;
                         continue;
                     }
                     pulldown_cmark::Tag::HtmlBlock => {
@@ -458,6 +575,40 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     pulldown_cmark::Tag::Superscript => Style::Superscript,
                     pulldown_cmark::Tag::Subscript => Style::Subscript,
 
+                    pulldown_cmark::Tag::Table(_) => {
+                        in_table = true;
+                        _table_alignments = Vec::new();
+                        table_header_rows = Vec::new();
+                        table_body_rows = Vec::new();
+                        table_current_row = Vec::new();
+                        table_current_cell = RichText::default();
+                        table_current_cell_style_stack = Vec::new();
+                        in_table_head = false;
+                        table_columns = 0;
+                        continue;
+                    }
+                    pulldown_cmark::Tag::TableHead => {
+                        in_table_head = true;
+                        continue;
+                    }
+                    pulldown_cmark::Tag::TableRow => {
+                        table_current_row = Vec::new();
+                        continue;
+                    }
+                    pulldown_cmark::Tag::TableCell => {
+                        table_current_cell = RichText::default();
+                        table_current_cell_style_stack.clear();
+                        continue;
+                    }
+
+                    pulldown_cmark::Tag::FootnoteDefinition(_) => {
+                        skip_until_depth = 1;
+                        continue;
+                    }
+                    pulldown_cmark::Tag::Image { .. } => {
+                        skip_end_count += 1;
+                        continue;
+                    }
                     ref unsupported => {
                         errors.push(StyledTextParseError::new(
                             E::UnsupportedMarkdown(unsupported_tag_name(unsupported)),
@@ -468,19 +619,37 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     }
                 };
 
-                let ParagraphBlock::Text(rt) =
-                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range)
-                else { unreachable!() };
+                if in_table {
+                    let start = table_current_cell.text.len();
+                    table_current_cell_style_stack.push((style, start));
+                } else {
+                    let ParagraphBlock::Text(rt) =
+                        get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range)
+                    else { unreachable!() };
 
-                style_stack.push((style, rt.text.len(), false));
+                    style_stack.push((style, rt.text.len(), false));
+                }
             }
             pulldown_cmark::Event::Text(text) => {
+                if in_table {
+                    table_current_cell.text.push_str(&text);
+                    continue;
+                }
                 let paragraph =
                     get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
 
                 substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
             }
             pulldown_cmark::Event::End(_) => {
+                if in_table {
+                    if let Some((style, start)) = table_current_cell_style_stack.pop() {
+                        table_current_cell.formatting.push(FormattedSpan {
+                            range: start..table_current_cell.text.len(),
+                            style,
+                        });
+                    }
+                    continue;
+                }
                 let (style, start, _from_html) = if let Some(value) = style_stack.pop() {
                     value
                 } else if skip_end_count > 0 {
@@ -511,6 +680,15 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 }
             }
             pulldown_cmark::Event::Code(text) => {
+                if in_table {
+                    let start = table_current_cell.text.len();
+                    table_current_cell.text.push_str(&text);
+                    table_current_cell.formatting.push(FormattedSpan {
+                        range: start..table_current_cell.text.len(),
+                        style: Style::Code,
+                    });
+                    continue;
+                }
                 let paragraph =
                     get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
                 let start = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
@@ -751,11 +929,49 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     }
                 }
             }
-            pulldown_cmark::Event::TaskListMarker(_)
-            | pulldown_cmark::Event::FootnoteReference(_)
-            | pulldown_cmark::Event::InlineMath(_)
-            | pulldown_cmark::Event::DisplayMath(_)
-            | pulldown_cmark::Event::Html(_) => {
+            pulldown_cmark::Event::FootnoteReference(name) => {
+                let paragraph =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+                let start = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                let ref_text = alloc::format!("[{}]", name);
+                substitute(paragraph, &ref_text, args, &mut arg_index, &mut errors, &event_range);
+                if let ParagraphBlock::Text(rt) = paragraph {
+                    rt.formatting.push(FormattedSpan {
+                        range: start..rt.text.len(),
+                        style: Style::Superscript,
+                    });
+                }
+            }
+            pulldown_cmark::Event::InlineMath(text) => {
+                let paragraph =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+                let start = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
+                if let ParagraphBlock::Text(rt) = paragraph {
+                    rt.formatting.push(FormattedSpan {
+                        range: start..rt.text.len(),
+                        style: Style::Math,
+                    });
+                }
+            }
+            pulldown_cmark::Event::DisplayMath(text) => {
+                if let Some(paragraph) =
+                    current_paragraph.replace(begin_paragraph(indentation, None))
+                {
+                    paragraphs.push(paragraph);
+                }
+                let paragraph =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+                let start = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
+                if let ParagraphBlock::Text(rt) = paragraph {
+                    rt.formatting.push(FormattedSpan {
+                        range: start..rt.text.len(),
+                        style: Style::Math,
+                    });
+                }
+            }
+            pulldown_cmark::Event::TaskListMarker(_) | pulldown_cmark::Event::Html(_) => {
                 errors.push(StyledTextParseError::new(
                     E::UnsupportedMarkdown(unsupported_event_name(&event)),
                     event_range,
@@ -1220,6 +1436,50 @@ fn markdown_horizontal_rules() {
 
 #[cfg(feature = "markdown")]
 #[test]
+fn markdown_block_quote() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("> Block quote text", &[])),
+        [ParagraphBlock::BlockQuote {
+            level: 1,
+            content: RichText {
+                text: "Block quote text".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![],
+            }
+        }]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_block_quote_multi_paragraph() {
+    let result = assert_no_errors(parse_interpolated::<&[_]>(
+        "> First paragraph\n>\n> Second paragraph",
+        &[]
+    ));
+    assert_eq!(result.len(), 2);
+    assert!(matches!(result[0], ParagraphBlock::BlockQuote { level: 1, .. }));
+    assert!(matches!(result[1], ParagraphBlock::BlockQuote { level: 1, .. }));
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_block_quote_with_formatting() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("> *Italic* in quote", &[])),
+        [ParagraphBlock::BlockQuote {
+            level: 1,
+            content: RichText {
+                text: "Italic in quote".into(),
+                formatting: alloc::vec![FormattedSpan { range: 0..6, style: Style::Emphasis }],
+                links: alloc::vec![],
+            }
+        }]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
 fn markdown_mixed_heading_and_rules() {
     assert_eq!(
         assert_no_errors(parse_interpolated::<&[_]>("# Title\n\nContent\n\n---\n\n## Subtitle", &[])),
@@ -1232,5 +1492,66 @@ fn markdown_mixed_heading_and_rules() {
             ParagraphBlock::Heading { level: 2, content: RichText { text: "Subtitle".into(), formatting: alloc::vec![], links: alloc::vec![] } },
             ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
         ]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_table_simple() {
+    let result = assert_no_errors(parse_interpolated::<&[_]>(
+        "| H1 | H2 |\n| --- | --- |\n| A1 | A2 |",
+        &[]
+    ));
+    assert_eq!(result.len(), 1);
+    assert!(matches!(result[0], ParagraphBlock::Table { .. }));
+    if let ParagraphBlock::Table { columns, ref header, ref body, .. } = result[0] {
+        assert_eq!(columns, 2);
+        assert_eq!(header.len(), 1);
+        assert_eq!(body.len(), 1);
+        assert_eq!(header[0][0].content.text, "H1");
+        assert_eq!(body[0][0].content.text, "A1");
+    }
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_footnote_reference() {
+    let result = assert_no_errors(parse_interpolated::<&[_]>(
+        "Text with a footnote[^1]\n\n[^1]: The footnote content",
+        &[]
+    ));
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], ParagraphBlock::Text(RichText {
+        text: "Text with a footnote[1]".into(),
+        formatting: alloc::vec![FormattedSpan { range: 20..23, style: Style::Superscript }],
+        links: alloc::vec![],
+    }));
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_math_inline() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("Math: $E=mc^2$", &[])),
+        [ParagraphBlock::Text(RichText {
+            text: "Math: E=mc^2".into(),
+            formatting: alloc::vec![
+                FormattedSpan { range: 6..12, style: Style::Math },
+            ],
+            links: alloc::vec![],
+        })]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_image() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("An image ![alt text](url.png)", &[])),
+        [ParagraphBlock::Text(RichText {
+            text: "An image alt text".into(),
+            formatting: alloc::vec![],
+            links: alloc::vec![],
+        })]
     );
 }

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -719,7 +719,11 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
         errors.push(StyledTextParseError::without_range(E::UnterminatedTag));
     }
 
-    if let Some(paragraph) = current_paragraph.take() {
+    if let Some(level) = current_heading_level.take() {
+        if let Some(ParagraphBlock::Text(content)) = current_paragraph.take() {
+            paragraphs.push(ParagraphBlock::Heading { level, content });
+        }
+    } else if let Some(paragraph) = current_paragraph.take() {
         paragraphs.push(paragraph);
     }
 

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -903,6 +903,7 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                 }
                             },
                             Ok(htmlparser::Token::ElementEnd { .. }) => {}
+                            Ok(htmlparser::Token::Comment { .. }) => {}
                             _ => {
                                 errors.push(StyledTextParseError::new(
                                     E::UnsupportedMarkdown(alloc::format!("{:?}", token)),
@@ -971,7 +972,18 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                     });
                 }
             }
-            pulldown_cmark::Event::TaskListMarker(_) | pulldown_cmark::Event::Html(_) => {
+            pulldown_cmark::Event::Html(ref html) => {
+                // HTML comments <!-- ... --> are silently skipped
+                if html.starts_with("<!--") {
+                    // skip
+                } else {
+                    errors.push(StyledTextParseError::new(
+                        E::UnsupportedMarkdown(unsupported_event_name(&event)),
+                        event_range,
+                    ));
+                }
+            }
+            pulldown_cmark::Event::TaskListMarker(_) => {
                 errors.push(StyledTextParseError::new(
                     E::UnsupportedMarkdown(unsupported_event_name(&event)),
                     event_range,
@@ -1550,6 +1562,19 @@ fn markdown_image() {
         assert_no_errors(parse_interpolated::<&[_]>("An image ![alt text](url.png)", &[])),
         [ParagraphBlock::Text(RichText {
             text: "An image alt text".into(),
+            formatting: alloc::vec![],
+            links: alloc::vec![],
+        })]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_html_comment() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("before<!-- comment --> after", &[])),
+        [ParagraphBlock::Text(RichText {
+            text: "before after".into(),
             formatting: alloc::vec![],
             links: alloc::vec![],
         })]

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -13,6 +13,8 @@ pub enum Style {
     Underline,
     // ARGB encoded
     Color(u32),
+    Superscript,
+    Subscript,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -302,8 +304,8 @@ fn unsupported_tag_name(tag: &pulldown_cmark::Tag<'_>) -> alloc::string::String 
         DefinitionList | DefinitionListTitle | DefinitionListDefinition => "definition lists",
         TableHead | TableRow | TableCell => "tables",
         MetadataBlock(_) => "metadata blocks",
-        Superscript => "superscript",
-        Subscript => "subscript",
+        // Superscript => "superscript",
+        // Subscript => "subscript",
         other => return alloc::format!("{:?}", other.to_end()),
     }
     .into()
@@ -331,7 +333,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
 
     let parser = pulldown_cmark::Parser::new_ext(
         format_string,
-        pulldown_cmark::Options::ENABLE_STRIKETHROUGH,
+        pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+            | pulldown_cmark::Options::ENABLE_SUBSCRIPT
+            | pulldown_cmark::Options::ENABLE_SUPERSCRIPT,
     );
 
     let mut list_state_stack: alloc::vec::Vec<Option<u64>> = alloc::vec::Vec::new();
@@ -450,6 +454,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                         current_heading_level = Some(level as u8);
                         continue;
                     }
+
+                    pulldown_cmark::Tag::Superscript => Style::Superscript,
+                    pulldown_cmark::Tag::Subscript => Style::Subscript,
 
                     ref unsupported => {
                         errors.push(StyledTextParseError::new(
@@ -1095,6 +1102,22 @@ fn markdown_heading_with_inline() {
             },
             ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
         ]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_subscript_superscript() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("~sub~ and ^super^", &[])),
+        [ParagraphBlock::Text(RichText {
+            text: "sub and super".into(),
+            formatting: alloc::vec![
+                FormattedSpan { range: 0..3, style: Style::Subscript },
+                FormattedSpan { range: 8..13, style: Style::Superscript },
+            ],
+            links: alloc::vec![],
+        })]
     );
 }
 

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -744,11 +744,11 @@ fn assert_no_errors(
 fn markdown_parsing() {
     assert_eq!(
         assert_no_errors(parse_interpolated::<&[_]>("hello *world*", &[])),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan { range: 6..11, style: Style::Emphasis }],
             links: alloc::vec::Vec::new()
-        }]
+        })]
     );
 
     assert_eq!(
@@ -760,16 +760,16 @@ fn markdown_parsing() {
             &[]
         )),
         [
-            StyledTextParagraph {
+            ParagraphBlock::Text(RichText {
                 text: "• line 1".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            },
-            StyledTextParagraph {
+            }),
+            ParagraphBlock::Text(RichText {
                 text: "• line 2".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            }
+            })
         ]
     );
 
@@ -783,21 +783,21 @@ fn markdown_parsing() {
             &[]
         )),
         [
-            StyledTextParagraph {
+            ParagraphBlock::Text(RichText {
                 text: "1. a".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            },
-            StyledTextParagraph {
+            }),
+            ParagraphBlock::Text(RichText {
                 text: "2. b".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            },
-            StyledTextParagraph {
+            }),
+            ParagraphBlock::Text(RichText {
                 text: "3. c".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            }
+            })
         ]
     );
 
@@ -810,7 +810,7 @@ new *line*
             &[]
         )),
         [
-            StyledTextParagraph {
+            ParagraphBlock::Text(RichText {
                 text: "Normal italic strong strikethrough code".into(),
                 formatting: alloc::vec![
                     FormattedSpan { range: 7..13, style: Style::Emphasis },
@@ -819,12 +819,12 @@ new *line*
                     FormattedSpan { range: 35..39, style: Style::Code }
                 ],
                 links: alloc::vec::Vec::new()
-            },
-            StyledTextParagraph {
+            }),
+            ParagraphBlock::Text(RichText {
                 text: "new line".into(),
                 formatting: alloc::vec![FormattedSpan { range: 4..8, style: Style::Emphasis },],
                 links: alloc::vec::Vec::new()
-            }
+            })
         ]
     );
 
@@ -839,48 +839,48 @@ new *line*
             &[]
         )),
         [
-            StyledTextParagraph {
+            ParagraphBlock::Text(RichText {
                 text: "• root".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            },
-            StyledTextParagraph {
+            }),
+            ParagraphBlock::Text(RichText {
                 text: "    ◦ child".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            },
-            StyledTextParagraph {
+            }),
+            ParagraphBlock::Text(RichText {
                 text: "        ▪ grandchild".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            },
-            StyledTextParagraph {
+            }),
+            ParagraphBlock::Text(RichText {
                 text: "            • great grandchild".into(),
                 formatting: alloc::vec::Vec::new(),
                 links: alloc::vec::Vec::new()
-            },
+            }),
         ]
     );
 
     assert_eq!(
         assert_no_errors(parse_interpolated::<&[_]>("hello [*world*](https://example.com)", &[])),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "hello world".into(),
             formatting: alloc::vec![
                 FormattedSpan { range: 6..11, style: Style::Emphasis },
                 FormattedSpan { range: 6..11, style: Style::Link }
             ],
             links: alloc::vec![(6..11, "https://example.com".into())]
-        }]
+        })]
     );
 
     assert_eq!(
         assert_no_errors(parse_interpolated::<&[_]>("<u>hello world</u>", &[])),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan { range: 0..11, style: Style::Underline },],
             links: alloc::vec::Vec::new()
-        }]
+        })]
     );
 
     assert_eq!(
@@ -888,14 +888,14 @@ new *line*
             r#"<font color="blue">hello world</font>"#,
             &[]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "hello world".into(),
             formatting: alloc::vec![FormattedSpan {
                 range: 0..11,
                 style: Style::Color(0xff_00_00_ff)
             },],
             links: alloc::vec::Vec::new()
-        }]
+        })]
     );
 
     assert_eq!(
@@ -903,14 +903,14 @@ new *line*
             r#"<u><font color="red">hello world</font></u>"#,
             &[]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "hello world".into(),
             formatting: alloc::vec![
                 FormattedSpan { range: 0..11, style: Style::Color(0xff_ff_00_00) },
                 FormattedSpan { range: 0..11, style: Style::Underline },
             ],
             links: alloc::vec::Vec::new()
-        }]
+        })]
     );
 
     // Invalid color: text still renders, error is reported
@@ -919,14 +919,14 @@ new *line*
             parse_interpolated::<&[_]>(r#"<u><font color="\#a">hello world</font></u>"#, &[]);
         assert_eq!(
             paragraphs,
-            [StyledTextParagraph {
+            [ParagraphBlock::Text(RichText {
                 text: "hello world".into(),
                 formatting: alloc::vec![
                     FormattedSpan { range: 0..11, style: Style::Color(0) },
                     FormattedSpan { range: 0..11, style: Style::Underline },
                 ],
                 links: alloc::vec::Vec::new()
-            }]
+            })]
         );
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].to_string(), r"Invalid color value '\#a'");
@@ -942,33 +942,33 @@ fn markdown_parsing_interpolated() {
             &format!("Text: *{MARKDOWN_INTERPOLATION_PLACEHOLDER}*"),
             &[&[paragraph_from_plain_text("italic".into())]]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "Text: italic".into(),
             formatting: alloc::vec![FormattedSpan { range: 6..12, style: Style::Emphasis }],
             links: alloc::vec![]
-        }]
+        })]
     );
     assert_eq!(
         assert_no_errors(parse_interpolated(
             &format!("Escaped text: {MARKDOWN_INTERPOLATION_PLACEHOLDER}"),
             &[&[paragraph_from_plain_text("*bold*".into())]]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "Escaped text: *bold*".into(),
             formatting: alloc::vec![],
             links: alloc::vec![]
-        }]
+        })]
     );
     assert_eq!(
         assert_no_errors(parse_interpolated(
             &format!("Code block text: `{MARKDOWN_INTERPOLATION_PLACEHOLDER}`"),
             &[&[paragraph_from_plain_text("*bold*".into())]]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "Code block text: *bold*".into(),
             formatting: alloc::vec![FormattedSpan { range: 17..23, style: Style::Code }],
             links: alloc::vec![]
-        }]
+        })]
     );
     assert_eq!(
         assert_no_errors(parse_interpolated(
@@ -980,28 +980,28 @@ fn markdown_parsing_interpolated() {
                 parse_interpolated::<&[_]>("*World*", &[]).0
             ]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "Hello World".into(),
             formatting: alloc::vec![
                 FormattedSpan { range: 0..5, style: Style::Strong },
                 FormattedSpan { range: 6..11, style: Style::Emphasis }
             ],
             links: alloc::vec![]
-        }]
+        })]
     );
     assert_eq!(
         assert_no_errors(parse_interpolated(
             &format!("<u>{MARKDOWN_INTERPOLATION_PLACEHOLDER}</u>"),
             &[parse_interpolated::<&[_]>("*underline_and_italic*", &[]).0]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "underline_and_italic".into(),
             formatting: alloc::vec![
                 FormattedSpan { range: 0..20, style: Style::Emphasis },
                 FormattedSpan { range: 0..20, style: Style::Underline },
             ],
             links: alloc::vec![]
-        }]
+        })]
     );
     // Empty paragraph list might be caused by a StyledText::default()
     assert_eq!(
@@ -1009,7 +1009,7 @@ fn markdown_parsing_interpolated() {
             &format!("{MARKDOWN_INTERPOLATION_PLACEHOLDER}"),
             &[[]]
         )),
-        [StyledTextParagraph { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }]
+        [ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] })]
     );
     // Interpolation in link URL
     assert_eq!(
@@ -1017,11 +1017,11 @@ fn markdown_parsing_interpolated() {
             &format!("[Click here]({MARKDOWN_INTERPOLATION_PLACEHOLDER})"),
             &[&[paragraph_from_plain_text("https://example.com".into())]]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "Click here".into(),
             formatting: alloc::vec![FormattedSpan { range: 0..10, style: Style::Link }],
             links: alloc::vec![(0..10, "https://example.com".into())]
-        }]
+        })]
     );
     // Interpolation in link URL with surrounding text
     assert_eq!(
@@ -1029,11 +1029,11 @@ fn markdown_parsing_interpolated() {
             &format!("[link](https://{MARKDOWN_INTERPOLATION_PLACEHOLDER}/path) after"),
             &[&[paragraph_from_plain_text("example.com".into())]]
         )),
-        [StyledTextParagraph {
+        [ParagraphBlock::Text(RichText {
             text: "link after".into(),
             formatting: alloc::vec![FormattedSpan { range: 0..4, style: Style::Link }],
             links: alloc::vec![(0..4, "https://example.com/path".into())]
-        }]
+        })]
     );
 }
 
@@ -1054,5 +1054,92 @@ fn markdown_interleaved_html_and_emphasis() {
     assert!(
         errors.iter().any(|e| e.to_string().contains("Closing html tag")),
         "Expected ClosingTagMismatch, got: {errors:?}"
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_heading_levels() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6", &[])),
+        [
+            ParagraphBlock::Heading { level: 1, content: RichText { text: "H1".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading { level: 2, content: RichText { text: "H2".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading { level: 3, content: RichText { text: "H3".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading { level: 4, content: RichText { text: "H4".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading { level: 5, content: RichText { text: "H5".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading { level: 6, content: RichText { text: "H6".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+        ]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_heading_with_inline() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("# *Italic* heading", &[])),
+        [
+            ParagraphBlock::Heading {
+                level: 1,
+                content: RichText {
+                    text: "Italic heading".into(),
+                    formatting: alloc::vec![FormattedSpan { range: 0..6, style: Style::Emphasis }],
+                    links: alloc::vec![],
+                }
+            },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+        ]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_heading_and_text() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("# Title\n\nBody text", &[])),
+        [
+            ParagraphBlock::Heading { level: 1, content: RichText { text: "Title".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Text(RichText { text: "Body text".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+        ]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_horizontal_rules() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("---\n\n***\n\n___", &[])),
+        [
+            ParagraphBlock::HorizontalRule,
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::HorizontalRule,
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::HorizontalRule,
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+        ]
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn markdown_mixed_heading_and_rules() {
+    assert_eq!(
+        assert_no_errors(parse_interpolated::<&[_]>("# Title\n\nContent\n\n---\n\n## Subtitle", &[])),
+        [
+            ParagraphBlock::Heading { level: 1, content: RichText { text: "Title".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Text(RichText { text: "Content".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::HorizontalRule,
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading { level: 2, content: RichText { text: "Subtitle".into(), formatting: alloc::vec![], links: alloc::vec![] } },
+            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+        ]
     );
 }

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -31,15 +31,19 @@ enum ListItemType {
     Unordered,
 }
 
-/// A section of styled text, split up by a linebreak
-#[derive(Clone, Debug, PartialEq)]
-pub struct StyledTextParagraph {
-    /// The raw paragraph text
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct RichText {
     pub text: alloc::string::String,
-    /// Formatting styles and spans
     pub formatting: alloc::vec::Vec<FormattedSpan>,
-    /// Locations of clickable links within the paragraph
     pub links: alloc::vec::Vec<(core::ops::Range<usize>, alloc::string::String)>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParagraphBlock {
+    Text(RichText),
+    /// level is 1-6
+    Heading { level: u8, content: RichText },
+    HorizontalRule,
 }
 
 /// Error returned by markdown styled text parsing
@@ -129,8 +133,8 @@ pub fn invalid_color_value(error: &StyledTextParseError) -> Option<&str> {
 }
 
 #[cfg(feature = "markdown")]
-pub fn paragraph_from_plain_text(text: alloc::string::String) -> StyledTextParagraph {
-    StyledTextParagraph { text, formatting: Default::default(), links: Default::default() }
+pub fn paragraph_from_plain_text(text: alloc::string::String) -> ParagraphBlock {
+    ParagraphBlock::Text(RichText { text, formatting: Default::default(), links: Default::default() })
 }
 
 #[cfg(feature = "markdown")]
@@ -138,47 +142,49 @@ pub fn paragraph_from_plain_text(text: alloc::string::String) -> StyledTextParag
 pub const MARKDOWN_INTERPOLATION_PLACEHOLDER: char = '\u{e541}';
 
 #[cfg(feature = "markdown")]
-fn begin_paragraph(indentation: u32, list_item_type: Option<ListItemType>) -> StyledTextParagraph {
+fn begin_paragraph(indentation: u32, list_item_type: Option<ListItemType>) -> ParagraphBlock {
     let mut text = alloc::string::String::with_capacity(indentation as usize * 4);
-    for _ in 0..indentation {
-        text.push_str("    ");
-    }
+    for _ in 0..indentation { text.push_str("    "); }
     match list_item_type {
         Some(ListItemType::Unordered) => {
             let remainder = indentation % 3;
-            if remainder == 0 {
-                text.push_str("• ")
-            } else if remainder == 1 {
-                text.push_str("◦ ")
-            } else {
-                text.push_str("▪ ")
-            }
+            text.push_str(if remainder == 0 { "• " } else if remainder == 1 { "◦ " } else { "▪ " });
         }
         Some(ListItemType::Ordered(num)) => text.push_str(&alloc::format!("{}. ", num)),
         None => {}
     };
-    StyledTextParagraph { text, formatting: Default::default(), links: Default::default() }
+    ParagraphBlock::Text(RichText { text, formatting: Default::default(), links: Default::default() })
 }
 
 #[cfg(feature = "markdown")]
-fn append_paragraph(target: &mut StyledTextParagraph, source: &StyledTextParagraph) {
+pub fn rich_text_content(block: &ParagraphBlock) -> Option<&RichText> {
+    match block {
+        ParagraphBlock::Text(content) | ParagraphBlock::Heading { content, .. } => Some(content),
+        ParagraphBlock::HorizontalRule => None,
+    }
+}
+
+#[cfg(feature = "markdown")]
+fn append_rich_text(target: &mut RichText, source: &RichText) {
     let offset = target.text.len();
     target.text.push_str(&source.text);
     target.formatting.extend(source.formatting.iter().cloned().map(|mut f| {
-        f.range.start += offset;
-        f.range.end += offset;
-        f
+        f.range.start += offset; f.range.end += offset; f
     }));
     target.links.extend(source.links.iter().cloned().map(|(mut range, link)| {
-        range.start += offset;
-        range.end += offset;
-        (range, link)
+        range.start += offset; range.end += offset; (range, link)
     }));
 }
 
+fn append_paragraph(target: &mut ParagraphBlock, source: &ParagraphBlock) {
+    let Some(source_rt) = rich_text_content(source) else { return };
+    let ParagraphBlock::Text(target_rt) = target else { return };
+    append_rich_text(target_rt, source_rt);
+}
+
 #[cfg(feature = "markdown")]
-fn substitute<S: AsRef<[StyledTextParagraph]>>(
-    paragraph: &mut StyledTextParagraph,
+fn substitute<S: AsRef<[ParagraphBlock]>>(
+    paragraph: &mut ParagraphBlock,
     string: &str,
     args: &[S],
     arg_index: &mut usize,
@@ -186,21 +192,28 @@ fn substitute<S: AsRef<[StyledTextParagraph]>>(
     event_range: &core::ops::Range<usize>,
 ) {
     use StyledTextParseErrorKind as E;
+    let ParagraphBlock::Text(rt) = paragraph else { return };
     let mut pos = 0;
     while let Some(mut p) = string[pos..].find(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
         p += pos;
-        paragraph.text.push_str(&string[pos..p]);
+        rt.text.push_str(&string[pos..p]);
 
         if let Some(arg) = args.get(*arg_index) {
             match arg.as_ref() {
-                [source] => append_paragraph(paragraph, source),
+                [source] => {
+                    if let Some(source_rt) = rich_text_content(source) {
+                        append_rich_text(rt, source_rt);
+                    }
+                }
                 [] => {}
                 [first, ..] => {
                     errors.push(StyledTextParseError::new(
                         E::MultiParagraphInterpolation,
                         event_range.clone(),
                     ));
-                    append_paragraph(paragraph, first);
+                    if let Some(source_rt) = rich_text_content(first) {
+                        append_rich_text(rt, source_rt);
+                    }
                 }
             }
         } else {
@@ -215,11 +228,11 @@ fn substitute<S: AsRef<[StyledTextParagraph]>>(
         p += MARKDOWN_INTERPOLATION_PLACEHOLDER.len_utf8();
         pos = p;
     }
-    paragraph.text.push_str(&string[pos..]);
+    rt.text.push_str(&string[pos..]);
 }
 
 #[cfg(feature = "markdown")]
-fn substitute_in_string<S: AsRef<[StyledTextParagraph]>>(
+fn substitute_in_string<S: AsRef<[ParagraphBlock]>>(
     string: &str,
     args: &[S],
     arg_index: &mut usize,
@@ -234,14 +247,20 @@ fn substitute_in_string<S: AsRef<[StyledTextParagraph]>>(
         result.push_str(&string[pos..p]);
         if let Some(arg) = args.get(*arg_index) {
             match arg.as_ref() {
-                [arg_paragraph] => result.push_str(&arg_paragraph.text),
+                [arg_paragraph] => {
+                    if let Some(rt) = rich_text_content(arg_paragraph) {
+                        result.push_str(&rt.text);
+                    }
+                }
                 [] => {}
                 [first, ..] => {
                     errors.push(StyledTextParseError::new(
                         E::MultiParagraphInterpolation,
                         event_range.clone(),
                     ));
-                    result.push_str(&first.text);
+                    if let Some(rt) = rich_text_content(first) {
+                        result.push_str(&rt.text);
+                    }
                 }
             }
         } else {
@@ -260,18 +279,18 @@ fn substitute_in_string<S: AsRef<[StyledTextParagraph]>>(
 
 #[cfg(feature = "markdown")]
 fn get_or_create_paragraph<'a>(
-    current_paragraph: &'a mut Option<StyledTextParagraph>,
+    current_paragraph: &'a mut Option<ParagraphBlock>,
     errors: &mut alloc::vec::Vec<StyledTextParseError>,
     event_range: &core::ops::Range<usize>,
-) -> &'a mut StyledTextParagraph {
+) -> &'a mut ParagraphBlock {
     use StyledTextParseErrorKind as E;
     if current_paragraph.is_none() {
         errors.push(StyledTextParseError::new(E::ParagraphNotStarted, event_range.clone()));
-        *current_paragraph = Some(StyledTextParagraph {
+        *current_paragraph = Some(ParagraphBlock::Text(RichText {
             text: Default::default(),
             formatting: Default::default(),
             links: Default::default(),
-        });
+        }));
     }
     current_paragraph.as_mut().unwrap()
 }
@@ -311,10 +330,10 @@ fn unsupported_event_name(event: &pulldown_cmark::Event<'_>) -> alloc::string::S
 }
 
 #[cfg(feature = "markdown")]
-pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
+pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
     format_string: &str,
     args: &[S],
-) -> (alloc::vec::Vec<StyledTextParagraph>, alloc::vec::Vec<StyledTextParseError>) {
+) -> (alloc::vec::Vec<ParagraphBlock>, alloc::vec::Vec<StyledTextParseError>) {
     use StyledTextParseErrorKind as E;
 
     let parser = pulldown_cmark::Parser::new_ext(
@@ -334,7 +353,9 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
     let mut skip_end_count: usize = 0;
     let mut interleaved_count: usize = 0;
 
-    let mut current_paragraph: Option<StyledTextParagraph> = None;
+    let mut current_heading_level: Option<u8> = None;
+
+    let mut current_paragraph: Option<ParagraphBlock> = None;
 
     for (event, event_range) in parser.into_offset_iter() {
         let indentation = list_state_stack.len().saturating_sub(1) as _;
@@ -347,6 +368,14 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     paragraphs.push(paragraph);
                 }
             }
+            pulldown_cmark::Event::Rule => {
+                if let Some(paragraph) =
+                    current_paragraph.replace(begin_paragraph(indentation, None))
+                {
+                    paragraphs.push(paragraph);
+                }
+                paragraphs.push(ParagraphBlock::HorizontalRule);
+            }
             pulldown_cmark::Event::End(pulldown_cmark::TagEnd::List(_)) => {
                 if list_state_stack.pop().is_none() {
                     errors.push(StyledTextParseError::new(E::Pop, event_range.clone()));
@@ -355,6 +384,14 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
             pulldown_cmark::Event::End(
                 pulldown_cmark::TagEnd::Paragraph | pulldown_cmark::TagEnd::Item,
             ) => {}
+            pulldown_cmark::Event::End(pulldown_cmark::TagEnd::Heading(_)) => {
+                if let Some(level) = current_heading_level.take() {
+                    if let Some(ParagraphBlock::Text(content)) = current_paragraph.take() {
+                        paragraphs.push(ParagraphBlock::Heading { level, content });
+                    }
+                }
+                current_paragraph = Some(begin_paragraph(indentation, None));
+            }
             pulldown_cmark::Event::Start(tag) => {
                 let style = match tag {
                     pulldown_cmark::Tag::Paragraph => {
@@ -411,6 +448,15 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                         skip_end_count += 1;
                         continue;
                     }
+                    pulldown_cmark::Tag::Heading { level, .. } => {
+                        if let Some(paragraph) =
+                            current_paragraph.replace(begin_paragraph(indentation, None))
+                        {
+                            paragraphs.push(paragraph);
+                        }
+                        current_heading_level = Some(level as u8);
+                        continue;
+                    }
 
                     ref unsupported => {
                         errors.push(StyledTextParseError::new(
@@ -422,10 +468,11 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     }
                 };
 
-                let paragraph =
-                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
+                let ParagraphBlock::Text(rt) =
+                    get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range)
+                else { unreachable!() };
 
-                style_stack.push((style, paragraph.text.len()));
+                style_stack.push((style, rt.text.len()));
             }
             pulldown_cmark::Event::Text(text) => {
                 let paragraph =
@@ -446,7 +493,7 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
 
                 let paragraph =
                     get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
-                let end = paragraph.text.len();
+                let end = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
 
                 if let Some(url) = current_url.take() {
                     let url = if url.contains(MARKDOWN_INTERPOLATION_PLACEHOLDER) {
@@ -454,20 +501,25 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     } else {
                         url.into()
                     };
-                    paragraph.links.push((start..end, url));
+                    if let ParagraphBlock::Text(rt) = paragraph {
+                        rt.links.push((start..end, url));
+                    }
                 }
 
-                paragraph.formatting.push(FormattedSpan { range: start..end, style });
+                if let ParagraphBlock::Text(rt) = paragraph {
+                    rt.formatting.push(FormattedSpan { range: start..end, style });
+                }
             }
             pulldown_cmark::Event::Code(text) => {
                 let paragraph =
                     get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
-                let start = paragraph.text.len();
+                let start = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
 
                 substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
-                paragraph
-                    .formatting
-                    .push(FormattedSpan { range: start..paragraph.text.len(), style: Style::Code });
+                if let ParagraphBlock::Text(rt) = paragraph {
+                    rt.formatting
+                        .push(FormattedSpan { range: start..rt.text.len(), style: Style::Code });
+                }
             }
             pulldown_cmark::Event::InlineHtml(html) => {
                 if html.starts_with("</") {
@@ -508,9 +560,10 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
 
                     let paragraph =
                         get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range);
-
-                    let end = paragraph.text.len();
-                    paragraph.formatting.push(FormattedSpan { range: start..end, style });
+                    let end = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                    if let ParagraphBlock::Text(rt) = paragraph {
+                        rt.formatting.push(FormattedSpan { range: start..end, style });
+                    }
                 } else {
                     let mut expecting_color_attribute = false;
                     let mut push_skip = false;
@@ -532,7 +585,8 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                                         &mut errors,
                                         &event_range,
                                     );
-                                    style_stack.push((Style::Underline, paragraph.text.len()));
+                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    style_stack.push((Style::Underline, len));
                                 }
                                 "font" => {
                                     expecting_color_attribute = true;
@@ -592,8 +646,8 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                                                 &mut errors,
                                                 &event_range,
                                             );
-                                            style_stack
-                                                .push((Style::Color(value), paragraph.text.len()));
+                                            let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                            style_stack.push((Style::Color(value), len));
                                         }
                                         None => {
                                             let r = base + span.start()..base + span.end();
@@ -608,8 +662,8 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                                                 &mut errors,
                                                 &event_range,
                                             );
-                                            style_stack
-                                                .push((Style::Color(0), paragraph.text.len()));
+                                            let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                            style_stack.push((Style::Color(0), len));
                                         }
                                     }
                                 }
@@ -648,8 +702,7 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
                     }
                 }
             }
-            pulldown_cmark::Event::Rule
-            | pulldown_cmark::Event::TaskListMarker(_)
+            pulldown_cmark::Event::TaskListMarker(_)
             | pulldown_cmark::Event::FootnoteReference(_)
             | pulldown_cmark::Event::InlineMath(_)
             | pulldown_cmark::Event::DisplayMath(_)
@@ -682,8 +735,8 @@ pub fn parse_interpolated<S: AsRef<[StyledTextParagraph]>>(
 
 #[cfg(all(feature = "markdown", test))]
 fn assert_no_errors(
-    result: (alloc::vec::Vec<StyledTextParagraph>, alloc::vec::Vec<StyledTextParseError>),
-) -> alloc::vec::Vec<StyledTextParagraph> {
+    result: (alloc::vec::Vec<ParagraphBlock>, alloc::vec::Vec<StyledTextParseError>),
+) -> alloc::vec::Vec<ParagraphBlock> {
     let (paragraphs, errors) = result;
     assert!(errors.is_empty(), "Unexpected errors: {errors:?}");
     paragraphs

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -60,9 +60,15 @@ pub struct TableCell {
 pub enum ParagraphBlock {
     Text(RichText),
     /// level is 1-6
-    Heading { level: u8, content: RichText },
+    Heading {
+        level: u8,
+        content: RichText,
+    },
     /// level is the nesting depth (1 for `>`, 2 for `>>`, etc.)
-    BlockQuote { level: u8, content: RichText },
+    BlockQuote {
+        level: u8,
+        content: RichText,
+    },
     HorizontalRule,
     Table {
         columns: usize,
@@ -70,7 +76,10 @@ pub enum ParagraphBlock {
         body: alloc::vec::Vec<alloc::vec::Vec<TableCell>>,
         alignments: alloc::vec::Vec<TableAlignment>,
     },
-    CodeBlock { language: Option<alloc::string::String>, text: alloc::string::String },
+    CodeBlock {
+        language: Option<alloc::string::String>,
+        text: alloc::string::String,
+    },
 }
 
 /// Error returned by markdown styled text parsing
@@ -161,7 +170,11 @@ pub fn invalid_color_value(error: &StyledTextParseError) -> Option<&str> {
 
 #[cfg(feature = "markdown")]
 pub fn paragraph_from_plain_text(text: alloc::string::String) -> ParagraphBlock {
-    ParagraphBlock::Text(RichText { text, formatting: Default::default(), links: Default::default() })
+    ParagraphBlock::Text(RichText {
+        text,
+        formatting: Default::default(),
+        links: Default::default(),
+    })
 }
 
 #[cfg(feature = "markdown")]
@@ -171,16 +184,28 @@ pub const MARKDOWN_INTERPOLATION_PLACEHOLDER: char = '\u{e541}';
 #[cfg(feature = "markdown")]
 fn begin_paragraph(indentation: u32, list_item_type: Option<ListItemType>) -> ParagraphBlock {
     let mut text = alloc::string::String::with_capacity(indentation as usize * 4);
-    for _ in 0..indentation { text.push_str("    "); }
+    for _ in 0..indentation {
+        text.push_str("    ");
+    }
     match list_item_type {
         Some(ListItemType::Unordered) => {
             let remainder = indentation % 3;
-            text.push_str(if remainder == 0 { "• " } else if remainder == 1 { "◦ " } else { "▪ " });
+            text.push_str(if remainder == 0 {
+                "• "
+            } else if remainder == 1 {
+                "◦ "
+            } else {
+                "▪ "
+            });
         }
         Some(ListItemType::Ordered(num)) => text.push_str(&alloc::format!("{:>3}. ", num)),
         None => {}
     };
-    ParagraphBlock::Text(RichText { text, formatting: Default::default(), links: Default::default() })
+    ParagraphBlock::Text(RichText {
+        text,
+        formatting: Default::default(),
+        links: Default::default(),
+    })
 }
 
 pub fn rich_text_content(block: &ParagraphBlock) -> Option<&RichText> {
@@ -199,10 +224,14 @@ fn append_rich_text(target: &mut RichText, source: &RichText) {
     let offset = target.text.len();
     target.text.push_str(&source.text);
     target.formatting.extend(source.formatting.iter().cloned().map(|mut f| {
-        f.range.start += offset; f.range.end += offset; f
+        f.range.start += offset;
+        f.range.end += offset;
+        f
     }));
     target.links.extend(source.links.iter().cloned().map(|(mut range, link)| {
-        range.start += offset; range.end += offset; (range, link)
+        range.start += offset;
+        range.end += offset;
+        (range, link)
     }));
 }
 
@@ -391,7 +420,8 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
     let mut code_block_text: Option<alloc::string::String> = None;
 
     let mut current_paragraph: Option<ParagraphBlock> = None;
-    let mut footnote_definitions: Vec<(alloc::string::String, alloc::vec::Vec<ParagraphBlock>)> = Vec::new();
+    let mut footnote_definitions: Vec<(alloc::string::String, alloc::vec::Vec<ParagraphBlock>)> =
+        Vec::new();
     let mut current_footnote_name: Option<alloc::string::String> = None;
     let mut footnote_start_index: usize = 0;
 
@@ -412,14 +442,14 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 if let Some(paragraph) =
                     current_paragraph.replace(begin_paragraph(indentation, None))
                 {
-                    if block_quote_level > 0 {
-                        if let ParagraphBlock::Text(content) = paragraph {
-                            paragraphs.push(ParagraphBlock::BlockQuote {
-                                level: block_quote_level as u8,
-                                content,
-                            });
-                            continue;
-                        }
+                    if block_quote_level > 0
+                        && let ParagraphBlock::Text(content) = paragraph
+                    {
+                        paragraphs.push(ParagraphBlock::BlockQuote {
+                            level: block_quote_level as u8,
+                            content,
+                        });
+                        continue;
                     }
                     paragraphs.push(paragraph);
                 }
@@ -457,12 +487,14 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
             pulldown_cmark::Event::End(pulldown_cmark::TagEnd::Table) => {
                 in_table = false;
 
-                let header: Vec<Vec<TableCell>> = table_header_rows.drain(..).map(|row| {
-                    row.into_iter().map(|content| TableCell { content }).collect()
-                }).collect();
-                let body: Vec<Vec<TableCell>> = table_body_rows.drain(..).map(|row| {
-                    row.into_iter().map(|content| TableCell { content }).collect()
-                }).collect();
+                let header: Vec<Vec<TableCell>> = table_header_rows
+                    .drain(..)
+                    .map(|row| row.into_iter().map(|content| TableCell { content }).collect())
+                    .collect();
+                let body: Vec<Vec<TableCell>> = table_body_rows
+                    .drain(..)
+                    .map(|row| row.into_iter().map(|content| TableCell { content }).collect())
+                    .collect();
 
                 paragraphs.push(ParagraphBlock::Table {
                     columns: table_columns,
@@ -482,21 +514,21 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 pulldown_cmark::TagEnd::Paragraph | pulldown_cmark::TagEnd::Item,
             ) => {}
             pulldown_cmark::Event::End(pulldown_cmark::TagEnd::Heading(_)) => {
-                if let Some(level) = current_heading_level.take() {
-                    if let Some(ParagraphBlock::Text(content)) = current_paragraph.take() {
-                        paragraphs.push(ParagraphBlock::Heading { level, content });
-                    }
+                if let Some(level) = current_heading_level.take()
+                    && let Some(ParagraphBlock::Text(content)) = current_paragraph.take()
+                {
+                    paragraphs.push(ParagraphBlock::Heading { level, content });
                 }
                 current_paragraph = Some(begin_paragraph(indentation, None));
             }
             pulldown_cmark::Event::End(pulldown_cmark::TagEnd::BlockQuote(_)) => {
-                if let Some(paragraph) = current_paragraph.take() {
-                    if let ParagraphBlock::Text(content) = paragraph {
-                        paragraphs.push(ParagraphBlock::BlockQuote {
-                            level: block_quote_level as u8,
-                            content,
-                        });
-                    }
+                if let Some(paragraph) = current_paragraph.take()
+                    && let ParagraphBlock::Text(content) = paragraph
+                {
+                    paragraphs.push(ParagraphBlock::BlockQuote {
+                        level: block_quote_level as u8,
+                        content,
+                    });
                 }
                 block_quote_level = block_quote_level.saturating_sub(1);
                 current_paragraph = None;
@@ -507,14 +539,14 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                         if let Some(paragraph) =
                             current_paragraph.replace(begin_paragraph(indentation, None))
                         {
-                            if block_quote_level > 0 {
-                                if let ParagraphBlock::Text(content) = paragraph {
-                                    paragraphs.push(ParagraphBlock::BlockQuote {
-                                        level: block_quote_level as u8,
-                                        content,
-                                    });
-                                    continue;
-                                }
+                            if block_quote_level > 0
+                                && let ParagraphBlock::Text(content) = paragraph
+                            {
+                                paragraphs.push(ParagraphBlock::BlockQuote {
+                                    level: block_quote_level as u8,
+                                    content,
+                                });
+                                continue;
                             }
                             paragraphs.push(paragraph);
                         }
@@ -573,12 +605,15 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
 
                     pulldown_cmark::Tag::Table(alignments) => {
                         in_table = true;
-                        table_alignments = alignments.iter().map(|a| match a {
-                            pulldown_cmark::Alignment::None => TableAlignment::None,
-                            pulldown_cmark::Alignment::Left => TableAlignment::Left,
-                            pulldown_cmark::Alignment::Center => TableAlignment::Center,
-                            pulldown_cmark::Alignment::Right => TableAlignment::Right,
-                        }).collect();
+                        table_alignments = alignments
+                            .iter()
+                            .map(|a| match a {
+                                pulldown_cmark::Alignment::None => TableAlignment::None,
+                                pulldown_cmark::Alignment::Left => TableAlignment::Left,
+                                pulldown_cmark::Alignment::Center => TableAlignment::Center,
+                                pulldown_cmark::Alignment::Right => TableAlignment::Right,
+                            })
+                            .collect();
                         table_header_rows = Vec::new();
                         table_body_rows = Vec::new();
                         table_current_row = Vec::new();
@@ -648,7 +683,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 } else {
                     let ParagraphBlock::Text(rt) =
                         get_or_create_paragraph(&mut current_paragraph, &mut errors, &event_range)
-                    else { unreachable!() };
+                    else {
+                        unreachable!()
+                    };
 
                     style_stack.push((style, rt.text.len(), false));
                 }
@@ -840,7 +877,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                         &mut errors,
                                         &event_range,
                                     );
-                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    let len = rich_text_content(paragraph)
+                                        .map(|r| r.text.len())
+                                        .unwrap_or(0);
                                     style_stack.push((Style::Underline, len, true));
                                 }
                                 "font" => {
@@ -852,7 +891,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                         &mut errors,
                                         &event_range,
                                     );
-                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    let len = rich_text_content(paragraph)
+                                        .map(|r| r.text.len())
+                                        .unwrap_or(0);
                                     style_stack.push((Style::Strikethrough, len, true));
                                 }
                                 "i" | "em" => {
@@ -861,7 +902,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                         &mut errors,
                                         &event_range,
                                     );
-                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    let len = rich_text_content(paragraph)
+                                        .map(|r| r.text.len())
+                                        .unwrap_or(0);
                                     style_stack.push((Style::Emphasis, len, true));
                                 }
                                 "b" | "strong" => {
@@ -870,7 +913,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                         &mut errors,
                                         &event_range,
                                     );
-                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    let len = rich_text_content(paragraph)
+                                        .map(|r| r.text.len())
+                                        .unwrap_or(0);
                                     style_stack.push((Style::Strong, len, true));
                                 }
                                 "sub" => {
@@ -879,7 +924,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                         &mut errors,
                                         &event_range,
                                     );
-                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    let len = rich_text_content(paragraph)
+                                        .map(|r| r.text.len())
+                                        .unwrap_or(0);
                                     style_stack.push((Style::Subscript, len, true));
                                 }
                                 "sup" => {
@@ -888,7 +935,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                         &mut errors,
                                         &event_range,
                                     );
-                                    let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                    let len = rich_text_content(paragraph)
+                                        .map(|r| r.text.len())
+                                        .unwrap_or(0);
                                     style_stack.push((Style::Superscript, len, true));
                                 }
                                 _ => {
@@ -946,7 +995,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                                 &mut errors,
                                                 &event_range,
                                             );
-                                            let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                            let len = rich_text_content(paragraph)
+                                                .map(|r| r.text.len())
+                                                .unwrap_or(0);
                                             style_stack.push((Style::Color(value), len, true));
                                         }
                                         None => {
@@ -962,7 +1013,9 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                                                 &mut errors,
                                                 &event_range,
                                             );
-                                            let len = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
+                                            let len = rich_text_content(paragraph)
+                                                .map(|r| r.text.len())
+                                                .unwrap_or(0);
                                             style_stack.push((Style::Color(0), len, true));
                                         }
                                     }
@@ -1022,10 +1075,8 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 let start = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
                 substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
                 if let ParagraphBlock::Text(rt) = paragraph {
-                    rt.formatting.push(FormattedSpan {
-                        range: start..rt.text.len(),
-                        style: Style::Math,
-                    });
+                    rt.formatting
+                        .push(FormattedSpan { range: start..rt.text.len(), style: Style::Math });
                 }
             }
             pulldown_cmark::Event::DisplayMath(text) => {
@@ -1039,10 +1090,8 @@ pub fn parse_interpolated<S: AsRef<[ParagraphBlock]>>(
                 let start = rich_text_content(paragraph).map(|r| r.text.len()).unwrap_or(0);
                 substitute(paragraph, &text, args, &mut arg_index, &mut errors, &event_range);
                 if let ParagraphBlock::Text(rt) = paragraph {
-                    rt.formatting.push(FormattedSpan {
-                        range: start..rt.text.len(),
-                        style: Style::Math,
-                    });
+                    rt.formatting
+                        .push(FormattedSpan { range: start..rt.text.len(), style: Style::Math });
                 }
             }
             pulldown_cmark::Event::Html(ref html) => {
@@ -1396,7 +1445,11 @@ fn markdown_parsing_interpolated() {
             &format!("{MARKDOWN_INTERPOLATION_PLACEHOLDER}"),
             &[[]]
         )),
-        [ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] })]
+        [ParagraphBlock::Text(RichText {
+            text: "".into(),
+            formatting: alloc::vec![],
+            links: alloc::vec![]
+        })]
     );
     // Interpolation in link URL
     assert_eq!(
@@ -1448,20 +1501,89 @@ fn markdown_interleaved_html_and_emphasis() {
 #[test]
 fn markdown_heading_levels() {
     assert_eq!(
-        assert_no_errors(parse_interpolated::<&[_]>("# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6", &[])),
+        assert_no_errors(parse_interpolated::<&[_]>(
+            "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6",
+            &[]
+        )),
         [
-            ParagraphBlock::Heading { level: 1, content: RichText { text: "H1".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Heading { level: 2, content: RichText { text: "H2".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Heading { level: 3, content: RichText { text: "H3".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Heading { level: 4, content: RichText { text: "H4".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Heading { level: 5, content: RichText { text: "H5".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Heading { level: 6, content: RichText { text: "H6".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading {
+                level: 1,
+                content: RichText {
+                    text: "H1".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Heading {
+                level: 2,
+                content: RichText {
+                    text: "H2".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Heading {
+                level: 3,
+                content: RichText {
+                    text: "H3".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Heading {
+                level: 4,
+                content: RichText {
+                    text: "H4".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Heading {
+                level: 5,
+                content: RichText {
+                    text: "H5".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Heading {
+                level: 6,
+                content: RichText {
+                    text: "H6".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
         ]
     );
 }
@@ -1480,7 +1602,11 @@ fn markdown_heading_with_inline() {
                     links: alloc::vec![],
                 }
             },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
         ]
     );
 }
@@ -1507,9 +1633,24 @@ fn markdown_heading_and_text() {
     assert_eq!(
         assert_no_errors(parse_interpolated::<&[_]>("# Title\n\nBody text", &[])),
         [
-            ParagraphBlock::Heading { level: 1, content: RichText { text: "Title".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Text(RichText { text: "Body text".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading {
+                level: 1,
+                content: RichText {
+                    text: "Title".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Text(RichText {
+                text: "Body text".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
         ]
     );
 }
@@ -1521,11 +1662,23 @@ fn markdown_horizontal_rules() {
         assert_no_errors(parse_interpolated::<&[_]>("---\n\n***\n\n___", &[])),
         [
             ParagraphBlock::HorizontalRule,
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
             ParagraphBlock::HorizontalRule,
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
             ParagraphBlock::HorizontalRule,
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
         ]
     );
 }
@@ -1551,7 +1704,7 @@ fn markdown_block_quote() {
 fn markdown_block_quote_multi_paragraph() {
     let result = assert_no_errors(parse_interpolated::<&[_]>(
         "> First paragraph\n>\n> Second paragraph",
-        &[]
+        &[],
     ));
     assert_eq!(result.len(), 2);
     assert!(matches!(result[0], ParagraphBlock::BlockQuote { level: 1, .. }));
@@ -1578,15 +1731,48 @@ fn markdown_block_quote_with_formatting() {
 #[test]
 fn markdown_mixed_heading_and_rules() {
     assert_eq!(
-        assert_no_errors(parse_interpolated::<&[_]>("# Title\n\nContent\n\n---\n\n## Subtitle", &[])),
+        assert_no_errors(parse_interpolated::<&[_]>(
+            "# Title\n\nContent\n\n---\n\n## Subtitle",
+            &[]
+        )),
         [
-            ParagraphBlock::Heading { level: 1, content: RichText { text: "Title".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Text(RichText { text: "Content".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Heading {
+                level: 1,
+                content: RichText {
+                    text: "Title".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Text(RichText {
+                text: "Content".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
             ParagraphBlock::HorizontalRule,
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
-            ParagraphBlock::Heading { level: 2, content: RichText { text: "Subtitle".into(), formatting: alloc::vec![], links: alloc::vec![] } },
-            ParagraphBlock::Text(RichText { text: "".into(), formatting: alloc::vec![], links: alloc::vec![] }),
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
+            ParagraphBlock::Heading {
+                level: 2,
+                content: RichText {
+                    text: "Subtitle".into(),
+                    formatting: alloc::vec![],
+                    links: alloc::vec![]
+                }
+            },
+            ParagraphBlock::Text(RichText {
+                text: "".into(),
+                formatting: alloc::vec![],
+                links: alloc::vec![]
+            }),
         ]
     );
 }
@@ -1596,7 +1782,7 @@ fn markdown_mixed_heading_and_rules() {
 fn markdown_table_simple() {
     let result = assert_no_errors(parse_interpolated::<&[_]>(
         "| H1 | H2 |\n| --- | --- |\n| A1 | A2 |",
-        &[]
+        &[],
     ));
     assert_eq!(result.len(), 1);
     assert!(matches!(result[0], ParagraphBlock::Table { .. }));
@@ -1614,25 +1800,34 @@ fn markdown_table_simple() {
 fn markdown_footnote_reference() {
     let result = assert_no_errors(parse_interpolated::<&[_]>(
         "Text with a footnote[^1]\n\n[^1]: The footnote content",
-        &[]
+        &[],
     ));
     assert_eq!(result.len(), 4);
-    assert_eq!(result[0], ParagraphBlock::Text(RichText {
-        text: "Text with a footnote[1]".into(),
-        formatting: alloc::vec![FormattedSpan { range: 20..23, style: Style::Superscript }],
-        links: alloc::vec![],
-    }));
+    assert_eq!(
+        result[0],
+        ParagraphBlock::Text(RichText {
+            text: "Text with a footnote[1]".into(),
+            formatting: alloc::vec![FormattedSpan { range: 20..23, style: Style::Superscript }],
+            links: alloc::vec![],
+        })
+    );
     assert_eq!(result[1], ParagraphBlock::HorizontalRule);
-    assert_eq!(result[2], ParagraphBlock::Text(RichText {
-        text: "[1] ".into(),
-        formatting: alloc::vec![],
-        links: alloc::vec![],
-    }));
-    assert_eq!(result[3], ParagraphBlock::Text(RichText {
-        text: "The footnote content".into(),
-        formatting: alloc::vec![],
-        links: alloc::vec![],
-    }));
+    assert_eq!(
+        result[2],
+        ParagraphBlock::Text(RichText {
+            text: "[1] ".into(),
+            formatting: alloc::vec![],
+            links: alloc::vec![],
+        })
+    );
+    assert_eq!(
+        result[3],
+        ParagraphBlock::Text(RichText {
+            text: "The footnote content".into(),
+            formatting: alloc::vec![],
+            links: alloc::vec![],
+        })
+    );
 }
 
 #[cfg(feature = "markdown")]
@@ -1642,9 +1837,7 @@ fn markdown_math_inline() {
         assert_no_errors(parse_interpolated::<&[_]>("Math: $E=mc^2$", &[])),
         [ParagraphBlock::Text(RichText {
             text: "Math: E=mc^2".into(),
-            formatting: alloc::vec![
-                FormattedSpan { range: 6..12, style: Style::Math },
-            ],
+            formatting: alloc::vec![FormattedSpan { range: 6..12, style: Style::Math },],
             links: alloc::vec![],
         })]
     );
@@ -1672,10 +1865,13 @@ fn markdown_code_block() {
         empty,
     ));
     assert!(
-        result.iter().any(|b| matches!(b, ParagraphBlock::CodeBlock { text, .. } if text == "code block\n")),
+        result
+            .iter()
+            .any(|b| matches!(b, ParagraphBlock::CodeBlock { text, .. } if text == "code block\n")),
         "Expected a CodeBlock with text 'code block\\n', got: {result:?}"
     );
-    let code_blocks: alloc::vec::Vec<_> = result.iter().filter(|b| matches!(b, ParagraphBlock::CodeBlock { .. })).collect();
+    let code_blocks: alloc::vec::Vec<_> =
+        result.iter().filter(|b| matches!(b, ParagraphBlock::CodeBlock { .. })).collect();
     assert_eq!(code_blocks.len(), 1);
     if let ParagraphBlock::CodeBlock { language, .. } = &code_blocks[0] {
         assert_eq!(*language, None);
@@ -1686,10 +1882,7 @@ fn markdown_code_block() {
 #[test]
 fn markdown_code_block_with_language() {
     let empty: &[&[ParagraphBlock]] = &[];
-    let result = assert_no_errors(parse_interpolated(
-        "```rust\nfn main() {}\n```",
-        empty,
-    ));
+    let result = assert_no_errors(parse_interpolated("```rust\nfn main() {}\n```", empty));
     assert!(
         result.iter().any(|b| matches!(b, ParagraphBlock::CodeBlock { language: Some(lang), text } if lang == "rust" && text.contains("fn main"))),
         "Expected a CodeBlock with language 'rust' containing 'fn main', got: {result:?}"
@@ -1700,10 +1893,7 @@ fn markdown_code_block_with_language() {
 #[test]
 fn markdown_code_block_indented() {
     let empty: &[&[ParagraphBlock]] = &[];
-    let result = assert_no_errors(parse_interpolated(
-        "    indented code block",
-        empty,
-    ));
+    let result = assert_no_errors(parse_interpolated("    indented code block", empty));
     assert!(
         result.iter().any(|b| matches!(b, ParagraphBlock::CodeBlock { .. })),
         "Expected a CodeBlock, got: {result:?}"

--- a/internal/common/styled_text.rs
+++ b/internal/common/styled_text.rs
@@ -156,7 +156,6 @@ fn begin_paragraph(indentation: u32, list_item_type: Option<ListItemType>) -> Pa
     ParagraphBlock::Text(RichText { text, formatting: Default::default(), links: Default::default() })
 }
 
-#[cfg(feature = "markdown")]
 pub fn rich_text_content(block: &ParagraphBlock) -> Option<&RichText> {
     match block {
         ParagraphBlock::Text(content) | ParagraphBlock::Heading { content, .. } => Some(content),
@@ -174,12 +173,6 @@ fn append_rich_text(target: &mut RichText, source: &RichText) {
     target.links.extend(source.links.iter().cloned().map(|(mut range, link)| {
         range.start += offset; range.end += offset; (range, link)
     }));
-}
-
-fn append_paragraph(target: &mut ParagraphBlock, source: &ParagraphBlock) {
-    let Some(source_rt) = rich_text_content(source) else { return };
-    let ParagraphBlock::Text(target_rt) = target else { return };
-    append_rich_text(target_rt, source_rt);
 }
 
 #[cfg(feature = "markdown")]

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1089,7 +1089,7 @@ impl Expression {
         let probe = markdown.replace(PLACEHOLDER, PROBE);
 
         let (_, parse_errors) = i_slint_common::styled_text::parse_interpolated::<
-            &[i_slint_common::styled_text::StyledTextParagraph],
+            &[i_slint_common::styled_text::ParagraphBlock],
         >(&probe, &[]);
 
         let mut color_indices = std::collections::BTreeSet::new();

--- a/internal/core/styled_text.rs
+++ b/internal/core/styled_text.rs
@@ -6,7 +6,7 @@
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct StyledText {
     /// Paragraphs of styled text
-    pub(crate) paragraphs: crate::SharedVector<i_slint_common::styled_text::StyledTextParagraph>,
+    pub(crate) paragraphs: crate::SharedVector<i_slint_common::styled_text::ParagraphBlock>,
 }
 
 /// Error returned when [`StyledText::from_markdown`] cannot parse the provided markdown input.
@@ -52,7 +52,7 @@ impl StyledText {
     /// Parses markdown into styled text.
     pub fn from_markdown(markdown: &str) -> Result<Self, StyledTextFromMarkdownError> {
         let (paragraphs, errors) = i_slint_common::styled_text::parse_interpolated::<
-            &[i_slint_common::styled_text::StyledTextParagraph],
+            &[i_slint_common::styled_text::ParagraphBlock],
         >(markdown, &[]);
 
         if errors.is_empty() {
@@ -66,14 +66,18 @@ impl StyledText {
 pub fn get_raw_text(styled_text: &StyledText) -> alloc::borrow::Cow<'_, str> {
     match styled_text.paragraphs.as_slice() {
         [] => "".into(),
-        [paragraph] => paragraph.text.as_str().into(),
+        [single] => i_slint_common::styled_text::rich_text_content(single)
+            .map_or("".into(), |rt| rt.text.as_str().into()),
         _ => {
             let mut result = alloc::string::String::new();
-            for paragraph in styled_text.paragraphs.iter() {
+            for block in styled_text.paragraphs.iter() {
+                let Some(rt) = i_slint_common::styled_text::rich_text_content(&block) else {
+                    continue;
+                };
                 if !result.is_empty() {
                     result.push('\n');
                 }
-                result.push_str(paragraph.text.as_str());
+                result.push_str(rt.text.as_str());
             }
             result.into()
         }

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -456,6 +456,18 @@ impl LayoutWithoutLineBreaksBuilder {
                             span.range,
                         );
                     }
+                    Style::Superscript => {
+                        builder.push(
+                            parley::StyleProperty::FontSize(self.pixel_size.get() * 0.7),
+                            span.range,
+                        );
+                    }
+                    Style::Subscript => {
+                        builder.push(
+                            parley::StyleProperty::FontSize(self.pixel_size.get() * 0.7),
+                            span.range,
+                        );
+                    }
                 }
             }
 

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -603,8 +603,9 @@ fn layout(
     };
 
     let body_font_size = layout_builder.pixel_size.get();
-    let rule_height = PhysicalLength::new(body_font_size * 0.8);
-    let rule_margin = PhysicalLength::new(body_font_size * 0.3);
+    let scale = scale_factor.get();
+    let rule_height = PhysicalLength::new(body_font_size * 0.8 * scale);
+    let rule_margin = PhysicalLength::new(body_font_size * 0.3 * scale);
 
     let mut para_y = 0.0;
     for para in paragraphs.iter_mut() {

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -174,7 +174,10 @@ pub use super::DEFAULT_FONT_SIZE;
 /// text. Matches the convention used by GitHub-style markdown renderers — the
 /// glyphs sit a little smaller than body text, inside a translucent capsule
 /// that visually marks them as code.
-pub enum BlockType { Normal, Heading(u8) }
+pub enum BlockType {
+    Normal,
+    Heading(u8),
+}
 
 const HEADING_FONT_SCALES: [f32; 6] = [2.0, 1.5, 1.17, 1.0, 0.83, 0.67];
 
@@ -512,41 +515,66 @@ fn create_text_paragraphs(
     selection: Option<(Range<usize>, Color)>,
     link_color: Color,
 ) -> Vec<TextParagraph> {
-    let paragraph_from_text =
-        |font_context: &mut parley::FontContext,
-         text: &str,
-         range: std::ops::Range<usize>,
-         formatting: Vec<i_slint_common::styled_text::FormattedSpan>,
-         links: Vec<(std::ops::Range<usize>, std::string::String)>,
-         is_horizontal_rule: bool,
-         is_code_block: bool,
-         block_type: BlockType,
-         block_quote_level: u8| {
-            let selection = selection.clone().and_then(|(selection, selection_color)| {
-                let sel_start = selection.start.max(range.start);
-                let sel_end = selection.end.min(range.end);
+    let paragraph_from_text = |font_context: &mut parley::FontContext,
+                               text: &str,
+                               range: std::ops::Range<usize>,
+                               formatting: Vec<i_slint_common::styled_text::FormattedSpan>,
+                               links: Vec<(std::ops::Range<usize>, std::string::String)>,
+                               is_horizontal_rule: bool,
+                               is_code_block: bool,
+                               block_type: BlockType,
+                               block_quote_level: u8| {
+        let selection = selection.clone().and_then(|(selection, selection_color)| {
+            let sel_start = selection.start.max(range.start);
+            let sel_end = selection.end.min(range.end);
 
-                if sel_start < sel_end {
-                    let local_selection = (sel_start - range.start)..(sel_end - range.start);
-                    Some((local_selection, selection_color))
-                } else {
-                    None
-                }
-            });
+            if sel_start < sel_end {
+                let local_selection = (sel_start - range.start)..(sel_end - range.start);
+                Some((local_selection, selection_color))
+            } else {
+                None
+            }
+        });
 
-            let code_ranges: alloc::vec::Vec<Range<usize>> = formatting
-                .iter()
-                .filter(|s| matches!(s.style, i_slint_common::styled_text::Style::Code | i_slint_common::styled_text::Style::Math))
-                .map(|s| s.range.clone())
-                .collect();
+        let code_ranges: alloc::vec::Vec<Range<usize>> = formatting
+            .iter()
+            .filter(|s| {
+                matches!(
+                    s.style,
+                    i_slint_common::styled_text::Style::Code
+                        | i_slint_common::styled_text::Style::Math
+                )
+            })
+            .map(|s| s.range.clone())
+            .collect();
 
-            let heading_level = match block_type { BlockType::Heading(level) => level, _ => 0 };
-
-            let layout =
-                layout_builder.build(font_context, text, selection, formatting, Some(link_color), block_type);
-
-            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule, is_code_block, block_quote_level, heading_level, table: None }
+        let heading_level = match block_type {
+            BlockType::Heading(level) => level,
+            _ => 0,
         };
+
+        let layout = layout_builder.build(
+            font_context,
+            text,
+            selection,
+            formatting,
+            Some(link_color),
+            block_type,
+        );
+
+        TextParagraph {
+            range,
+            y: PhysicalLength::default(),
+            layout,
+            links,
+            code_ranges,
+            is_horizontal_rule,
+            is_code_block,
+            block_quote_level,
+            heading_level,
+            table: None,
+        }
+    };
 
     let mut paragraphs = Vec::with_capacity(1);
 
@@ -571,38 +599,65 @@ fn create_text_paragraphs(
                 match block {
                     i_slint_common::styled_text::ParagraphBlock::Text(content) => {
                         paragraphs.push(paragraph_from_text(
-                            font_context, &content.text, 0..0,
-                            content.formatting.clone(), content.links.clone(),
-                            false, false, BlockType::Normal, 0,
+                            font_context,
+                            &content.text,
+                            0..0,
+                            content.formatting.clone(),
+                            content.links.clone(),
+                            false,
+                            false,
+                            BlockType::Normal,
+                            0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::Heading { level, content } => {
                         paragraphs.push(paragraph_from_text(
-                            font_context, &content.text, 0..0,
-                            content.formatting.clone(), content.links.clone(),
-                            false, false, BlockType::Heading(level), 0,
+                            font_context,
+                            &content.text,
+                            0..0,
+                            content.formatting.clone(),
+                            content.links.clone(),
+                            false,
+                            false,
+                            BlockType::Heading(level),
+                            0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::BlockQuote { level, content } => {
                         let indent_str = " ".repeat(level as usize + 2);
                         let indented_text = alloc::format!("{}{}", indent_str, content.text);
-                        let shifted_formatting: Vec<_> = content.formatting.iter().map(|s| {
-                            i_slint_common::styled_text::FormattedSpan {
-                                range: (s.range.start + indent_str.len())..(s.range.end + indent_str.len()),
+                        let shifted_formatting: Vec<_> = content
+                            .formatting
+                            .iter()
+                            .map(|s| i_slint_common::styled_text::FormattedSpan {
+                                range: (s.range.start + indent_str.len())
+                                    ..(s.range.end + indent_str.len()),
                                 style: s.style.clone(),
-                            }
-                        }).collect();
+                            })
+                            .collect();
                         paragraphs.push(paragraph_from_text(
-                            font_context, &indented_text, 0..0,
-                            shifted_formatting, content.links.clone(),
-                            false, false, BlockType::Normal, level,
+                            font_context,
+                            &indented_text,
+                            0..0,
+                            shifted_formatting,
+                            content.links.clone(),
+                            false,
+                            false,
+                            BlockType::Normal,
+                            level,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::HorizontalRule => {
                         paragraphs.push(paragraph_from_text(
-                            font_context, "", 0..0,
-                            Default::default(), Default::default(),
-                            true, false, BlockType::Normal, 0,
+                            font_context,
+                            "",
+                            0..0,
+                            Default::default(),
+                            Default::default(),
+                            true,
+                            false,
+                            BlockType::Normal,
+                            0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::CodeBlock { text, .. } => {
@@ -615,12 +670,23 @@ fn create_text_paragraphs(
                             }]
                         };
                         paragraphs.push(paragraph_from_text(
-                            font_context, &text, 0..0,
-                            formatting, Vec::new(),
-                            false, true, BlockType::Normal, 0,
+                            font_context,
+                            &text,
+                            0..0,
+                            formatting,
+                            Vec::new(),
+                            false,
+                            true,
+                            BlockType::Normal,
+                            0,
                         ));
                     }
-                    i_slint_common::styled_text::ParagraphBlock::Table { columns, header, body, .. } => {
+                    i_slint_common::styled_text::ParagraphBlock::Table {
+                        columns,
+                        header,
+                        body,
+                        ..
+                    } => {
                         let cell_border_spacing = PhysicalLength::new(8.0);
                         let padding = PhysicalLength::new(4.0);
                         let mut max_col_widths: Vec<PhysicalLength> = alloc::vec::Vec::new();
@@ -634,12 +700,16 @@ fn create_text_paragraphs(
                             for (col, cell) in row.iter().enumerate() {
                                 if col < columns {
                                     let mut cell_layout = layout_builder.build(
-                                        font_context, &cell.content.text, None,
+                                        font_context,
+                                        &cell.content.text,
+                                        None,
                                         cell.content.formatting.iter().cloned(),
-                                        None, BlockType::Normal,
+                                        None,
+                                        BlockType::Normal,
                                     );
                                     cell_layout.break_all_lines(None);
-                                    let w = PhysicalLength::new(cell_layout.full_width()) + cell_border_spacing;
+                                    let w = PhysicalLength::new(cell_layout.full_width())
+                                        + cell_border_spacing;
                                     max_col_widths[col] = max_col_widths[col].max(w);
                                     row_data.push(TableCellData {
                                         text: cell.content.text.clone(),
@@ -657,12 +727,16 @@ fn create_text_paragraphs(
                             for (col, cell) in row.iter().enumerate() {
                                 if col < columns {
                                     let mut cell_layout = layout_builder.build(
-                                        font_context, &cell.content.text, None,
+                                        font_context,
+                                        &cell.content.text,
+                                        None,
                                         cell.content.formatting.iter().cloned(),
-                                        None, BlockType::Normal,
+                                        None,
+                                        BlockType::Normal,
                                     );
                                     cell_layout.break_all_lines(None);
-                                    let w = PhysicalLength::new(cell_layout.full_width()) + cell_border_spacing;
+                                    let w = PhysicalLength::new(cell_layout.full_width())
+                                        + cell_border_spacing;
                                     max_col_widths[col] = max_col_widths[col].max(w);
                                     row_data.push(TableCellData {
                                         text: cell.content.text.clone(),
@@ -692,12 +766,18 @@ fn create_text_paragraphs(
                         for row in &table_header_data {
                             let mut max_h = PhysicalLength::new(layout_builder.pixel_size.get());
                             for (col, cell) in row.iter().enumerate() {
-                                if col >= column_widths_resolved.len() { break; }
-                                let available_width = column_widths_resolved[col].get() - cell_border_spacing.get();
+                                if col >= column_widths_resolved.len() {
+                                    break;
+                                }
+                                let available_width =
+                                    column_widths_resolved[col].get() - cell_border_spacing.get();
                                 let mut cell_layout = layout_builder.build(
-                                    font_context, &cell.text, None,
+                                    font_context,
+                                    &cell.text,
+                                    None,
                                     cell.formatting.iter().cloned(),
-                                    None, BlockType::Normal,
+                                    None,
+                                    BlockType::Normal,
                                 );
                                 if available_width > 0.0 {
                                     cell_layout.break_all_lines(Some(available_width));
@@ -707,7 +787,7 @@ fn create_text_paragraphs(
                                 let h = PhysicalLength::new(cell_layout.height());
                                 max_h = max_h.max(h);
                             }
-                            max_h = max_h + padding * 2.0;
+                            max_h += padding * 2.0;
                             row_positions.push(current_y);
                             row_heights.push(max_h);
                             current_y += max_h;
@@ -715,12 +795,18 @@ fn create_text_paragraphs(
                         for row in &table_body_data {
                             let mut max_h = PhysicalLength::new(layout_builder.pixel_size.get());
                             for (col, cell) in row.iter().enumerate() {
-                                if col >= column_widths_resolved.len() { break; }
-                                let available_width = column_widths_resolved[col].get() - cell_border_spacing.get();
+                                if col >= column_widths_resolved.len() {
+                                    break;
+                                }
+                                let available_width =
+                                    column_widths_resolved[col].get() - cell_border_spacing.get();
                                 let mut cell_layout = layout_builder.build(
-                                    font_context, &cell.text, None,
+                                    font_context,
+                                    &cell.text,
+                                    None,
                                     cell.formatting.iter().cloned(),
-                                    None, BlockType::Normal,
+                                    None,
+                                    BlockType::Normal,
                                 );
                                 if available_width > 0.0 {
                                     cell_layout.break_all_lines(Some(available_width));
@@ -730,7 +816,7 @@ fn create_text_paragraphs(
                                 let h = PhysicalLength::new(cell_layout.height());
                                 max_h = max_h.max(h);
                             }
-                            max_h = max_h + padding * 2.0;
+                            max_h += padding * 2.0;
                             row_positions.push(current_y);
                             row_heights.push(max_h);
                             current_y += max_h;
@@ -738,53 +824,78 @@ fn create_text_paragraphs(
                         let total_height = current_y;
 
                         // Shape header cell layouts with correct column widths
-                        let header_layouts: Vec<Vec<parley::Layout<Brush>>> = table_header_data.iter().map(|row| {
-                            row.iter().enumerate().map(|(col, cell)| {
-                                let cell_width = if col < column_widths_resolved.len() {
-                                    column_widths_resolved[col].get() - 8.0
-                                } else {
-                                    0.0
-                                };
-                                let mut layout = layout_builder.build(
-                                    font_context, &cell.text, None,
-                                    cell.formatting.iter().cloned(),
-                                    None, BlockType::Normal,
-                                );
-                                if cell_width > 0.0 {
-                                    layout.break_all_lines(Some(cell_width));
-                                } else {
-                                    layout.break_all_lines(None);
-                                }
-                                layout
-                            }).collect()
-                        }).collect();
+                        let header_layouts: Vec<Vec<parley::Layout<Brush>>> = table_header_data
+                            .iter()
+                            .map(|row| {
+                                row.iter()
+                                    .enumerate()
+                                    .map(|(col, cell)| {
+                                        let cell_width = if col < column_widths_resolved.len() {
+                                            column_widths_resolved[col].get() - 8.0
+                                        } else {
+                                            0.0
+                                        };
+                                        let mut layout = layout_builder.build(
+                                            font_context,
+                                            &cell.text,
+                                            None,
+                                            cell.formatting.iter().cloned(),
+                                            None,
+                                            BlockType::Normal,
+                                        );
+                                        if cell_width > 0.0 {
+                                            layout.break_all_lines(Some(cell_width));
+                                        } else {
+                                            layout.break_all_lines(None);
+                                        }
+                                        layout
+                                    })
+                                    .collect()
+                            })
+                            .collect();
 
                         // Shape body cell layouts with correct column widths
-                        let body_layouts: Vec<Vec<parley::Layout<Brush>>> = table_body_data.iter().map(|row| {
-                            row.iter().enumerate().map(|(col, cell)| {
-                                let cell_width = if col < column_widths_resolved.len() {
-                                    column_widths_resolved[col].get() - 8.0
-                                } else {
-                                    0.0
-                                };
-                                let mut layout = layout_builder.build(
-                                    font_context, &cell.text, None,
-                                    cell.formatting.iter().cloned(),
-                                    None, BlockType::Normal,
-                                );
-                                if cell_width > 0.0 {
-                                    layout.break_all_lines(Some(cell_width));
-                                } else {
-                                    layout.break_all_lines(None);
-                                }
-                                layout
-                            }).collect()
-                        }).collect();
+                        let body_layouts: Vec<Vec<parley::Layout<Brush>>> = table_body_data
+                            .iter()
+                            .map(|row| {
+                                row.iter()
+                                    .enumerate()
+                                    .map(|(col, cell)| {
+                                        let cell_width = if col < column_widths_resolved.len() {
+                                            column_widths_resolved[col].get() - 8.0
+                                        } else {
+                                            0.0
+                                        };
+                                        let mut layout = layout_builder.build(
+                                            font_context,
+                                            &cell.text,
+                                            None,
+                                            cell.formatting.iter().cloned(),
+                                            None,
+                                            BlockType::Normal,
+                                        );
+                                        if cell_width > 0.0 {
+                                            layout.break_all_lines(Some(cell_width));
+                                        } else {
+                                            layout.break_all_lines(None);
+                                        }
+                                        layout
+                                    })
+                                    .collect()
+                            })
+                            .collect();
 
                         paragraphs.push(TextParagraph {
                             range: 0..0,
                             y: PhysicalLength::default(),
-                            layout: layout_builder.build(font_context, "", None, None, None, BlockType::Normal),
+                            layout: layout_builder.build(
+                                font_context,
+                                "",
+                                None,
+                                None,
+                                None,
+                                BlockType::Normal,
+                            ),
                             links: Vec::new(),
                             code_ranges: Vec::new(),
                             is_horizontal_rule: false,
@@ -829,7 +940,8 @@ fn layout(
 
     // Returned None if failed to get the ellipsis glyph for some rare reason.
     let get_ellipsis_glyph = |font_context: &mut parley::FontContext| {
-        let mut layout = layout_builder.build(font_context, "…", None, None, None, BlockType::Normal);
+        let mut layout =
+            layout_builder.build(font_context, "…", None, None, None, BlockType::Normal);
         layout.break_all_lines(None);
         let line = layout.lines().next()?;
         let item = line.items().next()?;
@@ -864,22 +976,20 @@ fn layout(
     for para in paragraphs.iter_mut() {
         let spacing = if para_y == 0.0 {
             0.0
-        } else if para.heading_level > 0 && prev_heading_level == 0 {
+        } else if (para.heading_level > 0 && prev_heading_level == 0)
+            || (para.is_code_block && !prev_is_code_block)
+        {
             body_font_size * 1.0
-        } else if para.is_code_block && !prev_is_code_block {
-            body_font_size * 1.0
-        } else if para.block_quote_level > 0 && prev_block_quote_level == 0 {
-            body_font_size * 0.5
-        } else if prev_heading_level > 0 && para.heading_level == 0 {
+        } else if (para.block_quote_level > 0 && prev_block_quote_level == 0)
+            || (prev_heading_level > 0 && para.heading_level == 0)
+        {
             body_font_size * 0.5
         } else if para.heading_level > 0 && prev_heading_level > 0 {
             0.0
-        } else if !para.is_code_block && prev_is_code_block {
+        } else if (!para.is_code_block && prev_is_code_block)
+            || (para.table.is_some() && !prev_is_table)
+        {
             body_font_size * 0.5
-        } else if para.table.is_some() && !prev_is_table {
-            body_font_size * 0.5
-        } else if !para.table.is_some() && prev_is_table {
-            body_font_size * 0.3
         } else {
             body_font_size * 0.3
         };
@@ -1844,10 +1954,10 @@ impl Layout {
         let visible_extent = self.visible_extent();
         for (paragraph_index, paragraph) in self.paragraphs.iter().enumerate() {
             if paragraph.is_horizontal_rule {
-                if let Some(cut) = visible_extent {
-                    if paragraph_index > cut.last_paragraph {
-                        continue;
-                    }
+                if let Some(cut) = visible_extent
+                    && paragraph_index > cut.last_paragraph
+                {
+                    continue;
                 }
                 let y = self.y_offset + paragraph.y;
                 let line_y = y.get() + self.rule_margin.get();
@@ -1859,10 +1969,10 @@ impl Layout {
                 continue;
             }
             if let Some(ref table_info) = paragraph.table {
-                if let Some(cut) = visible_extent {
-                    if paragraph_index > cut.last_paragraph {
-                        continue;
-                    }
+                if let Some(cut) = visible_extent
+                    && paragraph_index > cut.last_paragraph
+                {
+                    continue;
                 }
                 let table_y = self.y_offset + paragraph.y;
                 let border_color = default_text_color.transparentize(0.8);
@@ -1885,7 +1995,7 @@ impl Layout {
                         .zip([&table_info.header, &table_info.body].iter())
                         .enumerate()
                 {
-                    for (row_idx, (row_layouts, row_data)) in
+                    for (row_idx, (row_layouts, _row_data)) in
                         layouts_section.iter().zip(data_section.iter()).enumerate()
                     {
                         let flat_row_idx = if section_idx == 0 {
@@ -1893,10 +2003,18 @@ impl Layout {
                         } else {
                             table_info.header_layouts.len() + row_idx
                         };
-                        let row_y = table_y + *table_info.row_positions.get(flat_row_idx).unwrap_or(&PhysicalLength::zero());
+                        let row_y = table_y
+                            + *table_info
+                                .row_positions
+                                .get(flat_row_idx)
+                                .unwrap_or(&PhysicalLength::zero());
 
                         for (col, cell_layout) in row_layouts.iter().enumerate() {
-                            let col_x = table_info.column_positions.get(col).copied().unwrap_or(PhysicalLength::zero());
+                            let col_x = table_info
+                                .column_positions
+                                .get(col)
+                                .copied()
+                                .unwrap_or(PhysicalLength::zero());
                             let cell_x = col_x + padding;
 
                             for line in cell_layout.lines() {
@@ -1925,7 +2043,12 @@ impl Layout {
 
                 // Draw horizontal grid lines
                 for row_idx in 0..=table_info.row_heights.len() {
-                    let y = table_y + table_info.row_positions.get(row_idx).copied().unwrap_or(table_info.total_height);
+                    let y = table_y
+                        + table_info
+                            .row_positions
+                            .get(row_idx)
+                            .copied()
+                            .unwrap_or(table_info.total_height);
                     let line = PhysicalRect::new(
                         PhysicalPoint::new(0.0, y.get()),
                         PhysicalSize::new(table_info.total_width.get(), 1.0),
@@ -1952,10 +2075,10 @@ impl Layout {
                 continue;
             }
             if paragraph.is_code_block {
-                if let Some(cut) = visible_extent {
-                    if paragraph_index > cut.last_paragraph {
-                        continue;
-                    }
+                if let Some(cut) = visible_extent
+                    && paragraph_index > cut.last_paragraph
+                {
+                    continue;
                 }
                 let y = self.y_offset + paragraph.y;
                 let para_height = PhysicalLength::new(paragraph.layout.height());
@@ -1963,7 +2086,10 @@ impl Layout {
                 let padding = PhysicalLength::new(4.0);
                 let bg_rect = PhysicalRect::new(
                     PhysicalPoint::new(0.0, y.get() - padding.get()),
-                    PhysicalSize::new(self.max_width.get(), para_height.get() + padding.get() * 2.0),
+                    PhysicalSize::new(
+                        self.max_width.get(),
+                        para_height.get() + padding.get() * 2.0,
+                    ),
                 );
                 item_renderer.fill_rectangle_with_color(bg_rect, bg_color);
             }
@@ -1980,7 +2106,8 @@ impl Layout {
                 item_renderer.fill_rectangle_with_color(rect, color);
             }
             if paragraph.heading_level == 1 || paragraph.heading_level == 2 {
-                let y = self.y_offset + paragraph.y + PhysicalLength::new(paragraph.layout.height());
+                let y =
+                    self.y_offset + paragraph.y + PhysicalLength::new(paragraph.layout.height());
                 let line_y = y.get() + 4.0;
                 let line_color = default_text_color.transparentize(0.7);
                 let rect = PhysicalRect::new(

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -18,6 +18,7 @@ use crate::{
     renderer::RendererSealed,
     textlayout::{TextHorizontalAlignment, TextOverflow, TextVerticalAlignment, TextWrap},
 };
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::ops::Range;
 use core::pin::Pin;
@@ -177,6 +178,7 @@ pub use super::DEFAULT_FONT_SIZE;
 pub enum BlockType {
     Normal,
     Heading(u8),
+    CodeBlock,
 }
 
 const HEADING_FONT_SCALES: [f32; 6] = [2.0, 1.5, 1.17, 1.0, 0.83, 0.67];
@@ -395,6 +397,13 @@ impl LayoutWithoutLineBreaksBuilder {
                         parley::style::FontWeight::BOLD,
                     ));
                 }
+                BlockType::CodeBlock => {
+                    builder.push_default(parley::StyleProperty::FontFamily(
+                        parley::style::FontFamily::Single(parley::style::FontFamilyName::Generic(
+                            parley::style::GenericFamily::Monospace,
+                        )),
+                    ));
+                }
                 BlockType::Normal => {}
             }
 
@@ -520,9 +529,7 @@ fn create_text_paragraphs(
                                range: std::ops::Range<usize>,
                                formatting: Vec<i_slint_common::styled_text::FormattedSpan>,
                                links: Vec<(std::ops::Range<usize>, std::string::String)>,
-                               is_horizontal_rule: bool,
-                               is_code_block: bool,
-                               block_type: BlockType,
+                               kind: ParagraphKind,
                                block_quote_level: u8| {
         let selection = selection.clone().and_then(|(selection, selection_color)| {
             let sel_start = selection.start.max(range.start);
@@ -548,9 +555,10 @@ fn create_text_paragraphs(
             .map(|s| s.range.clone())
             .collect();
 
-        let heading_level = match block_type {
-            BlockType::Heading(level) => level,
-            _ => 0,
+        let block_type = match kind {
+            ParagraphKind::Heading(level) => BlockType::Heading(level),
+            ParagraphKind::CodeBlock => BlockType::CodeBlock,
+            _ => BlockType::Normal,
         };
 
         let layout = layout_builder.build(
@@ -568,11 +576,8 @@ fn create_text_paragraphs(
             layout,
             links,
             code_ranges,
-            is_horizontal_rule,
-            is_code_block,
+            kind,
             block_quote_level,
-            heading_level,
-            table: None,
         }
     };
 
@@ -587,9 +592,7 @@ fn create_text_paragraphs(
                     range,
                     Default::default(),
                     Default::default(),
-                    false,
-                    false,
-                    BlockType::Normal,
+                    ParagraphKind::Normal,
                     0,
                 ));
             }
@@ -604,9 +607,7 @@ fn create_text_paragraphs(
                             0..0,
                             content.formatting.clone(),
                             content.links.clone(),
-                            false,
-                            false,
-                            BlockType::Normal,
+                            ParagraphKind::Normal,
                             0,
                         ));
                     }
@@ -617,9 +618,7 @@ fn create_text_paragraphs(
                             0..0,
                             content.formatting.clone(),
                             content.links.clone(),
-                            false,
-                            false,
-                            BlockType::Heading(level),
+                            ParagraphKind::Heading(level),
                             0,
                         ));
                     }
@@ -641,9 +640,7 @@ fn create_text_paragraphs(
                             0..0,
                             shifted_formatting,
                             content.links.clone(),
-                            false,
-                            false,
-                            BlockType::Normal,
+                            ParagraphKind::Normal,
                             level,
                         ));
                     }
@@ -654,30 +651,18 @@ fn create_text_paragraphs(
                             0..0,
                             Default::default(),
                             Default::default(),
-                            true,
-                            false,
-                            BlockType::Normal,
+                            ParagraphKind::HorizontalRule,
                             0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::CodeBlock { text, .. } => {
-                        let formatting = if text.is_empty() {
-                            Vec::new()
-                        } else {
-                            alloc::vec![i_slint_common::styled_text::FormattedSpan {
-                                range: 0..text.len(),
-                                style: i_slint_common::styled_text::Style::Code,
-                            }]
-                        };
                         paragraphs.push(paragraph_from_text(
                             font_context,
                             &text,
                             0..0,
-                            formatting,
                             Vec::new(),
-                            false,
-                            true,
-                            BlockType::Normal,
+                            Vec::new(),
+                            ParagraphKind::CodeBlock,
                             0,
                         ));
                     }
@@ -714,8 +699,6 @@ fn create_text_paragraphs(
                                     row_data.push(TableCellData {
                                         text: cell.content.text.clone(),
                                         formatting: cell.content.formatting.clone(),
-                                        links: cell.content.links.clone(),
-                                        is_header: true,
                                     });
                                 }
                             }
@@ -741,8 +724,6 @@ fn create_text_paragraphs(
                                     row_data.push(TableCellData {
                                         text: cell.content.text.clone(),
                                         formatting: cell.content.formatting.clone(),
-                                        links: cell.content.links.clone(),
-                                        is_header: false,
                                     });
                                 }
                             }
@@ -898,11 +879,7 @@ fn create_text_paragraphs(
                             ),
                             links: Vec::new(),
                             code_ranges: Vec::new(),
-                            is_horizontal_rule: false,
-                            is_code_block: false,
-                            block_quote_level: 0,
-                            heading_level: 0,
-                            table: Some(TableLayout {
+                            kind: ParagraphKind::Table(Box::new(TableLayout {
                                 column_widths: column_widths_resolved,
                                 column_positions,
                                 total_width,
@@ -913,7 +890,8 @@ fn create_text_paragraphs(
                                 total_height,
                                 header_layouts,
                                 body_layouts,
-                            }),
+                            })),
+                            block_quote_level: 0,
                         });
                     }
                 }
@@ -969,25 +947,25 @@ fn layout(
     let rule_margin = PhysicalLength::new(body_font_size * 0.3 * scale);
 
     let mut para_y = 0.0;
-    let mut prev_heading_level: u8 = 0;
+    let mut prev_kind = ParagraphKind::Normal;
     let mut prev_block_quote_level: u8 = 0;
-    let mut prev_is_code_block = false;
-    let mut prev_is_table = false;
     for para in paragraphs.iter_mut() {
-        let spacing = if para_y == 0.0 {
+        // FIXME: Improve the hacky spacing logic
+        let spacing = if para_y == 0.0
+            || matches!(para.kind, ParagraphKind::Heading(_))
+            || !matches!(prev_kind, ParagraphKind::Heading(_))
+        {
+            // heading spacing is already handled
             0.0
-        } else if (para.heading_level > 0 && prev_heading_level == 0)
-            || (para.is_code_block && !prev_is_code_block)
+        } else if matches!(para.kind, ParagraphKind::CodeBlock)
+            && !matches!(prev_kind, ParagraphKind::CodeBlock)
         {
             body_font_size * 1.0
         } else if (para.block_quote_level > 0 && prev_block_quote_level == 0)
-            || (prev_heading_level > 0 && para.heading_level == 0)
-        {
-            body_font_size * 0.5
-        } else if para.heading_level > 0 && prev_heading_level > 0 {
-            0.0
-        } else if (!para.is_code_block && prev_is_code_block)
-            || (para.table.is_some() && !prev_is_table)
+            || (matches!(prev_kind, ParagraphKind::CodeBlock)
+                && !matches!(para.kind, ParagraphKind::CodeBlock))
+            || (matches!(para.kind, ParagraphKind::Table(_))
+                && !matches!(prev_kind, ParagraphKind::Table(_)))
         {
             body_font_size * 0.5
         } else {
@@ -996,11 +974,11 @@ fn layout(
 
         para_y += spacing;
 
-        if para.is_horizontal_rule {
+        if para.is_horizontal_rule() {
             para.layout.break_all_lines(None);
             para.y = PhysicalLength::new(para_y);
             para_y += rule_height.get();
-        } else if let Some(ref table_info) = para.table {
+        } else if let ParagraphKind::Table(table_info) = &para.kind {
             para.layout.break_all_lines(None);
             para.y = PhysicalLength::new(para_y);
             para_y += table_info.total_height.get();
@@ -1023,10 +1001,8 @@ fn layout(
             para_y += para.layout.height();
         }
 
-        prev_heading_level = para.heading_level;
+        prev_kind = para.kind.clone();
         prev_block_quote_level = para.block_quote_level;
-        prev_is_code_block = para.is_code_block;
-        prev_is_table = para.table.is_some();
     }
 
     let line_limit_cut =
@@ -1072,14 +1048,10 @@ fn layout(
                 .expect("line_limit_cut returns an existing line index");
             para.y + PhysicalLength::new(line.metrics().block_max_coord)
         }
-        None => paragraphs.last().map_or(PhysicalLength::zero(), |p| {
-            if p.is_horizontal_rule {
-                p.y + rule_height
-            } else if let Some(ref table_info) = p.table {
-                p.y + table_info.total_height
-            } else {
-                p.y + PhysicalLength::new(p.layout.height())
-            }
+        None => paragraphs.last().map_or(PhysicalLength::zero(), |p| match &p.kind {
+            ParagraphKind::HorizontalRule => p.y + rule_height,
+            ParagraphKind::Table(table_info) => p.y + table_info.total_height,
+            _ => p.y + PhysicalLength::new(p.layout.height()),
         }),
     };
 
@@ -1097,7 +1069,6 @@ fn layout(
         height,
         max_physical_height,
         line_limit_cut,
-        rule_height,
         rule_margin,
     }
 }
@@ -1190,13 +1161,13 @@ fn line_fits_height(block_max_coord: f32, max_physical_height: PhysicalLength) -
     max_physical_height.get().ceil() >= block_max_coord
 }
 
+#[derive(Clone)]
 struct TableCellData {
     text: std::string::String,
     formatting: std::vec::Vec<i_slint_common::styled_text::FormattedSpan>,
-    links: std::vec::Vec<(std::ops::Range<usize>, std::string::String)>,
-    is_header: bool,
 }
 
+#[derive(Clone)]
 struct TableLayout {
     column_widths: Vec<PhysicalLength>,
     column_positions: Vec<PhysicalLength>,
@@ -1210,6 +1181,15 @@ struct TableLayout {
     body_layouts: Vec<Vec<parley::Layout<Brush>>>,
 }
 
+#[derive(Clone)]
+enum ParagraphKind {
+    Normal,
+    Heading(u8),
+    HorizontalRule,
+    CodeBlock,
+    Table(Box<TableLayout>),
+}
+
 struct TextParagraph {
     range: Range<usize>,
     y: PhysicalLength,
@@ -1219,11 +1199,25 @@ struct TextParagraph {
     /// translucent rounded background by `draw` for visual parity with common markdown
     /// renderers.
     code_ranges: std::vec::Vec<Range<usize>>,
-    is_horizontal_rule: bool,
-    is_code_block: bool,
+    kind: ParagraphKind,
     block_quote_level: u8,
-    heading_level: u8,
-    table: Option<TableLayout>,
+}
+
+impl TextParagraph {
+    fn heading_level(&self) -> u8 {
+        match &self.kind {
+            ParagraphKind::Heading(level) => *level,
+            _ => 0,
+        }
+    }
+
+    fn is_code_block(&self) -> bool {
+        matches!(self.kind, ParagraphKind::CodeBlock)
+    }
+
+    fn is_horizontal_rule(&self) -> bool {
+        matches!(self.kind, ParagraphKind::HorizontalRule)
+    }
 }
 
 impl TextParagraph {
@@ -1630,7 +1624,6 @@ struct Layout {
     /// Where an active `max-lines` limit drops lines, in the same coordinates as [`ElisionCut`]:
     /// the (paragraph index, line index) of the last kept line. See [`line_limit_cut`].
     line_limit_cut: Option<(usize, usize)>,
-    rule_height: PhysicalLength,
     rule_margin: PhysicalLength,
 }
 
@@ -1773,7 +1766,13 @@ impl Layout {
         let idx = self.visible_paragraphs().binary_search_by(|paragraph| {
             if y < paragraph.y {
                 core::cmp::Ordering::Greater
-            } else if y >= paragraph.y + PhysicalLength::new(paragraph.layout.height()) {
+            } else if y
+                >= paragraph.y
+                    + match &paragraph.kind {
+                        ParagraphKind::Table(table_info) => table_info.total_height,
+                        _ => PhysicalLength::new(paragraph.layout.height()),
+                    }
+            {
                 core::cmp::Ordering::Less
             } else {
                 core::cmp::Ordering::Equal
@@ -1953,7 +1952,7 @@ impl Layout {
         // elide as a single block (drop lines below the box, ellipsis on the last visible one).
         let visible_extent = self.visible_extent();
         for (paragraph_index, paragraph) in self.paragraphs.iter().enumerate() {
-            if paragraph.is_horizontal_rule {
+            if paragraph.is_horizontal_rule() {
                 if let Some(cut) = visible_extent
                     && paragraph_index > cut.last_paragraph
                 {
@@ -1968,7 +1967,7 @@ impl Layout {
                 item_renderer.fill_rectangle_with_color(rect, default_text_color);
                 continue;
             }
-            if let Some(ref table_info) = paragraph.table {
+            if let ParagraphKind::Table(table_info) = &paragraph.kind {
                 if let Some(cut) = visible_extent
                     && paragraph_index > cut.last_paragraph
                 {
@@ -2074,7 +2073,7 @@ impl Layout {
 
                 continue;
             }
-            if paragraph.is_code_block {
+            if paragraph.is_code_block() {
                 if let Some(cut) = visible_extent
                     && paragraph_index > cut.last_paragraph
                 {
@@ -2083,12 +2082,11 @@ impl Layout {
                 let y = self.y_offset + paragraph.y;
                 let para_height = PhysicalLength::new(paragraph.layout.height());
                 let bg_color = default_text_color.transparentize(0.9);
-                let padding = PhysicalLength::new(4.0);
                 let bg_rect = PhysicalRect::new(
-                    PhysicalPoint::new(0.0, y.get() - padding.get()),
+                    PhysicalPoint::new(0.0, y.get()),
                     PhysicalSize::new(
                         self.max_width.get(),
-                        para_height.get() + padding.get() * 2.0,
+                        para_height.get()
                     ),
                 );
                 item_renderer.fill_rectangle_with_color(bg_rect, bg_color);
@@ -2105,7 +2103,8 @@ impl Layout {
                 let color = default_text_color.transparentize(2.0 / 3.0);
                 item_renderer.fill_rectangle_with_color(rect, color);
             }
-            if paragraph.heading_level == 1 || paragraph.heading_level == 2 {
+            let hl = paragraph.heading_level();
+            if hl == 1 || hl == 2 {
                 let y =
                     self.y_offset + paragraph.y + PhysicalLength::new(paragraph.layout.height());
                 let line_y = y.get() + 4.0;

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -2084,10 +2084,7 @@ impl Layout {
                 let bg_color = default_text_color.transparentize(0.9);
                 let bg_rect = PhysicalRect::new(
                     PhysicalPoint::new(0.0, y.get()),
-                    PhysicalSize::new(
-                        self.max_width.get(),
-                        para_height.get()
-                    ),
+                    PhysicalSize::new(self.max_width.get(), para_height.get()),
                 );
                 item_renderer.fill_rectangle_with_color(bg_rect, bg_color);
             }

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -737,6 +737,50 @@ fn create_text_paragraphs(
                         }
                         let total_height = current_y;
 
+                        // Shape header cell layouts with correct column widths
+                        let header_layouts: Vec<Vec<parley::Layout<Brush>>> = table_header_data.iter().map(|row| {
+                            row.iter().enumerate().map(|(col, cell)| {
+                                let cell_width = if col < column_widths_resolved.len() {
+                                    column_widths_resolved[col].get() - 8.0
+                                } else {
+                                    0.0
+                                };
+                                let mut layout = layout_builder.build(
+                                    font_context, &cell.text, None,
+                                    cell.formatting.iter().cloned(),
+                                    None, BlockType::Normal,
+                                );
+                                if cell_width > 0.0 {
+                                    layout.break_all_lines(Some(cell_width));
+                                } else {
+                                    layout.break_all_lines(None);
+                                }
+                                layout
+                            }).collect()
+                        }).collect();
+
+                        // Shape body cell layouts with correct column widths
+                        let body_layouts: Vec<Vec<parley::Layout<Brush>>> = table_body_data.iter().map(|row| {
+                            row.iter().enumerate().map(|(col, cell)| {
+                                let cell_width = if col < column_widths_resolved.len() {
+                                    column_widths_resolved[col].get() - 8.0
+                                } else {
+                                    0.0
+                                };
+                                let mut layout = layout_builder.build(
+                                    font_context, &cell.text, None,
+                                    cell.formatting.iter().cloned(),
+                                    None, BlockType::Normal,
+                                );
+                                if cell_width > 0.0 {
+                                    layout.break_all_lines(Some(cell_width));
+                                } else {
+                                    layout.break_all_lines(None);
+                                }
+                                layout
+                            }).collect()
+                        }).collect();
+
                         paragraphs.push(TextParagraph {
                             range: 0..0,
                             y: PhysicalLength::default(),
@@ -756,6 +800,8 @@ fn create_text_paragraphs(
                                 row_heights,
                                 row_positions,
                                 total_height,
+                                header_layouts,
+                                body_layouts,
                             }),
                         });
                     }
@@ -821,7 +867,7 @@ fn layout(
         } else if para.heading_level > 0 && prev_heading_level == 0 {
             body_font_size * 1.0
         } else if para.is_code_block && !prev_is_code_block {
-            body_font_size * 0.5
+            body_font_size * 1.0
         } else if para.block_quote_level > 0 && prev_block_quote_level == 0 {
             body_font_size * 0.5
         } else if prev_heading_level > 0 && para.heading_level == 0 {
@@ -829,7 +875,7 @@ fn layout(
         } else if para.heading_level > 0 && prev_heading_level > 0 {
             0.0
         } else if !para.is_code_block && prev_is_code_block {
-            body_font_size * 0.3
+            body_font_size * 0.5
         } else if para.table.is_some() && !prev_is_table {
             body_font_size * 0.5
         } else if !para.table.is_some() && prev_is_table {
@@ -1050,6 +1096,8 @@ struct TableLayout {
     row_heights: Vec<PhysicalLength>,
     row_positions: Vec<PhysicalLength>,
     total_height: PhysicalLength,
+    header_layouts: Vec<Vec<parley::Layout<Brush>>>,
+    body_layouts: Vec<Vec<parley::Layout<Brush>>>,
 }
 
 struct TextParagraph {
@@ -1819,6 +1867,7 @@ impl Layout {
                 let table_y = self.y_offset + paragraph.y;
                 let border_color = default_text_color.transparentize(0.8);
                 let header_bg = default_text_color.transparentize(0.85);
+                let padding = PhysicalLength::new(4.0);
 
                 // Draw header row background
                 if let Some(first_row_h) = table_info.row_heights.first() {
@@ -1827,6 +1876,51 @@ impl Layout {
                         PhysicalSize::new(table_info.total_width.get(), first_row_h.get()),
                     );
                     item_renderer.fill_rectangle_with_color(header_rect, header_bg);
+                }
+
+                // Draw cell text
+                for (section_idx, (layouts_section, data_section)) in
+                    [&table_info.header_layouts, &table_info.body_layouts]
+                        .iter()
+                        .zip([&table_info.header, &table_info.body].iter())
+                        .enumerate()
+                {
+                    for (row_idx, (row_layouts, row_data)) in
+                        layouts_section.iter().zip(data_section.iter()).enumerate()
+                    {
+                        let flat_row_idx = if section_idx == 0 {
+                            row_idx
+                        } else {
+                            table_info.header_layouts.len() + row_idx
+                        };
+                        let row_y = table_y + *table_info.row_positions.get(flat_row_idx).unwrap_or(&PhysicalLength::zero());
+
+                        for (col, cell_layout) in row_layouts.iter().enumerate() {
+                            let col_x = table_info.column_positions.get(col).copied().unwrap_or(PhysicalLength::zero());
+                            let cell_x = col_x + padding;
+
+                            for line in cell_layout.lines() {
+                                for item in line.items() {
+                                    if let parley::PositionedLayoutItem::GlyphRun(run) = item {
+                                        draw_glyphs(
+                                            item_renderer,
+                                            run.run().font(),
+                                            PhysicalLength::new(run.run().font_size()),
+                                            run.run().normalized_coords(),
+                                            &run.run().synthesis(),
+                                            default_fill_brush.clone(),
+                                            row_y,
+                                            &mut run.positioned_glyphs().map(|g| {
+                                                let mut adjusted = g;
+                                                adjusted.x += cell_x.get();
+                                                adjusted
+                                            }),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Draw horizontal grid lines
@@ -1866,7 +1960,7 @@ impl Layout {
                 let y = self.y_offset + paragraph.y;
                 let para_height = PhysicalLength::new(paragraph.layout.height());
                 let bg_color = default_text_color.transparentize(0.9);
-                let padding = PhysicalLength::new(8.0);
+                let padding = PhysicalLength::new(4.0);
                 let bg_rect = PhysicalRect::new(
                     PhysicalPoint::new(0.0, y.get() - padding.get()),
                     PhysicalSize::new(self.max_width.get(), para_height.get() + padding.get() * 2.0),
@@ -1887,7 +1981,7 @@ impl Layout {
             }
             if paragraph.heading_level == 1 || paragraph.heading_level == 2 {
                 let y = self.y_offset + paragraph.y + PhysicalLength::new(paragraph.layout.height());
-                let line_y = y.get() - 2.0;
+                let line_y = y.get() + 4.0;
                 let line_color = default_text_color.transparentize(0.7);
                 let rect = PhysicalRect::new(
                     PhysicalPoint::new(0.0, line_y),

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -539,10 +539,12 @@ fn create_text_paragraphs(
                 .map(|s| s.range.clone())
                 .collect();
 
+            let heading_level = match block_type { BlockType::Heading(level) => level, _ => 0 };
+
             let layout =
                 layout_builder.build(font_context, text, selection, formatting, Some(link_color), block_type);
 
-            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule, block_quote_level, table: None }
+            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule, block_quote_level, heading_level, table: None }
         };
 
     let mut paragraphs = Vec::with_capacity(1);
@@ -595,35 +597,57 @@ fn create_text_paragraphs(
                     }
                     i_slint_common::styled_text::ParagraphBlock::Table { columns, header, body, .. } => {
                         let cell_border_spacing = PhysicalLength::new(8.0);
+                        let padding = PhysicalLength::new(4.0);
                         let mut max_col_widths: Vec<PhysicalLength> = alloc::vec::Vec::new();
                         max_col_widths.resize(columns, PhysicalLength::zero());
 
-                        let mut measure_cell = |text: &str, formatting: &[i_slint_common::styled_text::FormattedSpan]| -> PhysicalLength {
-                            let mut cell_layout = layout_builder.build(
-                                font_context, text, None,
-                                formatting.iter().cloned(),
-                                None, BlockType::Normal,
-                            );
-                            cell_layout.break_all_lines(None);
-                            PhysicalLength::new(cell_layout.full_width()) + cell_border_spacing
-                        };
+                        let mut table_header_data: Vec<Vec<TableCellData>> = Vec::new();
+                        let mut table_body_data: Vec<Vec<TableCellData>> = Vec::new();
 
-                        for row in header {
+                        for row in &header {
+                            let mut row_data = Vec::new();
                             for (col, cell) in row.iter().enumerate() {
                                 if col < columns {
-                                    let w = measure_cell(&cell.content.text, &cell.content.formatting);
+                                    let mut cell_layout = layout_builder.build(
+                                        font_context, &cell.content.text, None,
+                                        cell.content.formatting.iter().cloned(),
+                                        None, BlockType::Normal,
+                                    );
+                                    cell_layout.break_all_lines(None);
+                                    let w = PhysicalLength::new(cell_layout.full_width()) + cell_border_spacing;
                                     max_col_widths[col] = max_col_widths[col].max(w);
+                                    row_data.push(TableCellData {
+                                        text: cell.content.text.clone(),
+                                        formatting: cell.content.formatting.clone(),
+                                        links: cell.content.links.clone(),
+                                        is_header: true,
+                                    });
                                 }
                             }
+                            table_header_data.push(row_data);
                         }
 
-                        for row in body {
+                        for row in &body {
+                            let mut row_data = Vec::new();
                             for (col, cell) in row.iter().enumerate() {
                                 if col < columns {
-                                    let w = measure_cell(&cell.content.text, &cell.content.formatting);
+                                    let mut cell_layout = layout_builder.build(
+                                        font_context, &cell.content.text, None,
+                                        cell.content.formatting.iter().cloned(),
+                                        None, BlockType::Normal,
+                                    );
+                                    cell_layout.break_all_lines(None);
+                                    let w = PhysicalLength::new(cell_layout.full_width()) + cell_border_spacing;
                                     max_col_widths[col] = max_col_widths[col].max(w);
+                                    row_data.push(TableCellData {
+                                        text: cell.content.text.clone(),
+                                        formatting: cell.content.formatting.clone(),
+                                        links: cell.content.links.clone(),
+                                        is_header: false,
+                                    });
                                 }
                             }
+                            table_body_data.push(row_data);
                         }
 
                         let mut x = PhysicalLength::zero();
@@ -636,6 +660,58 @@ fn create_text_paragraphs(
                         }
                         let total_width = x;
 
+                        let mut row_heights = Vec::new();
+                        let mut row_positions = Vec::new();
+                        let mut current_y = PhysicalLength::zero();
+
+                        for row in &table_header_data {
+                            let mut max_h = PhysicalLength::new(layout_builder.pixel_size.get());
+                            for (col, cell) in row.iter().enumerate() {
+                                if col >= column_widths_resolved.len() { break; }
+                                let available_width = column_widths_resolved[col].get() - cell_border_spacing.get();
+                                let mut cell_layout = layout_builder.build(
+                                    font_context, &cell.text, None,
+                                    cell.formatting.iter().cloned(),
+                                    None, BlockType::Normal,
+                                );
+                                if available_width > 0.0 {
+                                    cell_layout.break_all_lines(Some(available_width));
+                                } else {
+                                    cell_layout.break_all_lines(None);
+                                }
+                                let h = PhysicalLength::new(cell_layout.height());
+                                max_h = max_h.max(h);
+                            }
+                            max_h = max_h + padding * 2.0;
+                            row_positions.push(current_y);
+                            row_heights.push(max_h);
+                            current_y += max_h;
+                        }
+                        for row in &table_body_data {
+                            let mut max_h = PhysicalLength::new(layout_builder.pixel_size.get());
+                            for (col, cell) in row.iter().enumerate() {
+                                if col >= column_widths_resolved.len() { break; }
+                                let available_width = column_widths_resolved[col].get() - cell_border_spacing.get();
+                                let mut cell_layout = layout_builder.build(
+                                    font_context, &cell.text, None,
+                                    cell.formatting.iter().cloned(),
+                                    None, BlockType::Normal,
+                                );
+                                if available_width > 0.0 {
+                                    cell_layout.break_all_lines(Some(available_width));
+                                } else {
+                                    cell_layout.break_all_lines(None);
+                                }
+                                let h = PhysicalLength::new(cell_layout.height());
+                                max_h = max_h.max(h);
+                            }
+                            max_h = max_h + padding * 2.0;
+                            row_positions.push(current_y);
+                            row_heights.push(max_h);
+                            current_y += max_h;
+                        }
+                        let total_height = current_y;
+
                         paragraphs.push(TextParagraph {
                             range: 0..0,
                             y: PhysicalLength::default(),
@@ -644,10 +720,16 @@ fn create_text_paragraphs(
                             code_ranges: Vec::new(),
                             is_horizontal_rule: false,
                             block_quote_level: 0,
+                            heading_level: 0,
                             table: Some(TableLayout {
                                 column_widths: column_widths_resolved,
                                 column_positions,
                                 total_width,
+                                header: table_header_data,
+                                body: table_body_data,
+                                row_heights,
+                                row_positions,
+                                total_height,
                             }),
                         });
                     }
@@ -703,35 +785,54 @@ fn layout(
     let rule_margin = PhysicalLength::new(body_font_size * 0.3 * scale);
 
     let mut para_y = 0.0;
+    let mut prev_heading_level: u8 = 0;
+    let mut prev_block_quote_level: u8 = 0;
     for para in paragraphs.iter_mut() {
+        let spacing = if para_y == 0.0 {
+            0.0
+        } else if para.heading_level > 0 && prev_heading_level == 0 {
+            body_font_size * 1.0
+        } else if para.block_quote_level > 0 && prev_block_quote_level == 0 {
+            body_font_size * 0.5
+        } else if prev_heading_level > 0 && para.heading_level == 0 {
+            body_font_size * 0.5
+        } else if para.heading_level > 0 && prev_heading_level > 0 {
+            0.0
+        } else {
+            body_font_size * 0.3
+        };
+
+        para_y += spacing;
+
         if para.is_horizontal_rule {
             para.layout.break_all_lines(None);
             para.y = PhysicalLength::new(para_y);
             para_y += rule_height.get();
-            continue;
-        }
-        if para.table.is_some() {
+        } else if let Some(ref table_info) = para.table {
             para.layout.break_all_lines(None);
             para.y = PhysicalLength::new(para_y);
-            para_y += body_font_size * 1.5 * 3.0; // estimated height for table
-            continue;
-        }
-        para.layout.break_all_lines(max_physical_width.map(|width| width.get()));
-        para.layout.align(
-            match options.horizontal_align {
-                TextHorizontalAlignment::Start | TextHorizontalAlignment::Left => {
-                    parley::Alignment::Left
-                }
-                TextHorizontalAlignment::Center => parley::Alignment::Center,
-                TextHorizontalAlignment::End | TextHorizontalAlignment::Right => {
-                    parley::Alignment::Right
-                }
-            },
-            parley::AlignmentOptions::default(),
-        );
+            para_y += table_info.total_height.get();
+        } else {
+            para.layout.break_all_lines(max_physical_width.map(|width| width.get()));
+            para.layout.align(
+                match options.horizontal_align {
+                    TextHorizontalAlignment::Start | TextHorizontalAlignment::Left => {
+                        parley::Alignment::Left
+                    }
+                    TextHorizontalAlignment::Center => parley::Alignment::Center,
+                    TextHorizontalAlignment::End | TextHorizontalAlignment::Right => {
+                        parley::Alignment::Right
+                    }
+                },
+                parley::AlignmentOptions::default(),
+            );
 
-        para.y = PhysicalLength::new(para_y);
-        para_y += para.layout.height();
+            para.y = PhysicalLength::new(para_y);
+            para_y += para.layout.height();
+        }
+
+        prev_heading_level = para.heading_level;
+        prev_block_quote_level = para.block_quote_level;
     }
 
     let line_limit_cut =
@@ -780,6 +881,8 @@ fn layout(
         None => paragraphs.last().map_or(PhysicalLength::zero(), |p| {
             if p.is_horizontal_rule {
                 p.y + rule_height
+            } else if let Some(ref table_info) = p.table {
+                p.y + table_info.total_height
             } else {
                 p.y + PhysicalLength::new(p.layout.height())
             }
@@ -893,10 +996,22 @@ fn line_fits_height(block_max_coord: f32, max_physical_height: PhysicalLength) -
     max_physical_height.get().ceil() >= block_max_coord
 }
 
+struct TableCellData {
+    text: std::string::String,
+    formatting: std::vec::Vec<i_slint_common::styled_text::FormattedSpan>,
+    links: std::vec::Vec<(std::ops::Range<usize>, std::string::String)>,
+    is_header: bool,
+}
+
 struct TableLayout {
     column_widths: Vec<PhysicalLength>,
     column_positions: Vec<PhysicalLength>,
     total_width: PhysicalLength,
+    header: Vec<Vec<TableCellData>>,
+    body: Vec<Vec<TableCellData>>,
+    row_heights: Vec<PhysicalLength>,
+    row_positions: Vec<PhysicalLength>,
+    total_height: PhysicalLength,
 }
 
 struct TextParagraph {
@@ -910,6 +1025,7 @@ struct TextParagraph {
     code_ranges: std::vec::Vec<Range<usize>>,
     is_horizontal_rule: bool,
     block_quote_level: u8,
+    heading_level: u8,
     table: Option<TableLayout>,
 }
 
@@ -1661,13 +1777,45 @@ impl Layout {
                         continue;
                     }
                 }
-                let y = self.y_offset + paragraph.y;
-                let header_bg = default_text_color.transparentize(0.8);
-                let rect = PhysicalRect::new(
-                    PhysicalPoint::new(0.0, y.get()),
-                    PhysicalSize::new(table_info.total_width.get(), 20.0),
-                );
-                item_renderer.fill_rectangle_with_color(rect, header_bg);
+                let table_y = self.y_offset + paragraph.y;
+                let border_color = default_text_color.transparentize(0.8);
+                let header_bg = default_text_color.transparentize(0.85);
+
+                // Draw header row background
+                if let Some(first_row_h) = table_info.row_heights.first() {
+                    let header_rect = PhysicalRect::new(
+                        PhysicalPoint::new(0.0, table_y.get()),
+                        PhysicalSize::new(table_info.total_width.get(), first_row_h.get()),
+                    );
+                    item_renderer.fill_rectangle_with_color(header_rect, header_bg);
+                }
+
+                // Draw horizontal grid lines
+                for row_idx in 0..=table_info.row_heights.len() {
+                    let y = table_y + table_info.row_positions.get(row_idx).copied().unwrap_or(table_info.total_height);
+                    let line = PhysicalRect::new(
+                        PhysicalPoint::new(0.0, y.get()),
+                        PhysicalSize::new(table_info.total_width.get(), 1.0),
+                    );
+                    item_renderer.fill_rectangle_with_color(line, border_color);
+                }
+
+                // Draw vertical grid lines
+                for col in 0..=table_info.column_widths.len() {
+                    let x = if col == 0 {
+                        PhysicalLength::zero()
+                    } else if col > 0 && col <= table_info.column_positions.len() {
+                        table_info.column_positions[col - 1] + table_info.column_widths[col - 1]
+                    } else {
+                        table_info.total_width
+                    };
+                    let line = PhysicalRect::new(
+                        PhysicalPoint::new(x.get(), table_y.get()),
+                        PhysicalSize::new(1.0, table_info.total_height.get()),
+                    );
+                    item_renderer.fill_rectangle_with_color(line, border_color);
+                }
+
                 continue;
             }
             if paragraph.block_quote_level > 0 {
@@ -1681,6 +1829,16 @@ impl Layout {
                 );
                 let color = default_text_color.transparentize(2.0 / 3.0);
                 item_renderer.fill_rectangle_with_color(rect, color);
+            }
+            if paragraph.heading_level == 1 || paragraph.heading_level == 2 {
+                let y = self.y_offset + paragraph.y + PhysicalLength::new(paragraph.layout.height());
+                let line_y = y.get() - 2.0;
+                let line_color = default_text_color.transparentize(0.7);
+                let rect = PhysicalRect::new(
+                    PhysicalPoint::new(0.0, line_y),
+                    PhysicalSize::new(self.max_width.get(), 1.0),
+                );
+                item_renderer.fill_rectangle_with_color(rect, line_color);
             }
             paragraph.draw(
                 self,

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -519,6 +519,7 @@ fn create_text_paragraphs(
          formatting: Vec<i_slint_common::styled_text::FormattedSpan>,
          links: Vec<(std::ops::Range<usize>, std::string::String)>,
          is_horizontal_rule: bool,
+         is_code_block: bool,
          block_type: BlockType,
          block_quote_level: u8| {
             let selection = selection.clone().and_then(|(selection, selection_color)| {
@@ -544,7 +545,7 @@ fn create_text_paragraphs(
             let layout =
                 layout_builder.build(font_context, text, selection, formatting, Some(link_color), block_type);
 
-            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule, block_quote_level, heading_level, table: None }
+            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule, is_code_block, block_quote_level, heading_level, table: None }
         };
 
     let mut paragraphs = Vec::with_capacity(1);
@@ -559,6 +560,7 @@ fn create_text_paragraphs(
                     Default::default(),
                     Default::default(),
                     false,
+                    false,
                     BlockType::Normal,
                     0,
                 ));
@@ -571,28 +573,51 @@ fn create_text_paragraphs(
                         paragraphs.push(paragraph_from_text(
                             font_context, &content.text, 0..0,
                             content.formatting.clone(), content.links.clone(),
-                            false, BlockType::Normal, 0,
+                            false, false, BlockType::Normal, 0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::Heading { level, content } => {
                         paragraphs.push(paragraph_from_text(
                             font_context, &content.text, 0..0,
                             content.formatting.clone(), content.links.clone(),
-                            false, BlockType::Heading(level), 0,
+                            false, false, BlockType::Heading(level), 0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::BlockQuote { level, content } => {
+                        let indent_str = " ".repeat(level as usize + 2);
+                        let indented_text = alloc::format!("{}{}", indent_str, content.text);
+                        let shifted_formatting: Vec<_> = content.formatting.iter().map(|s| {
+                            i_slint_common::styled_text::FormattedSpan {
+                                range: (s.range.start + indent_str.len())..(s.range.end + indent_str.len()),
+                                style: s.style.clone(),
+                            }
+                        }).collect();
                         paragraphs.push(paragraph_from_text(
-                            font_context, &content.text, 0..0,
-                            content.formatting.clone(), content.links.clone(),
-                            false, BlockType::Normal, level,
+                            font_context, &indented_text, 0..0,
+                            shifted_formatting, content.links.clone(),
+                            false, false, BlockType::Normal, level,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::HorizontalRule => {
                         paragraphs.push(paragraph_from_text(
                             font_context, "", 0..0,
                             Default::default(), Default::default(),
-                            true, BlockType::Normal, 0,
+                            true, false, BlockType::Normal, 0,
+                        ));
+                    }
+                    i_slint_common::styled_text::ParagraphBlock::CodeBlock { text, .. } => {
+                        let formatting = if text.is_empty() {
+                            Vec::new()
+                        } else {
+                            alloc::vec![i_slint_common::styled_text::FormattedSpan {
+                                range: 0..text.len(),
+                                style: i_slint_common::styled_text::Style::Code,
+                            }]
+                        };
+                        paragraphs.push(paragraph_from_text(
+                            font_context, &text, 0..0,
+                            formatting, Vec::new(),
+                            false, true, BlockType::Normal, 0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::Table { columns, header, body, .. } => {
@@ -719,6 +744,7 @@ fn create_text_paragraphs(
                             links: Vec::new(),
                             code_ranges: Vec::new(),
                             is_horizontal_rule: false,
+                            is_code_block: false,
                             block_quote_level: 0,
                             heading_level: 0,
                             table: Some(TableLayout {
@@ -787,17 +813,27 @@ fn layout(
     let mut para_y = 0.0;
     let mut prev_heading_level: u8 = 0;
     let mut prev_block_quote_level: u8 = 0;
+    let mut prev_is_code_block = false;
+    let mut prev_is_table = false;
     for para in paragraphs.iter_mut() {
         let spacing = if para_y == 0.0 {
             0.0
         } else if para.heading_level > 0 && prev_heading_level == 0 {
             body_font_size * 1.0
+        } else if para.is_code_block && !prev_is_code_block {
+            body_font_size * 0.5
         } else if para.block_quote_level > 0 && prev_block_quote_level == 0 {
             body_font_size * 0.5
         } else if prev_heading_level > 0 && para.heading_level == 0 {
             body_font_size * 0.5
         } else if para.heading_level > 0 && prev_heading_level > 0 {
             0.0
+        } else if !para.is_code_block && prev_is_code_block {
+            body_font_size * 0.3
+        } else if para.table.is_some() && !prev_is_table {
+            body_font_size * 0.5
+        } else if !para.table.is_some() && prev_is_table {
+            body_font_size * 0.3
         } else {
             body_font_size * 0.3
         };
@@ -833,6 +869,8 @@ fn layout(
 
         prev_heading_level = para.heading_level;
         prev_block_quote_level = para.block_quote_level;
+        prev_is_code_block = para.is_code_block;
+        prev_is_table = para.table.is_some();
     }
 
     let line_limit_cut =
@@ -1024,6 +1062,7 @@ struct TextParagraph {
     /// renderers.
     code_ranges: std::vec::Vec<Range<usize>>,
     is_horizontal_rule: bool,
+    is_code_block: bool,
     block_quote_level: u8,
     heading_level: u8,
     table: Option<TableLayout>,
@@ -1817,6 +1856,22 @@ impl Layout {
                 }
 
                 continue;
+            }
+            if paragraph.is_code_block {
+                if let Some(cut) = visible_extent {
+                    if paragraph_index > cut.last_paragraph {
+                        continue;
+                    }
+                }
+                let y = self.y_offset + paragraph.y;
+                let para_height = PhysicalLength::new(paragraph.layout.height());
+                let bg_color = default_text_color.transparentize(0.9);
+                let padding = PhysicalLength::new(8.0);
+                let bg_rect = PhysicalRect::new(
+                    PhysicalPoint::new(0.0, y.get() - padding.get()),
+                    PhysicalSize::new(self.max_width.get(), para_height.get() + padding.get() * 2.0),
+                );
+                item_renderer.fill_rectangle_with_color(bg_rect, bg_color);
             }
             if paragraph.block_quote_level > 0 {
                 let bar_width = PhysicalLength::new(3.0);

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -174,6 +174,10 @@ pub use super::DEFAULT_FONT_SIZE;
 /// text. Matches the convention used by GitHub-style markdown renderers — the
 /// glyphs sit a little smaller than body text, inside a translucent capsule
 /// that visually marks them as code.
+pub enum BlockType { Normal, Heading(u8) }
+
+const HEADING_FONT_SCALES: [f32; 6] = [2.0, 1.5, 1.17, 1.0, 0.83, 0.67];
+
 const INLINE_CODE_FONT_SCALE: f32 = 0.85;
 
 std::thread_local! {
@@ -358,6 +362,7 @@ impl LayoutWithoutLineBreaksBuilder {
         selection: Option<(Range<usize>, Color)>,
         formatting: impl IntoIterator<Item = i_slint_common::styled_text::FormattedSpan>,
         link_color: Option<Color>,
+        block_type: BlockType,
     ) -> parley::Layout<Brush> {
         use i_slint_common::styled_text::Style;
 
@@ -375,6 +380,19 @@ impl LayoutWithoutLineBreaksBuilder {
                         selection_range,
                     );
                 }
+            }
+
+            match block_type {
+                BlockType::Heading(level) => {
+                    let scale = HEADING_FONT_SCALES[level as usize - 1];
+                    builder.push_default(parley::StyleProperty::FontSize(
+                        self.pixel_size.get() * scale,
+                    ));
+                    builder.push_default(parley::StyleProperty::FontWeight(
+                        parley::style::FontWeight::BOLD,
+                    ));
+                }
+                BlockType::Normal => {}
             }
 
             // filter empty ranges otherwise parley will panic on assert
@@ -471,7 +489,9 @@ fn create_text_paragraphs(
          text: &str,
          range: std::ops::Range<usize>,
          formatting: Vec<i_slint_common::styled_text::FormattedSpan>,
-         links: Vec<(std::ops::Range<usize>, std::string::String)>| {
+         links: Vec<(std::ops::Range<usize>, std::string::String)>,
+         is_horizontal_rule: bool,
+         block_type: BlockType| {
             let selection = selection.clone().and_then(|(selection, selection_color)| {
                 let sel_start = selection.start.max(range.start);
                 let sel_end = selection.end.min(range.end);
@@ -491,9 +511,9 @@ fn create_text_paragraphs(
                 .collect();
 
             let layout =
-                layout_builder.build(font_context, text, selection, formatting, Some(link_color));
+                layout_builder.build(font_context, text, selection, formatting, Some(link_color), block_type);
 
-            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges }
+            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule }
         };
 
     let mut paragraphs = Vec::with_capacity(1);
@@ -507,23 +527,36 @@ fn create_text_paragraphs(
                     range,
                     Default::default(),
                     Default::default(),
+                    false,
+                    BlockType::Normal,
                 ));
             }
         }
         PlainOrStyledText::Styled(rich_text) => {
-            for paragraph in rich_text.paragraphs {
-                let Some(rt) =
-                    i_slint_common::styled_text::rich_text_content(&paragraph)
-                else {
-                    continue;
-                };
-                paragraphs.push(paragraph_from_text(
-                    font_context,
-                    &rt.text,
-                    0..0,
-                    rt.formatting.clone(),
-                    rt.links.clone(),
-                ));
+            for block in rich_text.paragraphs {
+                match block {
+                    i_slint_common::styled_text::ParagraphBlock::Text(content) => {
+                        paragraphs.push(paragraph_from_text(
+                            font_context, &content.text, 0..0,
+                            content.formatting.clone(), content.links.clone(),
+                            false, BlockType::Normal,
+                        ));
+                    }
+                    i_slint_common::styled_text::ParagraphBlock::Heading { level, content } => {
+                        paragraphs.push(paragraph_from_text(
+                            font_context, &content.text, 0..0,
+                            content.formatting.clone(), content.links.clone(),
+                            false, BlockType::Heading(level),
+                        ));
+                    }
+                    i_slint_common::styled_text::ParagraphBlock::HorizontalRule => {
+                        paragraphs.push(paragraph_from_text(
+                            font_context, "", 0..0,
+                            Default::default(), Default::default(),
+                            true, BlockType::Normal,
+                        ));
+                    }
+                }
             }
         }
     };
@@ -547,7 +580,7 @@ fn layout(
 
     // Returned None if failed to get the ellipsis glyph for some rare reason.
     let get_ellipsis_glyph = |font_context: &mut parley::FontContext| {
-        let mut layout = layout_builder.build(font_context, "…", None, None, None);
+        let mut layout = layout_builder.build(font_context, "…", None, None, None, BlockType::Normal);
         layout.break_all_lines(None);
         let line = layout.lines().next()?;
         let item = line.items().next()?;
@@ -569,8 +602,18 @@ fn layout(
         None
     };
 
+    let body_font_size = layout_builder.pixel_size.get();
+    let rule_height = PhysicalLength::new(body_font_size * 0.8);
+    let rule_margin = PhysicalLength::new(body_font_size * 0.3);
+
     let mut para_y = 0.0;
     for para in paragraphs.iter_mut() {
+        if para.is_horizontal_rule {
+            para.layout.break_all_lines(None);
+            para.y = PhysicalLength::new(para_y);
+            para_y += rule_height.get();
+            continue;
+        }
         para.layout.break_all_lines(max_physical_width.map(|width| width.get()));
         para.layout.align(
             match options.horizontal_align {
@@ -632,9 +675,13 @@ fn layout(
                 .expect("line_limit_cut returns an existing line index");
             para.y + PhysicalLength::new(line.metrics().block_max_coord)
         }
-        None => paragraphs
-            .last()
-            .map_or(PhysicalLength::zero(), |p| p.y + PhysicalLength::new(p.layout.height())),
+        None => paragraphs.last().map_or(PhysicalLength::zero(), |p| {
+            if p.is_horizontal_rule {
+                p.y + rule_height
+            } else {
+                p.y + PhysicalLength::new(p.layout.height())
+            }
+        }),
     };
 
     let y_offset = match (max_physical_height, options.vertical_align) {
@@ -651,6 +698,8 @@ fn layout(
         height,
         max_physical_height,
         line_limit_cut,
+        rule_height,
+        rule_margin,
     }
 }
 
@@ -751,6 +800,7 @@ struct TextParagraph {
     /// translucent rounded background by `draw` for visual parity with common markdown
     /// renderers.
     code_ranges: std::vec::Vec<Range<usize>>,
+    is_horizontal_rule: bool,
 }
 
 impl TextParagraph {
@@ -1157,6 +1207,8 @@ struct Layout {
     /// Where an active `max-lines` limit drops lines, in the same coordinates as [`ElisionCut`]:
     /// the (paragraph index, line index) of the last kept line. See [`line_limit_cut`].
     line_limit_cut: Option<(usize, usize)>,
+    rule_height: PhysicalLength,
+    rule_margin: PhysicalLength,
 }
 
 impl Layout {
@@ -1478,6 +1530,21 @@ impl Layout {
         // elide as a single block (drop lines below the box, ellipsis on the last visible one).
         let visible_extent = self.visible_extent();
         for (paragraph_index, paragraph) in self.paragraphs.iter().enumerate() {
+            if paragraph.is_horizontal_rule {
+                if let Some(cut) = visible_extent {
+                    if paragraph_index > cut.last_paragraph {
+                        continue;
+                    }
+                }
+                let y = self.y_offset + paragraph.y;
+                let line_y = y.get() + self.rule_margin.get();
+                let rect = PhysicalRect::new(
+                    PhysicalPoint::new(0.0, line_y),
+                    PhysicalSize::new(self.max_width.get(), 1.0),
+                );
+                item_renderer.fill_rectangle_with_color(rect, default_text_color);
+                continue;
+            }
             paragraph.draw(
                 self,
                 paragraph_index,

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -456,6 +456,22 @@ impl LayoutWithoutLineBreaksBuilder {
                             span.range,
                         );
                     }
+                    Style::Math => {
+                        builder.push(
+                            parley::StyleProperty::FontFamily(parley::style::FontFamily::Single(
+                                parley::style::FontFamilyName::Generic(
+                                    parley::style::GenericFamily::Monospace,
+                                ),
+                            )),
+                            span.range.clone(),
+                        );
+                        builder.push(
+                            parley::StyleProperty::FontSize(
+                                self.pixel_size.get() * INLINE_CODE_FONT_SCALE,
+                            ),
+                            span.range,
+                        );
+                    }
                     Style::Superscript => {
                         builder.push(
                             parley::StyleProperty::FontSize(self.pixel_size.get() * 0.7),
@@ -503,7 +519,8 @@ fn create_text_paragraphs(
          formatting: Vec<i_slint_common::styled_text::FormattedSpan>,
          links: Vec<(std::ops::Range<usize>, std::string::String)>,
          is_horizontal_rule: bool,
-         block_type: BlockType| {
+         block_type: BlockType,
+         block_quote_level: u8| {
             let selection = selection.clone().and_then(|(selection, selection_color)| {
                 let sel_start = selection.start.max(range.start);
                 let sel_end = selection.end.min(range.end);
@@ -518,14 +535,14 @@ fn create_text_paragraphs(
 
             let code_ranges: alloc::vec::Vec<Range<usize>> = formatting
                 .iter()
-                .filter(|s| matches!(s.style, i_slint_common::styled_text::Style::Code))
+                .filter(|s| matches!(s.style, i_slint_common::styled_text::Style::Code | i_slint_common::styled_text::Style::Math))
                 .map(|s| s.range.clone())
                 .collect();
 
             let layout =
                 layout_builder.build(font_context, text, selection, formatting, Some(link_color), block_type);
 
-            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule }
+            TextParagraph { range, y: PhysicalLength::default(), layout, links, code_ranges, is_horizontal_rule, block_quote_level, table: None }
         };
 
     let mut paragraphs = Vec::with_capacity(1);
@@ -541,6 +558,7 @@ fn create_text_paragraphs(
                     Default::default(),
                     false,
                     BlockType::Normal,
+                    0,
                 ));
             }
         }
@@ -551,22 +569,87 @@ fn create_text_paragraphs(
                         paragraphs.push(paragraph_from_text(
                             font_context, &content.text, 0..0,
                             content.formatting.clone(), content.links.clone(),
-                            false, BlockType::Normal,
+                            false, BlockType::Normal, 0,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::Heading { level, content } => {
                         paragraphs.push(paragraph_from_text(
                             font_context, &content.text, 0..0,
                             content.formatting.clone(), content.links.clone(),
-                            false, BlockType::Heading(level),
+                            false, BlockType::Heading(level), 0,
+                        ));
+                    }
+                    i_slint_common::styled_text::ParagraphBlock::BlockQuote { level, content } => {
+                        paragraphs.push(paragraph_from_text(
+                            font_context, &content.text, 0..0,
+                            content.formatting.clone(), content.links.clone(),
+                            false, BlockType::Normal, level,
                         ));
                     }
                     i_slint_common::styled_text::ParagraphBlock::HorizontalRule => {
                         paragraphs.push(paragraph_from_text(
                             font_context, "", 0..0,
                             Default::default(), Default::default(),
-                            true, BlockType::Normal,
+                            true, BlockType::Normal, 0,
                         ));
+                    }
+                    i_slint_common::styled_text::ParagraphBlock::Table { columns, header, body, .. } => {
+                        let cell_border_spacing = PhysicalLength::new(8.0);
+                        let mut max_col_widths: Vec<PhysicalLength> = alloc::vec::Vec::new();
+                        max_col_widths.resize(columns, PhysicalLength::zero());
+
+                        let mut measure_cell = |text: &str, formatting: &[i_slint_common::styled_text::FormattedSpan]| -> PhysicalLength {
+                            let mut cell_layout = layout_builder.build(
+                                font_context, text, None,
+                                formatting.iter().cloned(),
+                                None, BlockType::Normal,
+                            );
+                            cell_layout.break_all_lines(None);
+                            PhysicalLength::new(cell_layout.full_width()) + cell_border_spacing
+                        };
+
+                        for row in header {
+                            for (col, cell) in row.iter().enumerate() {
+                                if col < columns {
+                                    let w = measure_cell(&cell.content.text, &cell.content.formatting);
+                                    max_col_widths[col] = max_col_widths[col].max(w);
+                                }
+                            }
+                        }
+
+                        for row in body {
+                            for (col, cell) in row.iter().enumerate() {
+                                if col < columns {
+                                    let w = measure_cell(&cell.content.text, &cell.content.formatting);
+                                    max_col_widths[col] = max_col_widths[col].max(w);
+                                }
+                            }
+                        }
+
+                        let mut x = PhysicalLength::zero();
+                        let mut column_positions = Vec::with_capacity(columns);
+                        let mut column_widths_resolved = Vec::with_capacity(columns);
+                        for w in &max_col_widths {
+                            column_positions.push(x);
+                            column_widths_resolved.push(*w);
+                            x += *w;
+                        }
+                        let total_width = x;
+
+                        paragraphs.push(TextParagraph {
+                            range: 0..0,
+                            y: PhysicalLength::default(),
+                            layout: layout_builder.build(font_context, "", None, None, None, BlockType::Normal),
+                            links: Vec::new(),
+                            code_ranges: Vec::new(),
+                            is_horizontal_rule: false,
+                            block_quote_level: 0,
+                            table: Some(TableLayout {
+                                column_widths: column_widths_resolved,
+                                column_positions,
+                                total_width,
+                            }),
+                        });
                     }
                 }
             }
@@ -625,6 +708,12 @@ fn layout(
             para.layout.break_all_lines(None);
             para.y = PhysicalLength::new(para_y);
             para_y += rule_height.get();
+            continue;
+        }
+        if para.table.is_some() {
+            para.layout.break_all_lines(None);
+            para.y = PhysicalLength::new(para_y);
+            para_y += body_font_size * 1.5 * 3.0; // estimated height for table
             continue;
         }
         para.layout.break_all_lines(max_physical_width.map(|width| width.get()));
@@ -804,6 +893,12 @@ fn line_fits_height(block_max_coord: f32, max_physical_height: PhysicalLength) -
     max_physical_height.get().ceil() >= block_max_coord
 }
 
+struct TableLayout {
+    column_widths: Vec<PhysicalLength>,
+    column_positions: Vec<PhysicalLength>,
+    total_width: PhysicalLength,
+}
+
 struct TextParagraph {
     range: Range<usize>,
     y: PhysicalLength,
@@ -814,6 +909,8 @@ struct TextParagraph {
     /// renderers.
     code_ranges: std::vec::Vec<Range<usize>>,
     is_horizontal_rule: bool,
+    block_quote_level: u8,
+    table: Option<TableLayout>,
 }
 
 impl TextParagraph {
@@ -1557,6 +1654,33 @@ impl Layout {
                 );
                 item_renderer.fill_rectangle_with_color(rect, default_text_color);
                 continue;
+            }
+            if let Some(ref table_info) = paragraph.table {
+                if let Some(cut) = visible_extent {
+                    if paragraph_index > cut.last_paragraph {
+                        continue;
+                    }
+                }
+                let y = self.y_offset + paragraph.y;
+                let header_bg = default_text_color.transparentize(0.8);
+                let rect = PhysicalRect::new(
+                    PhysicalPoint::new(0.0, y.get()),
+                    PhysicalSize::new(table_info.total_width.get(), 20.0),
+                );
+                item_renderer.fill_rectangle_with_color(rect, header_bg);
+                continue;
+            }
+            if paragraph.block_quote_level > 0 {
+                let bar_width = PhysicalLength::new(3.0);
+                let bar_x = PhysicalLength::new(4.0 * paragraph.block_quote_level as f32);
+                let y = self.y_offset + paragraph.y;
+                let para_height = PhysicalLength::new(paragraph.layout.height());
+                let rect = PhysicalRect::new(
+                    PhysicalPoint::new(bar_x.get(), y.get()),
+                    PhysicalSize::new(bar_width.get(), para_height.get()),
+                );
+                let color = default_text_color.transparentize(2.0 / 3.0);
+                item_renderer.fill_rectangle_with_color(rect, color);
             }
             paragraph.draw(
                 self,

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -512,12 +512,17 @@ fn create_text_paragraphs(
         }
         PlainOrStyledText::Styled(rich_text) => {
             for paragraph in rich_text.paragraphs {
+                let Some(rt) =
+                    i_slint_common::styled_text::rich_text_content(&paragraph)
+                else {
+                    continue;
+                };
                 paragraphs.push(paragraph_from_text(
                     font_context,
-                    &paragraph.text,
+                    &rt.text,
                     0..0,
-                    paragraph.formatting,
-                    paragraph.links,
+                    rt.formatting.clone(),
+                    rt.links.clone(),
                 ));
             }
         }

--- a/tests/cases/types/styled_text.slint
+++ b/tests/cases/types/styled_text.slint
@@ -127,7 +127,8 @@ assert_eq!(plain2, md2);
 assert_eq!(instance.get_foo_bar(), StyledText::from_plain_text("foo bar"));
 
 // Public API: from_markdown rejects unsupported syntax
-assert!(StyledText::from_markdown("# heading").is_err());
+assert!(StyledText::from_markdown("# heading").is_ok());
+assert!(StyledText::from_markdown("---").is_ok());
 ```
 ```cpp
 auto handle = TestCase::create();
@@ -167,8 +168,10 @@ assert(plain2 == *md2);
 assert(instance.get_foo_bar() == slint::StyledText::from_plain_text("foo bar"));
 
 // from_markdown returns nullopt for unsupported syntax
-auto bad = slint::StyledText::from_markdown("# heading");
-assert(!bad.has_value());
+auto heading = slint::StyledText::from_markdown("# heading");
+assert(heading.has_value());
+auto hr = slint::StyledText::from_markdown("---");
+assert(hr.has_value());
 ```
 ```js
 var instance = new slint.TestCase({});
@@ -201,10 +204,8 @@ assert(plain2.equals(md2));
 // @markdown("foo bar") in .slint equals fromPlainText("foo bar")
 assert(instance.foo_bar.equals(StyledText.fromPlainText("foo bar")));
 
-// fromMarkdown throws for unsupported syntax
-let threw = false;
-try { StyledText.fromMarkdown("# heading"); } catch(e) { threw = true; }
-assert(threw);
+assert(StyledText.fromMarkdown("# heading") instanceof StyledText);
+assert(StyledText.fromMarkdown("---") instanceof StyledText);
 ```
 ```python
 instance = TestCase()
@@ -236,12 +237,7 @@ assert plain2 == md2
 # @markdown("foo bar") in .slint equals from_plain_text("foo bar")
 assert instance.foo_bar == slint.StyledText.from_plain_text("foo bar")
 
-# from_markdown raises for unsupported syntax
-threw = False
-try:
-    slint.StyledText.from_markdown("# heading")
-except ValueError:
-    threw = True
-assert threw
+assert isinstance(slint.StyledText.from_markdown("# heading"), slint.StyledText)
+assert isinstance(slint.StyledText.from_markdown("---"), slint.StyledText)
 ```
 */

--- a/tests/screenshots/cases/text/headings.slint
+++ b/tests/screenshots/cases/text/headings.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Skia font rendering is not consistent across platforms
+//ignore:skia
+// SIZE=320x200
+
+export component TestCase inherits Window {
+    width: 320px;
+    height: 200px;
+    background: white;
+    StyledText {
+        width: 100%;
+        height: 100%;
+        text: @markdown("# Heading 1\n## Heading 2\n### Heading 3\nBody text\n*Italic* body");
+        default-color: #025;
+    }
+}

--- a/tests/screenshots/cases/text/horizontal-rule.slint
+++ b/tests/screenshots/cases/text/horizontal-rule.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Skia font rendering is not consistent across platforms
+//ignore:skia
+// SIZE=200x100
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 100px;
+    background: white;
+    StyledText {
+        width: 100%;
+        height: 100%;
+        text: @markdown("Above\n\n---\n\nBelow");
+        default-color: #025;
+    }
+}


### PR DESCRIPTION
fixes https://github.com/slint-ui/slint/issues/12648

- **refactor(styled-text): replace StyledTextParagraph with ParagraphBlock enum**
- **fixup: ungate rich_text_content, remove dead append_paragraph**
- **fixup: handle unclosed heading at end of input**
- **feat(core): update StyledText wrapper for ParagraphBlock enum**
- **feat(renderer): add heading font-size scaling and horizontal rule rendering**
- **test: update tests for ParagraphBlock, headings, and horizontal rules**
- **test: add screenshot tests for headings and horizontal rules**
- **fixup: multiply rule spacing by scale factor for HiDPI support**
- **feat(markdown): add subscript and superscript support**
- **feat(markdown): support HTML inline tags \<s>, \<del>, \<i>, \<em>, \<b>, \<strong>**
- **feat(markdown): add footnotes, images, and math support**
- **feat(markdown): support HTML comments**
- **fix: heading spacing, list alignment, H1/H2 underline, table grid rendering**
- **fix: block quote indent, table alignments, table spacing**
- **feat(markdown): support \<sub> and \<sup> HTML tags**
- **chore: cleanup dead comments and fix InlineHtml in table cells**
- **chore: cargo fmt**

How it looks at present:
<img width="1920" height="1075" alt="image" src="https://github.com/user-attachments/assets/c412adff-a161-4272-983d-83050de6cb0b" />
<img width="1920" height="1075" alt="image" src="https://github.com/user-attachments/assets/f9383e63-28d1-4444-a6f6-dce5964e2e84" />
