### PR TITLE
docs: invert SC tagging to opt-in with <SC>

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -230,6 +230,7 @@ fract
 framebuffers
 freetype
 frontends
+frontmatter
 Fsvg
 fullsize
 Fullwidth

--- a/docs/astro/src/content.config.ts
+++ b/docs/astro/src/content.config.ts
@@ -16,10 +16,10 @@ export const collections = {
         loader: glob({ base: "src/content/docs", pattern: docsPattern }),
         schema: docsSchema({
             extend: z.object({
-                // Language-specification chapter that is not part of the
-                // Slint SC subset: the safety manual doesn't include it, and
-                // its `{#sls.…}` identifiers, if any, are dropped.
-                notInSC: z.boolean().optional(),
+                // Chapter that opts into the Slint SC subset: the safety
+                // manual includes the content it wraps in <SC>, and the
+                // `{#sls.…}` identifiers there become traceable anchors.
+                SC: z.boolean().optional(),
             }),
         }),
     }),

--- a/docs/astro/src/content/docs/reference/language/animations.mdx
+++ b/docs/astro/src/content/docs/reference/language/animations.mdx
@@ -1,7 +1,6 @@
 ---
 title: Animations
 description: Animating property changes with the animate keyword.
-notInSC: true
 ---
 
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';

--- a/docs/astro/src/content/docs/reference/language/bindings.mdx
+++ b/docs/astro/src/content/docs/reference/language/bindings.mdx
@@ -1,11 +1,13 @@
 ---
 title: Bindings
 description: Assigning expressions to properties.
+SC: true
 ---
 
-import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
+import SC from '@slint/common-files/src/components/SC.astro';
 import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
 
