### PR TITLE
slint-sc: cover sls.paint.invocation, sls.gen.prop.field is informative

### DIFF
--- a/api/slint-sc/tests/cases/component/window_background.slint
+++ b/api/slint-sc/tests/cases/component/window_background.slint
@@ -9,6 +9,8 @@ export component TestCase inherits Window {
 ```rust
 let x = TestCase::new();
 screenshot!(x);
+// The application renders by calling render_rgb8 itself.
+//#sls.paint.invocation
 //#sls.gen.render-rgb8
 let mut frame_buffer = [0u8; 64 * 64 * 3];
 x.render_rgb8(64, 64, &mut frame_buffer)?;

--- a/docs/safety/src/content/docs/reference/generated-code.mdx
+++ b/docs/safety/src/content/docs/reference/generated-code.mdx
@@ -45,7 +45,7 @@ returns `Err(RenderError::InvalidFrameBufferSize)` and paints nothing.
 
 The struct holds the value of each
 [property declared](/language/properties/#sls.prop.decl.form) on the
-root element in a private field. \{#sls.gen.prop.field}
+root element in a private field. \{#sls.gen.prop.field.meta}
 
 Kebab-case property names become snake_case in the generated names:
 the accessors of a property `foo-bar` are `get_foo_bar()` and

--- a/docs/safety/src/content/docs/reference/generated-code.mdx
+++ b/docs/safety/src/content/docs/reference/generated-code.mdx
@@ -43,9 +43,9 @@ returns `Err(RenderError::InvalidFrameBufferSize)` and paints nothing.
 
 ## Properties
 
-The struct holds the value of each
+The generated component holds the value of each
 [property declared](/language/properties/#sls.prop.decl.form) on the
-root element in a private field. \{#sls.gen.prop.field.meta}
+root element. \{#sls.gen.prop.values.meta}
 
 Kebab-case property names become snake_case in the generated names:
 the accessors of a property `foo-bar` are `get_foo_bar()` and


### PR DESCRIPTION
The window_background case already calls render_rgb8 directly; mark that invocation, which is how the application drives rendering. The generated struct's private property fields are not observable through the public API, so rename sls.gen.prop.field to carry a meta segment and drop it from the traceability matrix.
