### PR TITLE
Demos and examples: show alert on webgl init failure

### DIFF
--- a/demos/energy-monitor/index.html
+++ b/demos/energy-monitor/index.html
@@ -52,7 +52,17 @@
   </p>
   <script type="module">
     import init from './pkg/energy_monitor.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/demos/energy-monitor/src/lib.rs
+++ b/demos/energy-monitor/src/lib.rs
@@ -27,13 +27,13 @@ mod controllers {
 use controllers::*;
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let window = MainWindow::new().unwrap();
+    let window = MainWindow::new()?;
 
     // let _ to keep the timer alive.
     #[cfg(all(not(feature = "mcu-board-support"), feature = "chrono"))]
@@ -44,10 +44,12 @@ pub fn main() {
 
     let _kiosk_mode_timer = kiosk_timer(&window);
 
-    window.run().unwrap();
+    window.run()?;
 
     #[cfg(all(not(feature = "mcu-board-support"), feature = "network"))]
     weather_join.join().unwrap();
+
+    Ok(())
 }
 
 fn kiosk_timer(window: &MainWindow) -> Timer {
@@ -77,5 +79,5 @@ fn kiosk_timer(window: &MainWindow) -> Timer {
 #[unsafe(no_mangle)]
 fn android_main(app: slint::android::AndroidApp) {
     slint::android::init(app).unwrap();
-    main();
+    main().unwrap();
 }

--- a/demos/energy-monitor/src/main.rs
+++ b/demos/energy-monitor/src/main.rs
@@ -9,13 +9,13 @@ use mcu_board_support::prelude::*;
 
 #[cfg(not(feature = "mcu-board-support"))]
 pub fn main() {
-    energy_monitor::main();
+    energy_monitor::main().unwrap();
 }
 
 #[cfg(feature = "mcu-board-support")]
 #[mcu_board_support::entry]
 fn main() -> ! {
     mcu_board_support::init();
-    energy_monitor::main();
+    energy_monitor::main().unwrap();
     panic!("The MCU demo should not quit")
 }

--- a/demos/home-automation/rust/index.html
+++ b/demos/home-automation/rust/index.html
@@ -33,7 +33,14 @@
             <script type="module">
                 // import the generated file.
                 import init from "./pkg/home_automation_lib.js";
-                init();
+                try {
+                    await init();
+                } catch (error) {
+                    const errorMessage = error.toString();
+                    if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+                        alert('Error loading WASM: ' + errorMessage);
+                    }
+                }
             </script>
         </div>
     </body>

--- a/demos/home-automation/rust/lib.rs
+++ b/demos/home-automation/rust/lib.rs
@@ -19,13 +19,13 @@ slint::slint! {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let app = AppWindow::new().expect("AppWindow::new() failed");
+    let app = AppWindow::new()?;
     let app_weak = app.as_weak();
 
     let timer = Timer::default();
@@ -45,12 +45,12 @@ pub fn main() {
         }
     });
 
-    app.run().expect("AppWindow::run() failed");
+    app.run()
 }
 
 #[cfg(target_os = "android")]
 #[unsafe(no_mangle)]
 fn android_main(android_app: slint::android::AndroidApp) {
     slint::android::init(android_app).unwrap();
-    main();
+    main().unwrap();
 }