+<SC>
 A binding assigns an [expression](../expressions/) to a [property](../properties/) of the element in whose body it appears.
 It has the form of a property name, followed by `:`, an expression, and `;`. \{#sls.binding.form}
 
@@ -26,8 +28,7 @@ Every property and every expression has a type: `color`, `length`, or `brush`. \
 An expression whose type is not the type of the property binds to it only when a conversion applies. \{#sls.type.conversions}
 
 The type of the expression shall be the type of the property, or [convert](#sls.type.conversions) to it. \{#sls.binding.type}
+</SC>
 
-<NotInSC>
 A binding can also hold a [code block](../statements/),
 and the [`<=>` operator](../two-way-bindings/) links two properties.
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/language/callbacks.mdx
+++ b/docs/astro/src/content/docs/reference/language/callbacks.mdx
@@ -1,7 +1,6 @@
 ---
 title: Callbacks
 description: Declaring callbacks, setting handlers, aliases, and change callbacks.
-notInSC: true
 ---
 
 A *callback* is a member that carries an invocation from one place to another.

--- a/docs/astro/src/content/docs/reference/language/container-components.mdx
+++ b/docs/astro/src/content/docs/reference/language/container-components.mdx
@@ -1,7 +1,6 @@
 ---
 title: Container Components
 description: Controlling where child elements are placed with @children.
-notInSC: true
 ---
 
 When a component is used in an element tree, the child elements written inside its use site belong to that component.

--- a/docs/astro/src/content/docs/reference/language/evaluation-and-purity.mdx
+++ b/docs/astro/src/content/docs/reference/language/evaluation-and-purity.mdx
@@ -1,7 +1,6 @@
 ---
 title: Evaluation and Purity
 description: How bindings are evaluated, dependency tracking, and pure contexts.
-notInSC: true
 ---
 
 ## Dependency Tracking

--- a/docs/astro/src/content/docs/reference/language/exports.mdx
+++ b/docs/astro/src/content/docs/reference/language/exports.mdx
@@ -1,10 +1,12 @@
 ---
 title: Exports
 description: Making components in a file available to other files.
+SC: true
 ---
 
-import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
+import SC from '@slint/common-files/src/components/SC.astro';
 
+<SC>
 ## Placement
 
 Export statements may appear at the top level of a `.slint` source file, interleaved with [component definitions](../file-structure/#sls.file.component.definition-forms). \{#sls.export.placement}
@@ -43,8 +45,7 @@ Each identifier on the left of `as`, and each bare identifier, shall refer to a 
 
 A source file shall not export the same external name more than once.
 This includes the combination of any declaration-site export and any export-list entry. \{#sls.export.no-duplicates}
+</SC>
 
-<NotInSC>
 An export statement with a `from` clause [re-exports](../imports/#re-exports) declarations from another file.
 Besides components, [structs, enums](../structs-and-enums/), and [globals](../globals/) can be exported.
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/language/expressions.mdx
+++ b/docs/astro/src/content/docs/reference/language/expressions.mdx
@@ -1,19 +1,21 @@
 ---
 title: Expressions
 description: The expression forms and what they evaluate to.
+SC: true
 ---
 
-import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
+import SC from '@slint/common-files/src/components/SC.astro';
 
+<SC>
 An expression is a color literal or a length literal. \{#sls.expr.forms}
+</SC>
 
-<NotInSC>
 Further expression forms exist:
 [operators](../operators/), [member access](../operators/#member-access-and-indexing),
 function and callback calls, and the literals of the other
 [built-in types](../../property-types/).
-</NotInSC>
 
+<SC>
 ## Color Literals
 
 A color literal consists of `#` followed by 3, 4, 6, or 8 hexadecimal digits:
@@ -47,10 +49,11 @@ The number shall be integral: `10.5px` is an error. \{#sls.expr.length.integral}
 
 `px` is the only unit.
 A number literal with another unit, or without a unit, is an error. \{#sls.expr.length.px-only}
+</SC>
 
-<NotInSC>
 These restrictions apply to Slint SC.
 The full Slint language accepts fractional values and other units.
-</NotInSC>
 
+<SC>
 A length literal evaluates to a value of type `length`. \{#sls.expr.length.type}
+</SC>

--- a/docs/astro/src/content/docs/reference/language/file-structure.mdx
+++ b/docs/astro/src/content/docs/reference/language/file-structure.mdx
@@ -1,8 +1,12 @@
 ---
 title: File Structure
 description: Top-level structure of a Slint source file and the basic form of component definitions.
+SC: true
 ---
 
+import SC from '@slint/common-files/src/components/SC.astro';
+
+<SC>
 ## A Slint Source File
 
 A `.slint` source file is a sequence of zero or more *top-level items*, separated only by whitespace and comments. \{#sls.file.source-file}
@@ -65,3 +69,4 @@ export component Hello inherits Window {
 ```
 
 It exports one component, `Hello`, which inherits from `Window` and whose body contains two top-level `Rectangle` instantiations. \{#sls.file.example.description}
+</SC>

--- a/docs/astro/src/content/docs/reference/language/functions.mdx
+++ b/docs/astro/src/content/docs/reference/language/functions.mdx
@@ -1,7 +1,6 @@
 ---
 title: Functions
 description: Declaring and calling functions.
-notInSC: true
 ---
 
 A *function* names a block of Slint logic that takes parameters and returns a value.

--- a/docs/astro/src/content/docs/reference/language/geometry.mdx
+++ b/docs/astro/src/content/docs/reference/language/geometry.mdx
@@ -1,11 +1,13 @@
 ---
 title: Geometry
 description: Position and size of elements.
+SC: true
 ---
 
-import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
+import SC from '@slint/common-files/src/components/SC.astro';
 import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
 
+<SC>
 ## Properties
 
 Every element has the four geometry properties `x`, `y`, `width`, and `height`, of type `length`. \{#sls.geom.properties}
@@ -18,12 +20,12 @@ The `x` and `y` properties of the root element are meaningless and shall not be 
 <OnlyInSC>
 Binding a geometry property of the root element is an error. \{#sls.geom.window}
 </OnlyInSC>
+</SC>
 
-<NotInSC>
 Binding `x` or `y` of the root element is deprecated.
 The window size can be set through `width` and `height`.
-</NotInSC>
 
+<SC>
 ## Defaults
 
 When `x` has no binding, it defaults to `(parent.width - self.width) / 2`,
@@ -32,11 +34,11 @@ the value that centers the element within its parent along that axis. \{#sls.geo
 
 When `width` or `height` has no binding, the default depends on the element type:
 a `Rectangle` has the same width or height as its parent. \{#sls.geom.default-size}
+</SC>
 
-<NotInSC>
 Elements inside a layout are positioned and sized by the layout instead of these defaults.
-</NotInSC>
 
+<SC>
 In this example, both rectangles cover the whole window: \{#sls.geom.example.intro}
 
 ```slint
@@ -48,9 +50,8 @@ export component Example inherits Window {
     }
 }
 ```
+</SC>
 
-<NotInSC>
 A binding of `width` or `height` that evaluates to a [percentage](../../property-types/numeric-types/#percent)
 is relative to the parent's property of the same name:
 `width: 50%;` is short for `width: parent.width * 50%;`.
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/language/globals.mdx
+++ b/docs/astro/src/content/docs/reference/language/globals.mdx
@@ -1,7 +1,6 @@
 ---
 title: Globals
 description: Global singletons for properties and callbacks shared across the project.
-notInSC: true
 ---
 
 A *global* is a singleton declared at the top level of a `.slint` file with the `global` keyword.

--- a/docs/astro/src/content/docs/reference/language/imports.mdx
+++ b/docs/astro/src/content/docs/reference/language/imports.mdx
@@ -1,7 +1,6 @@
 ---
 title: Imports
 description: Bringing declarations from other files into scope.
-notInSC: true
 ---
 
 An import statement brings exported declarations from another file into the importing file's namespace. \{#sls.import.semantics}

--- a/docs/astro/src/content/docs/reference/language/index.mdx
+++ b/docs/astro/src/content/docs/reference/language/index.mdx
@@ -1,8 +1,12 @@
 ---
 title: Slint Language Specification
 description: Normative reference for the .slint markup language and the behavior it prescribes.
+SC: true
 ---
 
+import SC from '@slint/common-files/src/components/SC.astro';
+
+<SC>
 :::caution[Work in Progress]
 This specification is a work in progress and doesn't yet cover the whole Slint language.
 :::
@@ -26,3 +30,4 @@ Other prose is informative. \{#sls.meta.conventions.normative}
 ### Code Examples
 
 Code examples are formatted as `slint` fenced code blocks and are informative unless explicitly stated otherwise. \{#sls.meta.conventions.examples}
+</SC>

--- a/docs/astro/src/content/docs/reference/language/lexical-structure.mdx
+++ b/docs/astro/src/content/docs/reference/language/lexical-structure.mdx
@@ -1,10 +1,12 @@
 ---
 title: Lexical Structure
 description: Identifiers, contextual keywords, and element type names in the Slint language.
+SC: true
 ---
 
-import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
+import SC from '@slint/common-files/src/components/SC.astro';
 
+<SC>
 ## Tokens
 
 After whitespace and comments are removed (see [Source Files](../source-files/)), the remaining input is a sequence of tokens. \{#sls.lex.tokens}
@@ -35,8 +37,8 @@ The kebab-case form (with `U+002D`) is the canonical written form. \{#sls.lex.id
 
 Slint has no globally reserved words.
 Each language construct is introduced by a *contextual keyword*: an identifier that has a special meaning only when it appears in a position where the grammar expects that construct. \{#sls.lex.contextual-keywords}
+</SC>
 
-<NotInSC>
 :::note[The @ sigil]
 The `@` character introduces a fixed set of built-in constructs that can't be declared, each with its own parsing rules.
 Writing any other name after `@` is an error.
@@ -47,4 +49,3 @@ The constructs are:
 - [`@linear-gradient`, `@radial-gradient`, and `@conic-gradient`](../../property-types/colors-and-brushes/) build a gradient `brush`.
 - [`@children`](../container-components/) marks where a container component places its children.
 :::
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/language/name-resolution.mdx
+++ b/docs/astro/src/content/docs/reference/language/name-resolution.mdx
@@ -1,7 +1,6 @@
 ---
 title: Name Resolution
 description: Element names, pre-defined names, and lookup rules.
-notInSC: true
 ---
 
 Name resolution decides which declaration an identifier in an expression refers to.

--- a/docs/astro/src/content/docs/reference/language/operators.mdx
+++ b/docs/astro/src/content/docs/reference/language/operators.mdx
@@ -1,7 +1,6 @@
 ---
 title: Operators
 description: The operators of the Slint language.
-notInSC: true
 ---
 
 Slint has arithmetic, comparison, logical, and ternary operators, plus member access and indexing.

--- a/docs/astro/src/content/docs/reference/language/properties.mdx
+++ b/docs/astro/src/content/docs/reference/language/properties.mdx
@@ -1,11 +1,13 @@
 ---
 title: Properties
 description: Declaring properties on elements.
+SC: true
 ---
 
-import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
+import SC from '@slint/common-files/src/components/SC.astro';
 import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
 
+<SC>
 An element has a set of named *properties*, determined by the type of the element.
 A property holds a value. \{#sls.prop.def}
 
@@ -39,23 +41,22 @@ Private is the default: a declaration without a modifier declares a private prop
 <OnlyInSC>
 Properties shall only be declared on the root element. \{#sls.prop.decl.root-only}
 </OnlyInSC>
+</SC>
 
-<NotInSC>
 Properties can be declared on any element.
-</NotInSC>
 
+<SC>
 <OnlyInSC>
 The declared type shall be `length` or `color`. \{#sls.prop.decl.types}
 </OnlyInSC>
+</SC>
 
-<NotInSC>
 Any [property type](../../property-types/) can be declared.
-</NotInSC>
 
+<SC>
 Without a binding, the property has the default value of its
 type. \{#sls.prop.decl.default}
+</SC>
 
-<NotInSC>
 A [change callback](../callbacks/#change-callbacks) reacts to a property's value changing,
 and a declaration with a [two-way binding](../two-way-bindings/) links the new property to an existing one.
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/language/repetition-and-conditional-elements.mdx
+++ b/docs/astro/src/content/docs/reference/language/repetition-and-conditional-elements.mdx
@@ -1,7 +1,6 @@
 ---
 title: Repetition and Conditional Elements
 description: Instantiating elements with for and if.
-notInSC: true
 ---
 
 A *repeated element* and a *conditional element* instantiate a single element,

--- a/docs/astro/src/content/docs/reference/language/source-files.mdx
+++ b/docs/astro/src/content/docs/reference/language/source-files.mdx
@@ -1,8 +1,12 @@
 ---
 title: Source Files
 description: Slint source file extension, encoding, line terminators, whitespace, and comments.
+SC: true
 ---
 
+import SC from '@slint/common-files/src/components/SC.astro';
+
+<SC>
 ## File Extension
 
 Slint source files use the file extension `.slint`. \{#sls.source.file-extension}
@@ -45,3 +49,4 @@ The token sequences `///` and `/**` are recognized as ordinary line and block co
 
 /* Block comments /* may be nested */ like this. */
 ```
+</SC>

--- a/docs/astro/src/content/docs/reference/language/statements.mdx
+++ b/docs/astro/src/content/docs/reference/language/statements.mdx
@@ -1,7 +1,6 @@
 ---
 title: Statements
 description: The statements allowed in callback handlers and function bodies.
-notInSC: true
 ---
 
 A *code block* is a sequence of statements enclosed in `{ ... }`.

--- a/docs/astro/src/content/docs/reference/language/states-and-transitions.mdx
+++ b/docs/astro/src/content/docs/reference/language/states-and-transitions.mdx
@@ -1,7 +1,6 @@
 ---
 title: States and Transitions
 description: Declaring states and animating state changes.
-notInSC: true
 ---
 
 A `states` block declares a set of named *states* on an element.

--- a/docs/astro/src/content/docs/reference/language/structs-and-enums.mdx
+++ b/docs/astro/src/content/docs/reference/language/structs-and-enums.mdx
@@ -1,7 +1,6 @@
 ---
 title: Structs and Enums
 description: Declaring named structures and enumerations.
-notInSC: true
 ---
 
 ## Structs

--- a/docs/astro/src/content/docs/reference/language/two-way-bindings.mdx
+++ b/docs/astro/src/content/docs/reference/language/two-way-bindings.mdx
@@ -1,7 +1,6 @@
 ---
 title: Two-Way Bindings
 description: Linking two properties with the <=> operator.
-notInSC: true
 ---
 
 A *two-way binding*, written with `<=>`, links two properties so that they always hold the same value;

--- a/docs/astro/src/content/docs/reference/language/type-conversions.mdx
+++ b/docs/astro/src/content/docs/reference/language/type-conversions.mdx
@@ -1,7 +1,6 @@
 ---
 title: Type Conversions
 description: Implicit and explicit conversions between Slint types.
-notInSC: true
 ---
 
 import Link from '@slint/common-files/src/components/Link.astro';

--- a/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
@@ -1,7 +1,6 @@
 ---
 title: Arrays and Models
 description: Array types, array literals, and their operations.
-notInSC: true
 ---
 
 An *array* type holds an ordered, zero-indexed sequence of values of a single element type.

--- a/docs/astro/src/content/docs/reference/property-types/colors-and-brushes.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/colors-and-brushes.mdx
@@ -1,9 +1,11 @@
 ---
 title: Colors and Brushes
 description: Color literals, the Colors namespace, color functions, and gradients.
+SC: true
 ---
 {/* cSpell: ignore rgbacolor */}
 
+import SC from '@slint/common-files/src/components/SC.astro';
 import Link from '@slint/common-files/src/components/Link.astro';
 import CodeSnippetMD from "@slint/common-files/src/components/CodeSnippetMD.astro";
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
@@ -11,7 +13,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 import LangRefLink from '@slint/common-files/src/components/LangRefLink.astro';
 import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
 
-<NotInSC>
 Color literals follow the syntax of CSS:
 
 ```slint
@@ -28,7 +29,8 @@ draw the outline.
 
 CSS color names are in scope wherever a `color` or `brush` value is expected, including struct
 fields, array elements and function arguments. Elsewhere, access colors from the `Colors` namespace.
-</NotInSC>
+
+<SC>
 
 ## Types
 
@@ -83,8 +85,7 @@ In Python, properties or struct fields of the color type are mapped to <LangRefL
 </Tabs>
 </NotInSC>
 </SlintProperty>
-
-<NotInSC>
+</SC>
 
 ## Color Properties
 
@@ -321,5 +322,3 @@ Instead, use one of these workarounds:
 - Use variables: `property <angle> start: -90deg;` then use `start` in the gradient
 - Use explicit subtraction: `#ff0000 0deg - 90deg`
 :::
-
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/property-types/images.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/images.mdx
@@ -1,7 +1,6 @@
 ---
 title: Images
 description: The image type of the Slint language.
-notInSC: true
 ---
 {/* cSpell: ignore Farbfeld */}
 

--- a/docs/astro/src/content/docs/reference/property-types/index.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Types
 description: The types that properties, arguments, and return values can have.
-notInSC: true
 ---
 
 A *type* is what a [property](../language/properties/), a function or callback argument, or a return value can have:

--- a/docs/astro/src/content/docs/reference/property-types/numeric-types.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/numeric-types.mdx
@@ -1,24 +1,26 @@
 ---
 title: Primitive & Numeric Types
 description: The boolean, numeric, and unit types of the Slint language.
+SC: true
 ---
 
+import SC from '@slint/common-files/src/components/SC.astro';
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';
 import Link from '@slint/common-files/src/components/Link.astro';
 import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
 
-<NotInSC>
 ## Primitive Types
 
 ### bool
 <SlintProperty propName="bool" typeName="bool" defaultValue='false'>
 boolean whose value can be either `true` or `false`.
 </SlintProperty>
-</NotInSC>
+
+<SC>
 
 ## Numeric Types
 
-<NotInSC>
+</SC>
 
 ### angle
 <SlintProperty propName="angle" typeName="angle" defaultValue='0deg'>
@@ -69,7 +71,8 @@ Returns a string representation of the number but not localized. This means the 
 <SlintProperty propName="int" typeName="int" defaultValue='0'>
 Signed integral number.
 </SlintProperty>
-</NotInSC>
+
+<SC>
 
 ### length
 <SlintProperty propName="length" typeName="length" defaultValue='0px'>
@@ -81,7 +84,7 @@ The type used for `x`, `y`, `width` and `height` coordinates. Corresponds to a l
 A `length` is a distance.
 The default `length` is zero. \{#sls.type.length}
 
-<NotInSC>
+</SC>
 
 ### percent
 <SlintProperty propName="percent" typeName="percent" defaultValue='0%'>
@@ -101,4 +104,3 @@ Relative font size factor that is multiplied with the `Window.default-font-size`
 
 
 Please see the language specific API references how these types are mapped to the APIs of the different programming languages.
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/property-types/other-types.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/other-types.mdx
@@ -1,7 +1,6 @@
 ---
 title: Other
 description: The keys, easing, data-transfer, and mouse cursor types.
-notInSC: true
 ---
 
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';

--- a/docs/astro/src/content/docs/reference/property-types/strings.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/strings.mdx
@@ -1,7 +1,6 @@
 ---
 title: Strings
 description: The string and styled-text types of the Slint language.
-notInSC: true
 ---
 
 import SlintProperty from '@slint/common-files/src/components/SlintProperty.astro';

--- a/docs/common/src/components/SC.astro
+++ b/docs/common/src/components/SC.astro
@@ -1,0 +1,13 @@
+---
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// Content that is part of the certified Slint SC surface. Nothing reaches the
+// safety manual unless it is wrapped in <SC> (or <OnlyInSC>) on a page whose
+// frontmatter sets `SC: true`; everything else is main-documentation only.
+// This component itself is transparent -- it renders its children in both
+// sites -- and only acts as a marker that rehype-sls-ids, traceability.rs and
+// the safety-manual sync look for.
+---
+
+<slot />

--- a/docs/common/src/utils/rehype-sls-ids.mjs
+++ b/docs/common/src/utils/rehype-sls-ids.mjs
@@ -18,22 +18,23 @@
 // That keeps every producer of markers (the specification, builtins.slint doc
 // comments, and whatever else grows one) free to write them unconditionally.
 //
-// The pages that do carry identifiers are the language specification and, in
-// the safety manual, everything under `reference/`: the generated SC API
-// reference and the chapters the manual writes itself, like rendering and
-// generated code. Pass `{ referenceRequiresIds: true }` for those. They are
-// also checked for completeness -- a normative paragraph without an
-// identifier fails the build -- covering top-level paragraphs of the
-// specification and of the manual's own chapters (nested ones are asides and
-// list items) and every paragraph of the generated and property-types
-// reference. A page states no requirements, and so drops its markers instead
-// of assigning them, in two cases: a specification chapter with
-// `notInSC: true` covers the full language only, so the safety manual leaves
-// it out, and a page with `normative: false` is navigational, like a section
-// landing page. Dropping keeps the corpus and the traceability matrix in
-// step: the matrix cites neither kind of page, and an anchor it never cites
-// dead-links from nowhere and hides a marker that should have been checked.
-// The markers stay in the source for when a chapter joins the subset.
+// The pages that do carry identifiers are the specification and property-type
+// chapters that opt into the safety corpus with `SC: true` and, in the safety
+// manual, everything under `reference/`: the generated SC API reference and the
+// chapters the manual writes itself, like rendering and generated code. Pass
+// `{ referenceRequiresIds: true }` for the latter. They are also checked for
+// completeness -- a normative paragraph without an identifier fails the build
+// -- covering the paragraphs an `SC: true` page wraps in <SC>/<OnlyInSC>, the
+// top-level paragraphs of the manual's own chapters (nested ones are asides and
+// list items), and every paragraph of the generated reference. A page states no
+// requirements, and so drops its markers instead of assigning them, in two
+// cases: a specification chapter without `SC: true` documents the full language
+// only, so the safety manual leaves it out, and a page with `normative: false`
+// is navigational, like a section landing page. Dropping keeps the corpus and
+// the traceability matrix in step: the matrix cites neither kind of page, and
+// an anchor it never cites dead-links from nowhere and hides a marker that
+// should have been checked. The markers stay in the source for when a chapter
+// joins the subset.
 //
 // The same marker format lives in `split_marker` in
 // docs/slint-doc-generator/traceability.rs and in the `.sls-id` styling in
@@ -46,11 +47,11 @@
 
 const ID_MARKER = /\s*\{#(sls\.[a-z0-9.\-_]+)\}\s*$/;
 
-// The specification chapters and the property-types reference are the SC
-// corpus: their paragraphs carry identifiers unless a page opts out with
-// `notInSC: true`. Separator-agnostic so the checks also hold on Windows
-// paths, and anchored on `content/docs/` so an unrelated directory in the
-// checkout path can't match.
+// The specification and property-types chapters. A page in either joins the SC
+// corpus by setting `SC: true`; this path also tells such a chapter apart from
+// the generated and manual reference. Separator-agnostic so the checks also
+// hold on Windows paths, and anchored on `content/docs/` so an unrelated
+// directory in the checkout path can't match.
 const SPEC_PATH =
     /[\\/]content[\\/]docs[\\/](reference[\\/])?(language|property-types)[\\/]/;
 const GENERATED_REFERENCE_PATH =
@@ -66,14 +67,25 @@ const MANUAL_REFERENCE_PATH = /[\\/]content[\\/]docs[\\/]reference[\\/]/;
 // component: the safety manual renders nothing for it, but rehype runs before
 // any component does, so the paragraphs are still here to be skipped.
 const NOT_IN_SC = "NotInSC";
+// Certified content is wrapped in <SC>. Inside it, <OnlyInSC> marks wording
+// that holds for Slint SC alone (shown only in the safety manual); it is the
+// counterpart of <NotInSC>, which opts a nested part back out (shown only in
+// the main docs, e.g. a type description within a <SlintProperty>). Both <SC>
+// and <OnlyInSC> bound a certified block.
+const SC_TAGS = new Set(["SC", "OnlyInSC"]);
 
-function walk(node, fn, depth = 0, inNotInSc = false) {
-    if (node.type === "element") fn(node, depth, inNotInSc);
-    const nested =
-        inNotInSc ||
-        (node.type === "mdxJsxFlowElement" && node.name === NOT_IN_SC);
+function walk(node, fn, depth = 0, inNotInSc = false, scDepth = null) {
+    if (node.type === "element") fn(node, depth, inNotInSc, scDepth);
+    let childNotInSc = inNotInSc;
+    let childScDepth = scDepth;
+    if (node.type === "mdxJsxFlowElement") {
+        if (node.name === NOT_IN_SC) childNotInSc = true;
+        // Track the nearest enclosing certified block, so a paragraph directly
+        // inside an <OnlyInSC> nested in an <SC> is still checked.
+        if (SC_TAGS.has(node.name)) childScDepth = depth;
+    }
     for (const child of node.children ?? []) {
-        walk(child, fn, depth + 1, nested);
+        walk(child, fn, depth + 1, childNotInSc, childScDepth);
     }
 }
 
@@ -118,27 +130,23 @@ export default function rehypeSlsIds({
         const isManualReference =
             isReference && MANUAL_REFERENCE_PATH.test(sourcePath);
         const frontmatter = file?.data?.astro?.frontmatter;
-        // A chapter outside the SC subset, and a navigational page like a
-        // section landing page, both state no requirements: they carry no
-        // identifiers and their markers are dropped.
-        const statesNoRequirements =
-            (isSpec && Boolean(frontmatter?.notInSC)) ||
-            frontmatter?.normative === false;
+        // A spec/property-types chapter opts into the safety corpus with
+        // `SC: true`; only the content it then wraps in <SC> is certified.
+        const isSC = isSpec && frontmatter?.SC === true;
+        // A navigational page like a section landing page states no
+        // requirements: it carries no identifiers and its markers are dropped.
+        const statesNoRequirements = frontmatter?.normative === false;
         const assignsIds =
-            (isSpec || isGeneratedReference || isManualReference) &&
+            (isSC || isGeneratedReference || isManualReference) &&
             !statesNoRequirements;
         // Draft pages aren't published, so they need no ids.
         const requireIds = assignsIds && !frontmatter?.draft;
-        // In the language specification and the manual's own reference
-        // chapters, only top-level paragraphs are normative: nested ones are
-        // asides and list items. The generated SC reference and the
-        // property-types reference are normative at any depth -- both wrap
-        // normative prose in components like <SlintProperty>, so an untagged
-        // nested paragraph there is a mistake and fails the build rather than
-        // slipping through.
-        const isPropertyTypes =
-            isSpec && /[\\/]property-types[\\/]/.test(sourcePath);
-        const requiredAtAnyDepth = isGeneratedReference || isPropertyTypes;
+        // The generated SC reference is normative at any depth. On an `SC: true`
+        // page the normative paragraphs are the ones directly inside an
+        // <SC>/<OnlyInSC> block; in the manual's own reference chapters, the
+        // top-level paragraphs. Deeper paragraphs are asides and list items,
+        // and a <NotInSC> nested inside a certified block is exempt.
+        const requiredAtAnyDepth = isGeneratedReference;
 
         // Tracks ids claimed during *this* invocation, so re-processing the
         // same file (dev-mode hot reload) re-claims its own ids cleanly while
@@ -146,7 +154,7 @@ export default function rehypeSlsIds({
         const claimedHere = new Set();
         const missing = [];
 
-        walk(tree, (node, depth, inNotInSc) => {
+        walk(tree, (node, depth, inNotInSc, scDepth) => {
             if (node.tagName !== "p") return;
             // Such a paragraph documents what Slint SC leaves out, so it
             // states no requirement and carries no identifier.
@@ -155,7 +163,11 @@ export default function rehypeSlsIds({
             const match =
                 last?.type === "text" ? last.value.match(ID_MARKER) : null;
             if (!match) {
-                if (requireIds && (requiredAtAnyDepth || depth === 1)) {
+                const normative =
+                    requiredAtAnyDepth ||
+                    (isManualReference && depth === 1) ||
+                    (isSC && scDepth !== null && depth === scDepth + 1);
+                if (requireIds && normative) {
                     missing.push(node);
                 }
                 return;

--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -183,8 +183,8 @@ export default defineConfig({
                             label: "File Structure",
                             slug: "language/file-structure",
                         },
-                        // The Imports chapter is marked notInSC; list it here
-                        // once imports come into the SC subset.
+                        // The Imports chapter isn't in the SC subset yet (no
+                        // `SC: true`); list it here once it joins.
                         {
                             label: "Exports",
                             slug: "language/exports",

--- a/docs/safety/scripts/sync-language-spec.mjs
+++ b/docs/safety/scripts/sync-language-spec.mjs
@@ -4,8 +4,8 @@
 // Sync the language-specification chapters from their canonical location in
 // the main Slint docs (docs/astro/src/content/docs/reference/language/) into
 // this site's src/content/docs/language/ directory, which is gitignored.
-// Chapters with `notInSC: true` in their frontmatter cover the full language
-// only and are left out.
+// Only chapters that opt into the SC subset with `SC: true` in their
+// frontmatter are brought over, and only the content they wrap in <SC>.
 //
 // The chapters use relative links so that they resolve in both sites. Links
 // that point outside the specification differ per site and are rewritten via
@@ -22,20 +22,51 @@ import { fileURLToPath } from "node:url";
 // on the left, safety-manual form on the right.
 const LINK_MAP = new Map([["](../overview/)", "](../reference/)"]]);
 
-function isNotInSC(content) {
+function isSC(content) {
     const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-    return frontmatter != null && /^notInSC:\s*true\s*$/m.test(frontmatter[1]);
+    return frontmatter != null && /^SC:\s*true\s*$/m.test(frontmatter[1]);
 }
 
-// Drop `<NotInSC>` blocks entirely. The manual omits them at runtime anyway,
-// but MDX evaluates a component's children eagerly, so a throwing component
-// left inside one (e.g. CodeSnippetMD referencing a main-docs-only image)
-// would still break the build here. Removing them leaves only the SC content,
-// and with it only links this site can resolve: a block outside the subset
-// links to chapters the manual doesn't serve, which link validation would
-// reject once the links are written from the site base.
-function stripNotInSC(content) {
-    return content.replace(/<NotInSC>[\s\S]*?<\/NotInSC>\n?/g, "");
+// Keep only the certified content: the frontmatter, the imports, and the
+// <SC>/<OnlyInSC> blocks (an <SC> block may contain a nested <NotInSC> that the
+// manual omits at runtime). Everything outside a block is main-documentation
+// only and is dropped, so nothing uncertified reaches the safety manual -- and
+// with it only links this site can resolve (a dropped block outside the subset
+// links to chapters the manual doesn't serve, which link validation rejects),
+// and no throwing component in the dropped part (e.g. a CodeSnippetMD for a
+// main-docs-only image) can break the build here.
+//
+// An <OnlyInSC> nests inside an <SC>, so count nesting depth rather than a
+// single block, or the inner </OnlyInSC> would end the outer <SC> early.
+function keepOnlySC(content) {
+    const out = [];
+    let delimiters = 0;
+    let depth = 0;
+    for (const line of content.split("\n")) {
+        const t = line.trim();
+        if (delimiters < 2) {
+            out.push(line);
+            if (t === "---") delimiters++;
+            continue;
+        }
+        if (depth > 0) {
+            out.push(line);
+            if (t === "<SC>" || t === "<OnlyInSC>") depth++;
+            else if (t === "</SC>" || t === "</OnlyInSC>") depth--;
+            continue;
+        }
+        if (t === "<SC>" || t === "<OnlyInSC>") {
+            out.push(line);
+            depth++;
+            continue;
+        }
+        // Outside a certified block keep only imports and blank lines (for
+        // spacing); drop the main-docs-only content.
+        if (t === "" || t.startsWith("import ") || t.startsWith("{/*")) {
+            out.push(line);
+        }
+    }
+    return out.join("\n");
 }
 
 // Rewrite the markdown links of a page served at `pageUrl` from the site root,
@@ -99,14 +130,14 @@ for (const entry of readdirSync(source)) {
         continue;
     }
     let content = readFileSync(join(source, entry), "utf-8");
-    if (isNotInSC(content)) {
+    if (!isSC(content)) {
         continue;
     }
     wanted.add(entry);
     for (const [from, to] of LINK_MAP) {
         content = content.replaceAll(from, to);
     }
-    content = linksFromRoot(stripNotInSC(content), pageUrl("/language/", entry));
+    content = linksFromRoot(keepOnlySC(content), pageUrl("/language/", entry));
     const targetFile = join(target, entry);
     if (!existsSync(targetFile) || readFileSync(targetFile, "utf-8") !== content) {
         writeFileSync(targetFile, content);
@@ -119,15 +150,15 @@ for (const entry of readdirSync(target)) {
 }
 
 // Bring the SC property-types reference pages into the manual, where they are
-// served under reference/property-types/ (see astro.config.mjs). Pages marked
-// `notInSC: true` cover the full language only and are left out, just like the
-// specification chapters above.
+// served under reference/property-types/ (see astro.config.mjs). Only pages
+// that opt in with `SC: true` are brought over, just like the specification
+// chapters above.
 syncDir(
     join(here, "../../astro/src/content/docs/reference/property-types"),
     join(here, "../src/content/docs/reference/property-types"),
-    (content) => !isNotInSC(content),
+    (content) => isSC(content),
     (content, entry) =>
-        linksFromRoot(stripNotInSC(content), pageUrl("/reference/property-types/", entry)),
+        linksFromRoot(keepOnlySC(content), pageUrl("/reference/property-types/", entry)),
 );
 
 console.log(`Synced language specification from ${source}`);

--- a/docs/safety/src/content.config.ts
+++ b/docs/safety/src/content.config.ts
@@ -15,6 +15,9 @@ export const collections = {
                 // `reference/`, which the completeness check in
                 // rehype-sls-ids.mjs holds to the corpus rules.
                 normative: z.boolean().optional(),
+                // Carried over by the synced specification and property-types
+                // chapters: the manual includes the content they wrap in <SC>.
+                SC: z.boolean().optional(),
             }),
         }),
     }),

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -39,9 +39,9 @@ const TEST_ROOTS: &[(&str, &str)] =
 /// Handwritten safety-manual pages may also state requirements.
 const SAFETY_DOCS_DIR: &str = "docs/safety/src/content/docs";
 
-/// The property-types reference, part of the SC corpus except for pages marked
-/// `notInSC: true`. Anchors are scanned from this canonical location; the
-/// safety manual syncs and serves the SC ones under `reference/property-types/`.
+/// The property-types reference; the pages that opt into the SC corpus with
+/// `SC: true` are part of it. Anchors are scanned from this canonical location;
+/// the safety manual syncs and serves the SC ones under `reference/property-types/`.
 const PROPERTY_TYPES_DIR: &str = "docs/astro/src/content/docs/reference/property-types";
 
 /// Subdirectories of [`SAFETY_DOCS_DIR`] whose anchors are already scanned
@@ -72,9 +72,9 @@ struct SpecPage {
     anchors: Vec<(String, usize)>,
     /// Draft pages aren't published, so their anchors don't exist.
     draft: bool,
-    /// Covers the full language only: the safety manual leaves the chapter
-    /// out, so its anchors, if any, aren't part of the traceability corpus.
-    not_in_sc: bool,
+    /// Whether the page opts into the safety corpus with `SC: true`. Only the
+    /// content it wraps in `<SC>` is certified; other pages are left out.
+    sc: bool,
     /// States requirements, the default. A navigational page like a section
     /// landing page sets `normative: false`; rehype-sls-ids.mjs drops its
     /// markers rather than turning them into anchors, so citing one here
@@ -196,13 +196,16 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
         top_level: false,
         anchors: Vec::new(),
         draft: false,
-        not_in_sc: false,
+        sc: false,
         normative: true,
     };
     let mut in_comment = false;
     let mut in_fence = false;
-    // `<NotInSC>` regions aren't published in the safety manual, so whatever
-    // they enclose states no requirement. See rehype-not-in-sc.mjs.
+    // <SC> and the <OnlyInSC> that nests inside it are certified; a <NotInSC>
+    // nested in either opts a part back out. Count nesting depth so a closing
+    // </OnlyInSC> doesn't end the enclosing <SC>. See the SC/OnlyInSC/NotInSC
+    // components and rehype-sls-ids.mjs.
+    let mut sc_depth = 0u32;
     let mut in_not_in_sc = false;
     let mut frontmatter_delimiters = 0;
     for (i, line) in text.lines().enumerate() {
@@ -216,8 +219,8 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
                 slug = Some(s.trim().to_string());
             } else if t == "draft: true" {
                 page.draft = true;
-            } else if t == "notInSC: true" {
-                page.not_in_sc = true;
+            } else if t == "SC: true" {
+                page.sc = true;
             } else if t == "normative: false" {
                 page.normative = false;
             }
@@ -234,6 +237,14 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
         if in_fence {
             continue;
         }
+        if t == "<SC>" || t == "<OnlyInSC>" {
+            sc_depth += 1;
+            continue;
+        }
+        if t == "</SC>" || t == "</OnlyInSC>" {
+            sc_depth = sc_depth.saturating_sub(1);
+            continue;
+        }
         if t == "<NotInSC>" {
             in_not_in_sc = true;
             continue;
@@ -242,7 +253,11 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
             in_not_in_sc = false;
             continue;
         }
-        if in_not_in_sc {
+        // On an `SC: true` page anchors count only inside an <SC>/<OnlyInSC>
+        // block (and not inside a nested <NotInSC>). Generated reference pages
+        // carry no such wrapper -- the whole page is certified -- so they count
+        // every anchor outside a <NotInSC>.
+        if in_not_in_sc || (page.sc && sc_depth == 0) {
             continue;
         }
         // Both comment forms: markdown pages use `<!-- -->`, MDX `{/* */}`.
@@ -288,7 +303,7 @@ fn scan_spec_pages(dir: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Erro
         let text = std::fs::read_to_string(&path).context(format!("error reading {path:?}"))?;
         let file = path.file_name().unwrap_or_default().to_string_lossy();
         let (mut page, _) = parse_spec_page(&format!("{SPEC_DIR}/{file}"), &text);
-        if page.not_in_sc {
+        if !page.sc {
             continue;
         }
         // The index page is served at the root of the specification.
@@ -303,9 +318,8 @@ fn scan_spec_pages(dir: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Erro
 }
 
 /// Parse the property-types reference pages under [`PROPERTY_TYPES_DIR`] for
-/// their anchors. Pages marked `notInSC: true` cover the full language only, so
-/// they carry no requirements; the rest are served in the safety manual under
-/// `reference/property-types/`.
+/// their anchors. Only pages that opt in with `SC: true` carry requirements;
+/// those are served in the safety manual under `reference/property-types/`.
 fn scan_property_type_pages(root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let dir = root.join(PROPERTY_TYPES_DIR);
     let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
@@ -321,7 +335,7 @@ fn scan_property_type_pages(root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::e
         let stem = path.file_stem().unwrap_or_default().to_string_lossy().into_owned();
         let file = repo_relative(&path, root);
         let (mut page, _) = parse_spec_page(&file, &text);
-        if page.not_in_sc || page.anchors.is_empty() || page.draft {
+        if !page.sc || page.anchors.is_empty() || page.draft {
             continue;
         }
         page.base = format!("/reference/property-types/{stem}/");
@@ -622,14 +636,33 @@ Another paragraph. {#sls.two}
     assert!(draft.draft);
     assert_eq!(draft.anchors, [("sls.d".to_string(), 5)]);
 
-    assert!(!page.not_in_sc);
-    // The flag is parsed; scan_spec_pages skips such pages, anchors and all.
-    let (flagged, _) = parse_spec_page(
-        "spec/functions.mdx",
-        "---\ntitle: Functions\nnotInSC: true\n---\nFull-language prose. \\{#sls.fn.decl}\n",
-    );
-    assert!(flagged.not_in_sc);
-    assert_eq!(flagged.anchors, [("sls.fn.decl".to_string(), 5)]);
+    // A page without `SC: true` isn't part of the corpus, but its anchors are
+    // still parsed (the generated reference and safety pages rely on that).
+    assert!(!page.sc);
+    // On an `SC: true` page only anchors inside an <SC>/<OnlyInSC> block count;
+    // a nested <NotInSC> opts back out, and content outside is uncertified.
+    let sc_text = r#"---
+title: Geometry
+SC: true
+---
+
+<SC>
+Certified. {#sls.a}
+
+<OnlyInSC>
+Safety only. {#sls.b}
+</OnlyInSC>
+
+<NotInSC>
+Main only. {#sls.c}
+</NotInSC>
+</SC>
+
+Uncertified. {#sls.d}
+"#;
+    let (sc_page, _) = parse_spec_page("spec/geometry.mdx", sc_text);
+    assert!(sc_page.sc);
+    assert_eq!(sc_page.anchors, [("sls.a".to_string(), 7), ("sls.b".to_string(), 10)]);
 
     let (reference, slug) = parse_spec_page(
         "generated/elements/rectangle.mdx",
@@ -648,7 +681,7 @@ fn test_check_reports_all_errors() {
         top_level: false,
         anchors: anchors.iter().map(|(id, line)| (id.to_string(), *line)).collect(),
         draft: false,
-        not_in_sc: false,
+        sc: false,
         normative: true,
     };
     let test_ref = |id: &str, file: &str, line| TestRef {

--- a/tests/doctests/build.rs
+++ b/tests/doctests/build.rs
@@ -39,17 +39,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         writeln!(tests_file, "\nmod {stem} {{")?;
 
         // Language Specification examples are additionally compiled in
-        // Slint SC mode, unless the fence carries `no-sc-test` or the whole
-        // chapter is marked `notInSC: true` in its frontmatter.
-        let not_in_sc = file.starts_with("---\n")
+        // Slint SC mode when the chapter opts into the certified subset with
+        // `SC: true` in its frontmatter, unless the fence carries `no-sc-test`.
+        let sc_chapter = file.starts_with("---\n")
             && file[4..]
                 .split("\n---\n")
                 .next()
-                .is_some_and(|fm| fm.lines().any(|l| l.trim() == "notInSC: true"));
+                .is_some_and(|fm| fm.lines().any(|l| l.trim() == "SC: true"));
         let language_spec = path
             .strip_prefix(&prefix)?
             .starts_with("docs/astro/src/content/docs/reference/language")
-            && !not_in_sc;
+            && sc_chapter;
 
         let mut lines = file.lines().enumerate();
         while let Some((n, opening)) = lines.next() {


### PR DESCRIPTION
Chapters now join the safety manual by setting `SC: true` in their frontmatter and wrapping the certified content in <SC>, instead of the manual taking everything not wrapped in <NotInSC>. <NotInSC> stays for nested opt-outs (a type description inside a certified <SlintProperty>) and <OnlyInSC> for safety-only wording. The rendered output of both sites is unchanged.
