### PR TITLE
anyrender: don't build on 32-bit targets

### DIFF
--- a/internal/renderers/anyrender/Cargo.toml
+++ b/internal/renderers/anyrender/Cargo.toml
@@ -24,9 +24,13 @@ vtable = { workspace = true }
 lyon_path = { workspace = true }
 rgb = "0.8.27"
 
-anyrender = { version = "0.12" }
 peniko = { version = "0.6" }
 kurbo = { version = "0.13" }
+
+# anyrender asserts the size of FilterEffect for a 64-bit layout on every target except
+# wasm32, so it doesn't compile on i686/armv7 either. See the matching `cfg` in lib.rs.
+[target.'cfg(any(target_pointer_width = "64", target_arch = "wasm32"))'.dependencies]
+anyrender = { version = "0.12" }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/internal/renderers/anyrender/lib.rs
+++ b/internal/renderers/anyrender/lib.rs
@@ -19,6 +19,10 @@
 //! in their own crates and only need to implement `SlintWindowRenderer`.
 
 #![doc(html_logo_url = "https://slint.dev/logo/slint-logo-square-light.svg")]
+// anyrender doesn't compile on 32-bit targets, so this crate is empty there. The upstream
+// fix is https://github.com/DioxusLabs/anyrender/pull/74; drop this once it's released and
+// we've updated. See also the target dependency in Cargo.toml.
+#![cfg(any(target_pointer_width = "64", target_arch = "wasm32"))]
 
 use std::cell::{OnceCell, RefCell};
 use std::num::NonZeroU32;


### PR DESCRIPTION
anyrender asserts the size of FilterEffect for a 64-bit layout on every target except wasm32, so it fails to compile on i686 and armv7. Gate the dependency and the crate itself on the pointer width until the upstream fix (DioxusLabs/anyrender#74) is released, so that the workspace builds on 32-bit targets again.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
