### PR TITLE
FlexboxLayout: split per-item flex props out of the per-axis cell data

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -472,6 +472,11 @@ fn gen_corelib(
         "Rect",
         "BitmapFont",
         "DataTransferOpaque",
+        // Return type of the ItemTree vtable's flexbox_layout_item_info* methods.
+        // cbindgen can't see those (not extern "C"), and it is no longer reachable
+        // from an FFI function since the bulk cell data was split into
+        // LayoutItemInfo + FlexItemProps, so emit it explicitly.
+        "FlexboxLayoutItemInfo",
     ]
     .iter()
     .chain(items.iter())

--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -257,32 +257,38 @@ solve_flexbox_layout_with_measure(const cbindgen_private::FlexboxLayoutData &dat
     return result;
 }
 
-inline cbindgen_private::LayoutInfo flexbox_layout_info_main_axis(
-        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells, float spacing,
-        const cbindgen_private::Padding &padding, cbindgen_private::FlexboxLayoutWrap flex_wrap)
+inline cbindgen_private::LayoutInfo
+flexbox_layout_info_main_axis(cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> cells,
+                              cbindgen_private::Slice<cbindgen_private::FlexItemProps> flex_props,
+                              float spacing, const cbindgen_private::Padding &padding,
+                              cbindgen_private::FlexboxLayoutWrap flex_wrap)
 {
-    return cbindgen_private::slint_flexbox_layout_info_main_axis(cells, spacing, &padding,
-                                                                 flex_wrap);
+    return cbindgen_private::slint_flexbox_layout_info_main_axis(cells, flex_props, spacing,
+                                                                 &padding, flex_wrap);
 }
 
-inline float flexbox_layout_unwrapped_main(
-        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells, float spacing,
-        const cbindgen_private::Padding &padding)
+inline float
+flexbox_layout_unwrapped_main(cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> cells,
+                              cbindgen_private::Slice<cbindgen_private::FlexItemProps> flex_props,
+                              float spacing, const cbindgen_private::Padding &padding)
 {
-    return cbindgen_private::slint_flexbox_layout_unwrapped_main(cells, spacing, &padding);
+    return cbindgen_private::slint_flexbox_layout_unwrapped_main(cells, flex_props, spacing,
+                                                                 &padding);
 }
 
