### PR TITLE
Record backend input events in the event hook

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2181,8 +2181,8 @@ impl QtWindow {
             MouseEvent::Wheel { position, delta_x, delta_y, .. } => {
                 Some(WindowEvent::PointerScrolled {
                     position: logical_position_to_api(*position),
-                    delta_x: *delta_x as f32,
-                    delta_y: *delta_y as f32,
+                    delta_x: *delta_x,
+                    delta_y: *delta_y,
                 })
             }
             MouseEvent::Exit => Some(WindowEvent::PointerExited),

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -30,7 +30,7 @@ use i_slint_core::items::{
 use i_slint_core::layout::Orientation;
 use i_slint_core::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
-    PhysicalPx, ScaleFactor, logical_size_from_api,
+    PhysicalPx, ScaleFactor, logical_position_to_api, logical_size_from_api,
 };
 use i_slint_core::platform::{PlatformError, WindowEvent};
 use i_slint_core::string::ToSharedString;
@@ -347,7 +347,7 @@ cpp! {{
             if (!rust_window)
                 return;
             rust!(Slint_dragLeaveEvent [rust_window: &QtWindow as "void*"] {
-                rust_window.mouse_event(MouseEvent::Exit)
+                rust_window.drag_leave_event()
             });
         }
 
@@ -2162,7 +2162,43 @@ impl QtWindow {
     }
 
     fn mouse_event(&self, event: MouseEvent) {
-        WindowInner::from_pub(&self.window).process_mouse_input(event);
+        let recorded_event = match &event {
+            MouseEvent::Pressed { position, button, touch_finger_id: 0, .. } => {
+                Some(WindowEvent::PointerPressed {
+                    position: logical_position_to_api(*position),
+                    button: *button,
+                })
+            }
+            MouseEvent::Released { position, button, touch_finger_id: 0, .. } => {
+                Some(WindowEvent::PointerReleased {
+                    position: logical_position_to_api(*position),
+                    button: *button,
+                })
+            }
+            MouseEvent::Moved { position, touch_finger_id: 0 } => {
+                Some(WindowEvent::PointerMoved { position: logical_position_to_api(*position) })
+            }
+            MouseEvent::Wheel { position, delta_x, delta_y, .. } => {
+                Some(WindowEvent::PointerScrolled {
+                    position: logical_position_to_api(*position),
+                    delta_x: *delta_x as f32,
+                    delta_y: *delta_y as f32,
+                })
+            }
+            MouseEvent::Exit => Some(WindowEvent::PointerExited),
+            _ => None,
+        };
+        let runtime_window = WindowInner::from_pub(&self.window);
+        if let Some(recorded_event) = recorded_event {
+            runtime_window.process_mouse_input_and_notify(event, recorded_event);
+        } else {
+            runtime_window.process_mouse_input(event);
+        }
+        timer_event();
+    }
+
+    fn drag_leave_event(&self) {
+        WindowInner::from_pub(&self.window).process_mouse_input(MouseEvent::Exit);
         timer_event();
     }
 

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -1118,17 +1118,18 @@ fn test_accessibility_role_mapping_complete() {
     i_slint_common::for_each_enums!(test_accessibility_enum_mapping);
 }
 
-// `WindowEventDispatchResult` honesty for pointer events: verify that
-// `Window::dispatch_event_with_result` reports `Accepted` only when an item consumed the
-// event, and `Ignored` otherwise. Tests install the window-event hook directly
-// since that's the consumer the public contract is for.
+// `WindowEventDispatchResult` honesty: verify that public and backend dispatch paths
+// notify the window-event hook exactly once with the event's actual result.
 
 #[cfg(test)]
 mod dispatch_result_tests {
     use i_slint_core::api::LogicalPosition;
     use i_slint_core::api::WindowEventDispatchResult;
+    use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent};
     use i_slint_core::items::PointerEventButton;
+    use i_slint_core::lengths::LogicalPoint;
     use i_slint_core::platform::WindowEvent;
+    use i_slint_core::window::WindowInner;
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -1190,6 +1191,85 @@ mod dispatch_result_tests {
                 button: PointerEventButton::Left,
             },
             WindowEventDispatchResult::Accepted,
+        );
+    }
+
+    #[test]
+    fn backend_pointer_event_is_recorded_once() {
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+                TouchArea { width: 100%; height: 100%; }
+            }
+        }
+        let app = App::new().unwrap();
+        let recorded_event = WindowEvent::PointerPressed {
+            position: LogicalPosition::new(50.0, 50.0),
+            button: PointerEventButton::Left,
+        };
+        let (_guard, captured) = capture_hook();
+        let result = WindowInner::from_pub(app.window()).process_mouse_input_and_notify(
+            MouseEvent::Pressed {
+                position: LogicalPoint::new(50.0, 50.0),
+                button: PointerEventButton::Left,
+                click_count: 0,
+                touch_finger_id: 0,
+            },
+            recorded_event.clone(),
+        );
+
+        assert!(result.is_some_and(|result| result.accepted));
+        assert_eq!(*captured.borrow(), vec![(recorded_event, WindowEventDispatchResult::Accepted)]);
+    }
+
+    #[test]
+    fn backend_key_event_is_recorded_once() {
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+            }
+        }
+        let app = App::new().unwrap();
+        let text = slint::SharedString::from("x");
+        let recorded_event = WindowEvent::KeyPressRepeated { text: text.clone() };
+        let (_guard, captured) = capture_hook();
+        let mut key_event = KeyEvent::default();
+        key_event.text = text;
+        key_event.repeat = true;
+        let result = WindowInner::from_pub(app.window()).process_key_input_and_notify(
+            InternalKeyEvent {
+                event_type: KeyEventType::KeyPressed,
+                key_event,
+                ..Default::default()
+            },
+            recorded_event.clone(),
+        );
+
+        assert_eq!(result, i_slint_core::input::KeyEventResult::EventIgnored);
+        assert_eq!(*captured.borrow(), vec![(recorded_event, WindowEventDispatchResult::Ignored)]);
+    }
+
+    #[test]
+    fn backend_pointer_exit_is_recorded_as_accepted() {
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+            }
+        }
+        let app = App::new().unwrap();
+        let (_guard, captured) = capture_hook();
+        WindowInner::from_pub(app.window())
+            .process_mouse_input_and_notify(MouseEvent::Exit, WindowEvent::PointerExited);
+
+        assert_eq!(
+            *captured.borrow(),
+            vec![(WindowEvent::PointerExited, WindowEventDispatchResult::Accepted)]
         );
     }
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -137,7 +137,12 @@ impl EventLoopState {
             && let Some(window) = self.shared_backend_data.window_by_id(window_id)
         {
             let runtime_window = WindowInner::from_pub(window.window());
-            runtime_window.process_mouse_input(MouseEvent::Moved { position, touch_finger_id: 0 });
+            runtime_window.process_mouse_input_and_notify(
+                MouseEvent::Moved { position, touch_finger_id: 0 },
+                corelib::platform::WindowEvent::PointerMoved {
+                    position: corelib::lengths::logical_position_to_api(position),
+                },
+            );
         }
     }
 }
