### PR TITLE
python: Stop leaking timers on every asyncio await

### DIFF
--- a/api/python/slint/async_adapter.rs
+++ b/api/python/slint/async_adapter.rs
@@ -4,6 +4,7 @@
 use std::rc::Rc;
 
 use pyo3::prelude::*;
+use pyo3::{PyTraverseError, gc::PyVisit};
 
 #[cfg(unix)]
 struct PyFdWrapper(std::os::fd::RawFd);
@@ -64,6 +65,30 @@ impl AsyncAdapter {
             inner.writable_callback.replace(callback);
         });
     }
+
+    fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+        // The callbacks live behind an `Rc` that Python's cyclic GC can't see. Report them
+        // here, so that a selector registering its own bound methods - which is what
+        // `_SlintSelector.register()` does, while holding on to the adapter - stays
+        // collectable.
+        if let Some(inner) = self.inner.as_ref() {
+            for callback in
+                [&inner.readable_callback, &inner.writable_callback].into_iter().flatten()
+            {
+                visit.call(callback)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn __clear__(&mut self) {
+        // The polling task holds only a `Weak`, so dropping the last strong reference both
+        // releases the callbacks and makes the task finish on its next wake-up.
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+        self.inner = None;
+    }
 }
 
 impl AsyncAdapter {
@@ -74,7 +99,11 @@ impl AsyncAdapter {
 
         // This detaches and basically makes any existing future that might get woke up fail when
         // trying to upgrade the weak.
-        let mut inner = Rc::into_inner(self.inner.take().unwrap()).unwrap();
+        let Some(inner) = self.inner.take() else {
+            // Released by `__clear__`; the adapter is unreachable garbage at this point.
+            return;
+        };
+        let mut inner = Rc::into_inner(inner).unwrap();
 
         callback(&mut inner);
 

--- a/api/python/slint/slint/loop.py
+++ b/api/python/slint/slint/loop.py
@@ -112,6 +112,38 @@ class _SlintSelector(selectors.BaseSelector):
         writer._run()
 
 
+class _SlintTimerHandle(asyncio.TimerHandle):
+    """A `TimerHandle` that disarms the native timer backing it when cancelled.
+
+    `asyncio.TimerHandle.cancel()` only marks the handle. The native timer would stay
+    armed until its original deadline, wake the event loop just to find the handle dead,
+    and keep itself and its callback alive until then - for `call_later(3600, ...)`,
+    an hour.
+    """
+
+    __slots__ = ("_slint_key", "_slint_timers")
+
+    def __init__(
+        self,
+        when: float,
+        callback: typing.Callable[..., typing.Any],
+        args: typing.Sequence[typing.Any],
+        loop: asyncio.AbstractEventLoop,
+        context: typing.Any,
+        timers: dict[int, native.Timer],
+        key: int,
+    ) -> None:
+        super().__init__(when, callback, args, loop, context)
+        self._slint_timers = timers
+        self._slint_key = key
+
+    def cancel(self) -> None:
+        super().cancel()
+        timer = self._slint_timers.pop(self._slint_key, None)
+        if timer is not None:
+            timer.stop()
+
+
 class SlintEventLoop(asyncio.SelectorEventLoop):
     def __init__(self) -> None:
         self._is_running = False
@@ -182,17 +214,19 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
     def call_later(self, delay, callback, *args, context=None) -> asyncio.TimerHandle:
         timer = native.Timer()
 
-        handle = asyncio.TimerHandle(
+        timers = self._timers
+        self._timer_serial += 1
+        key = self._timer_serial
+
+        handle = _SlintTimerHandle(
             when=self.time() + delay,
             callback=callback,
             args=args,
             loop=self,
             context=context,
+            timers=timers,
+            key=key,
         )
-
-        timers = self._timers
-        self._timer_serial += 1
-        key = self._timer_serial
 
         # The callback below must key into `timers` rather than capture `timer`: capturing
         # it makes the timer and its callback keep each other alive. `Timer.__traverse__`

--- a/api/python/slint/slint/loop.py
+++ b/api/python/slint/slint/loop.py
@@ -115,7 +115,8 @@ class _SlintSelector(selectors.BaseSelector):
 class SlintEventLoop(asyncio.SelectorEventLoop):
     def __init__(self) -> None:
         self._is_running = False
-        self._timers: set[native.Timer] = set()
+        self._timers: dict[int, native.Timer] = {}
+        self._timer_serial = 0
         self.stop_run_forever_event = asyncio.Event()
         self._soon_tasks: list[asyncio.TimerHandle] = []
         super().__init__(_SlintSelector())
@@ -190,9 +191,15 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
         )
 
         timers = self._timers
+        self._timer_serial += 1
+        key = self._timer_serial
 
+        # The callback below must key into `timers` rather than capture `timer`: capturing
+        # it makes the timer and its callback keep each other alive. `Timer.__traverse__`
+        # makes that cycle collectable, but only by a full GC pass, and this runs on every
+        # await. Keyed by a serial, so a freed timer's key can never alias a live one.
         def timer_done_cb() -> None:
-            timers.remove(timer)
+            timers.pop(key, None)
             if not handle._cancelled:
                 handle._run()
 
@@ -202,7 +209,7 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
             callback=timer_done_cb,
         )
 
-        timers.add(timer)
+        timers[key] = timer
 
         return handle
 

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import asyncio
+import gc
 import platform
 import socket
 import sys
@@ -325,3 +326,44 @@ if sys.platform != "win32":
 
         with pytest.raises(KeyboardInterrupt):
             slint.run_event_loop(run())
+
+
+def test_sleep_does_not_leak_timers() -> None:
+    """Repeatedly awaiting asyncio.sleep() must not accumulate objects.
+
+    `SlintEventLoop.call_later()` arms a native timer per call, so a timer that
+    outlives its callback leaks once per await.
+    See https://github.com/slint-ui/slint/issues/12679.
+    """
+
+    def live_objects() -> int:
+        gc.collect()
+        return len(gc.get_objects())
+
+    async def run() -> None:
+        # A non-zero delay so that both timers per await are exercised: asyncio
+        # short-circuits sleep(0) without going through call_later().
+        delay = 0.001
+
+        # Warm up, so that one-time allocations don't count towards the baseline.
+        for _ in range(100):
+            await asyncio.sleep(delay)
+        baseline = live_objects()
+
+        for _ in range(500):
+            await asyncio.sleep(delay)
+        growth = live_objects() - baseline
+
+        # Before the fix this grew by ~15 objects per iteration.
+        assert growth < 100, f"leaked {growth} objects over 500 awaits"
+
+        # The timers must not be reclaimed by a collection pass either: call_later()
+        # is on the per-await hot path, so it has to avoid building cycles at all.
+        for _ in range(500):
+            await asyncio.sleep(delay)
+        cyclic = gc.collect()
+        assert cyclic < 100, f"{cyclic} cyclic objects over 500 awaits"
+
+        slint.quit_event_loop()
+
+    slint.run_event_loop(run())

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -18,6 +18,7 @@ import pytest
 from aiohttp import web
 
 import slint
+import slint.loop
 from slint import slint as native
 
 
@@ -399,3 +400,37 @@ def test_selector_adapter_cycle_is_collectable() -> None:
     finally:
         reader.close()
         writer.close()
+
+
+def test_cancelling_handle_disarms_native_timer() -> None:
+    """Cancelling a `call_later()` handle must stop the timer it armed.
+
+    Otherwise the timer stays armed until its original deadline, waking the loop for a
+    callback that will not run and pinning itself until then.
+    """
+
+    async def run() -> None:
+        loop = typing.cast(slint.loop.SlintEventLoop, asyncio.get_event_loop())
+
+        called = False
+
+        def never() -> None:
+            nonlocal called
+            called = True
+
+        before = len(loop._timers)
+        handle = loop.call_later(3600, never)
+        assert len(loop._timers) == before + 1
+
+        handle.cancel()
+        assert len(loop._timers) == before, "native timer left armed after cancel()"
+
+        # Cancelling twice must not raise.
+        handle.cancel()
+
+        await asyncio.sleep(0.05)
+        assert not called
+
+        slint.quit_event_loop()
+
+    slint.run_event_loop(run())

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -1,6 +1,8 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+# cSpell:ignore socketpair
+
 import asyncio
 import gc
 import platform
@@ -8,6 +10,7 @@ import socket
 import sys
 import threading
 import typing
+import weakref
 from datetime import timedelta
 
 import aiohttp
@@ -367,3 +370,32 @@ def test_sleep_does_not_leak_timers() -> None:
         slint.quit_event_loop()
 
     slint.run_event_loop(run())
+
+
+def test_selector_adapter_cycle_is_collectable() -> None:
+    """`_SlintSelector.register()` hands the adapter its own bound methods.
+
+    The adapter keeps them behind an `Rc` the GC cannot see, so selector and adapter
+    would keep each other alive for the lifetime of the process.
+    """
+
+    class Owner:
+        def __init__(self, fd: int) -> None:
+            self.adapter = native.AsyncAdapter(fd)
+            self.adapter.wait_for_readable(self.on_readable)
+
+        def on_readable(self, fd: int) -> None:
+            pass
+
+    reader, writer = socket.socketpair()
+    try:
+        owner = Owner(reader.fileno())
+        weak_owner = weakref.ref(owner)
+
+        del owner
+        gc.collect()
+
+        assert weak_owner() is None
+    finally:
+        reader.close()
+        writer.close()

--- a/api/python/slint/tests/test_timers.py
+++ b/api/python/slint/tests/test_timers.py
@@ -1,6 +1,8 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import gc
+import weakref
 from datetime import timedelta
 
 from slint import slint as native
@@ -32,3 +34,30 @@ def test_timer() -> None:
 def test_single_shot() -> None:
     native.Timer.single_shot(timedelta(milliseconds=100), native.quit_event_loop)
     native.run_event_loop()
+
+
+def test_callback_cycle_is_collectable() -> None:
+    # The pattern from Timer's own documentation - an object that owns the timer
+    # and hands it one of its own bound methods - is a reference cycle through
+    # the Rust closure. Without __traverse__/__clear__ it is never collected.
+    class Owner:
+        def __init__(self) -> None:
+            self.timer = native.Timer()
+            self.timer.start(
+                native.TimerMode.Repeated, timedelta(seconds=1), self.on_tick
+            )
+
+        def on_tick(self) -> None:
+            pass
+
+    owner = Owner()
+    weak_owner = weakref.ref(owner)
+
+    # Reported via __traverse__; without it the type isn't GC-tracked at all and
+    # the assertion below fails for a reason that is harder to read off.
+    assert gc.is_tracked(owner.timer)
+
+    del owner
+    gc.collect()
+
+    assert weak_owner() is None

--- a/api/python/slint/timer.rs
+++ b/api/python/slint/timer.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore timedelta
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use pyo3::prelude::*;
+use pyo3::{PyTraverseError, gc::PyVisit};
 
 /// The TimerMode specifies what should happen after the timer fired.
 ///
@@ -54,13 +58,16 @@ impl From<PyTimerMode> for i_slint_core::timers::TimerMode {
 #[pyclass(name = "Timer", unsendable)]
 pub struct PyTimer {
     timer: i_slint_core::timers::Timer,
+    /// Shared with the closure i-slint-core keeps in its (GC-invisible) timer list, so
+    /// that `__clear__` releases the core closure's reference too, not just ours.
+    callback: Rc<RefCell<Option<Py<PyAny>>>>,
 }
 
 #[pymethods]
 impl PyTimer {
     #[new]
     fn py_new() -> Self {
-        PyTimer { timer: Default::default() }
+        PyTimer { timer: Default::default(), callback: Default::default() }
     }
 
     /// Starts the timer with the given mode and interval, in order for the callback to called when the
@@ -80,8 +87,22 @@ impl PyTimer {
         let interval = interval
             .to_std()
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+
+        // Bind the old callback rather than discarding it in place: releasing it may run
+        // Python code that touches this timer, and a binding keeps that until after the
+        // borrow ends. (`let _ =` would drop it while the borrow is still held.)
+        let previous = self.callback.borrow_mut().replace(callback);
+        drop(previous);
+
+        let slot = self.callback.clone();
         self.timer.start(mode.into(), interval, move || {
             Python::attach(|py| {
+                // Take a strong reference and release the borrow before calling into
+                // Python: the callback may start or stop this very timer.
+                let Some(callback) = slot.borrow().as_ref().map(|cb| cb.clone_ref(py)) else {
+                    // Cleared by `__clear__` while the timer was still armed.
+                    return;
+                };
                 if let Err(err) = callback.call0(py) {
                     crate::handle_unraisable(
                         py,
@@ -156,5 +177,27 @@ impl PyTimer {
     #[getter]
     fn interval(&self) -> core::time::Duration {
         self.timer.interval()
+    }
+
+    fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+        // i-slint-core stores the callback inside a boxed closure in a thread local, where
+        // Python's cyclic GC can't see it. Report it here, so that the common
+        // `self.timer.start(..., self.on_tick)` pattern - a cycle through the timer - stays
+        // collectable.
+        if let Ok(slot) = self.callback.try_borrow()
+            && let Some(callback) = slot.as_ref()
+        {
+            visit.call(callback)?;
+        }
+        Ok(())
+    }
+
+    fn __clear__(&mut self) {
+        // Stop first: the closure in the core timer list outlives this call and would
+        // otherwise keep firing as a no-op until the timer is dropped.
+        self.timer.stop();
+        // `and_then` drops the borrow before yielding the callback, so releasing it here
+        // is already outside the borrow.
+        let _ = self.callback.try_borrow_mut().ok().and_then(|mut slot| slot.take());
     }
 }


### PR DESCRIPTION
`SlintEventLoop.call_later()` arms a native timer whose completion callback closed over that timer, while the timer holds the callback through a boxed closure in i-slint-core's timer list. The cyclic GC couldn't break that: `Timer` had no `__traverse__`, so the reference inside the Rust closure was invisible and the type wasn't even GC-tracked. Each `asyncio.sleep()` leaked two timers, ~15 objects.

`Timer` now keeps the callback in a slot shared with that closure and implements `__traverse__`/`__clear__` over it, so clearing releases the closure's reference too. This also covers the pattern from `Timer`'s own documentation, where an object owns the timer and passes it a bound method. `call_later()` additionally holds pending timers in a dict keyed by a serial number and captures only that key, so the hot asyncio path builds no cycle to collect in the first place.

changelog: Python: Fixed a memory leak when repeatedly awaiting `asyncio.sleep()`, and when a `Timer` callback refers back to the object owning the timer. (#12679)

Fixes #12679

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
