### PR TITLE
core: make Window.close() return whether the close was accepted

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1575,9 +1575,10 @@ component WindowItem {
     out property <Point> virtual-keyboard-position;
     /// On mobile devices, virtual keyboards (aka software keyboards or onscreen keyboards) are displayed on top of the application. When such a keyboard is shown, this property denotes the width and height of the rectangle covered by it in window coordinates.
     out property <Size> virtual-keyboard-size;
-    /// Request that the window be closed. This triggers the `close-requested` callback,
-    /// giving the application a chance to cancel the close. Returns `true` if the close
-    /// was dispatched, or `false` if the application declined.
+    /// Request that the window be closed.
+    /// This triggers the `close-requested` callback, giving the application a chance to cancel the close.
+    /// Returns `true` if the application accepted the close request; false otherwise.
+    /// Returns `false` if called on a child `Window` element, which can't be closed independently.
     //-shadowable
     function close() -> bool {
     }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1506,12 +1506,11 @@ impl WindowItem {
             return false;
         }
         let inner = WindowInner::from_pub(window_adapter.window());
-        if inner.request_close()
-            && let Err(err) = inner.hide()
-        {
+        let accepted = inner.request_close();
+        if accepted && let Err(err) = inner.hide() {
             crate::debug_log!("Slint: Failed to hide window after close request: {err}");
         }
-        true
+        accepted
     }
 
     pub fn hide(self: Pin<&Self>, window_adapter: &Rc<dyn WindowAdapter>, self_rc: &ItemRc) {

--- a/tests/cases/elements/window_actions.slint
+++ b/tests/cases/elements/window_actions.slint
@@ -73,21 +73,29 @@ assert!(!instance.get_win_minimized());
 instance.window().set_fullscreen(false);
 assert!(!instance.get_win_full_screen());
 
-// close() triggers the close-requested callback on the top-level window.
+// close() reports whether the application accepted the close request. The callback
+// keeps the window shown here, so close() returns false while still firing the callback.
 use std::cell::Cell;
 use std::rc::Rc;
+let response = Rc::new(Cell::new(slint::CloseRequestResponse::KeepWindowShown));
 let close_count = Rc::new(Cell::new(0u32));
 let close_count_clone = close_count.clone();
+let response_clone = response.clone();
 instance.window().on_close_requested(move || {
     close_count_clone.set(close_count_clone.get() + 1);
-    slint::CloseRequestResponse::KeepWindowShown
+    response_clone.get()
 });
-assert!(instance.invoke_do_close());
+assert!(!instance.invoke_do_close());
 assert_eq!(close_count.get(), 1);
+
+// When the callback accepts the close, close() returns true.
+response.set(slint::CloseRequestResponse::HideWindow);
+assert!(instance.invoke_do_close());
+assert_eq!(close_count.get(), 2);
 
 // close() returns false and fires no close-requested when called on a sub-window.
 assert!(!instance.invoke_close_inner());
-assert_eq!(close_count.get(), 1);
+assert_eq!(close_count.get(), 2);
 // hide() on a sub-window is also a no-op.
 instance.invoke_hide_inner();
 ```
@@ -118,18 +126,25 @@ assert(!instance.get_win_minimized());
 instance.window().set_fullscreen(false);
 assert(!instance.get_win_full_screen());
 
-// close() triggers the close-requested callback on the top-level window.
+// close() reports whether the application accepted the close request. The callback
+// keeps the window shown here, so close() returns false while still firing the callback.
 int close_count = 0;
-instance.window().on_close_requested([&close_count]() {
+auto close_response = slint::CloseRequestResponse::KeepWindowShown;
+instance.window().on_close_requested([&]() {
     ++close_count;
-    return slint::CloseRequestResponse::KeepWindowShown;
+    return close_response;
 });
-assert_eq(instance.invoke_do_close(), true);
+assert_eq(instance.invoke_do_close(), false);
 assert_eq(close_count, 1);
+
+// When the callback accepts the close, close() returns true.
+close_response = slint::CloseRequestResponse::HideWindow;
+assert_eq(instance.invoke_do_close(), true);
+assert_eq(close_count, 2);
 
 // close() returns false and fires no close-requested when called on a sub-window.
 assert_eq(instance.invoke_close_inner(), false);
-assert_eq(close_count, 1);
+assert_eq(close_count, 2);
 // hide() on a sub-window is also a no-op.
 instance.invoke_hide_inner();
 ```


### PR DESCRIPTION
Previously `Window.close()` returned `true` for any top-level window regardless
of the outcome, so callers could not tell whether the `close-requested`
callback actually let the window close.

`WindowItem::close()` now returns the result of the close request:

- `true` when the callback accepted the close (the window is hidden),
- `false` when the callback kept the window shown,
- `false` when called on a child `Window` element that can't be closed independently.

The builtin docs are updated to match (using the wording from review), and the
`window_actions` test now covers both the accepted and rejected paths.

Tests: `env RUSTC_WRAPPER= SLINT_TEST_FILTER=window_actions cargo test --manifest-path tests/Cargo.toml -p test-driver-rust`
