### PR TITLE
Fixed animation reset bug

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -178,6 +178,7 @@
     "regenerable",
     "replacen",
     "rehype",
+    "retarget",
     "Rgba",
     "riscv",
     "rowspan",

--- a/cspell.json
+++ b/cspell.json
@@ -122,6 +122,7 @@
     "radiobutton",
     "contexte",
     "cupertino",
+    "cramer",
     "datastructures",
     "dealloc",
     "distros",

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -212,7 +212,7 @@ fn c_set_animated_value<T: InterpolatedPropertyValue + Clone>(
 ) {
     let d = RefCell::new(properties_animations::PropertyValueAnimationData::new(
         from,
-        to,
+        Some(to),
         animation_data.clone(),
     ));
     // Safety: The BindingCallable is for type T
@@ -305,7 +305,7 @@ unsafe fn c_set_animated_binding<T: InterpolatedPropertyValue + Clone>(
         };
         let animation_data = RefCell::new(properties_animations::PropertyValueAnimationData::new(
             T::default(),
-            T::default(),
+            None,
             PropertyAnimation::default(),
         ));
 
@@ -331,7 +331,6 @@ unsafe fn c_set_animated_binding<T: InterpolatedPropertyValue + Clone>(
                 (anim, start_instant)
             },
             dirty_time: Cell::new(crate::animations::current_tick()),
-            has_started: Cell::new(false),
         });
         handle.0.mark_dirty();
     }

--- a/internal/core/properties/ffi.rs
+++ b/internal/core/properties/ffi.rs
@@ -330,6 +330,8 @@ unsafe fn c_set_animated_binding<T: InterpolatedPropertyValue + Clone>(
                 };
                 (anim, start_instant)
             },
+            dirty_time: Cell::new(crate::animations::current_tick()),
+            has_started: Cell::new(false),
         });
         handle.0.mark_dirty();
     }

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -63,14 +63,14 @@ where
 
 pub(super) struct PropertyValueAnimationData<T> {
     from_value: T,
-    to_value: T,
+    to_value: Option<T>,
     details: PropertyAnimation,
     start_time: crate::animations::Instant,
     state: AnimationState,
 }
 
 impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
