### PR TITLE
ci: cache the CMake-managed cargo target directories

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -32,6 +32,10 @@ inputs:
         description: "Condition to save the cache"
         required: false
         default: ${{ github.ref == 'refs/heads/master' }}
+    cache-directories:
+        description: "Additional directories for Swatinem/rust-cache, eg cargo target directories managed by CMake"
+        required: false
+        default: ""
 
 runs:
     using: composite
@@ -70,6 +74,7 @@ runs:
           if: inputs.cache == 'true'
           with:
               key: ${{ inputs.key }}-1
+              cache-directories: ${{ inputs.cache-directories }}
               # Workaround for https://github.com/Swatinem/rust-cache/issues/341:
               # on the updated macOS runner image, cache-bin's restored cargo/rustc
               # dispatches as rustup-init and fails with "unexpected argument".

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,6 +219,9 @@ jobs:
             - uses: ./.github/actions/setup-rust
               with:
                   toolchain: ${{ matrix.rust_version }}
+                  # Corrosion runs cargo with a target directory inside the
+                  # CMake build tree, which the default cache misses
+                  cache-directories: ${{ runner.workspace }}/cppbuild/cargo
             - uses: ilammy/msvc-dev-cmd@v1
             - name: Select MSVC (windows)
               if: runner.os == 'Windows'
@@ -471,6 +474,9 @@ jobs:
             - uses: Swatinem/rust-cache@v2
               with:
                 save-if: ${{ github.ref == 'refs/heads/master' }}
+                # Corrosion runs cargo with a target directory inside the
+                # CMake build tree, which the default cache misses
+                cache-directories: demos/printerdemo_mcu/esp-idf/build/cargo
             - name: Build and Test Printer demo
               shell: bash
               working-directory: demos/printerdemo_mcu/esp-idf


### PR DESCRIPTION
Corrosion runs cargo with a target directory inside the CMake build tree, which rust-cache's default of ./target misses. The cpp_cmake jobs rebuilt slint-cpp from scratch on every run despite a cache hit (7.5 minutes on Windows), and the esp-idf job rebuilt the xtensa library and the host slint-compiler (8.3 minutes) next to an empty cached ./target.

Let setup-rust pass extra directories to rust-cache and list the corrosion target directory of both jobs.