--- a/demos/home-automation/rust/main.rs
+++ b/demos/home-automation/rust/main.rs
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-fn main() {
-    home_automation_lib::main();
+fn main() -> Result<(), slint::PlatformError> {
+    home_automation_lib::main()
 }

--- a/demos/printerdemo/rust/index.html
+++ b/demos/printerdemo/rust/index.html
@@ -53,7 +53,17 @@
   </p>
   <script type="module">
     import init from './pkg/printerdemo_lib.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/demos/printerdemo/rust/lib.rs
+++ b/demos/printerdemo/rust/lib.rs
@@ -37,13 +37,13 @@ impl PrinterQueueData {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let main_window = MainWindow::new().unwrap();
+    let main_window = MainWindow::new()?;
     main_window.global::<PrinterState>().set_ink_levels(
         [
             InkLevel { color: slint::Color::from_rgb_u8(0, 255, 255), level: 0.40 },
@@ -130,12 +130,12 @@ pub fn main() {
         slint::select_bundled_translation(lang).unwrap();
     });
 
-    main_window.run().unwrap();
+    main_window.run()
 }
 
 #[cfg(target_os = "android")]
 #[unsafe(no_mangle)]
 fn android_main(app: slint::android::AndroidApp) {
     slint::android::init(app).unwrap();
-    main()
+    main().unwrap()
 }

--- a/demos/printerdemo/rust/main.rs
+++ b/demos/printerdemo/rust/main.rs
@@ -4,6 +4,6 @@
 // In order to be compatible with both desktop, wasm, and android, the example is both a binary and a library.
 // Just forward to the library in main
 
-fn main() {
-    printerdemo_lib::main();
+fn main() -> Result<(), slint::PlatformError> {
+    printerdemo_lib::main()
 }

--- a/demos/usecases/rust/index.html
+++ b/demos/usecases/rust/index.html
@@ -31,7 +31,17 @@
   </p>
   <script type="module">
     import init from './pkg/usecases_lib.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/demos/usecases/rust/src/lib.rs
+++ b/demos/usecases/rust/src/lib.rs
@@ -15,13 +15,13 @@ fn app() -> Result<App, slint::PlatformError> {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let app = app().unwrap();
+    let app = app()?;
     virtual_keyboard::init(&app);
 
     if let Err(slint::SelectBundledTranslationError::LanguageNotFound { .. }) =
@@ -30,7 +30,7 @@ pub fn main() {
         slint::select_bundled_translation("en").unwrap();
     }
 
-    app.run().unwrap();
+    app.run()
 }
 
 #[cfg(target_os = "android")]

--- a/demos/usecases/rust/src/main.rs
+++ b/demos/usecases/rust/src/main.rs
@@ -4,6 +4,6 @@
 // In order to be compatible with both desktop, wasm, and android, the example is both a binary and a library.
 // Just forward to the library in main
 
-fn main() {
-    usecases_lib::main();
+fn main() -> Result<(), slint::PlatformError> {
+    usecases_lib::main()
 }

--- a/demos/weather-demo/index.html
+++ b/demos/weather-demo/index.html
@@ -31,7 +31,14 @@
             <script type="module">
                 // import the generated file.
                 import init from "./pkg/weather_demo.js";
-                init();
+                try {
+                    await init();
+                } catch (error) {
+                    const errorMessage = error.toString();
+                    if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+                        alert('Error loading WASM: ' + errorMessage);
+                    }
+                }
             </script>
         </div>
     </body>

--- a/demos/weather-demo/src/lib.rs
+++ b/demos/weather-demo/src/lib.rs
@@ -64,7 +64,7 @@ fn android_main(android_app: slint::android::AndroidApp) -> Result<(), slint::Pl
 // Wasm
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen::prelude::wasm_bindgen(start)]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
 
@@ -80,11 +80,5 @@ pub fn main() {
 
     let res = app_handler.run();
     app_handler.save();
-
-    match res {
-        Ok(()) => {}
-        Err(e) => {
-            log::error!("Runtime error: {}", e);
-        }
-    }
+    res
 }

--- a/examples/carousel/rust/index.html
+++ b/examples/carousel/rust/index.html
@@ -53,7 +53,17 @@
   </p>
   <script type="module">
     import init from './pkg/carousel.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/examples/carousel/rust/main.rs
+++ b/examples/carousel/rust/main.rs
@@ -18,13 +18,13 @@ slint::include_modules!();
 
 #[cfg(not(feature = "mcu-board-support"))]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    MainWindow::new().unwrap().run().unwrap();
+    MainWindow::new()?.run()
 }
 
 #[cfg(any(feature = "mcu-board-support", feature = "simulator"))]

--- a/examples/dnd-kanban/index.html
+++ b/examples/dnd-kanban/index.html
@@ -28,7 +28,17 @@
     </p>
     <script type="module">
         import init from "./pkg/dnd_kanban.js";
-        init().finally(() => {
+        async function loadWasm() {
+          try {
+            await init();
+          } catch (error) {
+            const errorMessage = error.toString();
+            if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+              alert('Error loading WASM: ' + errorMessage);
+            }
+          }
+        }
+        loadWasm().finally(() => {
             document.getElementById("spinner").remove();
         });
     </script>

--- a/examples/gallery/index.html
+++ b/examples/gallery/index.html
@@ -127,7 +127,10 @@
           document.getElementById("canvas").hidden = false;
           document.getElementById("spinner").hidden = true;
         }).catch(error => {
-          console.error('Failed to initialize gallery:', error);
+          const errorMessage = error.toString();
+          if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+            alert('Error loading WASM: ' + errorMessage);
+          }
           document.getElementById("spinner").hidden = true;
         });
       }