-    pub fn new(from_value: T, to_value: T, details: PropertyAnimation) -> Self {
+    pub fn new(from_value: T, to_value: Option<T>, details: PropertyAnimation) -> Self {
         let start_time = crate::animations::current_tick();
 
         Self { from_value, to_value, details, start_time, state: AnimationState::Delaying }
@@ -79,8 +79,9 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
     /// Single iteration of the animation
     pub fn compute_interpolated_value(&mut self) -> (T, bool) {
         // If animation is disabled, immediately return the target value
+        let to_value = self.to_value.clone().expect("The animation should have a to_value");
         if !self.details.enabled {
-            return (self.to_value.clone(), true);
+            return (to_value, true);
         }
 
         let new_tick = crate::animations::current_tick();
@@ -105,11 +106,7 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
                 let delay = self.details.delay as u64;
 
                 if time_progress < delay {
-                    if reversed(0) {
-                        (self.to_value.clone(), false)
-                    } else {
-                        (self.from_value.clone(), false)
-                    }
+                    if reversed(0) { (to_value, false) } else { (self.from_value.clone(), false) }
                 } else {
                     self.start_time =
                         new_tick - core::time::Duration::from_millis(time_progress - delay);
@@ -145,7 +142,7 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
                         if reversed(current_iteration) { 1. - progress } else { progress }
                     };
                     let t = crate::animations::easing_curve(&self.details.easing, progress);
-                    let val = self.from_value.interpolate(&self.to_value, t);
+                    let val = self.from_value.interpolate(&to_value, t);
 
                     (val, false)
                 } else {
@@ -158,7 +155,7 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
                 if reversed(iteration_count) {
                     (self.from_value.clone(), true)
                 } else {
-                    (self.to_value.clone(), true)
+                    (to_value, true)
                 }
             }
         }
@@ -181,9 +178,6 @@ pub(super) struct AnimatedBindingCallable<T, A> {
     pub(super) compute_animation_details: A,
     /// Tick captured by `mark_dirty`
     pub(super) dirty_time: Cell<crate::animations::Instant>,
-    /// True if the callable has ever completed a retarget. Since `animation_data` starts
-    /// with default values, they can equal the first target and can cause errors.
-    pub(super) has_started: Cell<bool>,
 }
 
 pub(super) type AnimationDetail = (PropertyAnimation, Option<crate::animations::Instant>);
@@ -219,11 +213,13 @@ unsafe impl<T: InterpolatedPropertyValue + Clone, A: Fn() -> AnimationDetail> Bi
                 // if the change doesn't actually affect the computed value, it shouldn't restart
                 // the animation
                 let previous_to_value = animation_data.to_value.clone();
-                // Safety: `animation_data.to_value` is a valid mutable reference
-                unsafe { self.original_binding.update((&mut animation_data.to_value) as *mut T) };
+                let mut new_to_value = T::default();
+                // Safety: `new_to_value` is a valid mutable reference matching the
+                // original binding's value type
+                unsafe { self.original_binding.update(&mut new_to_value as *mut T) };
+                animation_data.to_value = Some(new_to_value);
 
-                if !self.has_started.get() || animation_data.to_value != previous_to_value {
-                    self.has_started.set(true);
+                if animation_data.to_value != previous_to_value {
                     animation_data.state = AnimationState::Delaying;
                     // Anchor timing to when the change was first signalled
                     animation_data.start_time = self.dirty_time.get();
@@ -325,7 +321,7 @@ impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
     pub fn set_animated_value(self: Pin<&Self>, value: T, animation_data: PropertyAnimation) {
         let d = RefCell::new(properties_animations::PropertyValueAnimationData::new(
             self.get(),
-            value,
+            Some(value),
             animation_data,
         ));
         // Safety: the BindingCallable will cast its argument to T
@@ -373,12 +369,11 @@ impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
             state: Cell::new(properties_animations::AnimatedBindingState::NotAnimating),
             animation_data: RefCell::new(properties_animations::PropertyValueAnimationData::new(
                 T::default(),
-                T::default(),
+                None,
                 PropertyAnimation::default(),
             )),
             compute_animation_details,
             dirty_time: Cell::new(crate::animations::current_tick()),
-            has_started: Cell::new(false),
         };
 
         // Safety: the `AnimatedBindingCallable`'s type match the property type

--- a/internal/core/properties/properties_animations.rs
+++ b/internal/core/properties/properties_animations.rs
@@ -163,11 +163,6 @@ impl<T: InterpolatedPropertyValue + Clone> PropertyValueAnimationData<T> {
             }
         }
     }
-
-    fn reset(&mut self) {
-        self.state = AnimationState::Delaying;
-        self.start_time = crate::animations::current_tick();
-    }
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
@@ -184,6 +179,11 @@ pub(super) struct AnimatedBindingCallable<T, A> {
     pub(super) state: Cell<AnimatedBindingState>,
     pub(super) animation_data: RefCell<PropertyValueAnimationData<T>>,
     pub(super) compute_animation_details: A,
+    /// Tick captured by `mark_dirty`
+    pub(super) dirty_time: Cell<crate::animations::Instant>,
+    /// True if the callable has ever completed a retarget. Since `animation_data` starts
+    /// with default values, they can equal the first target and can cause errors.
+    pub(super) has_started: Cell<bool>,
 }
 
 pub(super) type AnimationDetail = (PropertyAnimation, Option<crate::animations::Instant>);
@@ -213,18 +213,30 @@ unsafe impl<T: InterpolatedPropertyValue + Clone, A: Fn() -> AnimationDetail> Bi
                 unsafe { self.original_binding.update(value as *mut T) };
             }
             AnimatedBindingState::ShouldStart => {
-                self.state.set(AnimatedBindingState::Animating);
                 let mut animation_data = self.animation_data.borrow_mut();
-                // animation_data.details.iteration_count = 1.;
-                animation_data.from_value = value.clone();
-                let (details, start_time) = (self.compute_animation_details)();
-                if let Some(start_time) = start_time {
-                    animation_data.start_time = start_time;
-                }
-                animation_data.details = details;
 
+                // Since `mark_dirty` fires when dependencies of `original_binding` changes
+                // if the change doesn't actually affect the computed value, it shouldn't restart
+                // the animation
+                let previous_to_value = animation_data.to_value.clone();
                 // Safety: `animation_data.to_value` is a valid mutable reference
                 unsafe { self.original_binding.update((&mut animation_data.to_value) as *mut T) };
+
+                if !self.has_started.get() || animation_data.to_value != previous_to_value {
+                    self.has_started.set(true);
+                    animation_data.state = AnimationState::Delaying;
+                    // Anchor timing to when the change was first signalled
+                    animation_data.start_time = self.dirty_time.get();
+                    // animation_data.details.iteration_count = 1.;
+                    animation_data.from_value = value.clone();
+                    let (details, start_time) = (self.compute_animation_details)();
+                    if let Some(start_time) = start_time {
+                        animation_data.start_time = start_time;
+                    }
+                    animation_data.details = details;
+                }
+
+                self.state.set(AnimatedBindingState::Animating);
                 let (val, finished) = animation_data.compute_interpolated_value();
                 *value = val;
                 if finished {
@@ -244,7 +256,7 @@ unsafe impl<T: InterpolatedPropertyValue + Clone, A: Fn() -> AnimationDetail> Bi
         let original_dirty = self.original_binding.access(|b| b.unwrap().dirty.get());
         if original_dirty {
             self.state.set(AnimatedBindingState::ShouldStart);
-            self.animation_data.borrow_mut().reset();
+            self.dirty_time.set(crate::animations::current_tick());
         }
     }
 }
