### PR TITLE
Match element diagnostics improvements

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/match-elements.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/match-elements.mdx
@@ -3,7 +3,7 @@ title: Match Elements
 description: Experimental match elements for conditional element rendering.
 ---
 
-A `match` element conditionally renders elements from a set of cases based on the value of an expression.
+A `match` element conditionally renders elements from a set of cases based on the value of an expression (the subject).
 It is a more readable alternative to a chain of `if` elements when you need to select between several mutually exclusive states.
 
 > **Note**: `match` is experimental and subject to change.
@@ -12,33 +12,39 @@ It is a more readable alternative to a chain of `if` elements when you need to s
 ## Syntax
 
 ```slint no-test
-match <match-value> {
+match <match-subject> {
     <case-value>: ElementType { /* ... */ }
     <case-value>: ElementType { /* ... */ }
-    *: ElementType { /* ... */ }   // optional wildcard
+    *: ElementType { /* ... */ }   // optional wildcard, always last
 }
 ```
 
-Each `<case-value>` is a literal that is compared against the `<match_value>`. If a wildcard case `*` is present, it renders when none of the explicit cases match.
+Each `<case-value>` is a literal that is compared against the `<match-subject>`.
+When the subject equals a case value, that case's element is rendered.
+If a wildcard case `*` is present, it renders when none of the explicit cases match.
 
 ## Examples
 
 ### Matching on an integer
+
+Every value an `int` can take cannot be listed, so a wildcard `*` case is required.
 
 ```slint no-test
 export component StatusIndicator {
     in property <int> status: 0;
 
     match status {
+       -1: Rectangle { background: red; }
         0: Rectangle { background: green; }
         1: Rectangle { background: yellow; }
-        2: Rectangle { background: red; }
         *: Rectangle { background: gray; }
     }
 }
 ```
 
 ### Matching on a boolean
