### PR TITLE
slint-sc: test the type of color literals, drop sls.type.kinds

### DIFF
--- a/docs/astro/src/content/docs/reference/language/bindings.mdx
+++ b/docs/astro/src/content/docs/reference/language/bindings.mdx
@@ -5,7 +5,6 @@ SC: true
 ---
 
 import SC from '@slint/common-files/src/components/SC.astro';
-import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
 
 <SC>
 A binding assigns an [expression](../expressions/) to a [property](../properties/#sls.prop.def) of the element in whose body it appears.
@@ -20,10 +19,6 @@ export component Example inherits Window {
 ```
 
 The name shall refer to a property of the enclosing element. \{#sls.binding.target-must-exist}
-
-<OnlyInSC>
-Every property and every expression has a type: `color`, `length`, or `brush`. \{#sls.type.kinds}
-</OnlyInSC>
 
 An expression whose type is not the type of the property binds to it only when a conversion applies. \{#sls.type.conversions}
 

--- a/internal/compiler/tests/syntax/slint-sc/color_literals.slint
+++ b/internal/compiler/tests/syntax/slint-sc/color_literals.slint
@@ -72,4 +72,13 @@ export component Test inherits Window {
         background: #12g4;
 //                  >   <error{Invalid color literal}
     }
+
+    // A color literal has the type color: it binds to a color property
+    // directly, and not to a length property.
+    //#sls.expr.color.type
+    property <color> c: #123456;
+    Rectangle {
+        width: #123456;
+//             >      <error{Cannot convert color to length}
+    }
 }


### PR DESCRIPTION
A color literal binds directly to a color property and does not bind to a length property, pinning that the literal's type is color. The type-kinds enumeration in the bindings chapter added nothing over the conversion rules, remove it.
