### PR TITLE
text: make per-frame rendering cost proportional to the viewport, not the document

### DIFF
--- a/api/rs/slint/tests/text_layout_cache.rs
+++ b/api/rs/slint/tests/text_layout_cache.rs
@@ -649,3 +649,84 @@ fn ime_composition_is_not_served_a_stale_size() {
         ui.get_preferred()
     );
 }
+
+fn render_and_get_layout_miss_count(renderer: &SoftwareRenderer) -> u64 {
+    renderer.text_layout_cache().reset_layout_miss_count();
+    let mut buf = vec![TestPixel(false); WIDTH * HEIGHT];
+    renderer.render(buf.as_mut_slice(), WIDTH);
+    renderer.text_layout_cache().layout_miss_count()
+}
+
+#[test]
+fn unchanged_layout_inputs_reuse_the_line_breaking() {
+    let window = setup();
+
+    // Line breaking is retained in the cache entry alongside the shaped paragraphs: a draw whose
+    // breaking inputs (width, horizontal alignment, max-lines, overflow) match the retained state
+    // reuses it wholesale. Anything else -- moving the item, vertical alignment -- must not break
+    // lines again.
+    slint::slint! {
+        export component TestComponent inherits Window {
+            in property <length> item-x: 0px;
+            in property <length> w: 180px;
+            in property <bool> align-right: false;
+            in property <bool> align-bottom: false;
+            in property <string> content: "Hello World this text wraps across several lines";
+            TextInput {
+                x: item-x; y: 0; width: w; height: 80px;
+                horizontal-alignment: align-right ? TextHorizontalAlignment.right : TextHorizontalAlignment.left;
+                vertical-alignment: align-bottom ? TextVerticalAlignment.bottom : TextVerticalAlignment.top;
+                text: content;
+                wrap: word-wrap;
+            }
+        }
+    }
+
+    let ui = TestComponent::new().unwrap();
+    ui.show().unwrap();
+
+    let mut count = 0u64;
+    assert!(window.draw_if_needed(|renderer| {
+        count = render_and_get_layout_miss_count(renderer);
+    }));
+
+    // Moving the item redraws it at the same width: the retained breaking must be reused.
+    ui.set_item_x(5.0);
+    window.request_redraw();
+    assert!(window.draw_if_needed(|renderer| {
+        count = render_and_get_layout_miss_count(renderer);
+    }));
+    assert_eq!(count, 0, "moving the item must not break its lines again");
+
+    // The width is a breaking input.
+    ui.set_w(120.0);
+    window.request_redraw();
+    assert!(window.draw_if_needed(|renderer| {
+        count = render_and_get_layout_miss_count(renderer);
+    }));
+    assert!(count > 0, "a width change must break lines again");
+
+    // So is the horizontal alignment (parley bakes it into the line layout).
+    ui.set_align_right(true);
+    window.request_redraw();
+    assert!(window.draw_if_needed(|renderer| {
+        count = render_and_get_layout_miss_count(renderer);
+    }));
+    assert!(count > 0, "an alignment change must break lines again");
+
+    // Vertical alignment only moves the finished block; deliberately not a breaking input.
+    ui.set_align_bottom(true);
+    window.request_redraw();
+    assert!(window.draw_if_needed(|renderer| {
+        count = render_and_get_layout_miss_count(renderer);
+    }));
+    assert_eq!(count, 0, "vertical alignment must not break lines again");
+
+    // A text change reshapes, which discards the retained breaking with the entry.
+    ui.set_content("Different text that also wraps across several lines".into());
+    window.request_redraw();
+    assert!(window.draw_if_needed(|renderer| {
+        count = render_and_get_layout_miss_count(renderer);
+    }));
+    assert!(count > 0, "a text change must break lines again");
+}

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -338,15 +338,6 @@ pub fn draw_text_input(
         LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
         window_adapter.window(),
         |layout| {
-            // When a piece of text is first selected, it gets an empty range like `1..1`. If the
-            // text starts with a multi-byte character then this selection would be within that
-            // character and parley would panic, so empty ranges are filtered out.
-            let selection_spans = if selection_range.is_empty() {
-                SelectionSpans::default()
-            } else {
-                layout.selection_geometry(selection_range)
-            };
-
             item_renderer.save_state();
 
             let render = item_renderer.combine_clip(
@@ -356,6 +347,16 @@ pub fn draw_text_input(
             );
 
             if render {
+                // When a piece of text is first selected, it gets an empty range like `1..1`. If
+                // the text starts with a multi-byte character then this selection would be within
+                // that character and parley would panic, so empty ranges are filtered out. The
+                // spans only feed drawing (the highlight fill and the glyph clip), so only the
+                // lines the clip lets through need any.
+                let selection_spans = if selection_range.is_empty() {
+                    SelectionSpans::default()
+                } else {
+                    layout.selection_geometry(selection_range, &draw::visible_band(item_renderer))
+                };
                 // Inside the clip, like the glyphs it sits under: a line box taller than the item
                 // would otherwise paint the highlight over whatever follows the input.
                 for background in selection_spans.backgrounds() {

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -110,11 +110,21 @@ fn with_text_layout<R>(
             shape_paragraphs(text, item_rc, text_wrap, scale_factor, font_context)
         });
 
-    let layout = layout(layout_builder, &mut font_ctx, guard.take(), scale_factor, options);
+    let line_breaking = guard.take_line_breaking();
+    let layout =
+        layout(layout_builder, &mut font_ctx, guard.take(), scale_factor, options, line_breaking);
     drop(font_ctx);
 
+    if layout.broke_lines {
+        #[cfg(feature = "testing")]
+        if let Some(cache) = cache {
+            cache.count_layout_miss();
+        }
+    }
+
     let result = f(&layout);
-    guard.restore(layout.paragraphs);
+    let (paragraphs, line_breaking) = layout.dismantle();
+    guard.restore(paragraphs, line_breaking);
     Some(result)
 }
 

--- a/internal/core/textlayout/sharedparley/cache.rs
+++ b/internal/core/textlayout/sharedparley/cache.rs
@@ -10,6 +10,7 @@
 //! [`cached_paragraphs`] is only meant to be called through `with_text_layout`, which pairs it
 //! with the one shaping function every path must share.
 
+use super::layout::RetainedLineBreaking;
 use super::shaping::TextParagraph;
 use super::*;
 
@@ -24,6 +25,10 @@ use super::*;
 /// handled by the cache as a whole.
 struct CachedParagraphs {
     wrap: TextWrap,
+    /// What [`super::layout::layout`] derived when it last broke these paragraphs, so an
+    /// unchanged-input call can skip the breaking. `None` after a reshape (fresh entries
+    /// start without one) and while checked out through the guard.
+    line_breaking: Option<RetainedLineBreaking>,
     /// `None` while a [`CachedParagraphsGuard`] has the paragraphs checked out; the guard puts
     /// them back when it drops. Finding `None` here therefore means the previous caller returned
     /// without handing them back, and the entry has to be reshaped rather than served empty.
@@ -37,6 +42,8 @@ pub struct TextLayoutCache {
     inner: InnerTextLayoutCache,
     #[cfg(feature = "testing")]
     cache_miss_count: std::cell::Cell<u64>,
+    #[cfg(feature = "testing")]
+    layout_miss_count: std::cell::Cell<u64>,
 }
 
 #[allow(clippy::derivable_impls)] // clippy doesn't see the feature = "testing" code
@@ -46,6 +53,8 @@ impl Default for TextLayoutCache {
             inner: Default::default(),
             #[cfg(feature = "testing")]
             cache_miss_count: std::cell::Cell::new(0),
+            #[cfg(feature = "testing")]
+            layout_miss_count: std::cell::Cell::new(0),
         }
     }
 }
@@ -74,11 +83,23 @@ impl TextLayoutCache {
     pub fn reset_cache_miss_count(&self) {
         self.cache_miss_count.set(0);
     }
+    /// How many times a layout pass had to break the lines of a cached item again rather than
+    /// reuse the retained breaking.
+    pub fn layout_miss_count(&self) -> u64 {
+        self.layout_miss_count.get()
+    }
+    pub fn reset_layout_miss_count(&self) {
+        self.layout_miss_count.set(0);
+    }
+    pub(super) fn count_layout_miss(&self) {
+        self.layout_miss_count.set(self.layout_miss_count.get() + 1);
+    }
 }
 
 /// RAII guard: takes the shaped paragraphs out of the cache on creation, puts them back on drop.
 pub(super) struct CachedParagraphsGuard<'a> {
     paragraphs: Option<Vec<TextParagraph>>,
+    line_breaking: Option<RetainedLineBreaking>,
     container: Option<std::cell::RefMut<'a, CachedParagraphs>>,
 }
 
@@ -88,16 +109,32 @@ impl CachedParagraphsGuard<'_> {
         self.paragraphs.take().unwrap_or_default()
     }
 
