### PR TITLE
FlexboxLayout: fix the wrapping square estimate overshooting by one spacing

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -2077,7 +2077,10 @@ pub fn flexbox_layout_info_main_axis(
             let size = f.hypothetical_main_size(&c.constraint);
             acc += if started { spacing + size } else { size };
             started = true;
-            if acc >= target {
+            // `acc` is the real row width (no trailing gap), but `target` budgets
+            // a gap per item, so add one back before comparing — else a row grabs
+            // one item too many near an integer sqrt.
+            if acc + spacing >= target {
                 break;
             }
         }

--- a/tests/cases/layout/flexbox-preferred-grid-demo.slint
+++ b/tests/cases/layout/flexbox-preferred-grid-demo.slint
@@ -81,8 +81,8 @@ export component TestCase inherits Window {
         ? "FlexboxLayout — fill: flex.width \{round(flex.width / 1px)}px (preferred \{round(flex.preferred-width / 1px)}px)"
         : "FlexboxLayout — fit: preferred-width \{round(flex.preferred-width / 1px)}px";
 
-    in-out property <int> item-count: 32;
-    in-out property <int> spacing-px: 0;
+    in-out property <int> item-count: 16;
+    in-out property <int> spacing-px: 10;
     in-out property <bool> fill-window: false;
     property <[color]> palette: [#e6194b, #3cb44b, #4363d8, #f58231, #911eb4, #008080];
 
@@ -144,10 +144,13 @@ export component TestCase inherits Window {
         Rectangle { } // soak up remaining vertical space
     }
 
-    // Automated check at the default state (32 items, 50px, spacing 0, no padding):
-    // sqrt(32 * 50²) ≈ 283 → snaps to 6 items per row (6×50 = 300px); 32 items
-    // wrap into 6 rows. The widest single item (50px) sets min-width.
-    out property <bool> test: flex.preferred-width == 300px && flex.min-width == 50px;
+    // Automated check at the default state (16 items, 50px, spacing 10, no padding):
+    // sqrt(16 * 60²) = 240 → a square 4 items per row (4×50 + 3×10 = 230px); 16
+    // items wrap into 4 rows. With non-zero spacing this also pins the wrapping
+    // fix: the target counts a trailing gap per item but a row has none after its
+    // last item, so before the fix a fifth ragged column crept in (290px). The
+    // widest single item (50px) sets min-width.
+    out property <bool> test: flex.preferred-width == 230px && flex.min-width == 50px;
 }
 
 /*


### PR DESCRIPTION
The wrapping main-axis preferred size aims for a roughly square arrangement:
target = sqrt(sum of item areas), each item modeled as a (size + spacing)
square (3d7900bd55). The item-count loop then adds items until the row width
reaches that target. But the row width has no trailing gap after the last item,
while the target counts a trailing gap for every item, so the target is one
spacing larger than the matching row. Near an integer sqrt this tips a row into
grabbing one item too many: four equal items (sqrt = 2) wrapped 3 + 1 instead of
a square 2 + 2 (the printerdemo button grid).

Compare `acc + spacing` against the target so both sides count the trailing gap
the same way. Existing tests are unaffected.