@@ -365,6 +377,8 @@ impl<T: Clone + InterpolatedPropertyValue + 'static> Property<T> {
                 PropertyAnimation::default(),
             )),
             compute_animation_details,
+            dirty_time: Cell::new(crate::animations::current_tick()),
+            has_started: Cell::new(false),
         };
 
         // Safety: the `AnimatedBindingCallable`'s type match the property type
@@ -990,6 +1004,61 @@ mod animation_tests {
             .with(|driver| driver.update_animations(start_time + DELAY + DURATION + DURATION / 2));
         assert_eq!(get_prop_value(&compo.width), 200);
         assert_eq!(get_prop_value(&compo.width_times_two), 400);
+    }
+
+    #[test]
+    fn properties_test_animation_triggered_by_binding_with_unrelated_dirty() {
+        // Reproduces the dependency not changing target bug: the binding driving the
+        // animated property (`row.1`) never changes, but an *unrelated* field of the
+        // same source value (`row.0`) is rewritten every frame, like a repeated item's
+        // model row being touched by `VecModel::set_row_data` every tick.
+        #[derive(Default)]
+        struct Component {
+            width: Property<i32>,
+            row: Property<(i32, bool)>,
+        }
+
+        let compo = Rc::pin(Component::default());
+
+        let animation_details = PropertyAnimation {
+            duration: DURATION.as_millis() as _,
+            iteration_count: 1.,
+            ..PropertyAnimation::default()
+        };
+
+        let w = PinWeak::downgrade(compo.clone());
+        compo.width.set_animated_binding(
+            move || {
+                let compo = w.upgrade().unwrap();
+                if get_prop_value(&compo.row).1 { 200 } else { 40 }
+            },
+            move || (animation_details.clone(), None),
+        );
+
+        compo.row.set((0, false));
+        assert_eq!(get_prop_value(&compo.width), 40);
+
+        let start_time = crate::animations::current_tick();
+
+        // Flip the field the animation depends on: this should kick off a 40 -> 200
+        // animation over DURATION.
+        compo.row.set((0, true));
+        assert_eq!(get_prop_value(&compo.width), 40);
+
+        // Simulate ~700 real frames (16ms each -- more than DURATION worth of real time
+        // in total)
+        let tick = core::time::Duration::from_millis(16);
+        for i in 1..=700u32 {
+            compo.row.set((i as i32, true));
+            crate::animations::CURRENT_ANIMATION_DRIVER
+                .with(|driver| driver.update_animations(start_time + tick * i));
+            // Poll every frame like a real renderer repainting
+            let _ = get_prop_value(&compo.width);
+        }
+
+        // After more than DURATION worth of real time has elapsed, the animation should
+        // have completed regardless of the unrelated per-frame writes to `row.0`.
+        assert_eq!(get_prop_value(&compo.width), 200);
     }
 
     #[test]

