### PR TITLE
core+compiler: add a set-selection accessibility action

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -407,6 +407,32 @@ public:
         return std::nullopt;
     }
 
+    /// Selects the text between two UTF-8 offsets.
+    ///
+    /// This will invoke the `accessible-action-set-selection` callback.
+    void set_accessible_selection(int anchor, int focus) const
+    {
+        if (inner.element_index != 0)
+            return;
+        if (auto item = private_api::upgrade_item_weak(inner.item)) {
+            union SetSelectionHelper {
+                cbindgen_private::AccessibilityAction action;
+                SetSelectionHelper(int anchor, int focus)
+                {
+                    new (&action.set_selection)
+                            cbindgen_private::AccessibilityAction::SetSelection_Body {
+                                cbindgen_private::AccessibilityAction::Tag::SetSelection, anchor,
+                                focus
+                            };
+                }
+                ~SetSelectionHelper() { }
+
+            } action(anchor, focus);
+            item->item_tree.vtable()->accessibility_action(item->item_tree.borrow(), item->index,
+                                                           &action.action);
+        }
+    }
+
     /// Invokes the expand accessibility action of that element
     /// (`accessible-action-expand`).
     void invoke_accessible_expand_action() const

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -492,3 +492,6 @@ Invoked when the user requests to decrement the value.
 
 ### accessible-action-expand()
 Invoked when the user requests to expand the widget, such as disclose the list of available choices for a combo box.
+
+### accessible-action-set-selection(int, int)
+Invoked when the user wants to change the selected text. The arguments are the UTF-8 offsets of the selection's anchor and focus: the focus may precede the anchor when the selection was made backwards, and the two are equal when only the cursor moved.

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -493,5 +493,5 @@ Invoked when the user requests to decrement the value.
 ### accessible-action-expand()
 Invoked when the user requests to expand the widget, such as disclose the list of available choices for a combo box.
 
-### accessible-action-set-selection(int, int)
-Invoked when the user wants to change the selected text. The arguments are the UTF-8 offsets of the selection's anchor and focus: the focus may precede the anchor when the selection was made backwards, and the two are equal when only the cursor moved.
+### accessible-action-set-selection(anchor: int, focus: int)
+Invoked when the user wants to change the selected text. The arguments are UTF-8 offsets into the element's text: `anchor` is the end that stays put and `focus` the end being moved, so `focus` may precede `anchor` when the selection was made backwards, and the two are equal when only the cursor moved.

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -643,6 +643,18 @@ impl ElementHandle {
         }
     }
 
