### PR TITLE
Quote visibility in diagnostics

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1835,7 +1835,7 @@ impl Expression {
                     true
                 } else {
                     ctx.diag.push_error(
-                        format!("{what} on an {} property", lookup.property_visibility),
+                        format!("{what} on an '{}' property", lookup.property_visibility),
                         node,
                     );
                     false

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1830,8 +1830,13 @@ impl Expression {
                 } else if ctx.is_legacy_component()
                     && lookup.property_visibility == PropertyVisibility::Output
                 {
-                    ctx.diag
-                        .push_warning(format!("{what} on an output property is deprecated"), node);
+                    ctx.diag.push_warning(
+                        format!(
+                            "{what} on an '{}' property is deprecated",
+                            PropertyVisibility::Output
+                        ),
+                        node,
+                    );
                     true
                 } else {
                     ctx.diag.push_error(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3018,7 +3018,7 @@ fn lookup_property_from_qualified_name_for_state(
             } else if !lookup_result.is_valid_for_assignment() {
                 diag.push_error(
                     format!(
-                        "'{}' cannot be set in a state because it is {}",
+                        "'{}' cannot be set in a state because it is '{}'",
                         qualname, lookup_result.property_visibility
                     ),
                     &node,
@@ -3040,7 +3040,7 @@ fn lookup_property_from_qualified_name_for_state(
                 } else if !lookup_result.is_valid_for_assignment() {
                     diag.push_error(
                         format!(
-                            "'{}' cannot be set in a state because it is {}",
+                            "'{}' cannot be set in a state because it is '{}'",
                             qualname, lookup_result.property_visibility
                         ),
                         &node,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2387,7 +2387,10 @@ impl Element {
                     && lookup_result.property_visibility == PropertyVisibility::Output
                 {
                     diag.push_warning(
-                        format!("Assigning to output property '{unresolved_name}' is deprecated"),
+                        format!(
+                            "Assigning to '{}' property '{unresolved_name}' is deprecated",
+                            PropertyVisibility::Output
+                        ),
                         &name_token,
                     );
                 } else {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2393,7 +2393,7 @@ impl Element {
                 } else {
                     diag.push_error(
                         format!(
-                            "Cannot assign to {} property '{}'",
+                            "Cannot assign to '{}' property '{}'",
                             lookup_result.property_visibility, unresolved_name
                         ),
                         &name_token,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1832,7 +1832,7 @@ impl Element {
                             if !valid_assign {
                                 diag.push_error(
                                     format!(
-                                        "Cannot animate {} property '{}'",
+                                        "Cannot animate '{}' property '{}'",
                                         lookup_result.property_visibility, unresolved_prop_name
                                     ),
                                     &prop_name_token,

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2648,12 +2648,18 @@ fn resolve_two_way_bindings_for_element(
                         if lookup_ctx.is_legacy_component() {
                             debug_assert!(!diag.is_empty()); // warning should already be reported
                         } else {
-                            diag.push_error("Cannot link input property".into(), &node);
+                            diag.push_error(
+                                format!("Cannot link '{}' property", PropertyVisibility::Input),
+                                &node,
+                            );
                         }
                     } else if rhs_lookup.property_visibility == PropertyVisibility::InOut {
                         diag.push_warning(
-                            "Linking input properties to input output properties is deprecated"
-                                .into(),
+                            format!(
+                                "Linking '{}' properties to '{}' properties is deprecated",
+                                PropertyVisibility::Input,
+                                PropertyVisibility::InOut
+                            ),
                             &node,
                         );
                         marked_linked_read_only(&nr.element(), nr.name());

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2625,7 +2625,7 @@ fn resolve_two_way_bindings_for_element(
                             if lookup_ctx.is_legacy_component() {
                                 diag.push_warning(
                                     format!(
-                                        "Link to a {} property is deprecated",
+                                        "Link to an '{}' property is deprecated",
                                         rhs_lookup.property_visibility
                                     ),
                                     &node,

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2633,7 +2633,7 @@ fn resolve_two_way_bindings_for_element(
                             } else {
                                 diag.push_error(
                                     format!(
-                                        "Cannot link to a {} property",
+                                        "Cannot link to an '{}' property",
                                         rhs_lookup.property_visibility
                                     ),
                                     &node,

--- a/internal/compiler/tests/syntax/elements/text.slint
+++ b/internal/compiler/tests/syntax/elements/text.slint
@@ -4,7 +4,7 @@
 export component Foo inherits Rectangle {
     Text {
         font-metrics: 42;
-//      >          <error{Cannot assign to out property 'font-metrics'}
+//      >          <error{Cannot assign to 'out' property 'font-metrics'}
 //                    > <^error{Cannot convert float to FontMetrics}
 
     }

--- a/internal/compiler/tests/syntax/fuzzing/6632.slint
+++ b/internal/compiler/tests/syntax/fuzzing/6632.slint
@@ -4,6 +4,6 @@
 export component S{
     t:=TextInput{
         has-focus<=>t.has-focus;
-//      >       <error{Cannot assign to out property 'has-focus'}
+//      >       <error{Cannot assign to 'out' property 'has-focus'}
     }
 }

--- a/internal/compiler/tests/syntax/fuzzing/7095.slint
+++ b/internal/compiler/tests/syntax/fuzzing/7095.slint
@@ -10,6 +10,6 @@ OtherComp:=Rectangle{
 export ae:=Rectangle{
 //       ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     OtherComp { t<=>t;}
-//              ^warning{Assigning to output property 't' is deprecated}
+//              ^warning{Assigning to 'out' property 't' is deprecated}
 //              >    <^error{Property cannot alias to itself}
 }

--- a/internal/compiler/tests/syntax/lookup/absolute-position.slint
+++ b/internal/compiler/tests/syntax/lookup/absolute-position.slint
@@ -11,7 +11,7 @@ export component Hello {
     Rectangle {
         init => {
             self.absolute-position.x += 45px;
-//          >                              <error{Self assignment on an out property}
+//          >                              <error{Self assignment on an 'out' property}
         }
     }
 }

--- a/internal/compiler/tests/syntax/lookup/absolute-position.slint
+++ b/internal/compiler/tests/syntax/lookup/absolute-position.slint
@@ -4,7 +4,7 @@
 export component Hello {
     Rectangle {
         absolute-position: {x: 45px, y: 78px};
-//      >               <error{Cannot assign to out property 'absolute-position'}
+//      >               <error{Cannot assign to 'out' property 'absolute-position'}
 
     }
 

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -19,7 +19,7 @@ component Compo inherits Rectangle {
         }
 
         pressed: true;
-//      >     <error{Cannot assign to out property 'pressed'}
+//      >     <error{Cannot assign to 'out' property 'pressed'}
 
     }
 
@@ -64,9 +64,9 @@ export component Foo inherits Rectangle {
     c1 := OldCompo {
         inout2: 42;
         priv2: 55;
-//      >   <error{Cannot assign to private property 'priv2'}
+//      >   <error{Cannot assign to 'private' property 'priv2'}
         output1: 855;
-//      >     <error{Cannot assign to out property 'output1'}
+//      >     <error{Cannot assign to 'out' property 'output1'}
         input1: 12;
         inout1: 78;
 
@@ -80,11 +80,11 @@ export component Foo inherits Rectangle {
 
     c2 := Compo {
         priv1: 42;
-//      >   <error{Cannot assign to private property 'priv1'}
+//      >   <error{Cannot assign to 'private' property 'priv1'}
         priv2: 55;
-//      >   <error{Cannot assign to private property 'priv2'}
+//      >   <error{Cannot assign to 'private' property 'priv2'}
         output1: 585;
-//      >     <error{Cannot assign to out property 'output1'}
+//      >     <error{Cannot assign to 'out' property 'output1'}
         input1: 12;
         inout1: 78;
     }

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -14,7 +14,7 @@ component Compo inherits Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on an in property}
+//          >         <error{Assignment on an 'in' property}
             inout1 = 75;
         }
 
@@ -53,7 +53,7 @@ OldCompo := Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on an in property}
+//          >         <error{Assignment on an 'in' property}
             inout1 = 75;
         }
     }

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -29,7 +29,7 @@ component Compo inherits Rectangle {
             priv2: 55;
             output1: 55;
             input1: 12;
-//          >    <error{'input1' cannot be set in a state because it is in}
+//          >    <error{'input1' cannot be set in a state because it is 'in'}
             inout1: 78;
         }
     ]
@@ -92,13 +92,13 @@ export component Foo inherits Rectangle {
     states [
         foo when true: {
             c2.priv1: 45;
-//          >      <error{'c2.priv1' cannot be set in a state because it is private}
+//          >      <error{'c2.priv1' cannot be set in a state because it is 'private'}
 
             c1.priv2: 89;
-//          >      <error{'c1.priv2' cannot be set in a state because it is private}
+//          >      <error{'c1.priv2' cannot be set in a state because it is 'private'}
 
             c2.output1: 55;
-//          >        <error{'c2.output1' cannot be set in a state because it is out}
+//          >        <error{'c2.output1' cannot be set in a state because it is 'out'}
         }
     ]
 

--- a/internal/compiler/tests/syntax/new_syntax/input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output.slint
@@ -35,7 +35,7 @@ component Compo inherits Rectangle {
     ]
 
     animate input1 {}
-//          >     <error{Cannot animate in property 'input1'}
+//          >     <error{Cannot animate 'in' property 'input1'}
 }
 
 OldCompo := Rectangle {
@@ -71,10 +71,10 @@ export component Foo inherits Rectangle {
         inout1: 78;
 
         animate output1 {}
-//              >      <error{Cannot animate out property 'output1'}
+//              >      <error{Cannot animate 'out' property 'output1'}
 
         animate priv2 {}
-//              >    <error{Cannot animate private property 'priv2'}
+//              >    <error{Cannot animate 'private' property 'priv2'}
 
     }
 

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -61,7 +61,7 @@ OldCompo := Rectangle {
 //          >               <warning{Self assignment on an 'out' property is deprecated}
         }
         has-hover: true;
-//      >       <warning{Assigning to output property 'has-hover' is deprecated}
+//      >       <warning{Assigning to 'out' property 'has-hover' is deprecated}
     }
 }
 

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -12,7 +12,7 @@ global Glo {
     foo(x) => {
         out1 = 42;
         in1 = 55;
-//      >      <error{Assignment on an in property}
+//      >      <error{Assignment on an 'in' property}
     }
 }
 
@@ -29,11 +29,11 @@ component Compo inherits Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on an in property}
+//          >         <error{Assignment on an 'in' property}
             inout1 = 75;
 
             self.pressed-x = 42px;
-//          >                   <error{Assignment on an out property}
+//          >                   <error{Assignment on an 'out' property}
         }
     }
 
@@ -53,7 +53,7 @@ OldCompo := Rectangle {
             priv2 = 78;
             output1 = input1;
             input1 = 75;
-//          >         <error{Assignment on an in property}
+//          >         <error{Assignment on an 'in' property}
             inout1 = 75;
             pressed-x = 45px;
 //          >              <warning{Assignment on an output property is deprecated}
@@ -90,7 +90,7 @@ export component Foo inherits Rectangle {
             c1.priv2 = 78;
 //             >   <error{The property 'priv2' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             c1.output1 = c1.input1;
-//          >                    <error{Assignment on an out property}
+//          >                    <error{Assignment on an 'out' property}
             c1.input1 = 75;
             c1.inout1 = 75;
 
@@ -99,15 +99,15 @@ export component Foo inherits Rectangle {
             c2.priv2 = 78;
 //             >   <error{The property 'priv2' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             c2.output1 = c1.inout2;
-//          >                    <error{Assignment on an out property}
+//          >                    <error{Assignment on an 'out' property}
             c2.input1 = 75;
             c2.inout1 = 75;
 
             input_model[42] += 12;
-//          >                   <error{Self assignment on an in property}
+//          >                   <error{Self assignment on an 'in' property}
 
             Glo.out1 = Glo.in1;
-//          >                <error{Assignment on an out property}
+//          >                <error{Assignment on an 'out' property}
             Glo.inout1 = Glo.priv1;
 //                           >   <error{The property 'priv1' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
             Glo.priv2 = Glo.out1;

--- a/internal/compiler/tests/syntax/new_syntax/input_output2.slint
+++ b/internal/compiler/tests/syntax/new_syntax/input_output2.slint
@@ -56,9 +56,9 @@ OldCompo := Rectangle {
 //          >         <error{Assignment on an 'in' property}
             inout1 = 75;
             pressed-x = 45px;
-//          >              <warning{Assignment on an output property is deprecated}
+//          >              <warning{Assignment on an 'out' property is deprecated}
             pressed-y -= 45px;
-//          >               <warning{Self assignment on an output property is deprecated}
+//          >               <warning{Self assignment on an 'out' property is deprecated}
         }
         has-hover: true;
 //      >       <warning{Assigning to output property 'has-hover' is deprecated}

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -86,7 +86,7 @@ export component C3 {
     // checked is "input/output" in Button
     out <=> b.checked;
     in <=> b.checked;
-//  >               <warning{Linking input properties to input output properties is deprecated}
+//  >               <warning{Linking 'in' properties to 'in-out' properties is deprecated}
     inout <=> b.checked;
     priv <=> b.checked;
 
@@ -249,7 +249,7 @@ export component C10 {
 
     out property <bool> out <=> inout1;
     in property <bool> in <=> inout2;
-//                        >         <error{Cannot link input property}
+//                        >         <error{Cannot link 'in' property}
     in-out property <bool> inout <=> inout3;
     property <bool> priv <=> inout4;
 
@@ -299,11 +299,11 @@ export component C12 {
     in property <bool> in1 <=> btn.pressed;
 //                         >              <error{Cannot link to an 'out' property}
     in property <bool> in2 <=> btn.checked;
-//                         >              <warning{Linking input properties to input output properties is deprecated}
+//                         >              <warning{Linking 'in' properties to 'in-out' properties is deprecated}
     in property <bool> in3 <=> btn.enabled;
     in property <bool> in4 <=> btn.accessible-checked;
     in property <bool> in5 <=> inout1;
-//                         >         <error{Cannot link input property}
+//                         >         <error{Cannot link 'in' property}
 
     in property <bool> bogus1 <=> btn.internal;
 //                                    >      <error{The property 'internal' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -363,10 +363,10 @@ export Legacy1 := Rectangle {
 //             ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
     b1:= Button {}
     in property in1 <=> b1.pressed;
-//                  >             <warning{Link to a out property is deprecated}
+//                  >             <warning{Link to an 'out' property is deprecated}
     out property out1 <=> b1.pressed;
     in-out property inout1 <=> b1.pressed;
-//                         >             <warning{Link to a out property is deprecated}
+//                         >             <warning{Link to an 'out' property is deprecated}
 
 
     property <bool> p1;

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -327,35 +327,35 @@ export component C13 {
     property <bool> priv;
 
     Button { internal <=> in; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> out; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> priv; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> inout; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> self.checked; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
 
     Button { pressed <=> self.pressed; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
     Button { pressed <=> self.checked; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
     Button { pressed <=> self.enabled; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
     Button { pressed <=> self.accessible-checked; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
     Button { pressed <=> self.internal; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
 //                            >      <^error{The property 'internal' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
     Button { pressed <=> out; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
     Button { pressed <=> in; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
     Button { pressed <=> inout; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
     Button { pressed <=> priv; }
-//           >     <error{Cannot assign to out property 'pressed'}
+//           >     <error{Cannot assign to 'out' property 'pressed'}
 
 }
 
@@ -398,15 +398,15 @@ export Legacy2 := Rectangle {
     property <bool> priv;
 
     Button { internal <=> in; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> out; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> priv; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> inout; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
     Button { internal <=> self.checked; }
-//           >      <error{Cannot assign to private property 'internal'}
+//           >      <error{Cannot assign to 'private' property 'internal'}
 
     Button { pressed <=> self.pressed; }
 //           >     <warning{Assigning to output property 'pressed' is deprecated}

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -18,9 +18,9 @@ export component C1 {
     // pressed is "output" in Button
     out <=> b.pressed;  // ok  (but then there should be no other assignment?)
     in <=> b.pressed; // Error
-//  >               <error{Cannot link to a out property}
+//  >               <error{Cannot link to an 'out' property}
     inout <=> b.pressed;
-//  >                  <error{Cannot link to a out property}
+//  >                  <error{Cannot link to an 'out' property}
     priv <=> b.pressed; // makes assignment forbidden
 
 
@@ -136,7 +136,7 @@ export component C6 {
     }
     Button {
         checked <=> in;
-//      >             <error{Cannot link to a in property}
+//      >             <error{Cannot link to an 'in' property}
         clicked => { self.checked = !self.checked; }
     }
     Button {
@@ -172,7 +172,7 @@ export component C7 {
         }
     }
     Button { checked <=> b2.pressed;  }
-//           >                     <error{Cannot link to a out property}
+//           >                     <error{Cannot link to an 'out' property}
 
     b3 := Button {
         clicked => {
@@ -222,9 +222,9 @@ export component C9 {
 
     out property <bool> out <=> in1;
     in property <bool> in <=> in2;
-//                        >      <error{Cannot link to a in property}
+//                        >      <error{Cannot link to an 'in' property}
     in-out property <bool> inout <=> in3;
-//                               >      <error{Cannot link to a in property}
+//                               >      <error{Cannot link to an 'in' property}
     property <bool> priv <=> in4;
 
     Button {
@@ -297,7 +297,7 @@ export component C11 {
 
 export component C12 {
     in property <bool> in1 <=> btn.pressed;
-//                         >              <error{Cannot link to a out property}
+//                         >              <error{Cannot link to an 'out' property}
     in property <bool> in2 <=> btn.checked;
 //                         >              <warning{Linking input properties to input output properties is deprecated}
     in property <bool> in3 <=> btn.enabled;

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -28,7 +28,7 @@ export component C1 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on an in property}
+//          >      <error{Assignment on an 'in' property}
             out = !out;
 //          >        <error{Cannot modify a property that is linked to a read-only property}
             inout = !inout;
@@ -38,7 +38,7 @@ export component C1 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on an out property}
+//          >                          <error{Assignment on an 'out' property}
 
         }
     }
@@ -61,7 +61,7 @@ export component C1 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on an in property}
+//          >      <error{Assignment on an 'in' property}
             out = !out;
             inout = !inout;
             priv = !priv;
@@ -71,7 +71,7 @@ export component C1 {
 //          >                          <error{Cannot modify a property that is linked to a read-only property}
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on an out property}
+//          >                          <error{Assignment on an 'out' property}
 
         }
     }
@@ -93,7 +93,7 @@ export component C3 {
     b:= Button {
         clicked => {
             in = !in;
-//          >      <error{Assignment on an in property}
+//          >      <error{Assignment on an 'in' property}
             out = !out;
             inout = !inout;
             priv = !priv;
@@ -102,7 +102,7 @@ export component C3 {
             self.checked = !self.checked;
 //          >                          <error{Cannot modify a property that is linked to a read-only property}
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on an out property}
+//          >                          <error{Assignment on an 'out' property}
         }
     }
 }
@@ -155,7 +155,7 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on an out property}
+//          >                          <error{Assignment on an 'out' property}
         }
     }
     Button {
@@ -168,7 +168,7 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on an out property}
+//          >                          <error{Assignment on an 'out' property}
         }
     }
     Button { checked <=> b2.pressed;  }
@@ -179,7 +179,7 @@ export component C7 {
             self.enabled = !self.enabled;
             self.checked = !self.checked;
             self.pressed = !self.pressed;
-//          >                          <error{Assignment on an out property}
+//          >                          <error{Assignment on an 'out' property}
         }
     }
     Button {
@@ -232,7 +232,7 @@ export component C9 {
             out = !out;
 //          >        <error{Cannot modify a property that is linked to a read-only property}
             in = !in;
-//          >      <error{Assignment on an in property}
+//          >      <error{Assignment on an 'in' property}
             inout = !inout;
             priv = !priv;
 //          >          <error{Cannot modify a property that is linked to a read-only property}
@@ -261,7 +261,7 @@ export component C10 {
             inout4 = !inout4;
             out = !out;
             in = !in;
-//          >      <error{Assignment on an in property}
+//          >      <error{Assignment on an 'in' property}
             inout = !inout;
             priv = !priv;
         }
@@ -288,7 +288,7 @@ export component C11 {
             priv4 = !priv4;
             out = !out;
             in = !in;
-//          >      <error{Assignment on an in property}
+//          >      <error{Assignment on an 'in' property}
             inout = !inout;
             priv = !priv;
         }

--- a/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
+++ b/internal/compiler/tests/syntax/new_syntax/two_way_input_output.slint
@@ -372,7 +372,7 @@ export Legacy1 := Rectangle {
     property <bool> p1;
     Button {
         pressed <=> p1;
-//      >     <warning{Assigning to output property 'pressed' is deprecated}
+//      >     <warning{Assigning to 'out' property 'pressed' is deprecated}
         clicked => {
             p1 = !p1;
             out1 = !out1;
@@ -409,23 +409,23 @@ export Legacy2 := Rectangle {
 //           >      <error{Cannot assign to 'private' property 'internal'}
 
     Button { pressed <=> self.pressed; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
     Button { pressed <=> self.checked; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
     Button { pressed <=> self.enabled; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
     Button { pressed <=> self.accessible-checked; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
     Button { pressed <=> self.internal; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
 //                            >      <^error{The property 'internal' is private. Annotate it with 'in', 'out' or 'in-out' to make it accessible from other components}
     Button { pressed <=> out; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
     Button { pressed <=> in; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
     Button { pressed <=> inout; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
     Button { pressed <=> priv; }
-//           >     <warning{Assigning to output property 'pressed' is deprecated}
+//           >     <warning{Assigning to 'out' property 'pressed' is deprecated}
 
 }


### PR DESCRIPTION
Relates to #12592 where the display implementation for Input, Output, InOut visibilities was updated to use the expected syntax: `in`, `out`, `in-out`.

Now we quote the visibility in diagnostics to highlight the syntax.

