### PR TITLE
node: keep the dev loader in the slint-ui-dev tarball

### DIFF
--- a/api/node/dev-package/package.json
+++ b/api/node/dev-package/package.json
@@ -7,6 +7,12 @@
     "./loader": "./rust-module-dev.cjs",
     "./package.json": "./package.json"
   },
+  "files": [
+    "index.cjs",
+    "rust-module-dev.cjs",
+    "README.md",
+    "LICENSE.md"
+  ],
   "homepage": "https://github.com/slint-ui/slint",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/api/node/scripts/packaging.mts
+++ b/api/node/scripts/packaging.mts
@@ -153,6 +153,11 @@ export function setMainBinaryDeps(opts: {
  * Assemble and pack the slint-ui-dev meta-package: it ships the dev loader and
  * pulls in the matching platform's dev binary. Requires the dev loader
  * (rust-module-dev.cjs) to be built in api/node.
+ *
+ * The files copied in here are generated, so api/node/.gitignore covers them and
+ * pnpm would leave them out of the tarball. That's why dev-package/package.json
+ * lists them in "files": an explicit list wins over any ignore file. Keep the two
+ * in sync when adding a file here.
  */
 export async function packDevMeta(opts: {
     version: string;


### PR DESCRIPTION
pnpm 11 applies the parent directory's .gitignore when a package has no "files" field and no .npmignore, and api/node/.gitignore covers the generated rust-module-dev.cjs that packDevMeta copies into dev-package. The published package lost its "./loader" export, so binding.cjs could not find the dev binary and quietly stayed on the release one. Listing the files explicitly wins over any ignore file.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