+    /// Selects the text between two UTF-8 offsets, by invoking the element's
+    /// `accessible-action-set-selection` callback. Note that you can only do this if that callback
+    /// is declared in your Slint code.
+    pub fn set_accessible_selection(&self, anchor: i32, focus: i32) {
+        if self.element_index != 0 {
+            return;
+        }
+        if let Some(item) = self.item.upgrade() {
+            item.accessible_action(&AccessibilityAction::SetSelection { anchor, focus })
+        }
+    }
+
     /// Returns the value of the element's `accessible-value-maximum` property, if present.
     pub fn accessible_value_maximum(&self) -> Option<f32> {
         if self.element_index != 0 {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2729,14 +2729,28 @@ fn generate_sub_component(
         if what == "Role" {
             accessible_role_cases.push(format!("    case {index}: return {e};"));
         } else if let Some(what) = what.strip_prefix("Action") {
-            let has_args = matches!(&*expr.borrow(), llr::Expression::CallBackCall { arguments, .. } if !arguments.is_empty());
-
-            accessibility_action_cases.push(if has_args {
-                let member = ident(&crate::generator::to_kebab_case(what));
-                format!("    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): {{ auto arg_0 = action.{member}._0; return {e}; }}")
-            } else {
-                format!("    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): return {e};")
-            });
+            let case = match what {
+                "SetSelection" => {
+                    let member = ident(&crate::generator::to_kebab_case(what));
+                    format!(
+                        "    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): {{ auto arg_0 = action.{member}.anchor; auto arg_1 = action.{member}.focus; return {e}; }}"
+                    )
+                }
+                _ => {
+                    let has_args = matches!(&*expr.borrow(), llr::Expression::CallBackCall { arguments, .. } if !arguments.is_empty());
+                    if has_args {
+                        let member = ident(&crate::generator::to_kebab_case(what));
+                        format!(
+                            "    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): {{ auto arg_0 = action.{member}._0; return {e}; }}"
+                        )
+                    } else {
+                        format!(
+                            "    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): return {e};"
+                        )
+                    }
+                }
+            };
+            accessibility_action_cases.push(case);
             supported_accessibility_actions
                 .entry(*index)
                 .or_default()

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1480,15 +1480,26 @@ fn generate_sub_component(
         let e = compile_expression(&expr.borrow(), &ctx);
         if what == "Role" {
             accessible_role_branch.push(quote!(#index => #e,));
-        } else if let Some(what) = what.strip_prefix("Action") {
-            let what = ident(what);
-            let has_args = matches!(&*expr.borrow(), Expression::CallBackCall { arguments, .. } if !arguments.is_empty());
-            accessibility_action_branch.push(if has_args {
-                quote!((#index, sp::AccessibilityAction::#what(args)) => { let args = (args,); #e })
-            } else {
-                quote!((#index, sp::AccessibilityAction::#what) => { #e })
-            });
-            supported_accessibility_actions.entry(*index).or_default().insert(what);
+        } else if let Some(what_str) = what.strip_prefix("Action") {
+            let what_ident = ident(what_str);
+            let branch = match what_str {
+                "SetSelection" => quote!(
+                    (#index, sp::AccessibilityAction::SetSelection { anchor, focus }) => {
+                        let args = (anchor, focus);
+                        #e
+                    }
+                ),
+                _ => {
+                    let has_args = matches!(&*expr.borrow(), Expression::CallBackCall { arguments, .. } if !arguments.is_empty());
+                    if has_args {
+                        quote!((#index, sp::AccessibilityAction::#what_ident(args)) => { let args = (args,); #e })
+                    } else {
+                        quote!((#index, sp::AccessibilityAction::#what_ident) => { #e })
+                    }
+                }
+            };
+            accessibility_action_branch.push(branch);
+            supported_accessibility_actions.entry(*index).or_default().insert(what_ident);
         } else {
             let what = ident(what);
             accessible_string_property_branch

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -4,7 +4,7 @@
 //! Pass that lowers synthetic `accessible-*` properties
 
 use crate::diagnostics::BuildDiagnostics;
-use crate::expression_tree::{Callable, Expression, NamedReference};
+use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference};
 use crate::langtype::{EnumerationValue, Type};
 use crate::object_tree::{Component, ElementRc};
 
@@ -117,6 +117,19 @@ fn apply_builtin(e: &ElementRc) {
                         source_location: None,
                     },
                 ])
+            });
+        }
+        {
+            e.borrow_mut().set_binding_if_not_set("accessible-action-set-selection".into(), || {
+                Expression::FunctionCall {
+                    function: Callable::Builtin(BuiltinFunction::SetSelectionOffsets),
+                    arguments: vec![
+                        Expression::ElementReference(Rc::downgrade(e)),
+                        Expression::FunctionParameterReference { index: 0, ty: Type::Int32 },
+                        Expression::FunctionParameterReference { index: 1, ty: Type::Int32 },
+                    ],
+                    source_location: None,
+                }
             });
         }
     } else if bty.name == "Image" {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -93,6 +93,7 @@ pub struct BuiltinTypes {
     pub enums: BuiltinEnums,
     pub noarg_callback_type: Type,
     pub strarg_callback_type: Type,
+    pub two_int_args_callback_type: Type,
     pub logical_point_type: Arc<Struct>,
     pub logical_size_type: Arc<Struct>,
     pub font_metrics_type: Type,
@@ -156,6 +157,11 @@ impl BuiltinTypes {
             strarg_callback_type: Type::Callback(Arc::new(Function {
                 return_type: Type::Void,
                 args: vec![Type::String],
+                arg_names: Vec::new(),
+            })),
+            two_int_args_callback_type: Type::Callback(Arc::new(Function {
+                return_type: Type::Void,
+                args: vec![Type::Int32, Type::Int32],
                 arg_names: Vec::new(),
             })),
             layout_info_type: layout_info_type.clone(),
@@ -250,6 +256,10 @@ fn strarg_callback_type() -> Type {
     BUILTIN.strarg_callback_type.clone()
 }
 
+fn two_int_args_callback_type() -> Type {
+    BUILTIN.two_int_args_callback_type.clone()
+}
+
 pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str, Type)> {
     [
         //("accessible-role", ...)
@@ -271,6 +281,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-action-increment", noarg_callback_type()),
         ("accessible-action-decrement", noarg_callback_type()),
         ("accessible-action-set-value", strarg_callback_type()),
+        ("accessible-action-set-selection", two_int_args_callback_type()),
         ("accessible-action-expand", noarg_callback_type()),
         ("accessible-item-selectable", Type::Bool),
         ("accessible-item-selected", Type::Bool),

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -93,7 +93,7 @@ pub struct BuiltinTypes {
     pub enums: BuiltinEnums,
     pub noarg_callback_type: Type,
     pub strarg_callback_type: Type,
-    pub two_int_args_callback_type: Type,
+    pub set_selection_callback_type: Type,
     pub logical_point_type: Arc<Struct>,
     pub logical_size_type: Arc<Struct>,
     pub font_metrics_type: Type,
@@ -159,10 +159,10 @@ impl BuiltinTypes {
                 args: vec![Type::String],
                 arg_names: Vec::new(),
             })),
-            two_int_args_callback_type: Type::Callback(Arc::new(Function {
+            set_selection_callback_type: Type::Callback(Arc::new(Function {
                 return_type: Type::Void,
                 args: vec![Type::Int32, Type::Int32],
-                arg_names: Vec::new(),
+                arg_names: vec![SmolStr::new_static("anchor"), SmolStr::new_static("focus")],
             })),
             layout_info_type: layout_info_type.clone(),
             state_info_type: Arc::new(Struct::new(
@@ -256,8 +256,8 @@ fn strarg_callback_type() -> Type {
     BUILTIN.strarg_callback_type.clone()
 }
 
-fn two_int_args_callback_type() -> Type {
-    BUILTIN.two_int_args_callback_type.clone()
+fn set_selection_callback_type() -> Type {
+    BUILTIN.set_selection_callback_type.clone()
 }
 
 pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str, Type)> {
@@ -281,7 +281,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-action-increment", noarg_callback_type()),
         ("accessible-action-decrement", noarg_callback_type()),
         ("accessible-action-set-value", strarg_callback_type()),
-        ("accessible-action-set-selection", two_int_args_callback_type()),
+        ("accessible-action-set-selection", set_selection_callback_type()),
         ("accessible-action-expand", noarg_callback_type()),
         ("accessible-item-selectable", Type::Bool),
         ("accessible-item-selected", Type::Bool),

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -15,6 +15,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     vertical-stretch: 0;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -37,6 +37,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -19,6 +19,7 @@ export component LineEdit {
         text = v;
         edited(v);
     }
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     vertical-stretch: 0;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -91,6 +91,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
+    accessible-action-set-selection(anchor, focus) => { text-input.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         text-input.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -15,6 +15,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     vertical-stretch: 0;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -37,6 +37,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -16,6 +16,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     min-width: max(120px, layout.min-width);
     min-height: max(56px, layout.min-height);

--- a/internal/compiler/widgets/material/textedit.slint
+++ b/internal/compiler/widgets/material/textedit.slint
@@ -37,6 +37,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -14,6 +14,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
+    accessible-action-set-selection(anchor, focus) => { inner.set-selection-offsets(anchor, focus); }
 
     forward-focus: inner;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -36,6 +36,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
+    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -51,6 +51,12 @@ pub enum AccessibilityAction {
     /// This is currently unused
     ReplaceSelectedText(SharedString),
     SetValue(SharedString),
+    /// Select the text between two UTF-8 offsets: `anchor` is the end that stays put, `focus` the
+    /// end being moved.
+    SetSelection {
+        anchor: i32,
+        focus: i32,
+    },
 }
 
 bitflags! {
@@ -64,6 +70,7 @@ bitflags! {
         const Expand = 1 << 3;
         const ReplaceSelectedText = 1 << 4;
         const SetValue = 1 << 5;
+        const SetSelection = 1 << 6;
     }
 }
 

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -51,8 +51,8 @@ pub enum AccessibilityAction {
     /// This is currently unused
     ReplaceSelectedText(SharedString),
     SetValue(SharedString),
-    /// Select the text between two UTF-8 offsets: `anchor` is the end that stays put, `focus` the
-    /// end being moved.
+    /// Select the text between two UTF-8 offsets into the element's text: `anchor` is the end that
+    /// stays put, `focus` the end being moved.
     SetSelection {
         anchor: i32,
         focus: i32,

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2570,6 +2570,10 @@ extern "C" fn accessibility_action(
         AccessibilityAction::SetValue(a) => {
             perform("accessible-action-set-value", &[Value::String(a.clone())])
         }
+        AccessibilityAction::SetSelection { anchor, focus } => perform(
+            "accessible-action-set-selection",
+            &[Value::Number(*anchor as f64), Value::Number(*focus as f64)],
+        ),
     };
 }
 

--- a/tests/cases/accessibility/set_selection.slint
+++ b/tests/cases/accessibility/set_selection.slint
@@ -13,9 +13,6 @@ export component TestCase inherits Window {
 
     ti := TextInput {
         text: "Hello World";
-        accessible-action-set-selection(anchor, focus) => {
-            ti.set-selection-offsets(anchor, focus);
-        }
     }
 }
 

--- a/tests/cases/accessibility/set_selection.slint
+++ b/tests/cases/accessibility/set_selection.slint
@@ -1,0 +1,65 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
+export component TestCase inherits Window {
+    width: 400px;
+    height: 400px;
+
+    out property <int> anchor: ti.anchor-position-byte-offset;
+    out property <int> cursor: ti.cursor-position-byte-offset;
+
+    ti := TextInput {
+        text: "Hello World";
+        accessible-action-set-selection(anchor, focus) => {
+            ti.set-selection-offsets(anchor, focus);
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+let text_input =
+    slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::ti").next().unwrap();
+
+text_input.set_accessible_selection(2, 7);
+assert_eq!(instance.get_anchor(), 2);
+assert_eq!(instance.get_cursor(), 7);
+
+// A backwards selection keeps the focus before the anchor.
+text_input.set_accessible_selection(9, 4);
+assert_eq!(instance.get_anchor(), 9);
+assert_eq!(instance.get_cursor(), 4);
+
+// Equal offsets move the cursor without selecting anything.
+text_input.set_accessible_selection(5, 5);
+assert_eq!(instance.get_anchor(), 5);
+assert_eq!(instance.get_cursor(), 5);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+auto search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::ti");
+assert_eq(search.size(), 1);
+auto text_input = search[0];
+
+text_input.set_accessible_selection(2, 7);
+assert_eq(instance.get_anchor(), 2);
+assert_eq(instance.get_cursor(), 7);
+
+// A backwards selection keeps the focus before the anchor.
+text_input.set_accessible_selection(9, 4);
+assert_eq(instance.get_anchor(), 9);
+assert_eq(instance.get_cursor(), 4);
+
+// Equal offsets move the cursor without selecting anything.
+text_input.set_accessible_selection(5, 5);
+assert_eq(instance.get_anchor(), 5);
+assert_eq(instance.get_cursor(), 5);
+```
+*/


### PR DESCRIPTION
Part of #2895

There are quite a few changes needed and this isn't really linked to the rest so I'm sending this independently to easy code review.