### PR TITLE
Fix Skia WGPU renderer build with both wgpu 29 and wgpu 30 enabled

### DIFF
--- a/.github/workflows/bevy_examples.yaml
+++ b/.github/workflows/bevy_examples.yaml
@@ -51,5 +51,8 @@ jobs:
             - name: Cargo update
               if: ${{ inputs.update }}
               run: cargo update --manifest-path examples/Cargo.toml --package bevy-example --package bevy-hosts-slint --package bevy-hosts-slint-gpu
+            # wgpu_texture is included so Cargo unifies its slint/unstable-wgpu-30
+            # feature with the bevy examples' slint/unstable-wgpu-29, guarding the
+            # per-version SkiaWGPU*Renderer API against regressions (#12747).
             - name: Build Bevy Examples
-              run: cargo build --locked --manifest-path examples/Cargo.toml --package bevy-example --package bevy-hosts-slint --package bevy-hosts-slint-gpu
+              run: cargo build --locked --manifest-path examples/Cargo.toml --package bevy-example --package bevy-hosts-slint --package bevy-hosts-slint-gpu --package wgpu_texture

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -473,16 +473,10 @@ pub mod platform {
         )
     ))]
     pub mod skia_renderer {
-        /// Renders into wgpu 29 textures ([`slint::wgpu_29`](crate::wgpu_29)).
         #[cfg(feature = "unstable-wgpu-29")]
         pub use i_slint_renderer_skia::SkiaWGPU29Renderer;
-        /// Renders into wgpu 30 textures ([`slint::wgpu_30`](crate::wgpu_30)).
         #[cfg(feature = "unstable-wgpu-30")]
         pub use i_slint_renderer_skia::SkiaWGPU30Renderer;
-        /// Compatibility alias for the newest enabled wgpu version.
-        /// Prefer the versioned renderers above in new code; they don't change meaning
-        /// when another `unstable-wgpu-*` feature gets enabled elsewhere in the final
-        /// application's dependency graph.
         pub use i_slint_renderer_skia::SkiaWGPURenderer;
     }
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -479,9 +479,10 @@ pub mod platform {
         /// Renders into wgpu 30 textures ([`slint::wgpu_30`](crate::wgpu_30)).
         #[cfg(feature = "unstable-wgpu-30")]
         pub use i_slint_renderer_skia::SkiaWGPU30Renderer;
-        /// Renders into textures of the newest enabled wgpu version. Use the
-        /// version-specific renderers below when both `unstable-wgpu-*` features may be
-        /// enabled in the final application.
+        /// Compatibility alias for the newest enabled wgpu version.
+        /// Prefer the versioned renderers above in new code; they don't change meaning
+        /// when another `unstable-wgpu-*` feature gets enabled elsewhere in the final
+        /// application's dependency graph.
         pub use i_slint_renderer_skia::SkiaWGPURenderer;
     }
 

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -473,6 +473,15 @@ pub mod platform {
         )
     ))]
     pub mod skia_renderer {
+        /// Renders into wgpu 29 textures ([`slint::wgpu_29`](crate::wgpu_29)).
+        #[cfg(feature = "unstable-wgpu-29")]
+        pub use i_slint_renderer_skia::SkiaWGPU29Renderer;
+        /// Renders into wgpu 30 textures ([`slint::wgpu_30`](crate::wgpu_30)).
+        #[cfg(feature = "unstable-wgpu-30")]
+        pub use i_slint_renderer_skia::SkiaWGPU30Renderer;
+        /// Renders into textures of the newest enabled wgpu version. Use the
+        /// version-specific renderers below when both `unstable-wgpu-*` features may be
+        /// enabled in the final application.
         pub use i_slint_renderer_skia::SkiaWGPURenderer;
     }
 