--- a/tests/cases/properties/animation_unrelated_model_field_dirty.slint
+++ b/tests/cases/properties/animation_unrelated_model_field_dirty.slint
@@ -1,0 +1,51 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Reproduces a bug where an animated property bound to one field of a model
+// row would restart its animation every time an *unrelated* field of that
+// same row changed (e.g. a repeated item's row being touched by
+// `VecModel::set_row_data` on every frame), even though the animation's
+// target value never actually changed.
+
+export component TestCase inherits Rectangle {
+    width: 100phx;
+    height: 100phx;
+
+    in-out property <[{counter: int, selected: bool}]> model: [{counter: 0, selected: false}];
+
+    out property <int> width_prop: model[0].selected ? 200 : 40;
+    animate width_prop {
+        duration: 300ms;
+    }
+}
+
+/*
+```rust
+use slint::Model;
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_width_prop(), 40);
+
+let model = std::rc::Rc::new(slint::VecModel::from(vec![(0i32, false)]));
+instance.set_model(slint::ModelRc::from(model.clone()));
+assert_eq!(instance.get_width_prop(), 40);
+
+// Flip the field the animation depends on: this should kick off a 40 -> 200
+// animation over 300ms.
+model.set_row_data(0, (0, true));
+assert_eq!(instance.get_width_prop(), 40);
+
+// Simulate ~40 frames of 16ms each (more than 300ms of mocked time in total),
+// touching only the unrelated `counter` field on every frame -- like a real
+// renderer repaint while a repeated item's model row is updated -- while the
+// field the animation actually depends on (`selected`) stays `true`.
+for i in 1..=40 {
+    model.set_row_data(0, (i, true));
+    slint_testing::mock_elapsed_time(16);
+    let _ = instance.get_width_prop();
+}
+
+// After more than 300ms of mocked time has elapsed, the animation should
+// have completed regardless of the unrelated per-frame writes to `counter`.
+assert_eq!(instance.get_width_prop(), 200);
+```
+*/


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
An animation could be reset or not run if the dependencies of a binding are changed without actually changing the animation values. This is most notable on embedded hardware as you can force things to change at the frame rate therefore pausing the animation. On desktop it is noticeable as a jitter, and a reproducible example is:

AppWindow.slint
```slint
export struct Row { counter: int, active: bool }

export component AppWindow inherits Window {
    in property <[Row]> model;
    width: 300px;
    height: 100px;

    for row[i] in model : Rectangle {
        background: red;
        width: 50px;
        height: 50px;
        x: row.active ? 200px : 0px;
        animate x { duration: 3000ms; }
    }

    Text { text: model[0].counter; }
}
```
main.rs:
```rust
use slint::{Timer, TimerMode, VecModel, Model};
use std::rc::Rc;

slint::include_modules!();

fn main() {
    let app = AppWindow::new().unwrap();
    let rows = Rc::new(VecModel::from(vec![Row { counter: 0, active: false }]));
    app.set_model(rows.clone().into());

    // Spurious per-frame dirty: rewrites `counter` every ~16ms, `active` untouched.
    let timer = Timer::default();
    let rows_clone = rows.clone();
    timer.start(TimerMode::Repeated, std::time::Duration::from_millis(16), move || {
        let mut row = rows_clone.row_data(0).unwrap();
        row.counter += 1;
        rows_clone.set_row_data(0, row); // rewrites whole row -> marks dependents dirty every frame
    });

    // After 500ms, flip `active` once - this is the genuine change that should animate.
    let rows_clone2 = rows.clone();
    Timer::single_shot(std::time::Duration::from_millis(500), move || {
        let mut row = rows_clone2.row_data(0).unwrap();
        row.active = true;
        rows_clone2.set_row_data(0, row);
    });

    app.run().unwrap();
}
```