### PR TITLE
ci: run the redundant test drivers on one platform only

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -111,6 +111,7 @@ material_components:
  - *ci_config
 
 api_cpp:
+ - *compiler
  - 'api/cpp/**'
  - 'cmake/**'
  - 'tools/compiler/**'
@@ -132,9 +133,11 @@ api_node:
  - '.github/workflows/node_test_reusable.yaml'
 
 api_rs:
+ - *compiler
  - 'api/rs/**'
- - 'Cargo.toml'
  - 'internal/compiler/generator/rust*{,/**}'
+ # The slint crate re-exports i-slint-core as its api
+ - 'internal/core{,-macros}/**'
 
 # The test drivers (doctests are run by the docs build) and the testing
 # backend they use.
@@ -162,6 +165,9 @@ vsce:
 
 slintpad:
  - *internal
+ # The wasm build compiles the winit backend and the femtovg renderer
+ - 'internal/backends/winit/**'
+ - 'internal/renderers/femtovg/**'
  - '.github/workflows/wasm_editor_and_interpreter.yaml'
  - 'tools/slintpad/**'
  - 'api/wasm-interpreter/**'

--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -25,19 +25,24 @@ js_config: &js_config
  - '.npmrc'
  - 'pnpm-lock.yaml'
 
-# Compiler and runtime shared by all language APIs; they need the Qt widgets
-# and the testing backend, but no renderer. Language-specific generators and
-# the compiler's own test data are left to the api_* and `slint` groups.
-internal: &internal
- - 'internal/!({compiler,renderers,backends}/**)'
+# The compiler library and i-slint-common, without the language-specific
+# generator backends and the compiler's own test data.
+compiler: &compiler
+ - 'internal/common/**'
  - 'internal/compiler/!({tests,generator}/**)'
  - 'internal/compiler/generator/!(cpp*|python*|rust*|slint_sc*){,/**}'
- - 'internal/backends/qt/**'
- - 'internal/backends/testing/**'
- - 'helper_crates/**'
  - 'Cargo.toml' # the root Cargo.toml
  - '.cargo/**'
  - *ci_config
+
+# Compiler and runtime shared by all language APIs; they need the Qt widgets
+# and the testing backend, but no renderer.
+internal: &internal
+ - *compiler
+ - 'internal/!({compiler,renderers,backends}/**)'
+ - 'internal/backends/qt/**'
+ - 'internal/backends/testing/**'
+ - 'helper_crates/**'
 
 # What the integration tests in the tests/ workspace build against.
 integration: &integration
@@ -131,9 +136,11 @@ api_rs:
  - 'Cargo.toml'
  - 'internal/compiler/generator/rust*{,/**}'
 
-# All the test drivers except doctests, which only the docs build runs.
+# The test drivers (doctests are run by the docs build) and the testing
+# backend they use.
 tests:
  - 'tests/!(doctests/**)'
+ - 'internal/backends/testing/**'
 
 examples:
  # Some examples are tested separately and can be excluded from here
@@ -171,9 +178,12 @@ bevy_examples:
  - 'examples/bevy/**'
  - '.github/workflows/bevy_examples.yaml'
 
+# internal/compiler/tests because the job runs the compiler's own tests.
 slint_sc:
  - 'internal/common/**'
- - 'internal/compiler/**'
+ - *compiler
+ - 'internal/compiler/generator/slint_sc*{,/**}'
+ - 'internal/compiler/tests/**'
  - 'api/slint-sc/**'
  - 'tools/compiler/**'
  - *ci_config
@@ -183,7 +193,6 @@ safety_docs:
  - 'docs/safety/**'
  - 'docs/slint-doc-generator/**'
  - '.github/workflows/build_docs.yaml'
- - *ci_config
 
 rust_files:
  - '**/*.rs'

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -53,6 +53,11 @@ on:
                 required: false
                 type: boolean
                 default: true
+            test_rust_driver:
+                description: 'Run the rust test driver in the integration tests'
+                required: false
+                type: boolean
+                default: true
             build_examples:
                 description: 'Build the examples and demos workspaces'
                 required: false
@@ -143,7 +148,7 @@ jobs:
             # The C++/Node/Python drivers and doctests are run by dedicated jobs in ci.yaml.
             - name: Run integration tests
               if: inputs.test_integration
-              run: "cargo test --locked --verbose --all-features --workspace --timings --manifest-path tests/Cargo.toml ${{ inputs.extra_args }} --exclude doctests --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python -- --skip=qt::"
+              run: "cargo test --locked --verbose --all-features --workspace --timings --manifest-path tests/Cargo.toml ${{ inputs.extra_args }} ${{ !inputs.test_rust_driver && '--exclude test-driver-rust' || '' }} --exclude doctests --exclude test-driver-nodejs --exclude test-driver-cpp --exclude test-driver-python -- --skip=qt::"
               env:
                   SLINT_CREATE_SCREENSHOTS: 1
               shell: bash
