### PR TITLE
ci: run the integration tests when the anyrender renderer changes

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -50,7 +50,7 @@ integration: &integration
  - '.github/workflows/build_and_test_reusable.yaml'
  - 'api/rs/**'
  - 'internal/compiler/generator/rust*{,/**}'
- - 'internal/renderers/{skia,software}/**'
+ - 'internal/renderers/{anyrender,skia,software}/**'
  - 'internal/backends/winit/**'
 
 # Everything the root-workspace `cargo test` covers: all of internal/ (also


### PR DESCRIPTION
The screenshot driver's anyrender goldens and vello_cpu pixel references are only checked by the tests/ workspace run, which is gated on the integration path filter. That filter lists skia and software explicitly because the internal group excludes internal/renderers/**, so a change touching only the anyrender renderer skipped its own tests.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