-    /// Returns the paragraphs, so that the next caller reuses the shaping.
-    pub(super) fn restore(&mut self, paragraphs: Vec<TextParagraph>) {
+    /// Hands the retained breaking to [`layout`], which decides whether it still applies.
+    pub(super) fn take_line_breaking(&mut self) -> Option<RetainedLineBreaking> {
+        self.container.as_mut().and_then(|container| container.line_breaking.take())
+    }
+
+    /// Returns the paragraphs and the line breaking they carry, so that the next caller reuses
+    /// both the shaping and, with unchanged inputs, the breaking.
+    pub(super) fn restore(
+        &mut self,
+        paragraphs: Vec<TextParagraph>,
+        line_breaking: RetainedLineBreaking,
+    ) {
         self.paragraphs = Some(paragraphs);
+        self.line_breaking = Some(line_breaking);
     }
 }
 
 impl Drop for CachedParagraphsGuard<'_> {
     fn drop(&mut self) {
-        if let (Some(paragraphs), Some(container)) = (self.paragraphs.take(), &mut self.container) {
-            container.paragraphs = Some(paragraphs);
+        if let Some(container) = &mut self.container {
+            if let Some(paragraphs) = self.paragraphs.take() {
+                container.paragraphs = Some(paragraphs);
+            }
+            if let Some(line_breaking) = self.line_breaking.take() {
+                container.line_breaking = Some(line_breaking);
+            }
         }
     }
 }