@@ -163,8 +168,10 @@ jobs:
               if: inputs.build_examples
               run: "cargo test --locked --verbose --all-features --workspace --timings --manifest-path demos/Cargo.toml ${{ inputs.extra_args }} --exclude printerdemo_mcu"
               shell: bash
+            # One platform is enough for live-preview; Windows because the
+            # macOS job is the slower of the two.
             - name: live-preview for rust test
-              if: runner.os == 'macOS' && inputs.test_integration
+              if: runner.os == 'Windows' && inputs.test_integration
               env:
                 SLINT_LIVE_PREVIEW: 1
               run: cargo test --locked --verbose --all-features --manifest-path tests/Cargo.toml --features slint/live-preview -p test-driver-rust -- --skip=_qt::t

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,12 +347,12 @@ jobs:
                   buildtargets: esp32
                   ldproxy: false
             - name: Check pico-st7789
-              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') }}
+              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') }}
               env:
                   RUSTFLAGS: --cfg slint_int_coord -D warnings
               run: cargo check --target=thumbv6m-none-eabi --manifest-path demos/Cargo.toml -p printerdemo_mcu --no-default-features --features=mcu-board-support/pico-st7789 --release
             - name: Check mcu-embassy
-              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') }}
+              if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'examples_mcu') || contains(fromJSON(inputs.changes), 'api_rs') }}
               env:
                   RUSTFLAGS: --cfg slint_int_coord -D warnings
               run: cargo check --bin ui_mcu --target=thumbv8m.main-none-eabihf --no-default-features --features="mcu-embassy/mcu" --release
@@ -397,7 +397,7 @@ jobs:
             release: false
 
     wasm_demo:
-        if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'examples') || contains(fromJSON(inputs.changes), 'api_rs') }}
+        if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'examples') || contains(fromJSON(inputs.changes), 'api_rs') }}
         uses: ./.github/workflows/wasm_demos.yaml
         with:
           build_artifacts: false
@@ -505,7 +505,7 @@ jobs:
                   idf.py build
 
     android:
-        if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'internal') || contains(fromJSON(inputs.changes), 'api_rs') || contains(fromJSON(inputs.changes), 'examples') || contains(fromJSON(inputs.changes), 'android_backend') }}
+        if: ${{ inputs.full || contains(fromJSON(inputs.changes), 'api_rs') || contains(fromJSON(inputs.changes), 'examples') || contains(fromJSON(inputs.changes), 'android_backend') }}
         runs-on: ubuntu-latest
         env:
             RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,8 @@ jobs:
                     - os: windows-2022
                       name: "Windows 2022 1.92"
                       rust_version: "1.92"
-                      extra_args: "--exclude ffmpeg --exclude gstreamer-player --exclude material-gallery"
+                      # The platform-independent interpreter test driver only runs on macOS
+                      extra_args: "--exclude ffmpeg --exclude gstreamer-player --exclude material-gallery --exclude test-driver-interpreter"
                     - os: macos-14
                       name: "MacOS 14 beta"
                       rust_version: "beta"
@@ -71,6 +72,9 @@ jobs:
             run_qt: ${{ inputs.full || contains(fromJSON(inputs.changes), 'qt') }}
             test_workspace: ${{ inputs.full || contains(fromJSON(inputs.changes), 'slint') }}
             test_integration: ${{ inputs.full || contains(fromJSON(inputs.changes), 'integration') || contains(fromJSON(inputs.changes), 'tests') }}
+            # macOS only runs the rust driver when its inputs changed;
+            # Windows always does, for the live-preview test.
+            test_rust_driver: ${{ !startsWith(matrix.os, 'macos') || inputs.full || contains(fromJSON(inputs.changes), 'api_rs') || contains(fromJSON(inputs.changes), 'tests') || contains(fromJSON(inputs.changes), 'qt') }}
             build_examples: ${{ inputs.full || contains(fromJSON(inputs.changes), 'integration') || contains(fromJSON(inputs.changes), 'examples') }}
             save_if: ${{ github.ref == 'refs/heads/master' }}
 


### PR DESCRIPTION
The interpreter test driver runs only on the macOS job, the live-preview rust test only on Windows, and macOS skips the rust driver unless the tests, the rust generator/api, or qt changed. This never changes the feature set of a shared dependency, so the rust-cache saved on master still covers the reduced builds.

Also split a compiler-only group out of the internal path filter group and use it for slint_sc, and add the testing backend to the tests group so the cpp driver re-runs when it changes.