+
+`true` and `false` cover every value a `bool` can take, so no wildcard is needed.
 
 ```slint no-test
 export component Toggle {
@@ -53,16 +59,19 @@ export component Toggle {
 
 ### Matching on an enum
 
+When the subject's type is a known enum, case values may use the enum variant name directly, without qualifying it with the enum name.
+Listing every variant covers the enum exhaustively, so no wildcard is needed.
+
 ```slint no-test
 enum Mode { View, Edit, Preview }
 
 export component Editor {
-    in-out property <Mode> mode: Mode.View;
+    in-out property <Mode> mode: View;
 
     match mode {
-        Mode.View:    Text { text: "Viewing"; }
-        Mode.Edit:    TextInput { }
-        Mode.Preview: Rectangle { background: black; }
+        View:    Text { text: "Viewing"; }
+        Edit:    TextInput { }
+        Preview: Rectangle { background: black; }
     }
 }
 ```
@@ -84,8 +93,8 @@ export component Greeting {
 
 ## Wildcard case
 
-The `*` case acts as a catch-all that renders when no explicit case matches the expression.
-It must appear as the last case, and there must be at least one explicit case before it.
+The `*` case acts as a catch-all that renders when no explicit case matches the subject.
+It must appear as the last case, so any case written after it can never be reached and is an error.
 
 ```slint no-test
 match answer {
@@ -94,9 +103,28 @@ match answer {
 }
 ```
 
+## Exhaustiveness
+
+A `match` must handle every value its subject can take.
+
+- For `bool` and enum subjects, either list all values explicitly or provide a `*` case. A missing value is an error (for example, `Non-exhaustive match on bool: missing 'false'`).
+- For all other types (`int`, `string`, `color`, `length`, …) the set of values is unbounded, so a `*` case is required.
+
+## Duplicate cases
+
+Each case value must be distinct. A value that is already covered by an earlier case is an error, including values that are equal after conversion (for example `2` and `2.0`, or `1s` and `1000ms`).
+
+```slint no-test
+match count {
+    0: Rectangle { }
+    0: Rectangle { }   // error: Duplicate case value
+    *: Rectangle { }
+}
+```
+
 ## Empty element
 
-Any case that evaluates to the empty element `{ }` will be skipped and not rendered. Any case can evaluate to the empty element, including the wildcard case.
+Any case that evaluates to the empty element `{ }` renders nothing. Any case can be empty, including the wildcard case.
 
 ```slint no-test
 match show {
@@ -113,11 +141,13 @@ match toggle {
 }
 ```
 
-## Current limitations
+## Restrictions
 
 The match element feature is in its early stages. The following restrictions apply:
 
-- Cases must be literal values. Computed expressions, property references, destructured values, and function calls are not allowed as case values. Only plain literals (integers, floats, booleans, strings, enum variants, colors, lengths) are accepted.
+- A `match` must contain at least one case.
+
+- Cases must be literal values. Computed expressions, property references, and function calls are not allowed as case values. Only plain literals (integers, floats, booleans, strings, enum variants, colors, lengths), optionally negated, are accepted.
 
   ```slint no-test
   // Property reference as a case value
@@ -129,19 +159,10 @@ The match element feature is in its early stages. The following restrictions app
   match greeting {
       "hello " + "world": Text { }   // error
   }
-
-  // Function call as a case value
-  match count {
-      func(5): Rectangle { }   // error
-  }
   ```
 
-- Float comparisons produce a warning. Comparing floating-point values for exact equality is not reliable. The compiler emits a warning for each float case value.
+- Float comparisons produce a warning. Comparing floating-point values for exact equality is not reliable, so the compiler emits a warning for each fractional float case value.
 
-- `@children` cannot appear inside a match case. Placing the `@children` placeholder inside any case element is an error.
+- `@children` cannot appear inside a match case.
 
 - `match` cannot appear in global components or interfaces. Only regular components support match elements.
-
-- No exhaustiveness checking. Match elements do not verify that all possible values are covered. A missing case simply renders nothing.
-
-- No duplicate case detection. No warning will be produced if the same value appears in two different cases, and both components will render.

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -279,7 +279,7 @@ module.exports = grammar({
         $.function_definition,
         $.if_statement,
         $.implement_statement,
-        $.match_statement,
+        $.match_element,
         $.property,
         $.property_assignment,
         $.slot_declaration,
@@ -398,7 +398,7 @@ module.exports = grammar({
 
     for_range: ($) => choice($.value_list, $.expression),
 
-    match_statement: ($) =>
+    match_element: ($) =>
       seq("match",
         field("value", $.expression),
         "{",

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -400,7 +400,7 @@ module.exports = grammar({
 
     match_statement: ($) =>
       seq("match",
-        field("value", $.simple_identifier),
+        field("value", $.expression),
         "{",
         repeat($.match_case),
         optional($.wildcard_match_case),
@@ -410,13 +410,14 @@ module.exports = grammar({
     match_case: ($) =>
       seq(
         field("case", choice($._basic_value,
+          $.user_type_identifier,
           seq($.user_type_identifier, ".", $.user_type_identifier))),
         ":",
         choice($.component, seq("{", "}"))
       ),
 
     wildcard_match_case: ($) =>
-      seq("*", ":", $.component),
+      seq("*", ":", choice($.component, seq("{", "}"))),
 
     type_list: ($) => seq("[", commaSep($.type), optional(","), "]"),
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1329,15 +1329,34 @@ pub struct MatchElementInfo {
     /// The value that is matched on
     pub subject: Expression,
     /// Each case and the corresponding element
-    pub cases: Vec<(Expression, ElementRc)>,
-    /// The element shown by the `*` case
-    pub wildcard: Option<ElementRc>,
+    pub cases: Vec<MatchCaseInfo>,
+    /// The `*` case of the match element, if any
+    pub wildcard: WildcardMatchCaseInfo,
+}
+
+pub enum WildcardMatchCaseInfo {
+    None,
+    Empty,
+    Element(ElementRc),
+}
+
+/// One case of a match element
+pub struct MatchCaseInfo {
+    /// The value the subject is compared against
+    pub value: Expression,
+    /// The syntax node
+    pub node: syntax_nodes::Expression,
+    /// The element to potentially show. None for the empty case
+    pub element: Option<ElementRc>,
 }
 
 impl MatchElementInfo {
-    /// The elements of all the cases
+    /// The elements of all the cases, skipping the empty cases
     pub fn elements(&self) -> impl Iterator<Item = ElementRc> + '_ {
-        self.cases.iter().map(|(_, element)| element.clone()).chain(self.wildcard.clone())
+        self.cases.iter().filter_map(|case| case.element.clone()).chain(match &self.wildcard {
+            WildcardMatchCaseInfo::Element(e) => Some(e.clone()),
+            WildcardMatchCaseInfo::None | WildcardMatchCaseInfo::Empty => None,
+        })
     }
 
     /// Make every case a conditional element
@@ -1357,12 +1376,14 @@ impl MatchElementInfo {
             });
         };
 
-        for (value, element) in &self.cases {
-            show_when(element, compare(value, '='));
+        for case in &self.cases {
+            if let Some(element) = &case.element {
+                show_when(element, compare(&case.value, '='));
+            }
         }
-        if let Some(wildcard) = &self.wildcard {
+        if let WildcardMatchCaseInfo::Element(wildcard) = &self.wildcard {
             let condition =
-                self.cases.iter().map(|(value, _)| compare(value, '!')).reduce(|lhs, rhs| {
+                self.cases.iter().map(|case| compare(&case.value, '!')).reduce(|lhs, rhs| {
                     Expression::BinaryExpression { lhs: Box::new(lhs), rhs: Box::new(rhs), op: '&' }
                 });
             if let Some(condition) = condition {
@@ -2802,15 +2823,25 @@ impl Element {
                 tr,
             )
         };
+        // A case without a sub element is an empty case that shows nothing
         let cases = node
             .MatchCase()
-            .filter_map(|case| {
-                let sub_element = case.SubElement()?;
-                let value = Expression::Uncompiled(case.Expression().into());
-                Some((value, element_of(sub_element)))
+            .map(|case| {
+                let node = case.Expression();
+                MatchCaseInfo {
+                    value: Expression::Uncompiled(node.clone().into()),
+                    node,
+                    element: case.SubElement().map(&mut element_of),
+                }
             })
             .collect();
-        let wildcard = node.WildcardMatchCase().and_then(|w| w.SubElement()).map(element_of);
+        let wildcard = match node.WildcardMatchCase() {
+            None => WildcardMatchCaseInfo::None,
+            Some(w) => match w.SubElement().map(&mut element_of) {
+                None => WildcardMatchCaseInfo::Empty,
+                Some(element) => WildcardMatchCaseInfo::Element(element),
+            },
+        };
         MatchElementInfo {
             subject: Expression::Uncompiled(node.Expression().into()),
             cases,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1061,7 +1061,7 @@ pub struct Element {
 
     pub states: Vec<State>,
     pub transitions: Vec<Transition>,
-
+    pub match_elements: Vec<MatchElementInfo>,
     /// true when this item's geometry is handled by a layout
     pub child_of_layout: bool,
     /// true when this item is a direct cell of a `FlexboxLayout`. Narrower
@@ -1322,6 +1322,54 @@ pub struct RepeatedElementInfo {
     pub is_conditional_element: bool,
     /// When the for is the delegate of a ListView
     pub is_listview: Option<ListViewInfo>,
+}
+
+/// Struct for a match element that later is resolved into standard conditional elements
+pub struct MatchElementInfo {
+    /// The value that is matched on
+    pub subject: Expression,
+    /// Each case and the corresponding element
+    pub cases: Vec<(Expression, ElementRc)>,
+    /// The element shown by the `*` case
+    pub wildcard: Option<ElementRc>,
+}
+
+impl MatchElementInfo {
+    /// The elements of all the cases
+    pub fn elements(&self) -> impl Iterator<Item = ElementRc> + '_ {
+        self.cases.iter().map(|(_, element)| element.clone()).chain(self.wildcard.clone())
+    }
+
+    /// Make every case a conditional element
+    pub fn lower_to_conditional_elements(&self) {
+        let compare = |value: &Expression, op| Expression::BinaryExpression {
+            lhs: Box::new(self.subject.clone()),
+            rhs: Box::new(value.clone()),
+            op,
+        };
+        let show_when = |element: &ElementRc, condition| {
+            element.borrow_mut().repeated = Some(RepeatedElementInfo {
+                model: condition,
+                model_data_id: SmolStr::default(),
+                index_id: SmolStr::default(),
+                is_conditional_element: true,
+                is_listview: None,
+            });
+        };
+
+        for (value, element) in &self.cases {
+            show_when(element, compare(value, '='));
+        }
+        if let Some(wildcard) = &self.wildcard {
+            let condition =
+                self.cases.iter().map(|(value, _)| compare(value, '!')).reduce(|lhs, rhs| {
+                    Expression::BinaryExpression { lhs: Box::new(lhs), rhs: Box::new(rhs), op: '&' }
+                });
+            if let Some(condition) = condition {
+                show_when(wildcard, condition);
+            }
+        }
+    }
 }
 
 pub type ElementRc = Rc<RefCell<Element>>;
@@ -2308,7 +2356,7 @@ impl Element {
                 r.borrow_mut().children.push(rep);
             } else if se.kind() == SyntaxKind::MatchElement {
                 let mut sub_child_insertion_points = BTreeMap::new();
-                let rep = Element::from_match_node(
+                let match_element = Element::from_match_node(
                     se.into(),
                     r.borrow().base_type.clone(),
                     &mut sub_child_insertion_points,
@@ -2323,7 +2371,9 @@ impl Element {
                     sub_child_insertion_points,
                     "a match element",
                 );
-                r.borrow_mut().children.extend(rep);
+                let mut r = r.borrow_mut();
+                r.children.extend(match_element.elements());
+                r.match_elements.push(match_element);
             } else if se.kind() == SyntaxKind::ChildrenPlaceholder {
                 #[cfg(feature = "slint-sc")]
                 diag.slint_sc_error("The @children placeholder is", &se);
@@ -2734,31 +2784,15 @@ impl Element {
         is_in_legacy_component: bool,
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
-    ) -> Vec<ElementRc> {
+    ) -> MatchElementInfo {
         if !diag.enable_experimental {
             diag.push_error("match elements are an experimental feature".into(), &node);
         }
         if node.MatchCase().next().is_none() && node.WildcardMatchCase().is_none() {
             diag.push_error("Expected at least one case".into(), &node);
         }
-        let mut cases: Vec<ElementRc> = Vec::new();
-        let expr = node.Expression();
-        for case in node.MatchCase() {
-            let Some(sub_element) = case.SubElement() else {
-                continue;
-            };
-            let rei = RepeatedElementInfo {
-                model: Expression::BinaryExpression {
-                    lhs: (Box::new(Expression::Uncompiled(expr.clone().into()))),
-                    rhs: Box::new(Expression::Uncompiled(case.Expression().into())),
-                    op: '=',
-                },
-                model_data_id: SmolStr::default(),
-                index_id: SmolStr::default(),
-                is_conditional_element: true,
-                is_listview: None,
-            };
-            let e: Rc<RefCell<Element>> = Element::from_sub_element_node(
+        let mut element_of = |sub_element| {
+            Element::from_sub_element_node(
                 sub_element,
                 parent_type.clone(),
                 component_child_insertion_points,
@@ -2766,50 +2800,22 @@ impl Element {
                 is_in_legacy_component,
                 diag,
                 tr,
-            );
-            e.borrow_mut().repeated = Some(rei);
-            cases.push(e);
+            )
+        };
+        let cases = node
+            .MatchCase()
+            .filter_map(|case| {
+                let sub_element = case.SubElement()?;
+                let value = Expression::Uncompiled(case.Expression().into());
+                Some((value, element_of(sub_element)))
+            })
+            .collect();
+        let wildcard = node.WildcardMatchCase().and_then(|w| w.SubElement()).map(element_of);
+        MatchElementInfo {
+            subject: Expression::Uncompiled(node.Expression().into()),
+            cases,
+            wildcard,
         }
-        if let Some(wildcard) = node.WildcardMatchCase()
-            && let Some(sub_element) = wildcard.SubElement()
-        {
-            let case_exprs: Vec<_> = node.MatchCase().collect();
-            let mut condition = Expression::BinaryExpression {
-                lhs: Box::new(Expression::Uncompiled(expr.clone().into())),
-                rhs: Box::new(Expression::Uncompiled(case_exprs[0].Expression().into())),
-                op: '!',
-            };
-            for case in &case_exprs[1..] {
-                condition = Expression::BinaryExpression {
-                    lhs: Box::new(condition),
-                    rhs: Box::new(Expression::BinaryExpression {
-                        lhs: Box::new(Expression::Uncompiled(expr.clone().into())),
-                        rhs: Box::new(Expression::Uncompiled(case.Expression().into())),
-                        op: '!',
-                    }),
-                    op: '&',
-                };
-            }
-            let rei = RepeatedElementInfo {
-                model: condition,
-                model_data_id: SmolStr::default(),
-                index_id: SmolStr::default(),
-                is_conditional_element: true,
-                is_listview: None,
-            };
-            let e = Element::from_sub_element_node(
-                sub_element,
-                parent_type.clone(),
-                component_child_insertion_points,
-                declared_slots,
-                is_in_legacy_component,
-                diag,
-                tr,
-            );
-            e.borrow_mut().repeated = Some(rei);
-            cases.push(e);
-        }
-        cases
     }
 
     /// Return the type of a property in this element or its base, along with the final name, in case

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1326,6 +1326,8 @@ pub struct RepeatedElementInfo {
 
 /// Struct for a match element that later is resolved into standard conditional elements
 pub struct MatchElementInfo {
+    /// The match element node, used for diagnostics related to the match element as a whole
+    pub node: syntax_nodes::MatchElement,
     /// The value that is matched on
     pub subject: Expression,
     /// Each case and the corresponding element
@@ -2844,6 +2846,7 @@ impl Element {
         };
         MatchElementInfo {
             subject: Expression::Uncompiled(node.Expression().into()),
+            node,
             cases,
             wildcard,
         }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1408,7 +1408,7 @@ impl Element {
                     error_on(&cb, "an 'init' callback")
                 }
             });
-            node.MatchElement().for_each(|n| error_on(&n, "match statements"));
+            node.MatchElement().for_each(|n| error_on(&n, "match elements"));
             node.SlotDeclaration().for_each(|n| error_on(&n, "slots"));
 
             if parent_type == ElementType::Interface {
@@ -2736,7 +2736,7 @@ impl Element {
         tr: &TypeRegister,
     ) -> Vec<ElementRc> {
         if !diag.enable_experimental {
-            diag.push_error("match statements are an experimental feature".into(), &node);
+            diag.push_error("match elements are an experimental feature".into(), &node);
         }
         if node.MatchCase().next().is_none() && node.WildcardMatchCase().is_none() {
             diag.push_error("Expected at least one case".into(), &node);

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2738,6 +2738,9 @@ impl Element {
         if !diag.enable_experimental {
             diag.push_error("match statements are an experimental feature".into(), &node);
         }
+        if node.MatchCase().next().is_none() && node.WildcardMatchCase().is_none() {
+            diag.push_error("Expected at least one case".into(), &node);
+        }
         let mut cases: Vec<ElementRc> = Vec::new();
         let expr = node.Expression();
         for case in node.MatchCase() {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1384,13 +1384,17 @@ impl MatchElementInfo {
             }
         }
         if let WildcardMatchCaseInfo::Element(wildcard) = &self.wildcard {
-            let condition =
-                self.cases.iter().map(|case| compare(&case.value, '!')).reduce(|lhs, rhs| {
-                    Expression::BinaryExpression { lhs: Box::new(lhs), rhs: Box::new(rhs), op: '&' }
-                });
-            if let Some(condition) = condition {
-                show_when(wildcard, condition);
-            }
+            let condition = self
+                .cases
+                .iter()
+                .map(|case| compare(&case.value, '!'))
+                .reduce(|lhs, rhs| Expression::BinaryExpression {
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                    op: '&',
+                })
+                .unwrap_or(Expression::BoolLiteral(true));
+            show_when(wildcard, condition);
         }
     }
 }
@@ -2813,6 +2817,14 @@ impl Element {
         }
         if node.MatchCase().next().is_none() && node.WildcardMatchCase().is_none() {
             diag.push_error("Expected at least one case".into(), &node);
+        }
+        if let Some(wildcard) = node.WildcardMatchCase()
+            && node.MatchCase().next().is_none()
+        {
+            diag.push_warning(
+                "Unnecessary match statement always matches the '*' case".into(),
+                &wildcard,
+            );
         }
         let mut element_of = |sub_element| {
             Element::from_sub_element_node(

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -371,7 +371,7 @@ fn parse_match_case(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::MatchCase);
     parse_expression(&mut *p);
     if !p.test(SyntaxKind::Colon) {
-        p.error("Expected ':' after match case expression");
+        p.error("Expected ':' after match case");
         if p.peek().kind() != SyntaxKind::Identifier {
             p.consume();
         }

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -358,23 +358,7 @@ fn parse_match_element(p: &mut impl Parser) {
 fn parse_match_case(p: &mut impl Parser) {
     let mut p = p.start_node(SyntaxKind::MatchCase);
     parse_expression(&mut *p);
-    if !p.test(SyntaxKind::Colon) {
-        p.error("Expected ':' after match case");
-        if p.peek().kind() != SyntaxKind::Identifier {
-            p.consume();
-        }
-    }
-    if p.peek().kind() == SyntaxKind::LBrace {
-        // pass case
-        p.expect(SyntaxKind::LBrace);
-        if p.peek().kind() == SyntaxKind::Identifier {
-            p.error("Remove '{ }' around case element");
-            parse_sub_element(&mut *p);
-        }
-        p.expect(SyntaxKind::RBrace);
-        return;
-    }
-    parse_sub_element(&mut *p);
+    parse_case_inner(&mut *p, "match case");
 }
 
 #[cfg_attr(test, parser_test)]
@@ -385,18 +369,22 @@ fn parse_wildcard_case(p: &mut impl Parser) {
     debug_assert_eq!(p.peek().kind(), SyntaxKind::Star);
     let mut p = p.start_node(SyntaxKind::WildcardMatchCase);
     p.expect(SyntaxKind::Star);
+    parse_case_inner(&mut *p, "'*'");
+}
+
+fn parse_case_inner(p: &mut impl Parser, after: &str) {
     if !p.test(SyntaxKind::Colon) {
-        p.error("Expected ':' after '*'");
+        p.error(format!("Expected ':' after {after}"));
         if p.peek().kind() != SyntaxKind::Identifier {
             p.consume();
         }
-    };
+    }
     if p.peek().kind() == SyntaxKind::LBrace {
         // pass case
         p.expect(SyntaxKind::LBrace);
         if p.peek().kind() == SyntaxKind::Identifier {
             p.error("Remove '{ }' around case element");
-            return;
+            parse_sub_element(&mut *p);
         }
         p.expect(SyntaxKind::RBrace);
         return;

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -340,18 +340,6 @@ fn parse_match_element(p: &mut impl Parser) {
     if !p.test(SyntaxKind::LBrace) {
         p.error("Expected '{' to start cases");
     }
-    if p.peek().kind() == SyntaxKind::Star {
-        p.error("Expected at least one case before wildcard case");
-        {
-            p.test(SyntaxKind::Star);
-            p.test(SyntaxKind::Colon);
-            let mut p = p.start_node(SyntaxKind::MatchCase);
-            drop(p.start_node(SyntaxKind::Expression));
-            parse_sub_element(&mut *p);
-            p.test(SyntaxKind::RBrace);
-        }
-        return;
-    }
     while ![SyntaxKind::RBrace, SyntaxKind::Star, SyntaxKind::Eof].contains(&p.peek().kind()) {
         parse_match_case(&mut *p);
     }

--- a/internal/compiler/parser/element.rs
+++ b/internal/compiler/parser/element.rs
@@ -345,6 +345,21 @@ fn parse_match_element(p: &mut impl Parser) {
     }
     if p.peek().kind() == SyntaxKind::Star {
         parse_wildcard_case(&mut *p);
+        let mut reported = false;
+        while p.peek().kind() == SyntaxKind::Star
+            || (![SyntaxKind::RBrace, SyntaxKind::Eof].contains(&p.peek().kind())
+                && p.nth(1).kind() == SyntaxKind::Colon)
+        {
+            if !reported {
+                p.error("Cases after the '*' case are never hit");
+                reported = true;
+            }
+            if p.peek().kind() == SyntaxKind::Star {
+                parse_wildcard_case(&mut *p);
+            } else {
+                parse_match_case(&mut *p);
+            }
+        }
     }
     p.expect(SyntaxKind::RBrace);
 }

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -590,6 +590,7 @@ fn duplicate_element_with_mapping(
         debug: elem.debug.clone(),
         enclosing_component: Rc::downgrade(root_component),
         states: elem.states.clone(),
+        match_elements: Default::default(),
         transitions: elem
             .transitions
             .iter()

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -53,6 +53,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 enclosing_component: Default::default(),
                 states: std::mem::take(&mut original_elem.states),
                 transitions: std::mem::take(&mut original_elem.transitions),
+                match_elements: Default::default(),
                 child_of_layout: original_elem.child_of_layout || is_listview.is_some(),
                 child_of_flexbox: original_elem.child_of_flexbox,
                 parent_box_layout_orientation: original_elem.parent_box_layout_orientation,

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -113,7 +113,7 @@ fn resolve_expression(
             Expression::DebugHook { expression, .. } => **expression = new_expr,
             _ => *expr = new_expr,
         }
-    // Specifically used to resolve match expressions
+    // Specifically used to resolve match elements
     } else if let Expression::BinaryExpression { lhs, rhs, op } = expr {
         let op = *op;
         let rhs_node =
@@ -168,7 +168,7 @@ fn resolve_expression(
                 } else if is_cast {
                     diag.push_error("Cannot perform type conversion".into(), &node);
                 } else {
-                    diag.push_error("Match expressions must be literal values".into(), &node);
+                    diag.push_error("Cases must be literal values".into(), &node);
                 }
             }
         }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -126,6 +126,11 @@ fn resolve_match_elements(
 ) {
     let mut match_elements = std::mem::take(&mut elem.borrow_mut().match_elements);
     for match_element in &mut match_elements {
+        if match_element.cases.is_empty()
+            && matches!(match_element.wildcard, WildcardMatchCaseInfo::None)
+        {
+            continue;
+        }
         resolve_expression(
             elem,
             &mut match_element.subject,
@@ -150,7 +155,10 @@ fn resolve_match_elements(
             );
             check_case_value(&case.value, &case.node, diag);
         }
-        check_duplicate_cases(&match_element.cases, diag);
+        let values: Vec<Option<CaseValue>> =
+            match_element.cases.iter().map(|case| CaseValue::new(&case.value)).collect();
+        check_duplicate_cases(&match_element.cases, &values, diag);
+        check_exhaustiveness(match_element, &values, diag);
         match_element.lower_to_conditional_elements();
     }
 }
@@ -220,17 +228,86 @@ impl CaseValue {
 }
 
 /// Reports every case whose value is already covered by an earlier case
-fn check_duplicate_cases(cases: &[MatchCaseInfo], diag: &mut BuildDiagnostics) {
-    let mut seen = Vec::with_capacity(cases.len());
-    for case in cases {
-        let Some(value) = CaseValue::new(&case.value) else {
-            continue;
+fn check_duplicate_cases(
+    cases: &[MatchCaseInfo],
+    values: &[Option<CaseValue>],
+    diag: &mut BuildDiagnostics,
+) {
+    let mut seen: Vec<&CaseValue> = Vec::with_capacity(values.len());
+    for (case, value) in cases.iter().zip(values) {
+        let Some(value) = value else {
+            continue; // not a valid literal
         };
         if seen.contains(&value) {
             diag.push_error("Duplicate case value".into(), &case.node);
         } else {
             seen.push(value);
         }
+    }
+}
+
+impl std::fmt::Display for CaseValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CaseValue::Number(number, _) => write!(f, "{number}"),
+            CaseValue::String(string) => write!(f, "{string:?}"),
+            CaseValue::Bool(boolean) => write!(f, "{boolean}"),
+            CaseValue::Enumeration(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+/// Reports a match element that does not cover every value its subject can take
+fn check_exhaustiveness(
+    match_element: &MatchElementInfo,
+    values: &[Option<CaseValue>],
+    diag: &mut BuildDiagnostics,
+) {
+    if !matches!(match_element.wildcard, WildcardMatchCaseInfo::None) {
+        return;
+    }
+    // Prevents duplicated errors if both not a literal and not exhaustive
+    let mut covered: Vec<&CaseValue> = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(value) = value else {
+            return;
+        };
+        covered.push(value);
+    }
+    let subject_node = match_element.node.Expression();
+    let subject_type = match_element.subject.ty();
+    let expected: Vec<CaseValue> = match &subject_type {
+        Type::Bool => vec![CaseValue::Bool(true), CaseValue::Bool(false)],
+        Type::Enumeration(enumeration) => (0..enumeration.values.len())
+            .map(|value| {
+                CaseValue::Enumeration(langtype::EnumerationValue {
+                    value,
+                    enumeration: enumeration.clone(),
+                })
+            })
+            .collect(),
+        // The subject expression failed to resolve, so an error was already reported
+        Type::Invalid => return,
+        _ => {
+            diag.push_error(
+                format!("Non-exhaustive match on {subject_type}: a '*' case is required"),
+                &subject_node,
+            );
+            return;
+        }
+    };
+
+    let mut missing = Vec::new();
+    for value in &expected {
+        if !covered.contains(&value) {
+            missing.push(format!("'{value}'"));
+        }
+    }
+    if !missing.is_empty() {
+        diag.push_error(
+            format!("Non-exhaustive match on {subject_type}: missing {}", missing.join(", ")),
+            &subject_node,
+        );
     }
 }
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -137,12 +137,10 @@ fn resolve_match_elements(
             diag,
         );
         let case_type = match_element.subject.ty();
-        for (value, _) in &mut match_element.cases {
-            let node =
-                if let Expression::Uncompiled(node) = &value { Some(node.clone()) } else { None };
+        for case in &mut match_element.cases {
             resolve_expression(
                 elem,
-                value,
+                &mut case.value,
                 None,
                 case_type.clone(),
                 scope,
@@ -150,31 +148,30 @@ fn resolve_match_elements(
                 type_loader,
                 diag,
             );
-            if let Some(node) = &node {
-                check_case_value(value, node, diag);
-            }
+            check_case_value(&case.value, &case.node, diag);
         }
+        check_duplicate_cases(&match_element.cases, diag);
         match_element.lower_to_conditional_elements();
     }
 }
 
 /// Confirms that each case is a literal value and matches the type of the subject
 fn check_case_value(value: &Expression, node: &SyntaxNode, diag: &mut BuildDiagnostics) {
-    let is_literal = matches!(
-        value,
-        Expression::NumberLiteral(..)
-            | Expression::StringLiteral(..)
-            | Expression::BoolLiteral(..)
-            | Expression::EnumerationValue(..)
-    );
+    let is_literal = as_number_literal(value).is_some()
+        || matches!(
+            value,
+            Expression::StringLiteral(..)
+                | Expression::BoolLiteral(..)
+                | Expression::EnumerationValue(..)
+        );
     let is_valid_cast = matches!(
         value,
         Expression::Cast { from, to, .. }
-            if matches!(from.as_ref(), Expression::NumberLiteral(..))
+            if as_number_literal(from).is_some()
                 && matches!(to, Type::Color | Type::Int32)
     );
 
-    if let Expression::NumberLiteral(number, Unit::None) = value
+    if let Some((number, Unit::None)) = as_number_literal(value)
         && number.fract() != 0.0
     {
         diag.push_warning("Floating point comparison is not recommended".into(), node);
@@ -186,6 +183,54 @@ fn check_case_value(value: &Expression, node: &SyntaxNode, diag: &mut BuildDiagn
         diag.push_error("Cannot perform type conversion".into(), node);
     } else {
         diag.push_error("Cases must be literal values".into(), node);
+    }
+}
+
+fn as_number_literal(value: &Expression) -> Option<(f64, Unit)> {
+    match value {
+        Expression::NumberLiteral(number, unit) => Some((*number, *unit)),
+        Expression::UnaryOp { sub, op: '-' } => as_number_literal(sub).map(|(n, u)| (-n, u)),
+        _ => None,
+    }
+}
+
+#[derive(PartialEq)]
+enum CaseValue {
+    Number(f64, Unit),
+    String(SmolStr),
+    Bool(bool),
+    Enumeration(langtype::EnumerationValue),
+}
+
+impl CaseValue {
+    fn new(value: &Expression) -> Option<Self> {
+        match value {
+            Expression::Cast { from, .. } => Self::new(from),
+            Expression::UnaryOp { sub, op: '-' } => match Self::new(sub)? {
+                Self::Number(number, unit) => Some(Self::Number(-number, unit)),
+                _ => None,
+            },
+            Expression::NumberLiteral(number, unit) => Some(Self::Number(*number, *unit)),
+            Expression::StringLiteral(string) => Some(Self::String(string.clone())),
+            Expression::BoolLiteral(boolean) => Some(Self::Bool(*boolean)),
+            Expression::EnumerationValue(value) => Some(Self::Enumeration(value.clone())),
+            _ => None, // For invalid non-literals
+        }
+    }
+}
+
+/// Reports every case whose value is already covered by an earlier case
+fn check_duplicate_cases(cases: &[MatchCaseInfo], diag: &mut BuildDiagnostics) {
+    let mut seen = Vec::with_capacity(cases.len());
+    for case in cases {
+        let Some(value) = CaseValue::new(&case.value) else {
+            continue;
+        };
+        if seen.contains(&value) {
+            diag.push_error("Duplicate case value".into(), &case.node);
+        } else {
+            seen.push(value);
+        }
     }
 }
 

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -113,65 +113,79 @@ fn resolve_expression(
             Expression::DebugHook { expression, .. } => **expression = new_expr,
             _ => *expr = new_expr,
         }
-    // Specifically used to resolve match elements
-    } else if let Expression::BinaryExpression { lhs, rhs, op } = expr {
-        let op = *op;
-        let rhs_node =
-            if let Expression::Uncompiled(node) = rhs.as_ref() { Some(node.clone()) } else { None };
+    }
+}
 
+/// Resolve the subject and the case values to create a standard conditional element
+fn resolve_match_elements(
+    elem: &ElementRc,
+    scope: &[ElementRc],
+    type_register: &TypeRegister,
+    type_loader: &crate::typeloader::TypeLoader,
+    diag: &mut BuildDiagnostics,
+) {
+    let mut match_elements = std::mem::take(&mut elem.borrow_mut().match_elements);
+    for match_element in &mut match_elements {
         resolve_expression(
             elem,
-            lhs,
-            property_name,
+            &mut match_element.subject,
+            None,
             Type::Invalid,
             scope,
             type_register,
             type_loader,
             diag,
         );
-        resolve_expression(
-            elem,
-            rhs,
-            property_name,
-            lhs.ty(),
-            scope,
-            type_register,
-            type_loader,
-            diag,
-        );
-        if op == '=' {
-            let is_literal = matches!(
-                rhs.as_ref(),
-                Expression::NumberLiteral(..)
-                    | Expression::StringLiteral(..)
-                    | Expression::BoolLiteral(..)
-                    | Expression::EnumerationValue(..)
+        let case_type = match_element.subject.ty();
+        for (value, _) in &mut match_element.cases {
+            let node =
+                if let Expression::Uncompiled(node) = &value { Some(node.clone()) } else { None };
+            resolve_expression(
+                elem,
+                value,
+                None,
+                case_type.clone(),
+                scope,
+                type_register,
+                type_loader,
+                diag,
             );
-            let is_cast = matches!(rhs.as_ref(), Expression::Cast { .. });
-            let is_valid_cast = matches!(
-                rhs.as_ref(),
-                Expression::Cast { from, to, .. }
-                    if matches!(from.as_ref(), Expression::NumberLiteral(..))
-                        && matches!(to, Type::Color | Type::Int32)
-            );
-            if let Expression::NumberLiteral(val, unit) = rhs.as_ref()
-                && *unit == Unit::None
-                && val.fract() != 0.0
-                && let Some(node) = &rhs_node
-            {
-                diag.push_warning("Floating point comparison is not recommended".into(), node);
-            }
-
-            if let Some(node) = rhs_node {
-                if is_literal || is_valid_cast {
-                    // pass
-                } else if is_cast {
-                    diag.push_error("Cannot perform type conversion".into(), &node);
-                } else {
-                    diag.push_error("Cases must be literal values".into(), &node);
-                }
+            if let Some(node) = &node {
+                check_case_value(value, node, diag);
             }
         }
+        match_element.lower_to_conditional_elements();
+    }
+}
+
+/// Confirms that each case is a literal value and matches the type of the subject
+fn check_case_value(value: &Expression, node: &SyntaxNode, diag: &mut BuildDiagnostics) {
+    let is_literal = matches!(
+        value,
+        Expression::NumberLiteral(..)
+            | Expression::StringLiteral(..)
+            | Expression::BoolLiteral(..)
+            | Expression::EnumerationValue(..)
+    );
+    let is_valid_cast = matches!(
+        value,
+        Expression::Cast { from, to, .. }
+            if matches!(from.as_ref(), Expression::NumberLiteral(..))
+                && matches!(to, Type::Color | Type::Int32)
+    );
+
+    if let Expression::NumberLiteral(number, Unit::None) = value
+        && number.fract() != 0.0
+    {
+        diag.push_warning("Floating point comparison is not recommended".into(), node);
+    }
+
+    if is_literal || is_valid_cast {
+        // pass
+    } else if matches!(value, Expression::Cast { .. }) {
+        diag.push_error("Cannot perform type conversion".into(), node);
+    } else {
+        diag.push_error("Cases must be literal values".into(), node);
     }
 }
 
@@ -221,6 +235,8 @@ pub fn resolve_expressions(
                         );
                     });
                 }
+
+                resolve_match_elements(elem, &scope.0, &doc.local_registry, type_loader, diag);
 
                 resolve_two_way_bindings_for_element(elem, &scope.0, &doc.local_registry, diag);
 

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -52,6 +52,7 @@ pub fn ensure_window(
         repeated: Default::default(),
         states: Default::default(),
         transitions: Default::default(),
+        match_elements: Default::default(),
         child_of_layout: false,
         child_of_flexbox: false,
         parent_box_layout_orientation: None,

--- a/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
+++ b/internal/compiler/tests/syntax/component_slots/component_slots_placeholder.slint
@@ -52,5 +52,6 @@ export component NotInMatch inherits Rectangle {
             header {}
 //          >       <error{The slot 'header' cannot appear in a match element}
         }
+        *: { }
     }
 }

--- a/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
@@ -29,11 +29,11 @@ export interface InvalidContent {
 //  >            <error{An interface cannot have an 'init' callback}
 
     match i {
-//  >error{An interface cannot have match statements}
+//  >error{An interface cannot have match elements}
         1: Rectangle { }
         *: { }
     }
-//  <error{An interface cannot have match statements}
+//  <error{An interface cannot have match elements}
 
     init => {
 //  >error{An interface cannot have an 'init' callback}

--- a/internal/compiler/tests/syntax/match_element/basic_syntax.slint
+++ b/internal/compiler/tests/syntax/match_element/basic_syntax.slint
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 export component Foo {
-    in-out property <int> foo;
+    in-out property <bool> foo;
     match foo {
-        0: Rectangle { }
-        1: Rectangle { }
+        true: Rectangle { }
+        false: Rectangle { }
     }
 }
 

--- a/internal/compiler/tests/syntax/match_element/basic_syntax.slint
+++ b/internal/compiler/tests/syntax/match_element/basic_syntax.slint
@@ -35,3 +35,13 @@ export component Baz {
         *: Rectangle { }
     }
 }
+
+export component EmptyMatchElement {
+    in-out property <int> xx: 0;
+    match xx {
+//  >error{Expected at least one case}
+
+    }
+//  <error{Expected at least one case}
+    in-out property <int> yy: 20;
+}

--- a/internal/compiler/tests/syntax/match_element/basic_syntax.slint
+++ b/internal/compiler/tests/syntax/match_element/basic_syntax.slint
@@ -36,6 +36,15 @@ export component Baz {
     }
 }
 
+export component NegativeInt {
+    in-out property <int> num: 0;
+    match num {
+        -5: Rectangle { }
+        5: Rectangle { }
+        *: Rectangle { }
+    }
+}
+
 export component EmptyMatchElement {
     in-out property <int> xx: 0;
     match xx {

--- a/internal/compiler/tests/syntax/match_element/callbacks.slint
+++ b/internal/compiler/tests/syntax/match_element/callbacks.slint
@@ -14,7 +14,7 @@ export component Bar {
     callback match(int);
     match (foo) {
         return;
-//            ^error{Expected ':' after match case expression}
+//            ^error{Expected ':' after match case}
     }
 //  ^error{Syntax error: expected Identifier}
 }

--- a/internal/compiler/tests/syntax/match_element/cast.slint
+++ b/internal/compiler/tests/syntax/match_element/cast.slint
@@ -52,3 +52,19 @@ export component Baz {
 //      >          <error{Cannot convert MyEnum to string}
     }
 }
+
+export component CastWithWildcard {
+    in property <int> num: 42;
+    in property <int> num_2: 42;
+    in property <string> str_num: "42";
+
+    match num {
+        42: Rectangle { }
+        "42": Rectangle { }
+//      >  <error{Cannot convert string to int}
+        str_num: Rectangle { }
+//      >     <error{Cannot convert string to int}
+//      >     <^error{Cases must be literal values}
+        *: Rectangle { }
+    }
+}

--- a/internal/compiler/tests/syntax/match_element/cast.slint
+++ b/internal/compiler/tests/syntax/match_element/cast.slint
@@ -12,9 +12,9 @@ export component Foo {
 //      >  <error{Cannot convert string to int}
         str_num: Rectangle { }
 //      >     <error{Cannot convert string to int}
-//      >     <^error{Match expressions must be literal values}
+//      >     <^error{Cases must be literal values}
         num_2: Rectangle { }
-//      >   <error{Match expressions must be literal values}
+//      >   <error{Cases must be literal values}
     }
 }
 
@@ -30,7 +30,7 @@ export component Bar {
         num: Rectangle { }
 //      > <error{Cannot perform type conversion}
         str_num_2: Rectangle { }
-//      >       <error{Match expressions must be literal values}
+//      >       <error{Cases must be literal values}
     }
 }
 
@@ -47,7 +47,7 @@ export component Baz {
 //      >   <error{Cannot convert color to string}
         @markdown("hello"): Rectangle {}
 //      >                <error{Cannot convert styled-text to string}
-//      >                <^error{Match expressions must be literal values}
+//      >                <^error{Cases must be literal values}
         MyEnum.val2 : Rectangle {}
 //      >          <error{Cannot convert MyEnum to string}
     }

--- a/internal/compiler/tests/syntax/match_element/children.slint
+++ b/internal/compiler/tests/syntax/match_element/children.slint
@@ -26,6 +26,7 @@ export component Baz {
             @children
 //          >       <error{The @children placeholder cannot appear in a match element}
         }
+        false: Rectangle { }
     }
 }
 

--- a/internal/compiler/tests/syntax/match_element/colon.slint
+++ b/internal/compiler/tests/syntax/match_element/colon.slint
@@ -5,7 +5,7 @@ export component Foo {
     in-out property <bool> foo: false;
     match foo {
         true Rectangle { }
-//           >       <error{Expected ':' after match case expression}
+//           >       <error{Expected ':' after match case}
     }
 }
 
@@ -14,7 +14,7 @@ export component Bar {
     match foo {
         true: Rectangle { }
         false Rectangle { }
-//            >       <error{Expected ':' after match case expression}
+//            >       <error{Expected ':' after match case}
     }
 }
 
@@ -34,7 +34,7 @@ export component Qux {
 
     match foo {
         1 => Rectangle { }
-//        ><error{Expected ':' after match case expression}
+//        ><error{Expected ':' after match case}
     }
 }
 

--- a/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
+++ b/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
@@ -9,6 +9,7 @@ export component DuplicateCaseWithInt {
         0: Rectangle { }
 //      ^error{Duplicate case value}
         1: Rectangle { }
+        *: Rectangle { }
     }
 }
 

--- a/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
+++ b/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
@@ -78,13 +78,13 @@ enum Nums {
 }
 
 export component DuplicateCaseWithEnum {
-    in-out property <Nums> num: Nums.one;
+    in-out property <Nums> num: one;
 
     match num {
-        Nums.one: Rectangle { }
-        Nums.two: Rectangle { }
-        Nums.one: Rectangle { }
-//      >      <error{Duplicate case value}
+        one: Rectangle { }
+        two: Rectangle { }
+        one: Rectangle { }
+//      > <error{Duplicate case value}
         *: Rectangle { }
     }
 }

--- a/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
+++ b/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
@@ -1,0 +1,104 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nicholas Turner <nicholas.turner@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component DuplicateCaseWithInt {
+    in-out property <int> xx: 0;
+
+    match xx {
+        0: Rectangle { }
+        0: Rectangle { }
+//      ^error{Duplicate case value}
+        1: Rectangle { }
+    }
+}
+
+export component DuplicateCaseWithCast {
+    in-out property <int> xx: 0;
+
+    match xx {
+        2: Rectangle { }
+        2.0: Rectangle { }
+//      > <error{Duplicate case value}
+        *: Rectangle { }
+    }
+}
+
+
+export component DuplicateCaseWithUnits {
+    in-out property <duration> dur: 1s;
+
+    match dur {
+        1s: Rectangle { }
+        1000ms: Rectangle { }
+//      >    <error{Duplicate case value}
+        *: Rectangle { }
+    }
+}
+
+export component DuplicateCaseWithColor {
+    in-out property <color> zz: #123;
+
+    match zz {
+        #123: Rectangle { }
+        #456: Rectangle { }
+        #123: Rectangle { }
+//      >  <error{Duplicate case value}
+        *: Rectangle { }
+    }
+}
+
+export component DuplicateCaseWithString {
+    in-out property <string> str: "hello";
+
+    match str {
+        "hello": Rectangle { }
+        "world": Rectangle { }
+        "hello": Rectangle { }
+//      >     <error{Duplicate case value}
+        *: Rectangle { }
+    }
+}
+
+export component DuplicateCaseWithBool {
+    in-out property <bool> flag: true;
+
+    match flag {
+        true: Rectangle { }
+        false: Rectangle { }
+        true: Rectangle { }
+//      >  <error{Duplicate case value}
+    }
+}
+
+enum Nums {
+    one,
+    two,
+    three,
+}
+
+export component DuplicateCaseWithEnum {
+    in-out property <Nums> num: Nums.one;
+
+    match num {
+        Nums.one: Rectangle { }
+        Nums.two: Rectangle { }
+        Nums.one: Rectangle { }
+//      >      <error{Duplicate case value}
+        *: Rectangle { }
+    }
+}
+
+export component DuplicateCaseTwice {
+    in-out property <int> xx: 0;
+    in-out property <int> yy: 0;
+
+    match xx {
+        0: Rectangle { }
+        yy: Rectangle { }
+//      ><error{Cases must be literal values}
+        yy: Rectangle { }
+//      ><error{Cases must be literal values}
+        0: Rectangle { }
+//      ^error{Duplicate case value}
+    }
+}

--- a/internal/compiler/tests/syntax/match_element/exhaustiveness.slint
+++ b/internal/compiler/tests/syntax/match_element/exhaustiveness.slint
@@ -8,29 +8,29 @@ enum Nums {
 }
 
 export component ExhaustiveEnum {
-    in-out property <Nums> num: Nums.one;
+    in-out property <Nums> num: one;
 
     match num {
-        Nums.one: Rectangle { }
-        Nums.two: Rectangle { }
-        Nums.three: Rectangle { }
+        one: Rectangle { }
+        two: Rectangle { }
+        three: Rectangle { }
     }
 }
 
 export component NonExhaustiveEnum {
-    in-out property <Nums> num: Nums.one;
+    in-out property <Nums> num: one;
 
     match num {
 //        >  <error{Non-exhaustive match on Nums: missing 'two', 'three'}
-        Nums.one: Rectangle { }
+        one: Rectangle { }
     }
 }
 
 export component WildcardEnum {
-    in-out property <Nums> num: Nums.one;
+    in-out property <Nums> num: one;
 
     match num {
-        Nums.one: Rectangle { }
+        one: Rectangle { }
         *: Rectangle { }
     }
 }

--- a/internal/compiler/tests/syntax/match_element/exhaustiveness.slint
+++ b/internal/compiler/tests/syntax/match_element/exhaustiveness.slint
@@ -1,0 +1,83 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nicholas Turner <nicholas.turner@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+enum Nums {
+    one,
+    two,
+    three,
+}
+
+export component ExhaustiveEnum {
+    in-out property <Nums> num: Nums.one;
+
+    match num {
+        Nums.one: Rectangle { }
+        Nums.two: Rectangle { }
+        Nums.three: Rectangle { }
+    }
+}
+
+export component NonExhaustiveEnum {
+    in-out property <Nums> num: Nums.one;
+
+    match num {
+//        >  <error{Non-exhaustive match on Nums: missing 'two', 'three'}
+        Nums.one: Rectangle { }
+    }
+}
+
+export component WildcardEnum {
+    in-out property <Nums> num: Nums.one;
+
+    match num {
+        Nums.one: Rectangle { }
+        *: Rectangle { }
+    }
+}
+
+export component ExhaustiveBool {
+    in-out property <bool> flag: true;
+
+    match flag {
+        true: Rectangle { }
+        false: Rectangle { }
+    }
+}
+
+export component NonExhaustiveBool {
+    in-out property <bool> flag: true;
+
+    match flag {
+//        >   <error{Non-exhaustive match on bool: missing 'false'}
+        true: Rectangle { }
+    }
+}
+
+export component NonExhaustiveInt {
+    in-out property <int> num: 0;
+
+    match num {
+//        >  <error{Non-exhaustive match on int: a '*' case is required}
+        0: Rectangle { }
+        1: Rectangle { }
+    }
+}
+
+export component WildcardInt {
+    in-out property <int> num: 0;
+
+    match num {
+        0: Rectangle { }
+        1: Rectangle { }
+        *: Rectangle { }
+    }
+}
+
+export component NonExhaustiveString {
+    in-out property <string> str: "hello";
+
+    match str {
+//        >  <error{Non-exhaustive match on string: a '*' case is required}
+        "hello": Rectangle { }
+    }
+}

--- a/internal/compiler/tests/syntax/match_element/float_warning.slint
+++ b/internal/compiler/tests/syntax/match_element/float_warning.slint
@@ -11,5 +11,6 @@ export component Foo {
 //      > <warning{Floating point comparison is not recommended}
         3.2: Rectangle { }
 //      > <warning{Floating point comparison is not recommended}
+        *: Rectangle { }
     }
 }

--- a/internal/compiler/tests/syntax/match_element/globals.slint
+++ b/internal/compiler/tests/syntax/match_element/globals.slint
@@ -6,8 +6,8 @@ export global Palette {
 
     match primary {
 //  >error{A global component cannot have match elements}
-        Colors.blue: Rectangle { background: orange; }
-        Colors.red: Rectangle { background: green; }
+        blue: Rectangle { background: orange; }
+        red: Rectangle { background: green; }
         *: Rectangle { background: black; }
     }
 //  <error{A global component cannot have match elements}

--- a/internal/compiler/tests/syntax/match_element/globals.slint
+++ b/internal/compiler/tests/syntax/match_element/globals.slint
@@ -5,10 +5,10 @@ export global Palette {
     in-out property <color> primary: blue;
 
     match primary {
-//  >error{A global component cannot have match statements}
+//  >error{A global component cannot have match elements}
         Colors.blue: Rectangle { background: orange; }
         Colors.red: Rectangle { background: green; }
         *: Rectangle { background: black; }
     }
-//  <error{A global component cannot have match statements}
+//  <error{A global component cannot have match elements}
 }

--- a/internal/compiler/tests/syntax/match_element/interfaces.slint
+++ b/internal/compiler/tests/syntax/match_element/interfaces.slint
@@ -4,10 +4,10 @@
 export interface Foo {
     out property <string> message;
         match message {
-//      >error{An interface cannot have match statements}
+//      >error{An interface cannot have match elements}
             "hi": Rectangle { Text { text: "Hello!"; } }
             "bye": Rectangle { Text { text: "Bye!"; } }
             *: Rectangle { Text { text: "Welcome"; } }
     }
-//  <error{An interface cannot have match statements}
+//  <error{An interface cannot have match elements}
 }

--- a/internal/compiler/tests/syntax/match_element/literals.slint
+++ b/internal/compiler/tests/syntax/match_element/literals.slint
@@ -10,11 +10,11 @@ export component Foo {
 
     match num {
         case0: Rectangle { }
-//      >   <error{Match expressions must be literal values}
+//      >   <error{Cases must be literal values}
         case1: Rectangle { }
-//      >   <error{Match expressions must be literal values}
+//      >   <error{Cases must be literal values}
         case2: Rectangle { }
-//      >   <error{Match expressions must be literal values}
+//      >   <error{Cases must be literal values}
         *: Rectangle { }
     }
 }
@@ -25,7 +25,7 @@ export component Bar {
     match greeting {
         "hello": Rectangle { }
         "hello " + "world": Rectangle { }
-//      >                <error{Match expressions must be literal values}
+//      >                <error{Cases must be literal values}
         *: Rectangle { }
     }
 }
@@ -38,7 +38,7 @@ export component Baz {
 
     match greeting {
         func(0): Rectangle { }
-//      >     <error{Match expressions must be literal values}
+//      >     <error{Cases must be literal values}
         *: Rectangle { }
     }
 }
@@ -49,7 +49,7 @@ export component FooBar {
 
     match greeting {
         "hello \{world}": Rectangle { }
-//      >              <error{Match expressions must be literal values}
+//      >              <error{Cases must be literal values}
         "hello": Rectangle { }
     }
 }

--- a/internal/compiler/tests/syntax/match_element/unreachable_cases.slint
+++ b/internal/compiler/tests/syntax/match_element/unreachable_cases.slint
@@ -1,0 +1,30 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nicholas Turner <nicholas.turner@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component CaseAfterWildcard {
+    in-out property <int> foo: 0;
+    match foo {
+        *: Rectangle { }
+        5: Rectangle { }
+//      ^error{Cases after the '*' case are never hit}
+    }
+}
+
+export component DuplicateWildcard {
+    in-out property <int> foo: 0;
+    match foo {
+        *: Rectangle { }
+        *: Rectangle { }
+//      ^error{Cases after the '*' case are never hit}
+    }
+}
+
+export component WildcardInMiddle {
+    in-out property <int> foo: 0;
+    match foo {
+        0: Rectangle { }
+        *: Rectangle { }
+        1: Rectangle { }
+//      ^error{Cases after the '*' case are never hit}
+    }
+}

--- a/internal/compiler/tests/syntax/match_element/wildcard.slint
+++ b/internal/compiler/tests/syntax/match_element/wildcard.slint
@@ -15,6 +15,6 @@ export component Baz {
 
     match foo {
         *: Rectangle { }
-//      ^error{Expected at least one case before wildcard case}
+//      >              <warning{Unnecessary match statement always matches the '*' case}
     }
 }

--- a/tests/cases/match_element/basic_test.slint
+++ b/tests/cases/match_element/basic_test.slint
@@ -21,6 +21,7 @@ export component TestCase inherits Window {
                 var1 += self.xx;
             }
         }
+        false: { }
     }
 }
 

--- a/tests/cases/match_element/colors.slint
+++ b/tests/cases/match_element/colors.slint
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
     in-out property <color> primary: blue;
 
     match primary {
-        Colors.red: TouchArea {
+        red: TouchArea {
             Text {
                 text: var1;
             }
@@ -23,7 +23,7 @@ export component TestCase inherits Window {
                 var1 += self.xx;
             }
         }
-        Colors.green: TouchArea {
+        green: TouchArea {
             Text {
                 text: var2;
             }
@@ -37,7 +37,7 @@ export component TestCase inherits Window {
                 var2 += self.xx;
             }
         }
-        Colors.blue: TouchArea {
+        blue: TouchArea {
             Text {
                 text: var3;
             }
@@ -53,7 +53,7 @@ export component TestCase inherits Window {
         }
         *: { }
     }
-    in-out property <bool> test: var1 == 20 && var2 == 50 && var3 == 70 && primary == Colors.blue;
+    in-out property <bool> test: var1 == 20 && var2 == 50 && var3 == 70 && primary == blue;
 }
 
 /*

--- a/tests/cases/match_element/colors.slint
+++ b/tests/cases/match_element/colors.slint
@@ -51,6 +51,7 @@ export component TestCase inherits Window {
                 var3 += self.xx;
             }
         }
+        *: { }
     }
     in-out property <bool> test: var1 == 20 && var2 == 50 && var3 == 70 && primary == Colors.blue;
 }

--- a/tests/cases/match_element/enum.slint
+++ b/tests/cases/match_element/enum.slint
@@ -6,12 +6,12 @@ enum Mode {
     Bar,
 }
 export component TestCase inherits Window {
-    in-out property <Mode> mode: Mode.Foo;
+    in-out property <Mode> mode: Foo;
     in-out property <int> var1: 20;
     in-out property <int> var2: 50;
 
     match mode {
-        Mode.Foo: TouchArea {
+        Foo: TouchArea {
             Text {
                 text: var1;
             }
@@ -25,7 +25,7 @@ export component TestCase inherits Window {
                 var1 += self.xx;
             }
         }
-        Mode.Bar: TouchArea {
+        Bar: TouchArea {
             Text {
                 text: var2;
             }
@@ -41,7 +41,7 @@ export component TestCase inherits Window {
         }
         *: Rectangle { }
     }
-    in-out property <bool> test: mode == Mode.Foo && var1 == 20 && var2 == 50;
+    in-out property <bool> test: mode == Foo && var1 == 20 && var2 == 50;
 }
 
 

--- a/tests/cases/match_element/float.slint
+++ b/tests/cases/match_element/float.slint
@@ -51,6 +51,7 @@ export component TestCase inherits Window {
                 var3 += self.xx;
             }
         }
+        *: { }
     }
 }
 

--- a/tests/cases/match_element/length.slint
+++ b/tests/cases/match_element/length.slint
@@ -51,6 +51,7 @@ export component TestCase inherits Window {
                 var3 += self.xx;
             }
         }
+        *: { }
     }
 }
 

--- a/tests/cases/match_element/string.slint
+++ b/tests/cases/match_element/string.slint
@@ -51,6 +51,7 @@ export component TestCase inherits Window {
                 var3 += self.xx;
             }
         }
+        *: { }
     }
 }
 

--- a/tests/cases/match_element/unconditional_else.slint
+++ b/tests/cases/match_element/unconditional_else.slint
@@ -1,0 +1,75 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nicholas Turner <nicholas.turner@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    in-out property <int> var1: 20;
+
+    in-out property <int> cond: 0;
+
+    match cond {
+        *: TouchArea {
+            Text {
+                text: var1;
+            }
+
+            x: 0px;
+            y: 100px;
+            width: 100px;
+            height: 100px;
+            property <int> xx: var1;
+            clicked => {
+                var1 += self.xx;
+            }
+        }
+    }
+    in-out property <bool> test: var1 == 20 && cond == 0;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+assert_eq(instance.get_var1(), 20);
+assert_eq(instance.get_cond(), 0);
+
+slint_testing::send_mouse_click(&instance, 0., 100.);
+
+assert_eq(instance.get_var1(), 40);
+instance.set_cond(1);
+assert_eq(instance.get_cond(), 1);
+
+slint_testing::send_mouse_click(&instance, 0., 100.);
+
+assert_eq(instance.get_var1(), 80);
+instance.set_cond(2);
+assert_eq(instance.get_cond(), 2);
+
+slint_testing::send_mouse_click(&instance, 0., 100.);
+
+assert_eq(instance.get_var1(), 160);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+
+assert_eq!(instance.get_var1(), 20);
+assert_eq!(instance.get_cond(), 0);
+
+slint_testing::send_mouse_click(&instance, 0., 100.);
+
+assert_eq!(instance.get_var1(), 40);
+instance.set_cond(1);
+assert_eq!(instance.get_cond(), 1);
+
+slint_testing::send_mouse_click(&instance, 0., 100.);
+
+assert_eq!(instance.get_var1(), 80);
+instance.set_cond(2);
+assert_eq!(instance.get_cond(), 2);
+
+slint_testing::send_mouse_click(&instance, 0., 100.);
+
+assert_eq!(instance.get_var1(), 160);
+```
+*/


### PR DESCRIPTION
Addresses the `Diagnostics` section of [#1307](https://github.com/slint-ui/slint/issues/1307#issue-1257855957) after an experimental implementation of `match` elements was merged in [#12021](https://github.com/slint-ui/slint/pull/12021).

## Standardized Terminology
Updated all references to `match expression` or `match statement` to be `match element`.

``` slint no-test
export global Palette {
    in-out property <color> primary: blue;

    match primary {
//  >error{A global component cannot have match elements}
        Colors.blue: Rectangle { background: orange; }
        Colors.red: Rectangle { background: green; }
        *: Rectangle { background: black; }
    }
//  <error{A global component cannot have match elements}
}
```

## Zero Cases
A match element with zero cases will now produce a compiler error.

```slint no-test
export component EmptyMatchElement {
    in-out property <int> xx: 0;
    match x {

    }
//  ^error{Expected at least one case}
    in-out property <int> yy: 20;
}
```

## Duplicate Cases
A match element with two cases that resolve to the same value will now produce a compiler error.

```slint no-test
export component DuplicateCaseWithInt {
    in-out property <int> xx: 0;

    match xx {
        0: Rectangle { }
        0: Rectangle { }
//      ^error{Duplicate case value}
        1: Rectangle { }
    }
}
```

```slint no-test
export component DuplicateCaseWithCast {
    in-out property <int> xx: 0;

    match xx {
        2: Rectangle { }
        2.0: Rectangle { }
//      > <error{Duplicate case value}
        *: Rectangle { }
    }
}
```

## Exhaustiveness
A type that can be covered completely (bool, enum) must do so, otherwise a `*` case is required. All other types require the `*` case.

``` slint no-test
enum Nums {
    one,
    two,
    three,
}

export component ExhaustiveEnum {
    in-out property <Nums> num: Nums.one;

    match num {
        Nums.one: Rectangle { }
        Nums.two: Rectangle { }
        Nums.three: Rectangle { }
    }
}

export component NonExhaustiveEnum {
    in-out property <Nums> num: Nums.one;

    match num {
//        >  <error{Non-exhaustive match on enum Nums: missing two, three}
        Nums.one: Rectangle { }
    }
}
```

``` slint no-test
export component NonExhaustiveInt {
    in-out property <int> num: 0;

    match num {
//        >  <error{Non-exhaustive match on int: a '*' case is required}
        0: Rectangle { }
        1: Rectangle { }
    }
}

export component WildcardInt {
    in-out property <int> num: 0;

    match num {
        0: Rectangle { }
        1: Rectangle { }
        *: Rectangle { }
    }
}
```

## Unconditional Wildcard Cases
Added support for an empty match element with only a wildcard case to unconditionally render the wildcard case element.

``` slint no-test
export component UnconditionalWildcard{
   in-out property <int> num: 0;

    match num {
        *: Rectangle { }
    }
}
```

## Single Error Outputs
Fixed issue with the same error message being reported multiple times when a `*` case is present.

``` slint no-test
export component CastWithWildcard {
    in property <int> num: 42;
    in property <int> num_2: 42;
    in property <string> str_num: "42";

    match num {
        42: Rectangle { }
        "42": Rectangle { }
//      >  <error{Cannot convert string to int}
        str_num: Rectangle { }
//      >     <error{Cannot convert string to int}
//      >     <^error{Cases must be literal values}
        *: Rectangle { }
    }
}
```

## Support for Type-Based Enum Lookup
Enums now support type-based lookup without needing to include the enum name.
``` slint no-test
enum Nums {
    one,
    two,
    three,
}

...

in-out property <Nums> num: one;

match num {
    one: Rectangle { } // instead of Nums.one
    two: Rectangle { }
    three: Rectangle { }
}
```

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
