### PR TITLE
FlexboxLayout: honor percentage min/max constraints

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1424,7 +1424,7 @@ mod flexbox_taffy {
     use super::{
         Coord, CrossAxisAlignment, FlexboxLayoutAlignContent, FlexboxLayoutAlignSelf,
         FlexboxLayoutItemInfo, FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment,
-        Padding, Slice,
+        LayoutInfo, Padding, Slice,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
@@ -1465,14 +1465,48 @@ mod flexbox_taffy {
         pub fn new(params: FlexboxLayoutParams) -> Self {
             let mut taffy = TaffyTree::<usize>::new();
 
+            // The container's content box on each axis (the outer size minus that
+            // axis' padding), against which percentage constraints resolve.
+            // `None` when that axis has no finite size: either unknown (an
+            // auto-sized container in the info path) or the `Coord::MAX`
+            // "unbounded" sentinel the info path passes for a no-wrap main axis.
+            // A percentage then has no basis and only the absolute constraint
+            // applies — resolving against `MAX` would overflow the `_percent * s`
+            // product (i32 build) or yield infinity (f32).
+            let content_box = |size: Option<Coord>, pad: &Padding| -> Option<Coord> {
+                size.filter(|s| *s < Coord::MAX).map(|s| (s - pad.begin - pad.end).max(0 as Coord))
+            };
+            let content_w = content_box(params.container_width, params.padding_h);
+            let content_h = content_box(params.container_height, params.padding_v);
+
             // Cross-axis (width) upper bound for a column item: never wider than
             // the container's content box, so height-for-width items (e.g. wrapped
             // Text) measure against a real width.
             let column_cross_cap = match params.flex_direction {
-                TaffyFlexDirection::Column | TaffyFlexDirection::ColumnReverse => params
-                    .container_width
-                    .map(|cw| (cw - params.padding_h.begin - params.padding_h.end).max(0 as Coord)),
+                TaffyFlexDirection::Column | TaffyFlexDirection::ColumnReverse => content_w,
                 _ => None,
+            };
+
+            // Resolve a percentage min/max against the container's content box and
+            // fold it into the absolute constraint, matching how the box layouts
+            // handle percentages (see `solve_box_layout`). Applied only when the
+            // percentage is non-default and the content size is known, so an item
+            // without a percentage size keeps its plain min/max unchanged.
+            let eff_min = |c: &LayoutInfo, content: Option<Coord>| -> Coord {
+                match content {
+                    Some(s) if c.min_percent > 0 as Coord => {
+                        c.min.max(c.min_percent * s / 100 as Coord)
+                    }
+                    _ => c.min,
+                }
+            };
+            let eff_max = |c: &LayoutInfo, content: Option<Coord>| -> Coord {
+                match content {
+                    Some(s) if c.max_percent < 100 as Coord => {
+                        c.max.min(c.max_percent * s / 100 as Coord)
+                    }
+                    _ => c.max,
+                }
             };
 
             // Create child nodes from Slint constraints
@@ -1515,7 +1549,8 @@ mod flexbox_taffy {
                         }
                     };
 
-                    let max_width = h_constraint.max.min(column_cross_cap.unwrap_or(Coord::MAX));
+                    let max_width = eff_max(h_constraint, content_w)
+                        .min(column_cross_cap.unwrap_or(Coord::MAX));
                     let max_width_dim = if max_width < Coord::MAX {
                         Dimension::length(max_width as _)
                     } else {
@@ -1570,21 +1605,20 @@ mod flexbox_taffy {
                                     },
                                 },
                                 min_size: Size {
-                                    width: Dimension::length(h_constraint.min as _),
+                                    width: Dimension::length(eff_min(h_constraint, content_w) as _),
                                     height: Dimension::length(
-                                        v_constraint.map(|vc| vc.min as f32).unwrap_or(0.0),
+                                        v_constraint
+                                            .map(|vc| eff_min(vc, content_h) as f32)
+                                            .unwrap_or(0.0),
                                     ),
                                 },
                                 max_size: Size {
                                     width: max_width_dim,
-                                    height: if let Some(vc) = v_constraint {
-                                        if vc.max < Coord::MAX {
-                                            Dimension::length(vc.max as _)
-                                        } else {
-                                            Dimension::auto()
+                                    height: match v_constraint.map(|vc| eff_max(vc, content_h)) {
+                                        Some(max_h) if max_h < Coord::MAX => {
+                                            Dimension::length(max_h as _)
                                         }
-                                    } else {
-                                        Dimension::auto()
+                                        _ => Dimension::auto(),
                                     },
                                 },
                                 flex_grow: cell_h.flex_grow,
@@ -3187,5 +3221,61 @@ mod tests {
                 50.,
             );
         }
+    }
+
+    /// A percentage constraint must not be resolved against the `Coord::MAX`
+    /// "unbounded" sentinel that the info path passes for a no-wrap main axis.
+    /// `min_percent * MAX / 100` overflows the i32 build (debug panic) and gives
+    /// infinity in the f32 build, which taffy then bakes into the item's size.
+    /// When the container axis is unbounded a percentage has no basis, so the
+    /// item keeps its natural (here zero) size instead.
+    ///
+    /// Checked at the builder because the containing info function reports only
+    /// the *cross* size, while the overflow lands on the item's *main*-axis size;
+    /// the f32 build hides it at the container level but not at the item.
+    #[test]
+    fn percentage_against_unbounded_container_leaves_item_finite() {
+        // A single row cell with `width: 50%` (min_percent == max_percent == 50).
+        let cells_h = [FlexboxLayoutItemInfo {
+            constraint: LayoutInfo {
+                min_percent: 50 as Coord,
+                max_percent: 50 as Coord,
+                max: Coord::MAX,
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let cells_v = [FlexboxLayoutItemInfo {
+            constraint: LayoutInfo {
+                preferred: 30 as Coord,
+                max: Coord::MAX,
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let pad = Padding::default();
+        let mut builder =
+            flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
+                cells_h: &Slice::from_slice(&cells_h),
+                cells_v: &Slice::from_slice(&cells_v),
+                spacing_h: 0 as Coord,
+                spacing_v: 0 as Coord,
+                padding_h: &pad,
+                padding_v: &pad,
+                alignment: LayoutAlignment::Start,
+                align_content: FlexboxLayoutAlignContent::Stretch,
+                cross_axis_alignment: CrossAxisAlignment::Stretch,
+                flex_wrap: FlexboxLayoutWrap::NoWrap,
+                flex_direction: flexbox_taffy::TaffyFlexDirection::Row,
+                // The unbounded main axis: the value the info path feeds here.
+                container_width: Some(Coord::MAX),
+                container_height: None,
+                use_measure_for_cross_axis: false,
+            });
+        builder.compute_layout(Coord::MAX, Coord::MAX, None);
+        let (_x, _y, w, _h) = builder.child_geometry(0);
+        // Without the fix the dropped `50% * MAX` makes this the f32 sentinel
+        // (or panics under i32); with it the item just takes its natural size.
+        assert!(w.is_finite() && w < Coord::MAX, "item main-axis size was {w}");
     }
 }

--- a/tests/cases/layout/flexbox_percent_size.slint
+++ b/tests/cases/layout/flexbox_percent_size.slint
@@ -1,0 +1,221 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A percentage width/height on a flex child resolves against the container's
+// content box, like it does in the box layouts. The FlexboxLayout must honor
+// it so the item is sized and its siblings positioned accordingly, rather than
+// collapsing the item (taffy used to ignore the percentage constraints).
+//
+// The cases stay plain `Rectangle`s (so the tested layout-info is unchanged),
+// but the percentage cell is light blue and labeled "50%", the sibling is gray,
+// and each row has a title, so the rendered window explains itself: every blue
+// box should visibly span half of its container.
+
+// A 50%-wide item in a row: 200px of a 400px container, sibling placed after it
+component TestPercentRow inherits Rectangle {
+    VerticalLayout {
+        alignment: start;
+        Text { text: "row: 50% of 400px → 200px, sibling follows at 200"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            fl := FlexboxLayout {
+                width: 400px;
+                height: 30px;
+                flex-wrap: no-wrap;
+                spacing: 0px;
+                a := Rectangle {
+                    width: 50%;
+                    height: 30px;
+                    background: #cce6ff;
+                    Text { width: 100%; height: 100%; text: "50%"; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                b := Rectangle { preferred-width: 30px; height: 30px; background: #c8c8c8; }
+            }
+        }
+    }
+
+    out property <bool> test_a: a.width == 200px;
+    out property <bool> test_b: b.x == 200px;
+    out property <bool> test: test_a && test_b;
+}
+
+// The same markup in a HorizontalLayout, to pin that the two agree
+component TestPercentRowBox inherits Rectangle {
+    VerticalLayout {
+        alignment: start;
+        Text { text: "HorizontalLayout (same markup): also 200px"; font-size: 11px; }
+        HorizontalLayout {
+            width: 400px;
+            height: 30px;
+            spacing: 0px;
+            alignment: start;
+            a := Rectangle {
+                width: 50%;
+                height: 30px;
+                background: #cce6ff;
+                Text { width: 100%; height: 100%; text: "50%"; color: #003366;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            b := Rectangle { preferred-width: 30px; height: 30px; background: #c8c8c8; }
+        }
+    }
+
+    out property <bool> test_a: a.width == 200px;
+    out property <bool> test_b: b.x == 200px;
+    out property <bool> test: test_a && test_b;
+}
+
+// Percentage resolves against the content box, so padding is subtracted first:
+// 50% of (300 - 2*20) = 130
+component TestPercentPadding inherits Rectangle {
+    VerticalLayout {
+        alignment: start;
+        Text { text: "with padding: 50% of content box (300 − 2×20) = 130px"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            fl := FlexboxLayout {
+                width: 300px;
+                height: 70px;
+                flex-wrap: no-wrap;
+                padding: 20px;
+                spacing: 0px;
+                a := Rectangle {
+                    width: 50%;
+                    height: 30px;
+                    background: #cce6ff;
+                    Text { width: 100%; height: 100%; text: "50%"; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+    }
+
+    out property <bool> test: a.width == 130px;
+}
+
+// A column flex: a 50% height item is 100px of a 200px container
+component TestPercentColumn inherits Rectangle {
+    VerticalLayout {
+        alignment: start;
+        Text { text: "column: height 50% of 200px → 100px"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            fl := FlexboxLayout {
+                width: 40px;
+                height: 200px;
+                flex-direction: column;
+                flex-wrap: no-wrap;
+                spacing: 0px;
+                a := Rectangle {
+                    width: 40px;
+                    height: 50%;
+                    background: #cce6ff;
+                    Text { width: 100%; height: 100%; text: "50%"; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                b := Rectangle { preferred-height: 20px; width: 40px; background: #c8c8c8; }
+            }
+        }
+    }
+
+    out property <bool> test_a: a.height == 100px;
+    out property <bool> test_b: b.y == 100px;
+    out property <bool> test: test_a && test_b;
+}
+
+// The percentage resolves against the CSS content box, which does not subtract
+// spacing (unlike the box layouts). So 50% of a 400px container stays 200px
+// with spacing, and the sibling is placed at 200 + spacing.
+component TestPercentSpacing inherits Rectangle {
+    VerticalLayout {
+        alignment: start;
+        Text { text: "with spacing 20px: still 50% of 400 = 200px (content box ignores spacing)";
+            font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            fl := FlexboxLayout {
+                width: 400px;
+                height: 30px;
+                flex-wrap: no-wrap;
+                spacing: 20px;
+                a := Rectangle {
+                    width: 50%;
+                    height: 30px;
+                    background: #cce6ff;
+                    Text { width: 100%; height: 100%; text: "50%"; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                b := Rectangle { preferred-width: 30px; height: 30px; background: #c8c8c8; }
+            }
+        }
+    }
+
+    out property <bool> test_a: a.width == 200px;
+    out property <bool> test_b: b.x == 220px;
+    out property <bool> test: test_a && test_b;
+}
+
+// max_percent caps growth: a 50%-wide item with flex-grow stays at 50%, it does
+// not grow to fill the container.
+component TestPercentGrow inherits Rectangle {
+    VerticalLayout {
+        alignment: start;
+        Text { text: "flex-grow capped by max: stays 200px, does not fill"; font-size: 11px; }
+        HorizontalLayout {
+            alignment: start;
+            fl := FlexboxLayout {
+                width: 400px;
+                height: 30px;
+                flex-wrap: no-wrap;
+                spacing: 0px;
+                a := Rectangle {
+                    width: 50%;
+                    flex-grow: 1;
+                    height: 30px;
+                    background: #cce6ff;
+                    Text { width: 100%; height: 100%; text: "50%"; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+    }
+
+    out property <bool> test: a.width == 200px;
+}
+
+export component TestCase inherits Window {
+    width: 460px;
+    height: 620px;
+
+    VerticalLayout {
+        alignment: start;
+        spacing: 14px;
+        padding: 8px;
+        t1 := TestPercentRow { }
+        t2 := TestPercentRowBox { }
+        t3 := TestPercentPadding { }
+        t4 := TestPercentColumn { }
+        t5 := TestPercentSpacing { }
+        t6 := TestPercentGrow { }
+    }
+
+    out property <bool> test: t1.test && t2.test && t3.test && t4.test && t5.test && t6.test;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
The taffy builder fed taffy each cell's absolute min/max but dropped
min_percent/max_percent. A `width: 50%` child (which lowers to a percentage
min/max, not a fixed width) collapsed to zero and its siblings were positioned
on top of it, while the same markup in a HorizontalLayout worked.

Resolve the percentage against the container's content box (outer size minus
padding). Applied only when the percentage is non-default and the container
size on that axis is finite, so items without a percentage size are untouched.
Unlike solve_box_layout, spacing is not subtracted from the basis: this matches
the CSS content-box definition, so a percentage in a FlexboxLayout can differ
from the same value in a box layout when spacing is set.

Before/after screenshots
<img width="1226" height="853" alt="image" src="https://github.com/user-attachments/assets/a11f9950-2527-4cc2-9a0f-c8d0967ca7d9" />