@@ -118,7 +155,11 @@ pub(super) fn cached_paragraphs<'a>(
     shape: &dyn Fn(&mut parley::FontContext) -> Vec<TextParagraph>,
 ) -> CachedParagraphsGuard<'a> {
     let Some((cache, item_rc)) = cache.zip(item_rc) else {
-        return CachedParagraphsGuard { paragraphs: Some(shape(font_context)), container: None };
+        return CachedParagraphsGuard {
+            paragraphs: Some(shape(font_context)),
+            line_breaking: None,
+            container: None,
+        };
     };
 
     cache.clear_if_scale_factor_changed(window);
@@ -141,8 +182,12 @@ pub(super) fn cached_paragraphs<'a>(
     let mut entry = cache.inner.get_or_update_cache_entry_ref(item_rc, || {
         #[cfg(feature = "testing")]
         cache.cache_miss_count.set(cache.cache_miss_count.get() + 1);
-        CachedParagraphs { wrap, paragraphs: Some(shape(font_context)) }
+        CachedParagraphs { wrap, paragraphs: Some(shape(font_context)), line_breaking: None }
     });
     let paragraphs = entry.paragraphs.take().unwrap_or_default();
-    CachedParagraphsGuard { paragraphs: Some(paragraphs), container: Some(entry) }
+    CachedParagraphsGuard {
+        paragraphs: Some(paragraphs),
+        line_breaking: None,
+        container: Some(entry),
+    }
 }

--- a/internal/core/textlayout/sharedparley/draw.rs
+++ b/internal/core/textlayout/sharedparley/draw.rs
@@ -75,12 +75,24 @@ pub trait GlyphRenderer: crate::item_rendering::ItemRenderer {
     );
 }
 
