### PR TITLE
skia: Simplify the construction of SkiaRenderer

### DIFF
--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -176,13 +176,7 @@ pub struct SkiaRenderer {
     rendering_metrics_collector: RefCell<Option<Rc<RenderingMetricsCollector>>>,
     rendering_first_time: Cell<bool>,
     surface: RefCell<Option<Box<dyn Surface>>>,
-    surface_factory: fn(
-        &SkiaSharedContext,
-        window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
-        display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
-        size: PhysicalWindowSize,
-        requested_graphics_api: Option<RequestedGraphicsAPI>,
-    ) -> Result<Box<dyn Surface>, PlatformError>,
+    surface_factory: SurfaceFactoryFn,
     pre_present_callback: RefCell<Option<Box<dyn FnMut()>>>,
     partial_rendering_state: Option<PartialRenderingState>,
     dirty_region_debug_mode: DirtyRegionDebugMode,
@@ -191,8 +185,16 @@ pub struct SkiaRenderer {
     shared_context: SkiaSharedContext,
 }
 
-/// Creates a boxed surface of the concrete type `S`, in the shape of
-/// [`SkiaRenderer`]'s `surface_factory` function pointer.
+/// Function pointer for creating the surface to render on, when needed.
+type SurfaceFactoryFn = fn(
+    &SkiaSharedContext,
+    window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+    display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
+    size: PhysicalWindowSize,
+    requested_graphics_api: Option<RequestedGraphicsAPI>,
+) -> Result<Box<dyn Surface>, PlatformError>;
+
+/// Creates a boxed surface of the concrete type `S`, in the shape of [`SurfaceFactoryFn`].
 fn surface_factory<S: Surface + 'static>(
     context: &SkiaSharedContext,
     window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
@@ -207,13 +209,7 @@ fn surface_factory<S: Surface + 'static>(
 impl SkiaRenderer {
     fn new_with_surface_factory(
         context: &SkiaSharedContext,
-        surface_factory: fn(
-            &SkiaSharedContext,
-            Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
-            Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
-            PhysicalWindowSize,
-            Option<RequestedGraphicsAPI>,
-        ) -> Result<Box<dyn Surface>, PlatformError>,
+        surface_factory: SurfaceFactoryFn,
         partial_rendering_state: Option<PartialRenderingState>,
     ) -> Self {
         Self {

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -191,9 +191,31 @@ pub struct SkiaRenderer {
     shared_context: SkiaSharedContext,
 }
 
+/// Creates a boxed surface of the concrete type `S`, in the shape of
+/// [`SkiaRenderer`]'s `surface_factory` function pointer.
+fn surface_factory<S: Surface + 'static>(
+    context: &SkiaSharedContext,
+    window_handle: Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+    display_handle: Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
+    size: PhysicalWindowSize,
+    requested_graphics_api: Option<RequestedGraphicsAPI>,
+) -> Result<Box<dyn Surface>, PlatformError> {
+    S::new(context, window_handle, display_handle, size, requested_graphics_api)
+        .map(|r| Box::new(r) as Box<dyn Surface>)
+}
+
 impl SkiaRenderer {
-    #[cfg(skia_windowed)]
-    pub fn default(context: &SkiaSharedContext) -> Self {
+    fn new_with_surface_factory(
+        context: &SkiaSharedContext,
+        surface_factory: fn(
+            &SkiaSharedContext,
+            Arc<dyn raw_window_handle::HasWindowHandle + Send + Sync>,
+            Arc<dyn raw_window_handle::HasDisplayHandle + Send + Sync>,
+            PhysicalWindowSize,
+            Option<RequestedGraphicsAPI>,
+        ) -> Result<Box<dyn Surface>, PlatformError>,
+        partial_rendering_state: Option<PartialRenderingState>,
+    ) -> Self {
         Self {
             maybe_window_adapter: Default::default(),
             rendering_notifier: Default::default(),
@@ -205,265 +227,92 @@ impl SkiaRenderer {
             rendering_metrics_collector: Default::default(),
             rendering_first_time: Default::default(),
             surface: Default::default(),
-            surface_factory: create_default_surface,
+            surface_factory,
             pre_present_callback: Default::default(),
-            partial_rendering_state: create_partial_renderer_state(None),
+            partial_rendering_state,
             dirty_region_debug_mode: Default::default(),
             dirty_region_history: Default::default(),
             shared_context: context.clone(),
         }
+    }
+
+    #[cfg(skia_windowed)]
+    pub fn default(context: &SkiaSharedContext) -> Self {
+        Self::new_with_surface_factory(
+            context,
+            create_default_surface,
+            create_partial_renderer_state(None),
+        )
     }
 
     #[cfg(skia_backend_software)]
     /// Creates a new SkiaRenderer that will always use Skia's software renderer.
     pub fn default_software(context: &SkiaSharedContext) -> Self {
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Default::default(),
-            surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                software_surface::SoftwareSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
-            },
-            pre_present_callback: Default::default(),
-            partial_rendering_state: PartialRenderingState::default().into(),
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+        Self::new_with_surface_factory(
+            context,
+            surface_factory::<software_surface::SoftwareSurface>,
+            PartialRenderingState::default().into(),
+        )
     }
 
     #[cfg(any(not(target_vendor = "apple"), target_os = "macos"))]
     /// Creates a new SkiaRenderer that will always use Skia's OpenGL renderer.
     pub fn default_opengl(context: &SkiaSharedContext) -> Self {
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Default::default(),
-            surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                opengl_surface::OpenGLSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
-            },
-            pre_present_callback: Default::default(),
-            partial_rendering_state: create_partial_renderer_state(None),
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+        Self::new_with_surface_factory(
+            context,
+            surface_factory::<opengl_surface::OpenGLSurface>,
+            create_partial_renderer_state(None),
+        )
     }
 
     #[cfg(target_vendor = "apple")]
     /// Creates a new SkiaRenderer that will always use Skia's Metal renderer.
     pub fn default_metal(context: &SkiaSharedContext) -> Self {
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Default::default(),
-            surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                metal_surface::MetalSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
-            },
-            pre_present_callback: Default::default(),
-            partial_rendering_state: create_partial_renderer_state(None),
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+        Self::new_with_surface_factory(
+            context,
+            surface_factory::<metal_surface::MetalSurface>,
+            create_partial_renderer_state(None),
+        )
     }
 
     #[cfg(skia_backend_vulkan)]
     /// Creates a new SkiaRenderer that will always use Skia's Vulkan renderer.
     pub fn default_vulkan(context: &SkiaSharedContext) -> Self {
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Default::default(),
-            surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                vulkan_surface::VulkanSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
-            },
-            pre_present_callback: Default::default(),
-            partial_rendering_state: create_partial_renderer_state(None),
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+        Self::new_with_surface_factory(
+            context,
+            surface_factory::<vulkan_surface::VulkanSurface>,
+            create_partial_renderer_state(None),
+        )
     }
 
     #[cfg(target_family = "windows")]
     /// Creates a new SkiaRenderer that will always use Skia's Direct3D renderer.
     pub fn default_direct3d(context: &SkiaSharedContext) -> Self {
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Default::default(),
-            surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                d3d_surface::D3DSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
-            },
-            pre_present_callback: Default::default(),
-            partial_rendering_state: create_partial_renderer_state(None),
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+        Self::new_with_surface_factory(
+            context,
+            surface_factory::<d3d_surface::D3DSurface>,
+            create_partial_renderer_state(None),
+        )
     }
 
     #[cfg(feature = "unstable-wgpu-30")]
     /// Creates a new SkiaRenderer that will always use Skia's WGPU 30.x renderer.
     pub fn default_wgpu_30(context: &SkiaSharedContext) -> Self {
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Default::default(),
-            surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                wgpu_30_surface::WGPUSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
-            },
-            pre_present_callback: Default::default(),
-            partial_rendering_state: create_partial_renderer_state(None),
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+        Self::new_with_surface_factory(
+            context,
+            surface_factory::<wgpu_30_surface::WGPUSurface>,
+            create_partial_renderer_state(None),
+        )
     }
 
     #[cfg(feature = "unstable-wgpu-29")]
     /// Creates a new SkiaRenderer that will always use Skia's WGPU 29.x renderer.
     pub fn default_wgpu_29(context: &SkiaSharedContext) -> Self {
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Default::default(),
-            surface: Default::default(),
-            surface_factory: |context,
-                              window_handle,
-                              display_handle,
-                              size,
-                              requested_graphics_api| {
-                wgpu_29_surface::WGPUSurface::new(
-                    context,
-                    window_handle,
-                    display_handle,
-                    size,
-                    requested_graphics_api,
-                )
-                .map(|r| Box::new(r) as Box<dyn Surface>)
-            },
-            pre_present_callback: Default::default(),
-            partial_rendering_state: create_partial_renderer_state(None),
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+        Self::new_with_surface_factory(
+            context,
+            surface_factory::<wgpu_29_surface::WGPUSurface>,
+            create_partial_renderer_state(None),
+        )
     }
 
     /// Creates a new renderer is associated with the provided window adapter.
