### PR TITLE
Android: let a pending redraw shorten the poll timeout

### DIFF
--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -110,6 +110,11 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
                     None => frame_duration,
                 })
             }
+            // `request_redraw()` only raises the flag, so a request issued outside the
+            // poll would otherwise wait here for an unrelated wakeup.
+            if self.window.pending_redraw.get() {
+                timeout = Some(Duration::ZERO);
+            }
             let mut r = Ok(ControlFlow::Continue(()));
             self.app.poll_events(timeout, |e| {
                 i_slint_core::platform::update_timers_and_animations();


### PR DESCRIPTION
Fixes #12687.

`request_redraw()` on this backend only raises a flag, and the flag takes no
part in computing the poll timeout. An application that drives frames from the
rendering notifier, each frame requesting the next, therefore issues its request
after `poll_events` has already returned, and the loop goes back to sleep until
an unrelated wakeup arrives. On a Xiaomi 13 that left 928ms of idle in every
frame and pinned the application at one frame per second while the GPU work took
55ms. The issue has the full readings and the reasoning that ruled out the
application side.

Zeroing the timeout when a redraw is already pending is the smallest change that
honours the `WindowAdapter::request_redraw` contract: the poll returns
immediately, the existing code below renders, and a loop with no pending request
keeps sleeping exactly as before. The winit backend forwards the request to the
windowing system for the same reason.

Measured on the same device after the change: 12.92ms per frame (77fps), 0.79ms
idle. Twenty five minutes of continuous rendering put the battery at 35.0°C
against a 33.0°C baseline.

Pacing is left to the application, which is what the desktop backends do. Wiring
this to the Choreographer would be the better answer for "throttled to the
screen refresh rate", and I am happy to rework this if you would rather have
that.

One thing I checked: `PollEvent` has a `Timeout` variant and the poll callback
calls `update_timers_and_animations()` for every event including that one, so a
zero timeout does not starve Slint's timers or animations.
