### PR TITLE
Share adjust_rect_and_border_for_inner_drawing in i-slint-core

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -12,7 +12,7 @@ use i_slint_core::graphics::rendering_metrics_collector::{
 };
 use i_slint_core::graphics::{
     Brush, Color, ImageCacheKey, IntRect, Point, Rgba8Pixel, SharedImageBuffer, SharedPixelBuffer,
-    euclid,
+    adjust_rect_and_border_for_inner_drawing, euclid,
 };
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};
 use i_slint_core::item_rendering::{
@@ -823,16 +823,6 @@ macro_rules! check_geometry {
     }};
 }
 
-fn adjust_rect_and_border_for_inner_drawing(rect: &mut qttypes::QRectF, border_width: &mut f32) {
-    // If the border width exceeds the width, just fill the rectangle.
-    *border_width = border_width.min((rect.width as f32) / 2.);
-    // adjust the size so that the border is drawn within the geometry
-    rect.x += *border_width as f64 / 2.;
-    rect.y += *border_width as f64 / 2.;
-    rect.width -= *border_width as f64;
-    rect.height -= *border_width as f64;
-}
-
 struct QtItemRenderer<'a> {
     painter: QPainterPtr,
     cache: &'a ItemCache<qttypes::QPixmap>,
@@ -1126,18 +1116,17 @@ impl ItemRenderer for QtItemRenderer<'_> {
 
     fn combine_clip(
         &mut self,
-        rect: LogicalRect,
+        mut rect: LogicalRect,
         radius: LogicalBorderRadius,
-        border_width: LogicalLength,
+        mut border_width: LogicalLength,
     ) -> bool {
-        let mut border_width: f32 = border_width.get();
-        let mut clip_rect = qttypes::QRectF {
+        adjust_rect_and_border_for_inner_drawing(&mut rect, &mut border_width);
+        let clip_rect = qttypes::QRectF {
             x: rect.min_x() as _,
             y: rect.min_y() as _,
             width: rect.width() as _,
             height: rect.height() as _,
         };
-        adjust_rect_and_border_for_inner_drawing(&mut clip_rect, &mut border_width);
         let painter: &mut QPainterPtr = &mut self.painter;
         let top_left_radius = radius.top_left;
         let top_right_radius = radius.top_right;

--- a/internal/core/graphics.rs
+++ b/internal/core/graphics.rs
@@ -62,6 +62,22 @@ pub mod wgpu_29;
 #[cfg(feature = "wgpu-30")]
 pub mod wgpu_30;
 
+/// Adjusts a rectangle and a border width for drawing the border entirely inside the
+/// rectangle's geometry: renderers stroke a border centered on the path, so the rectangle
+/// is inset by half the border width. If the border width exceeds half of the rectangle's
+/// width, it is clamped so that the border just fills the rectangle.
+pub fn adjust_rect_and_border_for_inner_drawing<U>(
+    rect: &mut euclid::Rect<f32, U>,
+    border_width: &mut euclid::Length<f32, U>,
+) {
+    use crate::lengths::RectLengths;
+    // If the border width exceeds the width, just fill the rectangle.
+    *border_width = border_width.min(rect.width_length() / 2.);
+    // adjust the size so that the border is drawn within the geometry
+    rect.origin += euclid::Size2D::from_lengths(*border_width / 2., *border_width / 2.);
+    rect.size -= euclid::Size2D::from_lengths(*border_width, *border_width);
+}
+
 /// CachedGraphicsData allows the graphics backend to store an arbitrary piece of data associated with
 /// an item, which is typically computed by accessing properties. The dependency_tracker is used to allow
 /// for a lazy computation. Typically, back ends store either compute intensive data or handles that refer to

--- a/internal/renderers/anyrender/itemrenderer.rs
+++ b/internal/renderers/anyrender/itemrenderer.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyrender::PaintScene;
+use i_slint_core::graphics::adjust_rect_and_border_for_inner_drawing;
 use i_slint_core::graphics::euclid;
 use i_slint_core::graphics::{Image, ImageCacheKey, IntRect, SharedImageBuffer, SharedPixelBuffer};
 use i_slint_core::item_rendering::{
@@ -14,7 +15,7 @@ use i_slint_core::item_rendering::{
 use i_slint_core::items::{self, FillRule, ImageFit, ImageRendering, ItemRc};
 use i_slint_core::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
-    PhysicalBorderRadius, RectLengths, ScaleFactor, logical_size_from_api,
+    PhysicalBorderRadius, ScaleFactor, logical_size_from_api,
 };
 use i_slint_core::textlayout::sharedparley::{self, GlyphRenderer, fontique, parley};
 use i_slint_core::{Brush, Color, ImageInner, SharedString};
@@ -1204,17 +1205,6 @@ fn sanitize_color_stops<'a>(
             .collect(),
     );
     (stops, extent)
-}
-
-fn adjust_rect_and_border_for_inner_drawing(
-    rect: &mut PhysicalRect,
-    border_width: &mut PhysicalLength,
-) {
-    // If the border width exceeds the width, just fill the rectangle.
-    *border_width = border_width.min(rect.width_length() / 2.);
-    // Adjust the size so that the border is drawn within the geometry.
-    rect.origin += PhysicalSize::from_lengths(*border_width / 2., *border_width / 2.);
-    rect.size -= PhysicalSize::from_lengths(*border_width, *border_width);
 }
 
 /// Untyped because that is what [`i_slint_core::graphics::line_for_angle`]

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use euclid::approxeq::ApproxEq;
 use femtovg::Transform2D;
+use i_slint_core::graphics::adjust_rect_and_border_for_inner_drawing;
 use i_slint_core::graphics::boxshadowcache::BoxShadowCache;
 use i_slint_core::graphics::euclid::num::Zero;
 use i_slint_core::graphics::euclid::{self};
@@ -22,7 +23,7 @@ use i_slint_core::items::{
 };
 use i_slint_core::lengths::{
     LogicalBorderRadius, LogicalLength, LogicalPoint, LogicalRect, LogicalSize, LogicalVector,
-    RectLengths, ScaleFactor, logical_size_from_api,
+    ScaleFactor, logical_size_from_api,
 };
 use i_slint_core::textlayout::sharedparley::{self, GlyphRenderer, fontique, parley};
 use i_slint_core::{Brush, Color, ImageInner, SharedString};
@@ -137,18 +138,6 @@ fn rect_with_radius_to_path(
 
 fn rect_to_path(r: PhysicalRect) -> femtovg::Path {
     rect_with_radius_to_path(r, PhysicalBorderRadius::default())
-}
-
-fn adjust_rect_and_border_for_inner_drawing(
-    rect: &mut PhysicalRect,
-    border_width: &mut PhysicalLength,
-) {
-    // If the border width exceeds the width, just fill the rectangle.
-    *border_width = border_width.min(rect.width_length() / 2.);
-    // adjust the size so that the border is drawn within the geometry
-
-    rect.origin += PhysicalSize::from_lengths(*border_width / 2., *border_width / 2.);
-    rect.size -= PhysicalSize::from_lengths(*border_width, *border_width);
 }
 
 fn path_bounding_box<R: femtovg::Renderer>(

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 use super::{PhysicalBorderRadius, PhysicalLength, PhysicalPoint, PhysicalRect, PhysicalSize};
 use i_slint_core::graphics::ApproxEq;
+use i_slint_core::graphics::adjust_rect_and_border_for_inner_drawing;
 use i_slint_core::graphics::boxshadowcache::BoxShadowCache;
 use i_slint_core::graphics::euclid::num::Zero;
 use i_slint_core::graphics::euclid::{self, Vector2D};
@@ -1265,16 +1266,4 @@ pub fn to_skia_size(size: &PhysicalSize) -> skia_safe::Size {
 
 pub fn to_skia_color(col: &Color) -> skia_safe::Color {
     skia_safe::Color::from_argb(col.alpha(), col.red(), col.green(), col.blue())
-}
-
-fn adjust_rect_and_border_for_inner_drawing(
-    rect: &mut PhysicalRect,
-    border_width: &mut PhysicalLength,
-) {
-    // If the border width exceeds the width, just fill the rectangle.
-    *border_width = border_width.min(rect.width_length() / 2.);
-    // adjust the size so that the border is drawn within the geometry
-
-    rect.origin += PhysicalSize::from_lengths(*border_width / 2., *border_width / 2.);
-    rect.size -= PhysicalSize::from_lengths(*border_width, *border_width);
 }


### PR DESCRIPTION
The helper was copy-pasted in the skia, femtovg, and anyrender item renderers as well as the Qt backend. Move it into
i_slint_core::graphics, generic over the euclid unit tag, and use it from all four places.

The Qt backend now applies the adjustment to the logical rect before converting to QRectF instead of duplicating the math on QRectF.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
