### PR TITLE
ci: drop --exclude names that are no longer root workspace members

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -109,7 +109,8 @@ jobs:
                   name: docs-rust-cpp
                   path: artifact
             - name: "Check for docs warnings in internal crates"
-              run: cargo doc --workspace --no-deps --all-features --exclude slint-node --exclude pyslint --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude carousel --exclude test-* --exclude plotter --exclude uefi-demo --exclude ffmpeg --exclude gstreamer-player --exclude slint-cpp --exclude slint-python
+              # The excluded crates need a dedicated toolchain (node/python/cpp).
+              run: cargo doc --workspace --no-deps --all-features --exclude slint-node --exclude slint-cpp --exclude slint-python
 
     # Job 2: Build Astro docs and run tests
     astro-docs-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -730,7 +730,8 @@ jobs:
                   # the target's CFLAGS, so this augments rather than replaces its include flags.
                   CFLAGS: -msse2
                   CXXFLAGS: -msse2
-              run: cargo xwin build --target i686-pc-windows-msvc --locked --workspace --exclude doctests --exclude slint-node --exclude pyslint --exclude test-driver-node --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python --exclude mcu-board-support --exclude mcu-embassy --exclude printerdemo_mcu --exclude uefi-demo --exclude slint-cpp --exclude slint-python --exclude slint-sc --exclude ffmpeg --exclude gstreamer-player --exclude material-gallery --exclude test-driver-screenshots --exclude slint-doc-generator --exclude i-slint-renderer-skia
+              # The excluded crates need a dedicated toolchain or don't cross-compile here.
+              run: cargo xwin build --target i686-pc-windows-msvc --locked --workspace --exclude slint-node --exclude slint-cpp --exclude slint-python --exclude slint-sc --exclude slint-doc-generator --exclude i-slint-renderer-skia
 
     qa-tree-sitter-latest:
         if: ${{ inputs.full }}


### PR DESCRIPTION
The examples, demos, integration tests and material UI library moved to
their own workspaces, so those excludes match nothing and cargo only
warns about them. pyslint had already been renamed to slint-python.