### PR TITLE
Interfaces errors emit better notes

### DIFF
--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -13,6 +13,7 @@ use smol_str::SmolStr;
 
 use crate::expression_tree::{BuiltinFunction, Expression, Unit};
 use crate::object_tree::{Component, DEFAULT_SLOT_NAME, PropertyVisibility};
+use crate::parser::SyntaxNode;
 use crate::typeregister::TypeRegister;
 
 #[derive(Debug, Clone, Default)]
@@ -538,6 +539,14 @@ impl ElementType {
                 }
             }
             _ => PropertyLookupResult::invalid(Cow::Borrowed(name)),
+        }
+    }
+
+    /// Return the node declaring `name` in this type or one of its bases, if there is one.
+    pub fn property_declaration_node(&self, name: &str) -> Option<SyntaxNode> {
+        match self {
+            Self::Component(c) => c.root_element.borrow().property_declaration_node(name),
+            _ => None,
         }
     }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -13,6 +13,7 @@ use smol_str::SmolStr;
 
 use crate::expression_tree::{BuiltinFunction, Expression, Unit};
 use crate::object_tree::{Component, DEFAULT_SLOT_NAME, PropertyVisibility};
+use crate::parser::SyntaxNode;
 use crate::typeregister::TypeRegister;
 
 #[derive(Debug, Clone, Default)]
@@ -527,6 +528,14 @@ impl ElementType {
                 }
             }
             _ => PropertyLookupResult::invalid(Cow::Borrowed(name)),
+        }
+    }
+
+    /// Return the node declaring `name` in this type or one of its bases, if there is one.
+    pub fn property_declaration_node(&self, name: &str) -> Option<SyntaxNode> {
+        match self {
+            Self::Component(c) => c.root_element.borrow().property_declaration_node(name),
+            _ => None,
         }
     }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -986,7 +986,12 @@ impl Display for Function {
             }
             write!(formatter, "{arg}")?;
         }
-        write!(formatter, ") -> {}", self.return_type)
+        let return_type = if self.return_type == Type::Void {
+            String::new()
+        } else {
+            format!(" -> {}", self.return_type)
+        };
+        write!(formatter, "){}", return_type)
     }
 }
 

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -988,7 +988,12 @@ impl Display for Function {
             }
             write!(formatter, "{arg}")?;
         }
-        write!(formatter, ") -> {}", self.return_type)
+        let return_type = if self.return_type == Type::Void {
+            String::new()
+        } else {
+            format!(" -> {}", self.return_type)
+        };
+        write!(formatter, "){return_type}")
     }
 }
 

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2939,6 +2939,14 @@ impl Element {
         }
     }
 
+    /// Return the node declaring `name` in this element or one of its bases, if there is one.
+    pub fn property_declaration_node(&self, name: &str) -> Option<SyntaxNode> {
+        self.property_declarations
+            .get(name)
+            .and_then(|declaration| declaration.node.clone())
+            .or_else(|| self.base_type.property_declaration_node(name))
+    }
+
     fn slot_forwarding_expr_identifier(expression: &SyntaxNode) -> Option<SmolStr> {
         if expression.kind() != SyntaxKind::Expression {
             return None;

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -2852,6 +2852,14 @@ impl Element {
         }
     }
 
+    /// Return the node declaring `name` in this element or one of its bases, if there is one.
+    pub fn property_declaration_node(&self, name: &str) -> Option<SyntaxNode> {
+        self.property_declarations
+            .get(name)
+            .and_then(|declaration| declaration.node.clone())
+            .or_else(|| self.base_type.property_declaration_node(name))
+    }
+
     fn slot_forwarding_expr_identifier(expression: &SyntaxNode) -> Option<SmolStr> {
         if expression.kind() != SyntaxKind::Expression {
             return None;

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -355,12 +355,19 @@ pub(super) fn apply_child_implement_statements(
         }
 
         let mut conflicts = Vec::new();
+        let mut notes = Vec::new();
         for (name, prop_decl) in interface.borrow().property_declarations.iter() {
             let lookup_result = element.borrow().base_type.lookup_property(name);
             if let Err(message) =
                 check_property_declaration_conflicts(&lookup_result, &element.borrow().base_type)
             {
                 conflicts.push(message);
+                if let Some(source) = element.borrow().property_declaration_node(name) {
+                    notes.push(NoteWithSource {
+                        note: format!("'{name}' does not satisfy '{interface_name}'"),
+                        source,
+                    });
+                }
                 continue;
             }
 
@@ -414,6 +421,9 @@ pub(super) fn apply_child_implement_statements(
                 ),
                 &node.QualifiedName(),
             );
+            for note in notes {
+                diagnostics.push_note(note.note, &note.source);
+            }
         }
     }
 }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -274,18 +274,15 @@ fn validate_interface_member_implementation(
     }
 
     let lookup_result = element.lookup_property(member_name);
-    if lookup_result.property_type == Type::Invalid {
-        return Some(InterfaceMemberDiagnostics::from(missing_type_error(
-            member_name,
-            interface_member,
-        )));
-    }
-
     let Err(conflicts) =
         property_matches_interface(&lookup_result, interface_member, member_name, None)
     else {
         return None;
     };
