### PR TITLE
slint-sc: test that the root x and y are unusable

### DIFF
--- a/api/slint-sc/tests/cases/component/rectangle_position.slint
+++ b/api/slint-sc/tests/cases/component/rectangle_position.slint
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
 
 export component TestCase inherits Window {
+    // The children render at their absolute x/y because the root's own x/y are
+    // meaningless: the window's content origin is its top-left corner.
+    //#sls.geom.window.root
     //#sls.ref.window.background
     background: #123456;
     //#sls.ref.rectangle.empty

--- a/internal/compiler/tests/syntax/slint-sc/geometry_root.slint
+++ b/internal/compiler/tests/syntax/slint-sc/geometry_root.slint
@@ -1,0 +1,13 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The x and y of the root element are meaningless and shall not be used:
+// binding them in Slint SC is an error.
+//#sls.geom.window.root
+
+export component Test inherits Window {
+    x: 10px;
+//     >   <error{The property 'x' is not supported in Slint SC}
+    y: 20px;
+//     >   <error{The property 'y' is not supported in Slint SC}
+}


### PR DESCRIPTION
Cover sls.geom.window.root: a syntax test that binding the root's x or y is an error (negative), and the rectangle_position case where children render at their absolute x/y because the root origin is the window's top-left (positive).
