### PR TITLE
FlexboxLayout: fix the forwarded-min-height binding loop (#11168)

### DIFF
--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -198,6 +198,27 @@ pub struct LayoutConstraints {
     pub vertical_stretch: Option<NamedReference>,
     pub fixed_width: bool,
     pub fixed_height: bool,
+    /// For each constraint, whether it is set directly on the element (an
+    /// override) rather than inherited from a base component. Inherited layout
+    /// constraints are already baked into an element's own `layoutinfo-*`, so a
+    /// parent layout that measured the cell through its layout-info must not
+    /// re-apply them (double-count / height-for-width loop); locally-set ones
+    /// must be applied. See [`Self::to_apply`].
+    pub local: LayoutConstraintLocality,
+}
+
+/// Which [`LayoutConstraints`] are set directly on the element (depth 0) rather
+/// than inherited from a base component.
+#[derive(Debug, Default, Clone)]
+pub struct LayoutConstraintLocality {
+    pub min_width: bool,
+    pub max_width: bool,
+    pub min_height: bool,
+    pub max_height: bool,
+    pub preferred_width: bool,
+    pub preferred_height: bool,
+    pub horizontal_stretch: bool,
+    pub vertical_stretch: bool,
 }
 
 /// The [`LayoutConstraints`] fields along one orientation.
@@ -231,6 +252,23 @@ impl LayoutConstraints {
             vertical_stretch: binding_reference(element, "vertical-stretch"),
             fixed_width: false,
             fixed_height: false,
+            local: LayoutConstraintLocality {
+                // min/max-{width,height} may be derived from a local fixed
+                // `width`/`height` binding (see below), which is just as local
+                // an override as an explicit min/max constraint.
+                min_width: is_local_binding(element, "min-width")
+                    || is_local_binding(element, "width"),
+                max_width: is_local_binding(element, "max-width")
+                    || is_local_binding(element, "width"),
+                min_height: is_local_binding(element, "min-height")
+                    || is_local_binding(element, "height"),
+                max_height: is_local_binding(element, "max-height")
+                    || is_local_binding(element, "height"),
+                preferred_width: is_local_binding(element, "preferred-width"),
+                preferred_height: is_local_binding(element, "preferred-height"),
+                horizontal_stretch: is_local_binding(element, "horizontal-stretch"),
+                vertical_stretch: is_local_binding(element, "vertical-stretch"),
+            },
         };
         let mut apply_size_constraint =
             |prop: &'static str,
@@ -295,6 +333,50 @@ impl LayoutConstraints {
                     || self.vertical_stretch.is_some()
             }
         }
+    }
+
+    /// The constraints a parent layout should apply on top of a cell's measured
+    /// layout-info for `orientation`. Native items (whose layout-info doesn't
+    /// merge their constraints) keep everything. For elements whose `layoutinfo-*`
+    /// already includes their intrinsic constraints, only locally-set overrides
+    /// are kept — inherited constraints are already in the measured value, and
+    /// re-reading them unconstrained can reintroduce a height-for-width loop.
+    pub fn to_apply(&self, element: &ElementRc, orientation: Orientation) -> Self {
+        if !element.borrow().layout_info_includes_own_constraints(orientation) {
+            return self.clone();
+        }
+        let mut c = self.clone();
+        match orientation {
+            Orientation::Horizontal => {
+                if !self.local.min_width {
+                    c.min_width = None;
+                }
+                if !self.local.max_width {
+                    c.max_width = None;
+                }
+                if !self.local.preferred_width {
+                    c.preferred_width = None;
+                }
+                if !self.local.horizontal_stretch {
+                    c.horizontal_stretch = None;
+                }
+            }
+            Orientation::Vertical => {
+                if !self.local.min_height {
+                    c.min_height = None;
+                }
+                if !self.local.max_height {
+                    c.max_height = None;
+                }
+                if !self.local.preferred_height {
+                    c.preferred_height = None;
+                }
+                if !self.local.vertical_stretch {
+                    c.vertical_stretch = None;
+                }
+            }
+        }
+        c
     }
 
     pub fn for_orientation(&self, orientation: Orientation) -> OrientationConstraints<'_> {
