### PR TITLE
android: dispatch Back through OnBackInvokedCallback on API 34+

### DIFF
--- a/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
+++ b/internal/backends/android-activity/java/SlintAndroidJavaHelper.java
@@ -38,6 +38,8 @@ import android.widget.ImageView;
 import android.widget.PopupWindow;
 import android.view.inputmethod.BaseInputConnection;
 import android.os.Build;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 
 class InputHandle extends ImageView {
     private PopupWindow mPopupWindow;
@@ -423,6 +425,7 @@ class SlintInputView extends View {
 public class SlintAndroidJavaHelper {
     Activity mActivity;
     SlintInputView mInputView;
+    private OnBackInvokedCallback mBackCallback;
 
     public SlintAndroidJavaHelper(Activity activity) {
         this.mActivity = activity;
@@ -449,6 +452,13 @@ public class SlintAndroidJavaHelper {
                                     return dispatchInsets(insets);
                                 }
                             });
+                }
+                // On API 34+, Back arrives via OnBackInvokedDispatcher; forward
+                // it into Slint's key-event pipeline.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && mBackCallback == null) {
+                    mBackCallback = () -> SlintAndroidJavaHelper.onBackInvoked();
+                    mActivity.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                            OnBackInvokedDispatcher.PRIORITY_DEFAULT, mBackCallback);
                 }
             }
         });
@@ -561,12 +571,26 @@ public class SlintAndroidJavaHelper {
         });
     }
 
+    // Called from Rust when an OnBackInvokedCallback fires and Slint's key
+    // dispatch reports the Back key as unhandled — preserves the legacy
+    // Back-closes-the-activity default.
+    public void finish_activity() {
+        mActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                mActivity.finish();
+            }
+        });
+    }
+
     static public native void updateText(String text, int cursorPosition, int anchorPosition, int preeditStart,
             int preeditOffset);
 
     static public native void setNightMode(int nightMode);
 
     static public native void setFontScale(float fontScale);
+
+    static public native void onBackInvoked();
 
     static public native void moveCursorHandle(int id, int pos_x, int pos_y);
 

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -7,13 +7,13 @@ use i_slint_common::unicode_utils::{
     byte_offset_to_utf16_offset, utf16_offset_to_byte_offset_clamped,
 };
 use i_slint_core::SharedString;
-use i_slint_core::api::{PhysicalPosition, PhysicalSize};
+use i_slint_core::api::{PhysicalPosition, PhysicalSize, WindowEventDispatchResult};
 use i_slint_core::graphics::{Color, euclid};
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType};
 use i_slint_core::item_rendering::HasFont;
 use i_slint_core::items::{CapitalizationMode, ColorScheme, InputType};
 use i_slint_core::lengths::{LogicalLength, PhysicalEdges};
-use i_slint_core::platform::WindowAdapter;
+use i_slint_core::platform::{Key, WindowAdapter, WindowEvent};
 use jni::objects::{JClass, JClassLoader, JString, LoaderContext};
 use jni::sys::{jfloat, jint};
 use jni::{Env, JavaVM, bind_java_type};
@@ -62,6 +62,10 @@ bind_java_type! {
             name = "get_view_rect",
             sig = () -> AndroidRect,
         },
+        fn finish_activity {
+            name = "finish_activity",
+            sig = (),
+        },
         fn hide_keyboard {
             name = "hide_keyboard",
             sig = (),
@@ -105,6 +109,10 @@ bind_java_type! {
         pub static fn move_cursor_handle {
             sig = (id: jint, pos_x: jint, pos_y: jint) -> (),
             fn = callback_move_cursor_handle,
+        },
+        pub static fn on_back_invoked {
+            sig = () -> (),
+            fn = callback_on_back_invoked,
         },
         pub static fn popup_menu_action {
             sig = (id: jint) -> (),
@@ -557,6 +565,14 @@ impl JavaHelper {
     pub fn get_clipboard(&self) -> Result<String, jni::errors::Error> {
         self.with_jni_env(|env, helper| Ok(helper.get_clipboard(env)?.to_string()))
     }
+
+    /// Ask the Activity to finish. Used from `callback_on_back_invoked` when
+    /// Slint's key dispatch reports the Back key as unhandled so we preserve
+    /// the legacy Back-closes-the-activity behavior even under the
+    /// OnBackInvokedCallback flow.
+    pub fn finish_activity(&self) -> Result<(), jni::errors::Error> {
+        self.with_jni_env(|env, helper| helper.finish_activity(env))
+    }
 }
 
 fn callback_update_text<'local>(
@@ -766,6 +782,32 @@ fn callback_popup_menu_action<'local>(
         }
     })
     .unwrap();
+    Ok(())
+}
+
+fn callback_on_back_invoked<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+) -> Result<(), jni::errors::Error> {
+    // Forward Back as a Key.Back KeyPressed + KeyReleased pair; fall back to
+    // Activity.finish() if unhandled.
+    let _ = i_slint_core::api::invoke_from_event_loop(move || {
+        if let Some(adaptor) = CURRENT_WINDOW.with_borrow(|x| x.upgrade()) {
+            let text: SharedString = Key::Back.into();
+            let pressed = adaptor
+                .window
+                .dispatch_event_with_result(WindowEvent::KeyPressed { text: text.clone() });
+            let released =
+                adaptor.window.dispatch_event_with_result(WindowEvent::KeyReleased { text });
+            let handled = matches!(pressed, Ok(WindowEventDispatchResult::Accepted))
+                || matches!(released, Ok(WindowEventDispatchResult::Accepted));
+            if !handled {
+                if let Err(e) = adaptor.java_helper.finish_activity() {
+                    i_slint_core::debug_log!("finish_activity failed: {e:#?}");
+                }
+            }
+        }
+    });
     Ok(())
 }
 


### PR DESCRIPTION
Since target SDK 34, Android routes the system Back gesture through OnBackInvokedDispatcher instead of dispatching a KEYCODE_BACK KeyEvent, so slint's existing `Keycode::Back => Key::Back` KeyEvent mapping never fires and every Back press falls through to the activity's default finish() — even when the Slint UI wanted to catch it via a FocusScope's capture-key-pressed handler.

Register an OnBackInvokedCallback in SlintAndroidJavaHelper (gated on SDK >= UPSIDE_DOWN_CAKE) that calls back into Rust via a new `onBackInvoked` native. The callback dispatches a Key.Back KeyPressed + KeyReleased pair to the current window — the exact pair the legacy path used to produce — so app-side handlers keep working unchanged. If neither event is Accepted, we invoke the activity's finish() as a fallback, matching the legacy default when Back wasn't consumed.

The dispatcher API itself is available since API 33, but on 33 apps only route through it if they opt in via manifest
`enableOnBackInvokedCallback="true"`. No slint app would opt in without this fix (it would just break Back), so checking for 34 keeps the code and the story about it consistent.

Implementation notes for future readers:

- Dispatch is async (`invoke_from_event_loop`). Slint's event loop runs on this same UI thread and is currently blocked in `poll_events`, so a synchronous dispatch would deadlock. The contract violation (OnBackInvokedCallback is documented as synchronous) is knowingly accepted.
- The callback is never unregistered. `SlintAndroidJavaHelper` is a per-`AndroidPlatform` singleton and the activity's dispatcher dies with the activity, so the callback becomes unreachable on recreation. `mBackCallback` is stored only as a null-guard against double registration; if that invariant ever changes, it can be used to unregister.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
