### PR TITLE
python: Drain the native event queue between tests

### DIFF
--- a/api/python/slint/tests/conftest.py
+++ b/api/python/slint/tests/conftest.py
@@ -1,0 +1,61 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+"""Keep the native event queue from leaking between tests.
+
+The testing backend keeps one event queue for the whole process, and
+`run_event_loop()` returns as soon as it pops a quit request, so whatever sits
+behind that request stays queued for the next run.
+A test that leaves a stray quit behind therefore cuts the next test's loop short,
+and that test in turn strands its timers for a third one to trip over.
+"""
+
+import os
+
+import pytest
+
+from slint import slint as native
+
+# A drain needs one run per stale quit, so a queue that outlasts this many is
+# refilling itself faster than we can empty it.
+_MAX_RUNS = 10
+
+
+def drain_native_event_queue() -> None:
+    """Empties the native event queue.
+
+    Queues a sentinel behind whatever is already there and runs the loop until
+    the sentinel fires: each run dispatches the events ahead of it and returns,
+    either on the sentinel's own quit or on a stale one queued before it.
+    Twice, because an event can queue a quit of its own once it runs.
+    """
+    if os.environ.get("SLINT_BACKEND") != "testing":
+        # Only the testing backend keeps events queued from before the loop
+        # started. Elsewhere the sentinel never fires and this would hang.
+        return
+
+    for _ in range(2):
+        fired = False
+
+        def sentinel() -> None:
+            nonlocal fired
+            fired = True
+            native.quit_event_loop()
+
+        native.invoke_from_event_loop(sentinel)
+
+        runs = 0
+        while not fired:
+            native.run_event_loop()
+            runs += 1
+            if runs > _MAX_RUNS:
+                raise RuntimeError(
+                    "the native event queue keeps producing quit requests, "
+                    "the sentinel never got to run"
+                )
+
+
+@pytest.fixture(autouse=True)
+def drained_event_queue() -> None:
+    """Starts every test with an empty native event queue."""
+    drain_native_event_queue()

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -245,6 +245,23 @@ def test_exception_thrown() -> None:
 # defined in the stdlib stubs.
 if sys.platform != "win32":
 
+    def _start_quit_watchdog(done: list[bool]) -> None:
+        """Ends the loop if the signal a test is waiting for never arrives.
+
+        The queue outlives the loop, so the watchdog mustn't quit once the test
+        no longer needs it: that quit would sit in the queue and cut a later
+        test's loop short.
+        """
+        import threading
+        import time
+
+        def watchdog() -> None:
+            time.sleep(5)
+            if not done[0]:
+                native.invoke_from_event_loop(slint.quit_event_loop)
+
+        threading.Thread(target=watchdog, daemon=True).start()
+
     def test_add_signal_handler() -> None:
         import os
         import signal
@@ -282,11 +299,6 @@ if sys.platform != "win32":
             time.sleep(0.2)
             os.kill(os.getpid(), signal.SIGUSR1)
 
-        def watchdog() -> None:
-            time.sleep(5)
-            if not handler_called[0]:
-                native.invoke_from_event_loop(slint.quit_event_loop)
-
         async def run() -> None:
             loop = asyncio.get_running_loop()
 
@@ -297,7 +309,7 @@ if sys.platform != "win32":
             loop.add_signal_handler(signal.SIGUSR1, handler)
 
             threading.Thread(target=deliver_signal_later, daemon=True).start()
-            threading.Thread(target=watchdog, daemon=True).start()
+            _start_quit_watchdog(handler_called)
 
             await asyncio.Event().wait()
 
@@ -315,21 +327,22 @@ if sys.platform != "win32":
         import threading
         import time
 
+        interrupted = [False]
+
         def deliver_sigint_later() -> None:
             time.sleep(0.2)
             os.kill(os.getpid(), signal.SIGINT)
 
-        def watchdog() -> None:
-            time.sleep(5)
-            native.invoke_from_event_loop(slint.quit_event_loop)
-
         async def run() -> None:
             threading.Thread(target=deliver_sigint_later, daemon=True).start()
-            threading.Thread(target=watchdog, daemon=True).start()
+            _start_quit_watchdog(interrupted)
             await asyncio.Event().wait()
 
-        with pytest.raises(KeyboardInterrupt):
-            slint.run_event_loop(run())
+        try:
+            with pytest.raises(KeyboardInterrupt):
+                slint.run_event_loop(run())
+        finally:
+            interrupted[0] = True
 
 
 def test_sleep_does_not_leak_timers() -> None:

--- a/api/python/slint/tests/test_event_queue_isolation.py
+++ b/api/python/slint/tests/test_event_queue_isolation.py
@@ -1,0 +1,24 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import time
+from datetime import timedelta
+
+from conftest import drain_native_event_queue
+
+from slint import slint as native
+
+
+def test_drain_swallows_a_stray_quit() -> None:
+    # A test can end with a quit still queued, for example when two quits raced
+    # to end the same loop and only one of them was consumed.
+    native.quit_event_loop()
+    drain_native_event_queue()
+
+    # Without the drain the stray quit ends this loop right away, leaving the
+    # timer armed for whichever loop runs next.
+    native.Timer.single_shot(timedelta(milliseconds=50), native.quit_event_loop)
+    start = time.monotonic()
+    native.run_event_loop()
+
+    assert time.monotonic() - start >= 0.04

--- a/cspell.json
+++ b/cspell.json
@@ -114,6 +114,7 @@
     "Argb",
     "armv",
     "astrojs",
+    "autouse", // pytest.fixture(autouse=True)
     "Bezier",
     "Bézier",
     "cbindgen",


### PR DESCRIPTION
The backend keeps one event queue for the whole process, and run_event_loop() returns as soon as it pops a quit request, so anything behind that request stays queued for the next run. A test that left a stray quit behind made a later test's loop return immediately, which stranded that test's timers for a third test to fail on.

Drain the queue in an autouse fixture, and stop the SIGINT watchdog thread from quitting once its own test is done.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
