### PR TITLE
docs: fix cargo commands for the examples and demos workspace split

### DIFF
--- a/demos/energy-monitor/README.md
+++ b/demos/energy-monitor/README.md
@@ -14,7 +14,7 @@ Real-time weather data is fetched from [Open-Meteo](https://open-meteo.com/). No
 
 You can run the demo on a desktop or embedded Linux environment with the following command:
 ```sh
-cargo run -p energy-monitor
+cargo run --manifest-path demos/energy-monitor/Cargo.toml
 ```
 
 ### Microcontrollers (MCU)
@@ -24,7 +24,7 @@ Refer to the [MCU backend Readme](../../examples/mcu-board-support) for instruct
 To run the MCU-like code on desktop, use the `--features=simulator`
 
 ```sh
-cargo run -p energy-monitor --no-default-features --features=simulator --release
+cargo run --manifest-path demos/energy-monitor/Cargo.toml --no-default-features --features=simulator --release
 ```
 
 ### Android
@@ -33,7 +33,7 @@ First, [set up your Android environment](https://slint.dev/snapshots/master/docs
 Then, you can run the demo on an Android device with the following command:
 
 ```sh
-cargo apk run -p energy-monitor --target aarch64-linux-android --lib
+cargo apk run --manifest-path demos/energy-monitor/Cargo.toml --target aarch64-linux-android --lib
 ```
 
 ### Node.js

--- a/demos/launcher/README.md
+++ b/demos/launcher/README.md
@@ -9,5 +9,5 @@ At startup, the launcher checks a built-in catalog of known demo and example
 binary names against the directories in the `PATH` environment variable, and
 only shows the ones that are installed. The launcher's own directory is
 searched, too: in a development build the workspace's demos and examples land
-in the same cargo target directory, so `cargo run -p launcher` shows the ones
-that were built.
+in the same cargo target directory, so `cargo run --manifest-path demos/launcher/Cargo.toml`
+shows the ones that were built.

--- a/demos/launcher/main.rs
+++ b/demos/launcher/main.rs
@@ -125,7 +125,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut search_dirs = Vec::new();
     // In a development build, the demos and examples built from the workspace
     // land in the same cargo target directory as the launcher itself, so
-    // `cargo run -p launcher` finds them without any configuration.
+    // running the launcher with cargo finds them without any configuration.
     if let Ok(exe) = std::env::current_exe()
         && let Some(dir) = exe.parent()
     {

--- a/docs/astro/src/content/docs/guide/platforms/embedded.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/embedded.mdx
@@ -187,6 +187,10 @@ We provide templates for a few off-the-shelf development boards from some of the
 </TabItem>
 </Tabs>
 
+The Rust sections below show how to run the Slint Printer demo on various boards. The commands
+are meant to be run from the root of a checkout of the [Slint repository](https://github.com/slint-ui/slint);
+the demo lives in the `demos` Cargo workspace, hence the explicit `--manifest-path`.
+
 ### Espressif (ESP32)
 
 <Tabs syncKey="dev-language">
@@ -204,7 +208,7 @@ When flashing, with `espflash`, you will be prompted to select a USB port. If th
 To compile and run the Slint Printer demo:
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box-3 --release --config examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run --manifest-path demos/printerdemo_mcu/Cargo.toml --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box-3 --release --config examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
 ```
 </TabItem>
 <TabItem label="C++" icon="seti:cpp">
@@ -223,7 +227,7 @@ Follow the steps below to run the Slint Printer Demo
 Using [probe-rs](https://probe.rs).
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-rs run --chip STM32H735IGKx" cargo run -p printerdemo_mcu --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-rs run --chip STM32H735IGKx" cargo run --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
 ```
 </TabItem>
 <TabItem label="C++" icon="seti:cpp">
@@ -251,7 +255,7 @@ rustup target add thumbv6m-none-eabi
 Build the Slint Printer demo with:
 
 ```sh
-cargo build -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
+cargo build --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
 ```
 
 The resulting file can be flashed with [elf2uf2-rs](https://github.com/jonil/elf2uf2-rs). Install it using:
@@ -301,7 +305,7 @@ elf2uf2-rs -d target/thumbv6m-none-eabi/release/printerdemo_mcu
 Build the Slint Printer demo with:
 
 ```sh
-cargo build -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico2-st7789 --target=thumbv8m.main-none-eabihf --release
+cargo build --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features --features=mcu-board-support/pico2-st7789 --target=thumbv8m.main-none-eabihf --release
 ```
 
 The resulting file can be flashed conveniently with [picotool](https://github.com/raspberrypi/picotool). You should build it from source.
@@ -326,7 +330,7 @@ This requires [probe-rs](https://probe.rs) and to connect the pico via a probe
 Then you can simply run with `cargo run`
 
 ```sh
-CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER="flip-link" CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-rs run --chip RP2040" cargo run -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
+CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER="flip-link" CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-rs run --chip RP2040" cargo run --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
 ```
 
 #### Flashing and Debugging the Pico with `probe-rs`'s VSCode Plugin
@@ -342,7 +346,7 @@ Add this build task to your `.vscode/tasks.json`:
 			"type": "cargo",
 			"command": "build",
 			"args": [
-				"--package=printerdemo_mcu",
+				"--manifest-path=demos/printerdemo_mcu/Cargo.toml",
 				"--features=mcu-pico-st7789",
 				"--target=thumbv6m-none-eabi",
 				"--profile=release-with-debug"
@@ -359,7 +363,7 @@ Add this build task to your `.vscode/tasks.json`:
 
 The `release-with-debug` profile is needed, because the debug build does not fit into flash.
 
-You can define it like this in your top level `Cargo.toml`:
+You can define it like this in the `demos/Cargo.toml` workspace manifest:
 
 ```toml
 [profile.release-with-debug]

--- a/examples/async-io/README.md
+++ b/examples/async-io/README.md
@@ -10,7 +10,7 @@ The http GET requests fetch the closing prices of a few publicly traded stocks, 
 
 The Rust version is contained in [`main.rs`](./main.rs). It uses the `request` crate to establish a network connection and issue the HTTP get requests, using Rusts `async` functions. These are run inside a future run with `slint::spawn_local()`, where we can await for the result of the network request and update the UI directly - as we're being run in the UI thread.
 
-Run the Rust version via `cargo run -p stockticker`.
+Run the Rust version via `cargo run --manifest-path examples/async-io/Cargo.toml` from the root of the repository.
 
 # Python
 

--- a/examples/carousel/README.md
+++ b/examples/carousel/README.md
@@ -15,4 +15,4 @@ See the [MCU backend Readme](../mcu-board-support) to see how to run the example
 
 The example can run with the mcu simulator with the following command
 
-```cargo run -p carousel --no-default-features --features=simulator --release```
+```cargo run --manifest-path examples/carousel/rust/Cargo.toml --no-default-features --features=simulator --release```

--- a/examples/fancy_demo/README.md
+++ b/examples/fancy_demo/README.md
@@ -29,11 +29,7 @@ This example implements a complete widget set from scratch, demonstrating how to
 
 ## Running
 
-```sh
-cargo run -p fancy_demo
-```
-
-Or with the viewer:
+Open it with the viewer:
 
 ```sh
 cargo run --bin slint-viewer -- examples/fancy_demo/main.slint

--- a/examples/mcu-board-support/README.md
+++ b/examples/mcu-board-support/README.md
@@ -43,11 +43,14 @@ In your build.rs, you must include a call to `slint_build::print_rustc_flags().u
 
 ## Run the demo:
 
+The demo lives in the `demos` workspace, which is separate from the repository's root workspace.
+Run the commands below from the root of the Slint repository.
+
 ### The simulator
 
 
 ```sh
-cargo run -p printerdemo_mcu --features=simulator --release
+cargo run --manifest-path demos/printerdemo_mcu/Cargo.toml --features=simulator --release
 ```
 
 ### On the Raspberry Pi Pico
@@ -55,7 +58,7 @@ cargo run -p printerdemo_mcu --features=simulator --release
 Build the demo with:
 
 ```sh
-cargo build -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
+cargo build --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
 ```
 
 The resulting file can be flashed conveniently with [elf2uf2-rs](https://github.com/jonil/elf2uf2-rs). Install it using `cargo install`:
@@ -81,7 +84,7 @@ elf2uf2-rs -d target/thumbv6m-none-eabi/release/printerdemo_mcu
 Build the demo with:
 
 ```sh
-cargo build -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico2-st7789 --target=thumbv8m.main-none-eabihf --release
+cargo build --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features --features=mcu-board-support/pico2-st7789 --target=thumbv8m.main-none-eabihf --release
 ```
 
 The resulting file can be flashed conveniently with [picotool](https://github.com/raspberrypi/picotool). You should build it from source.
@@ -105,7 +108,7 @@ The [Waveshare Pico2 Touch LCD 2.8](https://www.waveshare.com/product/rp2350-tou
 Build the demo with:
 
 ```sh
-cargo build -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico2-touch-lcd-2-8 --target=thumbv8m.main-none-eabihf --release
+cargo build --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features --features=mcu-board-support/pico2-touch-lcd-2-8 --target=thumbv8m.main-none-eabihf --release
 ```
 
 Flash using [picotool](https://github.com/raspberrypi/picotool):
@@ -122,7 +125,7 @@ This requires [probe-rs](https://probe.rs) and to connect the pico via a probe
 Then you can simply run with `cargo run`
 
 ```sh
-CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER="flip-link" CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-rs run --chip RP2040" cargo run -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
+CARGO_TARGET_THUMBV6M_NONE_EABI_LINKER="flip-link" CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-rs run --chip RP2040" cargo run --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
 ```
 
 #### Flashing and Debugging the Pico with `probe-rs`'s VSCode Plugin
@@ -138,7 +141,7 @@ Add this build task to your `.vscode/tasks.json`:
 			"type": "cargo",
 			"command": "build",
 			"args": [
-				"--package=printerdemo_mcu",
+				"--manifest-path=demos/printerdemo_mcu/Cargo.toml",
 				"--no-default-features",
 				"--features=mcu-board-support/pico-st7789",
 				"--target=thumbv6m-none-eabi",
@@ -156,7 +159,7 @@ Add this build task to your `.vscode/tasks.json`:
 
 The `release-with-debug` profile is needed, because the debug build does not fit into flash.
 
-You can define it like this in your top level `Cargo.toml`:
+You can define it like this in the `demos/Cargo.toml` workspace manifest:
 
 ```toml
 [profile.release-with-debug]
@@ -202,7 +205,7 @@ This was tested using a second Raspberry Pi Pico programmed as a probe with [Dap
 Using [probe-rs](https://probe.rs).
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-rs run --chip STM32H735IGKx" cargo run -p printerdemo_mcu --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="probe-rs run --chip STM32H735IGKx" cargo run --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features  --features=mcu-board-support/stm32h735g --target=thumbv7em-none-eabihf --release
 ```
 
 ### STM32U5G9J-DK2
@@ -210,7 +213,7 @@ CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="pro
 Using [probe-rs](https://probe.rs).
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV8M_MAIN_NONE_EABIHF_RUNNER="probe-rs run --chip STM32U5G9ZJTxQ" cargo run -p printerdemo_mcu --no-default-features  --features=mcu-board-support/stm32u5g9j-dk2 --target=thumbv8m.main-none-eabihf --release
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_TARGET_THUMBV8M_MAIN_NONE_EABIHF_RUNNER="probe-rs run --chip STM32U5G9ZJTxQ" cargo run --manifest-path demos/printerdemo_mcu/Cargo.toml --no-default-features  --features=mcu-board-support/stm32u5g9j-dk2 --target=thumbv8m.main-none-eabihf --release
 ```
 
 ### ESP32
@@ -234,7 +237,7 @@ The ESP32-S3-Box development board features:
 To compile and run the demo:
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box-3 --release --config examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run --manifest-path demos/printerdemo_mcu/Cargo.toml --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-box-3 --release --config examples/mcu-board-support/esp32_s3_box_3/cargo-config.toml
 ```
 
 #### ESP32-S3-LCD-EV-Board
@@ -248,7 +251,7 @@ The ESP32-S3-LCD-EV-Board development board features:
 To compile and run the demo:
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-lcd-ev-board --release --config examples/mcu-board-support/esp32_s3_lcd_ev_board/cargo-config.toml
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run --manifest-path demos/printerdemo_mcu/Cargo.toml --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esp32-s3-lcd-ev-board --release --config examples/mcu-board-support/esp32_s3_lcd_ev_board/cargo-config.toml
 ```
 
 #### Waveshare ESP32-S3 Touch AMOLED 1.8"
@@ -262,7 +265,7 @@ The Waveshare ESP32-S3 Touch AMOLED 1.8" board features:
 To compile and run the demo:
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/waveshare-esp32-s3-touch-amoled-1-8 --release --config examples/mcu-board-support/waveshare_esp32_s3_touch_amoled_1_8/cargo-config.toml
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run --manifest-path demos/printerdemo_mcu/Cargo.toml --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/waveshare-esp32-s3-touch-amoled-1-8 --release --config examples/mcu-board-support/waveshare_esp32_s3_touch_amoled_1_8/cargo-config.toml
 ```
 
 #### M5Stack CoreS3
@@ -284,7 +287,7 @@ The board currently operates in display-only mode.
 To compile and run the demo:
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/m5stack-cores3 --release --config examples/mcu-board-support/m5stack_cores3/cargo-config.toml
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run --manifest-path demos/printerdemo_mcu/Cargo.toml --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/m5stack-cores3 --release --config examples/mcu-board-support/m5stack_cores3/cargo-config.toml
 ```
 
 #### ESoPe SLD_C_W_S3
@@ -295,6 +298,6 @@ for use in combination with [Smartwin displays](https://shop.schukat.com/de/de/E
 To compile and run the demo:
 
 ```sh
-CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esope-sld-c-w-s3 --release --config examples/mcu-board-support/esope_sld_c_w_s3/cargo-config.toml
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s cargo +esp run --manifest-path demos/printerdemo_mcu/Cargo.toml --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/esope-sld-c-w-s3 --release --config examples/mcu-board-support/esope_sld_c_w_s3/cargo-config.toml
 ```
 

--- a/examples/mcu-embassy/README.md
+++ b/examples/mcu-embassy/README.md
@@ -31,10 +31,13 @@ cargo install --force --locked probe-rs-tools
 
 # Running the application
 
+This crate is its own Cargo workspace with its own `.cargo/config.toml`, so run the
+commands below from the `examples/mcu-embassy` directory.
+
 Plug a usbc cable into the ST-LINK port on the dk2 and run the following:
 
 ```bash
-cargo run -p mcu-embassy --bin ui_mcu --release --features=mcu
+cargo run --bin ui_mcu --release --features=mcu
 ```
 
 Troubleshooting:
@@ -43,7 +46,7 @@ If you are getting some complication errors from cortex-m like  "error: invalid 
 
 You can specify the target in the cargo run command in the following file:
 
-In `.cargo/Cargo.toml`
+In `.cargo/config.toml`
 ```toml
 [build]
 target = "thumbv8m.main-none-eabihf"
@@ -68,14 +71,14 @@ Hardware like leds and buttons are emulated in the hardware module.
 
 To install SDL2 follow the instructions here: https://github.com/Rust-SDL2/rust-sdl2
 
-To run the simulator on a pc:
+To run the simulator on a pc (from the `examples/mcu-embassy` directory):
 ```bash
 # for linux
-cargo run -p mcu-embassy --bin ui_simulator --release --no-default-features --features=simulator --target x86_64-unknown-linux-gnu
+cargo run --bin ui_simulator --release --no-default-features --features=simulator --target x86_64-unknown-linux-gnu
 # for windows
-cargo run -p mcu-embassy --bin ui_simulator --release --no-default-features --features=simulator --target x86_64-pc-windows-msvc
+cargo run --bin ui_simulator --release --no-default-features --features=simulator --target x86_64-pc-windows-msvc
 # for mac
-cargo run -p mcu-embassy --bin ui_simulator --release --no-default-features --features=simulator --target x86_64-apple-darwin
+cargo run --bin ui_simulator --release --no-default-features --features=simulator --target x86_64-apple-darwin
 ```
 
 Note: Instead of specifying a target you can simply remove the arm target in .cargo/config.toml and cargo will use the host by default
@@ -86,7 +89,7 @@ If you are getting some compilation errors from arrayvec like "error: requires `
 
 Set the target correctly in the command line or comment out the following:
 
-In `.cargo/Cargo.toml`
+In `.cargo/config.toml`
 ```toml
 #[build]
 #target = "thumbv8m.main-none-eabihf"

--- a/examples/safe-ui/README.md
+++ b/examples/safe-ui/README.md
@@ -92,7 +92,7 @@ Once you've started your UI task, invoke `slint_app_main()` to start the Slint e
 For convenience, this example provides a "simulator" binary target in [./simulator/src/main.rs](./simulator/src/main.rs), so that you can just run this on a desktop system passing the desired pixel format as cargo feature, e.g with
 
 ```
-cargo run -p slint-safeui-simulator --features pixel-bgra8888
+cargo run --manifest-path examples/safe-ui/simulator/Cargo.toml --features pixel-bgra8888
 ```
 
 The "simulator" implements the same C system interface and runs the Slint UI safety layer example in a secondary thread.

--- a/examples/uefi-demo/README.md
+++ b/examples/uefi-demo/README.md
@@ -14,10 +14,11 @@ To build this example a suitable UEFI rust target must be installed first:
 rustup target install x86_64-unknown-uefi
 ```
 
-To build, simply pass the `--package` and `--target` arguments to cargo:
+To build, pass the `--manifest-path` and `--target` arguments to cargo from the
+root of the repository:
 
 ```shell
-cargo build --package uefi-demo --target x86_64-unknown-uefi
+cargo build --manifest-path examples/uefi-demo/Cargo.toml --target x86_64-unknown-uefi
 ```
 
 The produced UEFI binary can then either be tested on real hardware by booting

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 2.5.5
       '@napi-rs/cli':
         specifier: 3.7.4
-        version: 3.7.4(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(supports-color@10.2.2)
+        version: 3.7.4(@emnapi/runtime@1.11.2)(@types/node@24.12.0)(supports-color@10.2.2)
       '@types/capture-console':
         specifier: 1.0.5
         version: 1.0.5
@@ -9799,7 +9799,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@napi-rs/cli@3.7.4(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(supports-color@10.2.2)':
+  '@napi-rs/cli@3.7.4(@emnapi/runtime@1.11.2)(@types/node@24.12.0)(supports-color@10.2.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.12.0)
       '@napi-rs/cross-toolchain': 1.0.3(supports-color@10.2.2)
@@ -9814,7 +9814,7 @@ snapshots:
       semver: 7.8.5
       typanion: 3.14.0
     optionalDependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.11.2
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'


### PR DESCRIPTION
The example and demo crates are no longer members of the root workspace, so `cargo run -p <crate>` from the repository root fails. Use --manifest-path instead, or state the directory to run from for crates with their own .cargo/config.toml. Also remove the cargo run command for fancy_demo, which is no longer a crate.