### PR TITLE
docs: check the safety manual's traceability ids and links

### DIFF
--- a/docs/common/src/utils/rehype-sls-ids.mjs
+++ b/docs/common/src/utils/rehype-sls-ids.mjs
@@ -19,17 +19,21 @@
 // comments, and whatever else grows one) free to write them unconditionally.
 //
 // The pages that do carry identifiers are the language specification and, in
-// the safety manual, the generated SC API reference: pass
-// `{ generatedReferenceRequiresIds: true }` for the latter. Those pages are
+// the safety manual, everything under `reference/`: the generated SC API
+// reference and the chapters the manual writes itself, like rendering and
+// generated code. Pass `{ referenceRequiresIds: true }` for those. They are
 // also checked for completeness -- a normative paragraph without an
 // identifier fails the build -- covering top-level paragraphs of the
-// specification (nested ones are asides and list items) and every paragraph
-// of the generated reference. A specification chapter with `notInSC: true`
-// in its frontmatter covers the full language only: the safety manual leaves
-// it out, so it states no requirements and its markers are dropped like on
-// any other page that carries no identifiers -- an anchor there would
-// dead-link from the traceability matrix. The markers stay in the source for
-// when the chapter joins the subset.
+// specification and of the manual's own chapters (nested ones are asides and
+// list items) and every paragraph of the generated and property-types
+// reference. A page states no requirements, and so drops its markers instead
+// of assigning them, in two cases: a specification chapter with
+// `notInSC: true` covers the full language only, so the safety manual leaves
+// it out, and a page with `normative: false` is navigational, like a section
+// landing page. Dropping keeps the corpus and the traceability matrix in
+// step: the matrix cites neither kind of page, and an anchor it never cites
+// dead-links from nowhere and hides a marker that should have been checked.
+// The markers stay in the source for when a chapter joins the subset.
 //
 // The same marker format lives in `split_marker` in
 // docs/slint-doc-generator/traceability.rs and in the `.sls-id` styling in
@@ -51,6 +55,12 @@ const SPEC_PATH =
     /[\\/]content[\\/]docs[\\/](reference[\\/])?(language|property-types)[\\/]/;
 const GENERATED_REFERENCE_PATH =
     /[\\/]content[\\/]docs[\\/]generated[\\/]reference[\\/]/;
+// The reference chapters the safety manual writes itself. The main
+// documentation serves a much larger `reference/` that states no
+// requirements, so this only applies where `referenceRequiresIds` is set. The
+// manual's synced property-types pages sit below this path too, but they
+// match SPEC_PATH first.
+const MANUAL_REFERENCE_PATH = /[\\/]content[\\/]docs[\\/]reference[\\/]/;
 
 // A feature outside the certified subset is wrapped in the `<NotInSC>`
 // component: the safety manual renders nothing for it, but rehype runs before
