### PR TITLE
ci: merge the mcu and ffi_32bit_build jobs into one cross-compile job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -321,32 +321,42 @@ jobs:
               working-directory: editors/vscode
               run: pnpm test_grammar
 
-    # test to compile the mcu backend for no_std targets (ARM and ESP32)
-    mcu:
-        if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') }}
+    # Compile checks that need cross-compilation toolchains: the mcu backend
+    # for no_std targets (ARM and ESP32) and the 32-bit ARM FFI build. They
+    # share one job to keep the number of runners a PR occupies down; each
+    # step only runs when its own filter group matched.
+    cross_compile_checks:
+        if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') || contains(fromJSON(inputs.changes), 'api_cpp') }}
         env:
-            SLINT_FONT_SIZES: 8,11,10,12,13,14,15,16,18,20,22,24,32
-            RUSTFLAGS: --cfg slint_int_coord -D warnings
-            CARGO_PROFILE_RELEASE_OPT_LEVEL: s
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SLINT_FONT_SIZES: 8,11,10,12,13,14,15,16,18,20,22,24,32
+            CARGO_PROFILE_RELEASE_OPT_LEVEL: s
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v7
             - uses: ./.github/actions/setup-rust
               with:
-                  target: thumbv6m-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabihf
+                  target: thumbv6m-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabihf,armv7-unknown-linux-gnueabihf
             - uses: esp-rs/xtensa-toolchain@v1.7
               if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'examples_mcu') }}
               with:
                   buildtargets: esp32
                   ldproxy: false
             - name: Check pico-st7789
+              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') }}
+              env:
+                  RUSTFLAGS: --cfg slint_int_coord -D warnings
               run: cargo check --target=thumbv6m-none-eabi --manifest-path demos/Cargo.toml -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --release
             - name: Check mcu-embassy
+              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') }}
+              env:
+                  RUSTFLAGS: --cfg slint_int_coord -D warnings
               run: cargo check --bin ui_mcu --target=thumbv8m.main-none-eabihf --no-default-features --features="mcu-embassy/mcu" --release
               working-directory: examples/mcu-embassy
             - name: Check all boards
               if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'examples_mcu') }}
+              env:
+                  RUSTFLAGS: --cfg slint_int_coord -D warnings
               run: |
                   cargo check --target=thumbv8m.main-none-eabihf --manifest-path demos/Cargo.toml -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico2-st7789 --release
                   cargo check --target=thumbv8m.main-none-eabihf --manifest-path demos/Cargo.toml -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico2-touch-lcd-2-8 --release
@@ -358,18 +368,12 @@ jobs:
                   cargo +esp check --manifest-path demos/Cargo.toml -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/waveshare-esp32-s3-touch-amoled-1-8 --config examples/mcu-board-support/waveshare_esp32_s3_touch_amoled_1_8/cargo-config.toml --release
                   cargo +esp check --manifest-path demos/Cargo.toml -p printerdemo_mcu --target xtensa-esp32s3-none-elf --no-default-features --features=mcu-board-support/m5stack-cores3 --config examples/mcu-board-support/m5stack_cores3/cargo-config.toml --release
 
-    ffi_32bit_build:
-        if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'api_cpp') }}
-        runs-on: ubuntu-22.04
-        steps:
-            - uses: actions/checkout@v7
-            - uses: ./.github/actions/setup-rust
-              with:
-                  target: armv7-unknown-linux-gnueabihf
             - uses: baptiste0928/cargo-install@v3
+              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'api_cpp') }}
               with:
                   crate: cross
-            - name: Check
+            - name: Check the 32-bit ARM FFI build
+              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'api_cpp') }}
               run: cross check --target=armv7-unknown-linux-gnueabihf -p slint-cpp --no-default-features --features=testing,interpreter,std
 
     docs:


### PR DESCRIPTION
Both jobs run less than two minutes of checks behind a minute of identical setup, and both trigger on internal changes. One job frees a runner slot per PR, which is what the queue waits during busy hours are made of. Each step keeps its own filter-group condition, and RUSTFLAGS moves onto the mcu steps so the slint_int_coord cfg and -D warnings don't leak into the FFI check, which never had them.