--- a/examples/gallery/main.rs
+++ b/examples/gallery/main.rs
@@ -67,7 +67,7 @@ use std::rc::Rc;
 use slint::{Model, ModelExt, ModelRc, SharedString, StandardListViewItem, VecModel};
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
@@ -77,7 +77,7 @@ pub fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     slint::init_translations!(concat!(env!("CARGO_MANIFEST_DIR"), "/lang/"));
 
-    let app = App::new().unwrap();
+    let app = App::new()?;
 
     let row_data: Rc<VecModel<slint::ModelRc<StandardListViewItem>>> = Rc::new(VecModel::default());
 
@@ -94,7 +94,7 @@ pub fn main() {
     app.global::<TableViewPageAdapter>().set_row_data(row_data.clone().into());
     app.global::<TableViewPageAdapter>().on_filter_sort_model(filter_sort_model);
 
-    app.run().unwrap();
+    app.run()
 }
 
 fn filter_sort_model(

--- a/examples/imagefilter/rust/index.html
+++ b/examples/imagefilter/rust/index.html
@@ -30,7 +30,17 @@
     </p>
     <script type="module">
         import init from "./pkg/imagefilter.js";
-        init().finally(() => {
+        async function loadWasm() {
+          try {
+            await init();
+          } catch (error) {
+            const errorMessage = error.toString();
+            if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+              alert('Error loading WASM: ' + errorMessage);
+            }
+          }
+        }
+        loadWasm().finally(() => {
             document.getElementById("spinner").remove();
         });
     </script>

--- a/examples/imagefilter/rust/main.rs
+++ b/examples/imagefilter/rust/main.rs
@@ -33,13 +33,13 @@ impl slint::Model for Filters {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let main_window = MainWindow::new().unwrap();
+    let main_window = MainWindow::new()?;
 
     #[cfg(target_arch = "wasm32")]
     let source_image =
@@ -111,5 +111,5 @@ pub fn main() {
         ))
     });
 
-    main_window.run().unwrap();
+    main_window.run()
 }

--- a/examples/memory/index.html
+++ b/examples/memory/index.html
@@ -28,7 +28,17 @@
     </p>
     <script type="module">
         import init from "./pkg/memory.js";
-        init().finally(() => {
+        async function loadWasm() {
+          try {
+            await init();
+          } catch (error) {
+            const errorMessage = error.toString();
+            if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+              alert('Error loading WASM: ' + errorMessage);
+            }
+          }
+        }
+        loadWasm().finally(() => {
             document.getElementById("spinner").remove();
         });
     </script>

--- a/examples/memory/main.rs
+++ b/examples/memory/main.rs
@@ -13,13 +13,13 @@ slint::slint! {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let main_window = MainWindow::new().unwrap();
+    let main_window = MainWindow::new()?;
 
     let mut tiles: Vec<TileData> = main_window.get_memory_tiles().iter().collect();
     tiles.extend(tiles.clone());
@@ -62,5 +62,5 @@ pub fn main() {
         }
     });
 
-    main_window.run().unwrap();
+    main_window.run()
 }

--- a/examples/opengl_underlay/index.html
+++ b/examples/opengl_underlay/index.html
@@ -30,7 +30,17 @@
   </p>
   <script type="module">
     import init from './pkg/opengl_underlay.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/examples/opengl_underlay/main.rs
