### PR TITLE
FlexboxLayout: honor flex-basis correctly

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1237,6 +1237,17 @@ impl FlexboxLayoutItemInfo {
             self.hypothetical_main_size()
         }
     }
+
+    /// The item's minimum size along the main axis.
+    /// An item that cannot shrink (`flex-shrink: 0`) never goes below its hypothetical
+    /// main size, so that is what it contributes; anything else can be squeezed down
+    /// to its own minimum.
+    ///
+    /// Never below `constraint.min`, since `hypothetical_main_size()` is already clamped to it.
+    #[must_use]
+    fn flex_min_main(&self) -> Coord {
+        if self.flex_shrink <= 0. { self.hypothetical_main_size() } else { self.constraint.min }
+    }
 }
 
 /// Solve a BoxLayout
@@ -1967,10 +1978,10 @@ pub fn flexbox_layout_info_main_axis(
     }
     let num_spacings = cells.len().saturating_sub(1) as Coord;
     let min = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
-        cells.iter().map(|c| c.constraint.min).sum::<Coord>() + spacing * num_spacings + extra_pad
+        cells.iter().map(|c| c.flex_min_main()).sum::<Coord>() + spacing * num_spacings + extra_pad
     } else {
         // Wrapping: the widest single item must fit
-        cells.iter().map(|c| c.constraint.min).fold(0.0 as Coord, |a, b| a.max(b)) + extra_pad
+        cells.iter().map(|c| c.flex_min_main()).fold(0.0 as Coord, |a, b| a.max(b)) + extra_pad
     };
     let preferred = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
         // No wrapping: all items on one line

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1201,6 +1201,44 @@ impl From<LayoutItemInfo> for FlexboxLayoutItemInfo {
     }
 }
 
+impl FlexboxLayoutItemInfo {
+    /// The item's size along the main axis before growing or shrinking:
+    /// `flex-basis` when set (>= 0), otherwise the preferred size,
+    /// clamped to the item's min/max. This is CSS's hypothetical main size.
+    ///
+    /// Only meaningful for the main-axis cell list,
+    /// since `flex-basis` always refers to the main axis.
+    /// The cross axis must use `preferred_bounded()`.
+    #[must_use]
+    fn hypothetical_main_size(&self) -> Coord {
+        if self.flex_basis >= 0 as Coord {
+            self.flex_basis.min(self.constraint.max).max(self.constraint.min)
+        } else {
+            self.constraint.preferred_bounded()
+        }
+    }
+
+    /// What the item contributes to the container's preferred main size.
+    ///
+    /// A growable item treats its basis as a floor to grow from rather than a cap,
+    /// so it still needs room for its content: `flex-basis: 0` with `flex-grow: 1`
+    /// (the CSS `flex: 1 1 0` idiom) must not collapse the container to nothing.
+    ///
+    /// Taking the larger of the two is what taffy does: its max-content flex
+    /// fraction divides by the grow factor and then multiplies by it again, so the
+    /// factor cancels and an item contributes `max(content, basis)`. The spec would
+    /// scale every item by the line's largest fraction instead, but taffy, Chrome
+    /// and Firefox all skip that step.
+    #[must_use]
+    fn flex_preferred_main(&self) -> Coord {
+        if self.flex_grow > 0. {
+            self.hypothetical_main_size().max(self.constraint.preferred_bounded())
+        } else {
+            self.hypothetical_main_size()
+        }
+    }
+}
+
 /// Solve a BoxLayout
 pub fn solve_box_layout(data: &BoxLayoutData, repeater_indices: Slice<u32>) -> SharedVector<Coord> {
     let mut result = SharedVector::<Coord>::default();
@@ -1905,7 +1943,7 @@ pub fn flexbox_layout_unwrapped_main(
         return extra_pad;
     }
     let num_spacings = cells.len().saturating_sub(1) as Coord;
-    cells.iter().map(|c| c.constraint.preferred_bounded()).sum::<Coord>()
+    cells.iter().map(|c| c.flex_preferred_main()).sum::<Coord>()
         + spacing * num_spacings
         + extra_pad
 }
