### PR TITLE
git ignore: CMakePreset generates different build dir. Excludes all build* builddir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 *.code-workspace
 /build
 /build-release
+/build-debug-mold
 /_deps
 .DS_Store
 Pipfile.lock


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
