### PR TITLE
winit-software: present the actual dirty rectangles as damage

### DIFF
--- a/internal/backends/winit/renderer/sw.rs
+++ b/internal/backends/winit/renderer/sw.rs
@@ -149,18 +149,21 @@ impl super::WinitCompatibleRenderer for WinitSoftwareRenderer {
             })
         };
 
-        let size = region.bounding_box_size();
-        if let Some((w, h)) = Option::zip(NonZeroU32::new(size.width), NonZeroU32::new(size.height))
-        {
-            winit_window.pre_present_notify();
-            let pos = region.bounding_box_origin();
-            target_buffer
-                .present_with_damage(&[softbuffer::Rect {
-                    width: w,
-                    height: h,
+        let damage = region
+            .iter()
+            .filter_map(|(pos, size)| {
+                Some(softbuffer::Rect {
                     x: pos.x as u32,
                     y: pos.y as u32,
-                }])
+                    width: NonZeroU32::new(size.width)?,
+                    height: NonZeroU32::new(size.height)?,
+                })
+            })
+            .collect::<Vec<_>>();
+        if !damage.is_empty() {
+            winit_window.pre_present_notify();
+            target_buffer
+                .present_with_damage(&damage)
                 .map_err(|e| format!("Error presenting softbuffer buffer: {e}"))?;
         }
         Ok(DrawOutcome::Success)


### PR DESCRIPTION
The dirty region may contain several rectangles, but only their bounding box was presented as damaged. The pixels between the rectangles are not repainted, so with swapped buffers the compositor could show stale content from an older buffer in the gap.

Present the non-overlapping rectangles from PhysicalRegion::iter() instead.

Fixes: #12752
