### PR TITLE
ci: move the ESP-IDF prebuilt-package QA to the nightly workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -483,9 +483,9 @@ jobs:
           - id: set
             run: |
               # v5.3 (minimum supported) always runs; v6.0 (latest) only in full mode (home-automation needs IDF 6)
-              entries='[{"esp-idf-version":"release-v5.3","idf-extra-args":""}]'
+              entries='[{"esp-idf-version":"release-v5.3"}]'
               if [ "${{ inputs.full }}" = "true" ]; then
-                entries='[{"esp-idf-version":"release-v5.3","idf-extra-args":""},{"esp-idf-version":"release-v6.0","idf-extra-args":"-D SLINT_ESP_LOCAL_EXAMPLE=OFF"}]'
+                entries='[{"esp-idf-version":"release-v5.3"},{"esp-idf-version":"release-v6.0"}]'
               fi
               echo "matrix={\"include\":$entries}" >> "$GITHUB_OUTPUT"
 
@@ -519,14 +519,14 @@ jobs:
               working-directory: demos/printerdemo_mcu/esp-idf
               run: |
                   . ${IDF_PATH}/export.sh
-                  idf.py ${{ matrix.idf-extra-args }} build
+                  idf.py build
             - name: Build and Test Carousel example s3 box
               if: ${{ inputs.full }}
               shell: bash
               working-directory: examples/carousel/esp-idf/s3-box
               run: |
                   . ${IDF_PATH}/export.sh
-                  idf.py -D SLINT_ESP_LOCAL_EXAMPLE=OFF build
+                  idf.py build
             - name: Build Home Automation demo (ESP32-P4)
               # The demo requires ESP-IDF 6, so it only runs on the release-v6.0 entry
               if: ${{ inputs.full && matrix.esp-idf-version == 'release-v6.0' }}

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -861,3 +861,33 @@ jobs:
               with:
                   name: android-demos
                   path: android-demos/
+
+    # QA the freshly published nightly release: build an ESP-IDF demo against
+    # the prebuilt Slint C++ packages and slint-compiler downloaded from the
+    # `nightly` release tag (SLINT_ESP_LOCAL_EXAMPLE=OFF), the same way users
+    # consume them via FindSlint.cmake. This runs after prepare_release has
+    # updated the nightly tag, so the downloaded artifacts match this commit.
+    qa_esp_idf:
+        if: github.event.inputs.mode == 'full-nightly'
+        needs: [prepare_release]
+        strategy:
+          matrix:
+            esp-idf-version: [release-v5.3, release-v6.0]
+        runs-on: ubuntu-22.04
+        container: espressif/idf:${{ matrix.esp-idf-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Fix up pydantic regression (https://github.com/espressif/idf-component-manager/issues/97#issuecomment-3380777944)
+              run: |
+                  . ${IDF_PATH}/export.sh
+                  cd $IDF_PYTHON_ENV_PATH
+                  bin/pip install pydantic==2.11.10
+            - uses: actions/checkout@v7
+            - run: timeout 300 apt-get update && timeout 300 apt-get install -y libfontconfig1-dev
+            - name: Build Printer demo against the nightly package
+              shell: bash
+              working-directory: demos/printerdemo_mcu/esp-idf
+              run: |
+                  . ${IDF_PATH}/export.sh
+                  idf.py -D SLINT_ESP_LOCAL_EXAMPLE=OFF build


### PR DESCRIPTION
The SLINT_ESP_LOCAL_EXAMPLE=OFF builds download the prebuilt Slint C++ package and slint-compiler from the nightly release tag. In per-branch CI the demo source is ahead of the last nightly, so the old compiler fails to build it. Build the demos from source in ci.yaml instead, and run the prebuilt-package QA in nightly_snapshot after the nightly tag is published.
