### PR TITLE
Expose the content of text inputs to assistive technologies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,6 +3454,7 @@ dependencies = [
 name = "i-slint-core"
 version = "1.18.0"
 dependencies = [
+ "accesskit",
  "async-channel",
  "async-compat",
  "auto_enums",
@@ -5709,6 +5710,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
 dependencies = [
+ "accesskit",
  "fontique",
  "harfrust",
  "hashbrown 0.17.1",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2544,6 +2544,7 @@ dependencies = [
 name = "i-slint-core"
 version = "1.18.0"
 dependencies = [
+ "accesskit",
  "async-channel 2.5.0",
  "auto_enums",
  "bitflags 2.13.1",
@@ -4221,6 +4222,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
 dependencies = [
+ "accesskit",
  "fontique",
  "harfrust",
  "hashbrown 0.17.1",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6125,6 +6125,7 @@ dependencies = [
 name = "i-slint-core"
 version = "1.18.0"
 dependencies = [
+ "accesskit",
  "async-channel",
  "auto_enums",
  "bitflags 2.13.1",
@@ -9022,6 +9023,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
 dependencies = [
+ "accesskit",
  "fontique 0.11.0",
  "harfrust 0.10.0",
  "hashbrown 0.17.1",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -55,7 +55,7 @@ renderer-software = [
   "i-slint-renderer-software/std",
   "dep:bytemuck",
 ]
-accessibility = ["dep:accesskit", "dep:accesskit_winit"]
+accessibility = ["dep:accesskit", "dep:accesskit_winit", "i-slint-core/accessibility-text"]
 raw-window-handle-06 = ["i-slint-core/raw-window-handle-06"]
 unstable-wgpu-29 = ["i-slint-core/unstable-wgpu-29", "i-slint-renderer-skia?/unstable-wgpu-29"]
 unstable-wgpu-30 = [

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -12,6 +12,7 @@ use accesskit::{
 use i_slint_core::SharedString;
 use i_slint_core::accessibility::{
     AccessibilityAction, AccessibleStringProperty, SupportedAccessibilityAction,
+    find_text_input_with_rc,
 };
 use i_slint_core::api::Window;
 use i_slint_core::input::FocusReason;
@@ -176,13 +177,16 @@ impl AccessKitAdapter {
                 };
                 // A TextPosition names a TextRun sub-NodeId, so decode it back to the wrapper.
                 let (wrapper_parent, _) = decode_sub_node_id(sel.focus.node)?;
+                if wrapper_parent != request.target_node {
+                    return None;
+                }
                 let wrapper_item = self.nodes.item_rc_for_node_id(wrapper_parent)?;
                 let window_adapter = self.window_adapter_weak.upgrade()?;
-                let mut state = self
+                let (inner_item_rc, text_input) = find_text_input_with_rc(&wrapper_item)?;
+                let state = self
                     .nodes
                     .text_state
-                    .get_or_update_cache_entry_ref(&wrapper_item, Default::default);
-                let (inner_item_rc, text_input) = state.text_input(&wrapper_item)?;
+                    .get_or_update_cache_entry_ref(&inner_item_rc, Default::default);
                 let (anchor, focus) = state.decode_selection(
                     window_adapter.renderer().as_core_renderer(),
                     text_input.as_pin_ref(),
@@ -382,10 +386,9 @@ struct NodeCollection {
     all_nodes: Vec<CachedNode>,
     root_node_id: NodeId,
     focused_node_tracker: Pin<Box<PropertyTracker<false, DelegateFocusPropertyTracker>>>,
-    /// Emission state per `TextInput`, keyed by the wrapper widget's `ItemRc`. Its per-entry
-    /// property tracker stays empty on purpose: the state has to outlive the edits it describes,
-    /// so that NodeIds stay stable and screen readers see "node updated" rather than "subtree
-    /// replaced".
+    /// Emission state, keyed by the inner `TextInput`'s `ItemRc`. Its per-entry property tracker
+    /// stays empty on purpose: the state has to outlive the edits it describes, so that NodeIds
+    /// stay stable and screen readers see "node updated" rather than "subtree replaced".
     text_state: i_slint_core::item_rendering::ItemCache<
         i_slint_core::textlayout::sharedparley::CachedTextInputAccessibilityState,
     >,
@@ -557,10 +560,11 @@ impl NodeCollection {
         if !is_text_input_role(wrapper_node.role()) {
             return;
         }
-        let mut state = self.text_state.get_or_update_cache_entry_ref(item, Default::default);
-        let Some((inner_item_rc, text_input)) = state.text_input(item) else {
+        let Some((inner_item_rc, text_input)) = find_text_input_with_rc(item) else {
             return;
         };
+        let mut state =
+            self.text_state.get_or_update_cache_entry_ref(&inner_item_rc, Default::default);
 
         // The inner `TextInput`'s geometry: a `LineEdit` insets it for its border, so measuring
         // from the wrapper's origin would place every TextRun off by the padding.

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -77,6 +77,7 @@ impl AccessKitAdapter {
                         window_adapter_weak: window_adapter_weak.clone(),
                     },
                 )),
+                text_state: Default::default(),
             },
             global_property_tracker: Box::pin(PropertyTracker::new_with_dirty_handler(
                 AccessibilityPropertyDirtyHandler {
@@ -118,6 +119,7 @@ impl AccessKitAdapter {
             accesskit_winit::WindowEvent::ActionRequested(r) => self.handle_request(r),
             accesskit_winit::WindowEvent::AccessibilityDeactivated => {
                 self.initial_tree_sent = false;
+                self.nodes.text_state.clear_all();
                 None
             }
         }
@@ -167,6 +169,30 @@ impl AccessKitAdapter {
                 _ => return None,
             },
             Action::Expand => AccessibilityAction::Expand,
+            Action::SetTextSelection => {
+                let Some(accesskit::ActionData::SetTextSelection(sel)) = request.data.as_ref()
+                else {
+                    return None;
+                };
+                // A TextPosition names a TextRun sub-NodeId, so decode it back to the wrapper.
+                let (wrapper_parent, _) = decode_sub_node_id(sel.focus.node)?;
+                let wrapper_item = self.nodes.item_rc_for_node_id(wrapper_parent)?;
+                let window_adapter = self.window_adapter_weak.upgrade()?;
+                let mut state = self
+                    .nodes
+                    .text_state
+                    .get_or_update_cache_entry_ref(&wrapper_item, Default::default);
+                let (inner_item_rc, text_input) = state.text_input(&wrapper_item)?;
+                let (anchor, focus) = state.decode_selection(
+                    window_adapter.renderer().as_core_renderer(),
+                    text_input.as_pin_ref(),
+                    &inner_item_rc,
+                    inner_item_rc.geometry().size,
+                    &sel.anchor,
+                    &sel.focus,
+                )?;
+                AccessibilityAction::SetSelection(anchor as i32, focus as i32)
+            }
             _ => return None,
         };
         self.nodes
@@ -196,6 +222,7 @@ impl AccessKitAdapter {
             self.nodes.components_by_id.remove(&component_id);
             self.nodes.free_component_ids.push(component_id);
         }
+        self.nodes.text_state.component_destroyed(component);
         self.reload_tree();
     }
 
@@ -222,25 +249,50 @@ impl AccessKitAdapter {
 
         self.inner.update_if_active(|| {
             self.global_property_tracker.as_ref().evaluate_as_dependency_root(|| {
-                let nodes = self.nodes.all_nodes.iter().filter_map(|cached_node| {
-                    cached_node.tracker.as_ref().evaluate_if_dirty(|| {
-                        let scale_factor = ScaleFactor::new(window.scale_factor());
-                        let item = self.nodes.item_rc_for_node_id(cached_node.id)?;
+                let nodes_vec: Vec<(NodeId, Node)> = self
+                    .nodes
+                    .all_nodes
+                    .iter()
+                    .flat_map(|cached_node| {
+                        cached_node
+                            .tracker
+                            .as_ref()
+                            .evaluate_if_dirty(|| {
+                                let scale_factor = ScaleFactor::new(window.scale_factor());
+                                let Some(item) = self.nodes.item_rc_for_node_id(cached_node.id)
+                                else {
+                                    return Vec::new();
+                                };
 
-                        let mut node = self.nodes.build_node_without_children(
-                            &item,
-                            scale_factor,
-                            Default::default(),
-                        );
+                                let mut node = self.nodes.build_node_without_children(
+                                    &item,
+                                    scale_factor,
+                                    Default::default(),
+                                );
+                                node.set_children(cached_node.children.clone());
 
-                        node.set_children(cached_node.children.clone());
+                                let mut emitted: Vec<(NodeId, Node)> = Vec::new();
+                                self.nodes.try_emit_text_input_accessibility(
+                                    &item,
+                                    &mut node,
+                                    cached_node.id,
+                                    scale_factor,
+                                    Default::default(),
+                                    &mut emitted,
+                                    &window_adapter,
+                                );
 
-                        Some((cached_node.id, node))
-                    })?
-                });
+                                let mut out = Vec::with_capacity(1 + emitted.len());
+                                out.push((cached_node.id, node));
+                                out.extend(emitted);
+                                out
+                            })
+                            .unwrap_or_default()
+                    })
+                    .collect();
 
                 TreeUpdate {
-                    nodes: nodes.collect(),
+                    nodes: nodes_vec,
                     tree: None,
                     tree_id: TreeId::ROOT,
                     focus: self.nodes.focus_node(&self.window_adapter_weak),
@@ -277,7 +329,39 @@ fn accessible_parent_for_item_rc(mut item: ItemRc) -> ItemRc {
 
 const NODE_ID_INDEX_BITS: u32 = 16;
 const NODE_ID_INDEX_MASK: u64 = (1 << NODE_ID_INDEX_BITS) - 1; // 0xFFFF
-const NODE_ID_COMPONENT_MASK: u64 = (1 << 22) - 1; // 0x3FFFFF
+const NODE_ID_COMPONENT_BITS: u32 = 22;
+const NODE_ID_COMPONENT_MASK: u64 = (1 << NODE_ID_COMPONENT_BITS) - 1; // 0x3FFFFF
+
+// NodeIds for the TextRun children of a text input:
+//
+//   bits 38..=63 : sub-index, allocated per parent, never 0
+//   bits 0..=37  : the parent NodeId, which `encode_item_node_id` fits in exactly these bits
+//
+// A regular NodeId leaves the sub-index bits clear, so a non-zero sub-index is what tells the two
+// apart.
+const NODE_ID_PARENT_BITS: u32 = NODE_ID_INDEX_BITS + NODE_ID_COMPONENT_BITS;
+const NODE_ID_PARENT_MASK: u64 = (1u64 << NODE_ID_PARENT_BITS) - 1;
+const NODE_ID_SUB_INDEX_BITS: u32 = u64::BITS - NODE_ID_PARENT_BITS;
+const NODE_ID_SUB_INDEX_MASK: u64 = (1u64 << NODE_ID_SUB_INDEX_BITS) - 1;
+
+fn encode_sub_node_id(parent: NodeId, sub_index: u32) -> NodeId {
+    debug_assert!(sub_index >= 1, "sub_index 0 would collide with the parent NodeId");
+    debug_assert!(
+        (sub_index as u64) <= NODE_ID_SUB_INDEX_MASK,
+        "sub_index exceeds {NODE_ID_SUB_INDEX_BITS} bits"
+    );
+    debug_assert_eq!(
+        parent.0 & !NODE_ID_PARENT_MASK,
+        0,
+        "parent NodeId occupies more than {NODE_ID_PARENT_BITS} bits"
+    );
+    NodeId(((sub_index as u64) << NODE_ID_PARENT_BITS) | (parent.0 & NODE_ID_PARENT_MASK))
+}
+
+fn decode_sub_node_id(id: NodeId) -> Option<(NodeId, u32)> {
+    let sub_index = (id.0 >> NODE_ID_PARENT_BITS) as u32;
+    (sub_index != 0).then_some((NodeId(id.0 & NODE_ID_PARENT_MASK), sub_index))
+}
 
 fn is_text_input_role(role: Role) -> bool {
     matches!(
@@ -298,6 +382,13 @@ struct NodeCollection {
     all_nodes: Vec<CachedNode>,
     root_node_id: NodeId,
     focused_node_tracker: Pin<Box<PropertyTracker<false, DelegateFocusPropertyTracker>>>,
+    /// Emission state per `TextInput`, keyed by the wrapper widget's `ItemRc`. Its per-entry
+    /// property tracker stays empty on purpose: the state has to outlive the edits it describes,
+    /// so that NodeIds stay stable and screen readers see "node updated" rather than "subtree
+    /// replaced".
+    text_state: i_slint_core::item_rendering::ItemCache<
+        i_slint_core::textlayout::sharedparley::CachedTextInputAccessibilityState,
+    >,
 }
 
 impl NodeCollection {
@@ -368,6 +459,10 @@ impl NodeCollection {
             }
         };
 
+        debug_assert!(
+            (component_id as u64) <= NODE_ID_COMPONENT_MASK,
+            "component_id exceeds {NODE_ID_COMPONENT_BITS} bits"
+        );
         let index = item.index();
         NodeId((component_id as u64) << NODE_ID_INDEX_BITS | (index as u64 & NODE_ID_INDEX_MASK))
     }
@@ -379,13 +474,8 @@ impl NodeCollection {
         popups: &[AccessiblePopup],
         scale_factor: ScaleFactor,
         window_position: LogicalPoint,
+        window_adapter: &std::rc::Rc<WinitWindowAdapter>,
     ) -> NodeId {
-        let tracker = Box::pin(PropertyTracker::default());
-
-        let mut node = tracker
-            .as_ref()
-            .evaluate(|| self.build_node_without_children(&item, scale_factor, window_position));
-
         let id = self.encode_item_node_id(&item);
 
         let popup_children = popups
@@ -402,11 +492,12 @@ impl NodeCollection {
                     popups,
                     scale_factor,
                     popup.location,
+                    window_adapter,
                 ))
             })
             .collect::<Vec<_>>();
 
-        let children = i_slint_core::accessibility::accessible_descendents(&item)
+        let descendant_children = i_slint_core::accessibility::accessible_descendents(&item)
             .map(|child| {
                 self.build_node_for_item_recursively(
                     child,
@@ -414,18 +505,95 @@ impl NodeCollection {
                     popups,
                     scale_factor,
                     window_position,
+                    window_adapter,
                 )
             })
             .chain(popup_children)
             .collect::<Vec<NodeId>>();
 
-        node.set_children(children.clone());
+        let tracker = Box::pin(PropertyTracker::default());
+        // One tracker for both the wrapper attributes and the text emission, so that either
+        // going dirty rebuilds the node.
+        let (node, text_run_nodes) = {
+            let mut text_run_nodes: Vec<(NodeId, Node)> = Vec::new();
+            let node = tracker.as_ref().evaluate(|| {
+                let mut n = self.build_node_without_children(&item, scale_factor, window_position);
+                n.set_children(descendant_children.clone());
+                self.try_emit_text_input_accessibility(
+                    &item,
+                    &mut n,
+                    id,
+                    scale_factor,
+                    window_position,
+                    &mut text_run_nodes,
+                    window_adapter,
+                );
+                n
+            });
+            (node, text_run_nodes)
+        };
 
-        self.all_nodes.push(CachedNode { id, children, tracker });
+        // Only the regular descendants: every emit pushes the TextRun children again, and
+        // `accesskit_consumer` rejects a child that appears twice.
+        self.all_nodes.push(CachedNode { id, children: descendant_children, tracker });
 
         nodes.push((id, node));
+        nodes.extend(text_run_nodes);
 
         id
+    }
+
+    /// Emits the TextRun children of a text input, and the value and selection on `wrapper_node`.
+    fn try_emit_text_input_accessibility(
+        &self,
+        item: &ItemRc,
+        wrapper_node: &mut Node,
+        wrapper_id: NodeId,
+        scale_factor: ScaleFactor,
+        window_position: LogicalPoint,
+        text_run_nodes: &mut Vec<(NodeId, Node)>,
+        window_adapter: &std::rc::Rc<WinitWindowAdapter>,
+    ) {
+        if !is_text_input_role(wrapper_node.role()) {
+            return;
+        }
+        let mut state = self.text_state.get_or_update_cache_entry_ref(item, Default::default);
+        let Some((inner_item_rc, text_input)) = state.text_input(item) else {
+            return;
+        };
+
+        // The inner `TextInput`'s geometry: a `LineEdit` insets it for its border, so measuring
+        // from the wrapper's origin would place every TextRun off by the padding.
+        let inner_geometry = inner_item_rc.geometry();
+        let inner_absolute_origin =
+            inner_item_rc.map_to_window(inner_geometry.origin) + window_position.to_vector();
+        let physical_origin = (inner_absolute_origin * scale_factor).cast::<f64>();
+
+        let mut update =
+            TreeUpdate { nodes: Vec::new(), tree: None, tree_id: TreeId::ROOT, focus: NodeId(0) };
+
+        // Borrows the font context itself, so we must not be holding it here.
+        let emitted_runs = state.emit(
+            window_adapter.renderer().as_core_renderer(),
+            text_input.as_pin_ref(),
+            &inner_item_rc,
+            inner_geometry.size,
+            &mut update,
+            wrapper_node,
+            wrapper_id,
+            (physical_origin.x, physical_origin.y),
+            encode_sub_node_id,
+        );
+
+        if emitted_runs
+            && item
+                .supported_accessibility_actions()
+                .contains(SupportedAccessibilityAction::SetSelection)
+        {
+            wrapper_node.add_action(Action::SetTextSelection);
+        }
+
+        text_run_nodes.extend(update.nodes);
     }
 
     fn tree_info(&self, root: NodeId) -> Tree {
@@ -483,6 +651,7 @@ impl NodeCollection {
                 &popups,
                 ScaleFactor::new(window.scale_factor()),
                 Default::default(),
+                &window_adapter,
             )
         });
         self.root_node_id = root_id;

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -89,6 +89,8 @@ system-tray = ["dep:ksni", "dep:async-channel", "ksni/async-io", "ksni/blocking"
 
 shared-parley = ["shared-fontique", "dep:parley", "dep:skrifa", "dep:icu_normalizer"]
 
+accessibility-text = ["std", "shared-parley", "dep:accesskit", "parley?/accesskit"]
+
 shared-swash = ["dep:swash"]
 
 path = ["dep:auto_enums", "dep:lyon_path", "dep:lyon_geom", "dep:lyon_algorithms", "dep:lyon_extra"]
@@ -131,6 +133,7 @@ unicode-script = { version = "0.5.7", optional = true }
 icu_normalizer = { workspace = true, optional = true }
 sys-locale = { version = "0.3.2", optional = true, features = ["js"] }
 parley = { version = "0.11.0", optional = true, features = ["complex-scripts"] }
+accesskit = { version = "0.24", optional = true }
 
 image = { workspace = true, optional = true, default-features = false }
 clru = { workspace = true, optional = true }

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -124,15 +124,22 @@ pub fn accessible_descendents(root_item: &ItemRc) -> impl Iterator<Item = ItemRc
 
 /// Find the first built-in `TextInput` in `item` or its descendents.
 pub fn find_text_input(item: &ItemRc) -> Option<VRcMapped<ItemTreeVTable, TextInput>> {
+    find_text_input_with_rc(item).map(|(_, input)| input)
+}
+
+/// Same as [`find_text_input`], but also returns the `TextInput`'s `ItemRc`.
+pub fn find_text_input_with_rc(
+    item: &ItemRc,
+) -> Option<(ItemRc, VRcMapped<ItemTreeVTable, TextInput>)> {
     if let Some(input) = item.clone().downcast::<TextInput>() {
-        return Some(input);
+        return Some((item.clone(), input));
     }
 
     let mut child = item.first_child();
     while let Some(candidate) = child {
         child = candidate.next_sibling();
-        if let Some(input) = find_text_input(&candidate) {
-            return Some(input);
+        if let Some(found) = find_text_input_with_rc(&candidate) {
+            return Some(found);
         }
     }
     None

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1428,10 +1428,10 @@ pub struct TextInputVisualRepresentation {
 
 /// What the characters of a password field are displayed as. The same everywhere, so that
 /// measuring, hit-testing and drawing agree on the shaped text and can share it.
-const PASSWORD_CHARACTER: char = '\u{25cf}';
+pub(crate) const PASSWORD_CHARACTER: char = '\u{25cf}';
 
 /// Replaces every character of `text` with [`PASSWORD_CHARACTER`].
-fn mask_password(text: &str) -> SharedString {
+pub(crate) fn mask_password(text: &str) -> SharedString {
     core::iter::repeat_n(PASSWORD_CHARACTER, text.chars().count()).collect()
 }
 
@@ -2064,7 +2064,7 @@ impl TextInput {
     /// Deliberately reads less than [`Self::visual_representation`]: neither the cursor visibility
     /// nor the selection nor the colors, so that callers which only need the string -- sizing above
     /// all -- don't end up making the layout depend on the blinking cursor.
-    fn text_with_preedit(self: Pin<&Self>) -> (SharedString, core::ops::Range<usize>) {
+    pub(crate) fn text_with_preedit(self: Pin<&Self>) -> (SharedString, core::ops::Range<usize>) {
         let text = self.text();
         let preedit_text = self.preedit_text();
         if preedit_text.is_empty() {

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -229,27 +229,14 @@ pub trait RendererSealed {
         )
     }
 
-    /// Lays `text_input` out the way this renderer draws it and lends the result to `visitor`.
-    ///
-    /// Returns false if this renderer lays no text out through parley.
-    ///
-    /// The default implementation uses the shared parley text layout with [`Self::text_layout_cache`].
+    /// Whether this renderer lays `text_input`'s text out through parley.
     #[cfg(feature = "shared-parley")]
-    fn visit_text_input_layout(
+    fn text_input_has_parley_layout(
         &self,
-        text_input: Pin<&crate::items::TextInput>,
-        item_rc: &ItemRc,
-        size: LogicalSize,
-        visitor: &mut dyn crate::textlayout::sharedparley::TextInputLayoutVisitor,
+        _text_input: Pin<&crate::items::TextInput>,
+        _item_rc: &ItemRc,
     ) -> bool {
-        crate::textlayout::sharedparley::visit_text_input_layout(
-            self,
-            text_input,
-            item_rc,
-            size,
-            self.text_layout_cache(),
-            visitor,
-        )
+        true
     }
 
     /// Clear the caches for the items that are being removed

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -229,6 +229,29 @@ pub trait RendererSealed {
         )
     }
 
+    /// Lays `text_input` out the way this renderer draws it and lends the result to `visitor`.
+    ///
+    /// Returns false if this renderer lays no text out through parley.
+    ///
+    /// The default implementation uses the shared parley text layout with [`Self::text_layout_cache`].
+    #[cfg(feature = "shared-parley")]
+    fn visit_text_input_layout(
+        &self,
+        text_input: Pin<&crate::items::TextInput>,
+        item_rc: &ItemRc,
+        size: LogicalSize,
+        visitor: &mut dyn crate::textlayout::sharedparley::TextInputLayoutVisitor,
+    ) -> bool {
+        crate::textlayout::sharedparley::visit_text_input_layout(
+            self,
+            text_input,
+            item_rc,
+            size,
+            self.text_layout_cache(),
+            visitor,
+        )
+    }
+
     /// Clear the caches for the items that are being removed
     fn free_graphics_resources(
         &self,

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -712,7 +712,7 @@ fn text_input_cursor_rect_for_byte_offset_impl(
     .unwrap_or_default()
 }
 
-/// A `TextInput`'s laid-out text, lent to a [`TextInputLayoutVisitor`] for the duration of one call.
+/// A `TextInput`'s laid-out text, lent to [`with_text_input_layout`]'s callback for one call.
 #[allow(dead_code)]
 pub struct TextInputLayout<'a> {
     layout: &'a Layout,
@@ -748,52 +748,51 @@ pub(crate) struct TextInputParagraph<'a> {
     y: PhysicalLength,
 }
 
-/// Receives the laid-out text of a `TextInput` from
-/// [`crate::renderer::RendererSealed::visit_text_input_layout`].
-pub trait TextInputLayoutVisitor {
-    /// Must not lay text out itself: the cache entry stays checked out for the call, and
-    /// re-entering it panics.
-    fn visit(&mut self, layout: TextInputLayout<'_>);
-}
-
-/// Lays `text_input` out the way it is drawn and lends the result to `visitor`.
+/// Lays `text_input` out the way `renderer` draws it and lends the result to `f`.
 ///
-/// Returns false if the renderer can't lay text out, so the caller can tell that apart from an
-/// empty layout.
-pub fn visit_text_input_layout(
+/// `f` must not lay text out itself: the cache entry stays checked out for the call, and
+/// re-entering it panics.
+///
+/// Returns `None` if the renderer lays no text out through parley, so the caller can tell that
+/// apart from an empty layout.
+pub fn with_text_input_layout<R>(
     renderer: &(impl RendererSealed + ?Sized),
     text_input: Pin<&crate::items::TextInput>,
     item_rc: &crate::item_tree::ItemRc,
     size: LogicalSize,
-    cache: Option<&TextLayoutCache>,
-    visitor: &mut dyn TextInputLayoutVisitor,
-) -> bool {
-    visit_text_input_layout_impl(
+    f: impl FnOnce(TextInputLayout<'_>) -> R,
+) -> Option<R> {
+    if !renderer.text_input_has_parley_layout(text_input, item_rc) {
+        return None;
+    }
+    with_text_input_layout_impl(
         renderer.scale_factor(),
         renderer.window_adapter(),
+        renderer.text_layout_cache(),
         text_input,
         item_rc,
         size,
-        cache,
-        visitor,
+        f,
     )
 }
 
-fn visit_text_input_layout_impl(
+fn with_text_input_layout_impl<R>(
     scale_factor: Option<ScaleFactor>,
     window_adapter: Option<Rc<dyn WindowAdapter>>,
+    cache: Option<&TextLayoutCache>,
     text_input: Pin<&crate::items::TextInput>,
     item_rc: &crate::item_tree::ItemRc,
     size: LogicalSize,
-    cache: Option<&TextLayoutCache>,
-    visitor: &mut dyn TextInputLayoutVisitor,
-) -> bool {
-    let Some(scale_factor) = scale_factor else {
-        return false;
-    };
-    let Some(window_adapter) = window_adapter else {
-        return false;
-    };
+    f: impl FnOnce(TextInputLayout<'_>) -> R,
+) -> Option<R> {
+    let scale_factor = scale_factor?;
+    let window_adapter = window_adapter?;
+
+    let width = size.width_length();
+    let height = size.height_length();
+    if width.get() <= 0. || height.get() <= 0. {
+        return None;
+    }
 
     let layout_builder =
         shaping_builder(text_input, Some(item_rc), text_input.wrap(), scale_factor);
@@ -801,7 +800,7 @@ fn visit_text_input_layout_impl(
     // `RenderString for TextInput` yields plain text; a styled input doesn't exist.
     let PlainOrStyledText::Plain(text) = crate::item_rendering::RenderString::text(text_input)
     else {
-        return false;
+        return None;
     };
 
     with_text_layout(
@@ -809,217 +808,13 @@ fn visit_text_input_layout_impl(
         Some(item_rc),
         text_input,
         &layout_builder,
-        LayoutOptions::new_from_textinput(
-            text_input,
-            Some(size.width_length()),
-            Some(size.height_length()),
-        ),
+        LayoutOptions::new_from_textinput(text_input, Some(width), Some(height)),
         window_adapter.window(),
-        |layout| visitor.visit(TextInputLayout { layout, text: &text }),
+        |layout| f(TextInputLayout { layout, text: &text }),
     )
-    .is_some()
 }
 
 #[cfg(feature = "accessibility-text")]
 mod accessibility;
 #[cfg(feature = "accessibility-text")]
 pub use accessibility::CachedTextInputAccessibilityState;
-
-#[cfg(all(test, feature = "accessibility-text"))]
-mod accessibility_tests {
-    use super::*;
-    use accesskit::{Node, NodeId, Role, TreeId, TreeUpdate};
-    use parley::LayoutAccessibility;
-
-    fn empty_tree_update() -> TreeUpdate {
-        TreeUpdate {
-            nodes: alloc::vec::Vec::new(),
-            tree: None,
-            tree_id: TreeId::ROOT,
-            focus: NodeId(0),
-        }
-    }
-
-    fn build_one_paragraph(text: &str) -> parley::Layout<Brush> {
-        let builder = shaping::plain_builder_for_tests();
-        let collection = i_slint_common::sharedfontique::create_collection(false);
-        let mut font_ctx = parley::FontContext {
-            collection: collection.inner,
-            source_cache: collection.source_cache,
-        };
-        let mut layout = builder.build(&mut font_ctx, text, std::iter::empty(), None);
-        layout.break_all_lines(None);
-        layout.align(parley::Alignment::Left, parley::AlignmentOptions::default());
-        layout
-    }
-
-    fn collect_text_runs(update: &TreeUpdate) -> Vec<&Node> {
-        update.nodes.iter().filter_map(|(_, n)| (n.role() == Role::TextRun).then_some(n)).collect()
-    }
-
-    #[test]
-    fn build_nodes_emits_text_run_for_plain_paragraph() {
-        let layout = build_one_paragraph("Hello");
-        let mut layout_access = LayoutAccessibility::default();
-        let mut update = empty_tree_update();
-        let mut parent_node = Node::new(Role::TextInput);
-        let mut next_id: u64 = 1;
-
-        layout_access.build_nodes(
-            "Hello",
-            &layout,
-            &mut update,
-            &mut parent_node,
-            || {
-                let id = NodeId(next_id);
-                next_id += 1;
-                id
-            },
-            0.0,
-            0.0,
-            |_node, _style| {},
-        );
-
-        let text_runs = collect_text_runs(&update);
-        assert!(
-            !text_runs.is_empty(),
-            "expected at least one TextRun child for non-empty paragraph"
-        );
-        assert!(
-            text_runs.iter().any(|n| n.value().is_some_and(|v| v.contains("Hello"))),
-            "expected a TextRun whose value contains the input text, got: {:?}",
-            text_runs.iter().map(|n| n.value()).collect::<alloc::vec::Vec<_>>()
-        );
-    }
-
-    #[test]
-    fn build_nodes_handles_empty_paragraph_without_panic() {
-        // Empty paragraphs occur naturally in slint's per-paragraph split
-        // (e.g. text ending with `\n` produces a trailing empty paragraph).
-        // parley emits a placeholder TextRun for cursor positioning; we just
-        // need the call not to panic and not emit characters.
-        let layout = build_one_paragraph("");
-        let mut layout_access = LayoutAccessibility::default();
-        let mut update = empty_tree_update();
-        let mut parent_node = Node::new(Role::TextInput);
-        let mut next_id: u64 = 1;
-
-        layout_access.build_nodes(
-            "",
-            &layout,
-            &mut update,
-            &mut parent_node,
-            || {
-                let id = NodeId(next_id);
-                next_id += 1;
-                id
-            },
-            0.0,
-            0.0,
-            |_node, _style| {},
-        );
-
-        for node in collect_text_runs(&update) {
-            assert!(
-                node.value().is_none_or(|v| v.is_empty()),
-                "empty paragraph TextRun should carry empty value, got {:?}",
-                node.value()
-            );
-        }
-    }
-
-    #[test]
-    fn build_nodes_reuses_node_ids_across_passes() {
-        // Stable NodeIds across rebuilds are the entire point of holding
-        // `LayoutAccessibility` in a cache that survives shape changes:
-        // when the same `ClusterPath` reappears, the same `NodeId` is reused.
-        let layout1 = build_one_paragraph("Hello");
-        let mut layout_access = LayoutAccessibility::default();
-        let mut update1 = empty_tree_update();
-        let mut parent1 = Node::new(Role::TextInput);
-        let mut next_id: u64 = 1;
-        layout_access.build_nodes(
-            "Hello",
-            &layout1,
-            &mut update1,
-            &mut parent1,
-            || {
-                let id = NodeId(next_id);
-                next_id += 1;
-                id
-            },
-            0.0,
-            0.0,
-            |_, _| {},
-        );
-        let first_pass_ids: Vec<NodeId> = update1
-            .nodes
-            .iter()
-            .filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id))
-            .collect();
-
-        // Re-run on a fresh Layout for the same text. NodeIds for the same
-        // cluster paths must be reused.
-        let layout2 = build_one_paragraph("Hello");
-        let mut update2 = empty_tree_update();
-        let mut parent2 = Node::new(Role::TextInput);
-        layout_access.build_nodes(
-            "Hello",
-            &layout2,
-            &mut update2,
-            &mut parent2,
-            || {
-                let id = NodeId(next_id);
-                next_id += 1;
-                id
-            },
-            0.0,
-            0.0,
-            |_, _| {},
-        );
-        let second_pass_ids: Vec<NodeId> = update2
-            .nodes
-            .iter()
-            .filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id))
-            .collect();
-
-        assert_eq!(
-            first_pass_ids, second_pass_ids,
-            "NodeIds for unchanged spans must persist across build_nodes calls"
-        );
-    }
-
-    #[test]
-    fn cursor_to_access_position_round_trips() {
-        // `Cursor::to_access_position` requires that `build_nodes` ran first,
-        // because it consults `LayoutAccessibility::span_paths_by_cluster_path`.
-        let layout = build_one_paragraph("ab");
-        let mut layout_access = LayoutAccessibility::default();
-        let mut update = empty_tree_update();
-        let mut parent = Node::new(Role::TextInput);
-        let mut next_id: u64 = 1;
-        layout_access.build_nodes(
-            "ab",
-            &layout,
-            &mut update,
-            &mut parent,
-            || {
-                let id = NodeId(next_id);
-                next_id += 1;
-                id
-            },
-            0.0,
-            0.0,
-            |_, _| {},
-        );
-
-        // Round-trip the start-of-buffer cursor through the AT representation.
-        let cursor =
-            parley::Cursor::from_byte_index(&layout, 0, parley::layout::Affinity::Downstream);
-        let pos =
-            cursor.to_access_position(&layout, &layout_access).expect("position for cursor at 0");
-        let recovered = parley::Cursor::from_access_position(&pos, &layout, &layout_access)
-            .expect("cursor for AT position");
-        assert_eq!(recovered.index(), cursor.index());
-    }
-}

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -78,7 +78,8 @@ use cache::cached_paragraphs;
 use layout::{Layout, LayoutOptions, layout};
 use selection::{SelectionRendering, SelectionSpans};
 use shaping::{
-    LayoutWithoutLineBreaksBuilder, create_text_paragraphs, shape_paragraphs, shaping_builder,
+    Brush, LayoutWithoutLineBreaksBuilder, create_text_paragraphs, shape_paragraphs,
+    shaping_builder,
 };
 
 /// Lays out the shaped text of an item and runs `f` over the result.
@@ -711,6 +712,119 @@ fn text_input_cursor_rect_for_byte_offset_impl(
     .unwrap_or_default()
 }
 
+/// A `TextInput`'s laid-out text, lent to a [`TextInputLayoutVisitor`] for the duration of one call.
+#[allow(dead_code)]
+pub struct TextInputLayout<'a> {
+    layout: &'a Layout,
+    /// The string the paragraphs were shaped from, which [`TextInputParagraph::range`] indexes.
+    text: &'a str,
+}
+
+#[allow(dead_code)]
+impl<'a> TextInputLayout<'a> {
+    /// The paragraphs, top to bottom. A hard line break separates two of them and belongs to
+    /// neither, since Slint splits the text at `\n` before shaping.
+    pub(crate) fn paragraphs(&self) -> impl Iterator<Item = TextInputParagraph<'a>> {
+        let (text, y_offset) = (self.text, self.layout.y_offset);
+        self.layout.paragraphs.iter().map(move |para| TextInputParagraph {
+            range: para.range.clone(),
+            text: &text[para.range.clone()],
+            layout: &para.layout,
+            y: y_offset + para.y,
+        })
+    }
+}
+
+/// One paragraph of a [`TextInputLayout`].
+#[allow(dead_code)]
+pub(crate) struct TextInputParagraph<'a> {
+    /// Byte range within [`TextInputLayout::text`].
+    range: Range<usize>,
+    /// The slice of that text this paragraph covers.
+    text: &'a str,
+    /// Its shaped, line-broken and aligned glyphs.
+    layout: &'a parley::Layout<Brush>,
+    /// Physical y of its top edge, relative to the item's.
+    y: PhysicalLength,
+}
+
+/// Receives the laid-out text of a `TextInput` from
+/// [`crate::renderer::RendererSealed::visit_text_input_layout`].
+pub trait TextInputLayoutVisitor {
+    /// Must not lay text out itself: the cache entry stays checked out for the call, and
+    /// re-entering it panics.
+    fn visit(&mut self, layout: TextInputLayout<'_>);
+}
+
+/// Lays `text_input` out the way it is drawn and lends the result to `visitor`.
+///
+/// Returns false if the renderer can't lay text out, so the caller can tell that apart from an
+/// empty layout.
+pub fn visit_text_input_layout(
+    renderer: &(impl RendererSealed + ?Sized),
+    text_input: Pin<&crate::items::TextInput>,
+    item_rc: &crate::item_tree::ItemRc,
+    size: LogicalSize,
+    cache: Option<&TextLayoutCache>,
+    visitor: &mut dyn TextInputLayoutVisitor,
+) -> bool {
+    visit_text_input_layout_impl(
+        renderer.scale_factor(),
+        renderer.window_adapter(),
+        text_input,
+        item_rc,
+        size,
+        cache,
+        visitor,
+    )
+}
+
+fn visit_text_input_layout_impl(
+    scale_factor: Option<ScaleFactor>,
+    window_adapter: Option<Rc<dyn WindowAdapter>>,
+    text_input: Pin<&crate::items::TextInput>,
+    item_rc: &crate::item_tree::ItemRc,
+    size: LogicalSize,
+    cache: Option<&TextLayoutCache>,
+    visitor: &mut dyn TextInputLayoutVisitor,
+) -> bool {
+    let Some(scale_factor) = scale_factor else {
+        return false;
+    };
+    let Some(window_adapter) = window_adapter else {
+        return false;
+    };
+
+    let layout_builder =
+        shaping_builder(text_input, Some(item_rc), text_input.wrap(), scale_factor);
+
+    // `RenderString for TextInput` yields plain text; a styled input doesn't exist.
+    let PlainOrStyledText::Plain(text) = crate::item_rendering::RenderString::text(text_input)
+    else {
+        return false;
+    };
+
+    with_text_layout(
+        cache,
+        Some(item_rc),
+        text_input,
+        &layout_builder,
+        LayoutOptions::new_from_textinput(
+            text_input,
+            Some(size.width_length()),
+            Some(size.height_length()),
+        ),
+        window_adapter.window(),
+        |layout| visitor.visit(TextInputLayout { layout, text: &text }),
+    )
+    .is_some()
+}
+
+#[cfg(feature = "accessibility-text")]
+mod accessibility;
+#[cfg(feature = "accessibility-text")]
+pub use accessibility::CachedTextInputAccessibilityState;
+
 #[cfg(all(test, feature = "accessibility-text"))]
 mod accessibility_tests {
     use super::*;
@@ -718,42 +832,34 @@ mod accessibility_tests {
     use parley::LayoutAccessibility;
 
     fn empty_tree_update() -> TreeUpdate {
-        TreeUpdate { nodes: alloc::vec::Vec::new(), tree: None, tree_id: TreeId::ROOT, focus: NodeId(0) }
+        TreeUpdate {
+            nodes: alloc::vec::Vec::new(),
+            tree: None,
+            tree_id: TreeId::ROOT,
+            focus: NodeId(0),
+        }
     }
 
-    fn build_one_paragraph(text: &str, max_width: f32) -> parley::Layout<Brush> {
-        let scale_factor = ScaleFactor::new(1.0);
-        let builder = LayoutWithoutLineBreaksBuilder::new(
-            None,
-            TextWrap::WordWrap,
-            None,
-            scale_factor,
-        );
+    fn build_one_paragraph(text: &str) -> parley::Layout<Brush> {
+        let builder = shaping::plain_builder_for_tests();
         let collection = i_slint_common::sharedfontique::create_collection(false);
         let mut font_ctx = parley::FontContext {
             collection: collection.inner,
             source_cache: collection.source_cache,
         };
         let mut layout = builder.build(&mut font_ctx, text, std::iter::empty(), None);
-        apply_line_break_and_align(
-            &mut layout,
-            Some(PhysicalLength::new(max_width)),
-            TextHorizontalAlignment::Left,
-        );
+        layout.break_all_lines(None);
+        layout.align(parley::Alignment::Left, parley::AlignmentOptions::default());
         layout
     }
 
     fn collect_text_runs(update: &TreeUpdate) -> Vec<&Node> {
-        update
-            .nodes
-            .iter()
-            .filter_map(|(_, n)| (n.role() == Role::TextRun).then_some(n))
-            .collect()
+        update.nodes.iter().filter_map(|(_, n)| (n.role() == Role::TextRun).then_some(n)).collect()
     }
 
     #[test]
     fn build_nodes_emits_text_run_for_plain_paragraph() {
-        let layout = build_one_paragraph("Hello", 200.0);
+        let layout = build_one_paragraph("Hello");
         let mut layout_access = LayoutAccessibility::default();
         let mut update = empty_tree_update();
         let mut parent_node = Node::new(Role::TextInput);
@@ -792,7 +898,7 @@ mod accessibility_tests {
         // (e.g. text ending with `\n` produces a trailing empty paragraph).
         // parley emits a placeholder TextRun for cursor positioning; we just
         // need the call not to panic and not emit characters.
-        let layout = build_one_paragraph("", 200.0);
+        let layout = build_one_paragraph("");
         let mut layout_access = LayoutAccessibility::default();
         let mut update = empty_tree_update();
         let mut parent_node = Node::new(Role::TextInput);
@@ -827,7 +933,7 @@ mod accessibility_tests {
         // Stable NodeIds across rebuilds are the entire point of holding
         // `LayoutAccessibility` in a cache that survives shape changes:
         // when the same `ClusterPath` reappears, the same `NodeId` is reused.
-        let layout1 = build_one_paragraph("Hello", 200.0);
+        let layout1 = build_one_paragraph("Hello");
         let mut layout_access = LayoutAccessibility::default();
         let mut update1 = empty_tree_update();
         let mut parent1 = Node::new(Role::TextInput);
@@ -846,12 +952,15 @@ mod accessibility_tests {
             0.0,
             |_, _| {},
         );
-        let first_pass_ids: Vec<NodeId> =
-            update1.nodes.iter().filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id)).collect();
+        let first_pass_ids: Vec<NodeId> = update1
+            .nodes
+            .iter()
+            .filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id))
+            .collect();
 
         // Re-run on a fresh Layout for the same text. NodeIds for the same
         // cluster paths must be reused.
-        let layout2 = build_one_paragraph("Hello", 200.0);
+        let layout2 = build_one_paragraph("Hello");
         let mut update2 = empty_tree_update();
         let mut parent2 = Node::new(Role::TextInput);
         layout_access.build_nodes(
@@ -868,8 +977,11 @@ mod accessibility_tests {
             0.0,
             |_, _| {},
         );
-        let second_pass_ids: Vec<NodeId> =
-            update2.nodes.iter().filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id)).collect();
+        let second_pass_ids: Vec<NodeId> = update2
+            .nodes
+            .iter()
+            .filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id))
+            .collect();
 
         assert_eq!(
             first_pass_ids, second_pass_ids,
@@ -881,7 +993,7 @@ mod accessibility_tests {
     fn cursor_to_access_position_round_trips() {
         // `Cursor::to_access_position` requires that `build_nodes` ran first,
         // because it consults `LayoutAccessibility::span_paths_by_cluster_path`.
-        let layout = build_one_paragraph("ab", 200.0);
+        let layout = build_one_paragraph("ab");
         let mut layout_access = LayoutAccessibility::default();
         let mut update = empty_tree_update();
         let mut parent = Node::new(Role::TextInput);
@@ -902,8 +1014,10 @@ mod accessibility_tests {
         );
 
         // Round-trip the start-of-buffer cursor through the AT representation.
-        let cursor = parley::Cursor::from_byte_index(&layout, 0, parley::layout::Affinity::Downstream);
-        let pos = cursor.to_access_position(&layout, &layout_access).expect("position for cursor at 0");
+        let cursor =
+            parley::Cursor::from_byte_index(&layout, 0, parley::layout::Affinity::Downstream);
+        let pos =
+            cursor.to_access_position(&layout, &layout_access).expect("position for cursor at 0");
         let recovered = parley::Cursor::from_access_position(&pos, &layout, &layout_access)
             .expect("cursor for AT position");
         assert_eq!(recovered.index(), cursor.index());

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -710,3 +710,202 @@ fn text_input_cursor_rect_for_byte_offset_impl(
     )
     .unwrap_or_default()
 }
+
+#[cfg(all(test, feature = "accessibility-text"))]
+mod accessibility_tests {
+    use super::*;
+    use accesskit::{Node, NodeId, Role, TreeId, TreeUpdate};
+    use parley::LayoutAccessibility;
+
+    fn empty_tree_update() -> TreeUpdate {
+        TreeUpdate { nodes: alloc::vec::Vec::new(), tree: None, tree_id: TreeId::ROOT, focus: NodeId(0) }
+    }
+
+    fn build_one_paragraph(text: &str, max_width: f32) -> parley::Layout<Brush> {
+        let scale_factor = ScaleFactor::new(1.0);
+        let builder = LayoutWithoutLineBreaksBuilder::new(
+            None,
+            TextWrap::WordWrap,
+            None,
+            scale_factor,
+        );
+        let collection = i_slint_common::sharedfontique::create_collection(false);
+        let mut font_ctx = parley::FontContext {
+            collection: collection.inner,
+            source_cache: collection.source_cache,
+        };
+        let mut layout = builder.build(&mut font_ctx, text, std::iter::empty(), None);
+        apply_line_break_and_align(
+            &mut layout,
+            Some(PhysicalLength::new(max_width)),
+            TextHorizontalAlignment::Left,
+        );
+        layout
+    }
+
+    fn collect_text_runs(update: &TreeUpdate) -> Vec<&Node> {
+        update
+            .nodes
+            .iter()
+            .filter_map(|(_, n)| (n.role() == Role::TextRun).then_some(n))
+            .collect()
+    }
+
+    #[test]
+    fn build_nodes_emits_text_run_for_plain_paragraph() {
+        let layout = build_one_paragraph("Hello", 200.0);
+        let mut layout_access = LayoutAccessibility::default();
+        let mut update = empty_tree_update();
+        let mut parent_node = Node::new(Role::TextInput);
+        let mut next_id: u64 = 1;
+
+        layout_access.build_nodes(
+            "Hello",
+            &layout,
+            &mut update,
+            &mut parent_node,
+            || {
+                let id = NodeId(next_id);
+                next_id += 1;
+                id
+            },
+            0.0,
+            0.0,
+            |_node, _style| {},
+        );
+
+        let text_runs = collect_text_runs(&update);
+        assert!(
+            !text_runs.is_empty(),
+            "expected at least one TextRun child for non-empty paragraph"
+        );
+        assert!(
+            text_runs.iter().any(|n| n.value().is_some_and(|v| v.contains("Hello"))),
+            "expected a TextRun whose value contains the input text, got: {:?}",
+            text_runs.iter().map(|n| n.value()).collect::<alloc::vec::Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn build_nodes_handles_empty_paragraph_without_panic() {
+        // Empty paragraphs occur naturally in slint's per-paragraph split
+        // (e.g. text ending with `\n` produces a trailing empty paragraph).
+        // parley emits a placeholder TextRun for cursor positioning; we just
+        // need the call not to panic and not emit characters.
+        let layout = build_one_paragraph("", 200.0);
+        let mut layout_access = LayoutAccessibility::default();
+        let mut update = empty_tree_update();
+        let mut parent_node = Node::new(Role::TextInput);
+        let mut next_id: u64 = 1;
+
+        layout_access.build_nodes(
+            "",
+            &layout,
+            &mut update,
+            &mut parent_node,
+            || {
+                let id = NodeId(next_id);
+                next_id += 1;
+                id
+            },
+            0.0,
+            0.0,
+            |_node, _style| {},
+        );
+
+        for node in collect_text_runs(&update) {
+            assert!(
+                node.value().is_none_or(|v| v.is_empty()),
+                "empty paragraph TextRun should carry empty value, got {:?}",
+                node.value()
+            );
+        }
+    }
+
+    #[test]
+    fn build_nodes_reuses_node_ids_across_passes() {
+        // Stable NodeIds across rebuilds are the entire point of holding
+        // `LayoutAccessibility` in a cache that survives shape changes:
+        // when the same `ClusterPath` reappears, the same `NodeId` is reused.
+        let layout1 = build_one_paragraph("Hello", 200.0);
+        let mut layout_access = LayoutAccessibility::default();
+        let mut update1 = empty_tree_update();
+        let mut parent1 = Node::new(Role::TextInput);
+        let mut next_id: u64 = 1;
+        layout_access.build_nodes(
+            "Hello",
+            &layout1,
+            &mut update1,
+            &mut parent1,
+            || {
+                let id = NodeId(next_id);
+                next_id += 1;
+                id
+            },
+            0.0,
+            0.0,
+            |_, _| {},
+        );
+        let first_pass_ids: Vec<NodeId> =
+            update1.nodes.iter().filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id)).collect();
+
+        // Re-run on a fresh Layout for the same text. NodeIds for the same
+        // cluster paths must be reused.
+        let layout2 = build_one_paragraph("Hello", 200.0);
+        let mut update2 = empty_tree_update();
+        let mut parent2 = Node::new(Role::TextInput);
+        layout_access.build_nodes(
+            "Hello",
+            &layout2,
+            &mut update2,
+            &mut parent2,
+            || {
+                let id = NodeId(next_id);
+                next_id += 1;
+                id
+            },
+            0.0,
+            0.0,
+            |_, _| {},
+        );
+        let second_pass_ids: Vec<NodeId> =
+            update2.nodes.iter().filter_map(|(id, n)| (n.role() == Role::TextRun).then_some(*id)).collect();
+
+        assert_eq!(
+            first_pass_ids, second_pass_ids,
+            "NodeIds for unchanged spans must persist across build_nodes calls"
+        );
+    }
+
+    #[test]
+    fn cursor_to_access_position_round_trips() {
+        // `Cursor::to_access_position` requires that `build_nodes` ran first,
+        // because it consults `LayoutAccessibility::span_paths_by_cluster_path`.
+        let layout = build_one_paragraph("ab", 200.0);
+        let mut layout_access = LayoutAccessibility::default();
+        let mut update = empty_tree_update();
+        let mut parent = Node::new(Role::TextInput);
+        let mut next_id: u64 = 1;
+        layout_access.build_nodes(
+            "ab",
+            &layout,
+            &mut update,
+            &mut parent,
+            || {
+                let id = NodeId(next_id);
+                next_id += 1;
+                id
+            },
+            0.0,
+            0.0,
+            |_, _| {},
+        );
+
+        // Round-trip the start-of-buffer cursor through the AT representation.
+        let cursor = parley::Cursor::from_byte_index(&layout, 0, parley::layout::Affinity::Downstream);
+        let pos = cursor.to_access_position(&layout, &layout_access).expect("position for cursor at 0");
+        let recovered = parley::Cursor::from_access_position(&pos, &layout, &layout_access)
+            .expect("cursor for AT position");
+        assert_eq!(recovered.index(), cursor.index());
+    }
+}

--- a/internal/core/textlayout/sharedparley/accessibility.rs
+++ b/internal/core/textlayout/sharedparley/accessibility.rs
@@ -16,36 +16,18 @@ use parley::{Cursor, LayoutAccessibility};
 /// always the one on screen.
 pub struct CachedTextInputAccessibilityState {
     layout_access: Vec<LayoutAccessibility>,
-    /// Never reset, so that a later emission can't reuse an index for an unrelated span.
+    /// Never reset while this state lives, so that a later emission can't reuse an index for a
+    /// span an assistive technology may still remember.
     next_sub_index: u32,
-    text_input: crate::item_tree::ItemWeak,
 }
 
 impl Default for CachedTextInputAccessibilityState {
     fn default() -> Self {
-        Self { layout_access: Vec::new(), next_sub_index: 1, text_input: Default::default() }
+        Self { layout_access: Vec::new(), next_sub_index: 1 }
     }
 }
 
 impl CachedTextInputAccessibilityState {
-    /// The `TextInput` inside the accessible element `item`.
-    pub fn text_input(
-        &mut self,
-        item: &crate::item_tree::ItemRc,
-    ) -> Option<(
-        crate::item_tree::ItemRc,
-        vtable::VRcMapped<crate::item_tree::ItemTreeVTable, crate::items::TextInput>,
-    )> {
-        if let Some(item_rc) = self.text_input.upgrade()
-            && let Some(text_input) = item_rc.clone().downcast::<crate::items::TextInput>()
-        {
-            return Some((item_rc, text_input));
-        }
-        let found = crate::accessibility::find_text_input_with_rc(item)?;
-        self.text_input = found.0.downgrade();
-        Some(found)
-    }
-
     /// Emits TextRun children of `parent_node` describing the input's text, and sets its value and
     /// selection.
     ///
@@ -65,7 +47,7 @@ impl CachedTextInputAccessibilityState {
     ) -> bool {
         let (visible_anchor, visible_cursor) = selection_offsets(text_input);
 
-        // Before the visitor, so it survives a renderer with no layout to lend. The displayed
+        // Before the layout, so it survives a renderer with none to lend. The displayed
         // text, not `accessible-value`: that one is the raw `text`, which for a password field
         // would hand out the characters themselves.
         if let PlainOrStyledText::Plain(displayed) =
@@ -74,106 +56,77 @@ impl CachedTextInputAccessibilityState {
             parent_node.set_value(displayed.as_str().to_string());
         }
 
-        let mut emitter = Emitter {
-            state: self,
-            visible_anchor,
-            visible_cursor,
-            update,
-            parent_node,
-            parent_id,
-            physical_offset,
-            encode_sub_node_id,
-        };
-        renderer.visit_text_input_layout(text_input, item_rc, size, &mut emitter)
-    }
-}
+        with_text_input_layout(renderer, text_input, item_rc, size, |layout| {
+            let paragraphs: alloc::vec::Vec<_> = layout.paragraphs().collect();
 
-/// See [`CachedTextInputAccessibilityState::emit`].
-struct Emitter<'a, F> {
-    state: &'a mut CachedTextInputAccessibilityState,
-    visible_anchor: usize,
-    visible_cursor: usize,
-    update: &'a mut TreeUpdate,
-    parent_node: &'a mut Node,
-    parent_id: NodeId,
-    physical_offset: (f64, f64),
-    encode_sub_node_id: F,
-}
+            // Grow or shrink to one entry per paragraph; the ones that stay keep their NodeIds.
+            self.layout_access.resize_with(paragraphs.len(), Default::default);
 
-impl<F: Fn(NodeId, u32) -> NodeId> TextInputLayoutVisitor for Emitter<'_, F> {
-    fn visit(&mut self, layout: TextInputLayout<'_>) {
-        let paragraphs: alloc::vec::Vec<_> = layout.paragraphs().collect();
+            // Captures the persistent counter, so the indices keep growing across emissions.
+            let next_sub_index = &mut self.next_sub_index;
+            let mut allocate_sub = || {
+                let sub = *next_sub_index;
+                *next_sub_index = next_sub_index.saturating_add(1);
+                encode_sub_node_id(parent_id, sub)
+            };
 
-        // Grow or shrink to one entry per paragraph; the ones that stay keep their NodeIds.
-        self.state.layout_access.resize_with(paragraphs.len(), Default::default);
-
-        // Captures the persistent counter, so the indices keep growing across emissions.
-        let next_sub_index = &mut self.state.next_sub_index;
-        let (parent_id, encode_sub_node_id) = (self.parent_id, &self.encode_sub_node_id);
-        let mut allocate_sub = || {
-            let sub = *next_sub_index;
-            *next_sub_index = next_sub_index.saturating_add(1);
-            encode_sub_node_id(parent_id, sub)
-        };
-
-        let total_paragraphs = paragraphs.len();
-        for (i, (para, la)) in
-            paragraphs.iter().zip(self.state.layout_access.iter_mut()).enumerate()
-        {
-            let para_y_offset = self.physical_offset.1 + para.y.get() as f64;
-            let nodes_before = self.update.nodes.len();
-            la.build_nodes(
-                para.text,
-                para.layout,
-                self.update,
-                self.parent_node,
-                &mut allocate_sub,
-                self.physical_offset.0,
-                para_y_offset,
-                // A `TextInput`'s text is plain, so it carries no styled spans.
-                |_node, _style| {},
-            );
-
-            // We split the text at `\n` before shaping, so parley never sees the newline as
-            // a cluster. AccessKit expects it in the paragraph's last TextRun, otherwise a caret
-            // crossing the break announces the next line's first character instead.
-            if i + 1 < total_paragraphs
-                && self.update.nodes.len() > nodes_before
-                && let Some((_, node)) = self.update.nodes.last_mut()
+            let total_paragraphs = paragraphs.len();
+            for (i, (para, la)) in paragraphs.iter().zip(self.layout_access.iter_mut()).enumerate()
             {
-                let mut value = node.value().map(|s| s.to_string()).unwrap_or_default();
-                let mut lengths: alloc::vec::Vec<u8> = node.character_lengths().to_vec();
-                let mut widths: alloc::vec::Vec<f32> =
-                    node.character_widths().map(|s| s.to_vec()).unwrap_or_default();
-                let mut positions: alloc::vec::Vec<f32> =
-                    node.character_positions().map(|s| s.to_vec()).unwrap_or_default();
+                let para_y_offset = physical_offset.1 + para.y.get() as f64;
+                let nodes_before = update.nodes.len();
+                la.build_nodes(
+                    para.text,
+                    para.layout,
+                    update,
+                    parent_node,
+                    &mut allocate_sub,
+                    physical_offset.0,
+                    para_y_offset,
+                    // A `TextInput`'s text is plain, so it carries no styled spans.
+                    |_node, _style| {},
+                );
 
-                let last_x = positions.last().copied().unwrap_or(0.0)
-                    + widths.last().copied().unwrap_or(0.0);
-                value.push('\n');
-                lengths.push(1);
-                positions.push(last_x);
-                widths.push(0.0);
+                // We split the text at `\n` before shaping, so parley never sees the newline as
+                // a cluster. AccessKit expects it in the paragraph's last TextRun, otherwise a
+                // caret crossing the break announces the next line's first character instead.
+                if i + 1 < total_paragraphs
+                    && update.nodes.len() > nodes_before
+                    && let Some((_, node)) = update.nodes.last_mut()
+                {
+                    let mut value = node.value().map(|s| s.to_string()).unwrap_or_default();
+                    let mut lengths: alloc::vec::Vec<u8> = node.character_lengths().to_vec();
+                    let mut widths: alloc::vec::Vec<f32> =
+                        node.character_widths().map(|s| s.to_vec()).unwrap_or_default();
+                    let mut positions: alloc::vec::Vec<f32> =
+                        node.character_positions().map(|s| s.to_vec()).unwrap_or_default();
 
-                node.set_value(value);
-                node.set_character_lengths(lengths);
-                node.set_character_widths(widths);
-                node.set_character_positions(positions);
+                    let last_x = positions.last().copied().unwrap_or(0.0)
+                        + widths.last().copied().unwrap_or(0.0);
+                    value.push('\n');
+                    lengths.push(1);
+                    positions.push(last_x);
+                    widths.push(0.0);
+
+                    node.set_value(value);
+                    node.set_character_lengths(lengths);
+                    node.set_character_widths(widths);
+                    node.set_character_positions(positions);
+                }
             }
-        }
 
-        if let Some(selection) = compose_text_selection(
-            &paragraphs,
-            &self.state.layout_access,
-            self.visible_anchor,
-            self.visible_cursor,
-        ) {
-            self.parent_node.set_text_selection(selection);
-        }
+            if let Some(selection) = compose_text_selection(
+                &paragraphs,
+                &self.layout_access,
+                visible_anchor,
+                visible_cursor,
+            ) {
+                parent_node.set_text_selection(selection);
+            }
+        })
+        .is_some()
     }
-}
 
-impl CachedTextInputAccessibilityState {
     /// Translates an incoming selection into byte offsets in the input's text.
     pub fn decode_selection(
         &self,
@@ -184,10 +137,27 @@ impl CachedTextInputAccessibilityState {
         anchor: &TextPosition,
         focus: &TextPosition,
     ) -> Option<(usize, usize)> {
-        let mut decoder = Decoder { state: self, anchor, focus, decoded: None };
-        renderer.visit_text_input_layout(text_input, item_rc, size, &mut decoder);
-        let (anchor, focus) = decoder.decoded?;
+        let (anchor, focus) =
+            with_text_input_layout(renderer, text_input, item_rc, size, |layout| {
+                let paragraphs: alloc::vec::Vec<_> = layout.paragraphs().collect();
+                // Both ends have to resolve, or the selection means nothing.
+                self.byte_offset(&paragraphs, anchor).zip(self.byte_offset(&paragraphs, focus))
+            })
+            .flatten()?;
         Some((to_actual_offset(text_input, anchor), to_actual_offset(text_input, focus)))
+    }
+
+    fn byte_offset(
+        &self,
+        paragraphs: &[TextInputParagraph<'_>],
+        pos: &TextPosition,
+    ) -> Option<usize> {
+        for (para, la) in paragraphs.iter().zip(self.layout_access.iter()) {
+            if let Some(cursor) = Cursor::from_access_position(pos, para.layout, la) {
+                return Some(para.range.start + cursor.index());
+            }
+        }
+        None
     }
 }
 
@@ -213,39 +183,6 @@ fn to_actual_offset(text_input: Pin<&crate::items::TextInput>, displayed_offset:
         .char_indices()
         .nth(displayed_offset / crate::items::PASSWORD_CHARACTER.len_utf8())
         .map_or(unmasked.len(), |(offset, _)| offset)
-}
-
-/// See [`CachedTextInputAccessibilityState::decode_selection`].
-struct Decoder<'a> {
-    state: &'a CachedTextInputAccessibilityState,
-    anchor: &'a TextPosition,
-    focus: &'a TextPosition,
-    decoded: Option<(usize, usize)>,
-}
-
-impl Decoder<'_> {
-    fn byte_offset(
-        &self,
-        paragraphs: &[TextInputParagraph<'_>],
-        pos: &TextPosition,
-    ) -> Option<usize> {
-        for (para, la) in paragraphs.iter().zip(self.state.layout_access.iter()) {
-            if let Some(cursor) = Cursor::from_access_position(pos, para.layout, la) {
-                return Some(para.range.start + cursor.index());
-            }
-        }
-        None
-    }
-}
-
-impl TextInputLayoutVisitor for Decoder<'_> {
-    fn visit(&mut self, layout: TextInputLayout<'_>) {
-        let paragraphs: alloc::vec::Vec<_> = layout.paragraphs().collect();
-        // Both ends have to resolve, or the selection means nothing.
-        self.decoded = self
-            .byte_offset(&paragraphs, self.anchor)
-            .zip(self.byte_offset(&paragraphs, self.focus));
-    }
 }
 
 /// The selection anchor and cursor, as byte offsets into the text the input displays.

--- a/internal/core/textlayout/sharedparley/accessibility.rs
+++ b/internal/core/textlayout/sharedparley/accessibility.rs
@@ -1,0 +1,286 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! AccessKit emission for `TextInput`: turns the layout the renderer draws with into TextRun
+//! children, so that a screen reader sees per-character metrics and the selection rather than one
+//! opaque value.
+use super::*;
+use accesskit::{Node, NodeId, TextPosition, TextSelection, TreeUpdate};
+use alloc::string::ToString;
+use parley::{Cursor, LayoutAccessibility};
+
+/// What one `TextInput` needs to keep between emissions.
+///
+/// Only the `LayoutAccessibility` maps, which is what makes `build_nodes` reuse a `NodeId` for a
+/// span that survived an edit. The shaped paragraphs aren't kept, so the geometry reported is
+/// always the one on screen.
+pub struct CachedTextInputAccessibilityState {
+    layout_access: Vec<LayoutAccessibility>,
+    /// Never reset, so that a later emission can't reuse an index for an unrelated span.
+    next_sub_index: u32,
+    text_input: crate::item_tree::ItemWeak,
+}
+
+impl Default for CachedTextInputAccessibilityState {
+    fn default() -> Self {
+        Self { layout_access: Vec::new(), next_sub_index: 1, text_input: Default::default() }
+    }
+}
+
+impl CachedTextInputAccessibilityState {
+    /// The `TextInput` inside the accessible element `item`.
+    pub fn text_input(
+        &mut self,
+        item: &crate::item_tree::ItemRc,
+    ) -> Option<(
+        crate::item_tree::ItemRc,
+        vtable::VRcMapped<crate::item_tree::ItemTreeVTable, crate::items::TextInput>,
+    )> {
+        if let Some(item_rc) = self.text_input.upgrade()
+            && let Some(text_input) = item_rc.clone().downcast::<crate::items::TextInput>()
+        {
+            return Some((item_rc, text_input));
+        }
+        let found = crate::accessibility::find_text_input_with_rc(item)?;
+        self.text_input = found.0.downgrade();
+        Some(found)
+    }
+
+    /// Emits TextRun children of `parent_node` describing the input's text, and sets its value and
+    /// selection.
+    ///
+    /// `physical_offset` is where the wrapper sits in the AccessKit tree's coordinates, and
+    /// `encode_sub_node_id` mints a NodeId for a span, given its parent.
+    pub fn emit(
+        &mut self,
+        renderer: &dyn crate::renderer::Renderer,
+        text_input: Pin<&crate::items::TextInput>,
+        item_rc: &crate::item_tree::ItemRc,
+        size: LogicalSize,
+        update: &mut TreeUpdate,
+        parent_node: &mut Node,
+        parent_id: NodeId,
+        physical_offset: (f64, f64),
+        encode_sub_node_id: impl Fn(NodeId, u32) -> NodeId,
+    ) -> bool {
+        let (visible_anchor, visible_cursor) = selection_offsets(text_input);
+
+        // Before the visitor, so it survives a renderer with no layout to lend. The displayed
+        // text, not `accessible-value`: that one is the raw `text`, which for a password field
+        // would hand out the characters themselves.
+        if let PlainOrStyledText::Plain(displayed) =
+            crate::item_rendering::RenderString::text(text_input)
+        {
+            parent_node.set_value(displayed.as_str().to_string());
+        }
+
+        let mut emitter = Emitter {
+            state: self,
+            visible_anchor,
+            visible_cursor,
+            update,
+            parent_node,
+            parent_id,
+            physical_offset,
+            encode_sub_node_id,
+        };
+        renderer.visit_text_input_layout(text_input, item_rc, size, &mut emitter)
+    }
+}
+
+/// See [`CachedTextInputAccessibilityState::emit`].
+struct Emitter<'a, F> {
+    state: &'a mut CachedTextInputAccessibilityState,
+    visible_anchor: usize,
+    visible_cursor: usize,
+    update: &'a mut TreeUpdate,
+    parent_node: &'a mut Node,
+    parent_id: NodeId,
+    physical_offset: (f64, f64),
+    encode_sub_node_id: F,
+}
+
+impl<F: Fn(NodeId, u32) -> NodeId> TextInputLayoutVisitor for Emitter<'_, F> {
+    fn visit(&mut self, layout: TextInputLayout<'_>) {
+        let paragraphs: alloc::vec::Vec<_> = layout.paragraphs().collect();
+
+        // Grow or shrink to one entry per paragraph; the ones that stay keep their NodeIds.
+        self.state.layout_access.resize_with(paragraphs.len(), Default::default);
+
+        // Captures the persistent counter, so the indices keep growing across emissions.
+        let next_sub_index = &mut self.state.next_sub_index;
+        let (parent_id, encode_sub_node_id) = (self.parent_id, &self.encode_sub_node_id);
+        let mut allocate_sub = || {
+            let sub = *next_sub_index;
+            *next_sub_index = next_sub_index.saturating_add(1);
+            encode_sub_node_id(parent_id, sub)
+        };
+
+        let total_paragraphs = paragraphs.len();
+        for (i, (para, la)) in
+            paragraphs.iter().zip(self.state.layout_access.iter_mut()).enumerate()
+        {
+            let para_y_offset = self.physical_offset.1 + para.y.get() as f64;
+            let nodes_before = self.update.nodes.len();
+            la.build_nodes(
+                para.text,
+                para.layout,
+                self.update,
+                self.parent_node,
+                &mut allocate_sub,
+                self.physical_offset.0,
+                para_y_offset,
+                // A `TextInput`'s text is plain, so it carries no styled spans.
+                |_node, _style| {},
+            );
+
+            // We split the text at `\n` before shaping, so parley never sees the newline as
+            // a cluster. AccessKit expects it in the paragraph's last TextRun, otherwise a caret
+            // crossing the break announces the next line's first character instead.
+            if i + 1 < total_paragraphs
+                && self.update.nodes.len() > nodes_before
+                && let Some((_, node)) = self.update.nodes.last_mut()
+            {
+                let mut value = node.value().map(|s| s.to_string()).unwrap_or_default();
+                let mut lengths: alloc::vec::Vec<u8> = node.character_lengths().to_vec();
+                let mut widths: alloc::vec::Vec<f32> =
+                    node.character_widths().map(|s| s.to_vec()).unwrap_or_default();
+                let mut positions: alloc::vec::Vec<f32> =
+                    node.character_positions().map(|s| s.to_vec()).unwrap_or_default();
+
+                let last_x = positions.last().copied().unwrap_or(0.0)
+                    + widths.last().copied().unwrap_or(0.0);
+                value.push('\n');
+                lengths.push(1);
+                positions.push(last_x);
+                widths.push(0.0);
+
+                node.set_value(value);
+                node.set_character_lengths(lengths);
+                node.set_character_widths(widths);
+                node.set_character_positions(positions);
+            }
+        }
+
+        if let Some(selection) = compose_text_selection(
+            &paragraphs,
+            &self.state.layout_access,
+            self.visible_anchor,
+            self.visible_cursor,
+        ) {
+            self.parent_node.set_text_selection(selection);
+        }
+    }
+}
+
+impl CachedTextInputAccessibilityState {
+    /// Translates an incoming selection into byte offsets in the input's text.
+    pub fn decode_selection(
+        &self,
+        renderer: &dyn crate::renderer::Renderer,
+        text_input: Pin<&crate::items::TextInput>,
+        item_rc: &crate::item_tree::ItemRc,
+        size: LogicalSize,
+        anchor: &TextPosition,
+        focus: &TextPosition,
+    ) -> Option<(usize, usize)> {
+        let mut decoder = Decoder { state: self, anchor, focus, decoded: None };
+        renderer.visit_text_input_layout(text_input, item_rc, size, &mut decoder);
+        decoder.decoded
+    }
+}
+
+/// See [`CachedTextInputAccessibilityState::decode_selection`].
+struct Decoder<'a> {
+    state: &'a CachedTextInputAccessibilityState,
+    anchor: &'a TextPosition,
+    focus: &'a TextPosition,
+    decoded: Option<(usize, usize)>,
+}
+
+impl Decoder<'_> {
+    fn byte_offset(
+        &self,
+        paragraphs: &[TextInputParagraph<'_>],
+        pos: &TextPosition,
+    ) -> Option<usize> {
+        for (para, la) in paragraphs.iter().zip(self.state.layout_access.iter()) {
+            if let Some(cursor) = Cursor::from_access_position(pos, para.layout, la) {
+                return Some(para.range.start + cursor.index());
+            }
+        }
+        None
+    }
+}
+
+impl TextInputLayoutVisitor for Decoder<'_> {
+    fn visit(&mut self, layout: TextInputLayout<'_>) {
+        let paragraphs: alloc::vec::Vec<_> = layout.paragraphs().collect();
+        // Both ends have to resolve, or the selection means nothing.
+        self.decoded = self
+            .byte_offset(&paragraphs, self.anchor)
+            .zip(self.byte_offset(&paragraphs, self.focus));
+    }
+}
+
+/// The selection anchor and cursor, as byte offsets into the text the input displays.
+///
+/// Not read off a `TextInputVisualRepresentation`, which would subscribe to `cursor_visible` and
+/// invalidate the accessibility subtree on every blink.
+fn selection_offsets(text_input: Pin<&crate::items::TextInput>) -> (usize, usize) {
+    // The splice the shaping path reads, so these offsets index the string it shaped.
+    let (visible_pre_mask, composition) = text_input.text_with_preedit();
+
+    let (raw_anchor, raw_cursor) = if !composition.is_empty() {
+        // `preedit_selection` is private, so a selection inside the composition isn't reported;
+        // the caret goes to the end of it.
+        (composition.end, composition.end)
+    } else {
+        (
+            text_input.anchor_position(&visible_pre_mask),
+            text_input.cursor_position(&visible_pre_mask),
+        )
+    };
+
+    // Last, so the offsets end up indexing the masked string the layout was shaped from.
+    if text_input.is_password() {
+        let mask_char_len = crate::items::PASSWORD_CHARACTER.len_utf8();
+        let to_masked = |actual_offset: usize| -> usize {
+            visible_pre_mask[..actual_offset.min(visible_pre_mask.len())].chars().count()
+                * mask_char_len
+        };
+        (to_masked(raw_anchor), to_masked(raw_cursor))
+    } else {
+        (raw_anchor, raw_cursor)
+    }
+}
+
+fn position_for_byte_offset(
+    paragraphs: &[TextInputParagraph<'_>],
+    layout_access: &[LayoutAccessibility],
+    offset: usize,
+) -> Option<TextPosition> {
+    for (para, la) in paragraphs.iter().zip(layout_access.iter()) {
+        if offset < para.range.start || offset > para.range.end {
+            continue;
+        }
+        let local = offset - para.range.start;
+        let cursor =
+            Cursor::from_byte_index(para.layout, local, parley::layout::Affinity::Downstream);
+        if let Some(pos) = cursor.to_access_position(para.layout, la) {
+            return Some(pos);
+        }
+    }
+    None
+}
+
+fn compose_text_selection(
+    paragraphs: &[TextInputParagraph<'_>],
+    layout_access: &[LayoutAccessibility],
+    anchor: usize,
+    focus: usize,
+) -> Option<TextSelection> {
+    let anchor_pos = position_for_byte_offset(paragraphs, layout_access, anchor)?;
+    let focus_pos = position_for_byte_offset(paragraphs, layout_access, focus)?;
+    Some(TextSelection { anchor: anchor_pos, focus: focus_pos })
+}

--- a/internal/core/textlayout/sharedparley/accessibility.rs
+++ b/internal/core/textlayout/sharedparley/accessibility.rs
@@ -186,8 +186,33 @@ impl CachedTextInputAccessibilityState {
     ) -> Option<(usize, usize)> {
         let mut decoder = Decoder { state: self, anchor, focus, decoded: None };
         renderer.visit_text_input_layout(text_input, item_rc, size, &mut decoder);
-        decoder.decoded
+        let (anchor, focus) = decoder.decoded?;
+        Some((to_actual_offset(text_input, anchor), to_actual_offset(text_input, focus)))
     }
+}
+
+/// Maps a byte offset in the text the input *displays* back to one in the text it *holds*.
+///
+/// A password field displays [`crate::items::PASSWORD_CHARACTER`] per character, and that character
+/// is three bytes in UTF-8 where the ones it stands in for are often one, so the two run out of step
+/// as soon as anything past the first character is selected. The offsets an assistive technology
+/// hands back index the displayed text, while `TextInput::set-selection-offsets` indexes the held
+/// text, so they have to be converted on the way through.
+///
+/// This is what `TextInputVisualRepresentation::map_byte_offset_from_visual_text_to_actual_text`
+/// does for the renderer's hit-testing; the accessibility pass can't reuse it, because reaching a
+/// `TextInputVisualRepresentation` means reading `cursor_visible` and dirtying the AT subtree on
+/// every blink.
+fn to_actual_offset(text_input: Pin<&crate::items::TextInput>, displayed_offset: usize) -> usize {
+    if !text_input.is_password() {
+        return displayed_offset;
+    }
+    // One mask character per character of the text, so the offset divides out to an index.
+    let unmasked = text_input.text_with_preedit().0;
+    unmasked
+        .char_indices()
+        .nth(displayed_offset / crate::items::PASSWORD_CHARACTER.len_utf8())
+        .map_or(unmasked.len(), |(offset, _)| offset)
 }
 
 /// See [`CachedTextInputAccessibilityState::decode_selection`].

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -1115,6 +1115,37 @@ impl RendererSealed for SoftwareRenderer {
         }
     }
 
+    #[cfg(feature = "systemfonts")]
+    fn visit_text_input_layout(
+        &self,
+        text_input: Pin<&i_slint_core::items::TextInput>,
+        item_rc: &ItemRc,
+        size: LogicalSize,
+        visitor: &mut dyn sharedparley::TextInputLayoutVisitor,
+    ) -> bool {
+        let (Some(scale_factor), Some(slint_ctx)) = (self.scale_factor(), self.slint_context())
+        else {
+            return false;
+        };
+        let font_request = text_input.font_request(item_rc);
+        let font = {
+            let mut font_ctx = slint_ctx.font_context().borrow_mut();
+            fonts::match_font(&font_request, scale_factor, &mut font_ctx)
+        };
+
+        match (font, parley_disabled()) {
+            (fonts::Font::VectorFont(_), false) => sharedparley::visit_text_input_layout(
+                self,
+                text_input,
+                item_rc,
+                size,
+                Some(&self.text_layout_cache),
+                visitor,
+            ),
+            _ => false,
+        }
+    }
+
     fn text_input_cursor_rect_for_byte_offset(
         &self,
         text_input: Pin<&i_slint_core::items::TextInput>,

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -783,6 +783,11 @@ impl SoftwareRenderer {
 
 #[doc(hidden)]
 impl RendererSealed for SoftwareRenderer {
+    #[cfg(feature = "systemfonts")]
+    fn text_layout_cache(&self) -> Option<&sharedparley::TextLayoutCache> {
+        Some(&self.text_layout_cache)
+    }
+
     fn text_size(
         &self,
         text_item: Pin<&dyn i_slint_core::item_rendering::RenderString>,
@@ -1115,13 +1120,13 @@ impl RendererSealed for SoftwareRenderer {
         }
     }
 
+    // Keep in sync with the `draw_text_input` arm that takes the shared parley path, or the
+    // accessibility tree describes a layout that isn't the one drawn.
     #[cfg(feature = "systemfonts")]
-    fn visit_text_input_layout(
+    fn text_input_has_parley_layout(
         &self,
         text_input: Pin<&i_slint_core::items::TextInput>,
         item_rc: &ItemRc,
-        size: LogicalSize,
-        visitor: &mut dyn sharedparley::TextInputLayoutVisitor,
     ) -> bool {
         let (Some(scale_factor), Some(slint_ctx)) = (self.scale_factor(), self.slint_context())
         else {
@@ -1133,17 +1138,7 @@ impl RendererSealed for SoftwareRenderer {
             fonts::match_font(&font_request, scale_factor, &mut font_ctx)
         };
 
-        match (font, parley_disabled()) {
-            (fonts::Font::VectorFont(_), false) => sharedparley::visit_text_input_layout(
-                self,
-                text_input,
-                item_rc,
-                size,
-                Some(&self.text_layout_cache),
-                visitor,
-            ),
-            _ => false,
-        }
+        matches!(font, fonts::Font::VectorFont(_)) && !parley_disabled()
     }
 
     fn text_input_cursor_rect_for_byte_offset(
@@ -2957,6 +2952,7 @@ impl<T: ProcessScene> i_slint_core::item_rendering::ItemRenderer for SceneBuilde
         );
 
         match (font, parley_disabled()) {
+            // `SoftwareRenderer::text_input_has_parley_layout` must agree on this arm.
             #[cfg(feature = "systemfonts")]
             (fonts::Font::VectorFont(_), false) => {
                 drop(font_ctx);

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
 name = "i-slint-core"
 version = "1.18.0"
 dependencies = [
+ "accesskit",
  "async-channel",
  "auto_enums",
  "bitflags 2.13.1",
@@ -4183,6 +4184,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
 dependencies = [
+ "accesskit",
  "fontique",
  "harfrust",
  "hashbrown 0.17.1",


### PR DESCRIPTION
Closes #2895

Allows assistive technologies to see the textual content of text inputs, navigate it, do hit testing, inspect the selection and manipulate it.

This will later need to be generalized to rich/styled text and Markdown content, but I feel like the current parley API is not flexible enough. I have filed https://github.com/linebender/parley/pull/716 but I have no idea how it will turn out.

Part of https://github.com/AccessKit/accesskit/issues/565

## How to test

On a desktop platform (Windows/Linux/macOS), enable an assistive technology (preferably a screen reader such as NVDA), then run the gallery example:

```bash
cd examples/gallery
cargo run
```

- Go to the "Input" tab on the left.
- Navigate with the keyboard to the single line input.
- Once inside, observe that characters are now announced as the caret moves (use the arrow keys).
- Selection of multiple characters is also reported.
- If a Braille display is connected, observe that the caret can be seen blinking. Using routing keys (generally above the Braille cells) should allow moving the caret, double-clicking a routing key should select the nearest word.
- Some operating systems such as Windows have a feature to increase the visibility of the caret: observe that the visual highlight is now painted and follows the caret.
- When moving to the password field on the right, observe that the assistive technology can navigate the content but doesn't report it.
- When moving onto the multiline inputs below, observe that assistive technologies can differenciate between a "soft" and a "hard" line break.
- If supported by the assistive technology, observe that hovering the mouse over the text can make the AT report the paragraph under, not just the line.
- If the AT supports it, observe that you can navigate between words, lines or paragraphs.