### PR TITLE
Drop the WGPU newtype text delegation and fix stale comments

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -306,7 +306,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         _size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
-        // register a dependency for the partial renderer's dirty tracker. The actual rendering is done earlier in SkiaRenderer.
+        // Register a dependency for the dirty tracking; the actual rendering is done earlier in FemtoVGRenderer.
         let _ = rect.background();
     }
 

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -588,70 +588,12 @@ impl FemtoVGWGPURenderer {
 
 #[doc(hidden)]
 impl RendererSealed for FemtoVGWGPURenderer {
-    fn text_size(
+    // The text and font registration functions use their default implementations, which
+    // reach the inner renderer's state through this accessor and window_adapter().
+    fn text_layout_cache(
         &self,
-        text_item: Pin<&dyn i_slint_core::item_rendering::RenderString>,
-        item_rc: &i_slint_core::items::ItemRc,
-        max_width: Option<i_slint_core::lengths::LogicalLength>,
-        text_wrap: i_slint_core::items::TextWrap,
-    ) -> i_slint_core::lengths::LogicalSize {
-        self.0.text_size(text_item, item_rc, max_width, text_wrap)
-    }
-
-    fn text_content_widths(
-        &self,
-        text_item: Pin<&dyn i_slint_core::item_rendering::RenderString>,
-        item_rc: &i_slint_core::items::ItemRc,
-    ) -> Option<i_slint_core::renderer::ContentWidths> {
-        self.0.text_content_widths(text_item, item_rc)
-    }
-
-    fn char_size(
-        &self,
-        text_item: Pin<&dyn i_slint_core::item_rendering::HasFont>,
-        item_rc: &i_slint_core::items::ItemRc,
-        ch: char,
-    ) -> i_slint_core::lengths::LogicalSize {
-        self.0.char_size(text_item, item_rc, ch)
-    }
-
-    fn font_metrics(
-        &self,
-        font_request: i_slint_core::graphics::FontRequest,
-    ) -> i_slint_core::items::FontMetrics {
-        self.0.font_metrics(font_request)
-    }
-
-    fn text_input_byte_offset_for_position(
-        &self,
-        text_input: Pin<&i_slint_core::items::TextInput>,
-        item_rc: &i_slint_core::items::ItemRc,
-        pos: i_slint_core::lengths::LogicalPoint,
-    ) -> usize {
-        self.0.text_input_byte_offset_for_position(text_input, item_rc, pos)
-    }
-
-    fn text_input_cursor_rect_for_byte_offset(
-        &self,
-        text_input: Pin<&i_slint_core::items::TextInput>,
-        item_rc: &i_slint_core::items::ItemRc,
-        byte_offset: usize,
-    ) -> i_slint_core::lengths::LogicalRect {
-        self.0.text_input_cursor_rect_for_byte_offset(text_input, item_rc, byte_offset)
-    }
-
-    fn register_font_from_memory(
-        &self,
-        data: &'static [u8],
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.0.register_font_from_memory(data)
-    }
-
-    fn register_font_from_path(
-        &self,
-        path: &std::path::Path,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.0.register_font_from_path(path)
+    ) -> Option<&i_slint_core::textlayout::sharedparley::TextLayoutCache> {
+        RendererSealed::text_layout_cache(&self.0)
     }
 
     fn set_rendering_notifier(

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -597,9 +597,9 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
 
         let (background_rect, border_rect) = if opaque_border {
             // In CSS the border is entirely towards the inside of the boundary
-            // geometry, while in femtovg the line with for a stroke is 50% in-
-            // and 50% outwards. We choose the CSS model, so the inner rectangle
-            // is adjusted accordingly.
+            // geometry, while Skia strokes centered on the path, 50% in- and
+            // 50% outwards. We choose the CSS model, so the inner rectangle is
+            // adjusted accordingly.
             adjust_rect_and_border_for_inner_drawing(&mut geometry, &mut border_width);
 
             let rounded_rect = to_skia_rrect(&geometry, &stroke_border_radius);
@@ -609,9 +609,9 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
             let background_rect = to_skia_rrect(&geometry, &fill_radius);
 
             // In CSS the border is entirely towards the inside of the boundary
-            // geometry, while in femtovg the line with for a stroke is 50% in-
-            // and 50% outwards. We choose the CSS model, so the inner rectangle
-            // is adjusted accordingly.
+            // geometry, while Skia strokes centered on the path, 50% in- and
+            // 50% outwards. We choose the CSS model, so the inner rectangle is
+            // adjusted accordingly.
             adjust_rect_and_border_for_inner_drawing(&mut geometry, &mut border_width);
 
             let border_rect = to_skia_rrect(&geometry, &stroke_border_radius);
@@ -649,7 +649,8 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
         _size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
-        // The background is drawn directly by FemtoVG renderer (via clear_color, if necessary).
+        // The window background is cleared (solid color) or drawn (gradient)
+        // by SkiaRenderer before the item tree is rendered.
     }
 
     fn draw_image(
@@ -877,9 +878,9 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
         let mut rect = rect * self.scale_factor;
         let mut border_width = border_width * self.scale_factor;
         // In CSS the border is entirely towards the inside of the boundary
-        // geometry, while in femtovg the line with for a stroke is 50% in-
-        // and 50% outwards. We choose the CSS model, so the inner rectangle
-        // is adjusted accordingly.
+        // geometry, while Skia strokes centered on the path, 50% in- and
+        // 50% outwards. We choose the CSS model, so the inner rectangle is
+        // adjusted accordingly.
         adjust_rect_and_border_for_inner_drawing(&mut rect, &mut border_width);
 
         let radius = radius * self.scale_factor;

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -862,7 +862,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         }
     }
 
-    /// Returns an image buffer of what was rendered last by reading the previous front buffer (using glReadPixels).
+    /// Returns an image buffer with the contents of the window, obtained by re-rendering the scene into a CPU-side surface.
     fn take_snapshot(
         &self,
     ) -> Result<SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>, PlatformError> {

--- a/internal/renderers/skia/opengl_surface.rs
+++ b/internal/renderers/skia/opengl_surface.rs
@@ -433,7 +433,7 @@ impl OpenGLSurface {
 
         let context = not_current_gl_context.make_current(&surface)
             .map_err(|glutin_error: glutin::error::Error| -> PlatformError {
-                format!("FemtoVG Renderer: Failed to make newly created OpenGL context current: {glutin_error}")
+                format!("Skia Renderer: Failed to make newly created OpenGL context current: {glutin_error}")
                 .into()
         })?;
 

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -69,10 +69,14 @@ impl SkiaWGPURenderer {
         let surface = WGPUSurface::new_offscreen(instance, device, queue, backend, gr_context);
 
         let shared_context = SkiaSharedContext::default();
-        // Use SkiaRenderer::default() to stay resilient to field additions, then disable
-        // partial rendering — there is no buffer age tracking for external texture targets.
-        let mut renderer = SkiaRenderer::default(&shared_context);
-        renderer.partial_rendering_state = None;
+        // The renderer draws into caller-provided textures: there is no surface to
+        // (re-)create, and partial rendering stays off because there is no buffer age
+        // tracking for external texture targets.
+        let renderer = SkiaRenderer::new_with_surface_factory(
+            &shared_context,
+            |_, _, _, _, _| Err("SkiaWGPURenderer does not support dynamic surface creation".into()),
+            None,
+        );
 
         Ok(Self { renderer, surface })
     }
@@ -115,70 +119,12 @@ impl SkiaWGPURenderer {
 
 #[doc(hidden)]
 impl RendererSealed for SkiaWGPURenderer {
-    fn text_size(
+    // The text and font registration functions use their default implementations, which
+    // reach the inner renderer's state through this accessor and window_adapter().
+    fn text_layout_cache(
         &self,
-        text_item: Pin<&dyn i_slint_core::item_rendering::RenderString>,
-        item_rc: &i_slint_core::items::ItemRc,
-        max_width: Option<i_slint_core::lengths::LogicalLength>,
-        text_wrap: i_slint_core::items::TextWrap,
-    ) -> i_slint_core::lengths::LogicalSize {
-        self.renderer.text_size(text_item, item_rc, max_width, text_wrap)
-    }
-
-    fn text_content_widths(
-        &self,
-        text_item: Pin<&dyn i_slint_core::item_rendering::RenderString>,
-        item_rc: &i_slint_core::items::ItemRc,
-    ) -> Option<i_slint_core::renderer::ContentWidths> {
-        self.renderer.text_content_widths(text_item, item_rc)
-    }
-
-    fn char_size(
-        &self,
-        text_item: Pin<&dyn i_slint_core::item_rendering::HasFont>,
-        item_rc: &i_slint_core::items::ItemRc,
-        ch: char,
-    ) -> i_slint_core::lengths::LogicalSize {
-        self.renderer.char_size(text_item, item_rc, ch)
-    }
-
-    fn font_metrics(
-        &self,
-        font_request: i_slint_core::graphics::FontRequest,
-    ) -> i_slint_core::items::FontMetrics {
-        self.renderer.font_metrics(font_request)
-    }
-
-    fn text_input_byte_offset_for_position(
-        &self,
-        text_input: Pin<&i_slint_core::items::TextInput>,
-        item_rc: &i_slint_core::items::ItemRc,
-        pos: i_slint_core::lengths::LogicalPoint,
-    ) -> usize {
-        self.renderer.text_input_byte_offset_for_position(text_input, item_rc, pos)
-    }
-
-    fn text_input_cursor_rect_for_byte_offset(
-        &self,
-        text_input: Pin<&i_slint_core::items::TextInput>,
-        item_rc: &i_slint_core::items::ItemRc,
-        byte_offset: usize,
-    ) -> i_slint_core::lengths::LogicalRect {
-        self.renderer.text_input_cursor_rect_for_byte_offset(text_input, item_rc, byte_offset)
-    }
-
-    fn register_font_from_memory(
-        &self,
-        data: &'static [u8],
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.renderer.register_font_from_memory(data)
-    }
-
-    fn register_font_from_path(
-        &self,
-        path: &std::path::Path,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.renderer.register_font_from_path(path)
+    ) -> Option<&i_slint_core::textlayout::sharedparley::TextLayoutCache> {
+        RendererSealed::text_layout_cache(&self.renderer)
     }
 
     fn set_rendering_notifier(


### PR DESCRIPTION
Two follow-up cleanups: SkiaWGPURenderer and FemtoVGWGPURenderer now use the RendererSealed text function defaults through a single text_layout_cache() forward instead of eight hand-written delegation functions (and SkiaWGPURenderer constructs its inner renderer without mutating a private field); and a few comments and one error message that referred to the respectively other renderer are fixed.