### PR TITLE
deps: bump brace-expansion to 2.1.3 (CVE-2026-14257)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4372,8 +4372,8 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.3:
+    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -12054,7 +12054,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -14690,15 +14690,15 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimatch@7.4.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
minimatch 5.1.9, 7.4.9 and 9.0.9 all resolved to brace-expansion 2.1.2, which is still vulnerable. It ships a patched dist/commonjs/index.js and an advisory note, but its `main` points at the root index.js, which has no maxLength bound. A ~7.5 KB pattern is enough to crash the process with an uncatchable out-of-memory error.

The 2.x backport landed in 2.1.3 and satisfies the existing ^2.0.1 and ^2.0.2 ranges, so this is a lockfile-only change. This closes the runtime-scope exposure, since vscode-languageclient 9.0.1 is a dependency of the VS Code extension and pulls minimatch 5.1.9.

The 5.x copy was already handled in 5ccb3449fe.
brace-expansion 1.1.16 stays, as no fixed 1.x release exists. It is reachable only through the dev-only vscode-tmgrammar-test -> glob@7 -> minimatch@3.1.5 chain, and minimatch 3 skips expand() for brace-free patterns like the tests/grammar/*.slint literal it runs against.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