@@ -344,6 +349,17 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                         corelib::input::KeyEventType::KeyReleased
                     }
                 };
+                let recorded_event = match event.state {
+                    winit::event::ElementState::Pressed if event.repeat => {
+                        corelib::platform::WindowEvent::KeyPressRepeated { text: text.clone() }
+                    }
+                    winit::event::ElementState::Pressed => {
+                        corelib::platform::WindowEvent::KeyPressed { text: text.clone() }
+                    }
+                    winit::event::ElementState::Released => {
+                        corelib::platform::WindowEvent::KeyReleased { text: text.clone() }
+                    }
+                };
                 let mut key_event = KeyEvent::default();
                 key_event.text = text;
                 key_event.repeat = event.repeat;
@@ -356,7 +372,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     ..Default::default()
                 };
 
-                runtime_window.process_key_input(event);
+                runtime_window.process_key_input_and_notify(event, recorded_event);
             }
             WindowEvent::Ime(winit::event::Ime::Preedit(string, preedit_selection)) => {
                 let event = InternalKeyEvent {
@@ -397,7 +413,10 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 // On the html canvas, we don't get the mouse move or release event when outside the canvas. So we have no choice but canceling the event
                 if cfg!(target_arch = "wasm32") || !self.pressed {
                     self.pressed = false;
-                    runtime_window.process_mouse_input(MouseEvent::Exit);
+                    runtime_window.process_mouse_input_and_notify(
+                        MouseEvent::Exit,
+                        corelib::platform::WindowEvent::PointerExited,
+                    );
                 }
             }
             WindowEvent::MouseWheel { delta, phase, .. } => {
@@ -414,12 +433,14 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     winit::event::TouchPhase::Ended => TouchPhase::Ended,
                     winit::event::TouchPhase::Cancelled => TouchPhase::Cancelled,
                 };
-                runtime_window.process_mouse_input(MouseEvent::Wheel {
-                    position: self.cursor_pos,
-                    delta_x,
-                    delta_y,
-                    phase,
-                });
+                runtime_window.process_mouse_input_and_notify(
+                    MouseEvent::Wheel { position: self.cursor_pos, delta_x, delta_y, phase },
+                    corelib::platform::WindowEvent::PointerScrolled {
+                        position: corelib::lengths::logical_position_to_api(self.cursor_pos),
+                        delta_x: delta_x as f32,
+                        delta_y: delta_y as f32,
+                    },
+                );
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 let button = match button {
@@ -430,7 +451,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     winit::event::MouseButton::Forward => PointerEventButton::Forward,
                     winit::event::MouseButton::Other(_) => PointerEventButton::Other,
                 };
-                let ev = match state {
+                let (event, recorded_event) = match state {
                     winit::event::ElementState::Pressed => {
                         if button == PointerEventButton::Left
                             && self.current_resize_direction.is_some()
@@ -443,24 +464,40 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                         }
 
                         self.pressed = true;
-                        MouseEvent::Pressed {
-                            position: self.cursor_pos,
-                            button,
-                            click_count: 0,
-                            touch_finger_id: 0,
-                        }
+                        (
+                            MouseEvent::Pressed {
+                                position: self.cursor_pos,
+                                button,
+                                click_count: 0,
+                                touch_finger_id: 0,
+                            },
+                            corelib::platform::WindowEvent::PointerPressed {
+                                position: corelib::lengths::logical_position_to_api(
+                                    self.cursor_pos,
+                                ),
+                                button,
+                            },
+                        )
                     }
                     winit::event::ElementState::Released => {
                         self.pressed = false;
-                        MouseEvent::Released {
-                            position: self.cursor_pos,
-                            button,
-                            click_count: 0,
-                            touch_finger_id: 0,
-                        }
+                        (
+                            MouseEvent::Released {
+                                position: self.cursor_pos,
+                                button,
+                                click_count: 0,
+                                touch_finger_id: 0,
+                            },
+                            corelib::platform::WindowEvent::PointerReleased {
+                                position: corelib::lengths::logical_position_to_api(
+                                    self.cursor_pos,
+                                ),
+                                button,
+                            },
+                        )
                     }
                 };
-                runtime_window.process_mouse_input(ev);
+                runtime_window.process_mouse_input_and_notify(event, recorded_event);
             }
             WindowEvent::Touch(touch) => {
                 let location = touch.location.to_logical(runtime_window.scale_factor() as f64);

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -786,11 +786,8 @@ impl Window {
                 WindowEventDispatchResult::Accepted
             }
         };