@@ -484,27 +333,16 @@ impl SkiaRenderer {
         context: &SkiaSharedContext,
         surface: Box<dyn Surface + 'static>,
     ) -> Self {
-        let partial_rendering_state = create_partial_renderer_state(Some(surface.as_ref()));
-        Self {
-            maybe_window_adapter: Default::default(),
-            rendering_notifier: Default::default(),
-            image_cache: Default::default(),
-            layer_cache: Default::default(),
-            path_cache: Default::default(),
-            box_shadow_cache: Default::default(),
-            text_layout_cache: Default::default(),
-            rendering_metrics_collector: Default::default(),
-            rendering_first_time: Cell::new(true),
-            surface: RefCell::new(Some(surface)),
-            surface_factory: |_, _, _, _, _| {
+        let renderer = Self::new_with_surface_factory(
+            context,
+            |_, _, _, _, _| {
                 Err("Skia renderer constructed with surface does not support dynamic surface re-creation".into())
             },
-            pre_present_callback: Default::default(),
-            partial_rendering_state,
-            dirty_region_debug_mode: Default::default(),
-            dirty_region_history: Default::default(),
-            shared_context: context.clone(),
-        }
+            create_partial_renderer_state(Some(surface.as_ref())),
+        );
+        renderer.rendering_first_time.set(true);
+        *renderer.surface.borrow_mut() = Some(surface);
+        renderer
     }
 
     /// Reset the surface to a new surface. (destroy the previously set surface if any)


### PR DESCRIPTION
The eight backend-specific constructors were all the same 17-field struct literal, differing only in the surface factory and whether partial rendering is enabled by default. Introduce a private new_with_surface_factory constructor and a generic surface_factory<S> function that boxes any Surface implementation, and reduce each public constructor to a single call. new_with_surface also goes through the shared constructor and sets the surface and first-time flag afterwards through their cells.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
