### PR TITLE
compiler: generate the accessibility actions without special cases

### DIFF
--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -651,7 +651,7 @@ impl ElementHandle {
             return;
         }
         if let Some(item) = self.item.upgrade() {
-            item.accessible_action(&AccessibilityAction::SetSelection { anchor, focus })
+            item.accessible_action(&AccessibilityAction::SetSelection(anchor, focus))
         }
     }
 

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -521,6 +521,24 @@ pub fn to_kebab_case(str: &str) -> String {
     String::from_utf8(result).unwrap()
 }
 
+/// The number of arguments taken by the accessibility action of the given name, where the name
+/// is the `AccessibilityAction` variant in pascal case (such as `SetSelection`).
+///
+/// The `AccessibilityAction` enum of the run-time library mirrors the `accessible-action-*`
+/// callbacks declared in the type register: a variant has one field per callback argument, so
+/// that the generators can bind the fields without knowing about any particular action.
+pub fn accessibility_action_argument_count(action: &str) -> usize {
+    let property_name = format!("accessible-action-{}", to_kebab_case(action));
+    crate::typeregister::reserved_accessibility_properties()
+        .find_map(|(name, ty)| match ty {
+            crate::langtype::Type::Callback(function) if name == property_name => {
+                Some(function.args.len())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("Unknown accessibility action {action}"))
+}
+
 #[test]
 fn case_conversions() {
     assert_eq!(to_kebab_case("HelloWorld"), "hello-world");

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2738,7 +2738,7 @@ fn generate_sub_component(
             } else {
                 let member = ident(&crate::generator::to_kebab_case(what));
                 let args = (0..arg_count)
-                    .map(|i| format!("auto arg_{i} = action.{member}._{i}; "))
+                    .map(|i| format!("[[maybe_unused]] auto arg_{i} = action.{member}._{i}; "))
                     .join("");
                 format!("{label} {{ {args}return {e}; }}")
             });

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2729,28 +2729,19 @@ fn generate_sub_component(
         if what == "Role" {
             accessible_role_cases.push(format!("    case {index}: return {e};"));
         } else if let Some(what) = what.strip_prefix("Action") {
-            let case = match what {
-                "SetSelection" => {
-                    let member = ident(&crate::generator::to_kebab_case(what));
-                    format!(
-                        "    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): {{ auto arg_0 = action.{member}.anchor; auto arg_1 = action.{member}.focus; return {e}; }}"
-                    )
-                }
-                _ => {
-                    let has_args = matches!(&*expr.borrow(), llr::Expression::CallBackCall { arguments, .. } if !arguments.is_empty());
-                    if has_args {
-                        let member = ident(&crate::generator::to_kebab_case(what));
-                        format!(
-                            "    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): {{ auto arg_0 = action.{member}._0; return {e}; }}"
-                        )
-                    } else {
-                        format!(
-                            "    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}): return {e};"
-                        )
-                    }
-                }
-            };
-            accessibility_action_cases.push(case);
+            let label = format!(
+                "    case ({index} << 8) | uintptr_t(slint::cbindgen_private::AccessibilityAction::Tag::{what}):"
+            );
+            let arg_count = crate::generator::accessibility_action_argument_count(what);
+            accessibility_action_cases.push(if arg_count == 0 {
+                format!("{label} return {e};")
+            } else {
+                let member = ident(&crate::generator::to_kebab_case(what));
+                let args = (0..arg_count)
+                    .map(|i| format!("auto arg_{i} = action.{member}._{i}; "))
+                    .join("");
+                format!("{label} {{ {args}return {e}; }}")
+            });
             supported_accessibility_actions
                 .entry(*index)
                 .or_default()

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1480,26 +1480,16 @@ fn generate_sub_component(
         let e = compile_expression(&expr.borrow(), &ctx);
         if what == "Role" {
             accessible_role_branch.push(quote!(#index => #e,));
-        } else if let Some(what_str) = what.strip_prefix("Action") {
-            let what_ident = ident(what_str);
-            let branch = match what_str {
-                "SetSelection" => quote!(
-                    (#index, sp::AccessibilityAction::SetSelection { anchor, focus }) => {
-                        let args = (anchor, focus);
-                        #e
-                    }
-                ),
-                _ => {
-                    let has_args = matches!(&*expr.borrow(), Expression::CallBackCall { arguments, .. } if !arguments.is_empty());
-                    if has_args {
-                        quote!((#index, sp::AccessibilityAction::#what_ident(args)) => { let args = (args,); #e })
-                    } else {
-                        quote!((#index, sp::AccessibilityAction::#what_ident) => { #e })
-                    }
-                }
-            };
-            accessibility_action_branch.push(branch);
-            supported_accessibility_actions.entry(*index).or_default().insert(what_ident);
+        } else if let Some(what) = what.strip_prefix("Action") {
+            let arg_count = crate::generator::accessibility_action_argument_count(what);
+            let what = ident(what);
+            accessibility_action_branch.push(if arg_count == 0 {
+                quote!((#index, sp::AccessibilityAction::#what) => { #e })
+            } else {
+                let arg = (0..arg_count).map(|i| format_ident!("arg_{i}")).collect::<Vec<_>>();
+                quote!((#index, sp::AccessibilityAction::#what(#(#arg),*)) => { let args = (#(#arg,)*); #e })
+            });
+            supported_accessibility_actions.entry(*index).or_default().insert(what);
         } else {
             let what = ident(what);
             accessible_string_property_branch

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1487,7 +1487,7 @@ fn generate_sub_component(
                 quote!((#index, sp::AccessibilityAction::#what) => { #e })
             } else {
                 let arg = (0..arg_count).map(|i| format_ident!("arg_{i}")).collect::<Vec<_>>();
-                quote!((#index, sp::AccessibilityAction::#what(#(#arg),*)) => { let args = (#(#arg,)*); #e })
+                quote!((#index, sp::AccessibilityAction::#what(#(#arg),*)) => { #[allow(unused_variables)] let args = (#(#arg,)*); #e })
             });
             supported_accessibility_actions.entry(*index).or_default().insert(what);
         } else {

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -41,6 +41,11 @@ pub enum AccessibleStringProperty {
 }
 
 /// The argument of an accessible action.
+///
+/// Every variant mirrors one of the `accessible-action-*` callbacks declared in the compiler's
+/// type register, with one (unnamed) field per callback argument. The generated code relies on
+/// that: it binds the fields positionally, so a new action only needs to be added here and in
+/// the type register.
 #[repr(u32)]
 #[derive(PartialEq, Clone)]
 pub enum AccessibilityAction {
@@ -51,12 +56,9 @@ pub enum AccessibilityAction {
     /// This is currently unused
     ReplaceSelectedText(SharedString),
     SetValue(SharedString),
-    /// Select the text between two UTF-8 offsets into the element's text: `anchor` is the end that
-    /// stays put, `focus` the end being moved.
-    SetSelection {
-        anchor: i32,
-        focus: i32,
-    },
+    /// Select the text between two UTF-8 offsets into the element's text: the first offset is the
+    /// anchor, the end that stays put, the second one the focus, the end being moved.
+    SetSelection(i32, i32),
 }
 
 bitflags! {

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -2570,7 +2570,7 @@ extern "C" fn accessibility_action(
         AccessibilityAction::SetValue(a) => {
             perform("accessible-action-set-value", &[Value::String(a.clone())])
         }
-        AccessibilityAction::SetSelection { anchor, focus } => perform(
+        AccessibilityAction::SetSelection(anchor, focus) => perform(
             "accessible-action-set-selection",
             &[Value::Number(*anchor as f64), Value::Number(*focus as f64)],
         ),


### PR DESCRIPTION
Make `AccessibilityAction::SetSelection` a tuple variant like the other actions with arguments, and take the argument count from the callback declared in the type register rather than from the lowered expression, which can only tell no argument from one. Both generators now bind the fields positionally in a loop.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
