### PR TITLE
Make the clippy CI script fail on errors, and fix the clippy errors 

### DIFF
--- a/api/slint-sc/private_unstable_api/renderer.rs
+++ b/api/slint-sc/private_unstable_api/renderer.rs
@@ -22,8 +22,8 @@ pub fn fill_rect(
     let rgb = [color.red(), color.green(), color.blue()];
     for row in y0..y1 {
         let row_range = row * stride + x0 * 3..row * stride + x1 * 3;
-        for pixel in frame_buffer[row_range].chunks_exact_mut(3) {
-            pixel.copy_from_slice(&rgb);
+        for pixel in frame_buffer[row_range].as_chunks_mut::<3>().0 {
+            *pixel = rgb;
         }
     }
 }

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -331,7 +331,7 @@ fn scan_spec_pages(dir: &Path) -> Result<Vec<SpecPage>, Box<dyn std::error::Erro
         // The index page is served at the root of the specification.
         page.top_level = stem == "index";
         page.base =
-            if page.top_level { format!("/language/") } else { format!("/language/{stem}/") };
+            if page.top_level { "/language/".to_string() } else { format!("/language/{stem}/") };
         if !page.draft {
             pages.push(page);
         }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -499,10 +499,11 @@ impl WinitWindowAdapter {
         // Create the window at its preferred size: the renderer's surface is created together
         // with the window, and on Wayland resizing it afterwards only takes effect after the
         // next present, so the first frame would be rendered at the pre-show size.
-        if !self.has_explicit_size.get() && window_attributes.fullscreen.is_none() {
-            if let Some(preferred_size) = self.preferred_size() {
-                window_attributes.inner_size = Some(preferred_size.into());
-            }
+        if !self.has_explicit_size.get()
+            && window_attributes.fullscreen.is_none()
+            && let Some(preferred_size) = self.preferred_size()
+        {
+            window_attributes.inner_size = Some(preferred_size.into());
         }
 
         let winit_window =

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -70,8 +70,7 @@ fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> String 
     let llr::MemberReference::Relative { parent_level, local_reference } = pr else {
         unreachable!()
     };
-    let llr::LocalMemberIndex::Native { item_index, prop_name: _, .. } = &local_reference.reference
-    else {
+    let llr::LocalMemberIndex::Native { item_index, .. } = &local_reference.reference else {
         unreachable!()
     };
 
@@ -95,7 +94,7 @@ fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> String 
         format!("{component_access}tree_index_of_first_child + {item_index_in_tree} - 1")
     };
 
-    format!("{}, {}", &component_rc, item_index)
+    format!("{component_rc}, {item_index}")
 }
 
 /// This module contains some data structure that helps represent a C++ code.
@@ -1693,7 +1692,7 @@ fn generate_item_tree(
                     "{{ {}, {} offsetof({}, {}) }}",
                     item.ty.cpp_vtable_getter,
                     compo_offset,
-                    &ident(&sub_component.name),
+                    ident(&sub_component.name),
                     field_name(&item.name),
                 ));
             }
@@ -3362,7 +3361,7 @@ fn generate_global(
         )
     }
 