@@ -551,6 +560,10 @@ pub mod wgpu_29 {
     //! WGPU major version (29 vs 30) and the corresponding feature/selector/API names (`unstable-wgpu-29`,
     //! [`slint::BackendSelector::require_wgpu_29()`](i_slint_backend_selector::api::BackendSelector::require_wgpu_29()),
     //! [`slint::GraphicsAPI::WGPU29`](i_slint_core::api::GraphicsAPI::WGPU29)).
+    //!
+    //! When rendering offscreen with the Skia renderer, use `slint::platform::skia_renderer::SkiaWGPU29Renderer`
+    //! to select the wgpu 29 API explicitly, even if `unstable-wgpu-30` also ends up enabled through
+    //! Cargo feature unification.
     pub use i_slint_core::graphics::wgpu_29::api::*;
 }
 

--- a/examples/bevy/bevy-hosts-slint-gpu/main.rs
+++ b/examples/bevy/bevy-hosts-slint-gpu/main.rs
@@ -9,22 +9,22 @@
 //!
 //! ## Architecture Overview
 //!
-//! The integration uses Slint's `SkiaWGPURenderer` to render UI directly to a WGPU texture:
+//! The integration uses Slint's `SkiaWGPU29Renderer` to render UI directly to a WGPU texture:
 //!
 //! 1. Bevy creates a texture in its asset system
 //! 2. The texture handle is extracted to Bevy's render world via `ExtractResourcePlugin`
 //! 3. A channel passes the underlying WGPU texture from render world back to main world
-//! 4. `SkiaWGPURenderer::render_to_texture()` renders the UI directly to the GPU texture
+//! 4. `SkiaWGPU29Renderer::render_to_texture()` renders the UI directly to the GPU texture
 //! 5. Mouse input is handled by raycasting against the 3D quad and converting to Slint coordinates
 //!
 //! ## Key Difference from bevy-hosts-slint
 //!
 //! - **bevy-hosts-slint**: Uses `SoftwareRenderer` to CPU-render UI to a pixel buffer, then uploads to GPU
-//! - **bevy-hosts-slint-gpu**: Uses `SkiaWGPURenderer` for direct GPU rendering (better performance and font quality)
+//! - **bevy-hosts-slint-gpu**: Uses `SkiaWGPU29Renderer` for direct GPU rendering (better performance and font quality)
 //!
 //! ## Key Components
 //!
-//! - [`BevyWindowAdapter`]: Implements `slint::platform::WindowAdapter` using `SkiaWGPURenderer`
+//! - [`BevyWindowAdapter`]: Implements `slint::platform::WindowAdapter` using `SkiaWGPU29Renderer`
 //! - [`SlintBevyPlatform`]: Implements `slint::platform::Platform` to create window adapters
 //! - [`SlintSharedTexture`]: Manages texture sharing between Bevy's main and render worlds
 //! - [`render_slint`]: Bevy system that renders the Slint UI to the shared texture each frame
@@ -33,7 +33,7 @@
 //! ## Usage Pattern
 //!
 //! This example can serve as a template for GPU-accelerated Slint integration:
-//! 1. Implement the `Platform` and `WindowAdapter` traits with `SkiaWGPURenderer`
+//! 1. Implement the `Platform` and `WindowAdapter` traits with `SkiaWGPU29Renderer`
 //! 2. Share the WGPU texture between Bevy's render world and your Slint renderer
 //! 3. Call `render_to_texture()` each frame to render the UI directly on the GPU
 //! 4. Handle input by converting your coordinate system to Slint's logical coordinates
@@ -61,7 +61,7 @@ use bevy::{
         texture::GpuImage,
     },
 };