@@ -80,7 +90,7 @@ function textPreview(node) {
 }
 
 export default function rehypeSlsIds({
-    generatedReferenceRequiresIds = false,
+    referenceRequiresIds = false,
     renderBadge = true,
 } = {}) {
     // Closure-scoped: persists across files in one build, so a duplicate
@@ -100,28 +110,35 @@ export default function rehypeSlsIds({
         const isOwnPage = !siteRoot || sourcePath.startsWith(siteRoot);
         const isSpec = isOwnPage && SPEC_PATH.test(sourcePath);
         // Both sites generate the reference from the same doc comments, but
-        // only the safety manual treats it as normative.
-        const isNormativeReference =
-            generatedReferenceRequiresIds &&
-            isOwnPage &&
-            !isSpec &&
-            GENERATED_REFERENCE_PATH.test(sourcePath);
+        // only the safety manual treats it, and the reference chapters it
+        // writes itself, as normative.
+        const isReference = referenceRequiresIds && isOwnPage && !isSpec;
+        const isGeneratedReference =
+            isReference && GENERATED_REFERENCE_PATH.test(sourcePath);
+        const isManualReference =
+            isReference && MANUAL_REFERENCE_PATH.test(sourcePath);
         const frontmatter = file?.data?.astro?.frontmatter;
-        // A `notInSC: true` chapter is outside the safety corpus, so it
-        // carries no identifiers and its markers are dropped.
-        const notInSC = isSpec && Boolean(frontmatter?.notInSC);
-        const assignsIds = (isSpec && !notInSC) || isNormativeReference;
+        // A chapter outside the SC subset, and a navigational page like a
+        // section landing page, both state no requirements: they carry no
+        // identifiers and their markers are dropped.
+        const statesNoRequirements =
+            (isSpec && Boolean(frontmatter?.notInSC)) ||
+            frontmatter?.normative === false;
+        const assignsIds =
+            (isSpec || isGeneratedReference || isManualReference) &&
+            !statesNoRequirements;
         // Draft pages aren't published, so they need no ids.
         const requireIds = assignsIds && !frontmatter?.draft;
-        // In the language specification, only top-level paragraphs are
-        // normative: nested ones are asides and list items. The generated SC
-        // reference and the property-types reference are normative at any depth
-        // -- the latter wraps normative prose in components like
-        // <SlintProperty>, so an untagged nested paragraph there is a mistake
-        // and fails the build rather than slipping through.
+        // In the language specification and the manual's own reference
+        // chapters, only top-level paragraphs are normative: nested ones are
+        // asides and list items. The generated SC reference and the
+        // property-types reference are normative at any depth -- both wrap
+        // normative prose in components like <SlintProperty>, so an untagged
+        // nested paragraph there is a mistake and fails the build rather than
+        // slipping through.
         const isPropertyTypes =
             isSpec && /[\\/]property-types[\\/]/.test(sourcePath);
-        const requiredAtAnyDepth = isNormativeReference || isPropertyTypes;
+        const requiredAtAnyDepth = isGeneratedReference || isPropertyTypes;
 
         // Tracks ids claimed during *this* invocation, so re-processing the
         // same file (dev-mode hot reload) re-claims its own ids cleanly while

--- a/docs/common/src/utils/remark-base-links.mjs
+++ b/docs/common/src/utils/remark-base-links.mjs
@@ -1,0 +1,41 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// Prefix the site base to the internal links of a page. Astro doesn't apply
+// `base` to markdown links, so a site served under a path would need every
+// link to spell that path out. Sources instead write links from the site root
+// -- `/language/properties/` -- and this adds the base, in one place, at build
+// time. That keeps the sources free of the deployment layout, which the
+// release job rewrites per version.
+//
+// It matters for more than the output: starlight-links-validator resolves a
+// link against the deployed path, so an unprefixed link fails validation as a
+// link to an unknown page. Remark runs before the validator's rehype pass, so
+// what gets checked is the prefixed link.
+
+/** Rewrite the `url` of every link and link definition in the tree. */
+function walk(node, fn) {
+    if (node.type === "link" || node.type === "definition") {
+        fn(node);
+    }
+    for (const child of node.children ?? []) {
+        walk(child, fn);
+    }
+}
+
+export default function remarkBaseLinks({ base = "/" } = {}) {
+    const prefix = base.replace(/\/+$/, "");
+    // Served at the root, so the links already read as they should.
+    if (prefix === "") {
+        return () => {};
+    }
+    return (tree) => {
+        walk(tree, (node) => {
+            // A protocol-relative URL also starts with a slash and leaves the
+            // site, so it isn't ours to rewrite.
+            if (node.url?.startsWith("/") && !node.url.startsWith("//")) {
+                node.url = `${prefix}${node.url}`;
+            }
+        });
+    };
+}

--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
         // every paragraph of it carries a traceability id.
         rehypePlugins: [
             rehypeExternalLinksSlint,
-            [rehypeSlsIds, { generatedReferenceRequiresIds: true }],
+            [rehypeSlsIds, { referenceRequiresIds: true }],
         ],
     },
     integrations: [

--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -52,7 +52,7 @@ export default defineConfig({
                 Header: "@slint/common-files/src/components/Header.astro",
                 Banner: "@slint/common-files/src/components/Banner.astro",
             },
-            plugins: [slintStarlightLinksValidatorPlugin({ errorOnRelativeLinks: false })],
+            plugins: [slintStarlightLinksValidatorPlugin({ errorOnRelativeLinks: true })],
             social: slintStarlightSocial,
             sidebar: [
                 { label: "Slint SC Safety Manual", slug: "index" },

--- a/docs/safety/astro.config.mjs
+++ b/docs/safety/astro.config.mjs
@@ -15,6 +15,7 @@ import {
     SAFETY_DOCS_BASE_PATH,
 } from "./src/safety-site-config.mjs";
 import rehypeSlsIds from "@slint/common-files/src/utils/rehype-sls-ids.mjs";
+import remarkBaseLinks from "@slint/common-files/src/utils/remark-base-links.mjs";
 
 const _safetyOrigin = String(SAFETY_DOCS_BASE_URL).replace(/\/+$/, "");
 const _safetyAtRoot = SAFETY_DOCS_BASE_PATH === "/";
@@ -33,6 +34,7 @@ export default defineConfig({
     markdown: {
         // Only SC-covered content reaches this site's generated reference, so
         // every paragraph of it carries a traceability id.
+        remarkPlugins: [[remarkBaseLinks, { base: _safetyBase ?? "/" }]],
         rehypePlugins: [
             rehypeExternalLinksSlint,
             [rehypeSlsIds, { referenceRequiresIds: true }],

--- a/docs/safety/scripts/sync-language-spec.mjs
+++ b/docs/safety/scripts/sync-language-spec.mjs
@@ -17,10 +17,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { SAFETY_DOCS_BASE_PATH } from "../src/safety-site-config.mjs";
-
-// The path this site is served under, with a trailing `/`.
-const BASE = `/${SAFETY_DOCS_BASE_PATH.replace(/^\/+|\/+$/g, "")}/`.replace("//", "/");
 
 // Links that leave the specification directory: canonical (docs/astro) form
 // on the left, safety-manual form on the right.
@@ -42,11 +38,12 @@ function stripNotInSC(content) {
     return content.replace(/<NotInSC>[\s\S]*?<\/NotInSC>\n?/g, "");
 }
 
-// Rewrite the markdown links of a page served at `pageUrl` from the site base,
-// so that starlight-links-validator checks them. Resolving against the page's
-// own URL keeps the sources readable: they stay relative, and only the copies
-// this script writes carry the site's layout.
-function linksFromBase(content, pageUrl) {
+// Rewrite the markdown links of a page served at `pageUrl` from the site root,
+// so that starlight-links-validator checks them: it skips relative links
+// rather than resolving them. Resolving against the page's own URL keeps the
+// sources readable, since they stay relative. remark-base-links.mjs adds the
+// base at build time.
+function linksFromRoot(content, pageUrl) {
     return content.replace(/\]\((\.\.?\/[^)]*)\)/g, (_, url) => {
         const resolved = new URL(url, `https://slint.dev${pageUrl}`);
         return `](${resolved.pathname}${resolved.hash})`;
@@ -109,7 +106,7 @@ for (const entry of readdirSync(source)) {
     for (const [from, to] of LINK_MAP) {
         content = content.replaceAll(from, to);
     }
-    content = linksFromBase(stripNotInSC(content), pageUrl(`${BASE}language/`, entry));
+    content = linksFromRoot(stripNotInSC(content), pageUrl("/language/", entry));
     const targetFile = join(target, entry);
     if (!existsSync(targetFile) || readFileSync(targetFile, "utf-8") !== content) {
         writeFileSync(targetFile, content);
@@ -130,10 +127,7 @@ syncDir(
     join(here, "../src/content/docs/reference/property-types"),
     (content) => !isNotInSC(content),
     (content, entry) =>
-        linksFromBase(
-            stripNotInSC(content),
-            pageUrl(`${BASE}reference/property-types/`, entry),
-        ),
+        linksFromRoot(stripNotInSC(content), pageUrl("/reference/property-types/", entry)),
 );
 
 console.log(`Synced language specification from ${source}`);

--- a/docs/safety/scripts/sync-language-spec.mjs
+++ b/docs/safety/scripts/sync-language-spec.mjs
@@ -9,11 +9,18 @@
 //
 // The chapters use relative links so that they resolve in both sites. Links
 // that point outside the specification differ per site and are rewritten via
-// LINK_MAP below.
+// LINK_MAP below. The copies written here then get every link rewritten from
+// the site base, because starlight-links-validator skips relative links
+// entirely: a relative link would go unchecked and could rot into a dead one
+// unnoticed.
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { SAFETY_DOCS_BASE_PATH } from "../src/safety-site-config.mjs";
+
+// The path this site is served under, with a trailing `/`.
+const BASE = `/${SAFETY_DOCS_BASE_PATH.replace(/^\/+|\/+$/g, "")}/`.replace("//", "/");
 
 // Links that leave the specification directory: canonical (docs/astro) form
 // on the left, safety-manual form on the right.
@@ -27,9 +34,29 @@ function isNotInSC(content) {
 // Drop `<NotInSC>` blocks entirely. The manual omits them at runtime anyway,
 // but MDX evaluates a component's children eagerly, so a throwing component
 // left inside one (e.g. CodeSnippetMD referencing a main-docs-only image)
-// would still break the build here. Removing them leaves only the SC content.
+// would still break the build here. Removing them leaves only the SC content,
+// and with it only links this site can resolve: a block outside the subset
+// links to chapters the manual doesn't serve, which link validation would
+// reject once the links are written from the site base.
 function stripNotInSC(content) {
     return content.replace(/<NotInSC>[\s\S]*?<\/NotInSC>\n?/g, "");
+}
+
+// Rewrite the markdown links of a page served at `pageUrl` from the site base,
+// so that starlight-links-validator checks them. Resolving against the page's
+// own URL keeps the sources readable: they stay relative, and only the copies
+// this script writes carry the site's layout.
+function linksFromBase(content, pageUrl) {
+    return content.replace(/\]\((\.\.?\/[^)]*)\)/g, (_, url) => {
+        const resolved = new URL(url, `https://slint.dev${pageUrl}`);
+        return `](${resolved.pathname}${resolved.hash})`;
+    });
+}
+
+// URL of a synced page below `sectionUrl`; an index page heads its section.
+function pageUrl(sectionUrl, entry) {
+    const stem = entry.replace(/\.mdx?$/, "");
+    return stem === "index" ? sectionUrl : `${sectionUrl}${stem}/`;
 }
 
 // Copy the files under `sourceDir` accepted by `accept` into `targetDir`,
@@ -47,7 +74,7 @@ function syncDir(sourceDir, targetDir, accept, transform = (c) => c) {
             continue;
         }
         wanted.add(entry);
-        const out = transform(content);
+        const out = transform(content, entry);
         const targetFile = join(targetDir, entry);
         if (!existsSync(targetFile) || readFileSync(targetFile, "utf-8") !== out) {
             writeFileSync(targetFile, out);
@@ -82,6 +109,7 @@ for (const entry of readdirSync(source)) {
     for (const [from, to] of LINK_MAP) {
         content = content.replaceAll(from, to);
     }
+    content = linksFromBase(stripNotInSC(content), pageUrl(`${BASE}language/`, entry));
     const targetFile = join(target, entry);
     if (!existsSync(targetFile) || readFileSync(targetFile, "utf-8") !== content) {
         writeFileSync(targetFile, content);
@@ -101,7 +129,11 @@ syncDir(
     join(here, "../../astro/src/content/docs/reference/property-types"),
     join(here, "../src/content/docs/reference/property-types"),
     (content) => !isNotInSC(content),
-    stripNotInSC,
+    (content, entry) =>
+        linksFromBase(
+            stripNotInSC(content),
+            pageUrl(`${BASE}reference/property-types/`, entry),
+        ),
 );
 
 console.log(`Synced language specification from ${source}`);

--- a/docs/safety/src/content.config.ts
+++ b/docs/safety/src/content.config.ts
@@ -1,9 +1,21 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
-    docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+    docs: defineCollection({
+        loader: docsLoader(),
+        schema: docsSchema({
+            extend: z.object({
+                // Navigational page, like a section landing page: it states
+                // no requirements, so its paragraphs carry no `{#sls.…}`
+                // identifiers. Defaults to true for every other page under
+                // `reference/`, which the completeness check in
+                // rehype-sls-ids.mjs holds to the corpus rules.
+                normative: z.boolean().optional(),
+            }),
+        }),
+    }),
 };

--- a/docs/safety/src/content/docs/development-phases.mdx
+++ b/docs/safety/src/content/docs/development-phases.mdx
@@ -41,7 +41,7 @@ For external contributions, the reviewer must merge the PR.
 
 We have a set of tests that are executed as part of this phase.
 These tests can be run locally using the "cargo test" command.
-They are described in more detail here: [Tests](../qualification-plan/test-cases/).
+They are described in more detail here: [Tests](/qualification-plan/test-cases/).
 
 
 

--- a/docs/safety/src/content/docs/reference/generated-code.mdx
+++ b/docs/safety/src/content/docs/reference/generated-code.mdx
@@ -4,7 +4,7 @@ description: The Rust API that the Slint SC compiler generates.
 ---
 
 The Slint SC compiler translates a `.slint` file into Rust code that depends
-only on the `slint-sc` runtime crate.
+only on the `slint-sc` runtime crate. \{#sls.gen.output}
 
 ## The Component Struct
 

--- a/docs/safety/src/content/docs/reference/generated-code.mdx
+++ b/docs/safety/src/content/docs/reference/generated-code.mdx
@@ -28,7 +28,7 @@ pub fn render_rgb8(&self, width: u32, height: u32, frame_buffer: &mut [u8]) -> R
 ```
 
 Renders the window into `frame_buffer` as described in
-[Rendering](../rendering/):
+[Rendering](/reference/rendering/):
 `width * height` pixels in row-major order, each pixel three bytes — red,
 green, blue. \{#sls.gen.render-rgb8}
 
@@ -44,7 +44,7 @@ returns `Err(RenderError::InvalidFrameBufferSize)` and paints nothing.
 ## Properties
 
 The struct holds the value of each
-[property declared](../../language/properties/#sls.prop.decl.form) on the
+[property declared](/language/properties/#sls.prop.decl.form) on the
 root element in a private field. \{#sls.gen.prop.field}
 
 Kebab-case property names become snake_case in the generated names:

--- a/docs/safety/src/content/docs/reference/index.mdx
+++ b/docs/safety/src/content/docs/reference/index.mdx
@@ -2,6 +2,7 @@
 title: API Reference
 description: Reference for the Slint SC certified subset of the .slint language.
 slug: reference
+normative: false
 ---
 
 This section documents the elements, properties, callbacks, functions, structs

--- a/docs/safety/src/content/docs/reference/rendering.mdx
+++ b/docs/safety/src/content/docs/reference/rendering.mdx
@@ -4,7 +4,7 @@ description: How a window is rendered into a frame buffer.
 ---
 
 The application renders by calling the `render_rgb8` function of the
-[generated code](../generated-code/).
+[generated code](../generated-code/). \{#sls.paint.invocation}
 
 ## Model
 

--- a/docs/safety/src/content/docs/reference/rendering.mdx
+++ b/docs/safety/src/content/docs/reference/rendering.mdx
@@ -4,7 +4,7 @@ description: How a window is rendered into a frame buffer.
 ---
 
 The application renders by calling the `render_rgb8` function of the
-[generated code](../generated-code/). \{#sls.paint.invocation}
+[generated code](/reference/generated-code/). \{#sls.paint.invocation}
 
 ## Model
 

--- a/docs/safety/src/content/docs/requirements/index.mdx
+++ b/docs/safety/src/content/docs/requirements/index.mdx
@@ -24,14 +24,14 @@ Each Requirement under this Section has a descriptive ID that begins with SR_, a
 
 All ISO26262 references below are valid for the 2018 edition of the standard.
 
-* ISO 26262-4 5.x: See [Development Phases](../development-phases/).
-* ISO 26262-4 9.x: See [Validation](../qualification-plan/validation/).
-* ISO 26262-6 7.x: See [Architecture Design](../using-slint-sc/#slint-sc-architecture-design-iso-262626-74)
-* ISO 26262-8 5.x: See [Distributed Development](../development-process/#distributed-development-iso-26262-8-5x)
+* ISO 26262-4 5.x: See [Development Phases](/development-phases/).
+* ISO 26262-4 9.x: See [Validation](/qualification-plan/validation/).
+* ISO 26262-6 7.x: See [Architecture Design](/using-slint-sc/#slint-sc-architecture-design-iso-262626-74)
+* ISO 26262-8 5.x: See [Distributed Development](/development-process/#distributed-development-iso-26262-8-5x)
 * ISO 26262-8 6.4: The safety requirements shall be traceable to the safety goals and to the safety concept. The traceability shall be documented and maintained.
-* ISO 26262-8 7.x: See [Configuration Management](../development-process/#configuration-management-iso-26262-8-7x)
-* ISO 26262-8 8.x: See [Change Management](../development-process/#change-management-iso-26262-8-8x)
-* ISO 26262-8 9.4.x: See [Verification](../development-process/#verification-iso-26262-8-94x)
-* ISO 26262-8 11.4.8: See [The Development Process](../development-process/#the-development-process-iso-26262-8-1148)
-* ISO 26262-8 12.x: See [Software Component Qualification](../development-process/#software-component-qualification-iso-26262-8-12x)
+* ISO 26262-8 7.x: See [Configuration Management](/development-process/#configuration-management-iso-26262-8-7x)
+* ISO 26262-8 8.x: See [Change Management](/development-process/#change-management-iso-26262-8-8x)
+* ISO 26262-8 9.4.x: See [Verification](/development-process/#verification-iso-26262-8-94x)
+* ISO 26262-8 11.4.8: See [The Development Process](/development-process/#the-development-process-iso-26262-8-1148)
+* ISO 26262-8 12.x: See [Software Component Qualification](/development-process/#software-component-qualification-iso-26262-8-12x)
 

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -73,6 +73,11 @@ struct SpecPage {
     /// Covers the full language only: the safety manual leaves the chapter
     /// out, so its anchors, if any, aren't part of the traceability corpus.
     not_in_sc: bool,
+    /// States requirements, the default. A navigational page like a section
+    /// landing page sets `normative: false`; rehype-sls-ids.mjs drops its
+    /// markers rather than turning them into anchors, so citing one here
+    /// would dead-link.
+    normative: bool,
 }
 
 struct TestRef {
@@ -190,6 +195,7 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
         anchors: Vec::new(),
         draft: false,
         not_in_sc: false,
+        normative: true,
     };
     let mut in_comment = false;
     let mut in_fence = false;
@@ -210,6 +216,8 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
                 page.draft = true;
             } else if t == "notInSC: true" {
                 page.not_in_sc = true;
+            } else if t == "normative: false" {
+                page.normative = false;
             }
             continue;
         }
@@ -388,7 +396,7 @@ fn scan_safety_pages(repo_root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::err
             continue;
         }
         let (mut page, slug) = parse_spec_page(&file, &text);
-        if page.anchors.is_empty() || page.draft {
+        if page.anchors.is_empty() || page.draft || !page.normative {
             continue;
         }
         let relative = repo_relative(path, &dir);
@@ -642,6 +650,7 @@ fn test_check_reports_all_errors() {
         anchors: anchors.iter().map(|(id, line)| (id.to_string(), *line)).collect(),
         draft: false,
         not_in_sc: false,
+        normative: true,
     };
     let test_ref = |id: &str, file: &str, line| TestRef {
         id: id.to_string(),

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -53,12 +53,6 @@ const SAFETY_DOCS_EXCLUDE: &[&str] = &["generated", "language"];
 /// [`Config::qualification_plan_dir`], the section it belongs to.
 const MATRIX_FILE: &str = "traceability-matrix.mdx";
 
-/// Where the safety manual declares the path it is served under. The matrix
-/// links from that base rather than relatively, because
-/// starlight-links-validator skips relative links: a relative one here would
-/// go unchecked, and could rot into a dead anchor unnoticed.
-const SAFETY_SITE_CONFIG: &str = "docs/safety/src/safety-site-config.mjs";
-
 const REPO_URL: &str = env!("CARGO_PKG_REPOSITORY");
 
 struct SpecPage {
@@ -66,8 +60,10 @@ struct SpecPage {
     file: String,
     /// From the frontmatter.
     title: String,
-    /// URL of the page from the site base, for linking its anchors from the
-    /// matrix. See [`SAFETY_SITE_CONFIG`] for why it isn't relative.
+    /// URL of the page from the site root, for linking its anchors from the
+    /// matrix. Not relative, because starlight-links-validator skips relative
+    /// links: one here would go unchecked and could rot into a dead anchor.
+    /// remark-base-links.mjs adds the site base at build time.
     base: String,
     /// The specification index heads its section; every other page nests
     /// under one.
@@ -104,11 +100,10 @@ impl TestRef {
 
 pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     let root = crate::root_dir();
-    let base = safety_base(&root)?;
-    let mut spec_pages = scan_spec_pages(&root.join(SPEC_DIR), &base)?;
-    spec_pages.extend(scan_property_type_pages(&root, &base)?);
-    let reference_pages = scan_reference_pages(cfg, &root, &base)?;
-    let safety_pages = scan_safety_pages(&root, &base)?;
+    let mut spec_pages = scan_spec_pages(&root.join(SPEC_DIR))?;
+    spec_pages.extend(scan_property_type_pages(&root)?);
+    let reference_pages = scan_reference_pages(cfg, &root)?;
+    let safety_pages = scan_safety_pages(&root)?;
 
     let mut refs = Vec::new();
     for kind in TEST_ROOTS {
@@ -132,7 +127,7 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    write_matrix(cfg, &root, &base, &spec_pages, &reference_pages, &safety_pages, &tests_by_id)
+    write_matrix(cfg, &root, &spec_pages, &reference_pages, &safety_pages, &tests_by_id)
 }
 
 /// Validate the parsed pages and test references, returning one message per
@@ -266,19 +261,6 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
     (page, slug)
 }
 
-/// The path the safety manual is served under, with leading and trailing `/`.
-fn safety_base(repo_root: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let path = repo_root.join(SAFETY_SITE_CONFIG);
-    let text = std::fs::read_to_string(&path).context(format!("error reading {path:?}"))?;
-    let value = text
-        .lines()
-        .find_map(|line| line.trim().strip_prefix("export const SAFETY_DOCS_BASE_PATH ="))
-        .map(|value| value.trim().trim_end_matches(';').trim().trim_matches('"'))
-        .ok_or_else(|| anyhow::anyhow!("{SAFETY_SITE_CONFIG}: no SAFETY_DOCS_BASE_PATH"))?;
-    let trimmed = value.trim_matches('/');
-    Ok(if trimmed.is_empty() { "/".to_string() } else { format!("/{trimmed}/") })
-}
-
 /// Repository-relative path with `/` separators.
 fn repo_relative(path: &Path, repo_root: &Path) -> String {
     let relative = path.strip_prefix(repo_root).unwrap_or(path).to_string_lossy().into_owned();
@@ -289,7 +271,7 @@ fn repo_relative(path: &Path, repo_root: &Path) -> String {
     }
 }
 
-fn scan_spec_pages(dir: &Path, base: &str) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
+fn scan_spec_pages(dir: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
         .context(format!("error reading {dir:?}"))?
         .filter_map(|e| Some(e.ok()?.path()))
@@ -311,11 +293,8 @@ fn scan_spec_pages(dir: &Path, base: &str) -> Result<Vec<SpecPage>, Box<dyn std:
         }
         // The index page is served at the root of the specification.
         page.top_level = stem == "index";
-        page.base = if page.top_level {
-            format!("{base}language/")
-        } else {
-            format!("{base}language/{stem}/")
-        };
+        page.base =
+            if page.top_level { format!("/language/") } else { format!("/language/{stem}/") };
         if !page.draft {
             pages.push(page);
         }
@@ -327,10 +306,7 @@ fn scan_spec_pages(dir: &Path, base: &str) -> Result<Vec<SpecPage>, Box<dyn std:
 /// their anchors. Pages marked `notInSC: true` cover the full language only, so
 /// they carry no requirements; the rest are served in the safety manual under
 /// `reference/property-types/`.
-fn scan_property_type_pages(
-    root: &Path,
-    base: &str,
-) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
+fn scan_property_type_pages(root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let dir = root.join(PROPERTY_TYPES_DIR);
     let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
         .context(format!("error reading {dir:?}"))?
@@ -348,7 +324,7 @@ fn scan_property_type_pages(
         if page.not_in_sc || page.anchors.is_empty() || page.draft {
             continue;
         }
-        page.base = format!("{base}reference/property-types/{stem}/");
+        page.base = format!("/reference/property-types/{stem}/");
         pages.push(page);
     }
     Ok(pages)
@@ -359,7 +335,6 @@ fn scan_property_type_pages(
 fn scan_reference_pages(
     cfg: &Config,
     repo_root: &Path,
-    base: &str,
 ) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let mut pages = Vec::new();
     for entry in walkdir::WalkDir::new(cfg.reference_dir()).sort_by_file_name() {
@@ -379,7 +354,7 @@ fn scan_reference_pages(
         // couldn't link to the anchors it just found.
         let slug = slug
             .ok_or_else(|| anyhow::anyhow!("{file}: generated page carries anchors but no slug"))?;
-        page.base = format!("{base}{slug}/");
+        page.base = format!("/{slug}/");
         pages.push(page);
     }
     Ok(pages)
@@ -394,10 +369,7 @@ fn safety_page_slug(relative: &str) -> &str {
 }
 
 /// Parse the handwritten safety-manual pages for their anchors.
-fn scan_safety_pages(
-    repo_root: &Path,
-    base: &str,
-) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
+fn scan_safety_pages(repo_root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let dir = repo_root.join(SAFETY_DOCS_DIR);
     let mut pages = Vec::new();
     for entry in walkdir::WalkDir::new(&dir)
@@ -428,7 +400,7 @@ fn scan_safety_pages(
         }
         let relative = repo_relative(path, &dir);
         let slug = slug.unwrap_or_else(|| safety_page_slug(&relative).to_string());
-        page.base = format!("{base}{slug}/");
+        page.base = format!("/{slug}/");
         pages.push(page);
     }
     Ok(pages)
@@ -484,7 +456,6 @@ fn git_head(repo_root: &Path) -> String {
 fn write_matrix(
     cfg: &Config,
     repo_root: &Path,
-    base: &str,
     spec_pages: &[SpecPage],
     reference_pages: &[SpecPage],
     safety_pages: &[SpecPage],
@@ -512,7 +483,7 @@ description: Mapping between the requirement paragraphs of the Language Specific
 slug: qualification-plan/traceability-matrix
 ---
 
-Each requirement paragraph in the [Language Specification]({base}language/), the [SC API Reference]({base}reference/), and the other chapters of this manual carries a unique identifier,
+Each requirement paragraph in the [Language Specification](/language/), the [SC API Reference](/reference/), and the other chapters of this manual carries a unique identifier,
 shown as a `[sls.…]` badge at the end of the paragraph.
 A test case declares which requirements it verifies by listing their identifiers in `//#sls.…` comments.
 This matrix lists every requirement paragraph with the test cases that declare it.

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -53,6 +53,12 @@ const SAFETY_DOCS_EXCLUDE: &[&str] = &["generated", "language"];
 /// [`Config::qualification_plan_dir`], the section it belongs to.
 const MATRIX_FILE: &str = "traceability-matrix.mdx";
 
+/// Where the safety manual declares the path it is served under. The matrix
+/// links from that base rather than relatively, because
+/// starlight-links-validator skips relative links: a relative one here would
+/// go unchecked, and could rot into a dead anchor unnoticed.
+const SAFETY_SITE_CONFIG: &str = "docs/safety/src/safety-site-config.mjs";
+
 const REPO_URL: &str = env!("CARGO_PKG_REPOSITORY");
 
 struct SpecPage {
@@ -60,8 +66,8 @@ struct SpecPage {
     file: String,
     /// From the frontmatter.
     title: String,
-    /// Site-relative URL of the page, for linking its anchors from the matrix.
-    /// The matrix sits two levels deep, so it starts with `../../`.
+    /// URL of the page from the site base, for linking its anchors from the
+    /// matrix. See [`SAFETY_SITE_CONFIG`] for why it isn't relative.
     base: String,
     /// The specification index heads its section; every other page nests
     /// under one.
@@ -98,10 +104,11 @@ impl TestRef {
 
 pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     let root = crate::root_dir();
-    let mut spec_pages = scan_spec_pages(&root.join(SPEC_DIR))?;
-    spec_pages.extend(scan_property_type_pages(&root)?);
-    let reference_pages = scan_reference_pages(cfg, &root)?;
-    let safety_pages = scan_safety_pages(&root)?;
+    let base = safety_base(&root)?;
+    let mut spec_pages = scan_spec_pages(&root.join(SPEC_DIR), &base)?;
+    spec_pages.extend(scan_property_type_pages(&root, &base)?);
+    let reference_pages = scan_reference_pages(cfg, &root, &base)?;
+    let safety_pages = scan_safety_pages(&root, &base)?;
 
     let mut refs = Vec::new();
     for kind in TEST_ROOTS {
@@ -125,7 +132,7 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    write_matrix(cfg, &root, &spec_pages, &reference_pages, &safety_pages, &tests_by_id)
+    write_matrix(cfg, &root, &base, &spec_pages, &reference_pages, &safety_pages, &tests_by_id)
 }
 
 /// Validate the parsed pages and test references, returning one message per
@@ -259,6 +266,19 @@ fn parse_spec_page(file: &str, text: &str) -> (SpecPage, Option<String>) {
     (page, slug)
 }
 
+/// The path the safety manual is served under, with leading and trailing `/`.
+fn safety_base(repo_root: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let path = repo_root.join(SAFETY_SITE_CONFIG);
+    let text = std::fs::read_to_string(&path).context(format!("error reading {path:?}"))?;
+    let value = text
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("export const SAFETY_DOCS_BASE_PATH ="))
+        .map(|value| value.trim().trim_end_matches(';').trim().trim_matches('"'))
+        .ok_or_else(|| anyhow::anyhow!("{SAFETY_SITE_CONFIG}: no SAFETY_DOCS_BASE_PATH"))?;
+    let trimmed = value.trim_matches('/');
+    Ok(if trimmed.is_empty() { "/".to_string() } else { format!("/{trimmed}/") })
+}
+
 /// Repository-relative path with `/` separators.
 fn repo_relative(path: &Path, repo_root: &Path) -> String {
     let relative = path.strip_prefix(repo_root).unwrap_or(path).to_string_lossy().into_owned();
@@ -269,7 +289,7 @@ fn repo_relative(path: &Path, repo_root: &Path) -> String {
     }
 }
 
-fn scan_spec_pages(dir: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
+fn scan_spec_pages(dir: &Path, base: &str) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
         .context(format!("error reading {dir:?}"))?
         .filter_map(|e| Some(e.ok()?.path()))
@@ -292,9 +312,9 @@ fn scan_spec_pages(dir: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Erro
         // The index page is served at the root of the specification.
         page.top_level = stem == "index";
         page.base = if page.top_level {
-            "../../language/".to_string()
+            format!("{base}language/")
         } else {
-            format!("../../language/{stem}/")
+            format!("{base}language/{stem}/")
         };
         if !page.draft {
             pages.push(page);
@@ -307,7 +327,10 @@ fn scan_spec_pages(dir: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Erro
 /// their anchors. Pages marked `notInSC: true` cover the full language only, so
 /// they carry no requirements; the rest are served in the safety manual under
 /// `reference/property-types/`.
-fn scan_property_type_pages(root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
+fn scan_property_type_pages(
+    root: &Path,
+    base: &str,
+) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let dir = root.join(PROPERTY_TYPES_DIR);
     let mut paths: Vec<std::path::PathBuf> = std::fs::read_dir(&dir)
         .context(format!("error reading {dir:?}"))?
@@ -325,7 +348,7 @@ fn scan_property_type_pages(root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::e
         if page.not_in_sc || page.anchors.is_empty() || page.draft {
             continue;
         }
-        page.base = format!("../../reference/property-types/{stem}/");
+        page.base = format!("{base}reference/property-types/{stem}/");
         pages.push(page);
     }
     Ok(pages)
@@ -336,6 +359,7 @@ fn scan_property_type_pages(root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::e
 fn scan_reference_pages(
     cfg: &Config,
     repo_root: &Path,
+    base: &str,
 ) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let mut pages = Vec::new();
     for entry in walkdir::WalkDir::new(cfg.reference_dir()).sort_by_file_name() {
@@ -355,7 +379,7 @@ fn scan_reference_pages(
         // couldn't link to the anchors it just found.
         let slug = slug
             .ok_or_else(|| anyhow::anyhow!("{file}: generated page carries anchors but no slug"))?;
-        page.base = format!("../../{slug}/");
+        page.base = format!("{base}{slug}/");
         pages.push(page);
     }
     Ok(pages)
@@ -370,7 +394,10 @@ fn safety_page_slug(relative: &str) -> &str {
 }
 
 /// Parse the handwritten safety-manual pages for their anchors.
-fn scan_safety_pages(repo_root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
+fn scan_safety_pages(
+    repo_root: &Path,
+    base: &str,
+) -> Result<Vec<SpecPage>, Box<dyn std::error::Error>> {
     let dir = repo_root.join(SAFETY_DOCS_DIR);
     let mut pages = Vec::new();
     for entry in walkdir::WalkDir::new(&dir)
@@ -401,7 +428,7 @@ fn scan_safety_pages(repo_root: &Path) -> Result<Vec<SpecPage>, Box<dyn std::err
         }
         let relative = repo_relative(path, &dir);
         let slug = slug.unwrap_or_else(|| safety_page_slug(&relative).to_string());
-        page.base = format!("../../{slug}/");
+        page.base = format!("{base}{slug}/");
         pages.push(page);
     }
     Ok(pages)
@@ -457,6 +484,7 @@ fn git_head(repo_root: &Path) -> String {
 fn write_matrix(
     cfg: &Config,
     repo_root: &Path,
+    base: &str,
     spec_pages: &[SpecPage],
     reference_pages: &[SpecPage],
     safety_pages: &[SpecPage],
@@ -484,7 +512,7 @@ description: Mapping between the requirement paragraphs of the Language Specific
 slug: qualification-plan/traceability-matrix
 ---
 
-Each requirement paragraph in the [Language Specification](../../language/), the [SC API Reference](../../reference/), and the other chapters of this manual carries a unique identifier,
+Each requirement paragraph in the [Language Specification]({base}language/), the [SC API Reference]({base}reference/), and the other chapters of this manual carries a unique identifier,
 shown as a `[sls.…]` badge at the end of the paragraph.
 A test case declares which requirements it verifies by listing their identifiers in `//#sls.…` comments.
 This matrix lists every requirement paragraph with the test cases that declare it.


### PR DESCRIPTION
Two guards in the safety manual were silently ineffective.

The `{#sls.…}` completeness check skipped the manual's own reference chapters, so
`rendering` and `generated-code` went unchecked for missing markers, and the 14
they carried were stripped rather than turned into anchors. The traceability
matrix cited all 14 anyway, as dead links.

Nothing caught that, because `starlight-links-validator` skips relative links
instead of resolving them, and every internal link in the manual was relative.

Now the manual's `reference/` counts as normative, and every internal link is
written from the site base so the validator that already runs actually checks it.
With nothing relative left, `errorOnRelativeLinks` is on, so a link that can't be
checked fails the build.

Coverage moves to 65 of 92 requirement paragraphs: the completeness check caught
two untagged normative paragraphs, which are now identified but not yet tested.
