### PR TITLE
slint-sc: make definitional spec paragraphs informative

### DIFF
--- a/docs/astro/src/content/docs/reference/language/source-files.mdx
+++ b/docs/astro/src/content/docs/reference/language/source-files.mdx
@@ -9,7 +9,7 @@ import SC from '@slint/common-files/src/components/SC.astro';
 <SC>
 ## File Extension
 
-Slint source files use the file extension `.slint`. \{#sls.source.file-extension}
+Slint source files use the file extension `.slint`. \{#sls.source.file-extension.meta}
 
 ## Encoding
 
@@ -26,7 +26,7 @@ Source files should not contain bare carriage returns. \{#sls.source.bare-cr}
 
 ## Whitespace
 
-The whitespace characters are `U+0020` (SPACE), `U+0009` (CHARACTER TABULATION), and the line terminators defined in [Line Terminators](#line-terminators). \{#sls.source.whitespace.chars}
+The whitespace characters are `U+0020` (SPACE), `U+0009` (CHARACTER TABULATION), and the line terminators defined in [Line Terminators](#line-terminators). \{#sls.source.whitespace.meta.chars}
 
 Whitespace separates tokens but is otherwise insignificant; any sequence of one or more whitespace characters is equivalent to a single space. \{#sls.source.whitespace.collapse}
 

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -472,10 +472,11 @@ fn scan_test_refs(
 }
 
 /// Whether a paragraph is informative rather than a testable requirement:
-/// the document conventions (`sls.meta.…`) and examples. These are excluded
-/// from the matrix; examples are compiled by the doctests test instead.
+/// ids with a `meta` segment (document conventions, definitional prose) and
+/// examples. These are excluded from the matrix; examples are compiled by
+/// the doctests test instead.
 fn informative(id: &str) -> bool {
-    id.starts_with("sls.meta.") || id.split('.').any(|s| s == "example")
+    id.split('.').any(|s| s == "meta" || s == "example")
 }
 
 /// The commit to link test files to on GitHub.
@@ -526,7 +527,7 @@ shown as a `[sls.…]` badge at the end of the paragraph.
 A test case declares which requirements it verifies by listing their identifiers in `//#sls.…` comments.
 This matrix lists every requirement paragraph with the test cases that declare it.
 Requirements not yet covered by any test are marked ❌.
-Informative paragraphs — the document conventions (`sls.meta.…`) and examples — are not listed;
+Informative paragraphs — those whose identifier contains a `meta` segment, and examples — are not listed;
 the examples are compiled by the doctests test instead.
 
 Tests marked `case:` are executed test cases from `{case_root}/`,
@@ -612,8 +613,11 @@ fn test_informative() {
     assert!(informative("sls.meta.purpose"));
     assert!(informative("sls.file.example.intro"));
     assert!(informative("sls.file.example.description"));
+    assert!(informative("sls.source.file-extension.meta"));
+    assert!(informative("sls.source.whitespace.meta.chars"));
     assert!(!informative("sls.lex.identifier.normalization-example"));
     assert!(!informative("sls.file.component.body"));
+    assert!(!informative("sls.source.metadata"));
 }
 
 #[test]


### PR DESCRIPTION
The file-extension, whitespace-characters, and tokens paragraphs are definitional prose, not testable requirements. Rename their ids to carry a `meta` segment, and treat any `meta` segment as informative in the traceability matrix (subsumes the `sls.meta.` prefix rule).
