### PR TITLE
compiler: Declare builtin member implementations in builtins.slint

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -27,6 +27,14 @@
    This only works for members that the compiler itself never accesses by name —
    no default binding, and no compiler pass that looks the name up on user elements —
    as such accesses would resolve to the shadowing declaration and generate wrong code.
+
+   Mark a property `//-constexpr` (value known at compile time)
+   or `//-fake` (exists only at compile time).
+
+   A function names its `BuiltinFunction` implementation as its body:
+   `function start() { BuiltinFunction.StartTimer }`.
+   The declaration provides the signature and the docs.
+   An empty body declares a signature handled by a compiler pass.
  */
 
  component Empty {
@@ -683,6 +691,7 @@ component ComplexText inherits SimpleText {
     /// }
     /// ```
     in property <TextStrokeStyle> stroke-style;
+    // Inserted in typeregister.rs: the default value is computed per element.
     //! ### font-metrics
     //! <SlintProperty propName="font-metrics" typeName="struct" structName="FontMetrics" propertyVisibility="out">
     //! The design metrics of the font scaled to the font pixel size used by the element.
@@ -1782,6 +1791,7 @@ export component TextInput {
     in property <bool> read-only: false;
     // Internal, undocumented property, only exposed for IME.
     out property <string> preedit-text;
+    // Inserted in typeregister.rs: the default value is computed per element.
     //! ### font-metrics
     //! <SlintProperty propName="font-metrics" typeName="struct" structName="FontMetrics" propertyVisibility="out">
     //! The design metrics of the font scaled to the font pixel size used by the element.
@@ -1790,6 +1800,7 @@ export component TextInput {
     //-accepts_focus
     /// Selects the text between two UTF-8 offsets.
     function set-selection-offsets(start: int, end: int) {
+        BuiltinFunction.SetSelectionOffsets
     }
     /// Selects all text.
     function select-all() {
@@ -2393,7 +2404,8 @@ export component Path {
     //! If non-zero, the path will be scaled to fit into the specified height.
     //! </SlintProperty>
     //!
-    in property <string> commands;  // 'fake' hardcoded in typeregister.rs
+    //-fake
+    in property <string> commands;
     /// Defines how the path's view box is scaled to fit the element's width and height.
     /// If no view box is defined, the implicit bounding rectangle is used.
     /// \default contain
@@ -2428,12 +2440,16 @@ export component Path {
     /// If a `t` outside the bounds of 0 and 1 is passed, it will be converted to its decimal fraction.
     /// Ex: 1.5 -> 0.5 and 2.0 -> 1.0. This allows for N iterations of a loop
     /// by animating t from 0 to N. If `t` is animated from N to 0, it will loop N times backwards.
-    function point-at(t: float) -> Point {}
+    function point-at(t: float) -> Point {
+        BuiltinFunction.PathPointAt
+    }
     /// Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given `t`.
     /// The tangent points in the direction the path was defined, so this reflects the path's shape and not
     /// the object's current direction of travel. Returns 0 if the path is empty.
     /// If a `t` outside the bounds of 0 and 1 is passed, the decimal fraction will be passed.
-    function angle-at(t: float) -> angle {}
+    function angle-at(t: float) -> angle {
+        BuiltinFunction.PathAngleAt
+    }
     //!
     //! ## Path Using SVG Commands
     //!
@@ -2522,6 +2538,7 @@ component Tab {
 // Note: not a native class, handled in the lower_tabs pass
 export component TabWidget {
     in-out property <int> current-index;
+    //-constexpr
     in property <Orientation> orientation;
 
     //-disallow_global_types_as_child_elements
@@ -2583,22 +2600,25 @@ export component PopupWindow {
     in property <length> anchor_y;
     in property <length> anchor_height;
     in property <length> anchor_width;*/
+    //-constexpr
     in property <bool> close-on-click;
     /// By default, a PopupWindow closes when the user clicks. Set this to false to prevent that behavior and close it manually using the `close()` function.
     /// \default close-on-click
-    in property <PopupClosePolicy> close-policy; // constexpr hardcoded in typeregister.rs
+    //-constexpr
+    in property <PopupClosePolicy> close-policy;
     /// Use this read-only property to style the element that opened the popup, for example
     /// to rotate a ComboBox's arrow while the dropdown is open.
     /// `true` while the popup is shown on the screen, and `false` once it is closed, for example
     /// when dismissed by a click, by a selection, or by a programmatic `close()`.
     out property <bool> is-open;
-    //! ## Functions
-    //!
-    //! ### show()
-    //! Show the popup on the screen.
-    //!
-    //! ### close()
-    //! Closes the popup. Use this if you set the `close-policy` property to `no-auto-close`.
+    /// Show the popup on the screen.
+    function show() {
+        BuiltinFunction.ShowPopupWindow
+    }
+    /// Closes the popup. Use this if you set the `close-policy` property to `no-auto-close`.
+    function close() {
+        BuiltinFunction.ClosePopupWindow
+    }
 }
 
 // Internal hover tracker used with `Tooltip` lowering (the compiler inserts `TooltipArea` so `Tooltip` can react to hover and pointer position).
@@ -2814,12 +2834,15 @@ export component Timer {
     callback triggered;
     /// Start the timer (equivalent to setting `running` to true).
     function start() {
+        BuiltinFunction.StartTimer
     }
     /// Stop the timer (equivalent to setting `running` to false).
     function stop() {
+        BuiltinFunction.StopTimer
     }
     /// Restarts the timer if it was previously started.
     function restart() {
+        BuiltinFunction.RestartTimer
     }
     //-is_non_item_type
     //-disallow_global_types_as_child_elements

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -22,8 +22,9 @@ use std::sync::Arc;
 pub use crate::namedreference::NamedReference;
 pub use crate::passes::resolving;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-/// A function built into the run-time
+#[derive(Debug, Clone, PartialEq, Eq, strum::EnumString)]
+/// A function built into the run-time.
+/// Member functions in `builtins.slint` bind to a variant by naming it as their body.
 pub enum BuiltinFunction {
     GetWindowScaleFactor,
     GetWindowDefaultFontSize,
@@ -119,6 +120,7 @@ pub enum BuiltinFunction {
     ParseDate,
     TextInputFocused,
     SetTextInputFocused,
+    #[strum(disabled)]
     ImplicitLayoutInfo(Orientation),
     ItemAbsolutePosition,
     RegisterCustomFontByPath,

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::expression_tree::Expression;
+use crate::expression_tree::{BuiltinFunction, Expression};
 use crate::langtype::{
     BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, BuiltinStruct, DefaultSizeBinding,
     ElementType, Function, NativeClass, Type,
@@ -37,6 +37,34 @@ pub(crate) fn load_builtins(
     }
 
     assert_eq!(node.kind(), crate::parser::SyntaxKind::Document);
+
+    // A mistyped annotation key would otherwise be silently ignored.
+    const ANNOTATION_KEYS: [&str; 10] = [
+        "accepts_focus",
+        "builtin_struct",
+        "can_be_declared_without_children_slot",
+        "constexpr",
+        "default_size_binding",
+        "disallow_global_types_as_child_elements",
+        "fake",
+        "is_internal",
+        "is_non_item_type",
+        "shadowable",
+    ];
+    if cfg!(debug_assertions) {
+        for token in node.node.descendants_with_tokens().filter_map(|t| t.into_token()) {
+            if token.kind() == SyntaxKind::Comment
+                && let Some(rest) = token.text().strip_prefix("//-")
+            {
+                let key = rest.trim_end().split(':').next().unwrap();
+                assert!(
+                    ANNOTATION_KEYS.contains(&key),
+                    "unknown annotation `//-{key}` in builtins.slint"
+                );
+            }
+        }
+    }
+
     let doc: syntax_nodes::Document = node.into();
 
     let mut natives = HashMap::<SmolStr, Rc<BuiltinElement>>::new();
@@ -97,8 +125,14 @@ pub(crate) fn load_builtins(
                         }
                     }
 
+                    if member_annotation(&p, "constexpr") {
+                        info.property_visibility = PropertyVisibility::Constexpr;
+                    } else if member_annotation(&p, "fake") {
+                        info.property_visibility = PropertyVisibility::Fake;
+                    }
+
                     info.set_docs(docs::doc_comment(&p));
-                    info.shadowable = has_shadowable_annotation(&p);
+                    info.shadowable = member_annotation(&p, "shadowable");
 
                     if let Some(e) = p.BindingExpression() {
                         assert!(!info.shadowable, "shadowable property {id}::{prop_name} can't have a default value as it would end up on the shadowing declaration");
@@ -130,7 +164,7 @@ pub(crate) fn load_builtins(
                             .collect()
                     })));
                     info.set_docs(docs::doc_comment(&s));
-                    info.shadowable = has_shadowable_annotation(&s);
+                    info.shadowable = member_annotation(&s, "shadowable");
                     (identifier_text(&s.DeclaredIdentifier()).unwrap(), info)
                 }))
         );
@@ -182,11 +216,34 @@ pub(crate) fn load_builtins(
                 args.push(object_tree::type_from_node(a.Type(), *diag.borrow_mut(), register));
                 arg_names.push(identifier_text(&a.DeclaredIdentifier()).unwrap_or_default());
             }
-            let mut info = BuiltinPropertyInfo::new(Type::Function(
-                Function { return_type, args, arg_names }.into(),
-            ));
+            let mut info = match builtin_function_body(&f, &id, &name) {
+                Some(function) => {
+                    // The BuiltinFunction type prepends implicit ElementReference arguments.
+                    let ty = function.ty();
+                    let implicit = ty.args.len().saturating_sub(args.len());
+                    debug_assert!(
+                        ty.args.len() >= args.len()
+                            && ty.args[..implicit]
+                                .iter()
+                                .all(|t| matches!(t, Type::ElementReference))
+                            && ty.args[implicit..] == args[..]
+                            && ty.return_type == return_type,
+                        "the declared signature of {id}::{name} doesn't match {function:?}: {ty:?}"
+                    );
+                    let mut merged = (*ty).clone();
+                    merged.arg_names = std::iter::repeat_n(SmolStr::default(), implicit)
+                        .chain(arg_names)
+                        .collect();
+                    let mut info = BuiltinPropertyInfo::from(function);
+                    info.ty = Type::Function(Arc::new(merged));
+                    info
+                }
+                None => BuiltinPropertyInfo::new(Type::Function(
+                    Function { return_type, args, arg_names }.into(),
+                )),
+            };
             info.set_docs(docs::doc_comment(&f));
-            info.shadowable = has_shadowable_annotation(&f);
+            info.shadowable = member_annotation(&f, "shadowable");
             (name, info)
         }));
 
@@ -299,16 +356,14 @@ fn compiled(
     e
 }
 
-/// Check for a `//-shadowable` annotation in the comments immediately before a
-/// member declaration. Marks members that a component may shadow with a local
-/// declaration of the same name.
-fn has_shadowable_annotation(node: &SyntaxNode) -> bool {
+/// Return true when the member declaration is preceded by a `//-key` comment.
+fn member_annotation(node: &SyntaxNode, key: &str) -> bool {
     let mut cursor = node.node.prev_sibling_or_token();
     while let Some(cur) = cursor {
         match cur.kind() {
             SyntaxKind::Whitespace => {}
             SyntaxKind::Comment => {
-                if cur.as_token().unwrap().text().trim_end() == "//-shadowable" {
+                if cur.as_token().unwrap().text().trim_end().strip_prefix("//-") == Some(key) {
                     return true;
                 }
             }
@@ -317,6 +372,30 @@ fn has_shadowable_annotation(node: &SyntaxNode) -> bool {
         cursor = cur.prev_sibling_or_token();
     }
     false
+}
+
+/// Return the [`BuiltinFunction`] named by a member function's body, like
+/// `function start() { BuiltinFunction.StartTimer }`. `None` for an empty body.
+fn builtin_function_body(
+    f: &syntax_nodes::Function,
+    id: &SmolStr,
+    name: &SmolStr,
+) -> Option<BuiltinFunction> {
+    let expr = f.CodeBlock()?.Expression().next()?;
+    let function = expr.QualifiedName().and_then(|qn| {
+        match QualifiedTypeName::from_node(qn).members.as_slice() {
+            [namespace, variant] if namespace == "BuiltinFunction" => {
+                variant.parse::<BuiltinFunction>().ok()
+            }
+            _ => None,
+        }
+    });
+    let Some(function) = function else {
+        panic!(
+            "the body of {id}::{name} must name the BuiltinFunction variant that implements it, like `BuiltinFunction.StartTimer`"
+        )
+    };
+    Some(function)
 }
 
 /// Find out if there are comments that starts with `//-key` and returns `None`

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 
 use crate::expression_tree::BuiltinFunction;
 use crate::langtype::{
-    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, BuiltinStruct, ElementType,
-    Enumeration, Function, PropertyLookupResult, Struct, Type,
+    BuiltinElement, BuiltinPropertyDefault, BuiltinStruct, ElementType, Enumeration, Function,
+    PropertyLookupResult, Struct, Type,
 };
 use crate::object_tree::{Component, PropertyVisibility};
 use crate::typeloader;
@@ -573,66 +573,6 @@ impl TypeRegister {
             }
         }
 
-        match &mut register.elements.get_mut("PopupWindow").unwrap() {
-            ElementType::Builtin(b) => {
-                let popup = Rc::get_mut(b).unwrap();
-                popup.properties.insert(
-                    "show".into(),
-                    BuiltinPropertyInfo::from(BuiltinFunction::ShowPopupWindow),
-                );
-
-                popup.properties.insert(
-                    "close".into(),
-                    BuiltinPropertyInfo::from(BuiltinFunction::ClosePopupWindow),
-                );
-
-                popup.properties.get_mut("close-on-click").unwrap().property_visibility =
-                    PropertyVisibility::Constexpr;
-
-                popup.properties.get_mut("close-policy").unwrap().property_visibility =
-                    PropertyVisibility::Constexpr;
-            }
-            _ => unreachable!(),
-        };
-
-        match &mut register.elements.get_mut("Timer").unwrap() {
-            ElementType::Builtin(b) => {
-                let timer = Rc::get_mut(b).unwrap();
-                // `start` / `stop` / `restart` are declared as stub
-                // functions in `builtins.slint` so their doc comments get
-                // picked up, then replaced here with the real builtin
-                // implementations. Carry the docs over onto the
-                // replacements.
-                for (name, func) in [
-                    ("start", BuiltinFunction::StartTimer),
-                    ("stop", BuiltinFunction::StopTimer),
-                    ("restart", BuiltinFunction::RestartTimer),
-                ] {
-                    let existing_docs = timer.properties.get(name).and_then(|p| p.docs.clone());
-                    let mut info = BuiltinPropertyInfo::from(func);
-                    info.docs = existing_docs;
-                    timer.properties.insert(name.into(), info);
-                }
-            }
-            _ => unreachable!(),
-        }
-
-        match &mut register.elements.get_mut("Path").unwrap() {
-            ElementType::Builtin(b) => {
-                let path = Rc::get_mut(b).unwrap();
-                for (name, func) in [
-                    ("point-at", BuiltinFunction::PathPointAt),
-                    ("angle-at", BuiltinFunction::PathAngleAt),
-                ] {
-                    let existing_docs = path.properties.get(name).and_then(|p| p.docs.clone());
-                    let mut info = BuiltinPropertyInfo::from(func);
-                    info.docs = existing_docs;
-                    path.properties.insert(name.into(), info);
-                }
-            }
-            _ => unreachable!(),
-        }
-
         let font_metrics_prop = crate::langtype::BuiltinPropertyInfo {
             property_visibility: PropertyVisibility::Output,
             default_value: BuiltinPropertyDefault::WithElement(|elem| {
@@ -650,26 +590,6 @@ impl TypeRegister {
         match &mut register.elements.get_mut("TextInput").unwrap() {
             ElementType::Builtin(b) => {
                 let text_input = Rc::get_mut(b).unwrap();
-                // Replace the stub function with the real builtin
-                // implementation, carrying over docs and arg names.
-                let existing = text_input.properties.get("set-selection-offsets");
-                let existing_docs = existing.and_then(|p| p.docs.clone());
-                let arg_names = existing.and_then(|p| {
-                    if let Type::Function(f) = &p.ty { Some(f.arg_names.clone()) } else { None }
-                });
-                let mut info = BuiltinPropertyInfo::from(BuiltinFunction::SetSelectionOffsets);
-                info.docs = existing_docs;
-                if let (Some(names), Type::Function(f)) = (arg_names, &info.ty) {
-                    let mut func = (**f).clone();
-                    // The BuiltinFunction type includes an implicit ElementReference
-                    // first arg; skip it to match the public-facing arg names.
-                    func.arg_names =
-                        std::iter::repeat_n(SmolStr::default(), func.args.len() - names.len())
-                            .chain(names)
-                            .collect();
-                    info.ty = Type::Function(Arc::new(func));
-                }
-                text_input.properties.insert("set-selection-offsets".into(), info);
                 text_input.properties.insert("font-metrics".into(), font_metrics_prop.clone());
             }
 
@@ -684,25 +604,6 @@ impl TypeRegister {
 
             _ => unreachable!(),
         };
-
-        match &mut register.elements.get_mut("Path").unwrap() {
-            ElementType::Builtin(b) => {
-                let path = Rc::get_mut(b).unwrap();
-                path.properties.get_mut("commands").unwrap().property_visibility =
-                    PropertyVisibility::Fake;
-            }
-
-            _ => unreachable!(),
-        };
-
-        match &mut register.elements.get_mut("TabWidget").unwrap() {
-            ElementType::Builtin(b) => {
-                let tabwidget = Rc::get_mut(b).unwrap();
-                tabwidget.properties.get_mut("orientation").unwrap().property_visibility =
-                    PropertyVisibility::Constexpr;
-            }
-            _ => unreachable!(),
-        }
 
         register
     }


### PR DESCRIPTION
A function in builtins.slint now binds to its native implementation by naming a BuiltinFunction variant as its body, and a property can be annotated //-constexpr or //-fake. This replaces the type register patching that overwrote the declarations and lost their documentation and argument names, so function signatures in the generated documentation now show the argument names.

The signatures declared in builtins.slint and the annotation keys are checked against the native side in debug builds.