@@ -1951,18 +1989,17 @@ pub fn flexbox_layout_info_main_axis(
         // products (and their sum) would overflow for large items.
         let total_area: f64 = cells
             .iter()
-            .map(|c| c.constraint.preferred_bounded() as f64 + spacing as f64)
+            .map(|c| c.flex_preferred_main() as f64 + spacing as f64)
             .map(|w| w * w)
             .sum();
         let target = Float::sqrt(total_area as f32) as Coord;
         let mut acc = 0 as Coord;
         let mut started = false;
         for c in cells.iter() {
-            acc += if started {
-                spacing + c.constraint.preferred_bounded()
-            } else {
-                c.constraint.preferred_bounded()
-            };
+            // taffy breaks the lines on the hypothetical size, before any growing,
+            // so the line fitting has to measure the items the same way.
+            let size = c.hypothetical_main_size();
+            acc += if started { spacing + size } else { size };
             started = true;
             if acc >= target {
                 break;
@@ -2054,9 +2091,7 @@ pub fn flexbox_layout_info_cross_axis(
         let total_area: f64 = main_cells
             .iter()
             .zip(cross_cells.iter())
-            .map(|(m, c)| {
-                m.constraint.preferred_bounded() as f64 * c.constraint.preferred_bounded() as f64
-            })
+            .map(|(m, c)| m.flex_preferred_main() as f64 * c.constraint.preferred_bounded() as f64)
             .sum();
         let count = main_cells.len();
         Float::sqrt(total_area as f32) as Coord

--- a/tests/cases/layout/flexbox_basis_preferred_size.slint
+++ b/tests/cases/layout/flexbox_basis_preferred_size.slint
@@ -1,0 +1,585 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The FlexboxLayout's own preferred size must account for flex-basis, which
+// replaces the item's preferred size along the main axis. Otherwise the parent
+// gives the flexbox less room than it lays its children out at, and the
+// children overflow their own layout.
+//
+// Reading the rendered window: the orange outline is the size the flexbox asked
+// its parent for, blue cells carry a flex-basis, gray cells don't, and a pale
+// outlined bar is a size that got discarded or clamped. Every cell must sit
+// exactly inside the orange outline - a cell spilling out of it is the bug.
+//
+// The cells stay plain `Rectangle`s so the tested layout-info is unchanged, and
+// the labels and outlines set `x`/`y` so they stay out of their parent's
+// layout-info (see gen_layout_info_prop in default_geometry.rs) - without that a
+// label wider than its cell would push the cell's preferred size around.
+// Each case keeps a fixed size, since the tests run without showing a window.
+
+// Drawn on top of the cells, over the whole element that wraps the flexbox, so
+// it shows the size the flexbox reported to its parent.
+component FlexboxOutline inherits Rectangle {
+    border-width: 2px;
+    border-color: #d35400;
+}
+
+// Row: preferred width comes from flex-basis, not preferred-width
+component TestBasisRow inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "row: flex-basis replaces preferred-width (50px) → 200 + 100 = 300"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        preferred-width: 50px;
+                        flex-basis: 200px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 200"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    r2 := Rectangle {
+                        preferred-width: 50px;
+                        flex-basis: 100px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    // 200 + 100, and the children get exactly what the flexbox asked for
+    out property <bool> test_fl: fl.width == 300px;
+    out property <bool> test_r1: r1.width == 200px;
+    out property <bool> test_r2: r2.width == 100px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// Column: the main axis is vertical, so flex-basis feeds the preferred height
+component TestBasisColumn inherits Rectangle {
+    width: 520px;
+    height: 222px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "column: the main axis is vertical → basis feeds the height, 150 + 50 = 200"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-direction: column;
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        preferred-height: 20px;
+                        flex-basis: 150px;
+                        width: 100px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 150"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    r2 := Rectangle {
+                        preferred-height: 20px;
+                        flex-basis: 50px;
+                        width: 100px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 50"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.height == 200px;
+    out property <bool> test_r1: r1.height == 150px;
+    out property <bool> test_r2: r2.height == 50px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// Negative invariant: flex-basis is main-axis only and must leave the cross
+// axis alone — a row flex's height still comes from the item's preferred height
+component TestBasisNotCrossAxis inherits Rectangle {
+    width: 520px;
+    height: 52px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "cross axis untouched: basis 200 is main-axis only, the height stays the 30px preferred"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            VerticalLayout {
+                alignment: start;
+                Rectangle {
+                    fl := FlexboxLayout {
+                        flex-wrap: no-wrap;
+                        Rectangle {
+                            flex-basis: 200px;
+                            preferred-width: 20px;
+                            preferred-height: 30px;
+                            background: #cce6ff;
+                            border-width: 1px;
+                            border-color: #5b8db8;
+                            Text { x: 0px; width: 100%; height: 100%; text: "basis 200, preferred 20 × 30"; font-size: 10px; color: #003366;
+                                horizontal-alignment: center; vertical-alignment: center; }
+                        }
+                    }
+                    FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+                }
+            }
+        }
+    }
+
+    out property <bool> test: fl.height == 30px;
+}
+
+// flex-basis stays clamped by the item's own min/max, like a preferred size
+component TestBasisClamped inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "max-width clamps the basis down: basis 200 with max-width 80 → 80"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            spacing: 6px;
+            Rectangle {
+                width: 200px;
+                height: 24px;
+                border-width: 1px;
+                border-color: #c8c8c8;
+                Text { x: 0px; width: 100%; height: 100%; text: "basis 200"; font-size: 10px; color: #999999;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            Text { text: "→"; font-size: 11px; vertical-alignment: center; }
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        flex-basis: 200px;
+                        max-width: 80px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "max 80"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 80px;
+    out property <bool> test_r1: r1.width == 80px;
+    out property <bool> test: test_fl && test_r1;
+}
+
+// The basis is clamped up to the item's min, not just down to its max.
+// The second item has no min of its own, so the flexbox's reported minimum (80)
+// stays below its preferred size and cannot mask a missing clamp.
+component TestBasisBelowMin inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "min-width clamps the basis up: basis 20 with min-width 80 → 80, plus a 200px sibling = 280"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        flex-basis: 20px;
+                        min-width: 80px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "min 80"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    r2 := Rectangle {
+                        preferred-width: 200px;
+                        height: 24px;
+                        background: #dcdcdc;
+                        border-width: 1px;
+                        border-color: #a0a0a0;
+                        Text { x: 0px; width: 100%; height: 100%; text: "no basis, preferred 200"; font-size: 10px; color: #333333;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 280px;
+    out property <bool> test_r1: r1.width == 80px;
+    out property <bool> test_r2: r2.width == 200px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// With spacing, the flexbox must reserve basis + spacing
+component TestBasisSpacing inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "spacing is reserved too: 100 + 10 + 100 = 210"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    spacing: 10px;
+                    r1 := Rectangle {
+                        flex-basis: 100px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    r2 := Rectangle {
+                        flex-basis: 100px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 210px;
+    out property <bool> test_r1: r1.width == 100px;
+    out property <bool> test_r2: r2.width == 100px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// Without flex-grow the basis caps as well as floors: `flex-basis: 0` collapses
+// the item and the container with it. Contrast TestBasisZeroGrow.
+component TestBasisZeroNoGrow inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "basis 0 without flex-grow collapses the item: the 90px preferred width is discarded"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            spacing: 6px;
+            Rectangle {
+                width: 90px;
+                height: 24px;
+                border-width: 1px;
+                border-color: #c8c8c8;
+                Text { x: 0px; width: 100%; height: 100%; text: "preferred 90"; font-size: 10px; color: #999999;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            Text { text: "→"; font-size: 11px; vertical-alignment: center; }
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        flex-basis: 0px;
+                        preferred-width: 90px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+            Text { text: "nothing left to draw"; font-size: 10px; color: #999999; vertical-alignment: center; }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 0px;
+    out property <bool> test_r1: r1.width == 0px;
+    out property <bool> test: test_fl && test_r1;
+}
+
+// A growable item treats its basis as a floor, not a cap, so `flex: 1 1 0`
+// must not collapse the container: the items still need room for their content.
+component TestBasisZeroGrow inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "flex: 1 1 0 — container is 50 + 250 of content, then shared equally → 150 each"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        flex-grow: 1;
+                        flex-basis: 0px;
+                        preferred-width: 50px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "grow 1, content 50"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    r2 := Rectangle {
+                        flex-grow: 1;
+                        flex-basis: 0px;
+                        preferred-width: 250px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "grow 1, content 250"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    // Each item contributes its own content size, so the container is 50 + 250.
+    // The space is then shared equally, leaving r2 narrower than its content:
+    // that overflow is what taffy, Chrome and Firefox all do for `flex: 1 1 0`.
+    out property <bool> test_fl: fl.width == 300px;
+    out property <bool> test_r1: r1.width == 150px;
+    out property <bool> test_r2: r2.width == 150px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// Unequal grow factors do not change what the items contribute: the grow factor
+// cancels out of the max-content calculation, so the container is still the sum
+// of the content sizes and the space is then shared in proportion.
+component TestBasisZeroGrowUneven inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "same with grow factors 1 and 3: container is still 60 + 60, then shared 1:3 → 30 and 90"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        flex-grow: 1;
+                        flex-basis: 0px;
+                        preferred-width: 60px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "1"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                    r2 := Rectangle {
+                        flex-grow: 3;
+                        flex-basis: 0px;
+                        preferred-width: 60px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "3"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    // 60 + 60 of content, then the 120px is shared 1:3
+    out property <bool> test_fl: fl.width == 120px;
+    out property <bool> test_r1: r1.width == 30px;
+    out property <bool> test_r2: r2.width == 90px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// A basis above the content size still wins on a growable item, so growing
+// must not be confused with "ignore the basis"
+component TestBasisAboveContentGrow inherits Rectangle {
+    width: 520px;
+    height: 44px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "growing does not mean ignoring the basis: basis 200 beats the 50px content"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                fl := FlexboxLayout {
+                    flex-wrap: no-wrap;
+                    r1 := Rectangle {
+                        flex-grow: 1;
+                        flex-basis: 200px;
+                        preferred-width: 50px;
+                        height: 24px;
+                        background: #cce6ff;
+                        border-width: 1px;
+                        border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "grow 1, basis 200, content 50"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; }
+                    }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 200px;
+    out property <bool> test_r1: r1.width == 200px;
+    out property <bool> test: test_fl && test_r1;
+}
+
+// The wrapping preferred-size heuristic is fed by the basis too
+component TestBasisWrap inherits Rectangle {
+    width: 520px;
+    height: 152px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "wrap: four 100px items aim for a square 2×2 → 200 wide (spare height here, so the rows spread)"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            Rectangle {
+                height: 130px;
+                fl := FlexboxLayout {
+                    flex-wrap: wrap;
+                    r1 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; } }
+                    r2 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; } }
+                    r3 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; } }
+                    r4 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                        Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                            horizontal-alignment: center; vertical-alignment: center; } }
+                }
+                FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+            }
+        }
+    }
+
+    // Four 100px items aim for a roughly square 2x2 arrangement. The parent
+    // stretches the flexbox vertically, so the rows are compared to each other
+    // rather than to a fixed y; TestBasisWrapHeight pins the natural height.
+    out property <bool> test_fl: fl.width == 200px;
+    out property <bool> test_rows: r1.y == r2.y && r3.y == r4.y && r3.y > r1.y;
+    out property <bool> test: test_fl && test_rows;
+}
+
+// Same items, but nothing stretches the flexbox, so its own preferred cross-axis
+// size shows: two rows of 50px items.
+component TestBasisWrapHeight inherits Rectangle {
+    width: 520px;
+    height: 122px;
+    VerticalLayout {
+        alignment: start;
+        Text { text: "same items, nothing stretching them: the flexbox's own preferred size is 200 × 100"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            VerticalLayout {
+                alignment: start;
+                Rectangle {
+                    fl := FlexboxLayout {
+                        flex-wrap: wrap;
+                        r1 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                            Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                                horizontal-alignment: center; vertical-alignment: center; } }
+                        r2 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                            Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                                horizontal-alignment: center; vertical-alignment: center; } }
+                        r3 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                            Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                                horizontal-alignment: center; vertical-alignment: center; } }
+                        r4 := Rectangle { flex-basis: 100px; height: 50px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+                            Text { x: 0px; width: 100%; height: 100%; text: "basis 100"; font-size: 10px; color: #003366;
+                                horizontal-alignment: center; vertical-alignment: center; } }
+                    }
+                    FlexboxOutline { x: 0px; y: 0px; width: 100%; height: 100%; }
+                }
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 200px && fl.height == 100px;
+    out property <bool> test_row1: r1.y == 0px && r2.y == 0px;
+    out property <bool> test_row2: r3.y == 50px && r4.y == 50px;
+    out property <bool> test: test_fl && test_row1 && test_row2;
+}
+
+export component TestCase inherits Window {
+    width: 540px;
+    height: 1100px;
+
+    VerticalLayout {
+        alignment: start;
+        spacing: 12px;
+        padding: 8px;
+        Text {
+            text: "orange outline = the size the flexbox asked its parent for\nblue = cell with a flex-basis, gray = cell without one, pale = a size that got discarded or clamped";
+            font-size: 11px;
+            color: #555555;
+        }
+        t1 := TestBasisRow { }
+        t2 := TestBasisColumn { }
+        t3 := TestBasisNotCrossAxis { }
+        t4 := TestBasisClamped { }
+        t5 := TestBasisBelowMin { }
+        t6 := TestBasisSpacing { }
+        t7 := TestBasisZeroNoGrow { }
+        t8 := TestBasisZeroGrow { }
+        t9 := TestBasisZeroGrowUneven { }
+        t10 := TestBasisAboveContentGrow { }
+        t11 := TestBasisWrap { }
+        t12 := TestBasisWrapHeight { }
+    }
+
+    out property <bool> test: t1.test && t2.test && t3.test && t4.test && t5.test && t6.test
+        && t7.test && t8.test && t9.test && t10.test && t11.test && t12.test;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_no_shrink_min_size.slint
+++ b/tests/cases/layout/flexbox_no_shrink_min_size.slint
@@ -1,0 +1,147 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// An item with flex-shrink: 0 cannot go below its base size, so it must raise
+// the FlexboxLayout's reported minimum. Otherwise a parent squeezes the
+// flexbox below what its own children need and they overflow it.
+
+// No-wrap: the minimum is the sum of what the items refuse to give up
+component TestNoShrinkRow inherits Rectangle {
+    width: 200px;
+    height: 50px;
+    HorizontalLayout {
+        fl := FlexboxLayout {
+            flex-wrap: no-wrap;
+            r1 := Rectangle {
+                preferred-width: 150px;
+                flex-shrink: 0;
+                height: 50px;
+                background: red;
+            }
+            r2 := Rectangle {
+                preferred-width: 150px;
+                flex-shrink: 0;
+                height: 50px;
+                background: green;
+            }
+        }
+    }
+
+    // The parent is only 200px, but the items refuse to shrink below 150 each,
+    // so the flexbox reports (and gets) 300px and overflows the parent instead
+    // of overflowing itself.
+    out property <bool> test_fl: fl.width == 300px;
+    out property <bool> test_r1: r1.width == 150px;
+    out property <bool> test_r2: r2.width == 150px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// Contrast: the same layout with the default flex-shrink does compress
+component TestShrinkableRow inherits Rectangle {
+    width: 200px;
+    height: 50px;
+    HorizontalLayout {
+        fl := FlexboxLayout {
+            flex-wrap: no-wrap;
+            r1 := Rectangle {
+                preferred-width: 150px;
+                height: 50px;
+                background: red;
+            }
+            r2 := Rectangle {
+                preferred-width: 150px;
+                height: 50px;
+                background: green;
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 200px;
+    out property <bool> test_r1: r1.width == 100px;
+    out property <bool> test_r2: r2.width == 100px;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+// An explicit flex-basis is the base size the item refuses to go below
+component TestNoShrinkBasis inherits Rectangle {
+    width: 100px;
+    height: 50px;
+    HorizontalLayout {
+        fl := FlexboxLayout {
+            flex-wrap: no-wrap;
+            r1 := Rectangle {
+                preferred-width: 20px;
+                flex-basis: 120px;
+                flex-shrink: 0;
+                height: 50px;
+                background: red;
+            }
+        }
+    }
+
+    out property <bool> test_fl: fl.width == 120px;
+    out property <bool> test_r1: r1.width == 120px;
+    out property <bool> test: test_fl && test_r1;
+}
+
+// Wrapping: only the widest item has to fit, not the sum
+component TestNoShrinkWrap inherits Rectangle {
+    width: 100px;
+    height: 200px;
+    HorizontalLayout {
+        fl := FlexboxLayout {
+            flex-wrap: wrap;
+            r1 := Rectangle {
+                preferred-width: 150px;
+                flex-shrink: 0;
+                height: 50px;
+                background: red;
+            }
+            r2 := Rectangle {
+                preferred-width: 150px;
+                flex-shrink: 0;
+                height: 50px;
+                background: green;
+            }
+        }
+    }
+
+    // One item per row, each keeping the width it refuses to shrink below. The
+    // parent stretches the flexbox vertically, so the rows are compared to each
+    // other rather than to a fixed y.
+    out property <bool> test_fl: fl.width == 150px;
+    out property <bool> test_r1: r1.width == 150px;
+    out property <bool> test_r2: r2.width == 150px && r2.y > r1.y;
+    out property <bool> test: test_fl && test_r1 && test_r2;
+}
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 600px;
+
+    VerticalLayout {
+        t1 := TestNoShrinkRow { }
+        t2 := TestShrinkableRow { }
+        t3 := TestNoShrinkBasis { }
+        t4 := TestNoShrinkWrap { }
+    }
+
+    out property <bool> test: t1.test && t2.test && t3.test && t4.test;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
FlexboxLayout: account for flex-basis in the container's main-axis size

flex-basis replaces the item's preferred size along the main axis, but
flexbox_layout_info_main_axis() and flexbox_layout_unwrapped_main() summed
preferred_bounded() and ignored it. A parent then sized the flexbox from the
items' preferred sizes while taffy laid the items out at their basis, so the
children overflowed their own layout.

A growable item is the exception: it treats its basis as a floor to grow from
rather than a cap, so it still needs room for its content, and summing the
bases would collapse `flex-basis: 0` with `flex-grow: 1` (the CSS `flex: 1 1 0`
idiom) to nothing. Taking the larger of the two is also what taffy does: its
max-content flex fraction divides by the grow factor and then multiplies by it
again, so the factor cancels out. The spec would scale every item by the line's
largest fraction instead, but taffy, Chrome and Firefox all skip that step.

The wrap heuristic measures items twice over, on purpose. The sqrt-area target
uses the preferred contributions, since it estimates how much there is to
place, but the line fitting uses the hypothetical sizes, because taffy breaks
flex lines before any growing happens and the two must agree on where a line
ends.

The basis counts on both axes alike. That is what taffy does for a column; for
a row it leaves the basis out of the max-content size instead, matching Webkit
and Firefox, which is what lets the children overflow. That asymmetry comes
from CSS sizing the inline axis shrink-to-fit and the block axis to max-content
-- a writing-mode rule Slint has no equivalent of, so there is nothing here to
tell a row and a column apart.

The cross-axis info goes through taffy, which already honors the basis, so
only the main-axis path (plus the sqrt-area wrap heuristics on both) needed
the new helpers.

Reporting min from the basis is still missing: an item with flex-shrink: 0
cannot shrink below it, but that needs the shrink factor in the min
computation and is left for a follow-up.

Before/after screenshot

<img width="1441" height="1466" alt="image" src="https://github.com/user-attachments/assets/5fdbfa14-76a5-4b2d-ac4a-d4eba8b83e8e" />

---

FlexboxLayout: a non-shrinkable item raises the container's minimum

Follow-up to the previous commit, which left this out: flexbox_layout_info_main_axis()
took each item's own min, but an item with flex-shrink: 0 never goes below its
hypothetical main size, so that is its real contribution. A parent could squeeze
the flexbox below what its children need and they would overflow it.

Note this is not limited to an explicit flex-basis: the hypothetical main size
falls back to the preferred size, so flex-shrink: 0 alone is enough.
flex_min_main() is never below constraint.min, so the reported minimum can only
grow.

