### PR TITLE
compiler: call to_apply only for flexbox layout

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -474,7 +474,7 @@ pub(super) fn solve_flexbox_layout(
                     } else {
                         None
                     };
-                    let v_info = get_layout_info(
+                    let v_info = get_flex_cell_layout_info(
                         elem,
                         ctx,
                         &li.item.constraints,
@@ -490,7 +490,7 @@ pub(super) fn solve_flexbox_layout(
                                 )
                             },
                         );
-                    let h_info = get_layout_info(
+                    let h_info = get_flex_cell_layout_info(
                         elem,
                         ctx,
                         &li.item.constraints,
@@ -542,7 +542,7 @@ fn measure_cells_for(
                     ty: Type::LogicalLength,
                 }
             });
-            let v_info = get_layout_info(
+            let v_info = get_flex_cell_layout_info(
                 elem,
                 ctx,
                 &li.item.constraints,
@@ -556,7 +556,7 @@ fn measure_cells_for(
                         ty: Type::LogicalLength,
                     }
                 });
-            let h_info = get_layout_info(
+            let h_info = get_flex_cell_layout_info(
                 elem,
                 ctx,
                 &li.item.constraints,
@@ -929,7 +929,7 @@ fn flexbox_layout_data(
                 .iter()
                 .map(|li| {
                     let constraint = cell_h_constraint(&li.item.element);
-                    let layout_info_h = get_layout_info(
+                    let layout_info_h = get_flex_cell_layout_info(
                         &li.item.element,
                         ctx,
                         &li.item.constraints,
@@ -953,7 +953,7 @@ fn flexbox_layout_data(
                 .iter()
                 .map(|li| {
                     let constraint = cell_v_constraint(&li.item.element);
-                    let layout_info_v = get_layout_info(
+                    let layout_info_v = get_flex_cell_layout_info(
                         &li.item.element,
                         ctx,
                         &li.item.constraints,
@@ -997,7 +997,7 @@ fn flexbox_layout_data(
             } else {
                 // For static elements, we need both orientations
                 let h_constraint = cell_h_constraint(&item.item.element);
-                let layout_info_h = get_layout_info(
+                let layout_info_h = get_flex_cell_layout_info(
                     &item.item.element,
                     ctx,
                     &item.item.constraints,
@@ -1005,7 +1005,7 @@ fn flexbox_layout_data(
                     h_constraint,
                 );
                 let constraint = cell_v_constraint(&item.item.element);
-                let layout_info_v = get_layout_info(
+                let layout_info_v = get_flex_cell_layout_info(
                     &item.item.element,
                     ctx,
                     &item.item.constraints,
@@ -1744,6 +1744,27 @@ fn layout_geometry_size(
     }
 }
 
+/// A flex cell's `LayoutInfo`: same as [`get_layout_info`] but keeps only the
+/// cell's *locally-set* constraints on top of the measured layout-info. An
+/// inherited intrinsic min/max/preferred is already included in `layout_info`
+/// (via the parametrized `layoutinfo-{h,v}-with-constraint`), and re-reading it
+/// unconstrained would reintroduce a height-for-width loop through the flex
+/// solve. Only flex callers need this: box/grid measure the cell without the
+/// cross-axis being under solve, so re-applying inherited constraints there
+/// doesn't cycle — and it's necessary, because those inherited constraints
+/// aren't merged into the layout-info of a cell with a fixed size binding
+/// (see `default_geometry::gen_layout_info_prop`).
+pub fn get_flex_cell_layout_info(
+    elem: &ElementRc,
+    ctx: &mut ExpressionLoweringCtx,
+    constraints: &crate::layout::LayoutConstraints,
+    orientation: Orientation,
+    constraint: Option<crate::expression_tree::Expression>,
+) -> llr_Expression {
+    let effective = constraints.to_apply(elem, orientation);
+    get_layout_info(elem, ctx, &effective, orientation, constraint)
+}
+
 pub fn get_layout_info(
     elem: &ElementRc,
     ctx: &mut ExpressionLoweringCtx,
@@ -1781,11 +1802,6 @@ pub fn get_layout_info(
         )
     };
 
-    // Apply only the cell's locally-set constraints on top of the measured
-    // layout-info: an inherited intrinsic min/max/preferred is already included
-    // in `layout_info`, and re-reading it unconstrained would reintroduce a
-    // height-for-width loop through the layout solve.
-    let constraints = constraints.to_apply(elem, orientation);
     if constraints.has_explicit_restrictions(orientation) {
         let store = llr_Expression::StoreLocalVariable {
             name: "layout_info".into(),
@@ -1981,7 +1997,13 @@ pub fn get_layout_info_v_constrained_for_repeated(
             crate::expression_tree::Unit::Px,
         )
     });
-    Some(get_layout_info(element, ctx, constraints, Orientation::Vertical, Some(width_constraint)))
+    Some(get_flex_cell_layout_info(
+        element,
+        ctx,
+        constraints,
+        Orientation::Vertical,
+        Some(width_constraint),
+    ))
 }
 
 /// Name of the local that carries the cross-axis (container) width into the
@@ -2006,7 +2028,13 @@ pub fn get_layout_info_v_at_cross_width_for_repeated(
         name: FLEX_CROSS_WIDTH_LOCAL.into(),
         ty: Type::LogicalLength,
     };
-    Some(get_layout_info(element, ctx, constraints, Orientation::Vertical, Some(width_constraint)))
+    Some(get_flex_cell_layout_info(
+        element,
+        ctx,
+        constraints,
+        Orientation::Vertical,
+        Some(width_constraint),
+    ))
 }
 
 /// Horizontal `LayoutInfo` for a repeated element, computed with an unbounded
@@ -2029,7 +2057,7 @@ pub fn get_layout_info_h_constrained_for_repeated(
         f32::MAX as f64,
         crate::expression_tree::Unit::Px,
     );
-    Some(get_layout_info(
+    Some(get_flex_cell_layout_info(
         element,
         ctx,
         constraints,
@@ -2058,7 +2086,7 @@ pub fn get_layout_info_h_at_cross_height_for_repeated(
         name: FLEX_CROSS_HEIGHT_LOCAL.into(),
         ty: Type::LogicalLength,
     };
-    Some(get_layout_info(
+    Some(get_flex_cell_layout_info(
         element,
         ctx,
         constraints,

--- a/tests/cases/layout/box_layout_height_from_width_cell.slint
+++ b/tests/cases/layout/box_layout_height_from_width_cell.slint
@@ -1,0 +1,77 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test: a subcomponent whose base carries `height: self.width` (and
+// whose subtree contains a height-for-width descendant, so
+// `layoutinfo-v-with-constraint` is synthesized on it) must still have that
+// height constraint applied when placed as a cell in a plain VerticalLayout.
+//
+// Commit 5e122db stripped the cell's inherited `height` restriction unconditionally
+// in the LLR lowering (mirroring the interpreter's flex-only fix). Box layouts,
+// unlike flex, don't bake the height binding into the measured layout-info, so
+// the cross-axis-derived height was dropped and cells collapsed to zero on the
+// codegen backends (rust/cpp). The interpreter kept working because its fix was
+// scoped to the flex code path.
+//
+// The Text with `wrap: word-wrap` is only there to trigger the synthesis of
+// `layoutinfo-v-with-constraint` on Card (via `is_builtin_height_for_width`);
+// the assertion checks the enclosing cell's height, which is font-independent.
+
+component Card inherits Rectangle {
+    height: self.width;
+    // A height-for-width descendant, so the compiler synthesizes
+    // `layoutinfo-v-with-constraint` on Card.
+    Text { wrap: word-wrap; text: "x"; color: black; }
+}
+
+export component TestCase inherits Window {
+    width: 45px;
+    height: 300px;
+
+    VerticalLayout {
+        alignment: start;
+        b1 := Card { background: red; }
+        b2 := Card { background: green; }
+        b3 := Card { background: blue; }
+    }
+
+    out property <bool> h1_ok: b1.height == 45px;
+    out property <bool> h2_ok: b2.height == 45px;
+    out property <bool> h3_ok: b3.height == 45px;
+    out property <bool> stacked_ok:
+        b1.y == 0px && b2.y == 45px && b3.y == 90px;
+
+    out property <bool> test: h1_ok && h2_ok && h3_ok && stacked_ok;
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_h1_ok(), "b1 height wrong");
+assert!(instance.get_h2_ok(), "b2 height wrong");
+assert!(instance.get_h3_ok(), "b3 height wrong");
+assert!(instance.get_stacked_ok(), "cells not stacked at y=0,45,90");
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_h1_ok());
+assert(instance.get_h2_ok());
+assert(instance.get_h3_ok());
+assert(instance.get_stacked_ok());
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.h1_ok);
+assert(instance.h2_ok);
+assert(instance.h3_ok);
+assert(instance.stacked_ok);
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
Commit 5e122db put `constraints.to_apply(elem, orientation)` inside the shared `get_layout_info` helper — mirroring the interpreter's flex-only fix from 762e3674d, but through a helper used by every layout kind. Box and grid cells lost inherited height/width restrictions when the base carries a fixed size binding (default_geometry deliberately does not merge those into the cell's own `layoutinfo-*` to avoid a cycle), collapsing e.g. a `Card { height: self.width }` inside a VerticalLayout to zero height on rust/cpp. The interpreter kept working because its to_apply lives entirely in `eval_flexbox_layout`.

Move the filter into a `get_flex_cell_layout_info` wrapper used only at the flex call sites, restoring the pre-5e122db behaviour for box/grid. Add a rust/cpp/interpreter regression test.

Fixes: #12745

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