-    for (i, _) in global.change_callbacks.iter() {
+    for i in global.change_callbacks.keys() {
         global_struct.members.push((
             Access::Private,
             Declaration::Var(Var {
@@ -3607,7 +3606,7 @@ fn generate_public_api_for_properties(
                 Access::Public,
                 Declaration::Function(Function {
                     name: accessor_names::cpp_accessor_name(name, AccessorKind::Getter),
-                    signature: format!("() const -> {}", &cpp_property_type),
+                    signature: format!("() const -> {cpp_property_type}"),
                     statements: Some(prop_getter),
                     ..Default::default()
                 }),
@@ -3623,7 +3622,7 @@ fn generate_public_api_for_properties(
                     Access::Public,
                     Declaration::Function(Function {
                         name: accessor_names::cpp_accessor_name(name, AccessorKind::Setter),
-                        signature: format!("(const {} &value) const -> void", &cpp_property_type),
+                        signature: format!("(const {cpp_property_type} &value) const -> void"),
                         statements: Some(prop_setter),
                         ..Default::default()
                     }),
@@ -3789,7 +3788,7 @@ fn access_member(reference: &llr::MemberReference, ctx: &EvaluationContext) -> M
                     field(&global.callbacks[*callback_index].name)
                 }
                 llr::LocalMemberIndex::Function(function_index) => {
-                    ident(&format!("fn_{}", &global.functions[*function_index].name))
+                    ident(&format!("fn_{}", global.functions[*function_index].name))
                 }
                 _ => unreachable!(),
             };

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1796,19 +1796,19 @@ fn generate_item_tree(
                 // weak (matches the Rust backend).
                 vec![
                     format!("auto self = reinterpret_cast<const {item_tree_class_name}*>(component.instance);"),
-                    format!("if (auto parent = self->parent.lock()) {{"),
+                    "if (auto parent = self->parent.lock()) {".to_string(),
                     // TODO: store popup index in ctx and set it here instead of 0?
-                    format!("    *result = {{ (*parent)->self_weak, 0 }};"),
-                    format!("}}"),
+                    "    *result = { (*parent)->self_weak, 0 };".to_string(),
+                    "}".to_string(),
                     ]
                 }, |idx| {
                 let current_sub_component = &root.sub_components[parent.sub_component];
                 let parent_index = current_sub_component.repeated[idx].index_in_tree;
                 vec![
                     format!("auto self = reinterpret_cast<const {item_tree_class_name}*>(component.instance);"),
-                    format!("if (auto parent = self->parent.lock()) {{"),
+                    "if (auto parent = self->parent.lock()) {".to_string(),
                     format!("    *result = {{ (*parent)->self_weak, (*parent)->tree_index_of_first_child + {} }};", parent_index - 1),
-                    format!("}}"),
+                    "}".to_string(),
                 ]
             })
         })
@@ -2154,8 +2154,8 @@ fn generate_item_tree(
         }),
     ));
 