-use slint::platform::skia_renderer::SkiaWGPURenderer;
+use slint::platform::skia_renderer::SkiaWGPU29Renderer;
 use slint::{LogicalPosition, PhysicalSize, platform::WindowEvent};
 use std::{
     cell::{Cell, RefCell},
@@ -119,13 +119,13 @@ slint::slint! {
 
 /// Window adapter that bridges Slint to Bevy using GPU rendering.
 ///
-/// Instead of rendering to a native OS window, this adapter uses `SkiaWGPURenderer`
+/// Instead of rendering to a native OS window, this adapter uses `SkiaWGPU29Renderer`
 /// to render directly to a WGPU texture that Bevy displays on 3D geometry.
 struct BevyWindowAdapter {
     size: Cell<slint::PhysicalSize>,
     scale_factor: Cell<f32>,
     slint_window: slint::Window,
-    renderer: SkiaWGPURenderer,
+    renderer: SkiaWGPU29Renderer,
 }
 
 impl slint::platform::WindowAdapter for BevyWindowAdapter {
@@ -156,7 +156,7 @@ impl BevyWindowAdapter {
         queue: wgpu::Queue,
     ) -> Rc<Self> {
         // Create renderer using the new helper
-        let renderer = SkiaWGPURenderer::new(instance, adapter, device, queue)
+        let renderer = SkiaWGPU29Renderer::new(instance, adapter, device, queue)
             .expect("Failed to create renderer");
 
         Rc::new_cyclic(|self_weak: &Weak<Self>| Self {
@@ -181,7 +181,7 @@ impl BevyWindowAdapter {
 /// Slint platform implementation that creates GPU-rendered window adapters.
 ///
 /// Registered via `slint::platform::set_platform()` before creating Slint components.
-/// Stores the WGPU device and queue needed to create `SkiaWGPURenderer` instances.
+/// Stores the WGPU device and queue needed to create `SkiaWGPU29Renderer` instances.
 struct SlintBevyPlatform {
     instance: wgpu::Instance,
     adapter: wgpu::Adapter,

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -62,8 +62,12 @@ pub mod wgpu_29_surface;
 pub mod wgpu_30_surface;
 #[cfg(any(feature = "wgpu-29", feature = "wgpu-30"))]
 mod wgpu_renderer;
+#[cfg(feature = "wgpu-29")]
+pub use wgpu_renderer::SkiaWGPU29Renderer;
+#[cfg(feature = "wgpu-30")]
+pub use wgpu_renderer::SkiaWGPU30Renderer;
 #[cfg(any(feature = "wgpu-29", feature = "wgpu-30"))]
-pub use wgpu_renderer::SkiaWGPURenderer;
+pub use wgpu_renderer::{SkiaWGPURenderer, SkiaWGPURendererGeneric};
 
 use itemrenderer::to_skia_rect;
 pub use skia_safe;

--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -103,8 +103,6 @@ impl WGPUSurface {
         })
     }
 
-    // Only used by SkiaWGPURenderer, which is compiled against the newest enabled wgpu version.
-    #[cfg(not(feature = "wgpu-30"))]
     pub(crate) fn new_offscreen(
         instance: wgpu::Instance,
         device: wgpu::Device,

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -19,9 +19,9 @@ use crate::{SkiaRenderer, SkiaSharedContext};
 /// quality through platform-native text rasterizers.
 ///
 /// This type is generic over the wgpu version, one instantiation per enabled
-/// `unstable-wgpu-*` feature. Use it through the version-specific aliases:
-/// `SkiaWGPU29Renderer` for wgpu 29, `SkiaWGPU30Renderer` for wgpu 30, or
-/// `SkiaWGPURenderer` for the newest enabled version.
+/// `unstable-wgpu-*` feature. Use it through the version-specific aliases,
+/// `SkiaWGPU29Renderer` for wgpu 29 and `SkiaWGPU30Renderer` for wgpu 30 —
+/// they stay unambiguous when several wgpu versions are enabled at once.
 ///
 /// Rendering notifier callbacks registered via
 /// [`Window::set_rendering_notifier()`](i_slint_core::api::Window::set_rendering_notifier)
@@ -41,16 +41,18 @@ pub type SkiaWGPU29Renderer = SkiaWGPURendererGeneric<crate::wgpu_29_surface::WG
 #[cfg(feature = "wgpu-30")]
 pub type SkiaWGPU30Renderer = SkiaWGPURendererGeneric<crate::wgpu_30_surface::WGPUSurface>;
 
-/// Renders into textures of the newest enabled wgpu version: wgpu 30 when the
-/// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise. Use `SkiaWGPU29Renderer` or
-/// `SkiaWGPU30Renderer` to select a version explicitly — necessary when both features are
-/// enabled and the wgpu 29 API is wanted.
+/// Compatibility alias for the newest enabled wgpu version: wgpu 30 when the
+/// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise.
+/// Prefer the versioned names, `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer`, in new code;
+/// they don't change meaning when another `unstable-wgpu-*` feature gets enabled elsewhere
+/// in the dependency graph.
 #[cfg(feature = "wgpu-30")]
 pub type SkiaWGPURenderer = SkiaWGPU30Renderer;
-/// Renders into textures of the newest enabled wgpu version: wgpu 30 when the
-/// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise. Use `SkiaWGPU29Renderer` or
-/// `SkiaWGPU30Renderer` to select a version explicitly — necessary when both features are
-/// enabled and the wgpu 29 API is wanted.
+/// Compatibility alias for the newest enabled wgpu version: wgpu 30 when the
+/// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise.
+/// Prefer the versioned names, `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer`, in new code;
+/// they don't change meaning when another `unstable-wgpu-*` feature gets enabled elsewhere
+/// in the dependency graph.
 #[cfg(all(feature = "wgpu-29", not(feature = "wgpu-30")))]
 pub type SkiaWGPURenderer = SkiaWGPU29Renderer;
 

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -9,20 +9,6 @@ use i_slint_core::platform::PlatformError;
 use i_slint_core::renderer::RendererSealed;
 use i_slint_core::window::WindowAdapter;
 
-// When multiple wgpu versions are enabled, the renderer is compiled against the newest one,
-// consistent with the wgpu version selection in the winit and linuxkms backends.
-#[cfg(feature = "wgpu-30")]
-use wgpu_30 as wgpu;
-
-#[cfg(all(feature = "wgpu-29", not(feature = "wgpu-30")))]
-use wgpu_29 as wgpu;
-
-#[cfg(feature = "wgpu-30")]
-use crate::wgpu_30_surface::{Backend, WGPUSurface};
-
-#[cfg(all(feature = "wgpu-29", not(feature = "wgpu-30")))]
-use crate::wgpu_29_surface::{Backend, WGPUSurface};
-
 use crate::{SkiaRenderer, SkiaSharedContext};
 
 /// Use the Skia renderer with WGPU when implementing a custom Slint platform where you want the
@@ -32,62 +18,153 @@ use crate::{SkiaRenderer, SkiaSharedContext};
 /// This is the Skia equivalent of `FemtoVGWGPURenderer`, offering superior font rendering
 /// quality through platform-native text rasterizers.
 ///
-/// The wgpu types used by this renderer follow the newest enabled `unstable-wgpu-*` feature:
-/// wgpu 30 when `unstable-wgpu-30` is enabled, wgpu 29 otherwise.
+/// This type is generic over the wgpu version, one instantiation per enabled
+/// `unstable-wgpu-*` feature. Use it through the version-specific aliases:
+/// `SkiaWGPU29Renderer` for wgpu 29, `SkiaWGPU30Renderer` for wgpu 30, or
+/// `SkiaWGPURenderer` for the newest enabled version.
 ///
 /// Rendering notifier callbacks registered via
 /// [`Window::set_rendering_notifier()`](i_slint_core::api::Window::set_rendering_notifier)
-/// will receive [`GraphicsAPI::WGPU30`](i_slint_core::api::GraphicsAPI::WGPU30) (respectively
-/// [`GraphicsAPI::WGPU29`](i_slint_core::api::GraphicsAPI::WGPU29)) with the
+/// will receive [`GraphicsAPI::WGPU29`](i_slint_core::api::GraphicsAPI::WGPU29) (respectively
+/// [`GraphicsAPI::WGPU30`](i_slint_core::api::GraphicsAPI::WGPU30)) with the
 /// renderer's instance, device, and queue.
-pub struct SkiaWGPURenderer {
+pub struct SkiaWGPURendererGeneric<Surface> {
     renderer: SkiaRenderer,
-    surface: WGPUSurface,
+    surface: Surface,
 }
 
-impl SkiaWGPURenderer {
-    /// Creates a new SkiaWGPURenderer.
+/// Renders into wgpu 29 textures. Available with the `unstable-wgpu-29` feature.
+#[cfg(feature = "wgpu-29")]
+pub type SkiaWGPU29Renderer = SkiaWGPURendererGeneric<crate::wgpu_29_surface::WGPUSurface>;
+
+/// Renders into wgpu 30 textures. Available with the `unstable-wgpu-30` feature.
+#[cfg(feature = "wgpu-30")]
+pub type SkiaWGPU30Renderer = SkiaWGPURendererGeneric<crate::wgpu_30_surface::WGPUSurface>;
+
+/// Renders into textures of the newest enabled wgpu version: wgpu 30 when the
+/// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise. Use `SkiaWGPU29Renderer` or
+/// `SkiaWGPU30Renderer` to select a version explicitly — necessary when both features are
+/// enabled and the wgpu 29 API is wanted.
+#[cfg(feature = "wgpu-30")]
+pub type SkiaWGPURenderer = SkiaWGPU30Renderer;
+/// Renders into textures of the newest enabled wgpu version: wgpu 30 when the
+/// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise. Use `SkiaWGPU29Renderer` or
+/// `SkiaWGPU30Renderer` to select a version explicitly — necessary when both features are
+/// enabled and the wgpu 29 API is wanted.
+#[cfg(all(feature = "wgpu-29", not(feature = "wgpu-30")))]
+pub type SkiaWGPURenderer = SkiaWGPU29Renderer;
+
+impl<Surface> SkiaWGPURendererGeneric<Surface> {
+    fn new_with_surface(surface: Surface) -> Self {
+        let shared_context = SkiaSharedContext::default();
+        // Use SkiaRenderer::default() to stay resilient to field additions, then disable
+        // partial rendering — there is no buffer age tracking for external texture targets.
+        let mut renderer = SkiaRenderer::default(&shared_context);
+        renderer.partial_rendering_state = None;
+        Self { renderer, surface }
+    }
+}
+
+// The version-specific constructors and render entry points below are kept in sync manually,
+// like the wgpu_29_surface/wgpu_30_surface modules they build on.
+
+#[cfg(feature = "wgpu-29")]
+impl SkiaWGPU29Renderer {
+    /// Creates a new SkiaWGPU29Renderer.
     ///
     /// The `instance`, `adapter`, `device` and `queue` are the WGPU resources used for rendering.
     /// The `adapter` is needed to determine the GPU backend and create the Skia graphics context.
     ///
     /// The wgpu resources are also provided to rendering notifier callbacks via
-    /// [`GraphicsAPI::WGPU30`](i_slint_core::api::GraphicsAPI::WGPU30) (respectively
-    /// [`GraphicsAPI::WGPU29`](i_slint_core::api::GraphicsAPI::WGPU29)).
+    /// [`GraphicsAPI::WGPU29`](i_slint_core::api::GraphicsAPI::WGPU29).
     pub fn new(
-        instance: wgpu::Instance,
-        adapter: wgpu::Adapter,
-        device: wgpu::Device,
-        queue: wgpu::Queue,
+        instance: wgpu_29::Instance,
+        adapter: wgpu_29::Adapter,
+        device: wgpu_29::Device,
+        queue: wgpu_29::Queue,
     ) -> Result<Self, PlatformError> {
+        use crate::wgpu_29_surface::{Backend, WGPUSurface};
+
         let backend: Backend = adapter.get_info().backend.try_into()?;
 
         let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
             PlatformError::from("Failed to create Skia graphics context from WGPU")
         })?;
 
-        let surface = WGPUSurface::new_offscreen(instance, device, queue, backend, gr_context);
-
-        let shared_context = SkiaSharedContext::default();
-        // The renderer draws into caller-provided textures: there is no surface to
-        // (re-)create, and partial rendering stays off because there is no buffer age
-        // tracking for external texture targets.
-        let renderer = SkiaRenderer::new_with_surface_factory(
-            &shared_context,
-            |_, _, _, _, _| Err("SkiaWGPURenderer does not support dynamic surface creation".into()),
-            None,
-        );
-
-        Ok(Self { renderer, surface })
+        Ok(Self::new_with_surface(WGPUSurface::new_offscreen(
+            instance, device, queue, backend, gr_context,
+        )))
     }
 
     /// Render the scene to the given texture.
     ///
     /// The texture must have been created with `RENDER_ATTACHMENT` usage and have a supported
-    /// format.
-    /// Supported formats depend on the GPU backend: `Rgba8Unorm` and `Rgba8UnormSrgb` are
-    /// supported on all backends; `Bgra8Unorm` is additionally supported on Metal and Vulkan.
-    pub fn render_to_texture(&self, texture: &wgpu::Texture) -> Result<(), PlatformError> {
+    /// format. Supported formats depend on the GPU backend: `Rgba8Unorm` and `Rgba8UnormSrgb`
+    /// are supported on all backends; `Bgra8Unorm` is additionally supported on Metal and Vulkan.
+    pub fn render_to_texture(&self, texture: &wgpu_29::Texture) -> Result<(), PlatformError> {
+        self.renderer.invoke_rendering_notifier_setup(&self.surface)?;
+
+        let gr_context = &mut self.surface.gr_context.borrow_mut();
+
+        let mut skia_surface =
+            self.surface.backend.make_surface(gr_context, texture).ok_or_else(|| {
+                PlatformError::from("Failed to wrap WGPU texture as Skia render target")
+            })?;
+
+        let window_adapter = self.renderer.window_adapter()?;
+        let window = window_adapter.window();
+
+        self.renderer.render_to_canvas(
+            skia_surface.canvas(),
+            0.,
+            (0., 0.),
+            Some(gr_context),
+            0,
+            Some(&self.surface),
+            window,
+            None,
+        );
+
+        self.surface.flush_and_submit(gr_context);
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "wgpu-30")]
+impl SkiaWGPU30Renderer {
+    /// Creates a new SkiaWGPU30Renderer.
+    ///
+    /// The `instance`, `adapter`, `device` and `queue` are the WGPU resources used for rendering.
+    /// The `adapter` is needed to determine the GPU backend and create the Skia graphics context.
+    ///
+    /// The wgpu resources are also provided to rendering notifier callbacks via
+    /// [`GraphicsAPI::WGPU30`](i_slint_core::api::GraphicsAPI::WGPU30).
+    pub fn new(
+        instance: wgpu_30::Instance,
+        adapter: wgpu_30::Adapter,
+        device: wgpu_30::Device,
+        queue: wgpu_30::Queue,
+    ) -> Result<Self, PlatformError> {
+        use crate::wgpu_30_surface::{Backend, WGPUSurface};
+
+        let backend: Backend = adapter.get_info().backend.try_into()?;
+
+        let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
+            PlatformError::from("Failed to create Skia graphics context from WGPU")
+        })?;
+
+        Ok(Self::new_with_surface(WGPUSurface::new_offscreen(
+            instance, device, queue, backend, gr_context,
+        )))
+    }
+
+    /// Render the scene to the given texture.
+    ///
+    /// The texture must have been created with `RENDER_ATTACHMENT` usage and have a supported
+    /// format. Supported formats depend on the GPU backend: `Rgba8Unorm` and `Rgba8UnormSrgb`
+    /// are supported on all backends; `Bgra8Unorm` is additionally supported on Metal and Vulkan.
+    pub fn render_to_texture(&self, texture: &wgpu_30::Texture) -> Result<(), PlatformError> {
         self.renderer.invoke_rendering_notifier_setup(&self.surface)?;
 
         let gr_context = &mut self.surface.gr_context.borrow_mut();
@@ -118,10 +195,8 @@ impl SkiaWGPURenderer {
 }
 
 #[doc(hidden)]
-impl RendererSealed for SkiaWGPURenderer {
-    // The text and font registration functions use their default implementations, which
-    // reach the inner renderer's state through this accessor and window_adapter().
-    fn text_layout_cache(
+impl<Surface> RendererSealed for SkiaWGPURendererGeneric<Surface> {
+    fn text_size(
         &self,
     ) -> Option<&i_slint_core::textlayout::sharedparley::TextLayoutCache> {
         RendererSealed::text_layout_cache(&self.renderer)
@@ -166,4 +241,49 @@ impl RendererSealed for SkiaWGPURenderer {
     fn supports_transformations(&self) -> bool {
         self.renderer.supports_transformations()
     }
+}
+
+// Assert the consumer-visible signatures of every renderer name. Building the crate only
+// compiles the definitions; these coercions prove the intended calls resolve, in particular
+// that `SkiaWGPURenderer::new` stays unambiguous with both wgpu features enabled.
+#[cfg(test)]
+mod signature_tests {
+    use super::*;
+
+    #[cfg(feature = "wgpu-29")]
+    const _: fn(
+        wgpu_29::Instance,
+        wgpu_29::Adapter,
+        wgpu_29::Device,
+        wgpu_29::Queue,
+    ) -> Result<SkiaWGPU29Renderer, PlatformError> = SkiaWGPU29Renderer::new;
+    #[cfg(feature = "wgpu-29")]
+    const _: fn(&SkiaWGPU29Renderer, &wgpu_29::Texture) -> Result<(), PlatformError> =
+        SkiaWGPU29Renderer::render_to_texture;
+
+    #[cfg(feature = "wgpu-30")]
+    const _: fn(
+        wgpu_30::Instance,
+        wgpu_30::Adapter,
+        wgpu_30::Device,
+        wgpu_30::Queue,
+    ) -> Result<SkiaWGPU30Renderer, PlatformError> = SkiaWGPU30Renderer::new;
+    #[cfg(feature = "wgpu-30")]
+    const _: fn(&SkiaWGPU30Renderer, &wgpu_30::Texture) -> Result<(), PlatformError> =
+        SkiaWGPU30Renderer::render_to_texture;
+
+    #[cfg(feature = "wgpu-30")]
+    const _: fn(
+        wgpu_30::Instance,
+        wgpu_30::Adapter,
+        wgpu_30::Device,
+        wgpu_30::Queue,
+    ) -> Result<SkiaWGPURenderer, PlatformError> = SkiaWGPURenderer::new;
+    #[cfg(all(feature = "wgpu-29", not(feature = "wgpu-30")))]
+    const _: fn(
+        wgpu_29::Instance,
+        wgpu_29::Adapter,
+        wgpu_29::Device,
+        wgpu_29::Queue,
+    ) -> Result<SkiaWGPURenderer, PlatformError> = SkiaWGPURenderer::new;
 }

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -198,9 +198,7 @@ impl SkiaWGPU30Renderer {
 
 #[doc(hidden)]
 impl<Surface> RendererSealed for SkiaWGPURendererGeneric<Surface> {
-    fn text_size(
-        &self,
-    ) -> Option<&i_slint_core::textlayout::sharedparley::TextLayoutCache> {
+    fn text_size(&self) -> Option<&i_slint_core::textlayout::sharedparley::TextLayoutCache> {
         RendererSealed::text_layout_cache(&self.renderer)
     }
 

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -33,11 +33,13 @@ pub struct SkiaWGPURendererGeneric<Surface> {
     surface: Surface,
 }
 
-/// Renders into wgpu 29 textures. Available with the `unstable-wgpu-29` feature.
+/// Renders into wgpu 29 textures. Available with the `unstable-wgpu-29` feature;
+/// the matching wgpu API types are re-exported in the `slint::wgpu_29` module.
 #[cfg(feature = "wgpu-29")]
 pub type SkiaWGPU29Renderer = SkiaWGPURendererGeneric<crate::wgpu_29_surface::WGPUSurface>;
 
-/// Renders into wgpu 30 textures. Available with the `unstable-wgpu-30` feature.
+/// Renders into wgpu 30 textures. Available with the `unstable-wgpu-30` feature;
+/// the matching wgpu API types are re-exported in the `slint::wgpu_30` module.
 #[cfg(feature = "wgpu-30")]
 pub type SkiaWGPU30Renderer = SkiaWGPURendererGeneric<crate::wgpu_30_surface::WGPUSurface>;
 

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -198,7 +198,9 @@ impl SkiaWGPU30Renderer {
 
 #[doc(hidden)]
 impl<Surface> RendererSealed for SkiaWGPURendererGeneric<Surface> {
-    fn text_size(&self) -> Option<&i_slint_core::textlayout::sharedparley::TextLayoutCache> {
+    fn text_layout_cache(
+        &self,
+    ) -> Option<&i_slint_core::textlayout::sharedparley::TextLayoutCache> {
         RendererSealed::text_layout_cache(&self.renderer)
     }
 


### PR DESCRIPTION
Fixes #12747

When `unstable-wgpu-29` and `unstable-wgpu-30` are both enabled — e.g. through Cargo feature unification in a workspace where one crate targets bevy (wgpu 29) and another wgpu 30 — `SkiaWGPURenderer` compiled its public API against the newest version only, breaking callers that pass wgpu 29 types. This broke the examples workspace build (`bevy-hosts-slint-gpu` vs. `servo`/`wgpu_texture`).

### Approach

The rest of the wgpu integration already supports both versions side by side (parallel `wgpu_29`/`wgpu_30` core modules, `GraphicsAPI::WGPU29`/`WGPU30`, runtime selection in the winit backend); the offscreen renderer was the only newest-wins entry point. This PR makes it per-version too:

- The renderer becomes `SkiaWGPURendererGeneric<Surface>`, generic over the version-specific WGPU surface. The `RendererSealed` delegation is version-independent and written once; only `new()` and `render_to_texture()` are per version.
- `SkiaWGPU29Renderer` and `SkiaWGPU30Renderer` select a version explicitly. `SkiaWGPURenderer` remains as a concrete compatibility alias for the newest enabled version, so existing single-version users are unaffected (and it stays unambiguous with both features enabled).
- The bevy example uses `SkiaWGPU29Renderer` directly, making it immune to feature unification from other workspace members.
- CI: `wgpu_texture` is now built together with the bevy examples so the 29/30 unification is exercised in one cargo invocation — this package combination reproduces the original failure on master and builds cleanly with this PR.

### Verification

- `i-slint-renderer-skia` compiles under all `wgpu-29`/`wgpu-30`/`unstable-wgpu-*` feature combinations; compile-time signature assertions cover all three renderer names (they run in the existing `--all-features` workspace test job).
- The issue's repro (`cargo check --manifest-path examples/Cargo.toml --workspace ...`) passes, as does the standalone `bevy-hosts-slint-gpu` build.
- `cargo fmt`, clippy on the touched crate, and `RUSTDOCFLAGS="-D warnings" cargo doc -p slint` are clean.
