### PR TITLE
ci: keep the Windows Skia source build under MAX_PATH

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -36,6 +36,10 @@ inputs:
         description: "Additional directories for Swatinem/rust-cache, eg cargo target directories managed by CMake"
         required: false
         default: ""
+    cache-workspaces:
+        description: "Swatinem/rust-cache `workspaces` mapping, needed when CARGO_TARGET_DIR points outside the checkout"
+        required: false
+        default: ""
 
 runs:
     using: composite
@@ -75,6 +79,9 @@ runs:
           with:
               key: ${{ inputs.key }}-1
               cache-directories: ${{ inputs.cache-directories }}
+              # rust-cache resolves the target of each workspace relative to its
+              # root, so it needs to be told about a relocated CARGO_TARGET_DIR.
+              workspaces: ${{ inputs.cache-workspaces }}
               # Workaround for https://github.com/Swatinem/rust-cache/issues/341:
               # on the updated macOS runner image, cache-bin's restored cargo/rustc
               # dispatches as rustup-init and fails with "unexpected argument".

--- a/.github/workflows/build_and_test_reusable.yaml
+++ b/.github/workflows/build_and_test_reusable.yaml
@@ -120,12 +120,21 @@ jobs:
             - name: Setup headless display
               if: runner.os != 'macOS'
               uses: pyvista/setup-headless-display-action@v4
+            # Skia is built from source here, and ninja resolves cl.exe's relative
+            # includes with the ANSI GetFullPathNameA, so the paths have to stay
+            # below MAX_PATH; the default target directory is one character too
+            # long. Forward slashes keep it usable from the bash steps below.
+            - name: Shorten the target directory to fit the Skia build under MAX_PATH
+              if: runner.os == 'Windows'
+              shell: bash
+              run: echo "CARGO_TARGET_DIR=${RUNNER_WORKSPACE//\\//}/t" >> $GITHUB_ENV
             - uses: ./.github/actions/setup-rust
               with:
                   toolchain: ${{ inputs.rust_version }}
                   key: x-v3
                   save_if: ${{ inputs.save_if }}
                   cache: ${{ inputs.cache }}
+                  cache-workspaces: ${{ runner.os == 'Windows' && '. -> ../t' || '' }}
             - name: Cargo update
               if: inputs.update
               # Ignore rust_version for stable/nightly to test with latest dependencies
@@ -184,7 +193,11 @@ jobs:
               if: always()
               shell: bash
               run: |
-                  for dir in target/*/build/skia-bindings-*/out; do
+                  # Cargo used to name the directory build/skia-bindings-<hash>/out
+                  # and nightly now splits it into build/skia-bindings/<hash>/out,
+                  # so match both layouts.
+                  target_dir="${CARGO_TARGET_DIR:-target}"
+                  for dir in "$target_dir"/*/build/skia-bindings-*/out "$target_dir"/*/build/skia-bindings/*/out; do
                       [ -d "$dir" ] || continue
                       find "$dir/skia" -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} + 2>/dev/null || true
                       rm -rf "$dir/.cache"
@@ -198,7 +211,7 @@ jobs:
                   # here. Upload the whole directory to keep all of them (the plain
                   # cargo-timing.html is overwritten by each successive build).
                   name: cargo-timings-${{ inputs.os }}-${{ inputs.rust_version }}
-                  path: target/cargo-timings/
+                  path: ${{ env.CARGO_TARGET_DIR || 'target' }}/cargo-timings/
                   if-no-files-found: ignore
             - name: Archive screenshots after failed tests
               if: ${{ failure() }}

--- a/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
+++ b/docs/astro/src/content/docs/guide/backends-and-renderers/backends_and_renderers.mdx
@@ -2,7 +2,7 @@
 title: "Backends & Renderers"
 description: "Backends & Renderers"
 ---
-{/* cSpell: ignore linuxkms mfloat BINDGEN OECORE CCARGS xcrun gnueabi Foobj fontmgr Wunused cortexa skunicode cdecl */}
+{/* cSpell: ignore linuxkms mfloat BINDGEN OECORE CCARGS xcrun gnueabi Foobj fontmgr Wunused cortexa skunicode cdecl harfbuzz */}
 
 import Link from '@slint/common-files/src/components/Link.astro';
 import LangRefLink from '@slint/common-files/src/components/LangRefLink.astro';
@@ -119,6 +119,21 @@ issues we're aware of and how to resolve them.
   The error happens when that path contains spaces. By default that's in `%HOMEPATH%\.cargo`,
   which contains spaces if the login name contains spaces. To resolve this issue, set the `CARGO_HOME`
   environment variable to a path without spaces, such as `c:\cargo_home`.
+
+##### Compilation error on Windows about a file name that's too long
+
+  You may see this error when Skia is built from source:
+
+  ```
+   GetFullPathNameA(../../../../../../../../cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.99.0/skia/third_party/externals/harfbuzz/src/...): The filename or extension is too long.
+   ninja: build stopped: subcommand failed.
+  ```
+
+  The Skia build resolves the include paths that the compiler reports with a Windows API that's
+  limited to 260 characters, and it resolves them relative to the build directory. Deep paths for
+  the Cargo target directory or for `CARGO_HOME` exceed that limit. To resolve this issue, move both
+  close to the root of the drive, by setting the `CARGO_TARGET_DIR` environment variable to `c:\t`
+  and the `CARGO_HOME` environment variable to `c:\cargo_home`.
 
 ##### Compilation error when compiling for ARMv7 with hardware floating-point support
 


### PR DESCRIPTION
The Windows job builds Skia from source because --all-features turns on Vulkan and rust-skia publishes no prebuilt binaries for the resulting d3d+gl+textlayout+vulkan combination. Skia's ninja resolves the relative includes that cl.exe reports with the ANSI GetFullPathNameA, and cargo recently grew one more directory level for build script outputs (build/skia-bindings/<hash> instead of build/skia-bindings-<hash>). The extra `../` pushed the concatenation of the build directory and the path back to the sources from 258 to 261 characters, one past the limit, so ninja failed with "The filename or extension is too long".

Point CARGO_TARGET_DIR at a shorter directory next to the checkout on Windows, which brings the longest path back down to 247. rust-cache ignores CARGO_TARGET_DIR and resolves each workspace's target relative to its root, so pass it the matching mapping.

Also teach the Skia trim step about both build directory layouts, so the ninja intermediates keep out of the saved cache.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
