### PR TITLE
slint-sc: allow export lists and multiple exported components 

### DIFF
--- a/api/slint-sc/tests/cases/export/lists.slint
+++ b/api/slint-sc/tests/cases/export/lists.slint
@@ -1,0 +1,41 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+// An export list exports one or more names already defined in the file, with an
+// optional trailing comma. `Name as Other` exports under the external name.
+// A component that is not exported stays private and names no generated type.
+
+component Hidden inherits Window { background: #0000ff; }
+component Foo inherits Window { background: #ff0000; }
+component Bar inherits Window { background: #00ff00; }
+
+//#sls.export.forms
+//#sls.export.list
+//#sls.export.rename
+//#sls.export.no-duplicates
+export { Foo, Bar as Baz, }
+
+/*
+```rust
+// Foo is exported under its own name; Bar under the external name Baz. The two
+// external names are distinct, so the file exports no name more than once.
+let mut frame_buffer = [0u8; 8 * 8 * 3];
+Foo::new().render_rgb8(8, 8, &mut frame_buffer)?;
+assert!(frame_buffer.chunks(3).all(|pixel| pixel == [0xff, 0x00, 0x00]));
+Baz::new().render_rgb8(8, 8, &mut frame_buffer)?;
+assert!(frame_buffer.chunks(3).all(|pixel| pixel == [0x00, 0xff, 0x00]));
+```
+
+A name that is not exported names no generated type:
+```rust compile_fail
+//#sls.export.default-private
+let _ = Hidden::new();
+//~ ERROR undeclared type `Hidden`
+```
+
+The renamed component is reachable only under its external name:
+```rust compile_fail
+let _ = Bar::new();
+//~ ERROR undeclared type `Bar`
+```
+*/

--- a/api/slint-sc/tests/cases/export/placement.slint
+++ b/api/slint-sc/tests/cases/export/placement.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+// Export statements may appear at the top level interleaved with component
+// definitions: the `export { A }` statement sits between the two definitions.
+//#sls.export.placement
+
+component A inherits Window { background: #ff0000; }
+export { A }
+export component B inherits Window { background: #00ff00; }
+
+/*
+```rust
+let mut frame_buffer = [0u8; 8 * 8 * 3];
+A::new().render_rgb8(8, 8, &mut frame_buffer)?;
+assert!(frame_buffer.chunks(3).all(|pixel| pixel == [0xff, 0x00, 0x00]));
+B::new().render_rgb8(8, 8, &mut frame_buffer)?;
+assert!(frame_buffer.chunks(3).all(|pixel| pixel == [0x00, 0xff, 0x00]));
+```
+*/

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -105,27 +105,10 @@ impl Document {
             }
         }
 
-        #[cfg(feature = "slint-sc")]
-        let mut sc_exported_count: u32 = 0;
-
         let mut process_component =
             |n: syntax_nodes::Component,
              diag: &mut BuildDiagnostics,
-             local_registry: &mut TypeRegister,
-             #[cfg(feature = "slint-sc")] sc_exported_count: &mut u32,
-             #[cfg(feature = "slint-sc")] is_exported: bool| {
-                // Globals already get their own "Globals are not supported" message
-                #[cfg(feature = "slint-sc")]
-                if n.child_text(SyntaxKind::Identifier).as_deref() != Some("global") && is_exported
-                {
-                    *sc_exported_count += 1;
-                    if *sc_exported_count > 1 {
-                        diag.slint_sc_error(
-                            "Multiple exported components per file are",
-                            &n.DeclaredIdentifier(),
-                        );
-                    }
-                }
+             local_registry: &mut TypeRegister| {
                 let compo = Component::from_node(n, diag, local_registry);
                 if !local_registry.add(compo.clone()) {
                     diag.push_warning(format!("Component '{}' is replacing a previously defined component with the same name", compo.id), &compo.node.clone().unwrap().DeclaredIdentifier());
@@ -214,15 +197,7 @@ impl Document {
         for n in node.children() {
             match n.kind() {
                 SyntaxKind::Component => {
-                    process_component(
-                        n.into(),
-                        diag,
-                        &mut local_registry,
-                        #[cfg(feature = "slint-sc")]
-                        &mut sc_exported_count,
-                        #[cfg(feature = "slint-sc")]
-                        false,
-                    );
+                    process_component(n.into(), diag, &mut local_registry);
                 }
                 SyntaxKind::StructDeclaration => {
                     process_struct(n.into(), diag, &mut local_registry, &mut inner_types)
@@ -233,15 +208,9 @@ impl Document {
                 SyntaxKind::ExportsList => {
                     for n in n.children() {
                         match n.kind() {
-                            SyntaxKind::Component => process_component(
-                                n.into(),
-                                diag,
-                                &mut local_registry,
-                                #[cfg(feature = "slint-sc")]
-                                &mut sc_exported_count,
-                                #[cfg(feature = "slint-sc")]
-                                true,
-                            ),
+                            SyntaxKind::Component => {
+                                process_component(n.into(), diag, &mut local_registry)
+                            }
                             SyntaxKind::StructDeclaration => process_struct(
                                 n.into(),
                                 diag,
@@ -3663,8 +3632,6 @@ impl Exports {
                 .filter(|exports| exports.ExportModule().is_none())
                 .flat_map(|exports| exports.ExportSpecifier())
                 .filter_map(|export_specifier| {
-                    #[cfg(feature = "slint-sc")]
-                    diag.slint_sc_error("Export specifiers are", &export_specifier);
                     let (internal_name, exported_name) =
                         ExportedName::from_export_specifier(&export_specifier);
                     Some((

--- a/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
+++ b/internal/compiler/tests/syntax/slint-sc/component_declaration.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // Non-exported component declarations are allowed and can be instantiated.
-// Only one exported component per file is allowed.
+// A file may export more than one component.
 
 component Helper inherits Rectangle {
     width: 4px;
@@ -15,4 +15,3 @@ export component First inherits Window {
 }
 
 export component Second inherits Window { }
-//               >    <error{Multiple exported components per file are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/export_duplicate.slint
+++ b/internal/compiler/tests/syntax/slint-sc/export_duplicate.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A source file shall not export the same external name more than once,
+// including the combination of a declaration-site export and an export list.
+//#sls.export.no-duplicates
+
+export component Dup inherits Window { }
+//               > <error{Duplicated export 'Dup'}
+
+export { Dup }
+//       > <error{Duplicated export 'Dup'}

--- a/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
+++ b/internal/compiler/tests/syntax/slint-sc/export_specifiers.slint
@@ -1,17 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Export specifier lists are rejected in Slint SC mode.
+// An export list exports names already defined in the file. Each bare name,
+// and each name on the left of `as`, must refer to a name defined in the file.
 
 component Foo inherits Window { }
 
 export { Foo }
-//       >  <error{Export specifiers are not supported in Slint SC}
-
-export { Foo as Bar }
-//       >        <error{Export specifiers are not supported in Slint SC}
 
 //#sls.export.left-must-exist
 export { DoesNotExist }
-//       >           <error{Export specifiers are not supported in Slint SC}
-//       >          <^error{'DoesNotExist' not found}
+//       >          <error{'DoesNotExist' not found}

--- a/internal/compiler/tests/syntax/slint-sc/identifier_normalization_collision.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_normalization_collision.slint
@@ -12,9 +12,8 @@ export component Foo_Bar inherits Window {}
 //               >     <error{Duplicated export 'Foo-Bar'}
 //     >                                  <^warning{Component is neither used nor exported}
 export component Foo-Bar inherits Window {
-//               >     <error{Multiple exported components per file are not supported in Slint SC}
-//               >     <^warning{Component 'Foo-Bar' is replacing a previously defined component with the same name}
-//               >     <^^error{Duplicated export 'Foo-Bar'}
+//               >     <warning{Component 'Foo-Bar' is replacing a previously defined component with the same name}
+//               >     <^error{Duplicated export 'Foo-Bar'}
     a_b := Rectangle {}
 //         >        <error{duplicated element id 'a-b'}
     a-b := Rectangle {}


### PR DESCRIPTION
Remove the two front-end restrictions that rejected export specifier lists
and capped a file at one exported component. The SC code generator already
emits a struct per exported component using its external name, and the
duplicate-export diagnostic already exists, so lifting the restrictions is
enough to support export { Name, ... }, renaming with as, and multiple
exported components. Each exported component must still inherit Window.


Cover the sls.export.* requirements in tests