+
+    if !lookup_result.is_valid() {
+        return Some(InterfaceMemberDiagnostics::from(conflicts));
+    }
 
     if !lookup_result.is_local_to_component {
         if let Err(message) =

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -47,15 +47,23 @@ fn check_property_declaration_conflicts(
 #[derive(Debug, PartialEq)]
 pub(super) enum ImplementBinding {
     OnSelf,
-    OnChild(SmolStr),
+    OnChild {
+        /// The normalized id of the element.
+        child_id: SmolStr,
+        /// The id as used in the .slint source.
+        child_name: SmolStr,
+    },
 }
 
 impl ImplementBinding {
-    fn from_target(target_id: &SmolStr) -> ImplementBinding {
+    fn from_target(target_id: &SmolStr, target_name: &SmolStr) -> ImplementBinding {
         if target_id.as_str() == "self" {
             ImplementBinding::OnSelf
         } else {
-            ImplementBinding::OnChild(target_id.clone())
+            ImplementBinding::OnChild {
+                child_id: target_id.clone(),
+                child_name: target_name.clone(),
+            }
         }
     }
 }
@@ -82,7 +90,9 @@ fn resolve_implement_statement(
 
     let qualified_name = node.QualifiedName();
     let interface_name = QualifiedTypeName::from_node(qualified_name.clone()).to_smolstr();
-    let target_id = parser::identifier_text(&node.DeclaredIdentifier()).unwrap_or_default();
+    let target_name =
+        node.DeclaredIdentifier().child_text(SyntaxKind::Identifier).unwrap_or_default();
+    let target_id = parser::normalize_identifier(&target_name);
 
     if let Some(target) = match target_id.as_str() {
         "parent" => Some("a parent element"),
@@ -111,7 +121,7 @@ fn resolve_implement_statement(
                 node,
                 interface: c.root_element.clone(),
                 interface_name,
-                binding: ImplementBinding::from_target(&target_id),
+                binding: ImplementBinding::from_target(&target_id, &target_name),
             })
         }
         Ok(_) => {
@@ -217,13 +227,14 @@ pub(super) fn validate_self_implement_statements(
     implemented_interfaces: &[ImplementedInterface],
     diagnostics: &mut BuildDiagnostics,
 ) {
-    for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
+    for ImplementedInterface { interface, node, interface_name, binding } in implemented_interfaces
+    {
         validate_interface_implementation(
             element,
             interface,
             interface_name,
             &node.QualifiedName(),
-            None,
+            binding,
             diagnostics,
         );
     }
@@ -316,7 +327,7 @@ fn validate_interface_implementation(
     interface: &ElementRc,
     interface_name: &SmolStr,
     node: &SyntaxNode,
-    child_id: Option<&SmolStr>,
+    binding: &ImplementBinding,
     diagnostics: &mut BuildDiagnostics,
 ) -> bool {
     let mut errors = Vec::new();
@@ -327,7 +338,7 @@ fn validate_interface_implementation(
             member_name,
             member_declaration,
             interface_name,
-            child_id,
+            binding,
         ) {
             errors.push(conflict.error);
             notes.append(&mut conflict.notes);
@@ -335,9 +346,11 @@ fn validate_interface_implementation(
     }
 
     if !errors.is_empty() {
-        let based_on = match child_id {
-            Some(child_id) => format!(" based on '{child_id}'"),
-            None => String::new(),
+        let based_on = match binding {
+            ImplementBinding::OnChild { child_name, .. } => {
+                format!(" based on '{child_name}'")
+            }
+            ImplementBinding::OnSelf => String::new(),
         };
         diagnostics.push_error(
             format!("Cannot implement '{interface_name}'{based_on}.\n{}", errors.join("\n")),
@@ -356,7 +369,7 @@ fn validate_interface_member_implementation(
     member_name: &SmolStr,
     interface_member: &PropertyDeclaration,
     interface_name: &SmolStr,
-    child_id: Option<&SmolStr>,
+    binding: &ImplementBinding,
 ) -> Option<InterfaceMemberDiagnostics> {
     if matches!(interface_member.property_type, Type::Invalid) {
         // The interface's own declaration is invalid (e.g. an unknown property type). A diagnostic
@@ -371,7 +384,7 @@ fn validate_interface_member_implementation(
         interface_member,
         interface_name,
         member_name,
-        child_id,
+        binding,
     ) else {
         return None;
     };
@@ -400,12 +413,12 @@ pub(super) fn apply_child_implement_statements(
 ) {
     for ImplementedInterface { node, interface, interface_name, binding } in child_implements {
         debug_assert_ne!(binding, ImplementBinding::OnSelf);
-        let ImplementBinding::OnChild(child_id) = binding else {
+        let ImplementBinding::OnChild { child_id, child_name } = &binding else {
             continue;
         };
-        let Some(child) = find_element_by_id(element, &child_id) else {
+        let Some(child) = find_element_by_id(element, child_id) else {
             diagnostics
-                .push_error(format!("'{}' does not exist", child_id), &node.DeclaredIdentifier());
+                .push_error(format!("'{}' does not exist", child_name), &node.DeclaredIdentifier());
             continue;
         };
 
@@ -414,7 +427,7 @@ pub(super) fn apply_child_implement_statements(
             &interface,
             &interface_name,
             &node.DeclaredIdentifier(),
-            Some(&child_id),
+            &binding,
             diagnostics,
         ) {
             continue;
@@ -590,7 +603,7 @@ fn property_matches_interface(
     interface_declaration: &PropertyDeclaration,
     interface_name: &SmolStr,
     name: &SmolStr,
-    child_id: Option<&SmolStr>,
+    binding: &ImplementBinding,
 ) -> Result<(), Vec<MemberViolation>> {
     if property.property_type == Type::Invalid {
         return Err(vec![MemberViolation {
@@ -602,8 +615,11 @@ fn property_matches_interface(
 
     let mut errors = Vec::new();
 
-    let member_name =
-        if let Some(child_id) = child_id { format!("{child_id}.{name}") } else { name.to_string() };
+    let member_name = if let ImplementBinding::OnChild { child_name, .. } = binding {
+        format!("{child_name}.{name}")
+    } else {
+        name.to_string()
+    };
 
     if !property_type_matches_for_interface(
         &property.property_type,

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -393,6 +393,13 @@ pub(super) fn apply_child_implement_statements(
                     format!("Cannot override '{}' from '{}'", name, interface_name),
                     &source,
                 );
+                diagnostics.push_note(
+                    format!(
+                        "'{interface_name}' declares '{name}' as '{}'",
+                        syntax_for(&prop_decl, name)
+                    ),
+                    &node.QualifiedName(),
+                );
                 continue;
             }
 

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -521,25 +521,13 @@ fn syntax_for(
     pure: &Option<bool>,
     visibility: &PropertyVisibility,
 ) -> String {
-    let display_args =
-        |arguments: &Vec<Type>| -> String { arguments.iter().map(|t| t.to_string()).join(", ") };
-    let return_type = |return_type: &Type| -> String {
-        if *return_type == Type::Void { String::new() } else { format!(" -> {return_type}") }
-    };
     match property_type {
-        Type::Function(function) => format!(
-            "{}{} function {name}({}){} {{ }}",
-            purity_description(pure),
-            visibility,
-            display_args(&function.args),
-            return_type(&function.return_type)
-        ),
-        Type::Callback(function) => format!(
-            "{}callback {name}({}){};",
-            purity_description(pure),
-            display_args(&function.args),
-            return_type(&function.return_type)
-        ),
+        Type::Function(function) => {
+            format!("{}{} function {name}{} {{ }}", purity_description(pure), visibility, function)
+        }
+        Type::Callback(function) => {
+            format!("{}callback {name}{};", purity_description(pure), function)
+        }
         _ if property_type.is_property_type() => {
             format!("{} property <{}> {name};", visibility, property_type)
         }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -10,14 +10,14 @@ use std::sync::Arc;
 use itertools::Itertools;
 use smol_str::SmolStr;
 
-use crate::diagnostics::BuildDiagnostics;
+use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::expression_tree::{BindingExpression, Callable, Expression};
 use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
     Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
 };
-use crate::parser::{self, SyntaxNode};
+use crate::parser::{self, SyntaxNode, SyntaxToken};
 use crate::parser::{SyntaxKind, syntax_nodes};
 use crate::reject_experimental_feature;
 use crate::typeregister::TypeRegister;
@@ -230,7 +230,7 @@ pub(super) fn validate_self_implement_statements(
 
 struct NoteWithSource {
     note: String,
-    source: SyntaxNode,
+    source: SourceLocation,
 }
 
 struct InterfaceMemberDiagnostics {
@@ -242,6 +242,73 @@ impl From<String> for InterfaceMemberDiagnostics {
     fn from(error: String) -> Self {
         Self { error, notes: Default::default() }
     }
+}
+
+enum DeclarationAnchor {
+    Name,
+    PropertyType,
+    /// The n-th parameter of a callback or function.
+    Argument(usize),
+    ReturnType,
+    Visibility,
+    Purity,
+}
+
+const VISIBILITY_KEYWORDS: &[&str] =
+    &["in", "out", "in-out", "in_out", "private", "public", "protected"];
+
+impl DeclarationAnchor {
+    fn source_location(&self, declaration: &SyntaxNode) -> SourceLocation {
+        self.narrow(declaration)
+            .or_else(|| {
+                Some(declaration.child_node(SyntaxKind::DeclaredIdentifier)?.to_source_location())
+            })
+            .unwrap_or_else(|| declaration.to_source_location())
+    }
+
+    fn narrow(&self, declaration: &SyntaxNode) -> Option<SourceLocation> {
+        let node = match self {
+            Self::Name => return None,
+            Self::PropertyType => declaration.child_node(SyntaxKind::Type)?,
+            Self::Argument(index) => parameter_type(declaration, *index)?,
+            Self::ReturnType => declaration.child_node(SyntaxKind::ReturnType)?,
+            Self::Visibility => {
+                return Some(keyword_token(declaration, VISIBILITY_KEYWORDS)?.to_source_location());
+            }
+            Self::Purity => {
+                return Some(keyword_token(declaration, &["pure"])?.to_source_location());
+            }
+        };
+        Some(node.to_source_location())
+    }
+}
+
+fn parameter_type(declaration: &SyntaxNode, index: usize) -> Option<SyntaxNode> {
+    let parameter_kind = match declaration.kind() {
+        SyntaxKind::Function => SyntaxKind::ArgumentDeclaration,
+        SyntaxKind::CallbackDeclaration => SyntaxKind::CallbackDeclarationParameter,
+        _ => return None,
+    };
+    declaration
+        .children()
+        .filter(|child| child.kind() == parameter_kind)
+        .nth(index)?
+        .child_node(SyntaxKind::Type)
+}
+
+/// Visibility and purity are plain identifier tokens rather than syntax nodes, so they can only be
+/// located by their text - the inverse of how [`Element::from_node`] reads them.
+fn keyword_token(declaration: &SyntaxNode, keywords: &[&str]) -> Option<SyntaxToken> {
+    declaration
+        .children_with_tokens()
+        .filter_map(|child| child.into_token())
+        .find(|token| token.kind() == SyntaxKind::Identifier && keywords.contains(&token.text()))
+}
+
+struct MemberViolation {
+    error: String,
+    note: String,
+    anchor: DeclarationAnchor,
 }
 
 fn validate_interface_implementation(
@@ -278,7 +345,7 @@ fn validate_interface_implementation(
         );
 
         for note in notes {
-            diagnostics.push_note(note.note, &note.source);
+            diagnostics.push_note_with_span(note.note, note.source);
         }
     }
     errors.is_empty()
@@ -299,30 +366,41 @@ fn validate_interface_member_implementation(
     }
 
     let lookup_result = element.lookup_property(member_name);
-    let Err(conflicts) =
-        property_matches_interface(&lookup_result, interface_member, member_name, child_id)
-    else {
+    let Err(violations) = property_matches_interface(
+        &lookup_result,
+        interface_member,
+        interface_name,
+        member_name,
+        child_id,
+    ) else {
         return None;
     };
 
+    let joined_errors =
+        |violations: &[MemberViolation]| violations.iter().map(|v| v.error.as_str()).join("\n");
+
     if !lookup_result.is_valid() {
-        return Some(InterfaceMemberDiagnostics::from(conflicts));
+        return Some(InterfaceMemberDiagnostics::from(joined_errors(&violations)));
     }
 
-    let conflicts = if lookup_result.is_local_to_component || child_id.is_some() {
-        conflicts
-    } else {
-        check_property_declaration_conflicts(&lookup_result, &element.base_type)
-            .err()
-            .unwrap_or(conflicts)
+    let base_conflict = (!lookup_result.is_local_to_component && child_id.is_none())
+        .then(|| check_property_declaration_conflicts(&lookup_result, &element.base_type).err())
+        .flatten();
+
+    let error = match base_conflict {
+        Some(error) => error,
+        None => joined_errors(&violations),
     };
 
-    let mut conflicts = InterfaceMemberDiagnostics::from(conflicts);
+    let mut conflicts = InterfaceMemberDiagnostics::from(error);
     if let Some(source) = element.property_declaration_node(member_name) {
-        conflicts.notes.push(NoteWithSource {
-            note: format!("'{member_name}' does not satisfy '{interface_name}'"),
-            source,
-        });
+        conflicts.notes = violations
+            .into_iter()
+            .map(|violation| NoteWithSource {
+                note: violation.note,
+                source: violation.anchor.source_location(&source),
+            })
+            .collect();
     }
     Some(conflicts)
 }
@@ -364,8 +442,8 @@ pub(super) fn apply_child_implement_statements(
                 conflicts.push(message);
                 if let Some(source) = element.borrow().property_declaration_node(name) {
                     notes.push(NoteWithSource {
-                        note: format!("'{name}' does not satisfy '{interface_name}'"),
-                        source,
+                        note: declares_as_note(&interface_name, name, prop_decl),
+                        source: DeclarationAnchor::Name.source_location(&source),
                     });
                 }
                 continue;
@@ -394,10 +472,7 @@ pub(super) fn apply_child_implement_statements(
                     &source,
                 );
                 diagnostics.push_note(
-                    format!(
-                        "'{interface_name}' declares '{name}' as '{}'",
-                        syntax_for(&prop_decl, name)
-                    ),
+                    declares_as_note(&interface_name, name, &prop_decl),
                     &node.QualifiedName(),
                 );
                 continue;
@@ -496,6 +571,31 @@ fn missing_type_error(name: &SmolStr, interface_declaration: &PropertyDeclaratio
     format!("- missing '{}'", syntax_for(interface_declaration, name))
 }
 
+fn declares_as_note(
+    interface_name: &SmolStr,
+    name: &SmolStr,
+    interface_declaration: &PropertyDeclaration,
+) -> String {
+    format!("'{interface_name}' declares '{name}' as '{}'", syntax_for(interface_declaration, name))
+}
+
+fn signature_anchor(interface_declaration: &Function, declaration: &Function) -> DeclarationAnchor {
+    if let Some(index) = interface_declaration
+        .args
+        .iter()
+        .zip(declaration.args.iter())
+        .position(|(expected, declared)| expected != declared)
+    {
+        DeclarationAnchor::Argument(index)
+    } else if declaration.args.len() > interface_declaration.args.len() {
+        DeclarationAnchor::Argument(interface_declaration.args.len())
+    } else if declaration.args.len() < interface_declaration.args.len() {
+        DeclarationAnchor::Name
+    } else {
+        DeclarationAnchor::ReturnType
+    }
+}
+
 /// [PartialEq] for [Function] means that the argument names must match. That is not required for a valid interface implementation.
 fn function_matches_for_interface(lhs: &Function, rhs: &Function) -> bool {
     lhs.return_type == rhs.return_type && lhs.args == rhs.args
@@ -512,11 +612,16 @@ fn property_type_matches_for_interface(lhs: &Type, rhs: &Type) -> bool {
 fn property_matches_interface(
     property: &PropertyLookupResult,
     interface_declaration: &PropertyDeclaration,
+    interface_name: &SmolStr,
     name: &SmolStr,
     child_id: Option<&SmolStr>,
-) -> Result<(), String> {
+) -> Result<(), Vec<MemberViolation>> {
     if property.property_type == Type::Invalid {
-        return Err(missing_type_error(name, interface_declaration));
+        return Err(vec![MemberViolation {
+            error: missing_type_error(name, interface_declaration),
+            note: declares_as_note(interface_name, name, interface_declaration),
+            anchor: DeclarationAnchor::Name,
+        }]);
     }
 
     let mut errors = Vec::new();
@@ -554,27 +659,52 @@ fn property_matches_interface(
         };
 
         let actual = type_description(&property.property_type);
-        errors.push(format!("- '{member_name}' must be {expected} (found {actual})"));
+        let error = format!("- '{member_name}' must be {expected} (found {actual})");
 
         if !is_same_type {
             // Visibility and purity are unlikely to make sense, so return early in this case.
-            return Err(errors.join("\n"));
+            return Err(vec![MemberViolation {
+                error,
+                note: declares_as_note(interface_name, name, interface_declaration),
+                anchor: DeclarationAnchor::Name,
+            }]);
         }
+
+        let (note, anchor) = match (&interface_declaration.property_type, &property.property_type) {
+            (Type::Callback(expected), Type::Callback(declared))
+            | (Type::Function(expected), Type::Function(declared)) => (
+                declares_as_note(interface_name, name, interface_declaration),
+                signature_anchor(expected, declared),
+            ),
+            (_, _) => (
+                declares_as_note(interface_name, name, interface_declaration),
+                DeclarationAnchor::PropertyType,
+            ),
+        };
+        errors.push(MemberViolation { error, note, anchor });
     }
 
     if property.property_visibility != interface_declaration.visibility {
-        errors.push(format!(
-            "- '{member_name}' must be '{}' (found '{}')",
-            interface_declaration.visibility, property.property_visibility
-        ));
+        errors.push(MemberViolation {
+            error: format!(
+                "- '{member_name}' must be '{}' (found '{}')",
+                interface_declaration.visibility, property.property_visibility
+            ),
+            note: declares_as_note(interface_name, name, interface_declaration),
+            anchor: DeclarationAnchor::Visibility,
+        });
     }
 
     // The implementation can be "more pure" than the interface, but never less pure.
     if interface_declaration.pure.unwrap_or(false) && !property.declared_pure.unwrap_or(false) {
-        errors.push(format!("- '{member_name}' must be 'pure'"));
+        errors.push(MemberViolation {
+            error: format!("- '{member_name}' must be 'pure'"),
+            note: declares_as_note(interface_name, name, interface_declaration),
+            anchor: DeclarationAnchor::Purity,
+        });
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors.join("\n")) }
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
 }
 
 fn apply_uses_statement_function_binding(

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -515,31 +515,6 @@ fn purity_description(purity: &Option<bool>) -> &str {
     if purity.unwrap_or(false) { "pure " } else { "" }
 }
 
-fn missing_type_description(interface_declaration: &PropertyDeclaration) -> String {
-    match interface_declaration.property_type {
-        Type::Callback(..) => {
-            format!(
-                "a '{}{}'",
-                purity_description(&interface_declaration.pure),
-                interface_declaration.property_type
-            )
-        }
-        Type::Function(..) => {
-            format!(
-                "a 'public {}{}'",
-                purity_description(&interface_declaration.pure),
-                interface_declaration.property_type
-            )
-        }
-        _ => {
-            format!(
-                "an {} '{}' property",
-                interface_declaration.visibility, interface_declaration.property_type
-            )
-        }
-    }
-}
-
 fn syntax_for(
     name: &SmolStr,
     property_type: &Type,
@@ -578,6 +553,15 @@ fn syntax_for_declaration(interface_declaration: &PropertyDeclaration, name: &Sm
         &interface_declaration.property_type,
         &interface_declaration.pure,
         &interface_declaration.visibility,
+    )
+}
+
+fn syntax_for_lookup_result(lookup_result: &PropertyLookupResult, name: &SmolStr) -> String {
+    syntax_for(
+        name,
+        &lookup_result.property_type,
+        &lookup_result.declared_pure,
+        &lookup_result.property_visibility,
     )
 }
 
@@ -657,25 +641,20 @@ fn property_matches_interface(
             (lhs, rhs) => lhs.is_property_type() && rhs.is_property_type(),
         };
 
-        let type_description = |property_type: &Type| match property_type {
-            Type::Callback(..) => {
-                format!("a '{}'", property_type)
-            }
-            Type::Function(..) => {
-                format!("a '{}'", property_type)
-            }
-            _ => {
-                format!("a '{}' property", property_type)
-            }
-        };
+        let property_description = |property_type: &Type| format!("a '{}' property", property_type);
 
-        let expected = if !is_same_type {
-            missing_type_description(interface_declaration)
+        let expected = if is_same_type && interface_declaration.property_type.is_property_type() {
+            property_description(&interface_declaration.property_type)
         } else {
-            type_description(&interface_declaration.property_type)
+            format!("'{}'", syntax_for_declaration(interface_declaration, name))
         };
 
-        let actual = type_description(&property.property_type);
+        let actual = if property.property_type.is_property_type() {
+            property_description(&property.property_type)
+        } else {
+            format!("'{}'", syntax_for_lookup_result(property, name))
+        };
+
         let error = format!("- '{member_name}' must be {expected} (found {actual})");
 
         if !is_same_type {

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -284,22 +284,16 @@ fn validate_interface_member_implementation(
         return Some(InterfaceMemberDiagnostics::from(conflicts));
     }
 
-    if !lookup_result.is_local_to_component {
-        if let Err(message) =
-            check_property_declaration_conflicts(&lookup_result, &element.base_type)
-        {
-            return Some(InterfaceMemberDiagnostics::from(message));
-        }
-        return None;
-    }
+    let conflicts = if lookup_result.is_local_to_component {
+        conflicts
+    } else {
+        check_property_declaration_conflicts(&lookup_result, &element.base_type)
+            .err()
+            .unwrap_or(conflicts)
+    };
 
     let mut conflicts = InterfaceMemberDiagnostics::from(conflicts);
-    let source = element
-        .property_declarations
-        .get(member_name)
-        .and_then(|declaration| declaration.node.clone());
-
-    if let Some(source) = source {
+    if let Some(source) = element.property_declaration_node(member_name) {
         conflicts.notes.push(NoteWithSource {
             note: format!("'{member_name}' does not satisfy '{interface_name}'"),
             source,

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -318,7 +318,7 @@ fn keyword_token(declaration: &SyntaxNode, keyword: &str) -> Option<SyntaxToken>
 
 struct MemberViolation {
     error: String,
-    note: String,
+    expected_syntax: String,
     anchor: DeclarationAnchor,
 }
 
@@ -379,13 +379,9 @@ fn validate_interface_member_implementation(
     }
 
     let lookup_result = element.lookup_property(member_name);
-    let Err(violations) = property_matches_interface(
-        &lookup_result,
-        interface_member,
-        interface_name,
-        member_name,
-        binding,
-    ) else {
+    let Err(violations) =
+        property_matches_interface(&lookup_result, interface_member, member_name, binding)
+    else {
         return None;
     };
 
@@ -398,7 +394,12 @@ fn validate_interface_member_implementation(
         conflicts.notes = violations
             .into_iter()
             .map(|violation| NoteWithSource {
-                note: violation.note,
+                note: declared_here_note(
+                    member_name,
+                    interface_name,
+                    &violation.expected_syntax,
+                    &source,
+                ),
                 source: violation.anchor.source_location(&source),
             })
             .collect();
@@ -443,7 +444,12 @@ pub(super) fn apply_child_implement_statements(
                 conflicts.push(message);
                 if let Some(source) = element.borrow().property_declaration_node(name) {
                     notes.push(NoteWithSource {
-                        note: declares_as_note(&interface_name, name, prop_decl),
+                        note: declared_here_note(
+                            name,
+                            &interface_name,
+                            &syntax_for_declaration(prop_decl, name),
+                            &source,
+                        ),
                         source: DeclarationAnchor::Name.source_location(&source),
                     });
                 }
@@ -473,7 +479,11 @@ pub(super) fn apply_child_implement_statements(
                     &source,
                 );
                 diagnostics.push_note(
-                    declares_as_note(&interface_name, name, &prop_decl),
+                    declares_as_note(
+                        &interface_name,
+                        name,
+                        &syntax_for_declaration(&prop_decl, name),
+                    ),
                     &node.QualifiedName(),
                 );
                 continue;
@@ -557,14 +567,33 @@ fn missing_type_error(name: &SmolStr, interface_declaration: &PropertyDeclaratio
     format!("- missing '{}'", syntax_for_declaration(interface_declaration, name))
 }
 
-fn declares_as_note(
+fn declares_as_note(interface_name: &SmolStr, name: &SmolStr, expected_syntax: &String) -> String {
+    format!("'{interface_name}' declares '{name}' as '{expected_syntax}'")
+}
+
+fn declaring_component_name(declaration: SyntaxNode) -> Option<SmolStr> {
+    std::iter::successors(Some(declaration), SyntaxNode::parent).find_map(|node| {
+        match node.kind() {
+            SyntaxKind::SubElement => node.child_text(SyntaxKind::Identifier),
+            SyntaxKind::Component => {
+                parser::identifier_text(&node.child_node(SyntaxKind::DeclaredIdentifier)?)
+            }
+            _ => None,
+        }
+    })
+}
+
+fn declared_here_note(
+    member_name: &SmolStr,
     interface_name: &SmolStr,
-    name: &SmolStr,
-    interface_declaration: &PropertyDeclaration,
+    expected_syntax: &String,
+    property_declaration_source: &SyntaxNode,
 ) -> String {
+    let Some(declaring_type) = declaring_component_name(property_declaration_source.clone()) else {
+        return declares_as_note(interface_name, member_name, expected_syntax);
+    };
     format!(
-        "'{interface_name}' declares '{name}' as '{}'",
-        syntax_for_declaration(interface_declaration, name)
+        "'{declaring_type}' declares '{member_name}' here, '{interface_name}' expects '{expected_syntax}'"
     )
 }
 
@@ -601,14 +630,14 @@ fn property_type_matches_for_interface(lhs: &Type, rhs: &Type) -> bool {
 fn property_matches_interface(
     property: &PropertyLookupResult,
     interface_declaration: &PropertyDeclaration,
-    interface_name: &SmolStr,
     name: &SmolStr,
     binding: &ImplementBinding,
 ) -> Result<(), Vec<MemberViolation>> {
+    let expected_syntax = syntax_for_declaration(interface_declaration, name);
     if property.property_type == Type::Invalid {
         return Err(vec![MemberViolation {
             error: missing_type_error(name, interface_declaration),
-            note: declares_as_note(interface_name, name, interface_declaration),
+            expected_syntax,
             anchor: DeclarationAnchor::Name,
         }]);
     }
@@ -652,23 +681,20 @@ fn property_matches_interface(
             // Visibility and purity are unlikely to make sense, so return early in this case.
             return Err(vec![MemberViolation {
                 error,
-                note: declares_as_note(interface_name, name, interface_declaration),
+                expected_syntax,
                 anchor: DeclarationAnchor::Name,
             }]);
         }
 
-        let (note, anchor) = match (&interface_declaration.property_type, &property.property_type) {
+        let anchor = match (&interface_declaration.property_type, &property.property_type) {
             (Type::Callback(expected), Type::Callback(declared))
-            | (Type::Function(expected), Type::Function(declared)) => (
-                declares_as_note(interface_name, name, interface_declaration),
-                signature_anchor(expected, declared),
-            ),
-            (_, _) => (
-                declares_as_note(interface_name, name, interface_declaration),
-                DeclarationAnchor::PropertyType,
-            ),
+            | (Type::Function(expected), Type::Function(declared)) => {
+                signature_anchor(expected, declared)
+            }
+
+            (_, _) => DeclarationAnchor::PropertyType,
         };
-        errors.push(MemberViolation { error, note, anchor });
+        errors.push(MemberViolation { error, expected_syntax: expected_syntax.clone(), anchor });
     }
 
     if property.property_visibility != interface_declaration.visibility {
@@ -677,7 +703,7 @@ fn property_matches_interface(
                 "- '{member_name}' must be '{}' (found '{}')",
                 interface_declaration.visibility, property.property_visibility
             ),
-            note: declares_as_note(interface_name, name, interface_declaration),
+            expected_syntax: expected_syntax.clone(),
             anchor: DeclarationAnchor::Visibility(property.property_visibility),
         });
     }
@@ -686,7 +712,7 @@ fn property_matches_interface(
     if interface_declaration.pure.unwrap_or(false) && !property.declared_pure.unwrap_or(false) {
         errors.push(MemberViolation {
             error: format!("- '{member_name}' must be 'pure'"),
-            note: declares_as_note(interface_name, name, interface_declaration),
+            expected_syntax,
             anchor: DeclarationAnchor::Purity,
         });
     }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -10,14 +10,15 @@ use std::sync::Arc;
 use itertools::Itertools;
 use smol_str::SmolStr;
 
-use crate::diagnostics::BuildDiagnostics;
+use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::expression_tree::{BindingExpression, Callable, Expression};
 use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
-    Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
+    Element, ElementRc, PropertyDeclaration, PropertyVisibility, QualifiedTypeName,
+    find_element_by_id,
 };
-use crate::parser::{self, SyntaxNode};
+use crate::parser::{self, SyntaxNode, SyntaxToken};
 use crate::parser::{SyntaxKind, syntax_nodes};
 use crate::reject_experimental_feature;
 use crate::typeregister::TypeRegister;
@@ -217,36 +218,20 @@ pub(super) fn validate_self_implement_statements(
     diagnostics: &mut BuildDiagnostics,
 ) {
     for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
-        let mut errors = Vec::new();
-        let mut notes = Vec::new();
-        for (member_name, member_declaration) in interface.borrow().property_declarations.iter() {
-            if let Some(mut conflict) = validate_interface_member_implementation(
-                element,
-                member_name,
-                member_declaration,
-                interface_name,
-            ) {
-                errors.push(conflict.error);
-                notes.append(&mut conflict.notes);
-            };
-        }
-
-        if !errors.is_empty() {
-            diagnostics.push_error(
-                format!("Cannot implement '{interface_name}'.\n{}", errors.join("\n")),
-                &node.QualifiedName(),
-            );
-
-            for note in notes {
-                diagnostics.push_note(note.note, &note.source);
-            }
-        }
+        validate_interface_implementation(
+            element,
+            interface,
+            interface_name,
+            &node.QualifiedName(),
+            None,
+            diagnostics,
+        );
     }
 }
 
 struct NoteWithSource {
     note: String,
-    source: SyntaxNode,
+    source: SourceLocation,
 }
 
 struct InterfaceMemberDiagnostics {
@@ -260,11 +245,118 @@ impl From<String> for InterfaceMemberDiagnostics {
     }
 }
 
+enum DeclarationAnchor {
+    Name,
+    PropertyType,
+    /// The n-th parameter of a callback or function.
+    Argument(usize),
+    ReturnType,
+    Visibility(PropertyVisibility),
+    Purity,
+}
+
+impl DeclarationAnchor {
+    fn source_location(&self, declaration: &SyntaxNode) -> SourceLocation {
+        self.narrow(declaration)
+            .or_else(|| {
+                Some(declaration.child_node(SyntaxKind::DeclaredIdentifier)?.to_source_location())
+            })
+            .unwrap_or_else(|| declaration.to_source_location())
+    }
+
+    fn narrow(&self, declaration: &SyntaxNode) -> Option<SourceLocation> {
+        let node = match self {
+            Self::Name => return None,
+            Self::PropertyType => declaration.child_node(SyntaxKind::Type)?,
+            Self::Argument(index) => parameter_type(declaration, *index)?,
+            Self::ReturnType => declaration.child_node(SyntaxKind::ReturnType)?,
+            Self::Visibility(visibility) => {
+                return Some(
+                    keyword_token(declaration, &visibility.to_string())?.to_source_location(),
+                );
+            }
+            Self::Purity => {
+                return Some(keyword_token(declaration, "pure")?.to_source_location());
+            }
+        };
+        Some(node.to_source_location())
+    }
+}
+
+fn parameter_type(declaration: &SyntaxNode, index: usize) -> Option<SyntaxNode> {
+    let parameter_kind = match declaration.kind() {
+        SyntaxKind::Function => SyntaxKind::ArgumentDeclaration,
+        SyntaxKind::CallbackDeclaration => SyntaxKind::CallbackDeclarationParameter,
+        _ => return None,
+    };
+    declaration
+        .children()
+        .filter(|child| child.kind() == parameter_kind)
+        .nth(index)?
+        .child_node(SyntaxKind::Type)
+}
+
+/// Visibility and purity are plain identifier tokens rather than syntax nodes, so they can only be
+/// located by their text - the inverse of how [`Element::from_node`] reads them.
+fn keyword_token(declaration: &SyntaxNode, keyword: &str) -> Option<SyntaxToken> {
+    declaration.children_with_tokens().filter_map(|child| child.into_token()).find(|token| {
+        token.kind() == SyntaxKind::Identifier
+            && parser::normalize_identifier(token.text()) == keyword
+    })
+}
+
+struct MemberViolation {
+    error: String,
+    note: String,
+    anchor: DeclarationAnchor,
+}
+
+fn validate_interface_implementation(
+    element: &Element,
+    interface: &ElementRc,
+    interface_name: &SmolStr,
+    node: &SyntaxNode,
+    child_id: Option<&SmolStr>,
+    diagnostics: &mut BuildDiagnostics,
+) -> bool {
+    let mut errors = Vec::new();
+    let mut notes = Vec::new();
+    for (member_name, member_declaration) in interface.borrow().property_declarations.iter() {
+        if let Some(mut conflict) = validate_interface_member_implementation(
+            element,
+            member_name,
+            member_declaration,
+            interface_name,
+            child_id,
+        ) {
+            errors.push(conflict.error);
+            notes.append(&mut conflict.notes);
+        };
+    }
+
+    if !errors.is_empty() {
+        let based_on = match child_id {
+            Some(child_id) => format!(" based on '{child_id}'"),
+            None => String::new(),
+        };
+        diagnostics.push_error(
+            format!("Cannot implement '{interface_name}'{based_on}.\n{}", errors.join("\n")),
+            node,
+        );
+
+        for note in notes {
+            diagnostics.push_note_with_span(note.note, note.source);
+        }
+    }
+    errors.is_empty()
+}
+
 fn validate_interface_member_implementation(
     element: &Element,
     member_name: &SmolStr,
     interface_member: &PropertyDeclaration,
     interface_name: &SmolStr,
+    child_id: Option<&SmolStr>,
 ) -> Option<InterfaceMemberDiagnostics> {
     if matches!(interface_member.property_type, Type::Invalid) {
         // The interface's own declaration is invalid (e.g. an unknown property type). A diagnostic
@@ -274,39 +366,29 @@ fn validate_interface_member_implementation(
     }
 
     let lookup_result = element.lookup_property(member_name);
-    if lookup_result.property_type == Type::Invalid {
-        return Some(InterfaceMemberDiagnostics::from(missing_type_error(
-            member_name,
-            interface_member,
-        )));
-    }
-
-    let Err(conflicts) =
-        property_matches_interface(&lookup_result, interface_member, member_name, None)
-    else {
+    let Err(violations) = property_matches_interface(
+        &lookup_result,
+        interface_member,
+        interface_name,
+        member_name,
+        child_id,
+    ) else {
         return None;
     };
 
-    if !lookup_result.is_local_to_component {
-        if let Err(message) =
-            check_property_declaration_conflicts(&lookup_result, &element.base_type)
-        {
-            return Some(InterfaceMemberDiagnostics::from(message));
-        }
-        return None;
-    }
+    let joined_errors = violations.iter().map(|v| v.error.as_str()).join("\n");
+    let mut conflicts = InterfaceMemberDiagnostics::from(joined_errors);
 
-    let mut conflicts = InterfaceMemberDiagnostics::from(conflicts);
-    let source = element
-        .property_declarations
-        .get(member_name)
-        .and_then(|declaration| declaration.node.clone());
-
-    if let Some(source) = source {
-        conflicts.notes.push(NoteWithSource {
-            note: format!("'{member_name}' does not satisfy '{interface_name}'"),
-            source,
-        });
+    if lookup_result.is_valid()
+        && let Some(source) = element.property_declaration_node(member_name)
+    {
+        conflicts.notes = violations
+            .into_iter()
+            .map(|violation| NoteWithSource {
+                note: violation.note,
+                source: violation.anchor.source_location(&source),
+            })
+            .collect();
     }
     Some(conflicts)
 }
@@ -327,24 +409,31 @@ pub(super) fn apply_child_implement_statements(
             continue;
         };
 
-        if !element_implements_interface(
-            &child,
+        if !validate_interface_implementation(
+            &child.borrow(),
             &interface,
-            &child_id,
             &interface_name,
-            &node,
+            &node.DeclaredIdentifier(),
+            Some(&child_id),
             diagnostics,
         ) {
             continue;
         }
 
         let mut conflicts = Vec::new();
+        let mut notes = Vec::new();
         for (name, prop_decl) in interface.borrow().property_declarations.iter() {
             let lookup_result = element.borrow().base_type.lookup_property(name);
             if let Err(message) =
                 check_property_declaration_conflicts(&lookup_result, &element.borrow().base_type)
             {
                 conflicts.push(message);
+                if let Some(source) = element.borrow().property_declaration_node(name) {
+                    notes.push(NoteWithSource {
+                        note: declares_as_note(&interface_name, name, prop_decl),
+                        source: DeclarationAnchor::Name.source_location(&source),
+                    });
+                }
                 continue;
             }
 
@@ -369,6 +458,10 @@ pub(super) fn apply_child_implement_statements(
                 diagnostics.push_error(
                     format!("Cannot override '{}' from '{}'", name, interface_name),
                     &source,
+                );
+                diagnostics.push_note(
+                    declares_as_note(&interface_name, name, &prop_decl),
+                    &node.QualifiedName(),
                 );
                 continue;
             }
@@ -398,105 +491,85 @@ pub(super) fn apply_child_implement_statements(
                 ),
                 &node.QualifiedName(),
             );
+            for note in notes {
+                diagnostics.push_note(note.note, &note.source);
+            }
         }
     }
-}
-
-fn element_implements_interface(
-    element: &ElementRc,
-    interface: &ElementRc,
-    child_id: &SmolStr,
-    interface_name: &SmolStr,
-    implement_node: &syntax_nodes::ImplementStatement,
-    diagnostics: &mut BuildDiagnostics,
-) -> bool {
-    let mut errors = Vec::new();
-    let mut check = |property_name: &SmolStr, property_declaration: &PropertyDeclaration| {
-        let lookup_result = element.borrow().lookup_property(property_name);
-        if let Err(conflicts) = property_matches_interface(
-            &lookup_result,
-            property_declaration,
-            property_name,
-            Some(child_id),
-        ) {
-            errors.push(conflicts);
-        }
-    };
-
-    for (property_name, property_declaration) in interface.borrow().property_declarations.iter() {
-        check(property_name, property_declaration);
-    }
-
-    if !errors.is_empty() {
-        let errors = errors.join("\n");
-        diagnostics.push_error(
-            format!("Cannot implement '{}' based on '{}'.\n{}", interface_name, child_id, errors),
-            &implement_node.DeclaredIdentifier(),
-        );
-    }
-
-    errors.is_empty()
 }
 
 fn purity_description(purity: &Option<bool>) -> &str {
     if purity.unwrap_or(false) { "pure " } else { "" }
 }
 
-fn missing_type_description(interface_declaration: &PropertyDeclaration) -> String {
-    match interface_declaration.property_type {
-        Type::Callback(..) => {
-            format!(
-                "a '{}{}'",
-                purity_description(&interface_declaration.pure),
-                interface_declaration.property_type
-            )
+fn syntax_for(
+    name: &SmolStr,
+    property_type: &Type,
+    pure: &Option<bool>,
+    visibility: &PropertyVisibility,
+) -> String {
+    match property_type {
+        Type::Function(function) => {
+            format!("{}{} function {name}{} {{ }}", purity_description(pure), visibility, function)
         }
-        Type::Function(..) => {
-            format!(
-                "a 'public {}{}'",
-                purity_description(&interface_declaration.pure),
-                interface_declaration.property_type
-            )
+        Type::Callback(function) => {
+            format!("{}callback {name}{};", purity_description(pure), function)
         }
-        _ => {
-            format!(
-                "an {} '{}' property",
-                interface_declaration.visibility, interface_declaration.property_type
-            )
+        _ if property_type.is_property_type() => {
+            format!("{} property <{}> {name};", visibility, property_type)
         }
-    }
-}
-
-fn syntax_for(interface_declaration: &PropertyDeclaration, name: &SmolStr) -> String {
-    let display_args =
-        |arguments: &Vec<Type>| -> String { arguments.iter().map(|t| t.to_string()).join(", ") };
-    let return_type = |return_type: &Type| -> String {
-        if *return_type == Type::Void { String::new() } else { format!(" -> {return_type}") }
-    };
-    match &interface_declaration.property_type {
-        Type::Function(function) => format!(
-            "{}{} function {name}({}){} {{ }}",
-            purity_description(&interface_declaration.pure),
-            interface_declaration.visibility,
-            display_args(&function.args),
-            return_type(&function.return_type)
-        ),
-        Type::Callback(function) => format!(
-            "{}callback {name}({}){};",
-            purity_description(&interface_declaration.pure),
-            display_args(&function.args),
-            return_type(&function.return_type)
-        ),
-        _ if interface_declaration.property_type.is_property_type() => format!(
-            "{} property <{}> {name};",
-            interface_declaration.visibility, interface_declaration.property_type
-        ),
         _ => name.to_string(),
     }
 }
 
+fn syntax_for_declaration(interface_declaration: &PropertyDeclaration, name: &SmolStr) -> String {
+    syntax_for(
+        name,
+        &interface_declaration.property_type,
+        &interface_declaration.pure,
+        &interface_declaration.visibility,
+    )
+}
+
+fn syntax_for_lookup_result(lookup_result: &PropertyLookupResult, name: &SmolStr) -> String {
+    syntax_for(
+        name,
+        &lookup_result.property_type,
+        &lookup_result.declared_pure,
+        &lookup_result.property_visibility,
+    )
+}
+
 fn missing_type_error(name: &SmolStr, interface_declaration: &PropertyDeclaration) -> String {
-    format!("- missing '{}'", syntax_for(interface_declaration, name))
+    format!("- missing '{}'", syntax_for_declaration(interface_declaration, name))
+}
+
+fn declares_as_note(
+    interface_name: &SmolStr,
+    name: &SmolStr,
+    interface_declaration: &PropertyDeclaration,
+) -> String {
+    format!(
+        "'{interface_name}' declares '{name}' as '{}'",
+        syntax_for_declaration(interface_declaration, name)
+    )
+}
+
+fn signature_anchor(interface_declaration: &Function, declaration: &Function) -> DeclarationAnchor {
+    if let Some(index) = interface_declaration
+        .args
+        .iter()
+        .zip(declaration.args.iter())
+        .position(|(expected, declared)| expected != declared)
+    {
+        DeclarationAnchor::Argument(index)
+    } else if declaration.args.len() > interface_declaration.args.len() {
+        DeclarationAnchor::Argument(interface_declaration.args.len())
+    } else if declaration.args.len() < interface_declaration.args.len() {
+        DeclarationAnchor::Name
+    } else {
+        DeclarationAnchor::ReturnType
+    }
 }
 
 /// [PartialEq] for [Function] means that the argument names must match. That is not required for a valid interface implementation.
@@ -515,11 +588,16 @@ fn property_type_matches_for_interface(lhs: &Type, rhs: &Type) -> bool {
 fn property_matches_interface(
     property: &PropertyLookupResult,
     interface_declaration: &PropertyDeclaration,
+    interface_name: &SmolStr,
     name: &SmolStr,
     child_id: Option<&SmolStr>,
-) -> Result<(), String> {
+) -> Result<(), Vec<MemberViolation>> {
     if property.property_type == Type::Invalid {
-        return Err(missing_type_error(name, interface_declaration));
+        return Err(vec![MemberViolation {
+            error: missing_type_error(name, interface_declaration),
+            note: declares_as_note(interface_name, name, interface_declaration),
+            anchor: DeclarationAnchor::Name,
+        }]);
     }
 
     let mut errors = Vec::new();
@@ -538,46 +616,66 @@ fn property_matches_interface(
             (lhs, rhs) => lhs.is_property_type() && rhs.is_property_type(),
         };
 
-        let type_description = |property_type: &Type| match property_type {
-            Type::Callback(..) => {
-                format!("a '{}'", property_type)
-            }
-            Type::Function(..) => {
-                format!("a '{}'", property_type)
-            }
-            _ => {
-                format!("a '{}' property", property_type)
-            }
-        };
+        let property_description = |property_type: &Type| format!("a '{}' property", property_type);
 
-        let expected = if !is_same_type {
-            missing_type_description(interface_declaration)
+        let expected = if is_same_type && interface_declaration.property_type.is_property_type() {
+            property_description(&interface_declaration.property_type)
         } else {
-            type_description(&interface_declaration.property_type)
+            format!("'{}'", syntax_for_declaration(interface_declaration, name))
         };
 
-        let actual = type_description(&property.property_type);
-        errors.push(format!("- '{member_name}' must be {expected} (found {actual})"));
+        let actual = if property.property_type.is_property_type() {
+            property_description(&property.property_type)
+        } else {
+            format!("'{}'", syntax_for_lookup_result(property, name))
+        };
+
+        let error = format!("- '{member_name}' must be {expected} (found {actual})");
 
         if !is_same_type {
             // Visibility and purity are unlikely to make sense, so return early in this case.
-            return Err(errors.join("\n"));
+            return Err(vec![MemberViolation {
+                error,
+                note: declares_as_note(interface_name, name, interface_declaration),
+                anchor: DeclarationAnchor::Name,
+            }]);
         }
+
+        let (note, anchor) = match (&interface_declaration.property_type, &property.property_type) {
+            (Type::Callback(expected), Type::Callback(declared))
+            | (Type::Function(expected), Type::Function(declared)) => (
+                declares_as_note(interface_name, name, interface_declaration),
+                signature_anchor(expected, declared),
+            ),
+            (_, _) => (
+                declares_as_note(interface_name, name, interface_declaration),
+                DeclarationAnchor::PropertyType,
+            ),
+        };
+        errors.push(MemberViolation { error, note, anchor });
     }
 
     if property.property_visibility != interface_declaration.visibility {
-        errors.push(format!(
-            "- '{member_name}' must be '{}' (found '{}')",
-            interface_declaration.visibility, property.property_visibility
-        ));
+        errors.push(MemberViolation {
+            error: format!(
+                "- '{member_name}' must be '{}' (found '{}')",
+                interface_declaration.visibility, property.property_visibility
+            ),
+            note: declares_as_note(interface_name, name, interface_declaration),
+            anchor: DeclarationAnchor::Visibility(property.property_visibility),
+        });
     }
 
     // The implementation can be "more pure" than the interface, but never less pure.
     if interface_declaration.pure.unwrap_or(false) && !property.declared_pure.unwrap_or(false) {
-        errors.push(format!("- '{member_name}' must be 'pure'"));
+        errors.push(MemberViolation {
+            error: format!("- '{member_name}' must be 'pure'"),
+            note: declares_as_note(interface_name, name, interface_declaration),
+            anchor: DeclarationAnchor::Purity,
+        });
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors.join("\n")) }
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
 }
 
 fn apply_uses_statement_function_binding(

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -217,30 +217,14 @@ pub(super) fn validate_self_implement_statements(
     diagnostics: &mut BuildDiagnostics,
 ) {
     for ImplementedInterface { interface, node, interface_name, .. } in implemented_interfaces {
-        let mut errors = Vec::new();
-        let mut notes = Vec::new();
-        for (member_name, member_declaration) in interface.borrow().property_declarations.iter() {
-            if let Some(mut conflict) = validate_interface_member_implementation(
-                element,
-                member_name,
-                member_declaration,
-                interface_name,
-            ) {
-                errors.push(conflict.error);
-                notes.append(&mut conflict.notes);
-            };
-        }
-
-        if !errors.is_empty() {
-            diagnostics.push_error(
-                format!("Cannot implement '{interface_name}'.\n{}", errors.join("\n")),
-                &node.QualifiedName(),
-            );
-
-            for note in notes {
-                diagnostics.push_note(note.note, &note.source);
-            }
-        }
+        validate_interface_implementation(
+            element,
+            interface,
+            interface_name,
+            &node.QualifiedName(),
+            None,
+            diagnostics,
+        );
     }
 }
 
@@ -260,11 +244,52 @@ impl From<String> for InterfaceMemberDiagnostics {
     }
 }
 
+fn validate_interface_implementation(
+    element: &Element,
+    interface: &ElementRc,
+    interface_name: &SmolStr,
+    node: &SyntaxNode,
+    child_id: Option<&SmolStr>,
+    diagnostics: &mut BuildDiagnostics,
+) -> bool {
+    let mut errors = Vec::new();
+    let mut notes = Vec::new();
+    for (member_name, member_declaration) in interface.borrow().property_declarations.iter() {
+        if let Some(mut conflict) = validate_interface_member_implementation(
+            element,
+            member_name,
+            member_declaration,
+            interface_name,
+            child_id,
+        ) {
+            errors.push(conflict.error);
+            notes.append(&mut conflict.notes);
+        };
+    }
+
+    if !errors.is_empty() {
+        let based_on = match child_id {
+            Some(child_id) => format!(" based on '{child_id}'"),
+            None => String::new(),
+        };
+        diagnostics.push_error(
+            format!("Cannot implement '{interface_name}'{based_on}.\n{}", errors.join("\n")),
+            node,
+        );
+
+        for note in notes {
+            diagnostics.push_note(note.note, &note.source);
+        }
+    }
+    errors.is_empty()
+}
+
 fn validate_interface_member_implementation(
     element: &Element,
     member_name: &SmolStr,
     interface_member: &PropertyDeclaration,
     interface_name: &SmolStr,
+    child_id: Option<&SmolStr>,
 ) -> Option<InterfaceMemberDiagnostics> {
     if matches!(interface_member.property_type, Type::Invalid) {
         // The interface's own declaration is invalid (e.g. an unknown property type). A diagnostic
@@ -275,7 +300,7 @@ fn validate_interface_member_implementation(
 
     let lookup_result = element.lookup_property(member_name);
     let Err(conflicts) =
-        property_matches_interface(&lookup_result, interface_member, member_name, None)
+        property_matches_interface(&lookup_result, interface_member, member_name, child_id)
     else {
         return None;
     };
@@ -284,7 +309,7 @@ fn validate_interface_member_implementation(
         return Some(InterfaceMemberDiagnostics::from(conflicts));
     }
 
-    let conflicts = if lookup_result.is_local_to_component {
+    let conflicts = if lookup_result.is_local_to_component || child_id.is_some() {
         conflicts
     } else {
         check_property_declaration_conflicts(&lookup_result, &element.base_type)
@@ -318,12 +343,12 @@ pub(super) fn apply_child_implement_statements(
             continue;
         };
 
-        if !element_implements_interface(
-            &child,
+        if !validate_interface_implementation(
+            &child.borrow(),
             &interface,
-            &child_id,
             &interface_name,
-            &node,
+            &node.DeclaredIdentifier(),
+            Some(&child_id),
             diagnostics,
         ) {
             continue;
@@ -391,42 +416,6 @@ pub(super) fn apply_child_implement_statements(
             );
         }
     }
-}
-
-fn element_implements_interface(
-    element: &ElementRc,
-    interface: &ElementRc,
-    child_id: &SmolStr,
-    interface_name: &SmolStr,
-    implement_node: &syntax_nodes::ImplementStatement,
-    diagnostics: &mut BuildDiagnostics,
-) -> bool {
-    let mut errors = Vec::new();
-    let mut check = |property_name: &SmolStr, property_declaration: &PropertyDeclaration| {
-        let lookup_result = element.borrow().lookup_property(property_name);
-        if let Err(conflicts) = property_matches_interface(
-            &lookup_result,
-            property_declaration,
-            property_name,
-            Some(child_id),
-        ) {
-            errors.push(conflicts);
-        }
-    };
-
-    for (property_name, property_declaration) in interface.borrow().property_declarations.iter() {
-        check(property_name, property_declaration);
-    }
-
-    if !errors.is_empty() {
-        let errors = errors.join("\n");
-        diagnostics.push_error(
-            format!("Cannot implement '{}' based on '{}'.\n{}", interface_name, child_id, errors),
-            &implement_node.DeclaredIdentifier(),
-        );
-    }
-
-    errors.is_empty()
 }
 
 fn purity_description(purity: &Option<bool>) -> &str {

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -15,7 +15,8 @@ use crate::expression_tree::{BindingExpression, Callable, Expression};
 use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
-    Element, ElementRc, PropertyDeclaration, QualifiedTypeName, find_element_by_id,
+    Element, ElementRc, PropertyDeclaration, PropertyVisibility, QualifiedTypeName,
+    find_element_by_id,
 };
 use crate::parser::{self, SyntaxNode, SyntaxToken};
 use crate::parser::{SyntaxKind, syntax_nodes};
@@ -539,36 +540,49 @@ fn missing_type_description(interface_declaration: &PropertyDeclaration) -> Stri
     }
 }
 
-fn syntax_for(interface_declaration: &PropertyDeclaration, name: &SmolStr) -> String {
+fn syntax_for(
+    name: &SmolStr,
+    property_type: &Type,
+    pure: &Option<bool>,
+    visibility: &PropertyVisibility,
+) -> String {
     let display_args =
         |arguments: &Vec<Type>| -> String { arguments.iter().map(|t| t.to_string()).join(", ") };
     let return_type = |return_type: &Type| -> String {
         if *return_type == Type::Void { String::new() } else { format!(" -> {return_type}") }
     };
-    match &interface_declaration.property_type {
+    match property_type {
         Type::Function(function) => format!(
             "{}{} function {name}({}){} {{ }}",
-            purity_description(&interface_declaration.pure),
-            interface_declaration.visibility,
+            purity_description(pure),
+            visibility,
             display_args(&function.args),
             return_type(&function.return_type)
         ),
         Type::Callback(function) => format!(
             "{}callback {name}({}){};",
-            purity_description(&interface_declaration.pure),
+            purity_description(pure),
             display_args(&function.args),
             return_type(&function.return_type)
         ),
-        _ if interface_declaration.property_type.is_property_type() => format!(
-            "{} property <{}> {name};",
-            interface_declaration.visibility, interface_declaration.property_type
-        ),
+        _ if property_type.is_property_type() => {
+            format!("{} property <{}> {name};", visibility, property_type)
+        }
         _ => name.to_string(),
     }
 }
 
+fn syntax_for_declaration(interface_declaration: &PropertyDeclaration, name: &SmolStr) -> String {
+    syntax_for(
+        name,
+        &interface_declaration.property_type,
+        &interface_declaration.pure,
+        &interface_declaration.visibility,
+    )
+}
+
 fn missing_type_error(name: &SmolStr, interface_declaration: &PropertyDeclaration) -> String {
-    format!("- missing '{}'", syntax_for(interface_declaration, name))
+    format!("- missing '{}'", syntax_for_declaration(interface_declaration, name))
 }
 
 fn declares_as_note(
@@ -576,7 +590,10 @@ fn declares_as_note(
     name: &SmolStr,
     interface_declaration: &PropertyDeclaration,
 ) -> String {
-    format!("'{interface_name}' declares '{name}' as '{}'", syntax_for(interface_declaration, name))
+    format!(
+        "'{interface_name}' declares '{name}' as '{}'",
+        syntax_for_declaration(interface_declaration, name)
+    )
 }
 
 fn signature_anchor(interface_declaration: &Function, declaration: &Function) -> DeclarationAnchor {

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -28,6 +28,7 @@ export component ChildMissingMembers {
 // Member present but with the wrong visibility / type / callback signature / purity / arguments.
 component IncorrectVisibility {
     out property <int> value;
+//  > <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
     public pure function reset() {}
 }
@@ -40,6 +41,7 @@ export component ChildWrongVisibility {
 
 component IncorrectType {
     in-out property <float> value;
+//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
     public pure function reset() {}
 }
@@ -53,12 +55,13 @@ export component ChildWrongType {
 component IncorrectCallback {
     in-out property <int> value;
     callback speak() -> string;
+//                      >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public pure function reset() {}
 }
 
 export component ChildWrongCallback {
     implement ValidInterface <=> impl;
-//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.speak' must be a 'callback() -> void' (found a 'callback() -> string')}
+//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.speak' must be 'callback speak();' (found 'callback speak() -> string;')}
     impl := IncorrectCallback { }
 }
 
@@ -84,6 +87,7 @@ interface ImpureFunctionInterface {
 
 component IncorrectPurity {
     public function foo(i: int, s: string) -> bool {
+//                  > <note{'FunctionInterface' declares 'foo' as 'pure public function foo(int, string) -> bool { }'}
         return false;
     }
 
@@ -103,26 +107,30 @@ export component ChildWrongPurity {
 
 component IncorrectArguments {
     pure public function foo(i: int, s: int) -> bool {
+//                                      > <note{'FunctionInterface' declares 'foo' as 'pure public function foo(int, string) -> bool { }'}
         return false;
     }
 }
 
 export component ChildWrongArguments {
     implement FunctionInterface <=> base;
-//                                  >  <error{Cannot implement 'FunctionInterface' based on 'base'.↵- 'base.foo' must be a 'function(int, string) -> bool' (found a 'function(int, int) -> bool')}
+//                                  >  <error{Cannot implement 'FunctionInterface' based on 'base'.↵- 'base.foo' must be 'pure public function foo(int, string) -> bool { }' (found 'pure public function foo(int, int) -> bool { }')}
     base := IncorrectArguments { }
 }
 
 // Each member of the child declared as the wrong kind.
 component CrossKindImpl {
     callback value();
+//           >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     in-out property <int> speak;
+//                        >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     in-out property <int> reset;
+//                        >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
 }
 
 export component ChildCrossKind {
     implement ValidInterface <=> impl;
-//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.reset' must be a 'public pure function() -> void' (found a 'int' property)↵- 'impl.speak' must be a 'callback() -> void' (found a 'int' property)↵- 'impl.value' must be an in-out 'int' property (found a 'callback() -> void')}
+//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.reset' must be 'pure public function reset() { }' (found a 'int' property)↵- 'impl.speak' must be 'callback speak();' (found a 'int' property)↵- 'impl.value' must be 'in-out property <int> value;' (found 'callback value();')}
     impl := CrossKindImpl { }
 }
 
@@ -141,6 +149,9 @@ export component ChildImplicitlyImplements {
 // A forwarded member must not clash with a member already declared on the parent.
 export component OverridesDeclaration {
     implement ValidInterface <=> base;
+//            >             <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
+//            >             <^note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//            >             <^^note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     base := ValidBase { }
 
     in-out property <int> value;
@@ -154,8 +165,11 @@ export component OverridesDeclaration {
 // A forwarded member must not clash with a member inherited by the parent from its own base.
 component BaseWithConflicts {
     in-out property <int> value;
+//                        >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
+//           >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public pure function reset() {}
+//                       >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
     @children
 }
 

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -28,6 +28,7 @@ export component ChildMissingMembers {
 // Member present but with the wrong visibility / type / callback signature / purity / arguments.
 component IncorrectVisibility {
     out property <int> value;
+//  >                       <note{'value' does not satisfy 'ValidInterface'}
     callback speak();
     public pure function reset() {}
 }
@@ -40,6 +41,7 @@ export component ChildWrongVisibility {
 
 component IncorrectType {
     in-out property <float> value;
+//  >                            <note{'value' does not satisfy 'ValidInterface'}
     callback speak();
     public pure function reset() {}
 }
@@ -53,6 +55,7 @@ export component ChildWrongType {
 component IncorrectCallback {
     in-out property <int> value;
     callback speak() -> string;
+//  >                         <note{'speak' does not satisfy 'ValidInterface'}
     public pure function reset() {}
 }
 
@@ -84,8 +87,10 @@ interface ImpureFunctionInterface {
 
 component IncorrectPurity {
     public function foo(i: int, s: string) -> bool {
+//  >note{'foo' does not satisfy 'FunctionInterface'}
         return false;
     }
+//  <note{'foo' does not satisfy 'FunctionInterface'}
 
     // Implementation is pure, interface is not - this should not raise an error
     public pure function bar(i: int, s: string) -> bool {
@@ -103,8 +108,10 @@ export component ChildWrongPurity {
 
 component IncorrectArguments {
     pure public function foo(i: int, s: int) -> bool {
+//  >note{'foo' does not satisfy 'FunctionInterface'}
         return false;
     }
+//  <note{'foo' does not satisfy 'FunctionInterface'}
 }
 
 export component ChildWrongArguments {
@@ -116,8 +123,11 @@ export component ChildWrongArguments {
 // Each member of the child declared as the wrong kind.
 component CrossKindImpl {
     callback value();
+//  >               <note{'value' does not satisfy 'ValidInterface'}
     in-out property <int> speak;
+//  >                          <note{'speak' does not satisfy 'ValidInterface'}
     in-out property <int> reset;
+//  >                          <note{'reset' does not satisfy 'ValidInterface'}
 }
 
 export component ChildCrossKind {

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -28,7 +28,7 @@ export component ChildMissingMembers {
 // Member present but with the wrong visibility / type / callback signature / purity / arguments.
 component IncorrectVisibility {
     out property <int> value;
-//  > <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//  > <note{'IncorrectVisibility' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
     callback speak();
     public pure function reset() {}
 }
@@ -41,7 +41,7 @@ export component ChildWrongVisibility {
 
 component IncorrectType {
     in-out property <float> value;
-//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//                   >   <note{'IncorrectType' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
     callback speak();
     public pure function reset() {}
 }
@@ -55,7 +55,7 @@ export component ChildWrongType {
 component IncorrectCallback {
     in-out property <int> value;
     callback speak() -> string;
-//                      >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//                      >    <note{'IncorrectCallback' declares 'speak' here, 'ValidInterface' expects 'callback speak();'}
     public pure function reset() {}
 }
 
@@ -87,7 +87,7 @@ interface ImpureFunctionInterface {
 
 component IncorrectPurity {
     public function foo(i: int, s: string) -> bool {
-//                  > <note{'FunctionInterface' declares 'foo' as 'pure public function foo(int, string) -> bool { }'}
+//                  > <note{'IncorrectPurity' declares 'foo' here, 'FunctionInterface' expects 'pure public function foo(int, string) -> bool { }'}
         return false;
     }
 
@@ -107,7 +107,7 @@ export component ChildWrongPurity {
 
 component IncorrectArguments {
     pure public function foo(i: int, s: int) -> bool {
-//                                      > <note{'FunctionInterface' declares 'foo' as 'pure public function foo(int, string) -> bool { }'}
+//                                      > <note{'IncorrectArguments' declares 'foo' here, 'FunctionInterface' expects 'pure public function foo(int, string) -> bool { }'}
         return false;
     }
 }
@@ -121,11 +121,11 @@ export component ChildWrongArguments {
 // Each member of the child declared as the wrong kind.
 component CrossKindImpl {
     callback value();
-//           >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//           >   <note{'CrossKindImpl' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
     in-out property <int> speak;
-//                        >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//                        >   <note{'CrossKindImpl' declares 'speak' here, 'ValidInterface' expects 'callback speak();'}
     in-out property <int> reset;
-//                        >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
+//                        >   <note{'CrossKindImpl' declares 'reset' here, 'ValidInterface' expects 'pure public function reset() { }'}
 }
 
 export component ChildCrossKind {
@@ -165,11 +165,11 @@ export component OverridesDeclaration {
 // A forwarded member must not clash with a member inherited by the parent from its own base.
 component BaseWithConflicts {
     in-out property <int> value;
-//                        >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//                        >   <note{'BaseWithConflicts' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
     callback speak();
-//           >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//           >   <note{'BaseWithConflicts' declares 'speak' here, 'ValidInterface' expects 'callback speak();'}
     public pure function reset() {}
-//                       >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
+//                       >   <note{'BaseWithConflicts' declares 'reset' here, 'ValidInterface' expects 'pure public function reset() { }'}
     @children
 }
 
@@ -200,10 +200,10 @@ export component ChildWithProperties {
 
     child_with_conflicts := Rectangle {
         in-out property <float> value;
-//                       >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//                       >   <note{'child_with_conflicts' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
         public function speak() {}
-//                      >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//                      >   <note{'child_with_conflicts' declares 'speak' here, 'ValidInterface' expects 'callback speak();'}
         callback reset();
-//               >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
+//               >   <note{'child_with_conflicts' declares 'reset' here, 'ValidInterface' expects 'pure public function reset() { }'}
     }
 }

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -28,7 +28,7 @@ export component ChildMissingMembers {
 // Member present but with the wrong visibility / type / callback signature / purity / arguments.
 component IncorrectVisibility {
     out property <int> value;
-//  >                       <note{'value' does not satisfy 'ValidInterface'}
+//  > <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
     public pure function reset() {}
 }
@@ -41,7 +41,7 @@ export component ChildWrongVisibility {
 
 component IncorrectType {
     in-out property <float> value;
-//  >                            <note{'value' does not satisfy 'ValidInterface'}
+//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
     public pure function reset() {}
 }
@@ -55,7 +55,7 @@ export component ChildWrongType {
 component IncorrectCallback {
     in-out property <int> value;
     callback speak() -> string;
-//  >                         <note{'speak' does not satisfy 'ValidInterface'}
+//                      >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public pure function reset() {}
 }
 
@@ -87,10 +87,9 @@ interface ImpureFunctionInterface {
 
 component IncorrectPurity {
     public function foo(i: int, s: string) -> bool {
-//  >note{'foo' does not satisfy 'FunctionInterface'}
+//                  > <note{'FunctionInterface' declares 'foo' as 'pure public function foo(int, string) -> bool { }'}
         return false;
     }
-//  <note{'foo' does not satisfy 'FunctionInterface'}
 
     // Implementation is pure, interface is not - this should not raise an error
     public pure function bar(i: int, s: string) -> bool {
@@ -108,10 +107,9 @@ export component ChildWrongPurity {
 
 component IncorrectArguments {
     pure public function foo(i: int, s: int) -> bool {
-//  >note{'foo' does not satisfy 'FunctionInterface'}
+//                                      > <note{'FunctionInterface' declares 'foo' as 'pure public function foo(int, string) -> bool { }'}
         return false;
     }
-//  <note{'foo' does not satisfy 'FunctionInterface'}
 }
 
 export component ChildWrongArguments {
@@ -123,11 +121,11 @@ export component ChildWrongArguments {
 // Each member of the child declared as the wrong kind.
 component CrossKindImpl {
     callback value();
-//  >               <note{'value' does not satisfy 'ValidInterface'}
+//           >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     in-out property <int> speak;
-//  >                          <note{'speak' does not satisfy 'ValidInterface'}
+//                        >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     in-out property <int> reset;
-//  >                          <note{'reset' does not satisfy 'ValidInterface'}
+//                        >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
 }
 
 export component ChildCrossKind {
@@ -167,11 +165,11 @@ export component OverridesDeclaration {
 // A forwarded member must not clash with a member inherited by the parent from its own base.
 component BaseWithConflicts {
     in-out property <int> value;
-//  >                          <note{'value' does not satisfy 'ValidInterface'}
+//                        >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
-//  >               <note{'speak' does not satisfy 'ValidInterface'}
+//           >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public pure function reset() {}
-//  >                             <note{'reset' does not satisfy 'ValidInterface'}
+//                       >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
     @children
 }
 

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -61,7 +61,7 @@ component IncorrectCallback {
 
 export component ChildWrongCallback {
     implement ValidInterface <=> impl;
-//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.speak' must be a 'callback() -> void' (found a 'callback() -> string')}
+//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.speak' must be 'callback speak();' (found 'callback speak() -> string;')}
     impl := IncorrectCallback { }
 }
 
@@ -114,7 +114,7 @@ component IncorrectArguments {
 
 export component ChildWrongArguments {
     implement FunctionInterface <=> base;
-//                                  >  <error{Cannot implement 'FunctionInterface' based on 'base'.↵- 'base.foo' must be a 'function(int, string) -> bool' (found a 'function(int, int) -> bool')}
+//                                  >  <error{Cannot implement 'FunctionInterface' based on 'base'.↵- 'base.foo' must be 'pure public function foo(int, string) -> bool { }' (found 'pure public function foo(int, int) -> bool { }')}
     base := IncorrectArguments { }
 }
 
@@ -130,7 +130,7 @@ component CrossKindImpl {
 
 export component ChildCrossKind {
     implement ValidInterface <=> impl;
-//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.reset' must be a 'public pure function() -> void' (found a 'int' property)↵- 'impl.speak' must be a 'callback() -> void' (found a 'int' property)↵- 'impl.value' must be an in-out 'int' property (found a 'callback() -> void')}
+//                               >  <error{Cannot implement 'ValidInterface' based on 'impl'.↵- 'impl.reset' must be 'pure public function reset() { }' (found a 'int' property)↵- 'impl.speak' must be 'callback speak();' (found a 'int' property)↵- 'impl.value' must be 'in-out property <int> value;' (found 'callback value();')}
     impl := CrossKindImpl { }
 }
 

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -164,8 +164,11 @@ export component OverridesDeclaration {
 // A forwarded member must not clash with a member inherited by the parent from its own base.
 component BaseWithConflicts {
     in-out property <int> value;
+//  >                          <note{'value' does not satisfy 'ValidInterface'}
     callback speak();
+//  >               <note{'speak' does not satisfy 'ValidInterface'}
     public pure function reset() {}
+//  >                             <note{'reset' does not satisfy 'ValidInterface'}
     @children
 }
 

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -151,6 +151,9 @@ export component ChildImplicitlyImplements {
 // A forwarded member must not clash with a member already declared on the parent.
 export component OverridesDeclaration {
     implement ValidInterface <=> base;
+//            >             <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
+//            >             <^note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//            >             <^^note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     base := ValidBase { }
 
     in-out property <int> value;

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -178,3 +178,16 @@ export component ConflictsWithBase inherits BaseWithConflicts {
 //            >             <error{Cannot implement 'ValidInterface' based on 'base'.↵- 'reset' conflicts with an existing function in 'BaseWithConflicts'↵- 'speak' conflicts with an existing callback in 'BaseWithConflicts'↵- 'value' conflicts with an existing property in 'BaseWithConflicts'}
     base := ValidBase { }
 }
+
+interface Viewport {
+    in-out property <float> viewport-x;
+    in-out property <float> viewport-y;
+}
+
+// The Viewport interface properties conflict with the properties on the built-in Flickable component
+export component ConflictsWithBuiltIn {
+    implement Viewport <=> flickable;
+//                         >       <error{Cannot implement 'Viewport' based on 'flickable'.↵- 'flickable.viewport-x' must be a 'float' property (found a 'length' property)↵- 'flickable.viewport-y' must be a 'float' property (found a 'length' property)}
+
+    flickable := Flickable { }
+}

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -191,3 +191,19 @@ export component ConflictsWithBuiltIn {
 
     flickable := Flickable { }
 }
+
+// Verify that we don't get the normalized child id in the diagnostic messages.
+export component ChildWithProperties {
+
+    implement ValidInterface <=> child_with_conflicts;
+//                               >                  <error{Cannot implement 'ValidInterface' based on 'child_with_conflicts'.↵- 'child_with_conflicts.reset' must be 'pure public function reset() { }' (found 'callback reset();')↵- 'child_with_conflicts.speak' must be 'callback speak();' (found 'public function speak() { }')↵- 'child_with_conflicts.value' must be a 'int' property (found a 'float' property)}
+
+    child_with_conflicts := Rectangle {
+        in-out property <float> value;
+//                       >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+        public function speak() {}
+//                      >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+        callback reset();
+//               >   <note{'ValidInterface' declares 'reset' as 'pure public function reset() { }'}
+    }
+}

--- a/internal/compiler/tests/syntax/interfaces/implement_self.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_self.slint
@@ -100,7 +100,7 @@ export component IncorrectPropertyType {
 
 export component IncorrectCallbackType {
     implement ValidInterface <=> self;
-//            >             <error{Cannot implement 'ValidInterface'.↵- 'speak' must be a 'callback() -> void' (found a 'callback(string) -> void')}
+//            >             <error{Cannot implement 'ValidInterface'.↵- 'speak' must be 'callback speak();' (found 'callback speak(string);')}
 
     in-out property <int> value;
     callback speak(string);
@@ -155,7 +155,7 @@ export component ImpureFunction {
 
 export component IncorrectFunctionArguments {
     implement Calculator <=> self;
-//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be a 'function(int) -> string' (found a 'function(string, int) -> string')}
+//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be 'public function format(int) -> string { }' (found 'public function format(string, int) -> string { }')}
 
     in-out property <int> value;
     callback notify();
@@ -173,7 +173,7 @@ export component IncorrectFunctionArguments {
 // Too few arguments: there is no offending argument to point at, so the note falls back to the name.
 export component MissingFunctionArguments {
     implement Calculator <=> self;
-//            >         <error{Cannot implement 'Calculator'.↵- 'add' must be a 'function(int, int) -> int' (found a 'function(int) -> int')}
+//            >         <error{Cannot implement 'Calculator'.↵- 'add' must be 'pure public function add(int, int) -> int { }' (found 'pure public function add(int) -> int { }')}
 
     in-out property <int> value;
     callback notify();
@@ -190,7 +190,7 @@ export component MissingFunctionArguments {
 
 export component IncorrectFunctionReturnType {
     implement Calculator <=> self;
-//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be a 'function(int) -> string' (found a 'function(int) -> void')}
+//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be 'public function format(int) -> string { }' (found 'public function format(int) { }')}
 
     in-out property <int> value;
     callback notify();
@@ -224,7 +224,7 @@ export component IncorrectFunctionVisibility {
 // A member name resolving to the wrong kind (function name declared as a property / callback).
 export component CannotOverrideFunction {
     implement Calculator <=> self;
-//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be a 'public function(int) -> string' (found a 'string' property)↵- 'reset' must be a 'public function() -> void' (found a 'callback() -> void')}
+//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be 'public function format(int) -> string { }' (found a 'string' property)↵- 'reset' must be 'public function reset() { }' (found 'callback reset();')}
 
     in-out property <int> value;
     callback notify();
@@ -271,7 +271,7 @@ export component ImplementFunctionConflict inherits BaseWithFunction {
 // Each member declared as the wrong kind of member.
 export component CrossKindMismatch {
     implement ValidInterface <=> self;
-//            >             <error{Cannot implement 'ValidInterface'.↵- 'reset' must be a 'public function() -> void' (found a 'int' property)↵- 'speak' must be a 'callback() -> void' (found a 'int' property)↵- 'value' must be an in-out 'int' property (found a 'callback() -> void')}
+//            >             <error{Cannot implement 'ValidInterface'.↵- 'reset' must be 'public function reset() { }' (found a 'int' property)↵- 'speak' must be 'callback speak();' (found a 'int' property)↵- 'value' must be 'in-out property <int> value;' (found 'callback value();')}
 
     callback value();
 //           >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}

--- a/internal/compiler/tests/syntax/interfaces/implement_self.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_self.slint
@@ -93,18 +93,18 @@ export component IncorrectPropertyType {
 //            >             <error{Cannot implement 'ValidInterface'.↵- 'value' must be a 'int' property (found a 'float' property)}
 
     in-out property <float> value;
-//  >                            <note{'value' does not satisfy 'ValidInterface'}
+//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
     public function reset() {}
 }
 
 export component IncorrectCallbackType {
     implement ValidInterface <=> self;
-//            >             <error{Cannot implement 'ValidInterface'.↵- 'speak' must be a 'callback() -> void' (found a 'callback(string) -> void')}
+//            >             <error{Cannot implement 'ValidInterface'.↵- 'speak' must be 'callback speak();' (found 'callback speak(string);')}
 
     in-out property <int> value;
     callback speak(string);
-//  >                     <note{'speak' does not satisfy 'ValidInterface'}
+//                 >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public function reset() {}
 }
 
@@ -112,8 +112,9 @@ export component IncorrectPropertyVisibility {
     implement OutOnlyInterface <=> self;
 //            >               <error{Cannot implement 'OutOnlyInterface'.↵- 'count' must be 'out' (found 'in-out')}
 
-    in-out property <int> count;
-//  >                          <note{'count' does not satisfy 'OutOnlyInterface'}
+    // Intentionally use `in_out` to verify that keywords with underscores are correctly normalized.
+    in_out property <int> count;
+//  >    <note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
 }
 
 
@@ -127,7 +128,7 @@ export component IncorrectCallbackPurity {
     implement ImpureFunctionInterface <=> self;
 
     callback invert(bool) -> bool;
-//  >                            <note{'invert' does not satisfy 'Inverter'}
+//           >    <note{'Inverter' declares 'invert' as 'pure callback invert(bool) -> bool;'}
 
     // Implementation is pure, interface is not - this should not raise an error
     public pure function bar(i: int, s: string) -> bool {
@@ -144,10 +145,9 @@ export component ImpureFunction {
     callback notify();
 
     public function add(a: int, b: int) -> int {
-//  >note{'add' does not satisfy 'Calculator'}
+//                  > <note{'Calculator' declares 'add' as 'pure public function add(int, int) -> int { }'}
         return a + b;
     }
-//  <note{'add' does not satisfy 'Calculator'}
     public function format(value: int) -> string {
         return "";
     }
@@ -156,7 +156,7 @@ export component ImpureFunction {
 
 export component IncorrectFunctionArguments {
     implement Calculator <=> self;
-//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be a 'function(int) -> string' (found a 'function(string, int) -> string')}
+//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be 'public function format(int) -> string { }' (found 'public function format(string, int) -> string { }')}
 
     in-out property <int> value;
     callback notify();
@@ -165,16 +165,33 @@ export component IncorrectFunctionArguments {
         return a + b;
     }
     public function format(fmt: string, value: int) -> string {
-//  >note{'format' does not satisfy 'Calculator'}
+//                              >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
         return "";
     }
-//  <note{'format' does not satisfy 'Calculator'}
+    public function reset() {}
+}
+
+// Too few arguments: there is no offending argument to point at, so the note falls back to the name.
+export component MissingFunctionArguments {
+    implement Calculator <=> self;
+//            >         <error{Cannot implement 'Calculator'.↵- 'add' must be 'pure public function add(int, int) -> int { }' (found 'pure public function add(int) -> int { }')}
+
+    in-out property <int> value;
+    callback notify();
+
+    pure public function add(a: int) -> int {
+//                       > <note{'Calculator' declares 'add' as 'pure public function add(int, int) -> int { }'}
+        return a;
+    }
+    public function format(value: int) -> string {
+        return "";
+    }
     public function reset() {}
 }
 
 export component IncorrectFunctionReturnType {
     implement Calculator <=> self;
-//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be a 'function(int) -> string' (found a 'function(int) -> void')}
+//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be 'public function format(int) -> string { }' (found 'public function format(int) { }')}
 
     in-out property <int> value;
     callback notify();
@@ -183,9 +200,8 @@ export component IncorrectFunctionReturnType {
         return a + b;
     }
     public function format(value: int) {
-//  >note{'format' does not satisfy 'Calculator'}
+//                  >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
     }
-//  <note{'format' does not satisfy 'Calculator'}
     public function reset() {}
 }
 
@@ -203,13 +219,13 @@ export component IncorrectFunctionVisibility {
         return "";
     }
     protected function reset() {}
-//  >                           <note{'reset' does not satisfy 'Calculator'}
+//  >       <note{'Calculator' declares 'reset' as 'public function reset() { }'}
 }
 
 // A member name resolving to the wrong kind (function name declared as a property / callback).
 export component CannotOverrideFunction {
     implement Calculator <=> self;
-//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be a 'public function(int) -> string' (found a 'string' property)↵- 'reset' must be a 'public function() -> void' (found a 'callback() -> void')}
+//            >         <error{Cannot implement 'Calculator'.↵- 'format' must be 'public function format(int) -> string { }' (found a 'string' property)↵- 'reset' must be 'public function reset() { }' (found 'callback reset();')}
 
     in-out property <int> value;
     callback notify();
@@ -218,22 +234,24 @@ export component CannotOverrideFunction {
         return a + b;
     }
     in property <string> format;
-//  >                          <note{'format' does not satisfy 'Calculator'}
+//                       >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
     callback reset();
-//  >               <note{'reset' does not satisfy 'Calculator'}
+//           >   <note{'Calculator' declares 'reset' as 'public function reset() { }'}
 }
 
 // Conflicts with an inherited (non-local) member: property, callback and function variants.
 component BaseWithMembers {
     in-out property <float> value;
+//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak(string);
+//                 >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public function reset() {}
     @children
 }
 
 export component DerivedConflicts inherits BaseWithMembers {
     implement ValidInterface <=> self;
-//            >             <error{Cannot implement 'ValidInterface'.↵- 'speak' conflicts with an existing callback in 'BaseWithMembers'↵- 'value' conflicts with an existing property in 'BaseWithMembers'}
+//            >             <error{Cannot implement 'ValidInterface'.↵- 'speak' must be 'callback speak();' (found 'callback speak(string);')↵- 'value' must be a 'int' property (found a 'float' property)}
 }
 
 interface CallbackInterface {
@@ -242,25 +260,26 @@ interface CallbackInterface {
 
 component BaseWithFunction {
     public function action() {}
+//                  >    <note{'CallbackInterface' declares 'action' as 'callback action();'}
     @children
 }
 
 export component ImplementFunctionConflict inherits BaseWithFunction {
     implement CallbackInterface <=> self;
-//            >                <error{Cannot implement 'CallbackInterface'.↵- 'action' conflicts with an existing function in 'BaseWithFunction'}
+//            >                <error{Cannot implement 'CallbackInterface'.↵- 'action' must be 'callback action();' (found 'public function action() { }')}
 }
 
 // Each member declared as the wrong kind of member.
 export component CrossKindMismatch {
     implement ValidInterface <=> self;
-//            >             <error{Cannot implement 'ValidInterface'.↵- 'reset' must be a 'public function() -> void' (found a 'int' property)↵- 'speak' must be a 'callback() -> void' (found a 'int' property)↵- 'value' must be an in-out 'int' property (found a 'callback() -> void')}
+//            >             <error{Cannot implement 'ValidInterface'.↵- 'reset' must be 'public function reset() { }' (found a 'int' property)↵- 'speak' must be 'callback speak();' (found a 'int' property)↵- 'value' must be 'in-out property <int> value;' (found 'callback value();')}
 
     callback value();
-//  >               <note{'value' does not satisfy 'ValidInterface'}
+//           >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     in-out property <int> speak;
-//  >                          <note{'speak' does not satisfy 'ValidInterface'}
+//                        >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     in-out property <int> reset;
-//  >                          <note{'reset' does not satisfy 'ValidInterface'}
+//                        >   <note{'ValidInterface' declares 'reset' as 'public function reset() { }'}
 }
 
 // A single member that violates several constraints at once, joined into one message.
@@ -269,5 +288,6 @@ export component MultipleViolations {
 //            >               <error{Cannot implement 'OutOnlyInterface'.↵- 'count' must be a 'int' property (found a 'float' property)↵- 'count' must be 'out' (found 'in-out')}
 
     in-out property <float> count;
-//  >                            <note{'count' does not satisfy 'OutOnlyInterface'}
+//                   >   <note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
+//  >    <^note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
 }

--- a/internal/compiler/tests/syntax/interfaces/implement_self.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_self.slint
@@ -93,7 +93,7 @@ export component IncorrectPropertyType {
 //            >             <error{Cannot implement 'ValidInterface'.↵- 'value' must be a 'int' property (found a 'float' property)}
 
     in-out property <float> value;
-//  >                            <note{'value' does not satisfy 'ValidInterface'}
+//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak();
     public function reset() {}
 }
@@ -104,7 +104,7 @@ export component IncorrectCallbackType {
 
     in-out property <int> value;
     callback speak(string);
-//  >                     <note{'speak' does not satisfy 'ValidInterface'}
+//                 >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public function reset() {}
 }
 
@@ -113,7 +113,7 @@ export component IncorrectPropertyVisibility {
 //            >               <error{Cannot implement 'OutOnlyInterface'.↵- 'count' must be 'out' (found 'in-out')}
 
     in-out property <int> count;
-//  >                          <note{'count' does not satisfy 'OutOnlyInterface'}
+//  >    <note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
 }
 
 
@@ -127,7 +127,7 @@ export component IncorrectCallbackPurity {
     implement ImpureFunctionInterface <=> self;
 
     callback invert(bool) -> bool;
-//  >                            <note{'invert' does not satisfy 'Inverter'}
+//           >    <note{'Inverter' declares 'invert' as 'pure callback invert(bool) -> bool;'}
 
     // Implementation is pure, interface is not - this should not raise an error
     public pure function bar(i: int, s: string) -> bool {
@@ -144,10 +144,9 @@ export component ImpureFunction {
     callback notify();
 
     public function add(a: int, b: int) -> int {
-//  >note{'add' does not satisfy 'Calculator'}
+//                  > <note{'Calculator' declares 'add' as 'pure public function add(int, int) -> int { }'}
         return a + b;
     }
-//  <note{'add' does not satisfy 'Calculator'}
     public function format(value: int) -> string {
         return "";
     }
@@ -165,10 +164,27 @@ export component IncorrectFunctionArguments {
         return a + b;
     }
     public function format(fmt: string, value: int) -> string {
-//  >note{'format' does not satisfy 'Calculator'}
+//                              >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
         return "";
     }
-//  <note{'format' does not satisfy 'Calculator'}
+    public function reset() {}
+}
+
+// Too few arguments: there is no offending argument to point at, so the note falls back to the name.
+export component MissingFunctionArguments {
+    implement Calculator <=> self;
+//            >         <error{Cannot implement 'Calculator'.↵- 'add' must be a 'function(int, int) -> int' (found a 'function(int) -> int')}
+
+    in-out property <int> value;
+    callback notify();
+
+    pure public function add(a: int) -> int {
+//                       > <note{'Calculator' declares 'add' as 'pure public function add(int, int) -> int { }'}
+        return a;
+    }
+    public function format(value: int) -> string {
+        return "";
+    }
     public function reset() {}
 }
 
@@ -183,9 +199,8 @@ export component IncorrectFunctionReturnType {
         return a + b;
     }
     public function format(value: int) {
-//  >note{'format' does not satisfy 'Calculator'}
+//                  >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
     }
-//  <note{'format' does not satisfy 'Calculator'}
     public function reset() {}
 }
 
@@ -203,7 +218,7 @@ export component IncorrectFunctionVisibility {
         return "";
     }
     protected function reset() {}
-//  >                           <note{'reset' does not satisfy 'Calculator'}
+//  >       <note{'Calculator' declares 'reset' as 'public function reset() { }'}
 }
 
 // A member name resolving to the wrong kind (function name declared as a property / callback).
@@ -218,17 +233,17 @@ export component CannotOverrideFunction {
         return a + b;
     }
     in property <string> format;
-//  >                          <note{'format' does not satisfy 'Calculator'}
+//                       >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
     callback reset();
-//  >               <note{'reset' does not satisfy 'Calculator'}
+//           >   <note{'Calculator' declares 'reset' as 'public function reset() { }'}
 }
 
 // Conflicts with an inherited (non-local) member: property, callback and function variants.
 component BaseWithMembers {
     in-out property <float> value;
-//  >                            <note{'value' does not satisfy 'ValidInterface'}
+//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     callback speak(string);
-//  >                     <note{'speak' does not satisfy 'ValidInterface'}
+//                 >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     public function reset() {}
     @children
 }
@@ -244,7 +259,7 @@ interface CallbackInterface {
 
 component BaseWithFunction {
     public function action() {}
-//  >                         <note{'action' does not satisfy 'CallbackInterface'}
+//                  >    <note{'CallbackInterface' declares 'action' as 'callback action();'}
     @children
 }
 
@@ -259,11 +274,11 @@ export component CrossKindMismatch {
 //            >             <error{Cannot implement 'ValidInterface'.↵- 'reset' must be a 'public function() -> void' (found a 'int' property)↵- 'speak' must be a 'callback() -> void' (found a 'int' property)↵- 'value' must be an in-out 'int' property (found a 'callback() -> void')}
 
     callback value();
-//  >               <note{'value' does not satisfy 'ValidInterface'}
+//           >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
     in-out property <int> speak;
-//  >                          <note{'speak' does not satisfy 'ValidInterface'}
+//                        >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
     in-out property <int> reset;
-//  >                          <note{'reset' does not satisfy 'ValidInterface'}
+//                        >   <note{'ValidInterface' declares 'reset' as 'public function reset() { }'}
 }
 
 // A single member that violates several constraints at once, joined into one message.
@@ -272,5 +287,6 @@ export component MultipleViolations {
 //            >               <error{Cannot implement 'OutOnlyInterface'.↵- 'count' must be a 'int' property (found a 'float' property)↵- 'count' must be 'out' (found 'in-out')}
 
     in-out property <float> count;
-//  >                            <note{'count' does not satisfy 'OutOnlyInterface'}
+//                   >   <note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
+//  >    <^note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
 }

--- a/internal/compiler/tests/syntax/interfaces/implement_self.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_self.slint
@@ -291,3 +291,14 @@ export component MultipleViolations {
 //                   >   <note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
 //  >    <^note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
 }
+
+interface Viewport {
+    in-out property <float> viewport-x;
+    in-out property <float> viewport-y;
+}
+
+// The Viewport interface properties conflict with the properties on the built-in Flickable component
+export component ConflictsWithBuiltIn inherits Flickable {
+    implement Viewport <=> self;
+//            >       <error{Cannot implement 'Viewport'.↵- 'viewport-x' must be a 'float' property (found a 'length' property)↵- 'viewport-y' must be a 'float' property (found a 'length' property)}
+}

--- a/internal/compiler/tests/syntax/interfaces/implement_self.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_self.slint
@@ -226,7 +226,9 @@ export component CannotOverrideFunction {
 // Conflicts with an inherited (non-local) member: property, callback and function variants.
 component BaseWithMembers {
     in-out property <float> value;
+//  >                            <note{'value' does not satisfy 'ValidInterface'}
     callback speak(string);
+//  >                     <note{'speak' does not satisfy 'ValidInterface'}
     public function reset() {}
     @children
 }
@@ -242,6 +244,7 @@ interface CallbackInterface {
 
 component BaseWithFunction {
     public function action() {}
+//  >                         <note{'action' does not satisfy 'CallbackInterface'}
     @children
 }
 

--- a/internal/compiler/tests/syntax/interfaces/implement_self.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_self.slint
@@ -93,7 +93,7 @@ export component IncorrectPropertyType {
 //            >             <error{Cannot implement 'ValidInterface'.↵- 'value' must be a 'int' property (found a 'float' property)}
 
     in-out property <float> value;
-//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//                   >   <note{'IncorrectPropertyType' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
     callback speak();
     public function reset() {}
 }
@@ -104,7 +104,7 @@ export component IncorrectCallbackType {
 
     in-out property <int> value;
     callback speak(string);
-//                 >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//                 >    <note{'IncorrectCallbackType' declares 'speak' here, 'ValidInterface' expects 'callback speak();'}
     public function reset() {}
 }
 
@@ -114,7 +114,7 @@ export component IncorrectPropertyVisibility {
 
     // Intentionally use `in_out` to verify that keywords with underscores are correctly normalized.
     in_out property <int> count;
-//  >    <note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
+//  >    <note{'IncorrectPropertyVisibility' declares 'count' here, 'OutOnlyInterface' expects 'out property <int> count;'}
 }
 
 
@@ -128,7 +128,7 @@ export component IncorrectCallbackPurity {
     implement ImpureFunctionInterface <=> self;
 
     callback invert(bool) -> bool;
-//           >    <note{'Inverter' declares 'invert' as 'pure callback invert(bool) -> bool;'}
+//           >    <note{'IncorrectCallbackPurity' declares 'invert' here, 'Inverter' expects 'pure callback invert(bool) -> bool;'}
 
     // Implementation is pure, interface is not - this should not raise an error
     public pure function bar(i: int, s: string) -> bool {
@@ -145,7 +145,7 @@ export component ImpureFunction {
     callback notify();
 
     public function add(a: int, b: int) -> int {
-//                  > <note{'Calculator' declares 'add' as 'pure public function add(int, int) -> int { }'}
+//                  > <note{'ImpureFunction' declares 'add' here, 'Calculator' expects 'pure public function add(int, int) -> int { }'}
         return a + b;
     }
     public function format(value: int) -> string {
@@ -165,7 +165,7 @@ export component IncorrectFunctionArguments {
         return a + b;
     }
     public function format(fmt: string, value: int) -> string {
-//                              >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
+//                              >    <note{'IncorrectFunctionArguments' declares 'format' here, 'Calculator' expects 'public function format(int) -> string { }'}
         return "";
     }
     public function reset() {}
@@ -180,7 +180,7 @@ export component MissingFunctionArguments {
     callback notify();
 
     pure public function add(a: int) -> int {
-//                       > <note{'Calculator' declares 'add' as 'pure public function add(int, int) -> int { }'}
+//                       > <note{'MissingFunctionArguments' declares 'add' here, 'Calculator' expects 'pure public function add(int, int) -> int { }'}
         return a;
     }
     public function format(value: int) -> string {
@@ -200,7 +200,7 @@ export component IncorrectFunctionReturnType {
         return a + b;
     }
     public function format(value: int) {
-//                  >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
+//                  >    <note{'IncorrectFunctionReturnType' declares 'format' here, 'Calculator' expects 'public function format(int) -> string { }'}
     }
     public function reset() {}
 }
@@ -219,7 +219,7 @@ export component IncorrectFunctionVisibility {
         return "";
     }
     protected function reset() {}
-//  >       <note{'Calculator' declares 'reset' as 'public function reset() { }'}
+//  >       <note{'IncorrectFunctionVisibility' declares 'reset' here, 'Calculator' expects 'public function reset() { }'}
 }
 
 // A member name resolving to the wrong kind (function name declared as a property / callback).
@@ -234,17 +234,17 @@ export component CannotOverrideFunction {
         return a + b;
     }
     in property <string> format;
-//                       >    <note{'Calculator' declares 'format' as 'public function format(int) -> string { }'}
+//                       >    <note{'CannotOverrideFunction' declares 'format' here, 'Calculator' expects 'public function format(int) -> string { }'}
     callback reset();
-//           >   <note{'Calculator' declares 'reset' as 'public function reset() { }'}
+//           >   <note{'CannotOverrideFunction' declares 'reset' here, 'Calculator' expects 'public function reset() { }'}
 }
 
 // Conflicts with an inherited (non-local) member: property, callback and function variants.
 component BaseWithMembers {
     in-out property <float> value;
-//                   >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//                   >   <note{'BaseWithMembers' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
     callback speak(string);
-//                 >    <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//                 >    <note{'BaseWithMembers' declares 'speak' here, 'ValidInterface' expects 'callback speak();'}
     public function reset() {}
     @children
 }
@@ -260,7 +260,7 @@ interface CallbackInterface {
 
 component BaseWithFunction {
     public function action() {}
-//                  >    <note{'CallbackInterface' declares 'action' as 'callback action();'}
+//                  >    <note{'BaseWithFunction' declares 'action' here, 'CallbackInterface' expects 'callback action();'}
     @children
 }
 
@@ -275,11 +275,11 @@ export component CrossKindMismatch {
 //            >             <error{Cannot implement 'ValidInterface'.↵- 'reset' must be 'public function reset() { }' (found a 'int' property)↵- 'speak' must be 'callback speak();' (found a 'int' property)↵- 'value' must be 'in-out property <int> value;' (found 'callback value();')}
 
     callback value();
-//           >   <note{'ValidInterface' declares 'value' as 'in-out property <int> value;'}
+//           >   <note{'CrossKindMismatch' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
     in-out property <int> speak;
-//                        >   <note{'ValidInterface' declares 'speak' as 'callback speak();'}
+//                        >   <note{'CrossKindMismatch' declares 'speak' here, 'ValidInterface' expects 'callback speak();'}
     in-out property <int> reset;
-//                        >   <note{'ValidInterface' declares 'reset' as 'public function reset() { }'}
+//                        >   <note{'CrossKindMismatch' declares 'reset' here, 'ValidInterface' expects 'public function reset() { }'}
 }
 
 // A single member that violates several constraints at once, joined into one message.
@@ -288,8 +288,8 @@ export component MultipleViolations {
 //            >               <error{Cannot implement 'OutOnlyInterface'.↵- 'count' must be a 'int' property (found a 'float' property)↵- 'count' must be 'out' (found 'in-out')}
 
     in-out property <float> count;
-//                   >   <note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
-//  >    <^note{'OutOnlyInterface' declares 'count' as 'out property <int> count;'}
+//                   >   <note{'MultipleViolations' declares 'count' here, 'OutOnlyInterface' expects 'out property <int> count;'}
+//  >    <^note{'MultipleViolations' declares 'count' here, 'OutOnlyInterface' expects 'out property <int> count;'}
 }
 
 interface Viewport {

--- a/tools/lsp/common/token_info.rs
+++ b/tools/lsp/common/token_info.rs
@@ -63,18 +63,7 @@ impl TokenInfo {
             }
             TokenInfo::ElementRc(el) => Some(el.borrow().debug.first()?.node.clone().into()),
             TokenInfo::NamedReference(nr) => {
-                let mut el = nr.element();
-                loop {
-                    if let Some(x) = el.borrow().property_declarations.get(nr.name()) {
-                        return x.node.clone();
-                    }
-                    let base = el.borrow().base_type.clone();
-                    if let ElementType::Component(c) = base {
-                        el = c.root_element.clone();
-                    } else {
-                        return None;
-                    }
-                }
+                nr.element().borrow().property_declaration_node(nr.name())
             }
 
             TokenInfo::EnumerationValue(v) => {
@@ -90,15 +79,7 @@ impl TokenInfo {
             TokenInfo::LocalCallback(x) => Some(x.clone().into()),
             TokenInfo::LocalFunction(x) => Some(x.clone().into()),
             TokenInfo::IncompleteNamedReference(element_type, prop_name) => {
-                let mut element_type = element_type.clone();
-                while let ElementType::Component(com) = element_type {
-                    if let Some(p) = com.root_element.borrow().property_declarations.get(prop_name)
-                    {
-                        return p.node.clone();
-                    }
-                    element_type = com.root_element.borrow().base_type.clone();
-                }
-                None
+                element_type.property_declaration_node(prop_name)
             }
         }
     }


### PR DESCRIPTION
When an interface is not satisfied by the implementing component we emit notes that attempt to highlight the particular syntax that is causing the problem.

```
error: Cannot implement 'ValidInterface'.
       - 'value' must be a 'int' property (found a 'float' property)
   --> internal/compiler/tests/syntax/interfaces/implement_self.slint:92:15
    |
 92 |     implement ValidInterface <=> self;
    |               ^^^^^^^^^^^^^^^
note: 'ValidInterface' declares 'value' as 'in-out property <int> value;'
   --> internal/compiler/tests/syntax/interfaces/implement_self.slint:95:22
    |
 95 |     in-out property <float> value;
    |                      ^^^^^
```

In some cases, it is not possible to highlight the particular syntax causing the issue (e.g. missing `pure` keyword) so we fall back to emitting a note on the name identifier of the declarations:

```
error: Cannot implement 'Inverter'.
       - 'invert' must be 'pure'
   --> internal/compiler/tests/syntax/interfaces/implement_self.slint:125:15
    |
125 |     implement Inverter <=> self;
    |               ^^^^^^^^^
note: 'Inverter' declares 'invert' as 'pure callback invert(bool) -> bool;'
   --> internal/compiler/tests/syntax/interfaces/implement_self.slint:129:14
    |
129 |     callback invert(bool) -> bool;
    |              ^^^^^^
```

In some cases we may emit multiple notes for the same error. We aggregate errors for each `implement` statement into one error string, and emit notes for each part of the syntax that is incorrect:

```
error: Cannot implement 'OutOnlyInterface'.
       - 'count' must be a 'int' property (found a 'float' property)
       - 'count' must be 'out' (found 'in-out')
   --> internal/compiler/tests/syntax/interfaces/implement_self.slint:286:15
    |
286 |     implement OutOnlyInterface <=> self;
    |               ^^^^^^^^^^^^^^^^^
note: 'OutOnlyInterface' declares 'count' as 'out property <int> count;'
   --> internal/compiler/tests/syntax/interfaces/implement_self.slint:289:22
    |
289 |     in-out property <float> count;
    |                      ^^^^^
note: 'OutOnlyInterface' declares 'count' as 'out property <int> count;'
   --> internal/compiler/tests/syntax/interfaces/implement_self.slint:289:5
    |
289 |     in-out property <float> count;
    |     ^^^^^^
```

This might appear a bit repetitive, but the error text must contain the information needed to identify the error - the note does not appear in the IDE (otherwise we might emit one generic error for the `implement` statement, with specific notes for the problematic declarations).