### PR TITLE
Rename FlexboxLayout's align-content to cross-axis-line-alignment

### DIFF
--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -57,7 +57,7 @@ export component MainWindow inherits Window {
         LayoutAlignment.space-around,
         LayoutAlignment.space-evenly
     ];
-    property <[string]> align_content_options: [
+    property <[string]> cross_axis_line_alignment_options: [
         "Stretch",
         "Start",
         "End",
@@ -66,14 +66,14 @@ export component MainWindow inherits Window {
         "Space Around",
         "Space Evenly"
     ];
-    property <[FlexboxLayoutAlignContent]> align_content_values: [
-        FlexboxLayoutAlignContent.stretch,
-        FlexboxLayoutAlignContent.start,
-        FlexboxLayoutAlignContent.end,
-        FlexboxLayoutAlignContent.center,
-        FlexboxLayoutAlignContent.space-between,
-        FlexboxLayoutAlignContent.space-around,
-        FlexboxLayoutAlignContent.space-evenly
+    property <[CrossAxisLineAlignment]> cross_axis_line_alignment_values: [
+        CrossAxisLineAlignment.stretch,
+        CrossAxisLineAlignment.start,
+        CrossAxisLineAlignment.end,
+        CrossAxisLineAlignment.center,
+        CrossAxisLineAlignment.space-between,
+        CrossAxisLineAlignment.space-around,
+        CrossAxisLineAlignment.space-evenly
     ];
     property <[string]> cross_axis_alignment_options: ["Stretch", "Start", "End", "Center"];
     property <[CrossAxisAlignment]> cross_axis_alignment_values: [
@@ -125,12 +125,12 @@ export component MainWindow inherits Window {
         HorizontalLayout {
             spacing: 10phx;
             Text {
-                text: "Align Content:";
+                text: "Cross Axis Line Alignment:";
                 vertical-alignment: center;
             }
 
-            align_content_combo := ComboBox {
-                model: align_content_options;
+            cross_axis_line_alignment_combo := ComboBox {
+                model: cross_axis_line_alignment_options;
                 current-index: 0;
             }
 
@@ -154,7 +154,7 @@ export component MainWindow inherits Window {
             FlexboxLayout {
                 flex-direction: direction_values[direction_combo.current-index];
                 alignment: alignment_values[alignment_combo.current-index];
-                align-content: align_content_values[align_content_combo.current-index];
+                cross-axis-line-alignment: cross_axis_line_alignment_values[cross_axis_line_alignment_combo.current-index];
                 cross-axis-alignment: cross_axis_alignment_values[cross_axis_alignment_combo.current-index];
                 flex-wrap: flex_wrap_values[flex_wrap_combo.current-index];
                 padding: 10phx;

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -399,8 +399,9 @@ macro_rules! for_each_enums {
             }
 
             /// Controls the distribution of flex lines along the cross axis in a flex container.
+            /// Used as the `cross-axis-line-alignment` property of `FlexboxLayout`.
             #[non_exhaustive]
-            enum FlexboxLayoutAlignContent {
+            enum CrossAxisLineAlignment {
                 /// Lines are stretched to fill the container along the cross axis.
                 Stretch,
                 /// Lines are placed at the start of the cross axis.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2243,9 +2243,10 @@ export component FlexboxLayout {
     /// The primary direction in which items are placed. Set to `row` to place items horizontally left-to-right (default), or `column` to place items vertically top-to-bottom.
     /// It also supports `row-reverse` and `column-reverse` which invert the flow: `row-reverse` places items right-to-left (starting at the right edge), and `column-reverse` places items bottom-to-top (starting at the bottom edge).
     in property <FlexboxLayoutDirection> flex-direction;
-    /// Set the distribution of flex lines along the cross axis.
+    /// Set the distribution of flex lines along the cross axis. CSS Flexbox calls this "align-content";
+    /// the name here pairs with `cross-axis-alignment`, which aligns the items within one line.
     /// The default value is `stretch`.
-    in property <FlexboxLayoutAlignContent> align-content;
+    in property <CrossAxisLineAlignment> cross-axis-line-alignment;
     /// Set the alignment of individual items along the cross axis within each flex line.
     /// The default value is `stretch`.
     in property <CrossAxisAlignment> cross-axis-alignment;

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -756,7 +756,7 @@ pub struct FlexboxLayout {
     pub elems: Vec<FlexboxLayoutItem>,
     pub geometry: LayoutGeometry,
     pub direction: Option<NamedReference>,
-    pub align_content: Option<NamedReference>,
+    pub cross_axis_line_alignment: Option<NamedReference>,
     pub cross_axis_alignment: Option<NamedReference>,
     pub flex_wrap: Option<NamedReference>,
 }
@@ -852,7 +852,7 @@ impl FlexboxLayout {
         if let Some(e) = self.direction.as_mut() {
             visitor(&mut *e)
         }
-        if let Some(e) = self.align_content.as_mut() {
+        if let Some(e) = self.cross_axis_line_alignment.as_mut() {
             visitor(&mut *e)
         }
         if let Some(e) = self.cross_axis_alignment.as_mut() {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -386,11 +386,11 @@ pub(super) fn solve_flexbox_layout(
                 fld.direction,
             ),
             (
-                "align_content",
+                "cross_axis_line_alignment",
                 Type::Enumeration(
-                    crate::typeregister::BUILTIN.enums.FlexboxLayoutAlignContent.clone(),
+                    crate::typeregister::BUILTIN.enums.CrossAxisLineAlignment.clone(),
                 ),
-                fld.align_content,
+                fld.cross_axis_line_alignment,
             ),
             (
                 "cross_axis_alignment",
@@ -783,7 +783,7 @@ fn compute_flexbox_layout_info_for_direction(
 struct FlexboxLayoutDataResult {
     alignment: llr_Expression,
     direction: llr_Expression,
-    align_content: llr_Expression,
+    cross_axis_line_alignment: llr_Expression,
     cross_axis_alignment: llr_Expression,
     flex_wrap: llr_Expression,
     cells_h: llr_Expression,
@@ -828,10 +828,10 @@ fn flexbox_layout_data(
         })
     };
 
-    let align_content = if let Some(expr) = &layout.align_content {
+    let cross_axis_line_alignment = if let Some(expr) = &layout.cross_axis_line_alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.enums.FlexboxLayoutAlignContent.clone();
+        let e = crate::typeregister::BUILTIN.enums.CrossAxisLineAlignment.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,
@@ -994,7 +994,7 @@ fn flexbox_layout_data(
         FlexboxLayoutDataResult {
             alignment,
             direction,
-            align_content,
+            cross_axis_line_alignment,
             cross_axis_alignment,
             flex_wrap,
             cells_h,
@@ -1059,7 +1059,7 @@ fn flexbox_layout_data(
         FlexboxLayoutDataResult {
             alignment,
             direction,
-            align_content,
+            cross_axis_line_alignment,
             cross_axis_alignment,
             flex_wrap,
             cells_h,

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1852,7 +1852,8 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
     }
 
     let direction = crate::layout::binding_reference(layout_element, "flex-direction");
-    let align_content = crate::layout::binding_reference(layout_element, "align-content");
+    let cross_axis_line_alignment =
+        crate::layout::binding_reference(layout_element, "cross-axis-line-alignment");
     let cross_axis_alignment =
         crate::layout::binding_reference(layout_element, "cross-axis-alignment");
     let flex_wrap = crate::layout::binding_reference(layout_element, "flex-wrap");
@@ -1861,7 +1862,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
         elems: Default::default(),
         geometry: LayoutGeometry::new(layout_element),
         direction,
-        align_content,
+        cross_axis_line_alignment,
         cross_axis_alignment,
         flex_wrap,
     };

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -5,7 +5,7 @@ export component X inherits Rectangle {
 
     flex := FlexboxLayout {
         alignment: center;
-        align-content: stretch;
+        cross-axis-line-alignment: stretch;
         cross-axis-alignment: stretch;
         flex-wrap: wrap;
         gap: 10px;

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -710,7 +710,7 @@ impl TypeRegister {
 
         register.elements.remove("FlexboxLayout").unwrap();
         register.types.remove("FlexboxLayoutDirection").unwrap();
-        register.types.remove("FlexboxLayoutAlignContent").unwrap();
+        register.types.remove("CrossAxisLineAlignment").unwrap();
         register.types.remove("FlexboxLayoutWrap").unwrap();
         register.types.remove("FlexboxLayoutAlignSelf").unwrap();
 

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,7 +6,7 @@
 // cspell:ignore coord
 
 use crate::items::{
-    CrossAxisAlignment, DialogButtonRole, FlexboxLayoutAlignContent, FlexboxLayoutAlignSelf,
+    CrossAxisAlignment, CrossAxisLineAlignment, DialogButtonRole, FlexboxLayoutAlignSelf,
     FlexboxLayoutDirection, FlexboxLayoutWrap, LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
@@ -1151,7 +1151,7 @@ pub struct FlexboxLayoutData<'a> {
     pub padding_v: Padding,
     pub alignment: LayoutAlignment,
     pub direction: FlexboxLayoutDirection,
-    pub align_content: FlexboxLayoutAlignContent,
+    pub cross_axis_line_alignment: CrossAxisLineAlignment,
     pub cross_axis_alignment: CrossAxisAlignment,
     pub flex_wrap: FlexboxLayoutWrap,
     /// Horizontal constraints (width) for each cell
@@ -1437,9 +1437,9 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, CrossAxisAlignment, FlexItemProps, FlexboxLayoutAlignContent,
-        FlexboxLayoutAlignSelf, FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment,
-        LayoutInfo, LayoutItemInfo, Padding, Slice,
+        Coord, CrossAxisAlignment, CrossAxisLineAlignment, FlexItemProps, FlexboxLayoutAlignSelf,
+        FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment, LayoutInfo, LayoutItemInfo,
+        Padding, Slice,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
@@ -1455,7 +1455,7 @@ mod flexbox_taffy {
         pub padding_h: &'a Padding,
         pub padding_v: &'a Padding,
         pub alignment: LayoutAlignment,
-        pub align_content: FlexboxLayoutAlignContent,
+        pub cross_axis_line_alignment: CrossAxisLineAlignment,
         pub cross_axis_alignment: CrossAxisAlignment,
         pub flex_wrap: SlintFlexboxLayoutWrap,
         pub flex_direction: TaffyFlexDirection,
@@ -1697,14 +1697,14 @@ mod flexbox_taffy {
                             CrossAxisAlignment::End => AlignItems::FlexEnd,
                             CrossAxisAlignment::Center => AlignItems::Center,
                         }),
-                        align_content: Some(match params.align_content {
-                            FlexboxLayoutAlignContent::Stretch => AlignContent::Stretch,
-                            FlexboxLayoutAlignContent::Start => AlignContent::FlexStart,
-                            FlexboxLayoutAlignContent::End => AlignContent::FlexEnd,
-                            FlexboxLayoutAlignContent::Center => AlignContent::Center,
-                            FlexboxLayoutAlignContent::SpaceBetween => AlignContent::SpaceBetween,
-                            FlexboxLayoutAlignContent::SpaceAround => AlignContent::SpaceAround,
-                            FlexboxLayoutAlignContent::SpaceEvenly => AlignContent::SpaceEvenly,
+                        align_content: Some(match params.cross_axis_line_alignment {
+                            CrossAxisLineAlignment::Stretch => AlignContent::Stretch,
+                            CrossAxisLineAlignment::Start => AlignContent::FlexStart,
+                            CrossAxisLineAlignment::End => AlignContent::FlexEnd,
+                            CrossAxisLineAlignment::Center => AlignContent::Center,
+                            CrossAxisLineAlignment::SpaceBetween => AlignContent::SpaceBetween,
+                            CrossAxisLineAlignment::SpaceAround => AlignContent::SpaceAround,
+                            CrossAxisLineAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
                         }),
                         gap: Size {
                             width: LengthPercentage::length(params.spacing_h as _),
@@ -1945,7 +1945,7 @@ pub fn solve_flexbox_layout_with_measure(
         padding_h: &data.padding_h,
         padding_v: &data.padding_v,
         alignment: data.alignment,
-        align_content: data.align_content,
+        cross_axis_line_alignment: data.cross_axis_line_alignment,
         cross_axis_alignment: data.cross_axis_alignment,
         flex_wrap: data.flex_wrap,
         flex_direction: taffy_direction,
@@ -2207,7 +2207,7 @@ pub fn flexbox_layout_info_cross_axis(
         padding_h,
         padding_v,
         alignment: LayoutAlignment::Start,
-        align_content: FlexboxLayoutAlignContent::Stretch,
+        cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
         cross_axis_alignment: CrossAxisAlignment::Stretch,
         flex_wrap,
         flex_direction: taffy_direction,
@@ -3108,7 +3108,7 @@ mod tests {
                     padding_h: &pad,
                     padding_v: &pad,
                     alignment: LayoutAlignment::Start,
-                    align_content: FlexboxLayoutAlignContent::Stretch,
+                    cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
                     cross_axis_alignment: CrossAxisAlignment::Stretch,
                     flex_wrap: FlexboxLayoutWrap::NoWrap,
                     flex_direction: flexbox_taffy::TaffyFlexDirection::Row,
@@ -3210,7 +3210,7 @@ mod tests {
                     padding_h: &pad,
                     padding_v: &pad,
                     alignment: LayoutAlignment::Start,
-                    align_content: FlexboxLayoutAlignContent::Stretch,
+                    cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
                     cross_axis_alignment: CrossAxisAlignment::Stretch,
                     flex_wrap: FlexboxLayoutWrap::NoWrap,
                     flex_direction: flexbox_taffy::TaffyFlexDirection::Column,
@@ -3320,7 +3320,7 @@ mod tests {
                 padding_h: &pad,
                 padding_v: &pad,
                 alignment: LayoutAlignment::Start,
-                align_content: FlexboxLayoutAlignContent::Stretch,
+                cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
                 cross_axis_alignment: CrossAxisAlignment::Stretch,
                 flex_wrap: FlexboxLayoutWrap::NoWrap,
                 flex_direction: flexbox_taffy::TaffyFlexDirection::Row,

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -299,10 +299,10 @@ pub(crate) fn solve_flexbox_layout(
         .map_or(i_slint_core::items::LayoutAlignment::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
-    let align_content = flexbox_layout
-        .align_content
+    let cross_axis_line_alignment = flexbox_layout
+        .cross_axis_line_alignment
         .as_ref()
-        .map_or(i_slint_core::items::FlexboxLayoutAlignContent::default(), |nr| {
+        .map_or(i_slint_core::items::CrossAxisLineAlignment::default(), |nr| {
             eval::load_property(component, &nr.element(), nr.name()).unwrap().try_into().unwrap()
         });
     let cross_axis_alignment = flexbox_layout
@@ -332,7 +332,7 @@ pub(crate) fn solve_flexbox_layout(
         padding_v,
         alignment,
         direction,
-        align_content,
+        cross_axis_line_alignment,
         cross_axis_alignment,
         flex_wrap,
         cells_h: Slice::from(cells_h.as_slice()),

--- a/tests/cases/layout/flexbox-preferred-grid-demo.slint
+++ b/tests/cases/layout/flexbox-preferred-grid-demo.slint
@@ -120,7 +120,7 @@ export component TestCase inherits Window {
         HorizontalLayout {
             alignment: root.fill-window ? LayoutAlignment.stretch : LayoutAlignment.start;
             flex := FlexboxLayout {
-                align-content: start;
+                cross-axis-line-alignment: start;
                 spacing: root.spacing-px * 1px;
                 vertical-stretch: 0;
                 horizontal-stretch: root.fill-window ? 1.0 : 0.0;

--- a/tests/cases/layout/flexbox-preferred-width.slint
+++ b/tests/cases/layout/flexbox-preferred-width.slint
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
     min-height: 300px;
 
     flex := FlexboxLayout {
-        align-content: start;  // Don't stretch rows to fill the window height
+        cross-axis-line-alignment: start;  // Don't stretch rows to fill the window height
         spacing: 10px;
         vertical-stretch: 0;
         horizontal-stretch: 0;

--- a/tests/cases/layout/flexbox_column_definite_width_no_stretch.slint
+++ b/tests/cases/layout/flexbox_column_definite_width_no_stretch.slint
@@ -43,7 +43,7 @@ export component TestCase inherits Window {
     // `cross-axis-alignment` is NOT stretch. Here the container aligns items to
     // the start (so plain items keep their preferred 100px width), but s3 opts
     // into stretch and must therefore fill its flex line's cross size, which the
-    // default `align-content: stretch` grows wider than 100px.
+    // default `cross-axis-line-alignment: stretch` grows wider than 100px.
     Rectangle { x: 0; y: 200px; width: 300px; height: 96px; border-width: 1px; border-color: gray; }
     flex2 := FlexboxLayout {
         flex-direction: column;

--- a/tests/cases/layout/flexbox_column_multiple_columns.slint
+++ b/tests/cases/layout/flexbox_column_multiple_columns.slint
@@ -24,7 +24,7 @@ export component TestCase inherits Window {
     // Column 1: r1 (50px) + r2 (50px) + spacing = 105px < 150px
     // Column 2: r3 (50px) + r4 (50px) + spacing = 105px < 150px
     // Column 3: r5 (50px)
-    // With align-content: stretch (CSS default), columns are stretched to fill the 250px width.
+    // With cross-axis-line-alignment: stretch (CSS default), columns are stretched to fill the 250px width.
     out property <bool> test: r1.x == 0px && r1.y == 0px &&
                               r2.x == 0px && r2.y == 55px &&
                               r3.x == 85px && r3.y == 0px &&

--- a/tests/cases/layout/flexbox_cross_axis_alignment.slint
+++ b/tests/cases/layout/flexbox_cross_axis_alignment.slint
@@ -18,7 +18,7 @@ component TestAlignItemsStartRow inherits VisibleRect {
     height: 300px;
 
     FlexboxLayout {
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
 
         r1 := Rectangle {
@@ -51,7 +51,7 @@ component TestAlignItemsEndRow inherits VisibleRect {
     height: 300px;
 
     FlexboxLayout {
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: end;
 
         r1 := Rectangle {
@@ -84,7 +84,7 @@ component TestAlignItemsCenterRow inherits VisibleRect {
     height: 300px;
 
     FlexboxLayout {
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: center;
 
         r1 := Rectangle {
@@ -117,7 +117,7 @@ component TestAlignItemsStretchRow inherits VisibleRect {
     height: 300px;
 
     FlexboxLayout {
-        // align-content: stretch (default) — single line fills container height
+        // cross-axis-line-alignment: stretch (default) — single line fills container height
         // cross-axis-alignment: stretch (default) — items stretch to line height
         r1 := Rectangle {
             width: 50px;
@@ -149,7 +149,7 @@ component TestAlignItemsStartColumn inherits VisibleRect {
 
     FlexboxLayout {
         flex-direction: column;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
 
         r1 := Rectangle {
@@ -183,7 +183,7 @@ component TestAlignItemsEndColumn inherits VisibleRect {
 
     FlexboxLayout {
         flex-direction: column;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: end;
 
         r1 := Rectangle {
@@ -217,7 +217,7 @@ component TestAlignItemsCenterColumn inherits VisibleRect {
 
     FlexboxLayout {
         flex-direction: column;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: center;
 
         r1 := Rectangle {
@@ -251,7 +251,7 @@ component TestAlignItemsStretchColumn inherits VisibleRect {
 
     FlexboxLayout {
         flex-direction: column;
-        // align-content: stretch (default) — single column fills container width
+        // cross-axis-line-alignment: stretch (default) — single column fills container width
         // cross-axis-alignment: stretch (default) — items stretch to column width
         r1 := Rectangle {
             height: 50px;

--- a/tests/cases/layout/flexbox_cross_axis_line_alignment.slint
+++ b/tests/cases/layout/flexbox_cross_axis_line_alignment.slint
@@ -1,8 +1,8 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexboxLayout align-content property for row and column directions
-// align-content controls how flex lines are distributed along the cross axis.
+// Test FlexboxLayout cross-axis-line-alignment property for row and column directions
+// cross-axis-line-alignment controls how flex lines are distributed along the cross axis.
 
 component VisibleRect inherits Rectangle {
     border-width: 1px;
@@ -11,12 +11,12 @@ component VisibleRect inherits Rectangle {
 
 // === Row direction tests ===
 
-// Test 1: align-content: start (row) — rows packed at top
-component TestAlignContentStartRow inherits VisibleRect {
+// Test 1: cross-axis-line-alignment: start (row) — rows packed at top
+component TestLineAlignmentStartRow inherits VisibleRect {
     width: 200px;
     height: 200px;
     FlexboxLayout {
-        align-content: start;
+        cross-axis-line-alignment: start;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -39,18 +39,18 @@ component TestAlignContentStartRow inherits VisibleRect {
         // Row 2: r3 alone
     }
 
-    // With align-content: start, rows pack at y=0
+    // With cross-axis-line-alignment: start, rows pack at y=0
     // Row 1: y=0, Row 2: y=35 (30+5)
     out property <bool> test: r1.y == 0px && r2.y == 0px && r3.y == 35px;
 }
 
-    // Test 2: align-content: end (row) — rows packed at bottom
-component TestAlignContentEndRow inherits VisibleRect {
+    // Test 2: cross-axis-line-alignment: end (row) — rows packed at bottom
+component TestLineAlignmentEndRow inherits VisibleRect {
     width: 200px;
     height: 200px;
 
     FlexboxLayout {
-        align-content: end;
+        cross-axis-line-alignment: end;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -72,19 +72,19 @@ component TestAlignContentEndRow inherits VisibleRect {
         }
     }
 
-    // With align-content: end, rows pack at the bottom
+    // With cross-axis-line-alignment: end, rows pack at the bottom
     // Total content height: 30+5+30 = 65
     // Offset: 200-65 = 135
     out property <bool> test: r1.y == 135px && r2.y == 135px && r3.y == 170px;
 }
 
-    // Test 3: align-content: center (row) — rows centered vertically
-component TestAlignContentCenterRow inherits VisibleRect {
+    // Test 3: cross-axis-line-alignment: center (row) — rows centered vertically
+component TestLineAlignmentCenterRow inherits VisibleRect {
     width: 200px;
     height: 200px;
 
     FlexboxLayout {
-        align-content: center;
+        cross-axis-line-alignment: center;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -106,7 +106,7 @@ component TestAlignContentCenterRow inherits VisibleRect {
         }
     }
 
-    // With align-content: center, rows centered
+    // With cross-axis-line-alignment: center, rows centered
     // Total content height: 30+5+30 = 65
     // Offset: (200-65)/2 = 67.5 ≈ 68
     out property <bool> test_r1: r1.y >= 67px && r1.y <= 68px;
@@ -114,13 +114,13 @@ component TestAlignContentCenterRow inherits VisibleRect {
     out property <bool> test: test_r1 && test_r3;
 }
 
-    // Test 4: align-content: stretch (row, the default) — rows stretched to fill
-component TestAlignContentStretchRow inherits VisibleRect {
+    // Test 4: cross-axis-line-alignment: stretch (row, the default) — rows stretched to fill
+component TestLineAlignmentStretchRow inherits VisibleRect {
     width: 200px;
     height: 200px;
 
     FlexboxLayout {
-        align-content: stretch;
+        cross-axis-line-alignment: stretch;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -142,21 +142,21 @@ component TestAlignContentStretchRow inherits VisibleRect {
         }
     }
 
-    // With align-content: stretch, rows are stretched to fill the 200px height.
+    // With cross-axis-line-alignment: stretch, rows are stretched to fill the 200px height.
     // Row 2 starts well below row 1 since the remaining 135px is distributed.
     out property <bool> test: r1.y == 0px && r3.y > 35px;
 }
 
     // === Column direction tests ===
 
-// Test 5: align-content: start (column) — columns packed at left
-component TestAlignContentStartCol inherits VisibleRect {
+// Test 5: cross-axis-line-alignment: start (column) — columns packed at left
+component TestLineAlignmentStartCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
     FlexboxLayout {
         flex-direction: column;
-        align-content: start;
+        cross-axis-line-alignment: start;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -179,19 +179,19 @@ component TestAlignContentStartCol inherits VisibleRect {
         // Col 2: r3 alone
     }
 
-    // With align-content: start, columns pack at x=0
+    // With cross-axis-line-alignment: start, columns pack at x=0
     // Col 1: x=0, Col 2: x=35 (30+5)
     out property <bool> test: r1.x == 0px && r2.x == 0px && r3.x == 35px;
 }
 
-    // Test 6: align-content: end (column) — columns packed at right
-component TestAlignContentEndCol inherits VisibleRect {
+    // Test 6: cross-axis-line-alignment: end (column) — columns packed at right
+component TestLineAlignmentEndCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
     FlexboxLayout {
         flex-direction: column;
-        align-content: end;
+        cross-axis-line-alignment: end;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -213,20 +213,20 @@ component TestAlignContentEndCol inherits VisibleRect {
         }
     }
 
-    // With align-content: end, columns pack at the right
+    // With cross-axis-line-alignment: end, columns pack at the right
     // Total content width: 30+5+30 = 65
     // Offset: 200-65 = 135
     out property <bool> test: r1.x == 135px && r2.x == 135px && r3.x == 170px;
 }
 
-    // Test 7: align-content: center (column) — columns centered horizontally
-component TestAlignContentCenterCol inherits VisibleRect {
+    // Test 7: cross-axis-line-alignment: center (column) — columns centered horizontally
+component TestLineAlignmentCenterCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
     FlexboxLayout {
         flex-direction: column;
-        align-content: center;
+        cross-axis-line-alignment: center;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -248,7 +248,7 @@ component TestAlignContentCenterCol inherits VisibleRect {
         }
     }
 
-    // With align-content: center, columns centered
+    // With cross-axis-line-alignment: center, columns centered
     // Total content width: 30+5+30 = 65
     // Offset: (200-65)/2 = 67.5 ≈ 68
     out property <bool> test_r1: r1.x >= 67px && r1.x <= 68px;
@@ -256,14 +256,14 @@ component TestAlignContentCenterCol inherits VisibleRect {
     out property <bool> test: test_r1 && test_r3;
 }
 
-    // Test 8: align-content: stretch (column, the default) — columns stretched to fill
-component TestAlignContentStretchCol inherits VisibleRect {
+    // Test 8: cross-axis-line-alignment: stretch (column, the default) — columns stretched to fill
+component TestLineAlignmentStretchCol inherits VisibleRect {
     width: 200px;
     height: 200px;
 
     FlexboxLayout {
         flex-direction: column;
-        align-content: stretch;
+        cross-axis-line-alignment: stretch;
         spacing: 5px;
 
         r1 := Rectangle {
@@ -285,19 +285,19 @@ component TestAlignContentStretchCol inherits VisibleRect {
         }
     }
 
-    // With align-content: stretch, columns are stretched to fill the 200px width.
+    // With cross-axis-line-alignment: stretch, columns are stretched to fill the 200px width.
     // Column 2 starts well to the right of column 1 since the remaining 135px is distributed.
     out property <bool> test: r1.x == 0px && r3.x > 35px;
 }
 
 // === Row direction: space-between/around/evenly tests ===
 
-// Test 9: align-content: space-between (row) — first line at top, last at bottom
-component TestAlignContentSpaceBetweenRow inherits VisibleRect {
+// Test 9: cross-axis-line-alignment: space-between (row) — first line at top, last at bottom
+component TestLineAlignmentSpaceBetweenRow inherits VisibleRect {
     width: 200px;
     height: 200px;
     FlexboxLayout {
-        align-content: space-between;
+        cross-axis-line-alignment: space-between;
 
         r1 := Rectangle {
             width: 80px;
@@ -322,12 +322,12 @@ component TestAlignContentSpaceBetweenRow inherits VisibleRect {
     out property <bool> test: r1.y == 0px && r2.y == 0px && r3.y == 170px;
 }
 
-// Test 10: align-content: space-around (row) — equal space around each line
-component TestAlignContentSpaceAroundRow inherits VisibleRect {
+// Test 10: cross-axis-line-alignment: space-around (row) — equal space around each line
+component TestLineAlignmentSpaceAroundRow inherits VisibleRect {
     width: 200px;
     height: 200px;
     FlexboxLayout {
-        align-content: space-around;
+        cross-axis-line-alignment: space-around;
 
         r1 := Rectangle {
             width: 80px;
@@ -351,12 +351,12 @@ component TestAlignContentSpaceAroundRow inherits VisibleRect {
     out property <bool> test: r1.y == 35px && r2.y == 35px && r3.y == 135px;
 }
 
-// Test 11: align-content: space-evenly (row) — equal gaps everywhere
-component TestAlignContentSpaceEvenlyRow inherits VisibleRect {
+// Test 11: cross-axis-line-alignment: space-evenly (row) — equal gaps everywhere
+component TestLineAlignmentSpaceEvenlyRow inherits VisibleRect {
     width: 200px;
     height: 200px;
     FlexboxLayout {
-        align-content: space-evenly;
+        cross-axis-line-alignment: space-evenly;
 
         r1 := Rectangle {
             width: 80px;
@@ -384,13 +384,13 @@ component TestAlignContentSpaceEvenlyRow inherits VisibleRect {
 
 // === Column direction: space-between/around/evenly tests ===
 
-// Test 12: align-content: space-between (column)
-component TestAlignContentSpaceBetweenCol inherits VisibleRect {
+// Test 12: cross-axis-line-alignment: space-between (column)
+component TestLineAlignmentSpaceBetweenCol inherits VisibleRect {
     width: 200px;
     height: 200px;
     FlexboxLayout {
         flex-direction: column;
-        align-content: space-between;
+        cross-axis-line-alignment: space-between;
 
         r1 := Rectangle {
             width: 30px;
@@ -415,13 +415,13 @@ component TestAlignContentSpaceBetweenCol inherits VisibleRect {
     out property <bool> test: r1.x == 0px && r2.x == 0px && r3.x == 170px;
 }
 
-// Test 13: align-content: space-around (column)
-component TestAlignContentSpaceAroundCol inherits VisibleRect {
+// Test 13: cross-axis-line-alignment: space-around (column)
+component TestLineAlignmentSpaceAroundCol inherits VisibleRect {
     width: 200px;
     height: 200px;
     FlexboxLayout {
         flex-direction: column;
-        align-content: space-around;
+        cross-axis-line-alignment: space-around;
 
         r1 := Rectangle {
             width: 30px;
@@ -445,13 +445,13 @@ component TestAlignContentSpaceAroundCol inherits VisibleRect {
     out property <bool> test: r1.x == 35px && r2.x == 35px && r3.x == 135px;
 }
 
-// Test 14: align-content: space-evenly (column)
-component TestAlignContentSpaceEvenlyCol inherits VisibleRect {
+// Test 14: cross-axis-line-alignment: space-evenly (column)
+component TestLineAlignmentSpaceEvenlyCol inherits VisibleRect {
     width: 200px;
     height: 200px;
     FlexboxLayout {
         flex-direction: column;
-        align-content: space-evenly;
+        cross-axis-line-alignment: space-evenly;
 
         r1 := Rectangle {
             width: 30px;
@@ -487,25 +487,25 @@ export component TestCase inherits Window {
         VerticalLayout {
             spacing: 10px;
             padding: 10px;
-            t1 := TestAlignContentStartRow { }
-            t2 := TestAlignContentEndRow { }
-            t3 := TestAlignContentCenterRow { }
-            t4 := TestAlignContentStretchRow { }
-            t9 := TestAlignContentSpaceBetweenRow { }
-            t10 := TestAlignContentSpaceAroundRow { }
-            t11 := TestAlignContentSpaceEvenlyRow { }
+            t1 := TestLineAlignmentStartRow { }
+            t2 := TestLineAlignmentEndRow { }
+            t3 := TestLineAlignmentCenterRow { }
+            t4 := TestLineAlignmentStretchRow { }
+            t9 := TestLineAlignmentSpaceBetweenRow { }
+            t10 := TestLineAlignmentSpaceAroundRow { }
+            t11 := TestLineAlignmentSpaceEvenlyRow { }
         }
 
         VerticalLayout {
             spacing: 10px;
             padding: 10px;
-            t5 := TestAlignContentStartCol { }
-            t6 := TestAlignContentEndCol { }
-            t7 := TestAlignContentCenterCol { }
-            t8 := TestAlignContentStretchCol { }
-            t12 := TestAlignContentSpaceBetweenCol { }
-            t13 := TestAlignContentSpaceAroundCol { }
-            t14 := TestAlignContentSpaceEvenlyCol { }
+            t5 := TestLineAlignmentStartCol { }
+            t6 := TestLineAlignmentEndCol { }
+            t7 := TestLineAlignmentCenterCol { }
+            t8 := TestLineAlignmentStretchCol { }
+            t12 := TestLineAlignmentSpaceBetweenCol { }
+            t13 := TestLineAlignmentSpaceAroundCol { }
+            t14 := TestLineAlignmentSpaceEvenlyCol { }
         }
     }
 

--- a/tests/cases/layout/flexbox_min_width.slint
+++ b/tests/cases/layout/flexbox_min_width.slint
@@ -49,7 +49,7 @@ export component TestCase inherits Window {
     out property <bool> test_r2: r2.x == 85px && r2.y == 0px && r2.width == 60px;
 
     // Row 2: r3 clamped to max-width (80px) + r4 (respects min/max)
-    // With align-content: stretch (CSS default), rows are stretched to fill the 300px height.
+    // With cross-axis-line-alignment: stretch (CSS default), rows are stretched to fill the 300px height.
     out property <bool> test_r3: r3.x == 0px && r3.y == 153px && r3.width == 80px;
     out property <bool> test_r4: r4.x == 85px && r4.y == 153px && r4.width >= 40px && r4.width <= 60px;
 

--- a/tests/cases/layout/flexbox_multiple_rows.slint
+++ b/tests/cases/layout/flexbox_multiple_rows.slint
@@ -8,7 +8,7 @@ export component TestCase inherits Window {
     height: 300px;
 
     flex := FlexboxLayout {
-        align-content: start;
+        cross-axis-line-alignment: start;
         padding: 2px;
         spacing: 5px;
 

--- a/tests/cases/layout/flexbox_oversized.slint
+++ b/tests/cases/layout/flexbox_oversized.slint
@@ -10,7 +10,7 @@ export component TestCase inherits Window {
     // Test with wide items (one per row)
     FlexboxLayout {
         spacing: 5px;
-        align-content: start;
+        cross-axis-line-alignment: start;
 
         w1 := Rectangle { width: 100px; height: 30px; background: red; }
         w2 := Rectangle { width: 100px; height: 30px; background: green; }

--- a/tests/cases/layout/flexbox_repeated_wrapped_constrained_cell.slint
+++ b/tests/cases/layout/flexbox_repeated_wrapped_constrained_cell.slint
@@ -20,7 +20,7 @@ component WrapCol {
         flex-wrap: wrap;
         spacing: 0px;
         padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         Rectangle { width: 40px; height: 30px; background: red; }
         Rectangle { width: 40px; height: 30px; background: green; }
         Rectangle { width: 40px; height: 30px; background: blue; }
@@ -58,7 +58,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         WrapCol { min-height: 70px; max-height: 70px; }
         wStatic := Rectangle { width: 5px; height: 5px; }
@@ -70,7 +70,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         for x in [1]: WrapCol { min-height: 70px; max-height: 70px; opacity: cond ? 1.0 : 0.4; }
         wOpacity := Rectangle { width: 5px; height: 5px; }
@@ -82,7 +82,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         for x in [1]: WrapCol { min-height: 70px; max-height: 70px; visible: cond; }
         wVisible := Rectangle { width: 5px; height: 5px; }
@@ -98,7 +98,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         Card { label: long; flex-shrink: 0; flex-basis: 150px; }
         hStatic := Rectangle { width: 150px; height: 5px; }
@@ -110,7 +110,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         for s in [long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; opacity: cond ? 1.0 : 0.4; }
         hOpacity := Rectangle { width: 150px; height: 5px; }
@@ -122,7 +122,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         for s in [long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; visible: cond; }
         hVisible := Rectangle { width: 150px; height: 5px; }

--- a/tests/cases/layout/flexbox_repeater_column_width_for_height.slint
+++ b/tests/cases/layout/flexbox_repeater_column_width_for_height.slint
@@ -18,7 +18,7 @@ component WrapCol {
         flex-wrap: wrap;
         spacing: 0px;
         padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         Rectangle { width: 40px; height: 30px; background: red; }
         Rectangle { width: 40px; height: 30px; background: green; }
         Rectangle { width: 40px; height: 30px; background: blue; }
@@ -44,7 +44,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         for x in [1]: WrapCol { min-height: 70px; max-height: 70px; }
         aAnchor := Rectangle { width: 5px; height: 5px; }
@@ -56,7 +56,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         WrapCol { min-height: 70px; max-height: 70px; }
         bAnchor := Rectangle { width: 5px; height: 5px; }
@@ -69,7 +69,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         WrapCol { min-height: 70px; max-height: 70px; }
         cAnchor := Rectangle { width: 5px; height: 5px; }
@@ -83,7 +83,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         for x in [1, 2]: Rectangle { width: 0px; height: 0px; }
         WrapCol { min-height: 70px; max-height: 70px; }
@@ -98,7 +98,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         for x in [1, 2]: WrapCol { min-height: 70px; max-height: 70px; }
         eAnchor := Rectangle { width: 5px; height: 5px; }
@@ -111,7 +111,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         if true: WrapCol { min-height: 70px; max-height: 70px; }
         fAnchor := Rectangle { width: 5px; height: 5px; }
@@ -124,7 +124,7 @@ export component TestCase inherits Window {
         flex-direction: column;
         flex-wrap: wrap;
         spacing: 0px; padding: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: stretch;
         for x in empty-model: Rectangle { width: 0px; height: 0px; }
         WrapCol { min-height: 70px; max-height: 70px; }

--- a/tests/cases/layout/flexbox_repeater_row_height_for_width.slint
+++ b/tests/cases/layout/flexbox_repeater_row_height_for_width.slint
@@ -43,7 +43,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         padding: 0px; spacing: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         for s in [long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; }
         aAnchor := Rectangle { width: 150px; height: 5px; }
@@ -55,7 +55,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         padding: 0px; spacing: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         Card { label: long; flex-shrink: 0; flex-basis: 150px; }
         bAnchor := Rectangle { width: 150px; height: 5px; }
@@ -68,7 +68,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         padding: 0px; spacing: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         Card { label: long; flex-shrink: 0; flex-basis: 150px; }
         cAnchor := Rectangle { width: 150px; height: 5px; }
@@ -82,7 +82,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         padding: 0px; spacing: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         for x in [1, 2]: Rectangle { width: 0px; height: 0px; }
         Card { label: long; flex-shrink: 0; flex-basis: 150px; }
@@ -97,7 +97,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         padding: 0px; spacing: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         for s in [long, long]: Card { label: s; flex-shrink: 0; flex-basis: 150px; }
         eAnchor := Rectangle { width: 150px; height: 5px; }
@@ -110,7 +110,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         padding: 0px; spacing: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         if true: Card { label: long; flex-shrink: 0; flex-basis: 150px; }
         fAnchor := Rectangle { width: 150px; height: 5px; }
@@ -123,7 +123,7 @@ export component TestCase inherits Window {
         flex-direction: row;
         flex-wrap: wrap;
         padding: 0px; spacing: 0px;
-        align-content: start;
+        cross-axis-line-alignment: start;
         cross-axis-alignment: start;
         for x in empty-model: Rectangle { width: 0px; height: 0px; }
         Card { label: long; flex-shrink: 0; flex-basis: 150px; }

--- a/tests/cases/layout/flexbox_spacing_and_padding.slint
+++ b/tests/cases/layout/flexbox_spacing_and_padding.slint
@@ -14,7 +14,7 @@ export component TestCase inherits Window {
         border-color: black;
         border-width: 1px;
         FlexboxLayout {
-            align-content: start;
+            cross-axis-line-alignment: start;
             spacing: 5px;
             padding: 2px;
 
@@ -46,7 +46,7 @@ export component TestCase inherits Window {
         border-width: 1px;
 
         FlexboxLayout {
-            align-content: start;
+            cross-axis-line-alignment: start;
             spacing-vertical: 50px;
             spacing-horizontal: 10px;
             padding-top: 10phx;

--- a/tests/cases/layout/flexbox_varying_heights.slint
+++ b/tests/cases/layout/flexbox_varying_heights.slint
@@ -8,7 +8,7 @@ export component TestCase inherits Window {
     height: 200px;
 
     FlexboxLayout {
-        align-content: start;
+        cross-axis-line-alignment: start;
         spacing: 10px;
 
         // Row 1: items with different heights, row height = max(30, 50, 40) = 50

--- a/tests/cases/layout/flexbox_wrap.slint
+++ b/tests/cases/layout/flexbox_wrap.slint
@@ -18,7 +18,7 @@ component TestWrapRow inherits VisibleRect {
 
     FlexboxLayout {
         flex-wrap: wrap;
-        align-content: start;
+        cross-axis-line-alignment: start;
 
         r1 := Rectangle {
             width: 50px;


### PR DESCRIPTION
"align-content" is a CSS name that says nothing about what it does, and it
sits next to "cross-axis-alignment" without any hint of how the two differ.
The new name pairs them: cross-axis-alignment aligns the items within one
line, cross-axis-line-alignment distributes the lines themselves.

The enum follows: FlexboxLayoutAlignContent -> CrossAxisLineAlignment, like
the CrossAxisAlignment it pairs with. FlexboxLayout has not been in a
release yet, so this breaks no stable API.