+/// The vertical extent the renderer clip lets anything be drawn in, as a physical y range in the
+/// current item's coordinates. A conservative superset of what is visible -- see
+/// [`crate::item_rendering::ItemRenderer::get_current_clip`] -- so it is a safe bound for
+/// skipping draw work, never for layout decisions.
+pub(super) fn visible_band(item_renderer: &impl GlyphRenderer) -> Range<PhysicalLength> {
+    let scale_factor = ScaleFactor::new(item_renderer.scale_factor());
+    let clip = item_renderer.get_current_clip();
+    let top = clip.origin.y_length() * scale_factor;
+    top..(top + clip.height_length() * scale_factor)
+}
+
 impl TextParagraph {
     fn draw<R: GlyphRenderer>(
         &self,
         layout: &Layout,
         paragraph_index: usize,
         visible_extent: Option<ElisionCut>,
+        visible_band: &Range<PhysicalLength>,
         item_renderer: &mut R,
         default_fill_brush: &<R as GlyphRenderer>::PlatformBrush,
         default_stroke_brush: &Option<<R as GlyphRenderer>::PlatformBrush>,
@@ -119,6 +131,24 @@ impl TextParagraph {
                 break;
             }
             let metrics = line.metrics();
+
+            // Skip lines that can't reach the visible band. Ink may overhang the line's metrics
+            // box (stacked diacritics, swashes), so pad by one line height on each side before
+            // excluding -- the pad scales with the line itself. Lines are in block order, so the
+            // first line past the band ends the walk.
+            let line_height =
+                PhysicalLength::new(metrics.block_max_coord - metrics.block_min_coord);
+            if para_y + PhysicalLength::new(metrics.block_max_coord) + line_height
+                < visible_band.start
+            {
+                continue;
+            }
+            if para_y + PhysicalLength::new(metrics.block_min_coord) - line_height
+                > visible_band.end
+            {
+                break;
+            }
+
             // The kept line is always drawn, even when it slightly exceeds the box (#12197); other
             // lines are kept only while they fall within the box, taking vertical alignment into
             // account (bottom/center alignment clips lines off the top, not the bottom).
@@ -594,11 +624,35 @@ impl Layout {
         // Compute the cut once: explicit `\n` breaks produce one paragraph each, but they must
         // elide as a single block (drop lines below the box, ellipsis on the last visible one).
         let visible_extent = self.visible_extent();
-        for (paragraph_index, paragraph) in self.paragraphs.iter().enumerate() {
+
+        // Everything drawn below is cut to the renderer clip anyway, so lines that can't reach
+        // it are skipped instead of submitted: the clip is a bounding box of everything still
+        // drawable (see [`crate::item_rendering::ItemRenderer::get_current_clip`]), which makes
+        // skipping what lies outside it safe under any transform. The band only filters what is
+        // *drawn*; it never influences elision or `max-lines` accounting.
+        let visible_band = visible_band(item_renderer);
+
+        // Paragraphs are stacked in order, so binary-search the first one whose box reaches the
+        // band. Start one paragraph earlier and stop one past the band: glyph ink may overhang
+        // its line's metrics box, and the line-level cull in [`TextParagraph::draw`] trims those
+        // two edge paragraphs down to their edge lines.
+        let first = self
+            .paragraphs
+            .partition_point(|p| {
+                self.y_offset + p.y + PhysicalLength::new(p.layout.height()) < visible_band.start
+            })
+            .saturating_sub(1);
+        let mut past_band = false;
+        for (paragraph_index, paragraph) in self.paragraphs.iter().enumerate().skip(first) {
+            if past_band {
+                break;
+            }
+            past_band = self.y_offset + paragraph.y > visible_band.end;
             paragraph.draw(
                 self,
                 paragraph_index,
                 visible_extent,
+                &visible_band,
                 item_renderer,
                 &default_fill_brush,
                 &default_stroke_brush,

--- a/internal/core/textlayout/sharedparley/layout.rs
+++ b/internal/core/textlayout/sharedparley/layout.rs
@@ -35,15 +35,96 @@ impl LayoutOptions {
     }
 }
 
+/// The inputs the line breaking and its derived metrics depend on. Two [`layout`] calls with
+/// equal inputs produce identical breaking for the same shaped paragraphs, so a matching
+/// [`RetainedLineBreaking`] lets [`layout`] skip re-breaking every paragraph. Deliberately absent:
+/// `max_height` and the vertical alignment, which only feed the per-call `y_offset` and the
+/// height-based elision cut, both computed on the [`Layout`] itself.
+#[derive(Clone, Copy, PartialEq)]
+struct LineBreakingInputs {
+    max_physical_width: Option<PhysicalLength>,
+    /// The alignment as parley receives it, so `Start` and `Left` don't spuriously differ.
+    alignment: parley::Alignment,
+    max_lines: Option<usize>,
+    text_overflow: TextOverflow,
+}
+
+impl LineBreakingInputs {
+    fn new(options: &LayoutOptions, max_physical_width: Option<PhysicalLength>) -> Self {
+        Self {
+            max_physical_width,
+            alignment: match options.horizontal_align {
+                TextHorizontalAlignment::Start | TextHorizontalAlignment::Left => {
+                    parley::Alignment::Left
+                }
+                TextHorizontalAlignment::Center => parley::Alignment::Center,
+                TextHorizontalAlignment::End | TextHorizontalAlignment::Right => {
+                    parley::Alignment::Right
+                }
+            },
+            max_lines: options.max_lines,
+            text_overflow: options.text_overflow,
+        }
+    }
+}
+
+/// What a full [`layout`] pass computed, retained in the cache entry alongside the shaped
+/// paragraphs. The parley layouts already hold their broken lines and every `TextParagraph::y`
+/// its position, so together with these metrics the next [`layout`] call with equal
+/// [`LineBreakingInputs`] has nothing left to do.
+pub(super) struct RetainedLineBreaking {
+    inputs: LineBreakingInputs,
+    line_limit_cut: Option<(usize, usize)>,
+    max_width: PhysicalLength,
+    height: PhysicalLength,
+    elision_info: Option<ElisionInfo>,
+}
+
+/// Where vertical alignment puts the text within the box. Per call, not retained: it depends on
+/// `max_height`, which changes freely (e.g. during a resize) without affecting the breaking.
+fn vertical_offset(
+    max_physical_height: Option<PhysicalLength>,
+    vertical_align: TextVerticalAlignment,
+    height: PhysicalLength,
+) -> PhysicalLength {
+    match (max_physical_height, vertical_align) {
+        (Some(max_height), TextVerticalAlignment::Center) => (max_height - height) / 2.0,
+        (Some(max_height), TextVerticalAlignment::Bottom) => max_height - height,
+        (None, _) | (Some(_), TextVerticalAlignment::Top) => PhysicalLength::new(0.0),
+    }
+}
+
 pub(super) fn layout(
     layout_builder: &LayoutWithoutLineBreaksBuilder,
     font_context: &mut parley::FontContext,
     mut paragraphs: Vec<TextParagraph>,
     scale_factor: ScaleFactor,
     options: LayoutOptions,
+    line_breaking: Option<RetainedLineBreaking>,
 ) -> Layout {
     let max_physical_width = options.max_width.map(|max_width| max_width * scale_factor);
     let max_physical_height = options.max_height.map(|max_height| max_height * scale_factor);
+
+    let inputs = LineBreakingInputs::new(&options, max_physical_width);
+    if let Some(line_breaking) =
+        line_breaking.filter(|line_breaking| line_breaking.inputs == inputs)
+    {
+        return Layout {
+            y_offset: vertical_offset(
+                max_physical_height,
+                options.vertical_align,
+                line_breaking.height,
+            ),
+            paragraphs,
+            max_width: line_breaking.max_width,
+            height: line_breaking.height,
+            max_physical_height,
+            elision_info: line_breaking.elision_info,
+            line_limit_cut: line_breaking.line_limit_cut,
+            line_breaking_inputs: inputs,
+            broke_lines: false,
+        };
+    }
 
     // Returned None if failed to get the ellipsis glyph for some rare reason.
     let get_ellipsis_glyph = |font_context: &mut parley::FontContext| {
@@ -72,18 +153,7 @@ pub(super) fn layout(
     let mut para_y = 0.0;
     for para in paragraphs.iter_mut() {
         para.layout.break_all_lines(max_physical_width.map(|width| width.get()));
-        para.layout.align(
-            match options.horizontal_align {
-                TextHorizontalAlignment::Start | TextHorizontalAlignment::Left => {
-                    parley::Alignment::Left
-                }
-                TextHorizontalAlignment::Center => parley::Alignment::Center,
-                TextHorizontalAlignment::End | TextHorizontalAlignment::Right => {
-                    parley::Alignment::Right
-                }
-            },
-            parley::AlignmentOptions::default(),
-        );
+        para.layout.align(inputs.alignment, parley::AlignmentOptions::default());
 
         para.y = PhysicalLength::new(para_y);
         para_y += para.layout.height();
@@ -137,11 +207,7 @@ pub(super) fn layout(
             .map_or(PhysicalLength::zero(), |p| p.y + PhysicalLength::new(p.layout.height())),
     };
 
-    let y_offset = match (max_physical_height, options.vertical_align) {
-        (Some(max_height), TextVerticalAlignment::Center) => (max_height - height) / 2.0,
-        (Some(max_height), TextVerticalAlignment::Bottom) => max_height - height,
-        (None, _) | (Some(_), TextVerticalAlignment::Top) => PhysicalLength::new(0.0),
-    };
+    let y_offset = vertical_offset(max_physical_height, options.vertical_align, height);
 
     Layout {
         paragraphs,
@@ -151,6 +217,8 @@ pub(super) fn layout(
         height,
         max_physical_height,
         line_limit_cut,
+        line_breaking_inputs: inputs,
+        broke_lines: true,
     }
 }
 
@@ -210,6 +278,29 @@ pub(super) struct Layout {
     /// Where an active `max-lines` limit drops lines, in the same coordinates as [`ElisionCut`]:
     /// the (paragraph index, line index) of the last kept line. See [`line_limit_cut`].
     pub(super) line_limit_cut: Option<(usize, usize)>,
+    /// What the paragraphs' lines are currently broken for; travels back into the cache entry.
+    line_breaking_inputs: LineBreakingInputs,
+    /// Whether this layout ran the full breaking pass rather than reusing a [`RetainedLineBreaking`].
+    /// Read by the `layout_miss_count` test counter.
+    pub(super) broke_lines: bool,
+}
+
+impl Layout {
+    /// Takes the layout apart into what the cache entry retains: the paragraphs (holding their
+    /// broken lines and y positions) and the [`RetainedLineBreaking`] that lets the next [`layout`] call
+    /// with equal inputs skip the breaking.
+    pub(super) fn dismantle(self) -> (Vec<TextParagraph>, RetainedLineBreaking) {
+        (
+            self.paragraphs,
+            RetainedLineBreaking {
+                inputs: self.line_breaking_inputs,
+                line_limit_cut: self.line_limit_cut,
+                max_width: self.max_width,
+                height: self.height,
+                elision_info: self.elision_info,
+            },
+        )
+    }
 }
 
 impl Layout {

--- a/internal/core/textlayout/sharedparley/selection.rs
+++ b/internal/core/textlayout/sharedparley/selection.rs
@@ -103,16 +103,33 @@ pub(super) fn run_coverage(run_x: &Range<f32>, spans: &[SelectionSpan]) -> RunCo
 }
 
 impl Layout {
-    /// Resolves `selection_range` into per-line horizontal spans.
+    /// Resolves `selection_range` into per-line horizontal spans, for the lines whose boxes may
+    /// intersect `visible_band` (a physical y range in item coordinates; spans feed drawing only,
+    /// so off-screen lines need none). Pass an unbounded band to resolve everything.
     ///
     /// Parley already splits a ligature into one cluster per character and apportions the
     /// advance between them, so the geometry it reports is accurate to sub-glyph precision --
     /// selecting the `i` of an `fi` ligature yields exactly the ligature's right half. That
     /// precision is what makes clip-based selection drawing possible; see [`SelectionSpan`].
-    pub(super) fn selection_geometry(&self, selection_range: Range<usize>) -> SelectionSpans {
+    pub(super) fn selection_geometry(
+        &self,
+        selection_range: Range<usize>,
+        visible_band: &Range<PhysicalLength>,
+    ) -> SelectionSpans {
         let mut spans = Vec::new();
 
         for (paragraph_index, paragraph) in self.visible_paragraphs().iter().enumerate() {
+            // Like the draw cull, padded by an (average) line height for ink that overhangs its
+            // line box: such a line still draws, so it still needs its spans.
+            let paragraph_top = self.y_offset + paragraph.y;
+            let paragraph_height = PhysicalLength::new(paragraph.layout.height());
+            let line_pad = paragraph_height / paragraph.layout.lines().len().max(1) as f32;
+            if paragraph_top + paragraph_height + line_pad < visible_band.start
+                || paragraph_top - line_pad > visible_band.end
+            {
+                continue;
+            }
+
             let selection_start = selection_range.start.max(paragraph.range.start);
             let selection_end = selection_range.end.min(paragraph.range.end);
 
@@ -143,10 +160,17 @@ impl Layout {
                 if x.end <= x.start {
                     return;
                 }
+                // A giant wrapped paragraph passes the paragraph test above with all its lines;
+                // keep only the ones that can reach the band.
+                let top = PhysicalLength::new(rect.y0 as _) + paragraph_top;
+                let bottom = PhysicalLength::new(rect.y1 as _) + paragraph_top;
+                if bottom + line_pad < visible_band.start || top - line_pad > visible_band.end {
+                    return;
+                }
                 let background = PhysicalRect::new(
                     PhysicalPoint::from_lengths(
                         PhysicalLength::new(x.start),
-                        PhysicalLength::new(rect.y0 as _) + self.y_offset + paragraph.y,
+                        PhysicalLength::new(rect.y0 as _) + paragraph_top,
                     ),
                     PhysicalSize::new(x.end - x.start, rect.height() as _),
                 );

--- a/internal/core/textlayout/sharedparley/tests.rs
+++ b/internal/core/textlayout/sharedparley/tests.rs
@@ -58,7 +58,10 @@ fn bidi_selection_spans_are_ascending_in_x() {
             if start >= end {
                 continue;
             }
-            let spans = layout.selection_geometry(start..end);
+            let spans = layout.selection_geometry(
+                start..end,
+                &(PhysicalLength::new(f32::NEG_INFINITY)..PhysicalLength::new(f32::INFINITY)),
+            );
             saw_line_with_several_spans |= spans.0.len() > 1;
             for pair in spans.0.windows(2) {
                 let (left, right) = (&pair[0], &pair[1]);

--- a/internal/core/textlayout/sharedparley/tests.rs
+++ b/internal/core/textlayout/sharedparley/tests.rs
@@ -33,7 +33,7 @@ fn layout_text_with_options(text: &str, options: LayoutOptions) -> Layout {
         PlainOrStyledText::Plain(text.into()),
         Color::default(),
     );
-    layout(&builder, &mut font_ctx, paragraphs, ScaleFactor::new(1.0), options)
+    layout(&builder, &mut font_ctx, paragraphs, ScaleFactor::new(1.0), options, None)
 }
 
 fn layout_text(text: &str) -> Layout {


### PR DESCRIPTION
The shaped-text cache removed re-shaping from scrolling, but every frame still did O(document) work: `layout()` re-broke every paragraph's lines even when nothing changed, and drawing submitted every line for the renderer to clip away.

- Cull drawing to the renderer clip: lines that can't reach the visible band are skipped instead of submitted.
- Resolve selection spans only for the visible band, instead of one highlight rect per selected line.
- Retain the line breaking in the cache entry and skip `layout()`'s breaking pass while its inputs are unchanged.

Scrolling a 15000-line `TextInput` goes from ~9 fps to under a millisecond of text work per frame. A keystroke still reshapes the whole document; incremental reshaping is a follow-up.

Issue: #10087
