### PR TITLE
node: type-check the test specs

### DIFF
--- a/.github/workflows/node_test_reusable.yaml
+++ b/.github/workflows/node_test_reusable.yaml
@@ -52,11 +52,12 @@ jobs:
               # binary and are covered by the registry e2e test (publish gate).
               run: pnpm build:testing
               working-directory: api/node
-            - name: Type-check registry e2e fixtures
-              # Type-checked here (not in the standalone typecheck job) because it
-              # resolves slint-ui's types, which depend on the generated bindings
-              # produced by the build above.
-              run: pnpm exec tsc -p tsconfig.e2e.json
+            - name: Type-check tests and registry e2e fixtures
+              # Type-checked here (not in the standalone typecheck job) because the
+              # specs and fixtures resolve slint-ui's types, which depend on the
+              # generated bindings produced by the build above. For the same reason
+              # api/node is filtered out of the root type-check:ci script.
+              run: pnpm type-check
               working-directory: api/node
             - name: Run node tests
               working-directory: api/node

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -35,27 +35,27 @@ test("loadFile", () => {
 
     const errorPath = path.join(dirname, "resources/error.slint");
 
-    let error: any;
+    let error: CompileError | undefined;
     try {
         loadFile(errorPath);
     } catch (e) {
-        error = e;
+        error = e as CompileError;
     }
     expect(error).toBeDefined();
     expect(error).toBeInstanceOf(CompileError);
 
-    const formattedDiagnostics = error.diagnostics
+    const formattedDiagnostics = error!.diagnostics
         .map(
             (d) =>
                 `[${d.fileName}:${d.lineNumber}:${d.columnNumber}] ${d.message}`,
         )
         .join("\n");
-    expect(error.message).toBe(
+    expect(error!.message).toBe(
         "Could not compile " +
             errorPath +
             `\nDiagnostics:\n${formattedDiagnostics}`,
     );
-    expect(error.diagnostics).toStrictEqual([
+    expect(error!.diagnostics).toStrictEqual([
         {
             columnNumber: 18,
             level: 0,
@@ -142,26 +142,26 @@ test("loadSource", () => {
         out property bool> check: "Test";
     }`;
 
-    let error: any;
+    let error: CompileError | undefined;
     try {
         loadSource(errorSource, path);
     } catch (e) {
-        error = e;
+        error = e as CompileError;
     }
     expect(error).toBeDefined();
     expect(error).toBeInstanceOf(CompileError);
 
-    const formattedDiagnostics = error.diagnostics
+    const formattedDiagnostics = error!.diagnostics
         .map(
             (d) =>
                 `[${d.fileName}:${d.lineNumber}:${d.columnNumber}] ${d.message}`,
         )
         .join("\n");
-    expect(error.message).toBe(
+    expect(error!.message).toBe(
         "Could not compile " + path + `\nDiagnostics:\n${formattedDiagnostics}`,
     );
     // console.log(error?.diagnostics)
-    expect(error.diagnostics).toStrictEqual([
+    expect(error!.diagnostics).toStrictEqual([
         {
             columnNumber: 22,
             level: 0,

--- a/api/node/__test__/data_transfer.spec.mts
+++ b/api/node/__test__/data_transfer.spec.mts
@@ -161,7 +161,7 @@ test("DataTransfer round-trips through Slint callbacks", () => {
         export component App {}
         `,
         "data_transfer_callback.slint",
-    );
+    ) as any;
     const app = new ui.App() as unknown as {
         Api: {
             identity: (dt: DataTransfer) => DataTransfer;

--- a/api/node/__test__/eventloop.spec.mts
+++ b/api/node/__test__/eventloop.spec.mts
@@ -39,7 +39,10 @@ test.sequential("merged event loops with timer", async () => {
 });
 
 test.sequential("merged event loops with networking", async () => {
-    const listener = (request, result) => {
+    const listener = (
+        request: http.IncomingMessage,
+        result: http.ServerResponse,
+    ) => {
         result.writeHead(200);
         result.end("Hello World");
     };

--- a/api/node/__test__/gc.spec.mts
+++ b/api/node/__test__/gc.spec.mts
@@ -669,7 +669,7 @@ test("custom model capturing instance does not prevent GC", async () => {
         const instance = new demo.App();
 
         class CapturingModel extends ArrayModel<string> {
-            rowData(row: number): string | undefined {
+            rowData(row: number): string {
                 void instance.label;
                 return super.rowData(row);
             }

--- a/api/node/__test__/globals.spec.mts
+++ b/api/node/__test__/globals.spec.mts
@@ -156,7 +156,7 @@ test("invoke global callback", () => {
         expect(thrownError.message).toBe("Global MyGlobal not found");
     }
 
-    let speakTest: string;
+    let speakTest: string | undefined;
     instance!.setGlobalCallback(
         "Global",
         "great",

--- a/api/node/__test__/js_value_conversion.spec.mts
+++ b/api/node/__test__/js_value_conversion.spec.mts
@@ -233,7 +233,7 @@ test("get/set image properties", async () => {
         expect((slintImage as private_api.SlintImageData).height).toStrictEqual(
             64,
         );
-        expect((slintImage as ImageData).path.endsWith("rgb.png")).toBe(true);
+        expect((slintImage as ImageData).path!.endsWith("rgb.png")).toBe(true);
 
         const image = await read(path.join(dirname, "resources/rgb.png"));
         const rgbaImage =
@@ -902,7 +902,7 @@ test("invoke callback", () => {
         "",
     );
     const instance = createNonNullInstance(definition);
-    let speakTest: string;
+    let speakTest: string | undefined;
 
     instance.setCallback(
         "great",

--- a/api/node/__test__/tsconfig.json
+++ b/api/node/__test__/tsconfig.json
@@ -2,10 +2,12 @@
     "compilerOptions": {
         "module": "nodenext",
         "target": "esnext",
-        "outDir": "../build",
-        "skipLibCheck": true
+        "noEmit": true,
+        "skipLibCheck": true,
+        "types": ["node"]
     },
     "include": [
-        "*.mts"
-    ],
+        "*.mts",
+        "helpers/"
+    ]
 }

--- a/api/node/binding.d.cts
+++ b/api/node/binding.d.cts
@@ -5,4 +5,4 @@
 // generated type definitions of the default binary describe both. See
 // binding.cjs for the runtime loading logic.
 
-export * from "./rust-module.d.cts";
+export * from "./rust-module.cjs";

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -44,7 +44,7 @@
     "docs": "pnpm build && pnpm -C ../../docs/nodejs run build",
     "docs:dev": "pnpm build && pnpm -C ../../docs/nodejs run dev",
     "docs:debug": "pnpm build:debug && pnpm -C ../../docs/nodejs run build",
-    "type-check": "tsc -p __test__/tsconfig.json && tsc -p tsconfig.e2e.json",
+    "type-check": "tsc -p tsconfig.bindings.json && tsc -p __test__/tsconfig.json && tsc -p tsconfig.e2e.json",
     "check": "biome check",
     "format": "biome format",
     "format:fix": "biome format --write",

--- a/api/node/package.json
+++ b/api/node/package.json
@@ -44,6 +44,7 @@
     "docs": "pnpm build && pnpm -C ../../docs/nodejs run build",
     "docs:dev": "pnpm build && pnpm -C ../../docs/nodejs run dev",
     "docs:debug": "pnpm build:debug && pnpm -C ../../docs/nodejs run build",
+    "type-check": "tsc -p __test__/tsconfig.json && tsc -p tsconfig.e2e.json",
     "check": "biome check",
     "format": "biome format",
     "format:fix": "biome format --write",

--- a/api/node/rust/interpreter/component_compiler.rs
+++ b/api/node/rust/interpreter/component_compiler.rs
@@ -161,7 +161,7 @@ impl JsComponentCompiler {
     pub fn set_file_loader(
         &mut self,
         env: &Env,
-        callback: crate::DynFunction<'_>,
+        #[napi(ts_arg_type = "(path: string) => string")] callback: crate::DynFunction<'_>,
     ) -> napi::Result<()> {
         let func_ref = std::rc::Rc::new(callback.create_ref()?);
         let env = *env;

--- a/api/node/rust/interpreter/component_instance.rs
+++ b/api/node/rust/interpreter/component_instance.rs
@@ -193,7 +193,7 @@ impl JsComponentInstance {
         env: &Env,
         mut this: This<Object<'_>>,
         callback_name: String,
-        callback: DynFunction<'_>,
+        #[napi(ts_arg_type = "(...args: any[]) => any")] callback: DynFunction<'_>,
     ) -> Result<()> {
         let (ty, _) = self
             .inner
@@ -236,7 +236,7 @@ impl JsComponentInstance {
         mut this: This<Object<'_>>,
         global_name: String,
         callback_name: String,
-        callback: DynFunction<'_>,
+        #[napi(ts_arg_type = "(...args: any[]) => any")] callback: DynFunction<'_>,
     ) -> Result<()> {
         let (ty, _) = self
             .inner

--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -76,7 +76,10 @@ pub fn process_events() -> napi::Result<ProcessEventsResult> {
 }
 
 #[napi]
-pub fn invoke_from_event_loop(env: &Env, callback: DynFunction<'_>) -> napi::Result<()> {
+pub fn invoke_from_event_loop(
+    env: &Env,
+    #[napi(ts_arg_type = "() => void")] callback: DynFunction<'_>,
+) -> napi::Result<()> {
     i_slint_backend_selector::with_platform(|_b| {
         // Nothing to do, just make sure a backend was created
         Ok(())

--- a/api/node/rust/uv_event_loop.rs
+++ b/api/node/rust/uv_event_loop.rs
@@ -516,6 +516,9 @@ pub fn has_integrated_event_loop(env: Env) -> bool {
 }
 
 #[napi]
-pub fn start_integrated_event_loop(env: &Env, on_exit: crate::DynFunction<'_>) -> napi::Result<()> {
+pub fn start_integrated_event_loop(
+    env: &Env,
+    #[napi(ts_arg_type = "() => void")] on_exit: crate::DynFunction<'_>,
+) -> napi::Result<()> {
     platform::start_integrated_event_loop_impl(env, on_exit)
 }

--- a/api/node/tsconfig.bindings.json
+++ b/api/node/tsconfig.bindings.json
@@ -1,0 +1,14 @@
+// Type-checks the napi-generated declarations themselves, which the other
+// tsconfigs hide behind skipLibCheck. Without this nothing catches a type name
+// that the generator emits but never declares: the reference silently degrades
+// to `any` and every parameter using it stops being checked.
+{
+    "compilerOptions": {
+        "module": "nodenext",
+        "target": "esnext",
+        "noEmit": true,
+        "skipLibCheck": false,
+        "types": ["node"]
+    },
+    "files": ["binding.d.cts"]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "pnpm --stream -r lint",
     "lint:fix": "pnpm --stream -r lint:fix",
     "type-check": "pnpm --stream -r type-check",
-    "type-check:ci": "pnpm --stream --filter '!./editors/vscode' --filter '!slint_repository' --filter '!./docs/nodejs' --filter '!./docs/python' -r type-check"
+    "type-check:ci": "pnpm --stream --filter '!./editors/vscode' --filter '!./api/node' --filter '!slint_repository' --filter '!./docs/nodejs' --filter '!./docs/python' -r type-check"
   },
   "packageManager": "pnpm@11.17.0"
 }


### PR DESCRIPTION
The __test__/tsconfig.json was orphaned: nothing referenced it, and neither pnpm compile nor the CI typecheck job covered __test__/*.mts. Wire it up via a type-check script that runs in the node test workflow, after the build the specs' types depend on, and fix the 14 errors it surfaces.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
