### PR TITLE
slint-sc: cover RenderError's Display

### DIFF
--- a/api/slint-sc/tests/cases/component/window_background.slint
+++ b/api/slint-sc/tests/cases/component/window_background.slint
@@ -16,6 +16,8 @@ let mut frame_buffer = [0u8; 64 * 64 * 3];
 x.render_rgb8(64, 64, &mut frame_buffer)?;
 assert!(frame_buffer.chunks(3).all(|pixel| pixel == [0xff, 0x00, 0x00]));
 //#sls.gen.render-error
-assert_eq!(x.render_rgb8(64, 64, &mut [0u8; 8]), Err(slint_sc::RenderError::InvalidFrameBufferSize));
+let error = x.render_rgb8(64, 64, &mut [0u8; 8]).unwrap_err();
+assert_eq!(error, slint_sc::RenderError::InvalidFrameBufferSize);
+assert_eq!(std::format!("{error}"), "the frame buffer size doesn't match the requested width and height");
 ```
 */

--- a/api/slint-sc/tests/driver.rs
+++ b/api/slint-sc/tests/driver.rs
@@ -38,6 +38,15 @@ fn main() {
     let slint_sc_rlib = find_slint_sc_rlib(&target_dir);
     let rx = Regex::new(r"(?sU)\r?\n```rust( compile_fail)?\r?\n(.+)\r?\n```\r?\n").unwrap();
 
+    // The runtime code a case exercises is compiled into its own test binary,
+    // so its coverage lives in that binary rather than the crate's own build.
+    // When one is requested, keep the binaries here for the report step to
+    // pass to llvm-cov; otherwise they live in the per-case tempdir.
+    let cov_bin_dir = std::env::var_os("SLINT_SC_COV_BIN_DIR").map(PathBuf::from);
+    if let Some(dir) = &cov_bin_dir {
+        std::fs::create_dir_all(dir).expect("failed to create SLINT_SC_COV_BIN_DIR");
+    }
+
     let config = TestConfig {
         compiler: &compiler,
         slint_sc_rlib: &slint_sc_rlib,
@@ -45,6 +54,7 @@ fn main() {
         instrument_coverage,
         create_screenshots: std::env::var("SLINT_CREATE_SCREENSHOTS").is_ok_and(|var| var == "1"),
         rx: &rx,
+        cov_bin_dir: cov_bin_dir.as_deref(),
     };
 
     let results: Vec<(String, Result<(), String>)> = test_files
@@ -134,6 +144,9 @@ struct TestConfig<'a> {
     instrument_coverage: bool,
     create_screenshots: bool,
     rx: &'a Regex,
+    /// Where to keep each case's test binary so the coverage report can reach
+    /// it; `None` outside a coverage run, when the tempdir is enough.
+    cov_bin_dir: Option<&'a Path>,
 }
 
 fn find_target_dir() -> PathBuf {
@@ -216,8 +229,13 @@ fn run_test(slint_path: &Path, rel: &Path, config: &TestConfig) -> Result<(), St
     std::fs::write(&test_rs, assemble_program(&gen_path, &test_code))
         .map_err(|e| format!("write test.rs: {e}"))?;
 
-    // Step 4: Compile with rustc
-    let test_bin = tmp.path().join("test_bin");
+    // Step 4: Compile with rustc. During a coverage run the binary must
+    // outlive the tempdir so the report step can read its coverage map, so
+    // give it a stable per-case name in the kept directory.
+    let test_bin = match config.cov_bin_dir {
+        Some(dir) => dir.join(rel.with_extension("").to_string_lossy().replace(['/', '\\'], "_")),
+        None => tmp.path().join("test_bin"),
+    };
     let rustc_output = compile(config, &test_rs, &test_bin)?;
     if !rustc_output.status.success() {
         let stderr = String::from_utf8_lossy(&rustc_output.stderr);

--- a/scripts/slint_sc_test_suite.sh
+++ b/scripts/slint_sc_test_suite.sh
@@ -32,14 +32,46 @@ cargo test -p slint-compiler --features slint-sc --no-default-features
 
 cargo llvm-cov clean --workspace
 
+# Each .slint case is compiled into its own test binary that statically links
+# the runtime, so the coverage it produces is recorded against that binary's
+# copy of the crate, not the crate's own build. Keep those binaries so the
+# report below can attribute their coverage; without them only the runtime's
+# unit tests would count. The directory is rebuilt every run so cases that
+# were removed don't leave stale binaries behind.
+bins="$PWD/$out/test-bins"
+rm -rf "$bins"
+
 # --remap-path-prefix makes the reports use workspace-relative paths, so the
 # safety manual's per-line links don't depend on the checkout location.
-SLINT_TEST_REPORT="$PWD/$results/driver.json" CARGO_TERM_COLOR=never \
+SLINT_TEST_REPORT="$PWD/$results/driver.json" SLINT_SC_COV_BIN_DIR="$bins" CARGO_TERM_COLOR=never \
     cargo llvm-cov --no-report --remap-path-prefix -p slint-sc 2>&1 \
     | tee "$results/runtime-tests.log"
 
+# Report with llvm-cov directly rather than `cargo llvm-cov report`, which
+# only knows the binaries cargo built: the object set is the crate's unit-test
+# binary (its coverage map lists every runtime function, so untested ones are
+# counted) plus the per-case test binaries (their coverage from the integration
+# tests). The tools ship with the toolchain.
+llvm_bin="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/^host: //p')/bin"
+profdata="$out/coverage.profdata"
+"$llvm_bin/llvm-profdata" merge -sparse -o "$profdata" target/llvm-cov-target/*.profraw
+
+unit_bin=$(find target/llvm-cov-target/debug/deps -maxdepth 1 -type f -executable \
+    -name 'slint_sc-*' ! -name '*.d' -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2-)
+objects=(-object "$unit_bin")
+for bin in "$bins"/*; do
+    objects+=(-object "$bin")
+done
+
+# Keep only the runtime sources: the generated and test code compiled into the
+# per-case binaries lives at absolute paths or under tests/.
+ignore='(^/|(^|/)tests/|(^|/)[A-Za-z0-9_-]+[_-]?tests\.rs$|^target/)'
+
 # The full export (not --summary-only): the per-function region counts feed
 # the fully/partially/untested statistics in the safety manual.
-cargo llvm-cov report --remap-path-prefix --json --output-path "$out/coverage.json"
-cargo llvm-cov report --remap-path-prefix --lcov --output-path "$out/lcov.info"
-cargo llvm-cov report --remap-path-prefix --html --output-dir "$out"
+"$llvm_bin/llvm-cov" export -format=text -instr-profile="$profdata" \
+    -ignore-filename-regex="$ignore" "${objects[@]}" > "$out/coverage.json"
+"$llvm_bin/llvm-cov" export -format=lcov -instr-profile="$profdata" \
+    -ignore-filename-regex="$ignore" "${objects[@]}" > "$out/lcov.info"
+"$llvm_bin/llvm-cov" show -format=html -output-dir="$out/html" -instr-profile="$profdata" \
+    -ignore-filename-regex="$ignore" "${objects[@]}"


### PR DESCRIPTION
The render-error test checked the error value but never formatted it, so the Display impl was uncovered. Assert its message alongside the value.

