### PR TITLE
core: ItemRenderer::scale_factor returns a ScaleFactor

### DIFF
--- a/internal/backends/qt/qt_widgets.rs
+++ b/internal/backends/qt/qt_widgets.rs
@@ -60,7 +60,7 @@ macro_rules! fn_render {
     ($this:ident $dpr:ident $size:ident $painter:ident $widget:ident $initial_state:ident => $($tt:tt)*) => {
         fn render(self: Pin<&Self>, backend: &mut &mut dyn ItemRenderer, item_rc: &ItemRc, size: LogicalSize) -> RenderingResult {
             self.animation_tracker();
-            let $dpr: f32 = backend.scale_factor();
+            let $dpr: f32 = backend.scale_factor().get();
 
             let active: bool = backend.window().active();
             // This should include self.enabled() as well, but not every native widget

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1180,8 +1180,8 @@ impl ItemRenderer for QtItemRenderer<'_> {
         self.painter.restore()
     }
 
-    fn scale_factor(&self) -> f32 {
-        1.
+    fn scale_factor(&self) -> ScaleFactor {
+        ScaleFactor::new(1.)
         /* cpp! { unsafe [painter as "QPainterPtr*"] -> f32 as "float" {
             return (*painter)->paintEngine()->paintDevice()->devicePixelRatioF();
         }} */
@@ -1207,7 +1207,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
             self,
             std::pin::pin!((SharedString::from(string), Brush::from(color))),
             None,
-            logical_size_from_api(self.window.size().to_logical(self.scale_factor())),
+            logical_size_from_api(self.window.size().to_logical(self.scale_factor().get())),
             None,
         );
     }
@@ -1217,7 +1217,7 @@ impl ItemRenderer for QtItemRenderer<'_> {
         if source_size.is_empty() {
             return;
         }
-        let scale_factor = ScaleFactor::new(self.scale_factor());
+        let scale_factor = self.scale_factor();
         let target_size = LogicalSize::from_untyped(source_size.cast()) * scale_factor;
         let image_inner: &ImageInner = (&image).into();
         // Rasterize scalable sources at scale_factor so SVGs are crisp on high-DPI displays
@@ -1708,7 +1708,7 @@ impl QtItemRenderer<'_> {
                     // Source size & clipping is not implemented yet
                     None
                 } else {
-                    let scale_factor = ScaleFactor::new(self.scale_factor());
+                    let scale_factor = self.scale_factor();
                     let actual_target_size = i_slint_core::graphics::fit(
                         image.image_fit(),
                         // Query target_width/height here again to ensure that changes will invalidate the item rendering cache.
@@ -1757,7 +1757,7 @@ impl QtItemRenderer<'_> {
         let image_size = pixmap.size();
         let source_rect = source_rect
             .unwrap_or_else(|| euclid::rect(0, 0, image_size.width as _, image_size.height as _));
-        let scale_factor = ScaleFactor::new(self.scale_factor());
+        let scale_factor = self.scale_factor();
 
         let fit = if let ImageInner::NineSlice(nine) = <&ImageInner>::from(&image.source()) {
             i_slint_core::graphics::fit9slice(

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -10,6 +10,7 @@ use crate::item_tree::ItemTreeRc;
 use crate::item_tree::{ItemVisitor, ItemVisitorVTable, VisitChildrenResult};
 use crate::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
+    ScaleFactor,
 };
 pub use crate::partial_renderer::CachedRenderingData;
 use crate::window::WindowAdapterRc;
@@ -568,7 +569,7 @@ pub trait ItemRenderer {
     fn restore_state(&mut self);
 
     /// Returns the scale factor
-    fn scale_factor(&self) -> f32;
+    fn scale_factor(&self) -> ScaleFactor;
 
     /// Draw a pixmap in position indicated by the `pos`.
     /// The pixmap will be taken from cache if the cache is valid, otherwise, update_fn will be called
@@ -657,7 +658,7 @@ where
     R: LayerRenderer<'cache> + ?Sized + 'cache,
 {
     let cache = renderer.layer_cache();
-    let scale_factor = crate::lengths::ScaleFactor::new(renderer.scale_factor());
+    let scale_factor = renderer.scale_factor();
 
     let compute_bounds = |r: &R| -> LogicalRect {
         item_children_bounding_rect(item_rc, &r.window().window_adapter())

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -26,7 +26,7 @@ use crate::items::Path;
 use crate::items::{BoxShadow, Clip, ItemRc, ItemRef, Layer, Opacity, RenderingResult, TextInput};
 use crate::lengths::{
     ItemTransform, LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalPx, LogicalRect,
-    LogicalSize, LogicalVector,
+    LogicalSize, LogicalVector, ScaleFactor,
 };
 use crate::properties::PropertyTracker;
 use crate::window::WindowAdapter;
@@ -723,7 +723,7 @@ impl<T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRenderer<'_
         self.actual_renderer.restore_state()
     }
 
-    fn scale_factor(&self) -> f32 {
+    fn scale_factor(&self) -> ScaleFactor {
         self.actual_renderer.scale_factor()
     }
 

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -148,7 +148,7 @@ pub fn draw_text(
         return;
     };
 
-    let scale_factor = ScaleFactor::new(item_renderer.scale_factor());
+    let scale_factor = item_renderer.scale_factor();
 
     let (stroke_brush, stroke_width, stroke_style) = text.stroke();
     let platform_stroke_brush = if !stroke_brush.is_transparent() {
@@ -326,7 +326,7 @@ pub fn draw_text_input(
         visual_representation.selection_range.start..visual_representation.selection_range.end
     };
 
-    let scale_factor = ScaleFactor::new(item_renderer.scale_factor());
+    let scale_factor = item_renderer.scale_factor();
 
     let layout_builder =
         shaping_builder(text_input, Some(item_rc), text_input.wrap(), scale_factor);

--- a/internal/core/textlayout/sharedparley/draw.rs
+++ b/internal/core/textlayout/sharedparley/draw.rs
@@ -80,7 +80,7 @@ pub trait GlyphRenderer: crate::item_rendering::ItemRenderer {
 /// [`crate::item_rendering::ItemRenderer::get_current_clip`] -- so it is a safe bound for
 /// skipping draw work, never for layout decisions.
 pub(super) fn visible_band(item_renderer: &impl GlyphRenderer) -> Range<PhysicalLength> {
-    let scale_factor = ScaleFactor::new(item_renderer.scale_factor());
+    let scale_factor = item_renderer.scale_factor();
     let clip = item_renderer.get_current_clip();
     let top = clip.origin.y_length() * scale_factor;
     top..(top + clip.height_length() * scale_factor)
@@ -260,7 +260,7 @@ impl TextParagraph {
         // so the capsule edge doesn't sit flush against tall glyphs.
         const VERTICAL_PADDING_RATIO: f32 = 0.15;
 
-        let scale_factor = ScaleFactor::new(item_renderer.scale_factor());
+        let scale_factor = item_renderer.scale_factor();
         let border_width = BORDER_WIDTH * scale_factor;
 
         // Capsules only under lines that are drawn: lines past the visible-extent cut
@@ -440,7 +440,7 @@ impl TextParagraph {
 
         // Clip horizontally only: the vertical extent stays whatever is already in effect, so
         // accents and descenders reaching outside the line box are never sheared off.
-        let scale_factor = ScaleFactor::new(item_renderer.scale_factor());
+        let scale_factor = item_renderer.scale_factor();
         let current_clip = item_renderer.get_current_clip();
         let render = item_renderer.combine_clip(
             LogicalRect::new(

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -777,8 +777,8 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         self.canvas.borrow_mut().restore();
     }
 
-    fn scale_factor(&self) -> f32 {
-        self.scale_factor.get()
+    fn scale_factor(&self) -> ScaleFactor {
+        self.scale_factor
     }
 
     fn draw_cached_pixmap(
@@ -822,7 +822,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
             self,
             std::pin::pin!((SharedString::from(string), Brush::from(color))),
             None,
-            logical_size_from_api(self.window.size().to_logical(self.scale_factor())),
+            logical_size_from_api(self.window.size().to_logical(self.scale_factor().get())),
             None,
         );
     }

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -935,8 +935,8 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
         self.canvas.restore();
     }
 
-    fn scale_factor(&self) -> f32 {
-        self.scale_factor.get()
+    fn scale_factor(&self) -> ScaleFactor {
+        self.scale_factor
     }
 
     fn draw_cached_pixmap(
@@ -974,7 +974,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
             self,
             std::pin::pin!((SharedString::from(string), Brush::from(color))),
             None,
-            logical_size_from_api(self.window.size().to_logical(self.scale_factor())),
+            logical_size_from_api(self.window.size().to_logical(self.scale_factor().get())),
             None,
         );
     }

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -3238,8 +3238,8 @@ impl<T: ProcessScene> i_slint_core::item_rendering::ItemRenderer for SceneBuilde
         self.current_state = self.state_stack.pop().unwrap();
     }
 
-    fn scale_factor(&self) -> f32 {
-        self.scale_factor.0
+    fn scale_factor(&self) -> ScaleFactor {
+        self.scale_factor
     }
 
     fn draw_cached_pixmap(


### PR DESCRIPTION
Nearly every caller built a ScaleFactor out of the returned f32 anyway, and that type is what keeps logical -> physical conversions checked. Let the renderer hand out the typed value and leave .get() to the few api functions that still want a raw float.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