-inline cbindgen_private::LayoutInfo flexbox_layout_info_cross_axis(
-        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_h,
-        cbindgen_private::Slice<cbindgen_private::FlexboxLayoutItemInfo> cells_v, float spacing_h,
-        float spacing_v, const cbindgen_private::Padding &padding_h,
-        const cbindgen_private::Padding &padding_v,
-        cbindgen_private::FlexboxLayoutDirection direction,
-        cbindgen_private::FlexboxLayoutWrap flex_wrap, float constraint_size)
+inline cbindgen_private::LayoutInfo
+flexbox_layout_info_cross_axis(cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> cells_h,
+                               cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> cells_v,
+                               cbindgen_private::Slice<cbindgen_private::FlexItemProps> flex_props,
+                               float spacing_h, float spacing_v,
+                               const cbindgen_private::Padding &padding_h,
+                               const cbindgen_private::Padding &padding_v,
+                               cbindgen_private::FlexboxLayoutDirection direction,
+                               cbindgen_private::FlexboxLayoutWrap flex_wrap, float constraint_size)
 {
     return cbindgen_private::slint_flexbox_layout_info_cross_axis(
-            cells_h, cells_v, spacing_h, spacing_v, &padding_h, &padding_v, direction, flex_wrap,
-            constraint_size);
+            cells_h, cells_v, flex_props, spacing_h, spacing_v, &padding_h, &padding_v, direction,
+            flex_wrap, constraint_size);
 }
 
 /// Access the layout cache of an item within a repeater (standard cache)

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4624,6 +4624,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         Expression::WithFlexboxLayoutItemInfo {
             cells_h_variable,
             cells_v_variable,
+            flex_props_variable,
             repeater_indices_var_name,
             elements,
             repeated_cross_width,
@@ -4631,6 +4632,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         } => generate_with_flexbox_layout_item_info(
             cells_h_variable,
             cells_v_variable,
+            flex_props_variable,
             repeater_indices_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
             repeated_cross_width.as_deref(),
@@ -5704,8 +5706,12 @@ fn generate_with_layout_item_info(
 fn generate_with_flexbox_layout_item_info(
     cells_h_variable: &str,
     cells_v_variable: &str,
+    flex_props_variable: &str,
     repeated_indices_var_name: Option<&str>,
-    elements: &[Either<(llr::Expression, llr::Expression), llr::LayoutRepeatedElement>],
+    elements: &[Either<
+        (llr::Expression, llr::Expression, llr::Expression),
+        llr::LayoutRepeatedElement,
+    >],
     repeated_cross_width: Option<&llr::Expression>,
     sub_expression: &llr::Expression,
     ctx: &llr_EvaluationContext<CppGeneratorContext>,
@@ -5715,17 +5721,18 @@ fn generate_with_flexbox_layout_item_info(
     // so a height-for-width instance wraps to the real width like a static cell.
     let cross_width = repeated_cross_width.map(|w| compile_expression(w, ctx));
     let mut push_code =
-        "std::vector<slint::cbindgen_private::FlexboxLayoutItemInfo> cells_vector_h; std::vector<slint::cbindgen_private::FlexboxLayoutItemInfo> cells_vector_v;".to_owned();
+        "std::vector<slint::cbindgen_private::LayoutItemInfo> cells_vector_h; std::vector<slint::cbindgen_private::LayoutItemInfo> cells_vector_v; std::vector<slint::cbindgen_private::FlexItemProps> flex_props_vector;".to_owned();
     let mut repeater_idx = 0usize;
 
     for item in elements {
         match item {
-            Either::Left((value_h, value_v)) => {
+            Either::Left((value_h, value_v, value_flex)) => {
                 write!(
                     push_code,
-                    "cells_vector_h.push_back({{ {} }}); cells_vector_v.push_back({{ {} }});",
+                    "cells_vector_h.push_back({{ {} }}); cells_vector_v.push_back({{ {} }}); flex_props_vector.push_back({{ {} }});",
                     compile_expression(value_h, ctx),
-                    compile_expression(value_v, ctx)
+                    compile_expression(value_v, ctx),
+                    compile_expression(value_flex, ctx)
                 )
                 .unwrap();
             }
@@ -5754,22 +5761,28 @@ fn generate_with_flexbox_layout_item_info(
                 // (not-yet-instantiated rows get placeholders).
                 // For a column flex, measure each instance's vertical info at the
                 // container width; otherwise use its preferred-width default.
-                let v_push = match &cross_width {
+                let v_query = match &cross_width {
                     Some(w) => format!(
                         "sub_comp->flexbox_layout_item_info_at_cross_width(static_cast<float>({w}))"
                     ),
                     None => "sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Vertical, std::nullopt)".to_owned(),
                 };
+                // The instance vtable returns the bundled FlexboxLayoutItemInfo; split
+                // it into the constraint cell and the (axis-independent) flex props.
                 write!(
                     push_code,
                     "{{ \
                      auto start_offset = cells_vector_h.size(); \
                      self->repeater_{repeater_index}.for_each([&](const auto &sub_comp){{ \
-                     cells_vector_h.push_back(sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Horizontal, std::nullopt)); \
-                     cells_vector_v.push_back({v_push}); }}); \
+                     auto info_h = sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Horizontal, std::nullopt); \
+                     auto info_v = {v_query}; \
+                     flex_props_vector.push_back(info_h.props); \
+                     cells_vector_h.push_back({{ info_h.constraint }}); \
+                     cells_vector_v.push_back({{ info_v.constraint }}); }}); \
                      auto repeater_len = self->repeater_{repeater_index}.len(); \
                      cells_vector_h.resize(start_offset + repeater_len); \
-                     cells_vector_v.resize(start_offset + repeater_len); }}"
+                     cells_vector_v.resize(start_offset + repeater_len); \
+                     flex_props_vector.resize(start_offset + repeater_len); }}"
                 )
                 .unwrap();
             }
@@ -5785,10 +5798,11 @@ fn generate_with_flexbox_layout_item_info(
         format!("std::array<int, {}> {ri}_array;", 2 * repeater_idx)
     });
     format!(
-        "[&]{{ {ri} {push_code} [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexboxLayoutItemInfo>{cells_h} = slint::private_api::make_slice(std::span(cells_vector_h)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexboxLayoutItemInfo>{cells_v} = slint::private_api::make_slice(std::span(cells_vector_v)); return {}; }}()",
+        "[&]{{ {ri} {push_code} [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{cells_h} = slint::private_api::make_slice(std::span(cells_vector_h)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{cells_v} = slint::private_api::make_slice(std::span(cells_vector_v)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexItemProps>{flex_props} = slint::private_api::make_slice(std::span(flex_props_vector)); return {}; }}()",
         compile_expression(sub_expression, ctx),
         cells_h = ident(cells_h_variable),
         cells_v = ident(cells_v_variable),
+        flex_props = ident(flex_props_variable),
     )
 }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2996,8 +2996,10 @@ fn generate_flexbox_layout_item_info_decl(
              return info;"
         )
     } else {
+        // Equivalent of the Rust trait default `layout_item_info(o).into()`, whose
+        // props are FlexItemProps::default() (note flex_shrink defaults to 1, not 0).
         "auto base = layout_item_info(o, child_index); \
-         return { base.constraint, 0.0f, 0.0f, -1.0f, slint::cbindgen_private::FlexboxLayoutAlignSelf::Auto, 0 };"
+         return { base.constraint, { 0.0f, 1.0f, -1.0f, slint::cbindgen_private::FlexboxLayoutAlignSelf::Auto, 0 } };"
             .to_owned()
     };
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3530,6 +3530,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         Expression::WithFlexboxLayoutItemInfo {
             cells_h_variable,
             cells_v_variable,
+            flex_props_variable,
             repeater_indices_var_name,
             elements,
             repeated_cross_width,
@@ -3537,6 +3538,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         } => generate_with_flexbox_layout_item_info(
             cells_h_variable,
             cells_v_variable,
+            flex_props_variable,
             repeater_indices_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
             repeated_cross_width.as_deref(),
@@ -3962,6 +3964,7 @@ fn compile_struct(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
                         BS::LayoutInfo
                             | BS::LayoutItemInfo
                             | BS::FlexboxLayoutItemInfo
+                            | BS::FlexItemProps
                             | BS::Padding
                             | BS::PropertyAnimation
                             | BS::StateInfo
@@ -5410,8 +5413,9 @@ fn generate_with_layout_item_info(
 fn generate_with_flexbox_layout_item_info(
     cells_h_variable: &str,
     cells_v_variable: &str,
+    flex_props_variable: &str,
     repeated_indices_var_name: Option<&str>,
-    elements: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
+    elements: &[Either<(Expression, Expression, Expression), llr::LayoutRepeatedElement>],
     repeated_cross_width: Option<&Expression>,
     sub_expression: &Expression,
     ctx: &EvaluationContext,
@@ -5427,13 +5431,15 @@ fn generate_with_flexbox_layout_item_info(
 
     for item in elements {
         match item {
-            Either::Left((value_h, value_v)) => {
+            Either::Left((value_h, value_v, value_flex)) => {
                 let value_h = compile_expression(value_h, ctx);
                 let value_v = compile_expression(value_v, ctx);
+                let value_flex = compile_expression(value_flex, ctx);
                 fixed_count += 1;
                 push_code.push(quote!(
                     items_vec_h.push(#value_h);
                     items_vec_v.push(#value_v);
+                    items_vec_flex.push(#value_flex);
                 ))
             }
             Either::Right(repeater) => {
@@ -5449,7 +5455,7 @@ fn generate_with_flexbox_layout_item_info(
                 let repeater_id = format_ident!("repeater{}", usize::from(repeater.repeater_index));
                 // For a column flex, measure each instance's vertical info at the
                 // container width; otherwise use its preferred-width default.
-                let v_push = if let Some(w) = &cross_width {
+                let v_query = if let Some(w) = &cross_width {
                     quote!(sub_comp.as_pin_ref().flexbox_layout_item_info_at_cross_width((#w) as f32))
                 } else {
                     quote!(
@@ -5458,17 +5464,21 @@ fn generate_with_flexbox_layout_item_info(
                             .flexbox_layout_item_info(sp::Orientation::Vertical, None)
                     )
                 };
+                // The instance vtable returns the bundled `FlexboxLayoutItemInfo`;
+                // split it into the constraint cell and the flex props.
                 let loop_code = quote!(for i in 0.._self.#repeater_id.len() {
                     if let Some(sub_comp) = _self.#repeater_id.instance_at(i) {
-                        items_vec_h.push(
-                            sub_comp.as_pin_ref().flexbox_layout_item_info(sp::Orientation::Horizontal, None),
-                        );
-                        items_vec_v.push(#v_push);
+                        let info_h = sub_comp.as_pin_ref().flexbox_layout_item_info(sp::Orientation::Horizontal, None);
+                        let info_v = #v_query;
+                        items_vec_flex.push(info_h.props);
+                        items_vec_h.push(sp::LayoutItemInfo { constraint: info_h.constraint });
+                        items_vec_v.push(sp::LayoutItemInfo { constraint: info_v.constraint });
                     } else {
                         // Not-yet-instantiated slot: push placeholder cells so the cell
                         // count stays in sync with the repeater length written above.
                         items_vec_h.push(::core::default::Default::default());
                         items_vec_v.push(::core::default::Default::default());
+                        items_vec_flex.push(::core::default::Default::default());
                     }
                 });
                 push_code.push(quote!(
@@ -5489,15 +5499,18 @@ fn generate_with_flexbox_layout_item_info(
         repeated_indices_var_name.map(|ri| quote!(let #ri = sp::Slice::from_slice(&#ri);));
     let cells_h_variable = ident(cells_h_variable);
     let cells_v_variable = ident(cells_v_variable);
+    let flex_props_variable = ident(flex_props_variable);
     let sub_expression = compile_expression(sub_expression, ctx);
 
     quote! { {
         #ri_init_code
         let mut items_vec_h = sp::Vec::with_capacity(#fixed_count #repeated_count_code);
         let mut items_vec_v = sp::Vec::with_capacity(#fixed_count #repeated_count_code);
+        let mut items_vec_flex = sp::Vec::with_capacity(#fixed_count #repeated_count_code);
         #(#push_code)*
         let #cells_h_variable = sp::Slice::from_slice(&items_vec_h);
         let #cells_v_variable = sp::Slice::from_slice(&items_vec_v);
+        let #flex_props_variable = sp::Slice::from_slice(&items_vec_flex);
         #ri_from_slice
         #sub_expression
     } }

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -741,6 +741,7 @@ macro_rules! define_builtin_struct_enum {
             FlexboxLayoutData,
             LayoutItemInfo,
             FlexboxLayoutItemInfo,
+            FlexItemProps,
             Padding,
             LayoutInfo,
         }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -239,10 +239,13 @@ pub enum Expression {
         cells_h_variable: String,
         /// The local variable for vertical cells
         cells_v_variable: String,
+        /// The local variable for the per-item flex properties
+        flex_props_variable: String,
         /// The name for the local variable that contains the repeater indices
         repeater_indices_var_name: Option<SmolStr>,
-        /// Either an expression pair of type (LayoutItemInfo, LayoutItemInfo), or information about the repeater
-        elements: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
+        /// Either an expression triple of type (LayoutItemInfo, LayoutItemInfo,
+        /// FlexItemProps), or information about the repeater
+        elements: Vec<Either<(Expression, Expression, Expression), LayoutRepeatedElement>>,
         /// Container (cross-axis) width for a column flex: passed to each
         /// repeated cell's `flexbox_layout_item_info_at_cross_width` so a
         /// height-for-width instance wraps to the real width instead of its
@@ -588,9 +591,10 @@ macro_rules! visit_impl {
                 if let Some(w) = repeated_cross_width {
                     $visitor(w);
                 }
-                elements.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
+                elements.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v, f)| {
                     $visitor(h);
                     $visitor(v);
+                    $visitor(f);
                 });
             }
             Expression::SolveFlexboxLayoutWithMeasure {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -404,6 +404,7 @@ pub(super) fn solve_flexbox_layout(
             ),
             ("cells_h", fld.cells_h.ty(ctx), fld.cells_h),
             ("cells_v", fld.cells_v.ty(ctx), fld.cells_v),
+            ("flex_props", fld.flex_props.ty(ctx), fld.flex_props),
         ],
     );
     // Forward the container width to repeated cells so a column flex re-measures
@@ -420,7 +421,7 @@ pub(super) fn solve_flexbox_layout(
             || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
     });
     match fld.compute_cells {
-        Some((cells_h_var, cells_v_var, elements)) => {
+        Some((cells_h_var, cells_v_var, flex_var, elements)) => {
             let repeated_indices = || llr_Expression::ReadLocalVariable {
                 name: "repeated_indices".into(),
                 ty: Type::Array(Type::Int32.into()),
@@ -446,6 +447,7 @@ pub(super) fn solve_flexbox_layout(
             llr_Expression::WithFlexboxLayoutItemInfo {
                 cells_h_variable: cells_h_var,
                 cells_v_variable: cells_v_var,
+                flex_props_variable: flex_var,
                 repeater_indices_var_name: Some("repeated_indices".into()),
                 elements,
                 repeated_cross_width,
@@ -691,6 +693,7 @@ fn compute_flexbox_layout_info_for_direction(
         let arguments = vec![
             fld.cells_h,
             fld.cells_v,
+            fld.flex_props,
             spacing_h,
             spacing_v,
             padding_h,
@@ -701,10 +704,11 @@ fn compute_flexbox_layout_info_for_direction(
         ];
 
         match fld.compute_cells {
-            Some((cells_h_var, cells_v_var, elements)) => {
+            Some((cells_h_var, cells_v_var, flex_var, elements)) => {
                 llr_Expression::WithFlexboxLayoutItemInfo {
                     cells_h_variable: cells_h_var,
                     cells_v_variable: cells_v_var,
+                    flex_props_variable: flex_var,
                     repeater_indices_var_name: None,
                     elements,
                     // Info computation, not a solve: no container width to forward.
@@ -730,7 +734,7 @@ fn compute_flexbox_layout_info_for_direction(
         };
 
         match fld.compute_cells {
-            Some((cells_h_var, cells_v_var, elements)) => {
+            Some((cells_h_var, cells_v_var, flex_var, elements)) => {
                 let cells_var = match orientation {
                     Orientation::Horizontal => cells_h_var.clone(),
                     Orientation::Vertical => cells_v_var.clone(),
@@ -738,6 +742,7 @@ fn compute_flexbox_layout_info_for_direction(
                 llr_Expression::WithFlexboxLayoutItemInfo {
                     cells_h_variable: cells_h_var,
                     cells_v_variable: cells_v_var,
+                    flex_props_variable: flex_var.clone(),
                     repeater_indices_var_name: None,
                     elements,
                     // Info computation, not a solve: no container width to forward.
@@ -748,7 +753,13 @@ fn compute_flexbox_layout_info_for_direction(
                             llr_Expression::ReadLocalVariable {
                                 name: cells_var.into(),
                                 ty: Type::Array(Arc::new(
-                                    crate::typeregister::flexbox_layout_item_info_type(),
+                                    crate::typeregister::layout_item_info_type(),
+                                )),
+                            },
+                            llr_Expression::ReadLocalVariable {
+                                name: flex_var.into(),
+                                ty: Type::Array(Arc::new(
+                                    crate::typeregister::flex_item_props_type(),
                                 )),
                             },
                             spacing,
@@ -761,7 +772,7 @@ fn compute_flexbox_layout_info_for_direction(
             }
             None => llr_Expression::ExtraBuiltinFunctionCall {
                 function: "flexbox_layout_info_main_axis".into(),
-                arguments: vec![cells, spacing, padding, fld.flex_wrap],
+                arguments: vec![cells, fld.flex_props, spacing, padding, fld.flex_wrap],
                 return_ty: crate::typeregister::layout_info_type().into(),
             },
         }
@@ -777,12 +788,17 @@ struct FlexboxLayoutDataResult {
     flex_wrap: llr_Expression,
     cells_h: llr_Expression,
     cells_v: llr_Expression,
+    /// Per-item flex properties, parallel to `cells_h`/`cells_v` (or read from
+    /// the `flex_props` variable built by `WithFlexboxLayoutItemInfo`).
+    flex_props: llr_Expression,
     /// When there are repeaters involved, we need to do a WithFlexboxLayoutItemInfo with the
-    /// given cells_h/cells_v variable names and elements (each static element has a tuple of (h, v) layout info)
+    /// given cells_h/cells_v/flex_props variable names and elements (each static element
+    /// has a tuple of (h constraint, v constraint, flex props))
     compute_cells: Option<(
         String,
         String,
-        Vec<Either<(llr_Expression, llr_Expression), LayoutRepeatedElement>>,
+        String,
+        Vec<Either<(llr_Expression, llr_Expression, llr_Expression), LayoutRepeatedElement>>,
     )>,
 }
 
@@ -845,7 +861,8 @@ fn flexbox_layout_data(
     let repeater_count =
         layout.elems.iter().filter(|i| i.item.element.borrow().repeated.is_some()).count();
 
-    let element_ty = crate::typeregister::flexbox_layout_item_info_type();
+    let cell_ty = crate::typeregister::layout_item_info_type();
+    let flex_props_ty = crate::typeregister::flex_item_props_type();
 
     let flex_prop =
         |li: &crate::layout::FlexboxLayoutItem, ctx: &mut ExpressionLoweringCtx| -> FlexItemProps {
@@ -936,11 +953,10 @@ fn flexbox_layout_data(
                         Orientation::Horizontal,
                         constraint,
                     );
-                    let flex_props = flex_prop(li, ctx);
-                    make_flexbox_cell_data_struct(layout_info_h, flex_props)
+                    make_layout_cell_data_struct(layout_info_h)
                 })
                 .collect(),
-            element_ty: element_ty.clone(),
+            element_ty: cell_ty.clone(),
             output: llr_ArrayOutput::Slice,
         };
         // For cells_v, pass a width constraint for items that need
@@ -960,11 +976,19 @@ fn flexbox_layout_data(
                         Orientation::Vertical,
                         constraint,
                     );
-                    let flex_props = flex_prop(li, ctx);
-                    make_flexbox_cell_data_struct(layout_info_v, flex_props)
+                    make_layout_cell_data_struct(layout_info_v)
                 })
                 .collect(),
-            element_ty,
+            element_ty: cell_ty,
+            output: llr_ArrayOutput::Slice,
+        };
+        let flex_props = llr_Expression::Array {
+            values: layout
+                .elems
+                .iter()
+                .map(|li| make_flex_props_struct(flex_prop(li, ctx)))
+                .collect(),
+            element_ty: flex_props_ty,
             output: llr_ArrayOutput::Slice,
         };
         FlexboxLayoutDataResult {
@@ -975,6 +999,7 @@ fn flexbox_layout_data(
             flex_wrap,
             cells_h,
             cells_v,
+            flex_props,
             compute_cells: None,
         }
     } else {
@@ -1012,20 +1037,24 @@ fn flexbox_layout_data(
                     Orientation::Vertical,
                     constraint,
                 );
-                let flex_props = flex_prop(item, ctx);
                 elements.push(Either::Left((
-                    make_flexbox_cell_data_struct(layout_info_h, flex_props.clone()),
-                    make_flexbox_cell_data_struct(layout_info_v, flex_props),
+                    make_layout_cell_data_struct(layout_info_h),
+                    make_layout_cell_data_struct(layout_info_v),
+                    make_flex_props_struct(flex_prop(item, ctx)),
                 )));
             }
         }
         let cells_h = llr_Expression::ReadLocalVariable {
             name: "cells_h".into(),
-            ty: Type::Array(Arc::new(crate::typeregister::flexbox_layout_item_info_type())),
+            ty: Type::Array(Arc::new(crate::typeregister::layout_item_info_type())),
         };
         let cells_v = llr_Expression::ReadLocalVariable {
             name: "cells_v".into(),
-            ty: Type::Array(Arc::new(crate::typeregister::flexbox_layout_item_info_type())),
+            ty: Type::Array(Arc::new(crate::typeregister::layout_item_info_type())),
+        };
+        let flex_props = llr_Expression::ReadLocalVariable {
+            name: "flex_props".into(),
+            ty: Type::Array(Arc::new(crate::typeregister::flex_item_props_type())),
         };
         FlexboxLayoutDataResult {
             alignment,
@@ -1035,7 +1064,13 @@ fn flexbox_layout_data(
             flex_wrap,
             cells_h,
             cells_v,
-            compute_cells: Some(("cells_h".into(), "cells_v".into(), elements)),
+            flex_props,
+            compute_cells: Some((
+                "cells_h".into(),
+                "cells_v".into(),
+                "flex_props".into(),
+                elements,
+            )),
         }
     }
 }
@@ -1075,12 +1110,11 @@ struct FlexItemProps {
     order: llr_Expression,
 }
 
-fn make_flexbox_cell_data_struct(layout_info: llr_Expression, fp: FlexItemProps) -> llr_Expression {
+fn make_flex_props_struct(fp: FlexItemProps) -> llr_Expression {
     let (align_self_ty, _) = default_align_self();
     make_struct(
-        BuiltinStruct::FlexboxLayoutItemInfo,
+        BuiltinStruct::FlexItemProps,
         [
-            ("constraint", crate::typeregister::layout_info_type().into(), layout_info),
             ("flex-grow", Type::Float32, fp.grow),
             ("flex-shrink", Type::Float32, fp.shrink),
             ("flex-basis", Type::Float32, fp.basis),
@@ -1231,30 +1265,41 @@ fn flexbox_unwrapped_main_expr(
         Orientation::Horizontal => (spacing_h, padding_h),
         Orientation::Vertical => (spacing_v, padding_v),
     };
-    let array_ty = Type::Array(Arc::new(crate::typeregister::flexbox_layout_item_info_type()));
-    let cells_expr = match &fld.compute_cells {
-        Some((cells_h_var, cells_v_var, _)) => {
+    let cell_array_ty = Type::Array(Arc::new(crate::typeregister::layout_item_info_type()));
+    let flex_array_ty = Type::Array(Arc::new(crate::typeregister::flex_item_props_type()));
+    let (cells_expr, flex_expr) = match &fld.compute_cells {
+        Some((cells_h_var, cells_v_var, flex_var, _)) => {
             let cells_var = match orientation {
                 Orientation::Horizontal => cells_h_var.clone(),
                 Orientation::Vertical => cells_v_var.clone(),
             };
-            llr_Expression::ReadLocalVariable { name: cells_var.into(), ty: array_ty }
+            (
+                llr_Expression::ReadLocalVariable { name: cells_var.into(), ty: cell_array_ty },
+                llr_Expression::ReadLocalVariable {
+                    name: flex_var.clone().into(),
+                    ty: flex_array_ty,
+                },
+            )
         }
-        None => match orientation {
-            Orientation::Horizontal => fld.cells_h.clone(),
-            Orientation::Vertical => fld.cells_v.clone(),
-        },
+        None => {
+            let cells = match orientation {
+                Orientation::Horizontal => fld.cells_h.clone(),
+                Orientation::Vertical => fld.cells_v.clone(),
+            };
+            (cells, fld.flex_props.clone())
+        }
     };
     let call = llr_Expression::ExtraBuiltinFunctionCall {
         function: "flexbox_layout_unwrapped_main".into(),
-        arguments: vec![cells_expr, spacing, padding],
+        arguments: vec![cells_expr, flex_expr, spacing, padding],
         return_ty: Type::Float32,
     };
     match fld.compute_cells {
-        Some((cells_h_variable, cells_v_variable, elements)) => {
+        Some((cells_h_variable, cells_v_variable, flex_props_variable, elements)) => {
             llr_Expression::WithFlexboxLayoutItemInfo {
                 cells_h_variable,
                 cells_v_variable,
+                flex_props_variable,
                 repeater_indices_var_name: None,
                 elements,
                 // Info computation, not a solve: no container width to forward.
@@ -1925,7 +1970,7 @@ pub fn get_flexbox_layout_item_info_for_repeated(
             .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(&nr)))
     };
 
-    let (align_self_ty, align_self_default) = default_align_self();
+    let (_, align_self_default) = default_align_self();
 
     let grow = prop_ref("flex-grow").unwrap_or(llr_Expression::NumberLiteral(0.0));
     let shrink = prop_ref("flex-shrink").unwrap_or(llr_Expression::NumberLiteral(1.0));
@@ -1944,11 +1989,11 @@ pub fn get_flexbox_layout_item_info_for_repeated(
                 )
                 .unwrap(),
             ),
-            ("flex-grow", Type::Float32, grow),
-            ("flex-shrink", Type::Float32, shrink),
-            ("flex-basis", Type::Float32, basis),
-            ("flex-align-self", align_self_ty, align_self),
-            ("flex-order", Type::Int32, order),
+            (
+                "props",
+                crate::typeregister::flex_item_props_type(),
+                make_flex_props_struct(FlexItemProps { grow, shrink, basis, align_self, order }),
+            ),
         ],
     )
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -102,6 +102,7 @@ pub struct BuiltinTypes {
     pub path_element_type: Type,
     pub layout_item_info_type: Type,
     pub flexbox_layout_item_info_type: Type,
+    pub flex_item_props_type: Type,
 }
 
 impl BuiltinTypes {
@@ -120,6 +121,19 @@ impl BuiltinTypes {
         ));
         let enums = BuiltinEnums::new();
         let flex_align_self_type = Type::Enumeration(enums.FlexboxLayoutAlignSelf.clone());
+        // Shared by `flex_item_props_type` and nested as `props` in
+        // `flexbox_layout_item_info_type`, so the field list is defined once.
+        let flex_item_props_struct = Arc::new(Struct::new(
+            IntoIterator::into_iter([
+                ("flex-grow".into(), Type::Float32),
+                ("flex-shrink".into(), Type::Float32),
+                ("flex-basis".into(), Type::Float32),
+                ("flex-align-self".into(), flex_align_self_type),
+                ("flex-order".into(), Type::Int32),
+            ])
+            .collect(),
+            BuiltinStruct::FlexItemProps,
+        ));
         Self {
             enums,
             logical_point_type: Arc::new(Struct::new(
@@ -180,15 +194,12 @@ impl BuiltinTypes {
             flexbox_layout_item_info_type: Type::Struct(Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     ("constraint".into(), layout_info_type.into()),
-                    ("flex-grow".into(), Type::Float32),
-                    ("flex-shrink".into(), Type::Float32),
-                    ("flex-basis".into(), Type::Float32),
-                    ("flex-align-self".into(), flex_align_self_type),
-                    ("flex-order".into(), Type::Int32),
+                    ("props".into(), Type::Struct(flex_item_props_struct.clone())),
                 ])
                 .collect(),
                 BuiltinStruct::FlexboxLayoutItemInfo,
             ))),
+            flex_item_props_type: Type::Struct(flex_item_props_struct),
             gridlayout_input_data_type: Type::Struct(Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     ("row".into(), Type::Int32),
@@ -959,4 +970,9 @@ pub fn layout_item_info_type() -> Type {
 /// The [`Type`] for a runtime FlexboxLayoutItemInfo structure
 pub fn flexbox_layout_item_info_type() -> Type {
     BUILTIN.flexbox_layout_item_info_type.clone()
+}
+
+/// The [`Type`] for a runtime FlexItemProps structure
+pub fn flex_item_props_type() -> Type {
+    BUILTIN.flex_item_props_type.clone()
 }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1155,9 +1155,11 @@ pub struct FlexboxLayoutData<'a> {
     pub cross_axis_alignment: CrossAxisAlignment,
     pub flex_wrap: FlexboxLayoutWrap,
     /// Horizontal constraints (width) for each cell
-    pub cells_h: Slice<'a, FlexboxLayoutItemInfo>,
+    pub cells_h: Slice<'a, LayoutItemInfo>,
     /// Vertical constraints (height) for each cell
-    pub cells_v: Slice<'a, FlexboxLayoutItemInfo>,
+    pub cells_v: Slice<'a, LayoutItemInfo>,
+    /// Per-item flex properties, one per cell (axis-independent)
+    pub flex_props: Slice<'a, FlexItemProps>,
 }
 
 #[repr(C)]
@@ -1167,11 +1169,14 @@ pub struct LayoutItemInfo {
     pub constraint: LayoutInfo,
 }
 
+/// The per-item flex properties of a FlexboxLayout cell.
+///
+/// A cell's size constraint is per-axis (`cells_h`/`cells_v`), but these
+/// properties apply to the item as a whole, so they live in a single parallel
+/// array instead of being duplicated into both axes.
 #[repr(C)]
-#[derive(Debug, Clone)]
-/// The information about a single item in a flexbox layout
-pub struct FlexboxLayoutItemInfo {
-    pub constraint: LayoutInfo,
+#[derive(Debug, Clone, Copy)]
+pub struct FlexItemProps {
     /// Flex grow factor (0 = don't grow, default)
     pub flex_grow: f32,
     /// Flex shrink factor (0 = don't shrink, default)
@@ -1184,71 +1189,79 @@ pub struct FlexboxLayoutItemInfo {
     pub flex_order: i32,
 }
 
-impl Default for FlexboxLayoutItemInfo {
+impl Default for FlexItemProps {
     fn default() -> Self {
         Self {
-            constraint: LayoutInfo::default(),
             flex_grow: 0.0,
             flex_shrink: 1.0,
-            flex_basis: -1 as _,
+            flex_basis: -1 as Coord,
             flex_align_self: FlexboxLayoutAlignSelf::Auto,
             flex_order: 0,
         }
     }
 }
 
-impl From<LayoutItemInfo> for FlexboxLayoutItemInfo {
-    fn from(info: LayoutItemInfo) -> Self {
-        Self { constraint: info.constraint, ..Default::default() }
+impl FlexItemProps {
+    /// The item's size along the main axis before growing or shrinking:
+    /// `flex-basis` when set (>= 0), otherwise the preferred size,
+    /// clamped to the constraint's min/max. This is CSS's hypothetical main size.
+    ///
+    /// `c` must be the main-axis constraint, since `flex-basis` always refers to
+    /// the main axis. The cross axis must use `preferred_bounded()`.
+    #[must_use]
+    fn hypothetical_main_size(&self, c: &LayoutInfo) -> Coord {
+        if self.flex_basis >= 0 as Coord {
+            self.flex_basis.min(c.max).max(c.min)
+        } else {
+            c.preferred_bounded()
+        }
     }
 }
 
-impl FlexboxLayoutItemInfo {
-    /// The item's size along the main axis before growing or shrinking:
-    /// `flex-basis` when set (>= 0), otherwise the preferred size,
-    /// clamped to the item's min/max. This is CSS's hypothetical main size.
-    ///
-    /// Only meaningful for the main-axis cell list,
-    /// since `flex-basis` always refers to the main axis.
-    /// The cross axis must use `preferred_bounded()`.
-    #[must_use]
-    fn hypothetical_main_size(&self) -> Coord {
-        if self.flex_basis >= 0 as Coord {
-            self.flex_basis.min(self.constraint.max).max(self.constraint.min)
-        } else {
-            self.constraint.preferred_bounded()
-        }
+/// What one flexbox cell contributes to the container's preferred main size.
+///
+/// A growable item treats its basis as a floor to grow from rather than a cap,
+/// so it still needs room for its content: `flex-basis: 0` with `flex-grow: 1`
+/// (the CSS `flex: 1 1 0` idiom) must not collapse the container to nothing.
+///
+/// Taking the larger of the two is what taffy does: its max-content flex
+/// fraction divides by the grow factor and then multiplies by it again, so the
+/// factor cancels and an item contributes `max(content, basis)`. The spec would
+/// scale every item by the line's largest fraction instead, but taffy, Chrome
+/// and Firefox all skip that step.
+#[must_use]
+fn flex_preferred_main(c: &LayoutInfo, f: &FlexItemProps) -> Coord {
+    if f.flex_grow > 0. {
+        f.hypothetical_main_size(c).max(c.preferred_bounded())
+    } else {
+        f.hypothetical_main_size(c)
     }
+}
 
-    /// What the item contributes to the container's preferred main size.
-    ///
-    /// A growable item treats its basis as a floor to grow from rather than a cap,
-    /// so it still needs room for its content: `flex-basis: 0` with `flex-grow: 1`
-    /// (the CSS `flex: 1 1 0` idiom) must not collapse the container to nothing.
-    ///
-    /// Taking the larger of the two is what taffy does: its max-content flex
-    /// fraction divides by the grow factor and then multiplies by it again, so the
-    /// factor cancels and an item contributes `max(content, basis)`. The spec would
-    /// scale every item by the line's largest fraction instead, but taffy, Chrome
-    /// and Firefox all skip that step.
-    #[must_use]
-    fn flex_preferred_main(&self) -> Coord {
-        if self.flex_grow > 0. {
-            self.hypothetical_main_size().max(self.constraint.preferred_bounded())
-        } else {
-            self.hypothetical_main_size()
-        }
-    }
+/// One flexbox cell's minimum main-axis size.
+///
+/// An item that cannot shrink (`flex-shrink: 0`) never goes below its hypothetical
+/// main size, so that is what it contributes; anything else can be squeezed down
+/// to its own minimum. Never below `c.min`, since `hypothetical_main_size` is clamped to it.
+#[must_use]
+fn flex_min_main(c: &LayoutInfo, f: &FlexItemProps) -> Coord {
+    if f.flex_shrink <= 0. { f.hypothetical_main_size(c) } else { c.min }
+}
 
-    /// The item's minimum size along the main axis.
-    /// An item that cannot shrink (`flex-shrink: 0`) never goes below its hypothetical
-    /// main size, so that is what it contributes; anything else can be squeezed down
-    /// to its own minimum.
-    ///
-    /// Never below `constraint.min`, since `hypothetical_main_size()` is already clamped to it.
-    #[must_use]
-    fn flex_min_main(&self) -> Coord {
-        if self.flex_shrink <= 0. { self.hypothetical_main_size() } else { self.constraint.min }
+#[repr(C)]
+#[derive(Debug, Clone, Default)]
+/// One flexbox cell's full layout info, read from a single item instance via the
+/// item vtable. The bulk cell data in [`FlexboxLayoutData`] keeps the constraint
+/// and [`FlexItemProps`] in separate parallel arrays; this bundles both for the
+/// per-instance query.
+pub struct FlexboxLayoutItemInfo {
+    pub constraint: LayoutInfo,
+    pub props: FlexItemProps,
+}
+
+impl From<LayoutItemInfo> for FlexboxLayoutItemInfo {
+    fn from(info: LayoutItemInfo) -> Self {
+        Self { constraint: info.constraint, ..Default::default() }
     }
 }
 
@@ -1424,9 +1437,9 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, CrossAxisAlignment, FlexboxLayoutAlignContent, FlexboxLayoutAlignSelf,
-        FlexboxLayoutItemInfo, FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment,
-        LayoutInfo, Padding, Slice,
+        Coord, CrossAxisAlignment, FlexItemProps, FlexboxLayoutAlignContent,
+        FlexboxLayoutAlignSelf, FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment,
+        LayoutInfo, LayoutItemInfo, Padding, Slice,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
@@ -1434,8 +1447,9 @@ mod flexbox_taffy {
 
     /// Parameters for FlexboxTaffyBuilder::new
     pub struct FlexboxLayoutParams<'a> {
-        pub cells_h: &'a Slice<'a, FlexboxLayoutItemInfo>,
-        pub cells_v: &'a Slice<'a, FlexboxLayoutItemInfo>,
+        pub cells_h: &'a Slice<'a, LayoutItemInfo>,
+        pub cells_v: &'a Slice<'a, LayoutItemInfo>,
+        pub flex_props: &'a Slice<'a, FlexItemProps>,
         pub spacing_h: Coord,
         pub spacing_v: Coord,
         pub padding_h: &'a Padding,
@@ -1518,6 +1532,7 @@ mod flexbox_taffy {
                 .enumerate()
                 .map(|(idx, cell_h)| {
                     let cell_v = params.cells_v.get(idx);
+                    let flex = params.flex_props.get(idx).cloned().unwrap_or_default();
                     let h_constraint = &cell_h.constraint;
                     let v_constraint = cell_v.map(|c| &c.constraint);
 
@@ -1527,8 +1542,8 @@ mod flexbox_taffy {
                         v_constraint.map(|vc| vc.preferred_bounded()).unwrap_or(0 as Coord);
 
                     // flex_basis: use explicit value if set (>= 0), otherwise use preferred size
-                    let flex_basis = if cell_h.flex_basis >= 0 as Coord {
-                        Dimension::length(cell_h.flex_basis as _)
+                    let flex_basis = if flex.flex_basis >= 0 as Coord {
+                        Dimension::length(flex.flex_basis as _)
                     } else {
                         match params.flex_direction {
                             TaffyFlexDirection::Row | TaffyFlexDirection::RowReverse => {
@@ -1572,7 +1587,7 @@ mod flexbox_taffy {
                                             // per-column width when wrapped), not the whole
                                             // container. A per-item `flex-align-self`
                                             // overrides the container's alignment.
-                                            let stretches = match cell_h.flex_align_self {
+                                            let stretches = match flex.flex_align_self {
                                                 FlexboxLayoutAlignSelf::Auto => {
                                                     params.cross_axis_alignment
                                                         == CrossAxisAlignment::Stretch
@@ -1623,9 +1638,9 @@ mod flexbox_taffy {
                                         _ => Dimension::auto(),
                                     },
                                 },
-                                flex_grow: cell_h.flex_grow,
-                                flex_shrink: cell_h.flex_shrink,
-                                align_self: match cell_h.flex_align_self {
+                                flex_grow: flex.flex_grow,
+                                flex_shrink: flex.flex_shrink,
+                                align_self: match flex.flex_align_self {
                                     FlexboxLayoutAlignSelf::Auto => None,
                                     FlexboxLayoutAlignSelf::Stretch => Some(AlignSelf::Stretch),
                                     FlexboxLayoutAlignSelf::Start => Some(AlignSelf::FlexStart),
@@ -1642,11 +1657,11 @@ mod flexbox_taffy {
 
             // Sort children by CSS `order` property if any item has a non-zero order.
             // Build a mapping from sorted position -> original index.
-            let has_order = params.cells_h.iter().any(|c| c.flex_order != 0);
+            let has_order = params.flex_props.iter().any(|f| f.flex_order != 0);
             let order_map: Vec<usize> = if has_order {
                 let mut indices: Vec<usize> = (0..children.len()).collect();
                 // sort_by_key is a stable sort, as required by CSS
-                indices.sort_by_key(|&i| params.cells_h.get(i).map_or(0, |c| c.flex_order));
+                indices.sort_by_key(|&i| params.flex_props.get(i).map_or(0, |f| f.flex_order));
                 let sorted_children: Vec<NodeId> = indices.iter().map(|&i| children[i]).collect();
                 children = sorted_children;
                 indices
@@ -1924,6 +1939,7 @@ pub fn solve_flexbox_layout_with_measure(
     let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
         cells_h: &data.cells_h,
         cells_v: &data.cells_v,
+        flex_props: &data.flex_props,
         spacing_h: data.spacing_h,
         spacing_v: data.spacing_v,
         padding_h: &data.padding_h,
@@ -1981,16 +1997,22 @@ pub fn solve_flexbox_layout_with_measure(
 /// `sqrt`-area "square" that [`flexbox_layout_info_main_axis`] reports as
 /// `preferred`.
 pub fn flexbox_layout_unwrapped_main(
-    cells: Slice<FlexboxLayoutItemInfo>,
+    cells: Slice<LayoutItemInfo>,
+    flex_props: Slice<FlexItemProps>,
     spacing: Coord,
     padding: &Padding,
 ) -> Coord {
+    debug_assert_eq!(cells.len(), flex_props.len());
     let extra_pad = padding.begin + padding.end;
     if cells.is_empty() {
         return extra_pad;
     }
     let num_spacings = cells.len().saturating_sub(1) as Coord;
-    cells.iter().map(|c| c.flex_preferred_main()).sum::<Coord>()
+    cells
+        .iter()
+        .zip(flex_props.iter())
+        .map(|(c, f)| flex_preferred_main(&c.constraint, f))
+        .sum::<Coord>()
         + spacing * num_spacings
         + extra_pad
 }
@@ -1998,11 +2020,13 @@ pub fn flexbox_layout_unwrapped_main(
 /// Return main-axis LayoutInfo for a FlexboxLayout.
 /// Only needs the same-axis cells, avoiding a cross-axis binding loop.
 pub fn flexbox_layout_info_main_axis(
-    cells: Slice<FlexboxLayoutItemInfo>,
+    cells: Slice<LayoutItemInfo>,
+    flex_props: Slice<FlexItemProps>,
     spacing: Coord,
     padding: &Padding,
     flex_wrap: FlexboxLayoutWrap,
 ) -> LayoutInfo {
+    debug_assert_eq!(cells.len(), flex_props.len());
     let extra_pad = padding.begin + padding.end;
     if cells.is_empty() {
         return LayoutInfo {
@@ -2013,15 +2037,19 @@ pub fn flexbox_layout_info_main_axis(
         };
     }
     let num_spacings = cells.len().saturating_sub(1) as Coord;
+    let min_of = |(c, f): (&LayoutItemInfo, &FlexItemProps)| flex_min_main(&c.constraint, f);
     let min = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
-        cells.iter().map(|c| c.flex_min_main()).sum::<Coord>() + spacing * num_spacings + extra_pad
+        cells.iter().zip(flex_props.iter()).map(min_of).sum::<Coord>()
+            + spacing * num_spacings
+            + extra_pad
     } else {
         // Wrapping: the widest single item must fit
-        cells.iter().map(|c| c.flex_min_main()).fold(0.0 as Coord, |a, b| a.max(b)) + extra_pad
+        cells.iter().zip(flex_props.iter()).map(min_of).fold(0.0 as Coord, |a, b| a.max(b))
+            + extra_pad
     };
     let preferred = if matches!(flex_wrap, FlexboxLayoutWrap::NoWrap) {
         // No wrapping: all items on one line
-        flexbox_layout_unwrapped_main(cells, spacing, padding)
+        flexbox_layout_unwrapped_main(cells, flex_props, spacing, padding)
     } else {
         // Wrapping: aim for a roughly square (pixel-area) arrangement, using only
         // main-axis sizes so this stays independent of the cross axis. The square
@@ -2036,16 +2064,17 @@ pub fn flexbox_layout_info_main_axis(
         // products (and their sum) would overflow for large items.
         let total_area: f64 = cells
             .iter()
-            .map(|c| c.flex_preferred_main() as f64 + spacing as f64)
+            .zip(flex_props.iter())
+            .map(|(c, f)| flex_preferred_main(&c.constraint, f) as f64 + spacing as f64)
             .map(|w| w * w)
             .sum();
         let target = Float::sqrt(total_area as f32) as Coord;
         let mut acc = 0 as Coord;
         let mut started = false;
-        for c in cells.iter() {
+        for (c, f) in cells.iter().zip(flex_props.iter()) {
             // taffy breaks the lines on the hypothetical size, before any growing,
             // so the line fitting has to measure the items the same way.
-            let size = c.hypothetical_main_size();
+            let size = f.hypothetical_main_size(&c.constraint);
             acc += if started { spacing + size } else { size };
             started = true;
             if acc >= target {
@@ -2074,8 +2103,9 @@ pub fn flexbox_layout_info_main_axis(
 /// perpendicular flexboxes), falls back to a heuristic based on
 /// `flexbox_layout_info_main_axis`.
 pub fn flexbox_layout_info_cross_axis(
-    cells_h: Slice<FlexboxLayoutItemInfo>,
-    cells_v: Slice<FlexboxLayoutItemInfo>,
+    cells_h: Slice<LayoutItemInfo>,
+    cells_v: Slice<LayoutItemInfo>,
+    flex_props: Slice<FlexItemProps>,
     spacing_h: Coord,
     spacing_v: Coord,
     padding_h: &Padding,
@@ -2084,6 +2114,8 @@ pub fn flexbox_layout_info_cross_axis(
     flex_wrap: FlexboxLayoutWrap,
     constraint_size: Coord,
 ) -> LayoutInfo {
+    debug_assert_eq!(cells_h.len(), cells_v.len());
+    debug_assert_eq!(cells_h.len(), flex_props.len());
     if cells_h.is_empty() {
         assert!(cells_v.is_empty());
         let orientation = match direction {
@@ -2138,7 +2170,11 @@ pub fn flexbox_layout_info_cross_axis(
         let total_area: f64 = main_cells
             .iter()
             .zip(cross_cells.iter())
-            .map(|(m, c)| m.flex_preferred_main() as f64 * c.constraint.preferred_bounded() as f64)
+            .zip(flex_props.iter())
+            .map(|((m, c), f)| {
+                flex_preferred_main(&m.constraint, f) as f64
+                    * c.constraint.preferred_bounded() as f64
+            })
             .sum();
         let count = main_cells.len();
         Float::sqrt(total_area as f32) as Coord
@@ -2165,6 +2201,7 @@ pub fn flexbox_layout_info_cross_axis(
     let mut builder = flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
         cells_h: &cells_h,
         cells_v: &cells_v,
+        flex_props: &flex_props,
         spacing_h,
         spacing_v,
         padding_h,
@@ -2378,29 +2415,32 @@ pub(crate) mod ffi {
     #[unsafe(no_mangle)]
     /// Return main-axis LayoutInfo for a FlexboxLayout (single-axis, no cross-axis dependency).
     pub extern "C" fn slint_flexbox_layout_info_main_axis(
-        cells: Slice<FlexboxLayoutItemInfo>,
+        cells: Slice<LayoutItemInfo>,
+        flex_props: Slice<FlexItemProps>,
         spacing: Coord,
         padding: &Padding,
         flex_wrap: FlexboxLayoutWrap,
     ) -> LayoutInfo {
-        super::flexbox_layout_info_main_axis(cells, spacing, padding, flex_wrap)
+        super::flexbox_layout_info_main_axis(cells, flex_props, spacing, padding, flex_wrap)
     }
 
     #[unsafe(no_mangle)]
     /// Return the flex's natural single-line (no-wrap) main-axis size.
     pub extern "C" fn slint_flexbox_layout_unwrapped_main(
-        cells: Slice<FlexboxLayoutItemInfo>,
+        cells: Slice<LayoutItemInfo>,
+        flex_props: Slice<FlexItemProps>,
         spacing: Coord,
         padding: &Padding,
     ) -> Coord {
-        super::flexbox_layout_unwrapped_main(cells, spacing, padding)
+        super::flexbox_layout_unwrapped_main(cells, flex_props, spacing, padding)
     }
 
     #[unsafe(no_mangle)]
     /// Return cross-axis LayoutInfo for a FlexboxLayout.
     pub extern "C" fn slint_flexbox_layout_info_cross_axis(
-        cells_h: Slice<FlexboxLayoutItemInfo>,
-        cells_v: Slice<FlexboxLayoutItemInfo>,
+        cells_h: Slice<LayoutItemInfo>,
+        cells_v: Slice<LayoutItemInfo>,
+        flex_props: Slice<FlexItemProps>,
         spacing_h: Coord,
         spacing_v: Coord,
         padding_h: &Padding,
@@ -2412,6 +2452,7 @@ pub(crate) mod ffi {
         super::flexbox_layout_info_cross_axis(
             cells_h,
             cells_v,
+            flex_props,
             spacing_h,
             spacing_v,
             padding_h,
@@ -3029,30 +3070,39 @@ mod tests {
         ) -> FlexboxLayoutItemInfo {
             FlexboxLayoutItemInfo {
                 constraint: LayoutInfo { min, max, preferred, ..Default::default() },
-                flex_grow: grow,
-                flex_basis: basis,
-                ..Default::default()
+                props: FlexItemProps { flex_grow: grow, flex_basis: basis, ..Default::default() },
             }
+        }
+
+        /// Split the bundled test cells into the parallel (constraint, flex-props)
+        /// arrays the runtime takes.
+        fn split(cells: &[FlexboxLayoutItemInfo]) -> (Vec<LayoutItemInfo>, Vec<FlexItemProps>) {
+            (
+                cells.iter().map(|c| LayoutItemInfo { constraint: c.constraint.clone() }).collect(),
+                cells.iter().map(|c| c.props).collect(),
+            )
         }
 
         /// What taffy makes of the same cells, asked for its max-content main size.
         fn taffy_max_content_main(cells: &[FlexboxLayoutItemInfo]) -> Coord {
+            let (main, flex) = split(cells);
             // The cross axis is deliberately left unconstrained: the main-axis result
             // must not depend on it, which is what makes the loop-free path sound.
-            let cross: Vec<FlexboxLayoutItemInfo> = cells
+            let cross: Vec<LayoutItemInfo> = cells
                 .iter()
-                .map(|_| FlexboxLayoutItemInfo {
+                .map(|_| LayoutItemInfo {
                     constraint: LayoutInfo { max: Coord::MAX, ..Default::default() },
-                    ..Default::default()
                 })
                 .collect();
-            let cells_h = Slice::from_slice(cells);
+            let cells_h = Slice::from_slice(&main);
             let cells_v = Slice::from_slice(&cross);
+            let flex_props = Slice::from_slice(&flex);
             let pad = Padding::default();
             let mut builder =
                 flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
                     cells_h: &cells_h,
                     cells_v: &cells_v,
+                    flex_props: &flex_props,
                     spacing_h: 0 as Coord,
                     spacing_v: 0 as Coord,
                     padding_h: &pad,
@@ -3080,7 +3130,13 @@ mod tests {
         }
 
         fn ours(cells: &[FlexboxLayoutItemInfo]) -> Coord {
-            flexbox_layout_unwrapped_main(Slice::from_slice(cells), 0 as Coord, &Padding::default())
+            let (main, flex) = split(cells);
+            flexbox_layout_unwrapped_main(
+                Slice::from_slice(&main),
+                Slice::from_slice(&flex),
+                0 as Coord,
+                &Padding::default(),
+            )
         }
 
         #[track_caller]
@@ -3131,25 +3187,24 @@ mod tests {
         /// The same cells asked of a *column* container, where taffy does apply the
         /// basis to the max-content size.
         fn taffy_column_main(cells: &[FlexboxLayoutItemInfo]) -> Coord {
+            let (main, flex) = split(cells);
             // For a column the main axis is vertical: main-axis sizes live in cells_v,
-            // while the flex properties are always read from cells_h.
-            let h: Vec<FlexboxLayoutItemInfo> = cells
+            // while the cross-axis (width) constraint is left unbounded.
+            let h: Vec<LayoutItemInfo> = cells
                 .iter()
-                .map(|c| FlexboxLayoutItemInfo {
+                .map(|_| LayoutItemInfo {
                     constraint: LayoutInfo { max: Coord::MAX, ..Default::default() },
-                    flex_grow: c.flex_grow,
-                    flex_shrink: c.flex_shrink,
-                    flex_basis: c.flex_basis,
-                    ..Default::default()
                 })
                 .collect();
             let cells_h = Slice::from_slice(&h);
-            let cells_v = Slice::from_slice(cells);
+            let cells_v = Slice::from_slice(&main);
+            let flex_props = Slice::from_slice(&flex);
             let pad = Padding::default();
             let mut builder =
                 flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
                     cells_h: &cells_h,
                     cells_v: &cells_v,
+                    flex_props: &flex_props,
                     spacing_h: 0 as Coord,
                     spacing_v: 0 as Coord,
                     padding_h: &pad,
@@ -3238,28 +3293,28 @@ mod tests {
     #[test]
     fn percentage_against_unbounded_container_leaves_item_finite() {
         // A single row cell with `width: 50%` (min_percent == max_percent == 50).
-        let cells_h = [FlexboxLayoutItemInfo {
+        let cells_h = [LayoutItemInfo {
             constraint: LayoutInfo {
                 min_percent: 50 as Coord,
                 max_percent: 50 as Coord,
                 max: Coord::MAX,
                 ..Default::default()
             },
-            ..Default::default()
         }];
-        let cells_v = [FlexboxLayoutItemInfo {
+        let cells_v = [LayoutItemInfo {
             constraint: LayoutInfo {
                 preferred: 30 as Coord,
                 max: Coord::MAX,
                 ..Default::default()
             },
-            ..Default::default()
         }];
+        let flex_props = [FlexItemProps::default()];
         let pad = Padding::default();
         let mut builder =
             flexbox_taffy::FlexboxTaffyBuilder::new(flexbox_taffy::FlexboxLayoutParams {
                 cells_h: &Slice::from_slice(&cells_h),
                 cells_v: &Slice::from_slice(&cells_v),
+                flex_props: &Slice::from_slice(&flex_props),
                 spacing_h: 0 as Coord,
                 spacing_v: 0 as Coord,
                 padding_h: &pad,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -240,11 +240,13 @@ impl RepeatedItemTree for ErasedItemTreeBox {
 
         i_slint_core::layout::FlexboxLayoutItemInfo {
             constraint: self.layout_item_info(o, child_index).constraint,
-            flex_grow,
-            flex_shrink,
-            flex_basis,
-            flex_align_self,
-            flex_order,
+            props: i_slint_core::layout::FlexItemProps {
+                flex_grow,
+                flex_shrink,
+                flex_basis,
+                flex_align_self,
+                flex_order,
+            },
         }
     }
 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -283,7 +283,7 @@ pub(crate) fn solve_flexbox_layout(
         _ => None,
     };
 
-    let (cells_h, cells_v, repeated_indices) = flexbox_layout_data(
+    let (cells_h, cells_v, flex_props, repeated_indices) = flexbox_layout_data(
         flexbox_layout,
         component,
         &expr_eval,
@@ -337,6 +337,7 @@ pub(crate) fn solve_flexbox_layout(
         flex_wrap,
         cells_h: Slice::from(cells_h.as_slice()),
         cells_v: Slice::from(cells_v.as_slice()),
+        flex_props: Slice::from(flex_props.as_slice()),
     };
     let ri = Slice::from(repeated_indices.as_slice());
 
@@ -583,7 +584,7 @@ pub(crate) fn compute_flexbox_layout_info(
             padding_and_spacing(&flexbox_layout.geometry, Orientation::Vertical, &expr_eval);
         h - pad_v.begin - pad_v.end
     });
-    let (cells_h, cells_v, _repeated_indices) = flexbox_layout_data(
+    let (cells_h, cells_v, flex_props, _repeated_indices) = flexbox_layout_data(
         flexbox_layout,
         component,
         &expr_eval,
@@ -624,6 +625,7 @@ pub(crate) fn compute_flexbox_layout_info(
         };
         core_layout::flexbox_layout_info_main_axis(
             Slice::from(cells.as_slice()),
+            Slice::from(flex_props.as_slice()),
             spacing,
             padding,
             flex_wrap,
@@ -646,6 +648,7 @@ pub(crate) fn compute_flexbox_layout_info(
         core_layout::flexbox_layout_info_cross_axis(
             Slice::from(cells_h.as_slice()),
             Slice::from(cells_v.as_slice()),
+            Slice::from(flex_props.as_slice()),
             spacing_h,
             spacing_v,
             &padding_h,
@@ -665,22 +668,19 @@ fn flexbox_layout_data(
     _local_context: &mut EvalLocalContext,
     width_override: Option<f32>,
     height_override: Option<f32>,
-) -> (Vec<core_layout::FlexboxLayoutItemInfo>, Vec<core_layout::FlexboxLayoutItemInfo>, Vec<u32>) {
+) -> (
+    Vec<core_layout::LayoutItemInfo>,
+    Vec<core_layout::LayoutItemInfo>,
+    Vec<core_layout::FlexItemProps>,
+    Vec<u32>,
+) {
     let window_adapter = component.window_adapter();
     let mut cells_h = Vec::with_capacity(flexbox_layout.elems.len());
     let mut cells_v = Vec::with_capacity(flexbox_layout.elems.len());
     let mut repeated_indices = Vec::new();
 
     // First pass: collect horizontal layout_info for all children (no cycle risk)
-    // and flex properties. Store element refs for the second pass.
-    struct ChildInfo {
-        flex_grow: f32,
-        flex_shrink: f32,
-        flex_basis: f32,
-        flex_align_self: i_slint_core::items::FlexboxLayoutAlignSelf,
-        flex_order: i32,
-    }
-    let mut static_children: Vec<Option<ChildInfo>> = Vec::new(); // None = repeater
+    // and flex properties.
     // Instances of each repeater, in `elems` order, so the second pass doesn't walk them again.
     let mut repeater_instance_vecs: Vec<Vec<crate::dynamic_item_tree::DynamicComponentVRc>> =
         Vec::new();
@@ -705,10 +705,12 @@ fn flexbox_layout_data(
                 cells_v.resize_with(cells_v.len() + component_vec.len(), Default::default);
             } else {
                 cells_v.extend(component_vec.iter().map(|x| {
-                    x.as_pin_ref().flexbox_layout_item_info(to_runtime(Orientation::Vertical), None)
+                    let info = x
+                        .as_pin_ref()
+                        .flexbox_layout_item_info(to_runtime(Orientation::Vertical), None);
+                    core_layout::LayoutItemInfo { constraint: info.constraint }
                 }));
             }
-            static_children.resize_with(static_children.len() + component_vec.len(), || None);
             repeater_instance_vecs.push(component_vec);
         } else {
             // Dispatch via `layoutinfo-h-with-constraint` for cells that
@@ -755,21 +757,16 @@ fn flexbox_layout_data(
             let order = layout_elem.order.as_ref().map(expr_eval).unwrap_or(0.0) as i32;
             cells_h.push(core_layout::FlexboxLayoutItemInfo {
                 constraint: layout_info_h,
-                flex_grow,
-                flex_shrink,
-                flex_basis,
-                flex_align_self: align_self,
-                flex_order: order,
+                props: core_layout::FlexItemProps {
+                    flex_grow,
+                    flex_shrink,
+                    flex_basis,
+                    flex_align_self: align_self,
+                    flex_order: order,
+                },
             });
             // Placeholder for cells_v — filled in second pass
-            cells_v.push(core_layout::FlexboxLayoutItemInfo::default());
-            static_children.push(Some(ChildInfo {
-                flex_grow,
-                flex_shrink,
-                flex_basis,
-                flex_align_self: align_self,
-                flex_order: order,
-            }));
+            cells_v.push(core_layout::LayoutItemInfo::default());
         }
     }
 
@@ -829,16 +826,9 @@ fn flexbox_layout_data(
                         Orientation::Vertical,
                         &instance_expr_eval,
                     );
-                    // cells_v was deferred in the first pass; take the flex props
-                    // from cells_h (they are orientation-independent).
-                    cells_v[cell_idx] = core_layout::FlexboxLayoutItemInfo {
-                        constraint: layout_info_v,
-                        flex_grow: cells_h[cell_idx].flex_grow,
-                        flex_shrink: cells_h[cell_idx].flex_shrink,
-                        flex_basis: cells_h[cell_idx].flex_basis,
-                        flex_align_self: cells_h[cell_idx].flex_align_self,
-                        flex_order: cells_h[cell_idx].flex_order,
-                    };
+                    // cells_v was deferred in the first pass; fill in its constraint.
+                    // The flex props live in their own array, split from cells_h.
+                    cells_v[cell_idx] = core_layout::LayoutItemInfo { constraint: layout_info_v };
                 }
                 cell_idx += 1;
             }
@@ -867,21 +857,19 @@ fn flexbox_layout_data(
                 Orientation::Vertical,
                 expr_eval,
             );
-            if let Some(info) = &static_children[cell_idx] {
-                cells_v[cell_idx] = core_layout::FlexboxLayoutItemInfo {
-                    constraint: layout_info_v,
-                    flex_grow: info.flex_grow,
-                    flex_shrink: info.flex_shrink,
-                    flex_basis: info.flex_basis,
-                    flex_align_self: info.flex_align_self,
-                    flex_order: info.flex_order,
-                };
-            }
+            cells_v[cell_idx] = core_layout::LayoutItemInfo { constraint: layout_info_v };
             cell_idx += 1;
         }
     }
 
-    (cells_h, cells_v, repeated_indices)
+    // cells_h still bundles constraint + flex props; split it into the parallel
+    // arrays the runtime takes. cells_v already holds constraint-only cells.
+    let flex_props = cells_h.iter().map(|c| c.props).collect();
+    let cells_h = cells_h
+        .into_iter()
+        .map(|c| core_layout::LayoutItemInfo { constraint: c.constraint })
+        .collect();
+    (cells_h, cells_v, flex_props, repeated_indices)
 }
 
 /// Determine the evaluated padding and spacing values from the layout geometry
@@ -1382,7 +1370,7 @@ fn clamp_wrapping_flex_cross_preferred(
         return;
     }
 
-    let (cells_h, cells_v, _ri) =
+    let (cells_h, cells_v, flex_props, _ri) =
         flexbox_layout_data(&fl, component, expr_eval, local_context, None, None);
     let (cells, padding, spacing) = match orientation {
         Orientation::Horizontal => {
@@ -1398,6 +1386,7 @@ fn clamp_wrapping_flex_cross_preferred(
     };
     let unwrapped = core_layout::flexbox_layout_unwrapped_main(
         Slice::from(cells.as_slice()),
+        Slice::from(flex_props.as_slice()),
         spacing,
         &padding,
     );


### PR DESCRIPTION
The flex properties (grow/shrink/basis/align-self/order) apply to an item as a
whole, but FlexboxLayoutData carried them inside FlexboxLayoutItemInfo and built
one such struct per axis, so every cell's flex props were duplicated into both
cells_h and cells_v. Which copy was authoritative rested on an unenforced
convention (the taffy builder read cells_h, the main-axis info function read
whichever axis it was handed).

Split the bulk cell data into constraint-only LayoutItemInfo arrays plus a
single parallel FlexItemProps array. The types now make the axis question
un-askable, and the generated code emits each cell's flex props once instead of
twice (smaller output, relevant on MCU). FlexboxLayoutItemInfo stays only as the
bundled return of the item vtable's flexbox_layout_item_info* methods, where a
single-instance query is convenient; the build sites split it into the two
arrays. No behavior change.

Touches the runtime, the FFI (cbindgen now emits FlexItemProps and the C++
wrappers forward it), both code generators and the interpreter.