### PR TITLE
ci: don't rely on the runner providing npm in the musl containers

### DIFF
--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -108,13 +108,15 @@ jobs:
               with:
                   target: ${{ matrix.rust-target }}
                   key: ${{ matrix.rust-target }}
-            - uses: pnpm/action-setup@v6.0.9
             # Setup .npmrc file to publish to npm
+            # node before pnpm: the musl containers ship no node/npm, and the
+            # pnpm self-installer needs npm.
             - uses: actions/setup-node@v7
               with:
                   node-version: "24"
                   registry-url: "https://registry.npmjs.org"
                   package-manager-cache: false
+            - uses: pnpm/action-setup@v6.0.9
             - name: Set version
               working-directory: api/node
               shell: bash


### PR DESCRIPTION
The musl cross containers install no Node.js, so the npm that pnpm/action-setup's self-installer spawns came from the runner's own externals bundle mounted at /__e. A GitHub-side runner change took it away: within one run, musl jobs on actions-runner/cached/<version>/externals still install pnpm, while those on actions-runner/extracted/externals fail with "spawn npm ENOENT".

Run actions/setup-node first so npm comes from the Node we install ourselves.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
