### PR TITLE
CI: allow workerd build scripts so wrangler deploys work on pnpm 11

### DIFF
--- a/.github/workflows/deploy_preview.yaml
+++ b/.github/workflows/deploy_preview.yaml
@@ -167,7 +167,7 @@ jobs:
               working-directory: preview-deploy
               run: |
                 set +e
-                OUTPUT=$(pnpm dlx wrangler@4 versions upload 2>&1)
+                OUTPUT=$(pnpm dlx --allow-build=workerd wrangler@4 versions upload 2>&1)
                 STATUS=$?
                 set -e
                 echo "=== wrangler output ==="

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ allowBuilds:
   esbuild: true
   sharp: true
   skia-canvas: true
+  workerd: true
 
 # Security overrides. Each key pins the vulnerable range to a fixed version.
 overrides:


### PR DESCRIPTION
pnpm 11 defaults strictDepBuilds to true, so an unreviewed postinstall now fails the install instead of warning. wrangler-action installs wrangler at deploy time, which pulls in workerd, and the Cloudflare Pages deploy died with ERR_PNPM_IGNORED_BUILDS.

Allow workerd in the workspace config, and pass --allow-build to the pnpm dlx invocation in the preview deploy, which resolves outside the workspace and so does not pick up allowBuilds.

Upstream: https://github.com/cloudflare/wrangler-action/issues/436

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