-        if let Some(event_for_hook) = event_for_hook
-            && let Some(ctx) = self.0.try_context()
-            && let Some(hook) = ctx.0.window_event_hook.borrow().as_ref()
-        {
-            hook(&self.0.window_adapter(), &event_for_hook, dispatch_result.clone());
+        if let Some(event_for_hook) = event_for_hook {
+            self.0.notify_window_event(&event_for_hook, dispatch_result.clone());
         }
         Ok(dispatch_result)
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -66,7 +66,7 @@ pub enum WindowKind {
 ///
 /// - When receiving messages from the windowing system about state changes, such as the window being resized,
 ///   the user requested the window to be closed, input being received, etc. you need to create a
-///   [`WindowEvent`](crate::platform::WindowEvent) and send it to Slint via [`Window::dispatch_event_with_result()`].
+///   [`WindowEvent`] and send it to Slint via [`Window::dispatch_event_with_result()`].
 ///
 /// - Slint sends requests to change visibility, position, size, etc. via functions such as [`Self::set_visible`],
 ///   [`Self::set_size`], [`Self::set_position`], or [`Self::update_window_properties()`]. Re-implement these functions
@@ -118,7 +118,7 @@ pub trait WindowAdapter {
     /// The default implementation does nothing
     ///
     /// This function should sent the size to the Windowing system. If the window size actually changes, you
-    /// should dispatch a [`WindowEvent::Resized`](crate::platform::WindowEvent::Resized) using
+    /// should dispatch a [`WindowEvent::Resized`] using
     /// [`Window::dispatch_event()`] to propagate the new size to the slint view
     fn set_size(&self, _size: WindowSize) {}
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -7,7 +7,7 @@
 //! Exposed Window API
 use crate::api::{
     CloseRequestResponse, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize,
-    PlatformError, Window, WindowPosition, WindowSize,
+    PlatformError, Window, WindowEventDispatchResult, WindowPosition, WindowSize,
 };
 use crate::cursor::MouseCursorInner;
 use crate::input::{
@@ -24,6 +24,7 @@ use crate::items::{
 };
 use crate::lengths::{LogicalLength, LogicalPoint, LogicalRect, LogicalVector, SizeLengths};
 use crate::menus::MenuVTable;
+use crate::platform::WindowEvent;
 use crate::properties::{ChangeTracker, Property, PropertyTracker};
 use crate::renderer::Renderer;
 use crate::{Callback, Coord, SharedString, SharedVector};
@@ -1073,6 +1074,27 @@ impl WindowInner {
         Some(MouseDispatchResult { drag_action, accepted })
     }
 
+    /// Processes a backend mouse event and reports its public representation to the
+    /// window-event hook.
+    ///
+    /// Backends use this when the internal event carries information that
+    /// [`crate::api::Window::dispatch_event_with_result`] cannot represent.
+    #[doc(hidden)]
+    pub fn process_mouse_input_and_notify(
+        &self,
+        event: MouseEvent,
+        recorded_event: WindowEvent,
+    ) -> Option<MouseDispatchResult> {
+        let result = self.process_mouse_input(event);
+        let dispatch_result = if matches!(recorded_event, WindowEvent::PointerExited) {
+            WindowEventDispatchResult::Accepted
+        } else {
+            result.into()
+        };
+        self.notify_window_event(&recorded_event, dispatch_result);
+        result
+    }
+
     /// Remember (or clear) the in-flight native drag, so a backend can report completion or fall
     /// back, and a drop back onto this window can restore the data. Set by `offer_native_drag`.
     pub(crate) fn set_native_drag(&self, drag: Option<NativePendingDrag>) {
@@ -1314,6 +1336,22 @@ impl WindowInner {
 
         self.ensure_tree_instantiated();
         crate::input::KeyEventResult::EventIgnored
+    }
+
+    /// Processes a backend key event and reports its public representation to the
+    /// window-event hook.
+    ///
+    /// Backends use this when the internal event carries information that
+    /// [`crate::api::Window::dispatch_event_with_result`] cannot represent.
+    #[doc(hidden)]
+    pub fn process_key_input_and_notify(
+        &self,
+        internal_event: InternalKeyEvent,
+        recorded_event: WindowEvent,
+    ) -> KeyEventResult {
+        let result = self.process_key_input(internal_event);
+        self.notify_window_event(&recorded_event, result.into());
+        result
     }
 
     fn process_menubar_shortcuts(
@@ -2370,6 +2408,18 @@ impl WindowInner {
             let _ = self.ctx.set(ctx);
         }
         self.ctx.get()
+    }
+
+    pub(crate) fn notify_window_event(
+        &self,
+        event: &WindowEvent,
+        result: WindowEventDispatchResult,
+    ) {
+        if let Some(ctx) = self.try_context()
+            && let Some(hook) = ctx.0.window_event_hook.borrow().as_ref()
+        {
+            hook(&self.window_adapter(), event, result);
+        }
     }
 
     /// Set the SlintContext.


### PR DESCRIPTION
## What

Feeds real backend input (winit and Qt) through the `window_event_hook` so
that user-generated pointer, wheel and key events are observable to the hook,
each reported exactly once with its true dispatch result.

Previously the hook only saw events that were *replayed* through the public
`Window::dispatch_event_with_result`; input that arrived directly from the
backend and went straight into `process_mouse_input` / `process_key_input`
was invisible to it.

## How

- `WindowInner` gains two `#[doc(hidden)]` helpers,
  `process_mouse_input_and_notify` and `process_key_input_and_notify`, which
  run the normal internal dispatch and then notify the hook with the event's
  public `WindowEvent` representation and its `WindowEventDispatchResult`.
- A shared `notify_window_event` helper does the context/hook lookup;
  `dispatch_event_with_result` is refactored to reuse it (no behavior change).
- The winit and Qt backends map each raw input event to its public
  `WindowEvent` and route it through the new helpers.
- `PointerExited` is reported as `Accepted` unconditionally, matching the
  existing teardown-event semantics in `dispatch_event_with_result`.
- In Qt, a drag-leave is deliberately kept off the recording path (via a new
  `drag_leave_event`) so it is not mis-recorded as a pointer exit.

## Tests

Adds `dispatch_result_tests` coverage in the testing backend asserting that
the new backend helpers notify the hook exactly once with the correct result
for pointer, key and pointer-exit events.

## Notes / follow-ups

- Depends on / pairs with the one-line winit fix "winit: propagate the key
  auto-repeat flag to KeyEvent" (separate PR). This PR is independent and
  green on its own — it reads winit's `event.repeat` to emit
  `KeyPressRepeated` for recording — but the two are best merged together,
  the repeat fix first.
- Touch and gesture input (winit `Touch`, Qt pinch/rotation, multi-touch) is
  not recorded: the public `platform::WindowEvent` has no variant for it.
  Left as a follow-up.
- Scroll `phase` does not round-trip through the public `PointerScrolled`
  variant, which has no phase field.