@@ -559,6 +641,13 @@ fn find_binding<R>(
 /// Return a named reference to a property if a binding is set on that property
 pub fn binding_reference(element: &ElementRc, name: &'static str) -> Option<NamedReference> {
     find_binding(element, name, |_, _, _| NamedReference::new(element, SmolStr::new_static(name)))
+}
+
+/// Whether `name`'s binding is set directly on `element` (depth 0) rather than
+/// inherited from a base component. Must be evaluated while the binding is still
+/// present (i.e. when building [`LayoutConstraints`]); later passes may move it.
+fn is_local_binding(element: &ElementRc, name: &str) -> bool {
+    find_binding(element, name, |_, _, depth| depth == 0) == Some(true)
 }
 
 fn init_fake_property(

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -888,6 +888,19 @@ fn flexbox_layout_data(
     // body); otherwise fall back to the element's own preferred
     // horizontal size. Cells that are not height-for-width get `None`.
     let cell_v_constraint = |elem: &ElementRc| -> Option<crate::expression_tree::Expression> {
+        // A component that forwards a height-for-width layout (e.g. `min-height:
+        // inner.min-height` over a wrapped Text) has a `layoutinfo-v-with-constraint`
+        // but is not a builtin height-for-width cell. It must dispatch via that
+        // function instead of reading its own width — which would cycle through the
+        // flex solve. Mirror of `cell_h_constraint`.
+        if elem.borrow().inherited_layout_info_v_with_constraint().is_some() {
+            return Some(width_override.cloned().unwrap_or_else(|| {
+                crate::expression_tree::Expression::NumberLiteral(
+                    f32::MAX as f64,
+                    crate::expression_tree::Unit::Px,
+                )
+            }));
+        }
         if !is_height_for_width_cell(elem) {
             return None;
         }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1786,6 +1786,11 @@ pub fn get_layout_info(
         )
     };
 
+    // Apply only the cell's locally-set constraints on top of the measured
+    // layout-info: an inherited intrinsic min/max/preferred is already included
+    // in `layout_info`, and re-reading it unconstrained would reintroduce a
+    // height-for-width loop through the layout solve.
+    let constraints = constraints.to_apply(elem, orientation);
     if constraints.has_explicit_restrictions(orientation) {
         let store = llr_Expression::StoreLocalVariable {
             name: "layout_info".into(),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2569,6 +2569,24 @@ impl Element {
         None
     }
 
+    /// Whether this element's `layoutinfo-{orientation}` already incorporates its
+    /// own explicit min/max/preferred/stretch constraints. True for elements with
+    /// a `layoutinfo-*` property (layouts, sub-components) or an inherited
+    /// `layoutinfo-*-with-constraint` function (a component forwarding a
+    /// height-for-width layout).
+    ///
+    /// A parent layout must then NOT re-apply the cell's explicit constraints on
+    /// top of the measured info — they are already included, and re-reading them
+    /// unconstrained can reintroduce a height-for-width binding loop. Only native
+    /// items (no `layoutinfo-*`) need their constraints applied separately.
+    pub fn layout_info_includes_own_constraints(&self, orientation: Orientation) -> bool {
+        self.layout_info_prop(orientation).is_some()
+            || match orientation {
+                Orientation::Vertical => self.inherited_layout_info_v_with_constraint().is_some(),
+                Orientation::Horizontal => self.inherited_layout_info_h_with_constraint().is_some(),
+            }
+    }
+
     /// Returns the element's name as specified in the markup, not normalized.
     pub fn original_name(&self) -> SmolStr {
         self.debug

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -117,6 +117,38 @@ fn rewrite_layoutinfo_v_for_constraint(expr: &mut Expression, width_param: &Expr
                     prop_nr.name() == nr.name() && Rc::ptr_eq(&prop_nr.element(), &target)
                 })
                 .unwrap_or(false);
+            // A forwarded scalar constraint (`min-height: inner.min-height`) reads
+            // the target's implicit min/preferred/max-height, which is its
+            // layoutinfo-v at the *unconstrained* width. Thread the cross-axis
+            // width through the target's parametrized function instead.
+            let constraint_field = match nr.name().as_str() {
+                "min-height" => Some("min"),
+                "preferred-height" => Some("preferred"),
+                "max-height" => Some("max"),
+                "vertical-stretch" => Some("stretch"),
+                _ => None,
+            };
+            if let Some(field) = constraint_field {
+                if let Some(constrained_nr) =
+                    target.borrow().inherited_layout_info_v_with_constraint()
+                {
+                    *sub = Expression::StructFieldAccess {
+                        base: Expression::FunctionCall {
+                            function: Callable::Function(
+                                crate::namedreference::NamedReference::new(
+                                    &target,
+                                    constrained_nr.name().clone(),
+                                ),
+                            ),
+                            arguments: vec![width_param.clone()],
+                            source_location: None,
+                        }
+                        .into(),
+                        name: field.into(),
+                    };
+                }
+                return;
+            }
             if !is_vertical_layout_info {
                 return;
             }
@@ -350,7 +382,9 @@ pub fn synthesize_layoutinfo_v_with_constraint(component: &Rc<Component>) {
         if !has_v_cross || already_synthesized {
             return has_v_cross;
         }
-        let Some(v_nr) = v_nr_clone else { return has_v_cross };
+        let Some(v_nr) = v_nr_clone else {
+            return has_v_cross;
+        };
         let Some(v_binding) = elem.borrow().bindings.get(v_nr.name()).map(|b| b.borrow().clone())
         else {
             return has_v_cross;

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -725,6 +725,7 @@ impl Snapshotter {
                 .map(|lc| lc.snapshot(self)),
             fixed_width: layout_constraints.fixed_width,
             fixed_height: layout_constraints.fixed_height,
+            local: layout_constraints.local.clone(),
         }
     }
 

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -693,9 +693,21 @@ fn flexbox_layout_data(
             cells_h.extend(component_vec.iter().map(|x| {
                 x.as_pin_ref().flexbox_layout_item_info(to_runtime(Orientation::Horizontal), None)
             }));
-            cells_v.extend(component_vec.iter().map(|x| {
-                x.as_pin_ref().flexbox_layout_item_info(to_runtime(Orientation::Vertical), None)
-            }));
+            // A height-for-width repeated instance (e.g. a component forwarding a
+            // wrapped Text's min-height) must not have its vertical info read here at
+            // the still-unsolved width — that would cycle, just like the static branch
+            // warns below. Defer it to the second pass, which measures at the width
+            // constraint and copies the flex props from cells_h. Other repeated cells
+            // are safe to measure now.
+            let rep_root =
+                layout_elem.item.element.borrow().base_type.as_component().root_element.clone();
+            if rep_root.borrow().inherited_layout_info_v_with_constraint().is_some() {
+                cells_v.resize_with(cells_v.len() + component_vec.len(), Default::default);
+            } else {
+                cells_v.extend(component_vec.iter().map(|x| {
+                    x.as_pin_ref().flexbox_layout_item_info(to_runtime(Orientation::Vertical), None)
+                }));
+            }
             static_children.resize_with(static_children.len() + component_vec.len(), || None);
             repeater_instance_vecs.push(component_vec);
         } else {
@@ -802,13 +814,31 @@ fn flexbox_layout_data(
                             .try_into()
                             .unwrap()
                     };
+                    // Apply only the constraints not already merged into the cell's
+                    // own layout-info (see the static branch below): an inherited
+                    // forwarded min/max/preferred-height is in the value above, and
+                    // re-reading it unconstrained would reintroduce a height-for-width
+                    // loop through the flex solve.
+                    let effective = layout_elem
+                        .item
+                        .constraints
+                        .to_apply(&layout_elem.item.element, Orientation::Vertical);
                     fill_layout_info_constraints(
                         &mut layout_info_v,
-                        &layout_elem.item.constraints,
+                        &effective,
                         Orientation::Vertical,
                         &instance_expr_eval,
                     );
-                    cells_v[cell_idx].constraint = layout_info_v;
+                    // cells_v was deferred in the first pass; take the flex props
+                    // from cells_h (they are orientation-independent).
+                    cells_v[cell_idx] = core_layout::FlexboxLayoutItemInfo {
+                        constraint: layout_info_v,
+                        flex_grow: cells_h[cell_idx].flex_grow,
+                        flex_shrink: cells_h[cell_idx].flex_shrink,
+                        flex_basis: cells_h[cell_idx].flex_basis,
+                        flex_align_self: cells_h[cell_idx].flex_align_self,
+                        flex_order: cells_h[cell_idx].flex_order,
+                    };
                 }
                 cell_idx += 1;
             }
@@ -822,9 +852,18 @@ fn flexbox_layout_data(
                 Orientation::Vertical,
                 Some(width_constraint),
             );
+            // Apply only the constraints not already merged into the cell's own
+            // layout-info: an inherited intrinsic min/max/preferred-height is in
+            // the value above, and re-reading it unconstrained would reintroduce
+            // a height-for-width loop through the flex solve. Locally-set overrides
+            // (`WrapCol { min-height: 70px }`) are kept.
+            let effective = layout_elem
+                .item
+                .constraints
+                .to_apply(&layout_elem.item.element, Orientation::Vertical);
             fill_layout_info_constraints(
                 &mut layout_info_v,
-                &layout_elem.item.constraints,
+                &effective,
                 Orientation::Vertical,
                 expr_eval,
             );

--- a/tests/cases/layout/flexbox_forwarded_min_height.slint
+++ b/tests/cases/layout/flexbox_forwarded_min_height.slint
@@ -1,0 +1,129 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #11168: a component that forwards a height-for-width
+// layout's min-height (the AboutSlint pattern `min-height: inner.min-height`
+// over a wrapped Text/Image) panicked with "Recursion detected" when placed in
+// a FlexboxLayout — on every backend. The flex gathers both axes before solving,
+// so the forwarded min-height read self.width while the width was still unsolved.
+//
+// The assertions are font-independent (no wrapped-text metrics), so they hold on
+// the nodejs backend too.
+
+component Card {
+    // The AboutSlint pattern: forward the inner height-for-width layout's min-height.
+    min-height: inner.min-height;
+    in property <string> txt;
+    inner := VerticalLayout {
+        Text { text: root.txt; wrap: word-wrap; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 400px;
+
+    property <string> long: "a long text that wraps onto multiple lines when the width is narrow";
+    property <[{t: string, h: length}]> overrides: [{ t: long, h: 60px }, { t: long, h: 60px }];
+
+    // A: forwarded min-height in a FlexboxLayout. Reading `flAnchor.y` forces the
+    // flex to solve — which used to recurse. No panic, and the Card is laid out.
+    FlexboxLayout {
+        x: 0; y: 0; width: 100px; height: 200px;
+        flex-direction: column;
+        Card { txt: long; }
+        flAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // B: an explicit per-instance `min-height` override on such a cell must still
+    // win (it is not carried by the cell's own layout-info, so it is applied on
+    // top of the measured value).
+    FlexboxLayout {
+        x: 0; y: 200px; width: 100px; height: 200px;
+        flex-direction: column;
+        Card { txt: long; min-height: 150px; }
+        ovrAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // C: the same forwarded min-height on a *repeated* cell. The repeater path is
+    // measured separately from the static one and used to keep recursing after B
+    // was fixed. Reading `repAnchor.y` forces the flex solve.
+    FlexboxLayout {
+        x: 100px; y: 0; width: 100px; height: 200px;
+        flex-direction: column;
+        for it in [long, long]: Card { txt: it; }
+        repAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // D: a per-instance `min-height` override on a repeated forwarded cell must win
+    // too. Font-independent, so nodejs checks it: two 60px cells push the anchor
+    // past 119px.
+    FlexboxLayout {
+        x: 100px; y: 200px; width: 100px; height: 200px;
+        flex-direction: column;
+        for it in overrides: Card { txt: it.t; min-height: it.h; }
+        repOvrAnchor := Rectangle { width: 5px; height: 5px; }
+    }
+
+    // E: a forwarded min-height cell in a *row* flex. Here the cross axis is
+    // vertical with no container width-override, so the width comes from the cell's
+    // own preferred size. Reading `rowCard.height` forces the height-for-width
+    // measurement that used to recurse.
+    FlexboxLayout {
+        x: 0; y: 0; width: 200px; height: 40px;
+        flex-direction: row;
+        rowCard := Card { txt: long; }
+    }
+
+    out property <length> forwarded-y: flAnchor.y;
+    out property <length> override-y: ovrAnchor.y;
+    out property <length> rep-y: repAnchor.y;
+    out property <length> rep-override-y: repOvrAnchor.y;
+    out property <length> row-card-h: rowCard.height;
+
+    // No binding loop, and the forwarded-min-height Card was laid out.
+    out property <bool> no_loop: forwarded-y > 5px;
+    // The 150px override pushes the anchor below it.
+    out property <bool> override_ok: override-y >= 149px;
+    // Repeated forwarded cells were laid out (both stacked above the anchor).
+    out property <bool> rep_no_loop: rep-y > 5px;
+    // Both 60px overrides apply, pushing the anchor past their sum.
+    out property <bool> rep_override_ok: rep-override-y >= 119px;
+    // The row-direction forwarded cell got a real height-for-width height.
+    out property <bool> row_ok: row-card-h > 5px;
+
+    out property <bool> test: no_loop && override_ok && rep_no_loop && rep_override_ok && row_ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_no_loop(), "forwarded-min-height Card not laid out (forwarded_y={})", instance.get_forwarded_y());
+assert!(instance.get_override_ok(), "min-height override dropped (override_y={})", instance.get_override_y());
+assert!(instance.get_rep_no_loop(), "repeated forwarded-min-height Card not laid out (rep_y={})", instance.get_rep_y());
+assert!(instance.get_rep_override_ok(), "repeated min-height override dropped (rep_override_y={})", instance.get_rep_override_y());
+assert!(instance.get_row_ok(), "row-direction forwarded-min-height Card not laid out (row_card_h={})", instance.get_row_card_h());
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_no_loop());
+assert(instance.get_override_ok());
+assert(instance.get_rep_no_loop());
+assert(instance.get_rep_override_ok());
+assert(instance.get_row_ok());
+assert(instance.get_test());
+```
+
+```js
+// nodejs has no test fonts, so the wrapped Text may have zero height and the
+// `*_no_loop` / `row_ok` checks (which need a nonzero wrapped size) need not hold.
+// The override checks are font-independent, and reading `override-y` /
+// `rep-override-y` still forces the flex solves that used to recurse.
+var instance = new slint.TestCase({});
+assert(instance.override_ok);
+assert(instance.rep_override_ok);
+```
+*/


### PR DESCRIPTION
FlexboxLayout: fix the forwarded-min-height binding loop in the interpreter (#11168)

A component that forwards a height-for-width layout's min-height (like AboutSlint:
`min-height: inner.min-height` over a wrapped Text/Image) panicked with "Recursion
detected" when placed in a FlexboxLayout, on both backends. Box layouts resolve the
cross axis first and so avoid it; the flex gathers both axes before solving, so the
cell's forwarded min-height reads self.width while the width is still unsolved.

Fix the interpreter (and the shared compiler machinery it relies on):
- Thread the width through a component's `layoutinfo-v-with-constraint` body so a
  forwarded scalar min/max/preferred-height dispatches via the inner layout's
  constrained function instead of an unconstrained self.width read.
- When a flex measures a cell through its own layout-info, apply only the cell's
  *locally-set* constraints on top; inherited intrinsic ones are already baked in
  (re-reading them unconstrained re-introduces the loop). LayoutConstraints now
  records local-vs-inherited per constraint (including fixed width/height), exposed
  via `to_apply` / `Element::layout_info_includes_own_constraints`.

---

FlexboxLayout: fix the forwarded-min-height binding loop in generated code (#11168)

Mirror the interpreter fix in the LLR lowering that both code generators use: when
a flex cell is measured through its own layout-info, apply only its locally-set
constraints on top (`LayoutConstraints::to_apply`). An inherited intrinsic
min/max/preferred is already in the measured value; re-reading it unconstrained
was reintroducing the height-for-width loop through the flex solve.

Add a cross-backend regression test (rust, cpp, interpreter, nodejs) covering the
AboutSlint-style forwarded min-height in a FlexboxLayout plus an explicit
per-instance min-height override.