-    let destructor = vec![format!(
-        "if (auto &window = globals->m_window) window->window_handle().unregister_item_tree(this, item_array());"
+    let destructor = vec![String::from(
+        "if (auto &window = globals->m_window) window->window_handle().unregister_item_tree(this, item_array());",
     )];
 
     target_struct.members.push((

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3276,8 +3276,7 @@ fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> TokenSt
     let llr::MemberReference::Relative { parent_level, local_reference } = pr else {
         unreachable!()
     };
-    let llr::LocalMemberIndex::Native { item_index, prop_name: _, .. } = &local_reference.reference
-    else {
+    let llr::LocalMemberIndex::Native { item_index, .. } = &local_reference.reference else {
         unreachable!()
     };
 

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -2021,9 +2021,7 @@ pub fn get_layout_info_h_constrained_for_repeated(
     element: &ElementRc,
     constraints: &crate::layout::LayoutConstraints,
 ) -> Option<llr_Expression> {
-    if element.borrow().inherited_layout_info_h_with_constraint().is_none() {
-        return None;
-    }
+    element.borrow().inherited_layout_info_h_with_constraint()?;
     // Unbounded, the same default static width-for-height cells use: the
     // natural, unwrapped width. A flex re-measures at the height it really
     // assigns via `get_layout_info_h_at_cross_height_for_repeated`.
@@ -2055,9 +2053,7 @@ pub fn get_layout_info_h_at_cross_height_for_repeated(
     element: &ElementRc,
     constraints: &crate::layout::LayoutConstraints,
 ) -> Option<llr_Expression> {
-    if element.borrow().inherited_layout_info_h_with_constraint().is_none() {
-        return None;
-    }
+    element.borrow().inherited_layout_info_h_with_constraint()?;
     let height_constraint = crate::expression_tree::Expression::ReadLocalVariable {
         name: FLEX_CROSS_HEIGHT_LOCAL.into(),
         ty: Type::LogicalLength,

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -155,7 +155,7 @@ fn filter_conflicting_implement_statements(
             seen_interfaces.push(stmt.interface.clone());
 
             let mut valid = true;
-            for (prop_name, _) in stmt.interface.borrow().property_declarations.iter() {
+            for prop_name in stmt.interface.borrow().property_declarations.keys() {
                 if let Some(existing_interface) = seen_interface_api.get(prop_name) {
                     diagnostics.push_error(
                         format!(

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -470,9 +470,8 @@ fn missing_type_description(interface_declaration: &PropertyDeclaration) -> Stri
 }
 
 fn syntax_for(interface_declaration: &PropertyDeclaration, name: &SmolStr) -> String {
-    let display_args = |arguments: &Vec<Type>| -> String {
-        arguments.iter().map(|t| t.to_string()).join(", ")
-    };
+    let display_args =
+        |arguments: &Vec<Type>| -> String { arguments.iter().map(|t| t.to_string()).join(", ") };
     let return_type = |return_type: &Type| -> String {
         if *return_type == Type::Void { String::new() } else { format!(" -> {return_type}") }
     };

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -309,7 +309,7 @@ fn validate_interface_member_implementation(
             source,
         });
     }
-    return Some(conflicts);
+    Some(conflicts)
 }
 
 pub(super) fn apply_child_implement_statements(
@@ -471,7 +471,7 @@ fn missing_type_description(interface_declaration: &PropertyDeclaration) -> Stri
 
 fn syntax_for(interface_declaration: &PropertyDeclaration, name: &SmolStr) -> String {
     let display_args = |arguments: &Vec<Type>| -> String {
-        arguments.iter().map(|t| t.to_string()).join(", ").into()
+        arguments.iter().map(|t| t.to_string()).join(", ")
     };
     let return_type = |return_type: &Type| -> String {
         if *return_type == Type::Void { String::new() } else { format!(" -> {return_type}") }

--- a/internal/compiler/passes/remove_return.rs
+++ b/internal/compiler/passes/remove_return.rs
@@ -49,7 +49,7 @@ fn process_expression(
             process_codeblock(expr.into_iter().peekable(), toplevel, ty, ctx, symbol_counters)
         }
         Expression::Condition { condition, true_expr, false_expr } => {
-            process_condition(condition, true_expr, false_expr, ctx, ty, symbol_counters)
+            process_condition(condition, *true_expr, *false_expr, ctx, ty, symbol_counters)
         }
         Expression::Cast { from, to } => {
             let ty = if !has_value(ty) { ty.clone() } else { from.ty() };
@@ -57,7 +57,7 @@ fn process_expression(
                 .map_value(symbol_counters, |e| Expression::Cast { from: e.into(), to })
         }
         Expression::StoreLocalVariable { name, value } => {
-            process_store_local_variable(name, value, ctx, symbol_counters)
+            process_store_local_variable(name, *value, ctx, symbol_counters)
         }
         e => {
             // Normally there shouldn't be any 'return' statements in there since return are not allowed in arbitrary expressions
@@ -72,14 +72,14 @@ fn process_expression(
 
 fn process_condition(
     condition: Box<Expression>,
-    true_expr: Box<Expression>,
-    false_expr: Box<Expression>,
+    true_expr: Expression,
+    false_expr: Expression,
     ctx: &RemoveReturnContext,
     ty: &Type,
     symbol_counters: &SymbolCounters,
 ) -> ExpressionResult {
-    let te = process_expression(*true_expr, false, ctx, ty, symbol_counters);
-    let fe = process_expression(*false_expr, false, ctx, ty, symbol_counters);
+    let te = process_expression(true_expr, false, ctx, ty, symbol_counters);
+    let fe = process_expression(false_expr, false, ctx, ty, symbol_counters);
     merge_condition_branches(condition, te, fe, ctx, ty, symbol_counters)
 }
 
@@ -138,12 +138,12 @@ fn merge_condition_branches(
 
 fn process_store_local_variable(
     name: SmolStr,
-    value: Box<Expression>,
+    value: Expression,
     ctx: &RemoveReturnContext,
     symbol_counters: &SymbolCounters,
 ) -> ExpressionResult {
     let inner_ty = value.ty();
-    match process_expression(*value, false, ctx, &inner_ty, symbol_counters) {
+    match process_expression(value, false, ctx, &inner_ty, symbol_counters) {
         ExpressionResult::Just(e) => {
             ExpressionResult::Just(Expression::StoreLocalVariable { name, value: Box::new(e) })
         }

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -473,25 +473,23 @@ impl ImageInner {
                         let source = &ts.data[t.index + y * rect.width() * t.format.bpp()..];
                         match t.format {
                             TexturePixelFormat::Rgb => {
-                                let mut iter = source.chunks_exact(3).map(|p| Rgba8Pixel {
-                                    r: p[0],
-                                    g: p[1],
-                                    b: p[2],
-                                    a: 255,
-                                });
+                                let mut iter = source
+                                    .as_chunks::<3>()
+                                    .0
+                                    .iter()
+                                    .map(|p| Rgba8Pixel { r: p[0], g: p[1], b: p[2], a: 255 });
                                 slice.fill_with(|| iter.next().unwrap());
                             }
                             TexturePixelFormat::RgbaPremultiplied => {
-                                let mut iter = source.chunks_exact(4).map(|p| Rgba8Pixel {
-                                    r: p[0],
-                                    g: p[1],
-                                    b: p[2],
-                                    a: p[3],
-                                });
+                                let mut iter = source
+                                    .as_chunks::<4>()
+                                    .0
+                                    .iter()
+                                    .map(|p| Rgba8Pixel { r: p[0], g: p[1], b: p[2], a: p[3] });
                                 slice.fill_with(|| iter.next().unwrap());
                             }
                             TexturePixelFormat::Rgba => {
-                                let mut iter = source.chunks_exact(4).map(|p| {
+                                let mut iter = source.as_chunks::<4>().0.iter().map(|p| {
                                     let a = p[3];
                                     Rgba8Pixel {
                                         r: (p[0] as u16 * a as u16 / 255) as u8,

--- a/internal/core/item_focus.rs
+++ b/internal/core/item_focus.rs
@@ -18,11 +18,7 @@ pub fn step_out_of_node(
         if let Some(sibling) = item_tree.next_sibling(self_or_ancestor) {
             return Some(sibling);
         }
-        if let Some(ancestor) = item_tree.parent(self_or_ancestor) {
-            self_or_ancestor = ancestor;
-        } else {
-            return None;
-        }
+        self_or_ancestor = item_tree.parent(self_or_ancestor)?;
     }
 }
 

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -422,10 +422,10 @@ impl ItemRc {
         let mut visibility_clips = Vec::new();
         let mut current = Some(self.clone());
         while let Some(item) = current {
-            if let Some(clip) = item.downcast::<crate::items::Clip>() {
-                if clip.as_pin_ref().is_visibility_clip() {
-                    visibility_clips.push(VRcMapped::downgrade(&clip));
-                }
+            if let Some(clip) = item.downcast::<crate::items::Clip>()
+                && clip.as_pin_ref().is_visibility_clip()
+            {
+                visibility_clips.push(VRcMapped::downgrade(&clip));
             }
             current = item.parent_item(ParentItemTraversalMode::StopAtPopups);
         }

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1435,13 +1435,9 @@ impl WindowItem {
                 return Some(result);
             }
 
-            match window_item_rc
+            window_item_rc = window_item_rc
                 .parent_item(crate::item_tree::ParentItemTraversalMode::FindAllParents)
-                .and_then(|p| next_window_item(&p))
-            {
-                Some(item) => window_item_rc = item,
-                None => return None,
-            }
+                .and_then(|p| next_window_item(&p))?;
         }
     }
 

--- a/internal/core/items/system_tray/ksni.rs
+++ b/internal/core/items/system_tray/ksni.rs
@@ -242,7 +242,7 @@ fn image_to_argb_icon(image: &Image) -> Result<::ksni::Icon, Error> {
     let mut data = pixel_buffer.as_bytes().to_vec();
     let width = pixel_buffer.width() as i32;
     let height = pixel_buffer.height() as i32;
-    for pixel in data.chunks_exact_mut(4) {
+    for pixel in data.as_chunks_mut::<4>().0 {
         pixel.rotate_right(1) // rgba to argb
     }
     Ok(::ksni::Icon { width, height, data })

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -117,7 +117,7 @@ fn image_buffer_to_skia_image(buffer: &SharedImageBuffer) -> Option<skia_safe::I
     // order of magnitude slower than writes. The scan happens once per image;
     // the resulting skia_safe::Image is cached.
     fn opaque_or(rgba_bytes: &[u8], alpha_type: skia_safe::AlphaType) -> skia_safe::AlphaType {
-        if rgba_bytes.chunks_exact(4).all(|px| px[3] == 255) {
+        if rgba_bytes.as_chunks::<4>().0.iter().all(|px| px[3] == 255) {
             skia_safe::AlphaType::Opaque
         } else {
             alpha_type

--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -4,6 +4,8 @@
 #
 # Run cargo clippy (this script is used by CI)
 
+set -e
+
 export RUSTFLAGS="-D warnings"
 export CARGO_INCREMENTAL=false
 export CARGO_PROFILE_DEV_DEBUG=0

--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -13,6 +13,9 @@ export CARGO_PROFILE_DEV_DEBUG=0
 # The repository is split into several workspaces (root libraries/tools,
 # examples, demos and tests) that all share the same target directory, so the
 # common library crates are only built once across these clippy runs.
+# Run every workspace even when an earlier one fails, so a single CI run
+# reports the errors of all of them.
+status=0
 
 # Root workspace: libraries and tools.
 # slint-node/slint-cpp/slint-python need their language bindings toolchains.
@@ -20,7 +23,7 @@ cargo clippy --locked --all-features --workspace \
     --exclude slint-node \
     --exclude slint-cpp \
     --exclude slint-python \
-    -- -D warnings
+    -- -D warnings || status=1
 
 # Examples workspace. The mcu/uefi members need dedicated targets, and
 # bevy/servo have heavy dependencies and dedicated CI workflows.
@@ -34,12 +37,12 @@ cargo clippy --locked --all-features --workspace --manifest-path examples/Cargo.
     --exclude bevy-hosts-slint \
     --exclude bevy-hosts-slint-gpu \
     --exclude servo-example \
-    -- -D warnings
+    -- -D warnings || status=1
 
 # Demos workspace.
 cargo clippy --locked --all-features --workspace --manifest-path demos/Cargo.toml \
     --exclude printerdemo_mcu \
-    -- -D warnings
+    -- -D warnings || status=1
 
 # Tests workspace. The C++/Node/Python drivers need their language toolchains.
 cargo clippy --locked --all-features --workspace --manifest-path tests/Cargo.toml \
@@ -47,4 +50,6 @@ cargo clippy --locked --all-features --workspace --manifest-path tests/Cargo.tom
     --exclude test-driver-cpp \
     --exclude test-driver-python \
     --exclude bapp \
-    -- -D warnings
+    -- -D warnings || status=1
+
+exit $status

--- a/tools/lsp/common/document_cache.rs
+++ b/tools/lsp/common/document_cache.rs
@@ -502,7 +502,7 @@ mod tests {
     ) -> Option<String> {
         let result = dc.element_at_position(url, &lsp_types::Position { line, character })?;
         let element = result.element.borrow();
-        Some(format!("{}", &element.base_type))
+        Some(element.base_type.to_string())
     }
 
     #[test]

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -1535,11 +1535,8 @@ mod tests {
 
     fn assert_completion_found(expected: &CompletionItem, results: &[CompletionItem]) {
         let Some(found) = results.iter().find(|actual| actual.label == expected.label) else {
-            let labels = results
-                .iter()
-                .map(|ci| format!("\t'{}'", &ci.label))
-                .collect::<Vec<_>>()
-                .join("\n");
+            let labels =
+                results.iter().map(|ci| format!("\t'{}'", ci.label)).collect::<Vec<_>>().join("\n");
             panic!("missing completion for {}\nLabels:\n{labels}", expected.label,);
         };
 

--- a/tools/lsp/preview/preview_data.rs
+++ b/tools/lsp/preview/preview_data.rs
@@ -287,7 +287,7 @@ pub fn set_json_preview_data(
         return Err(failed_properties);
     }
 
-    if result.is_empty() { Err(vec![format!("No property set")]) } else { Ok(result) }
+    if result.is_empty() { Err(vec!["No property set".to_string()]) } else { Ok(result) }
 }
 
 #[cfg(test)]

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -826,7 +826,7 @@ fn element_at_source_code_position(
         util::text_size_to_lsp_position(&source_file, position.offset(), document_cache.format);
 
     Ok(document_cache.element_at_position(position.url(), &element_position).ok_or_else(|| {
-        format!("No element found at the given start position {:?}", &element_position)
+        format!("No element found at the given start position {element_position:?}")
     })?)
 }
 

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -144,11 +144,7 @@ pub fn find_element_indent(element: &common::ElementRcNode) -> Option<String> {
 /// ```
 pub fn lookup_current_element_type(mut node: SyntaxNode, tr: &TypeRegister) -> Option<ElementType> {
     while node.kind() != SyntaxKind::Element {
-        if let Some(parent) = node.parent() {
-            node = parent
-        } else {
-            return None;
-        }
+        node = node.parent()?;
     }
 
     let parent = node.parent()?;

--- a/tools/viewer/screenshot.rs
+++ b/tools/viewer/screenshot.rs
@@ -79,7 +79,8 @@ pub fn take_screenshot(args: &Cli) -> Result<()> {
     let (pixels, color) = if format.writing_enabled() && format != image::ImageFormat::Jpeg {
         (buffer.as_bytes().to_vec(), image::ExtendedColorType::Rgba8)
     } else {
-        let rgb = buffer.as_bytes().chunks_exact(4).flat_map(|p| [p[0], p[1], p[2]]).collect();
+        let rgb =
+            buffer.as_bytes().as_chunks::<4>().0.iter().flat_map(|p| [p[0], p[1], p[2]]).collect();
         (rgb, image::ExtendedColorType::Rgb8)
     };
 

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -944,7 +944,7 @@ impl LicenseHeaderCheck {
         for path in &collect_files()? {
             let result = self
                 .check_file(path.as_path())
-                .with_context(|| format!("checking {}", &path.to_string_lossy()));
+                .with_context(|| format!("checking {}", path.to_string_lossy()));
 
             if result.is_err() {
                 seen_errors = true;

--- a/xtask/src/reuse_compliance_check.rs
+++ b/xtask/src/reuse_compliance_check.rs
@@ -30,7 +30,7 @@ pub fn reuse_lint(sh: &Shell, reuse: &Path) -> Result<()> {
 
     if !output.status.success() {
         let stdout = String::from_utf8(output.stdout)?;
-        println!("{}", &stdout);
+        println!("{stdout}");
         anyhow::bail!("Project is not reuse compliant!");
     }
     Ok(())
@@ -301,8 +301,8 @@ fn validate_license_directory(dir: &Path, licenses: &[String], fix_it: bool) -> 
 
         println!(
             "Creating LICENSE symlink {} -> {}",
-            &source_path.to_string_lossy(),
-            &target_link_path.to_string_lossy()
+            source_path.to_string_lossy(),
+            target_link_path.to_string_lossy()
         );
 
         #[cfg(unix)]
@@ -372,7 +372,7 @@ impl ReuseComplianceCheck {
 
         if self.download_missing_licenses {
             let output = reuse_download(&sh, &reuse)?;
-            println!("{}", &output);
+            println!("{output}");
         }
 
         reuse_lint(&sh, &reuse)?;


### PR DESCRIPTION
Since the workspace split, scripts/run_clippy.sh runs one cargo clippy
invocation per workspace, but without `set -e` only the exit status of
the last invocation reached CI. 

Fix that and all the clippy error that were introduced in between.