+++ b/examples/opengl_underlay/main.rs
@@ -209,7 +209,7 @@ impl EGLUnderlay {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
@@ -220,7 +220,7 @@ pub fn main() {
         .select()
         .expect("Unable to create Slint backend with OpenGL ES renderer");
 
-    let app = App::new().unwrap();
+    let app = App::new()?;
 
     let mut underlay = None;
 
@@ -278,5 +278,5 @@ pub fn main() {
         })
         .expect("Unable to set rendering notifier");
 
-    app.run().unwrap();
+    app.run()
 }

--- a/examples/plotter/index.html
+++ b/examples/plotter/index.html
@@ -28,7 +28,17 @@
     </p>
     <script type="module">
         import init from "./pkg/plotter.js";
-        init().finally(() => {
+        async function loadWasm() {
+          try {
+            await init();
+          } catch (error) {
+            const errorMessage = error.toString();
+            if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+              alert('Error loading WASM: ' + errorMessage);
+            }
+          }
+        }
+        loadWasm().finally(() => {
             document.getElementById("spinner").remove();
         });
     </script>

--- a/examples/plotter/main.rs
+++ b/examples/plotter/main.rs
@@ -70,15 +70,15 @@ fn render_plot(pitch: f32, yaw: f32, amplitude: f32) -> slint::Image {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let main_window = MainWindow::new().unwrap();
+    let main_window = MainWindow::new()?;
 
     main_window.on_render_plot(render_plot);
 
-    main_window.run().unwrap();
+    main_window.run()
 }

--- a/examples/slide_puzzle/main.rs
+++ b/examples/slide_puzzle/main.rs
@@ -171,7 +171,7 @@ pub fn main() -> Result<(), slint::PlatformError> {
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let main_window = MainWindow::new().unwrap();
+    let main_window = MainWindow::new()?;
 
     let state = Rc::new(RefCell::new(AppState {
         pieces: Rc::new(slint::VecModel::<Piece>::from(vec![Piece::default(); 15])),
@@ -230,6 +230,5 @@ pub fn main() -> Result<(), slint::PlatformError> {
             state_copy.borrow().auto_play_timer.stop();
         }
     });
-    main_window.run()?;
-    Ok(())
+    main_window.run()
 }

--- a/examples/speedometer/rust/index.html
+++ b/examples/speedometer/rust/index.html
@@ -72,7 +72,17 @@
         </p>
         <script type="module">
           import init from './pkg/speedometer_lib.js';
-          init().finally(() => {
+          async function loadWasm() {
+            try {
+              await init();
+            } catch (error) {
+              const errorMessage = error.toString();
+              if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+                alert('Error loading WASM: ' + errorMessage);
+              }
+            }
+          }
+          loadWasm().finally(() => {
             document.getElementById("spinner").remove();
           });
         </script>

--- a/examples/speedometer/rust/lib.rs
+++ b/examples/speedometer/rust/lib.rs
@@ -15,13 +15,13 @@ slint::slint! {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
+pub fn main() -> Result<(), slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
     console_error_panic_hook::set_once();
 
-    let app = MainWindow::new().expect("MainWindow::new() failed");
+    let app = MainWindow::new()?;
 
-    app.run().expect("MainWindow::run() failed");
+    app.run()
 }

--- a/examples/speedometer/rust/main.rs
+++ b/examples/speedometer/rust/main.rs
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-fn main() {
-    speedometer_lib::main();
+fn main() -> Result<(), slint::PlatformError> {
+    speedometer_lib::main()
 }

--- a/examples/todo-mvc/rust/index.html
+++ b/examples/todo-mvc/rust/index.html
@@ -32,7 +32,17 @@
   </p>
   <script type="module">
     import init from './pkg/todo_lib_mvc.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/examples/todo-mvc/rust/src/lib.rs
+++ b/examples/todo-mvc/rust/src/lib.rs
@@ -12,28 +12,26 @@ mod callback;
 pub use callback::*;
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
-    let main_window = init();
+pub fn main() -> Result<(), slint::PlatformError> {
+    let main_window = init()?;
 
-    main_window.run().unwrap();
+    main_window.run()
 }
 
-fn init() -> ui::MainWindow {
-    let view_handle = ui::MainWindow::new().unwrap();
+fn init() -> Result<ui::MainWindow, slint::PlatformError> {
+    ui::MainWindow::new().inspect(|view_handle| {
+        let task_list_controller = mvc::TaskListController::new(mvc::task_repo());
+        ui::task_list_adapter::connect(view_handle, task_list_controller.clone());
+        ui::navigation_adapter::connect_task_list_controller(
+            view_handle,
+            task_list_controller.clone(),
+        );
 
-    let task_list_controller = mvc::TaskListController::new(mvc::task_repo());
-    ui::task_list_adapter::connect(&view_handle, task_list_controller.clone());
-    ui::navigation_adapter::connect_task_list_controller(
-        &view_handle,
-        task_list_controller.clone(),
-    );
-
-    let create_task_controller = mvc::CreateTaskController::new(mvc::date_time_repo());
-    ui::create_task_adapter::connect(&view_handle, create_task_controller.clone());
-    ui::navigation_adapter::connect_create_task_controller(&view_handle, create_task_controller);
-    ui::create_task_adapter::connect_task_list_controller(&view_handle, task_list_controller);
-
-    view_handle
+        let create_task_controller = mvc::CreateTaskController::new(mvc::date_time_repo());
+        ui::create_task_adapter::connect(view_handle, create_task_controller.clone());
+        ui::navigation_adapter::connect_create_task_controller(view_handle, create_task_controller);
+        ui::create_task_adapter::connect_task_list_controller(view_handle, task_list_controller);
+    })
 }
 
 // FIXME: android example

--- a/examples/todo-mvc/rust/src/main.rs
+++ b/examples/todo-mvc/rust/src/main.rs
@@ -1,6 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: MIT
 
-fn main() {
-    todo_lib_mvc::main();
+fn main() -> Result<(), slint::PlatformError> {
+    todo_lib_mvc::main()
 }

--- a/examples/todo/rust/index.html
+++ b/examples/todo/rust/index.html
@@ -32,7 +32,17 @@
   </p>
   <script type="module">
     import init from './pkg/todo_lib.js';
-    init().finally(() => {
+    async function loadWasm() {
+      try {
+        await init();
+      } catch (error) {
+        const errorMessage = error.toString();
+        if (!errorMessage.includes("Using exceptions for control flow, don't mind me")) {
+          alert('Error loading WASM: ' + errorMessage);
+        }
+      }
+    }
+    loadWasm().finally(() => {
       document.getElementById("spinner").remove();
     });
   </script>

--- a/examples/todo/rust/lib.rs
+++ b/examples/todo/rust/lib.rs
@@ -10,15 +10,15 @@ use wasm_bindgen::prelude::*;
 slint::include_modules!();
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(start))]
-pub fn main() {
-    let state = init();
+pub fn main() -> Result<(), slint::PlatformError> {
+    let state = init()?;
     let main_window = state.main_window.clone_strong();
     #[cfg(target_os = "android")]
     STATE.with(|ui| *ui.borrow_mut() = Some(state));
-    main_window.run().unwrap();
+    main_window.run()
 }
 
-fn init() -> State {
+fn init() -> Result<State, slint::PlatformError> {
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
     #[cfg(all(debug_assertions, target_arch = "wasm32"))]
@@ -35,7 +35,7 @@ fn init() -> State {
         TodoItem { checked: false, title: "Profit".into() },
     ]));
 
-    let main_window = MainWindow::new().unwrap();
+    let main_window = MainWindow::new()?;
 
     main_window.on_todo_added({
         let todo_model = todo_model.clone();
@@ -102,7 +102,7 @@ fn init() -> State {
 
     main_window.set_show_header(true);
     main_window.set_todo_model(todo_model.clone().into());
-    State { main_window, todo_model }
+    Ok(State { main_window, todo_model })
 }
 
 #[cfg(target_os = "android")]
@@ -130,7 +130,7 @@ fn android_main(app: slint::android::AndroidApp) {
         };
     })
     .unwrap();
-    main();
+    main().unwrap();
 }
 
 pub struct State {
@@ -176,7 +176,7 @@ fn press_add_adds_one_todo() {
     }
     i_slint_backend_testing::init_no_event_loop();
     use i_slint_backend_testing::{ElementHandle, ElementQuery};
-    let state = init();
+    let state = init().unwrap();
     state.todo_model.set_vec(vec![TodoItem { checked: false, title: "first".into() }]);
     let line_edit = ElementQuery::from_root(&state.main_window)
         .match_id("MainWindow::text-edit")

--- a/examples/todo/rust/main.rs
+++ b/examples/todo/rust/main.rs
@@ -4,6 +4,6 @@
 // In order to be compatible with both desktop, wasm, and android, the example is both a binary and a library.
 // Just forward to the library in main
 
-fn main() {
-    todo_lib::main();
+fn main() -> Result<(), slint::PlatformError> {
+    todo_lib::main()
 }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -142,7 +142,9 @@ fn try_create_window_with_fallback_renderer(
     _proxy: &winit::event_loop::EventLoopProxy<SlintEvent>,
     #[cfg(all(muda, target_os = "macos"))] muda_enable_default_menu_bar: bool,
 ) -> Option<Rc<WinitWindowAdapter>> {
-    [
+    let factories: &[fn(
+        &Rc<SharedBackendData>,
+    ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError>] = &[
         #[cfg(any(
             feature = "renderer-skia",
             feature = "renderer-skia-opengl",
@@ -157,11 +159,10 @@ fn try_create_window_with_fallback_renderer(
             not(feature = "renderer-femtovg-wgpu")
         ))]
         renderer::femtovg::GlutinFemtoVGRenderer::new_suspended,
-        #[cfg(feature = "renderer-software")]
+        #[cfg(all(feature = "renderer-software", not(target_arch = "wasm32")))]
         renderer::sw::WinitSoftwareRenderer::new_suspended,
-    ]
-    .into_iter()
-    .find_map(|renderer_factory| {
+    ];
+    factories.iter().find_map(|renderer_factory| {
         Some(WinitWindowAdapter::new(
             shared_backend_data.clone(),
             renderer_factory(shared_backend_data).ok()?,

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -34,6 +34,20 @@ impl GlutinFemtoVGRenderer {
     pub fn new_suspended(
         shared_backend_data: &Rc<crate::SharedBackendData>,
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
+        // create the webgl context early so that we can report errors about webgl support
+        // immediately and give more helpful error popup messages. when the event loop is already
+        // running, we just panic if this fails, which gives an unhelpful popup message
+        #[cfg(target_arch = "wasm32")]
+        if let Some(html_canvas) = web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.get_element_by_id("canvas"))
+            .and_then(|canvas_elem| {
+                wasm_bindgen::JsCast::dyn_into::<web_sys::HtmlCanvasElement>(canvas_elem).ok()
+            })
+        {
+            opengl::preemptively_create_webgl_context(&html_canvas)?;
+        }
+
         Ok(Box::new(Self {
             renderer: FemtoVGRenderer::new_suspended(),
             _requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -34,6 +34,20 @@ impl GlutinFemtoVGRenderer {
     pub fn new_suspended(
         shared_backend_data: &Rc<crate::SharedBackendData>,
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
+        // create the webgl context early so that we can report errors about webgl support
+        // immediately and give more helpful error popup messages. when the event loop is already
+        // running, we just panic if this fails, which gives an unhelpful popup message
+        #[cfg(target_arch = "wasm32")]
+        if let Some(html_canvas) = web_sys::window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.get_element_by_id("canvas"))
+            .and_then(|canvas_elem| {
+                wasm_bindgen::JsCast::dyn_into::<web_sys::HtmlCanvasElement>(canvas_elem).ok()
+            })
+        {
+            opengl::precreate_webgl_context(&html_canvas)?;
+        }
+
         Ok(Box::new(Self {
             renderer: FemtoVGRenderer::new_suspended(),
             _requested_graphics_api: shared_backend_data.requested_graphics_api.clone(),

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -130,8 +130,14 @@ impl OpenGLBackend {
                 context_2d.set_font("20px serif");
                 // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
                 context_2d.set_fill_style_str("red");
+                let max_width = html_canvas.width().max(1) as f64;
                 context_2d
-                    .fill_text("Slint requires WebGL to be enabled in your browser", 0., 30.)
+                    .fill_text_with_max_width(
+                        "Slint requires WebGL to be enabled in your browser",
+                        0.,
+                        30.,
+                        max_width,
+                    )
                     .unwrap();
                 panic!("Cannot proceed without WebGL - aborting")
             }

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -65,6 +65,56 @@ unsafe impl OpenGLInterface for WebGLNeedsNoCurrentContext {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn preemptively_create_webgl_context(
+    canvas: &web_sys::HtmlCanvasElement,
+) -> Result<(), PlatformError> {
+    use wasm_bindgen::JsCast;
+
+    // attributes used by femtovg::renderer::OpenGl::new_from_html_canvas().
+    // if attributes used there change, then this may break things, because we are in charge of
+    // initializing the canvas with the correct attributes. their attributes will be ignored
+    // and get_context_with_context_options will just return the existing context
+    let attrs = web_sys::WebGlContextAttributes::new();
+    attrs.set_stencil(true);
+    attrs.set_antialias(false);
+
+    match canvas.get_context_with_context_options("webgl2", &attrs) {
+        Ok(Some(context)) if context.is_instance_of::<web_sys::WebGl2RenderingContext>() => Ok(()),
+        _ => {
+            canvas_display_webgl_error(canvas);
+            Err(PlatformError::Other(
+                "Slint requires WebGL to be enabled in your browser".to_string(),
+            ))
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn canvas_display_webgl_error(html_canvas: &web_sys::HtmlCanvasElement) {
+    use wasm_bindgen::JsCast;
+
+    // I don't believe that there's a way of disabling the 2D canvas.
+    let context_2d = html_canvas
+        .get_context("2d")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<web_sys::CanvasRenderingContext2d>()
+        .unwrap();
+    context_2d.set_font("20px serif");
+    // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
+    context_2d.set_fill_style_str("red");
+    let max_width = html_canvas.width().max(1) as f64;
+    context_2d
+        .fill_text_with_max_width(
+            "Slint requires WebGL to be enabled in your browser",
+            0.,
+            30.,
+            max_width,
+        )
+        .unwrap();
+}
+
 struct SuspendedRenderer {}
 
 unsafe impl OpenGLInterface for SuspendedRenderer {
@@ -118,27 +168,7 @@ impl OpenGLBackend {
         let gl_renderer = match femtovg::renderer::OpenGl::new_from_html_canvas(&html_canvas) {
             Ok(gl_renderer) => gl_renderer,
             Err(_) => {
-                use wasm_bindgen::JsCast;
-
-                // I don't believe that there's a way of disabling the 2D canvas.
-                let context_2d = html_canvas
-                    .get_context("2d")
-                    .unwrap()
-                    .unwrap()
-                    .dyn_into::<web_sys::CanvasRenderingContext2d>()
-                    .unwrap();
-                context_2d.set_font("20px serif");
-                // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
-                context_2d.set_fill_style_str("red");
-                let max_width = html_canvas.width().max(1) as f64;
-                context_2d
-                    .fill_text_with_max_width(
-                        "Slint requires WebGL to be enabled in your browser",
-                        0.,
-                        30.,
-                        max_width,
-                    )
-                    .unwrap();
+                canvas_display_webgl_error(&html_canvas);
                 panic!("Cannot proceed without WebGL - aborting")
             }
         };

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -65,6 +65,54 @@ unsafe impl OpenGLInterface for WebGLNeedsNoCurrentContext {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn precreate_webgl_context(canvas: &web_sys::HtmlCanvasElement) -> Result<(), PlatformError> {
+    use wasm_bindgen::JsCast;
+
+    // attributes used by femtovg::renderer::OpenGl::new_from_html_canvas().
+    // if attributes used there change, then this may break things, because we are in charge of
+    // initializing the canvas with the correct attributes. their attributes will be ignored
+    // and get_context_with_context_options will just return the existing context
+    let attrs = web_sys::WebGlContextAttributes::new();
+    attrs.set_stencil(true);
+    attrs.set_antialias(false);
+
+    match canvas.get_context_with_context_options("webgl2", &attrs) {
+        Ok(Some(context)) if context.is_instance_of::<web_sys::WebGl2RenderingContext>() => Ok(()),
+        _ => {
+            canvas_display_webgl_error(canvas);
+            Err(PlatformError::Other(
+                "Slint requires WebGL to be enabled in your browser".to_string(),
+            ))
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn canvas_display_webgl_error(html_canvas: &web_sys::HtmlCanvasElement) {
+    use wasm_bindgen::JsCast;
+
+    // I don't believe that there's a way of disabling the 2D canvas.
+    let context_2d = html_canvas
+        .get_context("2d")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<web_sys::CanvasRenderingContext2d>()
+        .unwrap();
+    context_2d.set_font("20px serif");
+    // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
+    context_2d.set_fill_style_str("red");
+    let max_width = html_canvas.width().max(1) as f64;
+    context_2d
+        .fill_text_with_max_width(
+            "Slint requires WebGL to be enabled in your browser",
+            0.,
+            30.,
+            max_width,
+        )
+        .unwrap();
+}
+
 struct SuspendedRenderer {}
 
 unsafe impl OpenGLInterface for SuspendedRenderer {
@@ -118,27 +166,7 @@ impl OpenGLBackend {
         let gl_renderer = match femtovg::renderer::OpenGl::new_from_html_canvas(&html_canvas) {
             Ok(gl_renderer) => gl_renderer,
             Err(_) => {
-                use wasm_bindgen::JsCast;
-
-                // I don't believe that there's a way of disabling the 2D canvas.
-                let context_2d = html_canvas
-                    .get_context("2d")
-                    .unwrap()
-                    .unwrap()
-                    .dyn_into::<web_sys::CanvasRenderingContext2d>()
-                    .unwrap();
-                context_2d.set_font("20px serif");
-                // We don't know if we're rendering on dark or white background, so choose a "color" in the middle for the text.
-                context_2d.set_fill_style_str("red");
-                let max_width = html_canvas.width().max(1) as f64;
-                context_2d
-                    .fill_text_with_max_width(
-                        "Slint requires WebGL to be enabled in your browser",
-                        0.,
-                        30.,
-                        max_width,
-                    )
-                    .unwrap();
+                canvas_display_webgl_error(&html_canvas);
                 panic!("Cannot proceed without WebGL - aborting")
             }
         };


### PR DESCRIPTION
This PR addresses #896 and makes it so that all examples have an obvious error popup if a platform error (such as webgl not loading) happens at startup.

Previously, only the slide puzzle example had this feature. However, it was only able to observe that the main wasm module had panicked and could not get its error message (on panic, the error displayed said something like "unreachable executed"). There was also some unused stuff to return any error from `MainWindow::run()` out of `main()`. While that would successfully be converted to an exception and be displayed in an alert, it would never happen on web because `run()` just throws a js exception and never returns: https://docs.rs/winit/latest/winit/event_loop/struct.EventLoop.html#method.run_app (called [here](https://github.com/slint-ui/slint/blob/cc3dbb948559a47facb2b72472031ba8afb6b7fc/internal/backends/winit/event_loop.rs#L704)). The documentation on `run_app()` suggests using `EventLoopExtWebSys::spawn_app()` instead but I do not see an easy way to migrate to that.

I considered making it so that any exit of the event loop would throw an exception + display an error, but I am not certain that every error should be displayed to the user in that way, so I just kept it in the scope of the issue and just made errors returned from `create_inactive_windows()` be propagated into exceptions + alerts.

I also reverted the changes related to returning `PlatformError` from main since unwrapping those is fine/consistent with other examples and it was unused on web anyways.

Opening a demo in a browser with webgl disabled:
<img width="1249" height="697" alt="Screenshot 2026-08-03 at 3 34 38 PM" src="https://github.com/user-attachments/assets/b085a6a2-cd76-4642-b729-fcbfb5dbf1a7" />

After pressing OK:
<img width="1249" height="697" alt="Screenshot 2026-08-03 at 3 34 52 PM" src="https://github.com/user-attachments/assets/b0f7e72c-e597-47e5-ab19-0dff2a2067eb" />

I also made a slight change to how the "Slint requires WebGL to be enabled in your browser" warning text appears in the canvas window, since it was getting cut off for me when viewing things like the home automation demo. Previously it looked like this:

<img width="1199" height="677" alt="Screenshot 2026-08-03 at 10 51 29 AM" src="https://github.com/user-attachments/assets/7fd98fa1-fd64-4088-a5e0-d4c061e47e72" />