### PR TITLE
compiler: Make `langtype::Type` `Send`

### DIFF
--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use i_slint_compiler::generator::python::ident;
 use pyo3::IntoPyObjectExt;
@@ -249,7 +250,7 @@ impl CompilationResult {
 fn lookup_signature(
     definition: &slint_interpreter::ComponentDefinition,
     name: &str,
-) -> Option<Rc<SlintFunction>> {
+) -> Option<Arc<SlintFunction>> {
     let normalized = normalize_identifier(name);
     definition.properties_and_callbacks().find_map(|(prop_name, (ty, _))| {
         (normalize_identifier(&prop_name) == normalized)
@@ -266,7 +267,7 @@ fn lookup_global_signature(
     definition: &slint_interpreter::ComponentDefinition,
     global_name: &str,
     name: &str,
-) -> Option<Rc<SlintFunction>> {
+) -> Option<Arc<SlintFunction>> {
     let normalized = normalize_identifier(name);
     definition.global_properties_and_callbacks(global_name)?.find_map(|(prop_name, (ty, _))| {
         (normalize_identifier(&prop_name) == normalized)
@@ -653,7 +654,7 @@ impl GcVisibleCallbacks {
         &self,
         name: String,
         callable: Py<PyAny>,
-        signature: Option<Rc<SlintFunction>>,
+        signature: Option<Arc<SlintFunction>>,
     ) -> impl Fn(&[Value]) -> Value + 'static {
         self.callables.borrow_mut().insert(name.clone(), callable);
 

--- a/internal/compiler/benches/semantic_analysis.rs
+++ b/internal/compiler/benches/semantic_analysis.rs
@@ -198,7 +198,7 @@ fn parse_source(source: &str) -> parser::SyntaxNode {
     let mut diagnostics = BuildDiagnostics::default();
     let tokens = i_slint_compiler::lexer::lex(source);
     let source_file: SourceFile =
-        Rc::new(SourceFileInner::new(PathBuf::from("bench.slint"), source.to_string()));
+        Arc::new(SourceFileInner::new(PathBuf::from("bench.slint"), source.to_string()));
     parser::parse_tokens(tokens, source_file, &mut diagnostics)
 }
 

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -3,7 +3,7 @@
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::parser::TextSize;
 use std::collections::BTreeSet;
@@ -73,7 +73,7 @@ pub struct SourceFileInner {
     source: Option<String>,
 
     /// The offset of each linebreak
-    line_offsets: std::cell::OnceCell<Vec<usize>>,
+    line_offsets: std::sync::OnceLock<Vec<usize>>,
 }
 
 impl std::fmt::Debug for SourceFileInner {
@@ -92,8 +92,8 @@ impl SourceFileInner {
     }
 
     /// Create a SourceFile that has just a path, but no contents
-    pub fn from_path_only(path: PathBuf) -> Rc<Self> {
-        Rc::new(Self { path, ..Default::default() })
+    pub fn from_path_only(path: PathBuf) -> Arc<Self> {
+        Arc::new(Self { path, ..Default::default() })
     }
 
     /// Returns a tuple with the line (starting at 1) and column number (starting at 1)
@@ -187,7 +187,7 @@ pub enum ByteFormat {
     Utf16,
 }
 
-pub type SourceFile = Rc<SourceFileInner>;
+pub type SourceFile = Arc<SourceFileInner>;
 
 pub fn load_from_path(path: &Path) -> Result<String, Diagnostic> {
     let string = (if path == Path::new("-") {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -16,6 +16,7 @@ use smol_str::{SmolStr, format_smolstr};
 use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::rc::{Rc, Weak};
+use std::sync::Arc;
 
 // FIXME remove the pub
 pub use crate::namedreference::NamedReference;
@@ -177,12 +178,12 @@ macro_rules! declare_builtin_function_types {
     ($( $Name:ident $(($Pattern:tt))? : ($( $Arg:expr ),*) -> $ReturnType:expr $(,)? )*) => {
         #[allow(non_snake_case)]
         pub struct BuiltinFunctionTypes {
-            $(pub $Name : Rc<Function>),*
+            $(pub $Name : Arc<Function>),*
         }
         impl BuiltinFunctionTypes {
             pub fn new() -> Self {
                 Self {
-                    $($Name : Rc::new(Function{
+                    $($Name : Arc::new(Function{
                         args: vec![$($Arg),*],
                         return_type: $ReturnType,
                         arg_names: Vec::new(),
@@ -190,7 +191,7 @@ macro_rules! declare_builtin_function_types {
                 }
             }
 
-            pub fn ty(&self, function: &BuiltinFunction) -> Rc<Function> {
+            pub fn ty(&self, function: &BuiltinFunction) -> Arc<Function> {
                 match function {
                     $(BuiltinFunction::$Name $(($Pattern))? => self.$Name.clone()),*
                 }
@@ -243,21 +244,21 @@ declare_builtin_function_types!(
     StringEndsWith: (Type::String, Type::String) -> Type::Bool,
     KeysToString: (Type::Keys) -> Type::String,
     ImplicitLayoutInfo(..): (Type::ElementReference, Type::Float32) -> typeregister::layout_info_type().into(),
-    ColorRgbaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
+    ColorRgbaStruct: (Type::Color) -> Type::Struct(Arc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("red"), Type::Int32),
             (SmolStr::new_static("green"), Type::Int32),
             (SmolStr::new_static("blue"), Type::Int32),
             (SmolStr::new_static("alpha"), Type::Int32),
         ])
         .collect(), BuiltinStruct::Color))),
-    ColorHsvaStruct: (Type::Color) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
+    ColorHsvaStruct: (Type::Color) -> Type::Struct(Arc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("hue"), Type::Float32),
             (SmolStr::new_static("saturation"), Type::Float32),
             (SmolStr::new_static("value"), Type::Float32),
             (SmolStr::new_static("alpha"), Type::Float32),
         ])
         .collect(), BuiltinStruct::Color))),
-    ColorOklchStruct: (Type::Color) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
+    ColorOklchStruct: (Type::Color) -> Type::Struct(Arc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("lightness"), Type::Float32),
             (SmolStr::new_static("chroma"), Type::Float32),
             (SmolStr::new_static("hue"), Type::Float32),
@@ -269,7 +270,7 @@ declare_builtin_function_types!(
     ColorTransparentize: (Type::Brush, Type::Float32) -> Type::Brush,
     ColorWithAlpha: (Type::Brush, Type::Float32) -> Type::Brush,
     ColorMix: (Type::Color, Type::Color, Type::Float32) -> Type::Color,
-    ImageSize: (Type::Image) -> Type::Struct(Rc::new(Struct::new(IntoIterator::into_iter([
+    ImageSize: (Type::Image) -> Type::Struct(Arc::new(Struct::new(IntoIterator::into_iter([
             (SmolStr::new_static("width"), Type::Int32),
             (SmolStr::new_static("height"), Type::Int32),
         ])
@@ -295,9 +296,9 @@ declare_builtin_function_types!(
     MonthOffset: (Type::Int32, Type::Int32) -> Type::Int32,
     FormatDate: (Type::String, Type::Int32, Type::Int32, Type::Int32) -> Type::String,
     TextInputFocused: () -> Type::Bool,
-    DateNow: () -> Type::Array(Rc::new(Type::Int32)),
+    DateNow: () -> Type::Array(Arc::new(Type::Int32)),
     ValidDate: (Type::String, Type::String) -> Type::Bool,
-    ParseDate: (Type::String, Type::String) -> Type::Array(Rc::new(Type::Int32)),
+    ParseDate: (Type::String, Type::String) -> Type::Array(Arc::new(Type::Int32)),
     SetTextInputFocused: (Type::Bool) -> Type::Void,
     ItemAbsolutePosition: (Type::ElementReference) -> typeregister::logical_point_type().into(),
     RegisterCustomFontByPath: (Type::String) -> Type::Void,
@@ -327,7 +328,7 @@ impl Default for BuiltinFunctionTypes {
 }
 
 impl BuiltinFunction {
-    pub fn ty(&self) -> Rc<Function> {
+    pub fn ty(&self) -> Arc<Function> {
         thread_local! {
             static TYPES: BuiltinFunctionTypes = BuiltinFunctionTypes::new();
         }
@@ -848,7 +849,7 @@ pub enum Expression {
         values: Vec<Expression>,
     },
     Struct {
-        ty: Rc<Struct>,
+        ty: Arc<Struct>,
         values: BTreeMap<SmolStr, Expression>,
     },
 
@@ -1080,7 +1081,7 @@ impl Expression {
                 }
             }
             Expression::UnaryOp { sub, .. } => sub.ty(),
-            Expression::Array { element_ty, .. } => Type::Array(Rc::new(element_ty.clone())),
+            Expression::Array { element_ty, .. } => Type::Array(Arc::new(element_ty.clone())),
             Expression::Struct { ty, .. } => ty.clone().into(),
             Expression::PathData { .. } => Type::PathData,
             Expression::EmptyDataTransfer => Type::DataTransfer,

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -284,7 +284,7 @@ declare_builtin_function_types!(
     Hsv: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
     Oklch: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
     ColorScheme: () -> Type::Enumeration(
-        typeregister::BUILTIN.with(|e| e.enums.ColorScheme.clone()),
+        typeregister::BUILTIN.enums.ColorScheme.clone(),
     ),
     AccentColor: () -> Type::Color,
     SupportsNativeMenuBar: () -> Type::Bool,
@@ -309,7 +309,7 @@ declare_builtin_function_types!(
     Use24HourFormat: () -> Type::Bool,
     UpdateTimers: () -> Type::Void,
     DetectOperatingSystem: () -> Type::Enumeration(
-        typeregister::BUILTIN.with(|e| e.enums.OperatingSystemType.clone()),
+        typeregister::BUILTIN.enums.OperatingSystemType.clone(),
     ),
     StartTimer: (Type::ElementReference) -> Type::Void,
     StopTimer: (Type::ElementReference) -> Type::Void,
@@ -329,10 +329,9 @@ impl Default for BuiltinFunctionTypes {
 
 impl BuiltinFunction {
     pub fn ty(&self) -> Arc<Function> {
-        thread_local! {
-            static TYPES: BuiltinFunctionTypes = BuiltinFunctionTypes::new();
-        }
-        TYPES.with(|types| types.ty(self))
+        static TYPES: std::sync::LazyLock<BuiltinFunctionTypes> =
+            std::sync::LazyLock::new(BuiltinFunctionTypes::new);
+        TYPES.ty(self)
     }
 
     /// It is const if the return value only depends on its argument and has no side effect
@@ -1764,7 +1763,7 @@ impl Expression {
             },
             Type::Easing => Expression::EasingCurve(EasingCurve::default()),
             Type::MouseCursor => {
-                let e = crate::typeregister::BUILTIN.with(|e| e.enums.BuiltInMouseCursor.clone());
+                let e = crate::typeregister::BUILTIN.enums.BuiltInMouseCursor.clone();
                 Expression::MouseCursor(MouseCursorInner::BuiltIn(Box::new(
                     Expression::EnumerationValue(e.default_value()),
                 )))

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -10,6 +10,7 @@ use super::accessor_names::{self, AccessorKind};
 use crate::fileaccess;
 use std::collections::HashSet;
 use std::fmt::{Formatter, Write};
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use smol_str::{SmolStr, StrExt, format_smolstr};
@@ -1381,7 +1382,7 @@ fn generate_struct(
     file.declarations.push(Declaration::Struct(Struct { name, members, ..Default::default() }))
 }
 
-fn generate_enum(file: &mut File, en: &std::rc::Rc<Enumeration>) {
+fn generate_enum(file: &mut File, en: &std::sync::Arc<Enumeration>) {
     file.declarations.push(Declaration::Enum(Enum {
         name: ident(&en.name),
         values: (0..en.values.len())

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -10,7 +10,6 @@ use super::accessor_names::{self, AccessorKind};
 use crate::fileaccess;
 use std::collections::HashSet;
 use std::fmt::{Formatter, Write};
-use std::sync::Arc;
 use std::sync::OnceLock;
 
 use smol_str::{SmolStr, StrExt, format_smolstr};
@@ -1330,7 +1329,7 @@ fn generate_struct(
     unit: &llr::CompilationUnit,
     conditional_includes: &ConditionalIncludes,
 ) {
-    let StructName::User { name: user_name, node } = &the_struct.name else {
+    let StructName::User { name: user_name, .. } = &the_struct.name else {
         panic!("internal error: Cannot generate anonymous struct");
     };
     // Constant expressions cannot access the globals; make sure a bug in that
@@ -1343,13 +1342,14 @@ fn generate_struct(
         },
     );
     let name = ident(user_name);
-    let mut members = node
-        .ObjectTypeMember()
-        .map(|n| crate::parser::identifier_text(&n).unwrap())
+    // Emit members in declaration order: C++ users initialize structs positionally.
+    let mut members = the_struct
+        .field_order()
+        .iter()
         .map(|name| {
             // When any field has a declared default value, initialize the remaining fields, too,
             // so that default construction is fully deterministic, like in the other language backends.
-            let init = match the_struct.field_defaults.get(&name) {
+            let init = match the_struct.field_defaults.get(name) {
                 Some(default_value) => {
                     Some(compile_expression(&lower_constant_expression(default_value), &ctx))
                 }
@@ -1359,8 +1359,8 @@ fn generate_struct(
             (
                 Access::Public,
                 Declaration::Var(Var {
-                    ty: the_struct.fields.get(&name).unwrap().cpp_type().unwrap(),
-                    name: ident(&name),
+                    ty: the_struct.fields.get(name).unwrap().cpp_type().unwrap(),
+                    name: ident(name),
                     init,
                     ..Default::default()
                 }),

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -7,8 +7,9 @@
 // cSpell:ignore cmath constexpr cstdlib decltype intptr itertools nullptr prepended struc subcomponent uintptr vals enumty fundecl pycompo pyenum structty
 
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
 use std::sync::OnceLock;
-use std::{collections::HashSet, rc::Rc};
 
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
@@ -154,10 +155,10 @@ pub struct PyStruct {
 
 pub struct AnonymousStruct;
 
-impl TryFrom<&Rc<crate::langtype::Struct>> for PyStruct {
+impl TryFrom<&Arc<crate::langtype::Struct>> for PyStruct {
     type Error = AnonymousStruct;
 
-    fn try_from(structty: &Rc<crate::langtype::Struct>) -> Result<Self, Self::Error> {
+    fn try_from(structty: &Arc<crate::langtype::Struct>) -> Result<Self, Self::Error> {
         let StructName::User { name, .. } = &structty.name else {
             return Err(AnonymousStruct);
         };
@@ -234,8 +235,8 @@ pub struct PyEnum {
     aliases: Vec<SmolStr>,
 }
 
-impl From<&Rc<crate::langtype::Enumeration>> for PyEnum {
-    fn from(enumty: &Rc<crate::langtype::Enumeration>) -> Self {
+impl From<&Arc<crate::langtype::Enumeration>> for PyEnum {
+    fn from(enumty: &Arc<crate::langtype::Enumeration>) -> Self {
         Self {
             name: ident(&enumty.name),
             variants: enumty

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -15,7 +15,7 @@ Some convention used in the generated code:
 use super::accessor_names::{self, AccessorKind};
 use crate::CompilerConfiguration;
 use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp, OperatorClass};
-use crate::langtype::{Enumeration, EnumerationValue, Struct, StructName, Type};
+use crate::langtype::{DeclNode, Enumeration, EnumerationValue, Struct, StructName, Type};
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
 use crate::llr::{
@@ -708,6 +708,27 @@ fn generate_shared_globals(
     }
 }
 
+/// Compile the `@rust-attr(...)` captured on a struct or enum declaration into outer
+/// attributes, emitting a `compile_error!` for any whose text does not tokenize.
+fn rust_attributes_tokens(
+    attributes: &[SmolStr],
+    kind: &str,
+    name: &SmolStr,
+    node: Option<&DeclNode>,
+) -> TokenStream {
+    let attrs = attributes.iter().map(|attr| match TokenStream::from_str(attr) {
+        Ok(t) => quote!(#[#t]),
+        Err(_) => {
+            let source_location = node.map(|n| n.to_source_location()).unwrap_or_default();
+            let error = format!(
+                "Error parsing @rust-attr for {kind} '{name}' declared at {source_location}"
+            );
+            quote!(compile_error!(#error);)
+        }
+    });
+    quote! { #(#attrs)* }
+}
+
 fn generate_struct(the_struct: &Struct, unit: &llr::CompilationUnit) -> TokenStream {
     let component_id = struct_name_to_tokens(&the_struct.name).unwrap();
     let (declared_property_vars, declared_property_types): (Vec<_>, Vec<_>) = the_struct
@@ -716,26 +737,12 @@ fn generate_struct(the_struct: &Struct, unit: &llr::CompilationUnit) -> TokenStr
         .map(|(name, ty)| (ident(name), rust_primitive_type(ty).unwrap()))
         .unzip();
 
-    let StructName::User { name, node } = &the_struct.name else {
+    let StructName::User { name, .. } = &the_struct.name else {
         unreachable!("generating non-user struct")
     };
 
     let attributes =
-        node.parent().and_then(crate::parser::syntax_nodes::StructDeclaration::new).map(|node| {
-            let attrs = node.AtRustAttr().map(|attr| {
-                match TokenStream::from_str(&attr.text().to_string()) {
-                    Ok(t) => quote!(#[#t]),
-                    Err(_) => {
-                        let source_location = crate::diagnostics::Spanned::to_source_location(&attr);
-                        let error = format!(
-                            "Error parsing @rust-attr for struct '{name}' declared at {source_location}"
-                        );
-                        quote!(compile_error!(#error);)
-                    }
-                }
-            });
-            quote! { #(#attrs)* }
-        });
+        rust_attributes_tokens(the_struct.rust_attributes(), "struct", name, the_struct.node());
 
     // With user-declared field default values, `Default` cannot be derived anymore
     let default_impl = (!the_struct.field_defaults.is_empty()).then(|| {
@@ -788,21 +795,8 @@ fn generate_enum(en: &std::sync::Arc<Enumeration>) -> TokenStream {
         let i = ident(&EnumerationValue { value, enumeration: en.clone() }.to_pascal_case());
         if value == en.default_value { quote!(#[default] #i) } else { quote!(#i) }
     });
-    let attributes = en.node.as_ref().map(|node| {
-        let attrs =
-            node.AtRustAttr().map(|attr| match TokenStream::from_str(&attr.text().to_string()) {
-                Ok(t) => quote!(#[#t]),
-                Err(_) => {
-                    let name = &en.name;
-                    let source_location = crate::diagnostics::Spanned::to_source_location(&attr);
-                    let error = format!(
-                        "Error parsing @rust-attr for enum '{name}' declared at {source_location}"
-                    );
-                    quote!(compile_error!(#error);)
-                }
-            });
-        quote! { #(#attrs)* }
-    });
+    let attributes =
+        rust_attributes_tokens(&en.rust_attributes, "enum", &en.name, en.node.as_ref());
     quote! {
         #attributes
         #[allow(dead_code)]

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -781,7 +781,7 @@ fn generate_struct(the_struct: &Struct, unit: &llr::CompilationUnit) -> TokenStr
     }
 }
 
-fn generate_enum(en: &std::rc::Rc<Enumeration>) -> TokenStream {
+fn generate_enum(en: &std::sync::Arc<Enumeration>) -> TokenStream {
     let enum_name = ident(&en.name);
 
     let enum_values = (0..en.values.len()).map(|value| {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use itertools::Itertools;
 
@@ -27,8 +28,8 @@ pub enum Type {
     /// The type of a callback alias whose type was not yet inferred
     InferredCallback,
 
-    Callback(Rc<Function>),
-    Function(Rc<Function>),
+    Callback(Arc<Function>),
+    Function(Arc<Function>),
 
     ComponentFactory,
 
@@ -51,9 +52,9 @@ pub enum Type {
     Easing,
     Brush,
     /// This is usually a model
-    Array(Rc<Type>),
-    Struct(Rc<Struct>),
-    Enumeration(Rc<Enumeration>),
+    Array(Arc<Type>),
+    Struct(Arc<Struct>),
+    Enumeration(Arc<Enumeration>),
     Keys,
     /// `data-transfer` - a special type that handles reading a value from the system with
     /// some set of available MIME types.
@@ -182,8 +183,8 @@ impl Display for Type {
     }
 }
 
-impl From<Rc<Struct>> for Type {
-    fn from(value: Rc<Struct>) -> Self {
+impl From<Arc<Struct>> for Type {
+    fn from(value: Arc<Struct>) -> Self {
         Self::Struct(value)
     }
 }
@@ -231,7 +232,7 @@ impl Type {
     }
 
     /// Assume it is an enumeration, panic if it isn't
-    pub fn as_enum(&self) -> &Rc<Enumeration> {
+    pub fn as_enum(&self) -> &Arc<Enumeration> {
         match self {
             Type::Enumeration(e) => e,
             _ => panic!("should be an enumeration, bug in compiler pass"),
@@ -439,7 +440,7 @@ pub enum ElementType {
     /// The element is a builtin element
     Builtin(Rc<BuiltinElement>),
     /// The native type was resolved by the resolve_native_class pass.
-    Native(Rc<NativeClass>),
+    Native(Arc<NativeClass>),
     /// The base element couldn't be looked up
     #[default]
     Error,
@@ -454,7 +455,7 @@ impl PartialEq for ElementType {
         match (self, other) {
             (Self::Component(a), Self::Component(b)) => Rc::ptr_eq(a, b),
             (Self::Builtin(a), Self::Builtin(b)) => Rc::ptr_eq(a, b),
-            (Self::Native(a), Self::Native(b)) => Rc::ptr_eq(a, b),
+            (Self::Native(a), Self::Native(b)) => Arc::ptr_eq(a, b),
             (Self::Error, Self::Error)
             | (Self::Global, Self::Global)
             | (Self::Interface, Self::Interface) => true,
@@ -791,7 +792,7 @@ impl BuiltinStruct {
 
 #[derive(Debug, Clone, Default)]
 pub struct NativeClass {
-    pub parent: Option<Rc<NativeClass>>,
+    pub parent: Option<Arc<NativeClass>>,
     pub class_name: SmolStr,
     pub cpp_vtable_getter: String,
     pub properties: BTreeMap<SmolStr, BuiltinPropertyInfo>,
@@ -862,7 +863,7 @@ pub enum DefaultSizeBinding {
 #[derive(Debug, Clone, Default)]
 pub struct BuiltinElement {
     pub name: SmolStr,
-    pub native_class: Rc<NativeClass>,
+    pub native_class: Arc<NativeClass>,
     pub properties: BTreeMap<SmolStr, BuiltinPropertyInfo>,
     /// Additional builtin element that can be accepted as child of this element
     /// (example `Tab` in `TabWidget`, `Row` in `GridLayout` and the path elements in `Path`)
@@ -889,7 +890,7 @@ pub struct BuiltinElement {
 }
 
 impl BuiltinElement {
-    pub fn new(native_class: Rc<NativeClass>) -> Self {
+    pub fn new(native_class: Arc<NativeClass>) -> Self {
         Self { name: native_class.class_name.clone(), native_class, ..Default::default() }
     }
 }
@@ -1094,7 +1095,7 @@ pub enum ConstantExpression {
         op: char,
     },
     Struct {
-        ty: Rc<Struct>,
+        ty: Arc<Struct>,
         values: BTreeMap<SmolStr, ConstantExpression>,
     },
     Array {
@@ -1188,11 +1189,11 @@ impl PartialEq for Enumeration {
 }
 
 impl Enumeration {
-    pub fn default_value(self: Rc<Self>) -> EnumerationValue {
+    pub fn default_value(self: Arc<Self>) -> EnumerationValue {
         EnumerationValue { value: self.default_value, enumeration: self.clone() }
     }
 
-    pub fn try_value_from_string(self: Rc<Self>, value: &str) -> Option<EnumerationValue> {
+    pub fn try_value_from_string(self: Arc<Self>, value: &str) -> Option<EnumerationValue> {
         self.values.iter().enumerate().find_map(|(idx, name)| {
             if name == value {
                 Some(EnumerationValue { value: idx, enumeration: self.clone() })
@@ -1258,12 +1259,12 @@ impl std::fmt::Display for Keys {
 #[derive(Clone, Debug)]
 pub struct EnumerationValue {
     pub value: usize, // index in enumeration.values
-    pub enumeration: Rc<Enumeration>,
+    pub enumeration: Arc<Enumeration>,
 }
 
 impl PartialEq for EnumerationValue {
     fn eq(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.enumeration, &other.enumeration) && self.value == other.value
+        Arc::ptr_eq(&self.enumeration, &other.enumeration) && self.value == other.value
     }
 }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -13,7 +13,6 @@ use smol_str::SmolStr;
 
 use crate::expression_tree::{BuiltinFunction, Expression, Unit};
 use crate::object_tree::{Component, PropertyVisibility};
-use crate::parser::syntax_nodes;
 use crate::typeregister::TypeRegister;
 
 #[derive(Debug, Clone, Default)]
@@ -977,14 +976,60 @@ impl Display for Function {
     }
 }
 
+/// A `Send` + `Sync` reference to *where* a user-declared struct or enum was
+/// written: the source file and the text range of its declaration node.
+///
+/// It deliberately carries no syntax tree, so the langtype graph (and therefore
+/// the LLR) stays compact and `Send` without pinning parsed documents at
+/// runtime. Everything the code generators need from the declaration is captured
+/// into the type at build time (e.g. `@rust-attr` in `rust_attributes`); the
+/// language server, which keeps every open document, resolves the actual syntax
+/// node from its own `DocumentCache` using [`Self::text_range`].
+#[derive(Debug, Clone)]
+pub struct DeclNode {
+    source_file: crate::diagnostics::SourceFile,
+    range: rowan::TextRange,
+}
+
+impl DeclNode {
+    pub fn new(node: &crate::parser::SyntaxNode) -> Self {
+        Self { source_file: node.source_file.clone(), range: node.node.text_range() }
+    }
+
+    /// The absolute text range of the declaration node within its document.
+    pub fn text_range(&self) -> rowan::TextRange {
+        self.range
+    }
+
+    /// The source file the declaration was parsed from.
+    pub fn source_file(&self) -> &crate::diagnostics::SourceFile {
+        &self.source_file
+    }
+
+    /// The source location (file + span) of the declaration.
+    pub fn to_source_location(&self) -> crate::diagnostics::SourceLocation {
+        crate::diagnostics::SourceLocation {
+            source_file: Some(self.source_file.clone()),
+            span: crate::diagnostics::Span::new(self.range.start().into(), self.range.len().into()),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum StructName {
     None,
     /// When declared in .slint as  `struct Foo { }`, then the name is "Foo"
     User {
         name: SmolStr,
-        /// When declared in .slint, this is the node of the declaration.
-        node: syntax_nodes::ObjectType,
+        /// Where the declaration was written (for the language server).
+        node: DeclNode,
+        /// The raw text of each `@rust-attr(...)` on the declaration, captured
+        /// at build time so the Rust generator does not need the syntax tree.
+        rust_attributes: Vec<SmolStr>,
+        /// The field names in declaration order. The C++ generator emits struct
+        /// members in this order (positional aggregate initialization relies on
+        /// it), which `fields` — a sorted map — does not preserve.
+        field_order: Vec<SmolStr>,
     },
     Builtin(BuiltinStruct),
 }
@@ -992,10 +1037,9 @@ pub enum StructName {
 impl PartialEq for StructName {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (
-                Self::User { name: l_user_name, node: _ },
-                Self::User { name: r_user_name, node: _ },
-            ) => l_user_name == r_user_name,
+            (Self::User { name: l_user_name, .. }, Self::User { name: r_user_name, .. }) => {
+                l_user_name == r_user_name
+            }
             (Self::Builtin(l0), Self::Builtin(r0)) => l0 == r0,
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
@@ -1049,10 +1093,27 @@ impl Struct {
         Self { fields, field_defaults: Default::default(), name: name.into() }
     }
 
-    pub fn node(&self) -> Option<&syntax_nodes::ObjectType> {
+    /// Where a user-declared struct was written (for the language server).
+    pub fn node(&self) -> Option<&DeclNode> {
         match &self.name {
             StructName::User { node, .. } => Some(node),
             _ => None,
+        }
+    }
+
+    /// The raw text of each `@rust-attr(...)` on a user-declared struct.
+    pub fn rust_attributes(&self) -> &[SmolStr] {
+        match &self.name {
+            StructName::User { rust_attributes, .. } => rust_attributes,
+            _ => &[],
+        }
+    }
+
+    /// The field names in declaration order for a user-declared struct.
+    pub fn field_order(&self) -> &[SmolStr] {
+        match &self.name {
+            StructName::User { field_order, .. } => field_order,
+            _ => &[],
         }
     }
 
@@ -1178,8 +1239,11 @@ pub struct Enumeration {
     pub name: SmolStr,
     pub values: Vec<SmolStr>,
     pub default_value: usize, // index in values
-    // For non-builtins enums, this is the declaration node
-    pub node: Option<syntax_nodes::EnumDeclaration>,
+    // For non-builtins enums, this is where the declaration was written.
+    pub node: Option<DeclNode>,
+    /// The raw text of each `@rust-attr(...)` on the declaration, captured at
+    /// build time so the Rust generator does not need the syntax tree.
+    pub rust_attributes: Vec<SmolStr>,
 }
 
 impl PartialEq for Enumeration {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -381,7 +381,7 @@ impl Expression {
             },
             Type::Easing => Expression::EasingCurve(crate::expression_tree::EasingCurve::default()),
             Type::MouseCursor => {
-                let e = crate::typeregister::BUILTIN.with(|e| e.enums.BuiltInMouseCursor.clone());
+                let e = crate::typeregister::BUILTIN.enums.BuiltInMouseCursor.clone();
                 Expression::MouseCursor(MouseCursorInner::BuiltIn(Box::new(
                     Expression::EnumerationValue(e.default_value()),
                 )))

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -12,7 +12,7 @@ use crate::layout::Orientation;
 use itertools::Either;
 use smol_str::SmolStr;
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub enum ArrayOutput {
@@ -162,7 +162,7 @@ pub enum Expression {
         output: ArrayOutput,
     },
     Struct {
-        ty: Rc<crate::langtype::Struct>,
+        ty: Arc<crate::langtype::Struct>,
         values: BTreeMap<SmolStr, Expression>,
     },
 

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -7,7 +7,7 @@ use derive_more::{From, Into};
 use smol_str::SmolStr;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap};
-use std::rc::Rc;
+use std::sync::Arc;
 use typed_index_collections::TiVec;
 
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -421,7 +421,7 @@ pub struct ComponentContainerElement {
 }
 
 pub struct Item {
-    pub ty: Rc<NativeClass>,
+    pub ty: Arc<NativeClass>,
     pub name: SmolStr,
     /// Index in the item tree array
     pub index_in_tree: u32,

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -750,7 +750,7 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             (SmolStr::new_static("iteration-count"), Type::Float32),
             (
                 SmolStr::new_static("direction"),
-                Type::Enumeration(BUILTIN.with(|e| e.enums.AnimationDirection.clone())),
+                Type::Enumeration(BUILTIN.enums.AnimationDirection.clone()),
             ),
             (SmolStr::new_static("easing"), Type::Easing),
             (SmolStr::new_static("delay"), Type::Int32),

--- a/internal/compiler/llr/lower_expression.rs
+++ b/internal/compiler/llr/lower_expression.rs
@@ -4,6 +4,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::{Rc, Weak};
+use std::sync::Arc;
 
 use smol_str::SmolStr;
 
@@ -757,8 +758,8 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
         ])
     }
 
-    fn animation_ty() -> Rc<Struct> {
-        Rc::new(Struct::new(animation_fields().collect(), BuiltinStruct::PropertyAnimation))
+    fn animation_ty() -> Arc<Struct> {
+        Arc::new(Struct::new(animation_fields().collect(), BuiltinStruct::PropertyAnimation))
     }
 
     match a {
@@ -799,7 +800,7 @@ pub fn lower_animation(a: &PropertyAnimation, ctx: &mut ExpressionLoweringCtx<'_
             }
             let result = llr_Expression::Struct {
                 // This is going to be a tuple
-                ty: Rc::new(Struct::new(
+                ty: Arc::new(Struct::new(
                     IntoIterator::into_iter([
                         (SmolStr::new_static("0"), animation_ty),
                         // The type is an instant, which does not exist in our type system
@@ -850,7 +851,7 @@ fn compile_path(
             let converted_elements = elements
                 .iter()
                 .map(|element| {
-                    let element_type = Rc::new(Struct::new(
+                    let element_type = Arc::new(Struct::new(
                         element
                             .element_type
                             .properties
@@ -908,7 +909,7 @@ fn compile_path(
 
             llr_Expression::Cast {
                 from: llr_Expression::Struct {
-                    ty: Rc::new(Struct::new(
+                    ty: Arc::new(Struct::new(
                         IntoIterator::into_iter([
                             (SmolStr::new_static("events"), Type::Array(event_type.clone().into())),
                             (SmolStr::new_static("points"), Type::Array(point_type.clone().into())),
@@ -958,5 +959,5 @@ pub fn make_struct(
         values.insert(SmolStr::new(name), expr);
     }
 
-    llr_Expression::Struct { ty: Rc::new(Struct::new(fields, name)), values }
+    llr_Expression::Struct { ty: Arc::new(Struct::new(fields, name)), values }
 }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -39,7 +39,7 @@ pub(super) fn compute_grid_layout_info(
     let constraints_result = grid_layout_cell_constraints(layout, o, ctx, cross_axis_size_override);
     let orientation_literal = llr_Expression::EnumerationValue(EnumerationValue {
         value: o as _,
-        enumeration: crate::typeregister::BUILTIN.with(|b| b.enums.Orientation.clone()),
+        enumeration: crate::typeregister::BUILTIN.enums.Orientation.clone(),
     });
 
     let sub_expression = llr_Expression::ExtraBuiltinFunctionCall {
@@ -125,7 +125,7 @@ pub(super) fn organize_grid_layout(
     let input_data = grid_layout_input_data(layout, ctx);
 
     if let Some(button_roles) = &layout.dialog_button_roles {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.DialogButtonRole.clone());
+        let e = crate::typeregister::BUILTIN.enums.DialogButtonRole.clone();
         let roles = button_roles
             .iter()
             .map(|r| {
@@ -194,7 +194,7 @@ pub(super) fn solve_grid_layout(
     let size = layout_geometry_size(&layout.geometry.rect, o, ctx);
     let orientation_expr = llr_Expression::EnumerationValue(EnumerationValue {
         value: o as _,
-        enumeration: crate::typeregister::BUILTIN.with(|b| b.enums.Orientation.clone()),
+        enumeration: crate::typeregister::BUILTIN.enums.Orientation.clone(),
     });
     let data = make_struct(
         BuiltinStruct::GridLayoutData,
@@ -278,8 +278,7 @@ pub(super) fn solve_box_layout(
                 ("padding", padding.ty(ctx), padding),
                 (
                     "alignment",
-                    crate::typeregister::BUILTIN
-                        .with(|e| Type::Enumeration(e.enums.LayoutAlignment.clone())),
+                    Type::Enumeration(crate::typeregister::BUILTIN.enums.LayoutAlignment.clone()),
                     bld.alignment,
                 ),
                 ("cells", bld.cells.ty(ctx), bld.cells),
@@ -287,12 +286,12 @@ pub(super) fn solve_box_layout(
         );
         (data, "solve_box_layout")
     } else {
-        let cross_axis_alignment_ty = crate::typeregister::BUILTIN
-            .with(|e| Type::Enumeration(e.enums.CrossAxisAlignment.clone()));
+        let cross_axis_alignment_ty =
+            Type::Enumeration(crate::typeregister::BUILTIN.enums.CrossAxisAlignment.clone());
         let cross_axis_alignment = if let Some(nr) = &layout.cross_alignment {
             llr_Expression::PropertyReference(ctx.map_property_reference(nr))
         } else {
-            let e = crate::typeregister::BUILTIN.with(|e| e.enums.CrossAxisAlignment.clone());
+            let e = crate::typeregister::BUILTIN.enums.CrossAxisAlignment.clone();
             llr_Expression::EnumerationValue(EnumerationValue {
                 value: e.default_value,
                 enumeration: e,
@@ -376,32 +375,31 @@ pub(super) fn solve_flexbox_layout(
             ("padding_v", padding_v.ty(ctx), padding_v),
             (
                 "alignment",
-                crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.LayoutAlignment.clone())),
+                Type::Enumeration(crate::typeregister::BUILTIN.enums.LayoutAlignment.clone()),
                 fld.alignment,
             ),
             (
                 "direction",
-                crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutDirection.clone())),
+                Type::Enumeration(
+                    crate::typeregister::BUILTIN.enums.FlexboxLayoutDirection.clone(),
+                ),
                 fld.direction,
             ),
             (
                 "align_content",
-                crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutAlignContent.clone())),
+                Type::Enumeration(
+                    crate::typeregister::BUILTIN.enums.FlexboxLayoutAlignContent.clone(),
+                ),
                 fld.align_content,
             ),
             (
                 "cross_axis_alignment",
-                crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.CrossAxisAlignment.clone())),
+                Type::Enumeration(crate::typeregister::BUILTIN.enums.CrossAxisAlignment.clone()),
                 fld.cross_axis_alignment,
             ),
             (
                 "flex_wrap",
-                crate::typeregister::BUILTIN
-                    .with(|e| Type::Enumeration(e.enums.FlexboxLayoutWrap.clone())),
+                Type::Enumeration(crate::typeregister::BUILTIN.enums.FlexboxLayoutWrap.clone()),
                 fld.flex_wrap,
             ),
             ("cells_h", fld.cells_h.ty(ctx), fld.cells_h),
@@ -625,8 +623,7 @@ pub(super) fn compute_flexbox_layout_info(
             );
 
             // Condition: direction == Row || direction == RowReverse
-            let direction_enum =
-                crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
+            let direction_enum = crate::typeregister::BUILTIN.enums.FlexboxLayoutDirection.clone();
             let direction_ref = llr_Expression::PropertyReference(
                 ctx.map_property_reference(layout.direction.as_ref().unwrap()),
             );
@@ -798,7 +795,7 @@ fn flexbox_layout_data(
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.LayoutAlignment.clone());
+        let e = crate::typeregister::BUILTIN.enums.LayoutAlignment.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -808,7 +805,7 @@ fn flexbox_layout_data(
     let direction = if let Some(expr) = &layout.direction {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
+        let e = crate::typeregister::BUILTIN.enums.FlexboxLayoutDirection.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -818,7 +815,7 @@ fn flexbox_layout_data(
     let align_content = if let Some(expr) = &layout.align_content {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutAlignContent.clone());
+        let e = crate::typeregister::BUILTIN.enums.FlexboxLayoutAlignContent.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -828,7 +825,7 @@ fn flexbox_layout_data(
     let cross_axis_alignment = if let Some(expr) = &layout.cross_axis_alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.CrossAxisAlignment.clone());
+        let e = crate::typeregister::BUILTIN.enums.CrossAxisAlignment.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -838,7 +835,7 @@ fn flexbox_layout_data(
     let flex_wrap = if let Some(expr) = &layout.flex_wrap {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutWrap.clone());
+        let e = crate::typeregister::BUILTIN.enums.FlexboxLayoutWrap.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -1039,7 +1036,7 @@ struct BoxLayoutDataResult {
 }
 
 fn default_align_self() -> (Type, llr_Expression) {
-    let e = crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutAlignSelf.clone());
+    let e = crate::typeregister::BUILTIN.enums.FlexboxLayoutAlignSelf.clone();
     (
         Type::Enumeration(e.clone()),
         llr_Expression::EnumerationValue(EnumerationValue {
@@ -1090,7 +1087,7 @@ fn box_layout_data(
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.LayoutAlignment.clone());
+        let e = crate::typeregister::BUILTIN.enums.LayoutAlignment.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -1304,8 +1301,7 @@ fn clamp_wrapping_flex_cross_preferred(
     // wrapping flex is clamped. Decide at runtime when flex-wrap is dynamic.
     let new_preferred = match &flex.flex_wrap {
         Some(nr) => {
-            let wrap_enum =
-                crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutWrap.clone());
+            let wrap_enum = crate::typeregister::BUILTIN.enums.FlexboxLayoutWrap.clone();
             let is_no_wrap = llr_Expression::BinaryExpression {
                 lhs: Box::new(llr_Expression::PropertyReference(ctx.map_property_reference(nr))),
                 rhs: Box::new(llr_Expression::EnumerationValue(EnumerationValue {
@@ -1337,8 +1333,7 @@ fn clamp_wrapping_flex_cross_preferred(
         FlexboxAxisRelation::MainAxis => clamped_struct,
         FlexboxAxisRelation::CrossAxis => unreachable!("returned early above"),
         FlexboxAxisRelation::Unknown => {
-            let direction_enum =
-                crate::typeregister::BUILTIN.with(|e| e.enums.FlexboxLayoutDirection.clone());
+            let direction_enum = crate::typeregister::BUILTIN.enums.FlexboxLayoutDirection.clone();
             let direction_ref = llr_Expression::PropertyReference(
                 ctx.map_property_reference(flex.direction.as_ref().unwrap()),
             );

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use itertools::Either;
 use smol_str::SmolStr;
@@ -750,7 +750,7 @@ fn compute_flexbox_layout_info_for_direction(
                         arguments: vec![
                             llr_Expression::ReadLocalVariable {
                                 name: cells_var.into(),
-                                ty: Type::Array(Rc::new(
+                                ty: Type::Array(Arc::new(
                                     crate::typeregister::flexbox_layout_item_info_type(),
                                 )),
                             },
@@ -1011,11 +1011,11 @@ fn flexbox_layout_data(
         }
         let cells_h = llr_Expression::ReadLocalVariable {
             name: "cells_h".into(),
-            ty: Type::Array(Rc::new(crate::typeregister::flexbox_layout_item_info_type())),
+            ty: Type::Array(Arc::new(crate::typeregister::flexbox_layout_item_info_type())),
         };
         let cells_v = llr_Expression::ReadLocalVariable {
             name: "cells_v".into(),
-            ty: Type::Array(Rc::new(crate::typeregister::flexbox_layout_item_info_type())),
+            ty: Type::Array(Arc::new(crate::typeregister::flexbox_layout_item_info_type())),
         };
         FlexboxLayoutDataResult {
             alignment,
@@ -1150,7 +1150,7 @@ fn box_layout_data(
         }
         let cells = llr_Expression::ReadLocalVariable {
             name: "cells".into(),
-            ty: Type::Array(Rc::new(crate::typeregister::layout_info_type().into())),
+            ty: Type::Array(Arc::new(crate::typeregister::layout_info_type().into())),
         };
         BoxLayoutDataResult { alignment, cells, compute_cells: Some(("cells".into(), elements)) }
     }
@@ -1221,7 +1221,7 @@ fn flexbox_unwrapped_main_expr(
         Orientation::Horizontal => (spacing_h, padding_h),
         Orientation::Vertical => (spacing_v, padding_v),
     };
-    let array_ty = Type::Array(Rc::new(crate::typeregister::flexbox_layout_item_info_type()));
+    let array_ty = Type::Array(Arc::new(crate::typeregister::flexbox_layout_item_info_type()));
     let cells_expr = match &fld.compute_cells {
         Some((cells_h_var, cells_v_var, _)) => {
             let cells_var = match orientation {
@@ -1444,7 +1444,7 @@ fn grid_layout_cell_constraints(
         }
         let cells = llr_Expression::ReadLocalVariable {
             name: "cells".into(),
-            ty: Type::Array(Rc::new(crate::typeregister::layout_info_type().into())),
+            ty: Type::Array(Arc::new(crate::typeregister::layout_info_type().into())),
         };
         GridLayoutCellConstraintsResult { cells, compute_cells: Some(("cells".into(), elements)) }
     }
@@ -1543,14 +1543,14 @@ fn grid_layout_input_data(
         }
         let cells = llr_Expression::ReadLocalVariable {
             name: "cells".into(),
-            ty: Type::Array(Rc::new(element_ty)),
+            ty: Type::Array(Arc::new(element_ty)),
         };
         GridLayoutInputDataResult { cells, compute_cells: Some(("cells".into(), elements)) }
     }
 }
 
 pub(super) fn grid_layout_input_data_ty() -> Type {
-    Type::Struct(Rc::new(Struct::new(
+    Type::Struct(Arc::new(Struct::new(
         IntoIterator::into_iter([
             (SmolStr::new_static("new_row"), Type::Bool),
             (SmolStr::new_static("row"), Type::Int32),

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use by_address::ByAddress;
+use std::sync::Arc;
 
 use super::lower_expression::{ExpressionLoweringCtx, ExpressionLoweringCtxInner};
 use crate::CompilerConfiguration;
@@ -869,7 +870,7 @@ fn lower_geometry(
         values
             .insert(f.into(), super::Expression::PropertyReference(ctx.map_property_reference(v)));
     }
-    super::Expression::Struct { ty: Rc::new(Struct::new(fields, StructName::None)), values }
+    super::Expression::Struct { ty: Arc::new(Struct::new(fields, StructName::None)), values }
 }
 
 fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::PropertyAnalysis {

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -9,6 +9,7 @@ use smol_str::{SmolStr, ToSmolStr};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::expression_tree::Expression;
 use crate::langtype::{
@@ -109,7 +110,7 @@ pub(crate) fn load_builtins(
                     (prop_name, info)
                 })
                 .chain(e.CallbackDeclaration().map(|s| {
-                    let mut info = BuiltinPropertyInfo::new(Type::Callback(Rc::new(Function{
+                    let mut info = BuiltinPropertyInfo::new(Type::Callback(Arc::new(Function{
                         args: s
                             .CallbackDeclarationParameter()
                             .map(|a| {
@@ -189,7 +190,9 @@ pub(crate) fn load_builtins(
             (name, info)
         }));
 
-        let mut builtin = BuiltinElement::new(Rc::new(n));
+        // NativeClass is not Send yet; the Arc is for the shared langtype graph.
+        #[allow(clippy::arc_with_non_send_sync)]
+        let mut builtin = BuiltinElement::new(Arc::new(n));
         builtin.is_global = matches!(base, Base::Global);
         let properties = &mut builtin.properties;
         if let Base::NativeParent(parent) = &base {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -4,6 +4,7 @@
 //! Helper to do lookup in expressions
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{
@@ -121,7 +122,7 @@ pub enum LookupResult {
         /// "The property 'xxx' has been deprecated." (e.g. "Please use 'yyy' instead")
         deprecated: Option<SmolStr>,
     },
-    Enumeration(Rc<Enumeration>),
+    Enumeration(Arc<Enumeration>),
     Namespace(BuiltinNamespace),
     Callable(LookupResultCallable),
 }
@@ -803,7 +804,7 @@ impl LookupObject for FontWeightLookup {
     }
 }
 
-impl LookupObject for Rc<Enumeration> {
+impl LookupObject for Arc<Enumeration> {
     fn for_each_entry<R>(
         &self,
         _ctx: &LookupCtx,

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -863,7 +863,7 @@ impl LookupObject for MouseCursorSpecific {
         _ctx: &LookupCtx,
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
-        let e = crate::typeregister::BUILTIN.with(|e| e.enums.BuiltInMouseCursor.clone());
+        let e = crate::typeregister::BUILTIN.enums.BuiltInMouseCursor.clone();
         let mut cursor = |n, e| f(n, Expression::MouseCursor(MouseCursorInner::BuiltIn(e)).into());
         let mut r = None;
         for value in &e.values {
@@ -892,10 +892,10 @@ impl LookupObject for SlintInternal {
             f(
                 "color-scheme",
                 if style.is_some_and(|s| s.ends_with("-light")) {
-                    let e = crate::typeregister::BUILTIN.with(|e| e.enums.ColorScheme.clone());
+                    let e = crate::typeregister::BUILTIN.enums.ColorScheme.clone();
                     Expression::EnumerationValue(e.try_value_from_string("light").unwrap())
                 } else if style.is_some_and(|s| s.ends_with("-dark")) {
-                    let e = crate::typeregister::BUILTIN.with(|e| e.enums.ColorScheme.clone());
+                    let e = crate::typeregister::BUILTIN.enums.ColorScheme.clone();
                     Expression::EnumerationValue(e.try_value_from_string("dark").unwrap())
                 } else {
                     Expression::FunctionCall {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -28,6 +28,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
 use std::path::PathBuf;
 use std::rc::{Rc, Weak};
+use std::sync::Arc;
 
 mod interfaces;
 
@@ -193,7 +194,7 @@ impl Document {
                 diag.push_error("Enums must have at least one value".into(), &n);
             }
 
-            let ty = Type::Enumeration(Rc::new(en));
+            let ty = Type::Enumeration(Arc::new(en));
             if !local_registry.insert_type_with_name(ty.clone(), name.clone()) {
                 diag.push_warning(
                     format!(
@@ -1611,7 +1612,7 @@ impl Element {
             r.property_declarations.insert(
                 name,
                 PropertyDeclaration {
-                    property_type: Type::Callback(Rc::new(Function {
+                    property_type: Type::Callback(Arc::new(Function {
                         return_type,
                         args,
                         arg_names,
@@ -1702,7 +1703,7 @@ impl Element {
             }
 
             let declaration = PropertyDeclaration {
-                property_type: Type::Function(Rc::new(Function { return_type, args, arg_names })),
+                property_type: Type::Function(Arc::new(Function { return_type, args, arg_names })),
                 node: Some(func.clone().into()),
                 visibility,
                 pure,
@@ -2461,7 +2462,7 @@ impl Element {
         self.callback_alias_declaration_node(name)
     }
 
-    pub fn native_class(&self) -> Option<Rc<NativeClass>> {
+    pub fn native_class(&self) -> Option<Arc<NativeClass>> {
         let mut base_type = self.base_type.clone();
         loop {
             match &base_type {
@@ -2822,7 +2823,7 @@ pub fn type_from_node(
     } else if let Some(array_node) = node.ArrayType() {
         #[cfg(feature = "slint-sc")]
         diag.slint_sc_error("Array types are", &array_node);
-        Type::Array(Rc::new(type_from_node(array_node.Type(), diag, tr)))
+        Type::Array(Arc::new(type_from_node(array_node.Type(), diag, tr)))
     } else {
         assert!(diag.has_errors());
         Type::Invalid
@@ -2866,7 +2867,7 @@ pub fn type_struct_from_node(
             (field_name, field_ty)
         })
         .collect();
-    Type::Struct(Rc::new(Struct {
+    Type::Struct(Arc::new(Struct {
         fields,
         field_defaults,
         name: name.map_or(StructName::None, |name| StructName::User { name, node: object_node }),

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -188,8 +188,16 @@ impl Document {
                     }
                 })
                 .collect();
-            let en =
-                Enumeration { name: name.clone(), values, default_value: 0, node: Some(n.clone()) };
+            let en = Enumeration {
+                name: name.clone(),
+                values,
+                default_value: 0,
+                node: Some(crate::langtype::DeclNode::new(&n)),
+                rust_attributes: n
+                    .AtRustAttr()
+                    .map(|a| SmolStr::from(a.text().to_string()))
+                    .collect(),
+            };
             if en.values.is_empty() {
                 diag.push_error("Enums must have at least one value".into(), &n);
             }
@@ -2842,10 +2850,12 @@ pub fn type_struct_from_node(
     symbol_counters: Option<&Rc<crate::symbol_counters::SymbolCounters>>,
 ) -> Type {
     let mut field_defaults = BTreeMap::default();
+    let mut field_order = Vec::new();
     let fields: BTreeMap<SmolStr, Type> = object_node
         .ObjectTypeMember()
         .map(|member| {
             let field_name = parser::identifier_text(&member).unwrap_or_default();
+            field_order.push(field_name.clone());
             let field_ty = type_from_node(member.Type(), diag, tr);
             if let Some(default_value_node) = member.Expression() {
                 if name.is_none() {
@@ -2867,10 +2877,21 @@ pub fn type_struct_from_node(
             (field_name, field_ty)
         })
         .collect();
+    // The `@rust-attr` attributes and the declaration node live on the
+    // enclosing `StructDeclaration` (the parent of the `ObjectType`).
+    let struct_decl = object_node.parent();
     Type::Struct(Arc::new(Struct {
         fields,
         field_defaults,
-        name: name.map_or(StructName::None, |name| StructName::User { name, node: object_node }),
+        name: name.map_or(StructName::None, |name| {
+            let rust_attributes = struct_decl
+                .as_ref()
+                .and_then(|p| syntax_nodes::StructDeclaration::new(p.clone()))
+                .map(|d| d.AtRustAttr().map(|a| SmolStr::from(a.text().to_string())).collect())
+                .unwrap_or_default();
+            let node = crate::langtype::DeclNode::new(struct_decl.as_ref().unwrap_or(&object_node));
+            StructName::User { name, node, rust_attributes, field_order }
+        }),
     }))
 }
 

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -7,6 +7,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use itertools::Itertools;
 use smol_str::{SmolStr, ToSmolStr};
@@ -577,7 +578,7 @@ fn apply_uses_statement_function_binding(
     element: &ElementRc,
     child: &ElementRc,
     name: &SmolStr,
-    function: &Rc<Function>,
+    function: &Arc<Function>,
 ) -> Option<RefCell<BindingExpression>> {
     let args_expr: Vec<Expression> = function
         .args

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -1084,7 +1084,7 @@ pub fn parse(
     build_diagnostics: &mut BuildDiagnostics,
 ) -> SyntaxNode {
     let mut p = DefaultParser::new(&source, build_diagnostics);
-    p.source_file = std::rc::Rc::new(crate::diagnostics::SourceFileInner::new(
+    p.source_file = std::sync::Arc::new(crate::diagnostics::SourceFileInner::new(
         path.map(crate::pathutils::clean_path).unwrap_or_default(),
         source,
     ));

--- a/internal/compiler/passes/clip.rs
+++ b/internal/compiler/passes/clip.rs
@@ -6,6 +6,7 @@
 use smol_str::{SmolStr, format_smolstr};
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};
@@ -26,7 +27,7 @@ pub fn handle_clip(
         &(),
         &mut |elem_rc: &ElementRc, _| {
             let elem = elem_rc.borrow();
-            if elem.native_class().is_some_and(|n| Rc::ptr_eq(&n, &native_clip)) {
+            if elem.native_class().is_some_and(|n| Arc::ptr_eq(&n, &native_clip)) {
                 return;
             }
             if elem.bindings.contains_key("clip")
@@ -57,7 +58,7 @@ pub fn handle_clip(
     );
 }
 
-fn create_clip_element(parent_elem: &ElementRc, native_clip: &Rc<NativeClass>) {
+fn create_clip_element(parent_elem: &ElementRc, native_clip: &Arc<NativeClass>) {
     let mut parent = parent_elem.borrow_mut();
     let clip = Element::make_rc(Element {
         id: format_smolstr!("{}-clip", parent.id),

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -147,7 +147,7 @@ fn compile_path_from_string_literal(
     )?;
     let path = builder.build();
 
-    let event_enum = crate::typeregister::BUILTIN.with(|e| e.enums.PathEvent.clone());
+    let event_enum = crate::typeregister::BUILTIN.enums.PathEvent.clone();
     let point_type = Arc::new(Struct::new(
         IntoIterator::into_iter([
             (SmolStr::new_static("x"), Type::Float32),

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -16,6 +16,7 @@ use crate::object_tree::*;
 use smol_str::SmolStr;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 pub fn compile_paths(
     component: &Rc<Component>,
@@ -147,7 +148,7 @@ fn compile_path_from_string_literal(
     let path = builder.build();
 
     let event_enum = crate::typeregister::BUILTIN.with(|e| e.enums.PathEvent.clone());
-    let point_type = Rc::new(Struct::new(
+    let point_type = Arc::new(Struct::new(
         IntoIterator::into_iter([
             (SmolStr::new_static("x"), Type::Float32),
             (SmolStr::new_static("y"), Type::Float32),

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -18,6 +18,7 @@ use crate::typeregister::TypeRegister;
 use core::cell::RefCell;
 use smol_str::{SmolStr, format_smolstr};
 use std::rc::Rc;
+use std::sync::Arc;
 
 pub fn is_flickable_element(element: &ElementRc) -> bool {
     matches!(&element.borrow().base_type, ElementType::Builtin(n) if n.name == "Flickable")
@@ -43,7 +44,7 @@ pub fn handle_flickable(root_component: &Rc<Component>, tr: &TypeRegister) {
     )
 }
 
-fn create_content_element(flickable: &ElementRc, native_empty: &Rc<NativeClass>) {
+fn create_content_element(flickable: &ElementRc, native_empty: &Arc<NativeClass>) {
     let children = std::mem::take(&mut flickable.borrow_mut().children);
     let is_listview = children
         .iter()

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -10,6 +10,7 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::expression_tree::{BuiltinFunction, Callable, Expression};
@@ -224,7 +225,7 @@ impl<'a> LocalFocusForwards<'a> {
                     elem.borrow_mut().property_declarations.insert(
                         function.name().into(),
                         PropertyDeclaration {
-                            property_type: Type::Function(Rc::new(Function {
+                            property_type: Type::Function(Arc::new(Function {
                                 return_type: Type::Void,
                                 args: Vec::new(),
                                 arg_names: Vec::new(),

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -66,7 +66,7 @@ fn apply_builtin(e: &ElementRc) {
     let bty = if let Some(bty) = e.borrow().builtin_type() { bty } else { return };
     if bty.name == "Text" {
         e.borrow_mut().set_binding_if_not_set("accessible-role".into(), || {
-            let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone());
+            let enum_ty = crate::typeregister::BUILTIN.enums.AccessibleRole.clone();
             Expression::EnumerationValue(EnumerationValue {
                 value: enum_ty.values.iter().position(|v| v == "text").unwrap(),
                 enumeration: enum_ty,
@@ -78,7 +78,7 @@ fn apply_builtin(e: &ElementRc) {
         });
     } else if bty.name == "TextInput" {
         e.borrow_mut().set_binding_if_not_set("accessible-role".into(), || {
-            let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone());
+            let enum_ty = crate::typeregister::BUILTIN.enums.AccessibleRole.clone();
             Expression::EnumerationValue(EnumerationValue {
                 value: enum_ty.values.iter().position(|v| v == "text-input").unwrap(),
                 enumeration: enum_ty,
@@ -121,7 +121,7 @@ fn apply_builtin(e: &ElementRc) {
         }
     } else if bty.name == "Image" {
         e.borrow_mut().set_binding_if_not_set("accessible-role".into(), || {
-            let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone());
+            let enum_ty = crate::typeregister::BUILTIN.enums.AccessibleRole.clone();
             Expression::EnumerationValue(EnumerationValue {
                 value: enum_ty.values.iter().position(|v| v == "image").unwrap(),
                 enumeration: enum_ty,

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -4,6 +4,7 @@
 //! This pass computes the layout constraint
 
 use lyon_path::geom::euclid::approxeq::ApproxEq;
+use std::sync::Arc;
 
 use crate::diagnostics::{BuildDiagnostics, DiagnosticLevel, Spanned};
 use crate::expression_tree::*;
@@ -26,7 +27,7 @@ pub(crate) fn synthesize_layoutinfo_v_with_constraint_on(
     span: crate::diagnostics::SourceLocation,
     body: Expression,
 ) {
-    let function_ty = Type::Function(Rc::new(crate::langtype::Function {
+    let function_ty = Type::Function(Arc::new(crate::langtype::Function {
         return_type: crate::typeregister::layout_info_type().into(),
         args: vec![Type::LogicalLength],
         arg_names: vec![SmolStr::new_static("width")],
@@ -142,7 +143,7 @@ pub(crate) fn synthesize_layoutinfo_h_with_constraint_on(
     span: crate::diagnostics::SourceLocation,
     body: Expression,
 ) {
-    let function_ty = Type::Function(Rc::new(crate::langtype::Function {
+    let function_ty = Type::Function(Arc::new(crate::langtype::Function {
         return_type: crate::typeregister::layout_info_type().into(),
         args: vec![Type::LogicalLength],
         arg_names: vec![SmolStr::new_static("height")],

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -118,7 +118,7 @@ fn lower_popup_window(
             assert!(diag.has_errors());
             return None;
         };
-        let enum_ty = crate::typeregister::BUILTIN.with(|e| e.enums.PopupClosePolicy.clone());
+        let enum_ty = crate::typeregister::BUILTIN.enums.PopupClosePolicy.clone();
         let s = if *v { "close-on-click" } else { "no-auto-close" };
         Some(EnumerationValue {
             value: enum_ty.values.iter().position(|v| v == s).unwrap(),
@@ -177,7 +177,7 @@ fn lower_popup_window(
         })
         .unwrap_or_else(|| EnumerationValue {
             value: 0,
-            enumeration: crate::typeregister::BUILTIN.with(|e| e.enums.PopupClosePolicy.clone()),
+            enumeration: crate::typeregister::BUILTIN.enums.PopupClosePolicy.clone(),
         });
 
     let popup_comp = Rc::new(Component {

--- a/internal/compiler/passes/lower_radiogroup.rs
+++ b/internal/compiler/passes/lower_radiogroup.rs
@@ -164,7 +164,9 @@ fn wire_radio_button(
     // row / col for the parent GridLayout — stack vertically (column 0,
     // increasing rows) for vertical orientation, otherwise stack horizontally.
     let orientation_vertical = crate::typeregister::BUILTIN
-        .with(|e| e.enums.Orientation.clone())
+        .enums
+        .Orientation
+        .clone()
         .try_value_from_string("vertical")
         .unwrap();
     let is_vertical = Expression::BinaryExpression {

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
 
 pub fn lower_states(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
-    let state_info_type = crate::typeregister::BUILTIN.with(|b| b.state_info_type.clone().into());
+    let state_info_type = crate::typeregister::BUILTIN.state_info_type.clone().into();
     recurse_elem(&component.root_element, &(), &mut |elem, _| {
         lower_state_in_element(elem, &state_info_type, diag)
     });

--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -138,7 +138,9 @@ fn process_tabwidget(
             );
         }
         let role = crate::typeregister::BUILTIN
-            .with(|e| e.enums.AccessibleRole.clone())
+            .enums
+            .AccessibleRole
+            .clone()
             .try_value_from_string("tab-panel")
             .unwrap();
         let old = child.borrow_mut().bindings.insert(

--- a/internal/compiler/passes/lower_tooltips.rs
+++ b/internal/compiler/passes/lower_tooltips.rs
@@ -268,7 +268,7 @@ fn lower_tooltips_in_component(
     let tooltip_area_type = type_register.lookup_builtin_element(TOOLTIP_AREA_ELEMENT).unwrap();
     let popup_window_type = type_register.lookup_builtin_element(POPUP_WINDOW_ELEMENT).unwrap();
 
-    let popup_close_policy_enum = BUILTIN.with(|e| e.enums.PopupClosePolicy.clone());
+    let popup_close_policy_enum = BUILTIN.enums.PopupClosePolicy.clone();
     let popup_close_policy_no_auto_close = EnumerationValue {
         value: popup_close_policy_enum.values.iter().position(|v| v == "no-auto-close").unwrap(),
         enumeration: popup_close_policy_enum,

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -135,7 +135,7 @@ pub(crate) fn should_materialize(
         } else if prop == "close-policy" {
             // PopupWindow::close-policy
             return Some(Type::Enumeration(
-                crate::typeregister::BUILTIN.with(|e| e.enums.PopupClosePolicy.clone()),
+                crate::typeregister::BUILTIN.enums.PopupClosePolicy.clone(),
             ));
         } else {
             let ty = base_type.lookup_property(prop).property_type.clone();

--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -3,7 +3,7 @@
 
 use smol_str::SmolStr;
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::expression_tree::Expression;
 use crate::langtype::{Struct, StructName, Type};
@@ -582,7 +582,7 @@ fn make_struct(it: impl Iterator<Item = (&'static str, Type, Expression)>) -> Ex
     }
     codeblock_with_expr(
         voids,
-        Expression::Struct { ty: Rc::new(Struct::new(fields, StructName::None)), values },
+        Expression::Struct { ty: Arc::new(Struct::new(fields, StructName::None)), values },
     )
 }
 

--- a/internal/compiler/passes/resolve_native_classes.rs
+++ b/internal/compiler/passes/resolve_native_classes.rs
@@ -6,7 +6,7 @@
 
 use smol_str::SmolStr;
 use std::collections::HashSet;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::langtype::{ElementType, NativeClass};
 use crate::object_tree::{Component, recurse_elem_including_sub_components};
@@ -52,7 +52,7 @@ pub fn resolve_native_classes(component: &Component) {
     })
 }
 
-fn lookup_property_distance(mut class: Rc<NativeClass>, name: &str) -> (usize, Rc<NativeClass>) {
+fn lookup_property_distance(mut class: Arc<NativeClass>, name: &str) -> (usize, Arc<NativeClass>) {
     let mut distance = 0;
     loop {
         if class.properties.contains_key(name)
@@ -66,9 +66,9 @@ fn lookup_property_distance(mut class: Rc<NativeClass>, name: &str) -> (usize, R
 }
 
 fn select_minimal_class_based_on_property_usage<'a>(
-    class: &Rc<NativeClass>,
+    class: &Arc<NativeClass>,
     properties_used: impl Iterator<Item = &'a SmolStr>,
-) -> Rc<NativeClass> {
+) -> Arc<NativeClass> {
     let mut minimal_class = class.clone();
     while let Some(class) = minimal_class.parent.clone() {
         minimal_class = class;
@@ -92,7 +92,7 @@ fn select_minimal_class_based_on_property_usage<'a>(
 fn test_select_minimal_class_based_on_property_usage() {
     use crate::langtype::{BuiltinPropertyInfo, Type};
     use smol_str::ToSmolStr;
-    let first = Rc::new(NativeClass::new_with_properties(
+    let first = Arc::new(NativeClass::new_with_properties(
         "first_class",
         [("first_prop".to_smolstr(), BuiltinPropertyInfo::new(Type::Int32))].iter().cloned(),
     ));
@@ -102,7 +102,7 @@ fn test_select_minimal_class_based_on_property_usage() {
         [("second_prop".to_smolstr(), BuiltinPropertyInfo::new(Type::Int32))].iter().cloned(),
     );
     second.parent = Some(first.clone());
-    let second = Rc::new(second);
+    let second = Arc::new(second);
 
     let reduce_to_first =
         select_minimal_class_based_on_property_usage(&second, ["first_prop".to_smolstr()].iter());

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -22,6 +22,7 @@ use core::num::IntErrorKind;
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::BTreeMap;
 use std::rc::Rc;
+use std::sync::Arc;
 use unicode_segmentation::UnicodeSegmentation;
 
 mod remove_noop;
@@ -1963,7 +1964,7 @@ impl Expression {
                 (name, value)
             })
             .collect();
-        let ty = Rc::new(Struct::new(
+        let ty = Arc::new(Struct::new(
             values.iter().map(|(k, v)| (k.clone(), v.ty())).collect(),
             StructName::None,
         ));
@@ -2063,7 +2064,7 @@ impl Expression {
                         }
                         // The field defaults must come from the same struct as the name
                         let source = if result.name.is_some() { &result } else { &elem };
-                        Type::Struct(Rc::new(Struct {
+                        Type::Struct(Arc::new(Struct {
                             fields,
                             field_defaults: source.field_defaults.clone(),
                             name: source.name.clone(),
@@ -2115,7 +2116,7 @@ fn common_expression_type(true_expr: &Expression, false_expr: &Expression) -> Ty
     fn merge_struct(origin: &Struct, other: &Struct) -> Type {
         let mut fields = other.fields.clone();
         fields.extend(origin.fields.iter().map(|(k, v)| (k.clone(), v.clone())));
-        Rc::new(Struct::new(fields, StructName::None)).into()
+        Arc::new(Struct::new(fields, StructName::None)).into()
     }
 
     if let Expression::Struct { ty, values } = true_expr {
@@ -2133,7 +2134,7 @@ fn common_expression_type(true_expr: &Expression, false_expr: &Expression) -> Ty
                     fields.insert(k.clone(), v.ty());
                 }
             }
-            return Type::Struct(Rc::new(Struct::new(fields, StructName::None)));
+            return Type::Struct(Arc::new(Struct::new(fields, StructName::None)));
         } else if let Type::Struct(false_ty) = false_expr.ty() {
             return merge_struct(&false_ty, ty);
         }

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -6,6 +6,7 @@
 use smol_str::{SmolStr, format_smolstr};
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};
@@ -52,7 +53,7 @@ pub fn handle_visible(
         &(),
         &mut |elem: &ElementRc, _| {
             let is_lowered_from_visible_property = elem.borrow().native_class().is_some_and(|n| {
-                Rc::ptr_eq(&n, &native_clip) && elem.borrow().id.ends_with("-visibility")
+                Arc::ptr_eq(&n, &native_clip) && elem.borrow().id.ends_with("-visibility")
             });
             if is_lowered_from_visible_property {
                 // This is the element we just created. Skip it.
@@ -98,7 +99,7 @@ pub fn handle_visible(
     );
 }
 
-fn create_visibility_element(child: &ElementRc, native_clip: &Rc<NativeClass>) -> ElementRc {
+fn create_visibility_element(child: &ElementRc, native_clip: &Arc<NativeClass>) -> ElementRc {
     let element = Element {
         id: format_smolstr!("{}-visibility", child.borrow().id),
         base_type: ElementType::Native(native_clip.clone()),

--- a/internal/compiler/tests/consistent_styles.rs
+++ b/internal/compiler/tests/consistent_styles.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(PartialEq, Debug)]
 struct PropertyInfo {
@@ -103,7 +104,7 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                     result.properties.insert(
                         "focus".into(),
                         PropertyInfo {
-                            ty: Type::Function(Rc::new(Function {
+                            ty: Type::Function(Arc::new(Function {
                                 return_type: Type::Void,
                                 args: Vec::new(),
                                 arg_names: Vec::new(),
@@ -115,7 +116,7 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
                     result.properties.insert(
                         "clear-focus".into(),
                         PropertyInfo {
-                            ty: Type::Function(Rc::new(Function {
+                            ty: Type::Function(Arc::new(Function {
                                 return_type: Type::Void,
                                 args: Vec::new(),
                                 arg_names: Vec::new(),

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -7,6 +7,7 @@ use smol_str::{SmolStr, StrExt, ToSmolStr};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::expression_tree::BuiltinFunction;
 use crate::langtype::{
@@ -60,12 +61,12 @@ macro_rules! declare_enums {
     ($( $(#[$enum_doc:meta])* $vis:vis enum $Name:ident { $( $(#[$value_doc:meta])* $Value:ident,)* })*) => {
         #[allow(non_snake_case)]
         pub struct BuiltinEnums {
-            $(pub $Name : Rc<Enumeration>),*
+            $(pub $Name : Arc<Enumeration>),*
         }
         impl BuiltinEnums {
             fn new() -> Self {
                 Self {
-                    $($Name : Rc::new(Enumeration {
+                    $($Name : Arc::new(Enumeration {
                         name: stringify!($Name).replace_smolstr("_", "-"),
                         values: vec![$(crate::generator::to_kebab_case(stringify!($Value).trim_start_matches("r#")).into()),*],
                         default_value: 0,
@@ -91,11 +92,11 @@ pub struct BuiltinTypes {
     pub enums: BuiltinEnums,
     pub noarg_callback_type: Type,
     pub strarg_callback_type: Type,
-    pub logical_point_type: Rc<Struct>,
-    pub logical_size_type: Rc<Struct>,
+    pub logical_point_type: Arc<Struct>,
+    pub logical_size_type: Arc<Struct>,
     pub font_metrics_type: Type,
-    pub layout_info_type: Rc<Struct>,
-    pub state_info_type: Rc<Struct>,
+    pub layout_info_type: Arc<Struct>,
+    pub state_info_type: Arc<Struct>,
     pub gridlayout_input_data_type: Type,
     pub path_element_type: Type,
     pub layout_item_info_type: Type,
@@ -104,7 +105,7 @@ pub struct BuiltinTypes {
 
 impl BuiltinTypes {
     fn new() -> Self {
-        let layout_info_type = Rc::new(Struct::new(
+        let layout_info_type = Arc::new(Struct::new(
             ["min", "max", "preferred"]
                 .iter()
                 .map(|s| (SmolStr::new_static(s), Type::LogicalLength))
@@ -120,7 +121,7 @@ impl BuiltinTypes {
         let flex_align_self_type = Type::Enumeration(enums.FlexboxLayoutAlignSelf.clone());
         Self {
             enums,
-            logical_point_type: Rc::new(Struct::new(
+            logical_point_type: Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     (SmolStr::new_static("x"), Type::LogicalLength),
                     (SmolStr::new_static("y"), Type::LogicalLength),
@@ -128,7 +129,7 @@ impl BuiltinTypes {
                 .collect(),
                 BuiltinStruct::LogicalPosition,
             )),
-            logical_size_type: Rc::new(Struct::new(
+            logical_size_type: Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     (SmolStr::new_static("width"), Type::LogicalLength),
                     (SmolStr::new_static("height"), Type::LogicalLength),
@@ -136,7 +137,7 @@ impl BuiltinTypes {
                 .collect(),
                 BuiltinStruct::LogicalSize,
             )),
-            font_metrics_type: Type::Struct(Rc::new(Struct::new(
+            font_metrics_type: Type::Struct(Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     (SmolStr::new_static("ascent"), Type::LogicalLength),
                     (SmolStr::new_static("descent"), Type::LogicalLength),
@@ -146,18 +147,18 @@ impl BuiltinTypes {
                 .collect(),
                 BuiltinStruct::FontMetrics,
             ))),
-            noarg_callback_type: Type::Callback(Rc::new(Function {
+            noarg_callback_type: Type::Callback(Arc::new(Function {
                 return_type: Type::Void,
                 args: Vec::new(),
                 arg_names: Vec::new(),
             })),
-            strarg_callback_type: Type::Callback(Rc::new(Function {
+            strarg_callback_type: Type::Callback(Arc::new(Function {
                 return_type: Type::Void,
                 args: vec![Type::String],
                 arg_names: Vec::new(),
             })),
             layout_info_type: layout_info_type.clone(),
-            state_info_type: Rc::new(Struct::new(
+            state_info_type: Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     (SmolStr::new_static("current-state"), Type::Int32),
                     (SmolStr::new_static("previous-state"), Type::Int32),
@@ -166,16 +167,16 @@ impl BuiltinTypes {
                 .collect(),
                 BuiltinStruct::StateInfo,
             )),
-            path_element_type: Type::Struct(Rc::new(Struct::new(
+            path_element_type: Type::Struct(Arc::new(Struct::new(
                 Default::default(),
                 BuiltinStruct::PathElement,
             ))),
-            layout_item_info_type: Type::Struct(Rc::new(Struct::new(
+            layout_item_info_type: Type::Struct(Arc::new(Struct::new(
                 IntoIterator::into_iter([("constraint".into(), layout_info_type.clone().into())])
                     .collect(),
                 BuiltinStruct::LayoutItemInfo,
             ))),
-            flexbox_layout_item_info_type: Type::Struct(Rc::new(Struct::new(
+            flexbox_layout_item_info_type: Type::Struct(Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     ("constraint".into(), layout_info_type.into()),
                     ("flex-grow".into(), Type::Float32),
@@ -187,7 +188,7 @@ impl BuiltinTypes {
                 .collect(),
                 BuiltinStruct::FlexboxLayoutItemInfo,
             ))),
-            gridlayout_input_data_type: Type::Struct(Rc::new(Struct::new(
+            gridlayout_input_data_type: Type::Struct(Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     ("row".into(), Type::Int32),
                     ("column".into(), Type::Int32),
@@ -235,7 +236,7 @@ pub const RESERVED_TRANSFORM_PROPERTIES: &[(&str, Type)] = &[
     ("transform-scale", Type::Float32),
 ];
 
-pub fn transform_origin_property() -> (&'static str, Rc<Struct>) {
+pub fn transform_origin_property() -> (&'static str, Arc<Struct>) {
     ("transform-origin", logical_point_type())
 }
 
@@ -626,7 +627,7 @@ impl TypeRegister {
                         std::iter::repeat_n(SmolStr::default(), func.args.len() - names.len())
                             .chain(names)
                             .collect();
-                    info.ty = Type::Function(Rc::new(func));
+                    info.ty = Type::Function(Arc::new(func));
                 }
                 text_input.properties.insert("set-selection-offsets".into(), info);
                 text_input.properties.insert("font-metrics".into(), font_metrics_prop.clone());
@@ -876,7 +877,7 @@ pub mod builtin_structs {
             pub struct BuiltinStructs {
                 $(
                 #[allow(non_snake_case)]
-                $Name: Rc<Struct>
+                $Name: Arc<Struct>
                 ),*
             }
             impl BuiltinStructs {
@@ -896,7 +897,7 @@ pub mod builtin_structs {
                                 );)?
                                 fields.insert(field_name, field_type);
                             )*
-                            Rc::new(Struct {
+                            Arc::new(Struct {
                                 fields,
                                 field_defaults,
                                 name: BuiltinStruct::$Name.into(),
@@ -918,7 +919,7 @@ pub mod builtin_structs {
 
             $(
             #[allow(non_snake_case)]
-            pub fn $Name() -> Rc<Struct> {
+            pub fn $Name() -> Arc<Struct> {
                 BUILTIN_STRUCTS.with(|types| types.$Name.clone())
             }
             )*
@@ -927,11 +928,11 @@ pub mod builtin_structs {
     i_slint_common::for_each_builtin_structs!(declare_builtin_structs);
 }
 
-pub fn logical_point_type() -> Rc<Struct> {
+pub fn logical_point_type() -> Arc<Struct> {
     BUILTIN.with(|types| types.logical_point_type.clone())
 }
 
-pub fn logical_size_type() -> Rc<Struct> {
+pub fn logical_size_type() -> Arc<Struct> {
     BUILTIN.with(|types| types.logical_size_type.clone())
 }
 
@@ -940,7 +941,7 @@ pub fn font_metrics_type() -> Type {
 }
 
 /// The [`Type`] for a runtime LayoutInfo structure
-pub fn layout_info_type() -> Rc<Struct> {
+pub fn layout_info_type() -> Arc<Struct> {
     BUILTIN.with(|types| types.layout_info_type.clone())
 }
 

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -49,7 +49,7 @@ pub const RESERVED_GRIDLAYOUT_PROPERTIES: &[(&str, Type)] = &[
 ];
 
 // Note: flex-align-self is also a flexbox property but is added in reserved_properties()
-// because Type::Enumeration requires a runtime Rc allocation.
+// because Type::Enumeration requires a runtime Arc allocation.
 pub const RESERVED_FLEXBOXLAYOUT_PROPERTIES: &[(&str, Type)] = &[
     ("flex-grow", Type::Float32),
     ("flex-shrink", Type::Float32),
@@ -203,9 +203,7 @@ impl BuiltinTypes {
     }
 }
 
-thread_local! {
-    pub static BUILTIN: BuiltinTypes = BuiltinTypes::new();
-}
+pub static BUILTIN: std::sync::LazyLock<BuiltinTypes> = std::sync::LazyLock::new(BuiltinTypes::new);
 
 const RESERVED_OTHER_PROPERTIES: &[(&str, Type)] = &[
     ("clip", Type::Bool),
@@ -245,11 +243,11 @@ pub const DEPRECATED_ROTATION_ORIGIN_PROPERTIES: [(&str, Type); 2] =
     [("rotation-origin-x", Type::LogicalLength), ("rotation-origin-y", Type::LogicalLength)];
 
 pub fn noarg_callback_type() -> Type {
-    BUILTIN.with(|types| types.noarg_callback_type.clone())
+    BUILTIN.noarg_callback_type.clone()
 }
 
 fn strarg_callback_type() -> Type {
-    BUILTIN.with(|types| types.strarg_callback_type.clone())
+    BUILTIN.strarg_callback_type.clone()
 }
 
 pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str, Type)> {
@@ -310,10 +308,10 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
                 .map(|(k, v)| (*k, v.clone(), PropertyVisibility::Input)),
         )
         // flex-align-self is a flexbox-layout property but can't be in the const array
-        // because Type::Enumeration requires a runtime Rc allocation.
+        // because Type::Enumeration requires a runtime Arc allocation.
         .chain(std::iter::once((
             "flex-align-self",
-            Type::Enumeration(BUILTIN.with(|e| e.enums.FlexboxLayoutAlignSelf.clone())),
+            Type::Enumeration(BUILTIN.enums.FlexboxLayoutAlignSelf.clone()),
             PropertyVisibility::Input,
         )))
         .chain(IntoIterator::into_iter([
@@ -331,22 +329,22 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
             ),
             (
                 "dialog-button-role",
-                Type::Enumeration(BUILTIN.with(|e| e.enums.DialogButtonRole.clone())),
+                Type::Enumeration(BUILTIN.enums.DialogButtonRole.clone()),
                 PropertyVisibility::Constexpr,
             ),
             (
                 "accessible-role",
-                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleRole.clone())),
+                Type::Enumeration(BUILTIN.enums.AccessibleRole.clone()),
                 PropertyVisibility::Constexpr,
             ),
             (
                 "accessible-orientation",
-                Type::Enumeration(BUILTIN.with(|e| e.enums.Orientation.clone())),
+                Type::Enumeration(BUILTIN.enums.Orientation.clone()),
                 PropertyVisibility::Input,
             ),
             (
                 "accessible-live-region",
-                Type::Enumeration(BUILTIN.with(|e| e.enums.AccessibleLiveness.clone())),
+                Type::Enumeration(BUILTIN.enums.AccessibleLiveness.clone()),
                 PropertyVisibility::Input,
             ),
         ]))
@@ -355,12 +353,15 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
 
 /// lookup reserved property injected in every item
 pub fn reserved_property(name: std::borrow::Cow<'_, str>) -> PropertyLookupResult<'_> {
-    thread_local! {
-        static RESERVED_PROPERTIES: HashMap<&'static str, (Type, PropertyVisibility, Option<BuiltinFunction>)>
-            = reserved_properties().map(|(name, ty, visibility)| (name, (ty, visibility, reserved_member_function(name)))).collect();
-    }
+    static RESERVED_PROPERTIES: std::sync::LazyLock<
+        HashMap<&'static str, (Type, PropertyVisibility, Option<BuiltinFunction>)>,
+    > = std::sync::LazyLock::new(|| {
+        reserved_properties()
+            .map(|(name, ty, visibility)| (name, (ty, visibility, reserved_member_function(name))))
+            .collect()
+    });
     if let Some((ty, visibility, builtin_function)) =
-        RESERVED_PROPERTIES.with(|reserved| reserved.get(name.as_ref()).cloned())
+        RESERVED_PROPERTIES.get(name.as_ref()).cloned()
     {
         return PropertyLookupResult {
             property_type: ty,
@@ -496,7 +497,7 @@ impl TypeRegister {
         register.types.insert("Point".into(), logical_point_type().into());
         register.types.insert("Size".into(), logical_size_type().into());
 
-        BUILTIN.with(|e| e.enums.fill_register(&mut register));
+        BUILTIN.enums.fill_register(&mut register);
 
         register.supported_property_animation_types.insert(Type::Float32.to_string());
         register.supported_property_animation_types.insert(Type::Int32.to_string());
@@ -827,9 +828,8 @@ pub mod builtin_structs {
     use super::*;
     use crate::langtype::ConstantExpression;
 
-    thread_local! {
-        pub static BUILTIN_STRUCTS: BuiltinStructs = BuiltinStructs::new();
-    }
+    pub static BUILTIN_STRUCTS: std::sync::LazyLock<BuiltinStructs> =
+        std::sync::LazyLock::new(BuiltinStructs::new);
 
     #[rustfmt::skip]
     macro_rules! map_type {
@@ -850,7 +850,7 @@ pub mod builtin_structs {
         };
         // builtin enums
         ($pub_type:ident, $_:ident) => {
-            BUILTIN.with(|e| Type::Enumeration(e.enums.$pub_type.clone()))
+            Type::Enumeration(BUILTIN.enums.$pub_type.clone())
         };
     }
 
@@ -859,11 +859,11 @@ pub mod builtin_structs {
         (false) => { ConstantExpression::BoolLiteral(false) };
         ($lit:literal) => { ConstantExpression::NumberLiteral($lit as _, Unit::None) };
         ($enum:ident :: $value:ident) => {
-            ConstantExpression::EnumerationValue(BUILTIN.with(|e| {
+            ConstantExpression::EnumerationValue({
                 let variant = crate::generator::to_kebab_case(stringify!($value));
-                e.enums.$enum.clone().try_value_from_string(&variant)
+                BUILTIN.enums.$enum.clone().try_value_from_string(&variant)
                     .expect(concat!("unknown enum variant in field default ", stringify!($enum), "::", stringify!($value)))
-            }))
+            })
         };
         (($($tt:tt)*)) => { parse_default_field!($($tt)*) };
     }
@@ -921,7 +921,7 @@ pub mod builtin_structs {
             $(
             #[allow(non_snake_case)]
             pub fn $Name() -> Arc<Struct> {
-                BUILTIN_STRUCTS.with(|types| types.$Name.clone())
+                BUILTIN_STRUCTS.$Name.clone()
             }
             )*
         };
@@ -930,33 +930,33 @@ pub mod builtin_structs {
 }
 
 pub fn logical_point_type() -> Arc<Struct> {
-    BUILTIN.with(|types| types.logical_point_type.clone())
+    BUILTIN.logical_point_type.clone()
 }
 
 pub fn logical_size_type() -> Arc<Struct> {
-    BUILTIN.with(|types| types.logical_size_type.clone())
+    BUILTIN.logical_size_type.clone()
 }
 
 pub fn font_metrics_type() -> Type {
-    BUILTIN.with(|types| types.font_metrics_type.clone())
+    BUILTIN.font_metrics_type.clone()
 }
 
 /// The [`Type`] for a runtime LayoutInfo structure
 pub fn layout_info_type() -> Arc<Struct> {
-    BUILTIN.with(|types| types.layout_info_type.clone())
+    BUILTIN.layout_info_type.clone()
 }
 
 /// The [`Type`] for a runtime PathElement structure
 pub fn path_element_type() -> Type {
-    BUILTIN.with(|types| types.path_element_type.clone())
+    BUILTIN.path_element_type.clone()
 }
 
 /// The [`Type`] for a runtime LayoutItemInfo structure
 pub fn layout_item_info_type() -> Type {
-    BUILTIN.with(|types| types.layout_item_info_type.clone())
+    BUILTIN.layout_item_info_type.clone()
 }
 
 /// The [`Type`] for a runtime FlexboxLayoutItemInfo structure
 pub fn flexbox_layout_item_info_type() -> Type {
-    BUILTIN.with(|types| types.flexbox_layout_item_info_type.clone())
+    BUILTIN.flexbox_layout_item_info_type.clone()
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -71,6 +71,7 @@ macro_rules! declare_enums {
                         values: vec![$(crate::generator::to_kebab_case(stringify!($Value).trim_start_matches("r#")).into()),*],
                         default_value: 0,
                         node: None,
+                        rust_attributes: Vec::new(),
                     })),*
                 }
             }

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+#[cfg(test)]
+use std::sync::Arc;
 
 #[doc(inline)]
 pub use i_slint_compiler::diagnostics::{Diagnostic, DiagnosticLevel};
@@ -2256,10 +2258,10 @@ fn lang_type_to_value_type() {
     assert_eq!(ValueType::from(LangType::String), ValueType::String);
     assert_eq!(ValueType::from(LangType::Color), ValueType::Brush);
     assert_eq!(ValueType::from(LangType::Brush), ValueType::Brush);
-    assert_eq!(ValueType::from(LangType::Array(Rc::new(LangType::Void))), ValueType::Model);
+    assert_eq!(ValueType::from(LangType::Array(Arc::new(LangType::Void))), ValueType::Model);
     assert_eq!(ValueType::from(LangType::Bool), ValueType::Bool);
     assert_eq!(
-        ValueType::from(LangType::Struct(Rc::new(LangStruct::new(
+        ValueType::from(LangType::Struct(Arc::new(LangStruct::new(
             BTreeMap::default(),
             i_slint_compiler::langtype::StructName::None
         )))),

--- a/tools/lsp/common.rs
+++ b/tools/lsp/common.rs
@@ -389,7 +389,7 @@ impl ElementRcNode {
             return false;
         };
 
-        std::rc::Rc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range()
+        std::sync::Arc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range()
     }
 
     pub fn contains_offset(&self, offset: TextSize) -> bool {

--- a/tools/lsp/common/host_language_search.rs
+++ b/tools/lsp/common/host_language_search.rs
@@ -18,7 +18,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use i_slint_compiler::diagnostics::{ByteFormat, SourceFile, SourceFileInner};
 use i_slint_compiler::generator::accessor_names::{self, DeclarationKind};
@@ -152,7 +152,7 @@ pub fn search_replace_host_language_accessors(
         };
         // Synthesize a SourceFile for line/column conversion. Host-language
         // files are not in the LSP document cache, so they have no version.
-        let source_file: SourceFile = Rc::new(SourceFileInner::new(path.clone(), contents));
+        let source_file: SourceFile = Arc::new(SourceFileInner::new(path.clone(), contents));
         for (range, new_text) in file_edits {
             let lsp_range = byte_range_to_lsp_range(&source_file, range, format);
             edits.push(SingleTextEdit {

--- a/tools/lsp/common/rename_component.rs
+++ b/tools/lsp/common/rename_component.rs
@@ -57,6 +57,7 @@
 
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::{common, util};
 
@@ -678,7 +679,7 @@ fn matching_decl_in_inheritance_chain(
         if let Some(decl) = element_borrow.property_declarations.get(name)
             && let Some(node) = decl.node.as_ref()
             && node.text_range() == declaration_node.text_range()
-            && Rc::ptr_eq(&node.source_file, source_file)
+            && Arc::ptr_eq(&node.source_file, source_file)
         {
             if decl.visibility == object_tree::PropertyVisibility::Private {
                 return false;
@@ -754,7 +755,7 @@ impl TokenInformation {
             node: &SyntaxNode,
         ) -> bool {
             if element.borrow().debug.iter().any(|di| {
-                Rc::ptr_eq(&di.node.source_file, &node.source_file)
+                Arc::ptr_eq(&di.node.source_file, &node.source_file)
                     && di.node.text_range() == node.text_range()
             }) {
                 return true;
@@ -783,7 +784,7 @@ impl TokenInformation {
             (
                 common::token_info::TokenInfo::LocalProperty(s),
                 common::token_info::TokenInfo::LocalProperty(o),
-            ) => Rc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range(),
+            ) => Arc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range(),
             (
                 common::token_info::TokenInfo::NamedReference(nl),
                 common::token_info::TokenInfo::NamedReference(nr),
@@ -837,7 +838,7 @@ impl TokenInformation {
             (
                 common::token_info::TokenInfo::LocalCallback(s),
                 common::token_info::TokenInfo::LocalCallback(o),
-            ) => Rc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range(),
+            ) => Arc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range(),
             (
                 common::token_info::TokenInfo::NamedReference(nr),
                 common::token_info::TokenInfo::LocalCallback(s),
@@ -866,7 +867,7 @@ impl TokenInformation {
             (
                 common::token_info::TokenInfo::LocalFunction(s),
                 common::token_info::TokenInfo::LocalFunction(o),
-            ) => Rc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range(),
+            ) => Arc::ptr_eq(&s.source_file, &o.source_file) && s.text_range() == o.text_range(),
             (
                 common::token_info::TokenInfo::NamedReference(nr),
                 common::token_info::TokenInfo::LocalFunction(s),

--- a/tools/lsp/common/text_edit.rs
+++ b/tools/lsp/common/text_edit.rs
@@ -939,7 +939,7 @@ fn test_texteditor_no_content_in_source_file() {
 fn test_texteditor_edit_out_of_range() {
     use i_slint_compiler::diagnostics::SourceFileInner;
 
-    let source_file = std::rc::Rc::new(SourceFileInner::new(
+    let source_file = std::sync::Arc::new(SourceFileInner::new(
         std::path::PathBuf::from("/tmp/foo.slint"),
         r#""#.to_string(),
     ));
@@ -960,7 +960,7 @@ fn test_texteditor_edit_out_of_range() {
 fn test_texteditor_delete_everything() {
     use i_slint_compiler::diagnostics::SourceFileInner;
 
-    let source_file = std::rc::Rc::new(SourceFileInner::new(
+    let source_file = std::sync::Arc::new(SourceFileInner::new(
         std::path::PathBuf::from("/tmp/foo.slint"),
         r#"abc
 def
@@ -990,7 +990,7 @@ geh"#
 fn test_texteditor_replace() {
     use i_slint_compiler::diagnostics::SourceFileInner;
 
-    let source_file = std::rc::Rc::new(SourceFileInner::new(
+    let source_file = std::sync::Arc::new(SourceFileInner::new(
         std::path::PathBuf::from("/tmp/foo.slint"),
         r#"abc
 def
@@ -1025,7 +1025,7 @@ geh"#
 fn test_texteditor_2step_replace_all() {
     use i_slint_compiler::diagnostics::SourceFileInner;
 
-    let source_file = std::rc::Rc::new(SourceFileInner::new(
+    let source_file = std::sync::Arc::new(SourceFileInner::new(
         std::path::PathBuf::from("/tmp/foo.slint"),
         r#"abc
 def

--- a/tools/lsp/common/token_info.rs
+++ b/tools/lsp/common/token_info.rs
@@ -30,13 +30,27 @@ pub enum TokenInfo {
     IncompleteNamedReference(ElementType, SmolStr),
 }
 
+/// Resolve a struct/enum declaration reference to its syntax node using the
+/// documents the language server already keeps loaded, so the compiled type does
+/// not need to carry a syntax tree.
+pub(crate) fn node_for_decl(
+    document_cache: &common::DocumentCache,
+    decl: &i_slint_compiler::langtype::DeclNode,
+) -> Option<SyntaxNode> {
+    let doc = document_cache.get_document_for_source_file(decl.source_file())?;
+    let node = doc.node.as_ref()?.covering_element(decl.text_range()).into_node()?;
+    Some(SyntaxNode { node, source_file: decl.source_file().clone() })
+}
+
 impl TokenInfo {
     /// Returns the node to the declaration of what the token represents, if it exists
-    pub fn declaration(&self) -> Option<SyntaxNode> {
+    pub fn declaration(&self, document_cache: &common::DocumentCache) -> Option<SyntaxNode> {
         match self {
             TokenInfo::Type(ty) => match ty {
-                Type::Struct(s) if s.node().is_some() => s.node().unwrap().parent().clone(),
-                Type::Enumeration(e) => e.node.as_deref().cloned(),
+                Type::Struct(s) => s.node().and_then(|n| node_for_decl(document_cache, n)),
+                Type::Enumeration(e) => {
+                    e.node.as_ref().and_then(|n| node_for_decl(document_cache, n))
+                }
                 _ => None,
             },
 
@@ -64,7 +78,9 @@ impl TokenInfo {
             }
 
             TokenInfo::EnumerationValue(v) => {
-                let enum_node = v.enumeration.node.as_ref()?;
+                let enum_node = i_slint_compiler::parser::syntax_nodes::EnumDeclaration::from(
+                    node_for_decl(document_cache, v.enumeration.node.as_ref()?)?,
+                );
                 enum_node.EnumValue().nth(v.value).map(|x| x.clone().into())
             }
 
@@ -304,7 +320,6 @@ pub fn token_info(document_cache: &common::DocumentCache, token: SyntaxToken) ->
                 match &ty {
                     Type::Struct(s)
                         if s.node()
-                            .and_then(|n| n.parent())
                             .map(|n| n.text_range().contains_range(token.text_range()))
                             .unwrap_or_default() =>
                     {

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1719,30 +1719,42 @@ fn get_document_symbols(
         })
         .collect::<Vec<_>>();
 
-    r.extend(inner_types.iter().filter_map(|c| match c {
-        Type::Struct(s) => s.node().and_then(|node| {
-            Some(DocumentSymbol {
-                range: util::node_to_lsp_range(node.parent().as_ref()?, document_cache.format),
-                selection_range: util::node_to_lsp_range(
-                    &node.parent()?.child_node(SyntaxKind::DeclaredIdentifier)?,
-                    document_cache.format,
-                ),
-                name: s.name.slint_name().unwrap().to_string(),
-                kind: lsp_types::SymbolKind::STRUCT,
-                ..ds.clone()
-            })
-        }),
-        Type::Enumeration(enumeration) => enumeration.node.as_ref().map(|node| DocumentSymbol {
-            range: util::node_to_lsp_range(node, document_cache.format),
-            selection_range: util::node_to_lsp_range(
-                &node.DeclaredIdentifier(),
-                document_cache.format,
-            ),
-            name: enumeration.name.to_string(),
-            kind: lsp_types::SymbolKind::ENUM,
-            ..ds.clone()
-        }),
-        _ => None,
+    r.extend(inner_types.iter().filter_map(|c| {
+        match c {
+            Type::Struct(s) => s
+                .node()
+                .and_then(|n| crate::common::token_info::node_for_decl(document_cache, n))
+                .and_then(|node| {
+                    Some(DocumentSymbol {
+                        range: util::node_to_lsp_range(&node, document_cache.format),
+                        selection_range: util::node_to_lsp_range(
+                            &node.child_node(SyntaxKind::DeclaredIdentifier)?,
+                            document_cache.format,
+                        ),
+                        name: s.name.slint_name().unwrap().to_string(),
+                        kind: lsp_types::SymbolKind::STRUCT,
+                        ..ds.clone()
+                    })
+                }),
+            Type::Enumeration(enumeration) => enumeration
+                .node
+                .as_ref()
+                .and_then(|n| crate::common::token_info::node_for_decl(document_cache, n))
+                .map(|node| {
+                    let node = i_slint_compiler::parser::syntax_nodes::EnumDeclaration::from(node);
+                    DocumentSymbol {
+                        range: util::node_to_lsp_range(&node, document_cache.format),
+                        selection_range: util::node_to_lsp_range(
+                            &node.DeclaredIdentifier(),
+                            document_cache.format,
+                        ),
+                        name: enumeration.name.to_string(),
+                        kind: lsp_types::SymbolKind::ENUM,
+                        ..ds.clone()
+                    }
+                }),
+            _ => None,
+        }
     }));
 
     fn gen_children(

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -17,7 +17,7 @@ pub fn goto_definition(
     token: SyntaxToken,
 ) -> Option<GotoDefinitionResponse> {
     let token_info = token_info(document_cache, token.clone())?;
-    if let Some(node) = token_info.declaration() {
+    if let Some(node) = token_info.declaration(document_cache) {
         return goto_node(&node, document_cache.format);
     }
     match token_info {

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -18,7 +18,8 @@ pub fn get_tooltip(
     token: SyntaxToken,
 ) -> Option<Hover> {
     let token_info = token_info(document_cache, token.clone())?;
-    let documentation = token_info.declaration().and_then(|x| extract_documentation(&x));
+    let documentation =
+        token_info.declaration(document_cache).and_then(|x| extract_documentation(&x));
     let documentation = documentation.as_deref();
     let contents = match token_info {
         TokenInfo::Type(ty) => match ty {

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -569,7 +569,7 @@ pub(super) fn get_properties(
             name: "accessible-role".into(),
             priority: DEFAULT_PRIORITY - 100,
             ty: Type::Enumeration(
-                i_slint_compiler::typeregister::BUILTIN.with(|e| e.enums.AccessibleRole.clone()),
+                i_slint_compiler::typeregister::BUILTIN.enums.AccessibleRole.clone(),
             ),
             visibility: PropertyVisibility::InOut,
             declared_at: None,


### PR DESCRIPTION
As a first step to get the LLR Send.


The most annoying part is the "make struct/enum declaration nodes Send" commit, because the Struct and Enum contains a SyntaxNode.