### PR TITLE
winit: propagate the key auto-repeat flag to KeyEvent

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -346,6 +346,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 };
                 let mut key_event = KeyEvent::default();
                 key_event.text = text;
+                key_event.repeat = event.repeat;
 
                 let event = corelib::input::InternalKeyEvent {
                     key_event,


### PR DESCRIPTION
## What

The winit backend never forwarded winit's `KeyEvent::repeat` flag into
Slint's `KeyEvent`, so `FocusScope` key handlers always observed
`repeat: false` for keys held down on the native desktop path.

## Why

`KeyEvent.repeat` is a documented, public field. It is already set correctly on:

- the public dispatch path — `Window::dispatch_event_with_result` maps
  `WindowEvent::KeyPressRepeated` to a `KeyEvent` with `repeat: true`, and
- the wasm backend, which dispatches `KeyPressRepeated` through that same public API.

Only the native winit path bypassed it: it builds the `KeyEvent` and calls
`process_key_input` directly, leaving `repeat` at its default `false`.

## Change

Set `key_event.repeat` from the winit event so held keys are reported as
repeats on the native path too, matching the documented behavior and the
other input paths.

Single-line change; no behavior change other than the now-correct `repeat`
flag reaching key handlers.
