### PR TITLE
ci: run the autofix tasks in parallel

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -33,7 +33,7 @@ jobs:
             - name: Install rust dependencies
               run: rustup toolchain install stable-x86_64-unknown-linux-gnu --profile default
             - name: Run fixes
-              run: mise run --force --jobs=1 'ci:autofix:fix'
+              run: mise run --force 'ci:autofix:fix'
             - name: Suggest format changes
               uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
 
@@ -49,7 +49,7 @@ jobs:
             - name: Install rust dependencies
               run: rustup toolchain install stable-x86_64-unknown-linux-gnu --profile default
             - name: Run lints
-              run: mise run --force --jobs=1 'ci:autofix:lint'
+              run: mise run --force 'ci:autofix:lint'
             - name: Spell check
               uses: streetsidesoftware/cspell-action@v8
               with:

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -13,6 +13,7 @@ tools = { "pipx:clang-format" = "20.1.3" }
 
 ["fix:rust:lockfile:root"]
 description = "Update the main lockfile (if absolutely necessary)"
+wait_for = ["fix:toml:format"]
 # Use cargo build -p xtask to test if the lockfile needs updating.
 # The fix:legal:copyright task needs the xtask anyhow, so this has a double use.
 run = "cargo build --locked -p xtask || (echo \"### Updating Main Lockfile! ###\" && cargo update)"
@@ -23,16 +24,19 @@ run = "cargo build --locked -p xtask || (echo \"### Updating Main Lockfile! ###\
 # --format-version suppresses "warning: please specify `--format-version` flag explicitly to avoid compatibility problems"
 ["fix:rust:lockfile:examples"]
 description = "Update the examples workspace lockfile (if absolutely necessary)"
+wait_for = ["fix:toml:format"]
 run = "cargo metadata --locked --format-version=1 > /dev/null || (echo \"### Updating Examples Lockfile! ###\" && cargo update)"
 dir = "examples"
 
 ["fix:rust:lockfile:demos"]
 description = "Update the demos workspace lockfile (if absolutely necessary)"
+wait_for = ["fix:toml:format"]
 run = "cargo metadata --locked --format-version=1 > /dev/null || (echo \"### Updating Demos Lockfile! ###\" && cargo update)"
 dir = "demos"
 
 ["fix:rust:lockfile:tests"]
 description = "Update the tests workspace lockfile (if absolutely necessary)"
+wait_for = ["fix:toml:format"]
 run = "cargo metadata --locked --format-version=1 > /dev/null || (echo \"### Updating Tests Lockfile! ###\" && cargo update)"
 dir = "tests"
 
@@ -40,6 +44,15 @@ dir = "tests"
 description = "Run the check_license_headers --fix xtask"
 run = "cargo xtask check_license_headers --fix-it"
 depends = ["fix:rust:lockfile:root"]
+# Edits the same files as the formatters, so don't run concurrently with them
+wait_for = [
+  "fix:cpp:format",
+  "fix:python:format",
+  "fix:rust:format:all",
+  "fix:toml:format",
+  "fix:ts:format",
+  "fix:ts:biome",
+]
 
 ["fix:python:format"]
 description = "Run ruff format"
@@ -91,6 +104,7 @@ depends = ["prepare:pnpm-install"]
 description = "Run pnpm format:fix"
 run = "pnpm run format:fix"
 depends = ["prepare:pnpm-install"]
+wait_for = ["fix:ts:biome"]
 
 ["fix:ts:biome"]
 description = "Run pnpm lint:fix"

--- a/.mise/tasks/fix/text/trailing_spaces
+++ b/.mise/tasks/fix/text/trailing_spaces
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #MISE description="Run trailing WS fix on all files"
+# Touches every text file, so don't run concurrently with the other fixers
+#MISE wait_for=["fix:cpp:format", "fix:legal:copyright", "fix:pnpm:dedupe", "fix:pnpm:lock", "fix:python:format", "fix:rust:format:all", "fix:toml:format", "fix:ts:biome", "fix:ts:format"]
 
-# cSpell: ignore OSTYPE INPLACE
+# cSpell: ignore OSTYPE INPLACE dedupe
 
 set -e
 


### PR DESCRIPTION
The fix tasks ran with --jobs=1 because several of them edit the same files: the trailing-spaces fixer and the copyright fixer touch every file type that the per-language formatters format, and biome and the ts formatter share their file set. Express those conflicts with wait_for, which only orders tasks that run in the same invocation, and drop --jobs=1. The per-language formatters are disjoint by file type and run concurrently; cargo's own locking already serializes the lockfile tasks sharing the target directory.

The fix step goes from 30 to 8 seconds locally; on the CI runner it should roughly halve the format_fix job, which gates all other jobs.
