### PR TITLE
Make the per-item flex-* properties an experimental feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Slint's `.slint` language intentionally stays close to CSS syntax for visual pro
 Examples already in place:
 - **Color literals** follow CSS syntax (`#rrggbb`, `#rgb`, named colors, `rgb()`, `rgba()`, `hsl()`, `hsla()`).
 - **Gradient syntax** mirrors CSS: `@linear-gradient(angle, color stop, ...)`, `@radial-gradient(...)`.
-- **FlexboxLayout** implements the CSS flexbox model (via the `taffy` crate); property names map closely to their CSS counterparts.
+- **FlexboxLayout** implements the CSS flexbox model (via the `taffy` crate). Its property names follow CSS only where that doesn't clash with Slint's own naming: `gap` is `spacing`, `justify-content` is `alignment`, `align-content` is `cross-axis-line-alignment`.
 - **Filter/shadow properties** (`drop-shadow`, `box-shadow`, `blur`) follow CSS conventions.
 
 When this principle applies: any time you design syntax for a new visual or layout property, check how CSS spells it first. Deviate only when Slint's type system or consistency with existing Slint naming requires it, and document the divergence.

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -271,6 +271,10 @@ export default defineConfig({
                                                   label: "Deprecated Properties",
                                                   slug: "guide/experimental/deprecated",
                                               },
+                                              {
+                                                  label: "Flexbox Item Properties",
+                                                  slug: "guide/experimental/flexbox-item-properties",
+                                              },
                                           ],
                                       },
                                   ]

--- a/docs/astro/src/content/docs/guide/experimental/flexbox-item-properties.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/flexbox-item-properties.mdx
@@ -1,0 +1,37 @@
+---
+title: Flexbox Item Properties
+description: Experimental per-item properties for FlexboxLayout children.
+---
+
+The children of a `FlexboxLayout` can set `flex-grow`, `flex-shrink`, `flex-basis`,
+`flex-align-self` and `flex-order` to control how the layout treats them individually.
+
+> **Note**: these properties are experimental and subject to change.
+> Per-item properties shouldn't be specific to `FlexboxLayout` — they should work in
+> `HorizontalLayout`, `VerticalLayout` and `GridLayout` too, and preferably reuse the existing
+> `horizontal-stretch`/`vertical-stretch` and min/max/preferred size properties. That design
+> discussion is still open, which is why these five are not part of the stable API yet.
+> Expect them to be renamed, or replaced by the properties the other layouts already use.
+>
+> The Experimental Features overview page explains how to enable them.
+
+```slint no-test
+FlexboxLayout {
+    Rectangle { flex-grow: 1; }
+    Rectangle { flex-grow: 2; }
+}
+```
+
+Each one behaves like the CSS property of the same name, with the same default, so refer to the CSS
+flexbox documentation for what they do:
+
+| Property          | CSS property  | Default |
+| ----------------- | ------------- | ------- |
+| `flex-grow`       | `flex-grow`   | `0`     |
+| `flex-shrink`     | `flex-shrink` | `1`     |
+| `flex-basis`      | `flex-basis`  | `auto`  |
+| `flex-align-self` | `align-self`  | `auto`  |
+| `flex-order`      | `order`       | `0`     |
+
+One difference: an `auto` `flex-basis` uses the item's `preferred-width` (row direction) or
+`preferred-height` (column direction), rather than sizing it from its content.

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -1,6 +1,9 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: MIT
 
+// The per-item flex-* properties are experimental, so this needs
+// SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 in the environment of the viewer.
+
 import { ComboBox } from "std-widgets.slint";
 
 component Cell inherits Rectangle {

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2161,41 +2161,6 @@ export component HorizontalLayout {
 /// In row direction, items are placed from left to right. When the available width is exceeded, items automatically wrap to the next row. In column direction, items are placed from top to bottom and wrap to the next column when the available height is exceeded.
 ///
 /// \footer
-/// ## Per-Item Properties
-///
-/// The following properties can be set on individual children of a `FlexboxLayout`:
-///
-/// ### flex-grow
-/// <SlintProperty propName="flex-grow" typeName="float">
-/// Controls how much an item grows relative to other flex items when there is extra space along the main axis.
-/// A value of `0` (default) means the item does not grow. Items with higher values receive proportionally more extra space.
-/// </SlintProperty>
-///
-/// ### flex-shrink
-/// <SlintProperty propName="flex-shrink" typeName="float">
-/// Controls how much an item shrinks relative to other flex items when items overflow the container along the main axis.
-/// Default is `1` (matching CSS behavior). A value of `0` means the item does not shrink. Items with higher values shrink proportionally more.
-/// </SlintProperty>
-///
-/// ### flex-basis
-/// <SlintProperty propName="flex-basis" typeName="length">
-/// Sets the initial main size of a flex item before growing or shrinking is applied.
-/// If not set, the item's `preferred-width` (row) or `preferred-height` (column) is used.
-/// </SlintProperty>
-///
-/// ### flex-align-self
-/// <SlintProperty propName="flex-align-self" typeName="enum" enumName="FlexboxLayoutAlignSelf">
-/// Overrides the container's `cross-axis-alignment` for this specific item.
-/// The default value is `auto`, which inherits the container's `cross-axis-alignment` setting.
-/// </SlintProperty>
-///
-/// ### flex-order
-/// <SlintProperty propName="flex-order" typeName="int">
-/// Controls the visual order of flex items. Items with lower values appear first.
-/// Items with the same order value preserve their declaration order.
-/// The default value is `0`.
-/// </SlintProperty>
-///
 /// ## Layout Behavior
 ///
 /// The layouting algorithm for FlexboxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -498,7 +498,7 @@ fn lower_element_layout(
         None
     };
 
-    check_no_layout_properties(elem, &layout_type, parent_layout_type, diag);
+    check_no_layout_properties(elem, &layout_type, parent_layout_type, type_register, diag);
 
     match layout_type.as_ref()?.as_str() {
         "Row" => return layout_type,
@@ -2526,11 +2526,12 @@ fn recognized_layout_types() -> &'static [&'static str] {
     &["Row", "GridLayout", "HorizontalLayout", "VerticalLayout", "FlexboxLayout", "Dialog"]
 }
 
-/// Checks that there are no grid-layout specific properties used wrongly
+/// Checks that there are no layout specific properties used wrongly
 fn check_no_layout_properties(
     item: &ElementRc,
     layout_type: &Option<SmolStr>,
     parent_layout_type: &Option<SmolStr>,
+    type_register: &TypeRegister,
     diag: &mut BuildDiagnostics,
 ) {
     let elem = item.borrow();
@@ -2540,13 +2541,17 @@ fn check_no_layout_properties(
         {
             diag.push_error(format!("{prop} used outside of a GridLayout's cell"), &*expr.borrow());
         }
-        if parent_layout_type.as_deref() != Some("FlexboxLayout")
-            && matches!(
-                prop.as_ref(),
-                "flex-grow" | "flex-shrink" | "flex-basis" | "flex-align-self" | "flex-order"
-            )
-        {
-            diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
+        if matches!(
+            prop.as_ref(),
+            "flex-grow" | "flex-shrink" | "flex-basis" | "flex-align-self" | "flex-order"
+        ) {
+            if parent_layout_type.as_deref() != Some("FlexboxLayout") {
+                diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
+            } else {
+                // These are not stable API yet: whether they should rather be expressed with
+                // the properties the other layouts already use is still being discussed.
+                crate::reject_experimental_feature(diag, type_register, prop, &*expr.borrow());
+            }
         }
         if parent_layout_type.as_deref() != Some("Dialog")
             && matches!(prop.as_ref(), "dialog-button-role")

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -540,6 +540,7 @@ fn is_reserved_prop_valid(
     prop: &str,
     element_type: &ElementType,
     parent_element_type: Option<&ElementType>,
+    enable_experimental: bool,
 ) -> bool {
     let name_of = |t: &ElementType| -> Option<SmolStr> {
         match t {
@@ -559,7 +560,8 @@ fn is_reserved_prop_valid(
     if prop == "flex-align-self"
         || name_in(i_slint_compiler::typeregister::RESERVED_FLEXBOXLAYOUT_PROPERTIES)
     {
-        return parent_name == Some("FlexboxLayout");
+        // Not stable API yet, the compiler only accepts them as an experimental feature.
+        return enable_experimental && parent_name == Some("FlexboxLayout");
     }
     if name_in(i_slint_compiler::typeregister::RESERVED_DROP_SHADOW_PROPERTIES) {
         return name_of(element_type).as_deref() == Some("Rectangle");
@@ -582,6 +584,7 @@ fn properties_for_changed_callbacks(
         }
         node = node.parent()?;
     };
+    let enable_experimental = document_cache.compiler_configuration().enable_experimental;
     let global_tr = document_cache.global_type_registry();
     let tr = element
         .source_file()
@@ -612,7 +615,12 @@ fn properties_for_changed_callbacks(
             if !ty.is_property_type() {
                 return None;
             }
-            if !is_reserved_prop_valid(k, &element_type, parent_element_type.as_ref()) {
+            if !is_reserved_prop_valid(
+                k,
+                &element_type,
+                parent_element_type.as_ref(),
+                enable_experimental,
+            ) {
                 return None;
             }
             let mut c = CompletionItem::new_simple(k.into(), ty.to_string());
@@ -644,6 +652,7 @@ fn resolve_element_scope(
             }
         };
 
+    let enable_experimental = document_cache.compiler_configuration().enable_experimental;
     let global_tr = document_cache.global_type_registry();
     let tr = element
         .source_file()
@@ -750,7 +759,12 @@ fn resolve_element_scope(
                     if matches!(ty, Type::Function { .. }) {
                         return None;
                     }
-                    if !is_reserved_prop_valid(k, &element_type, parent_element_type.as_ref()) {
+                    if !is_reserved_prop_valid(
+                        k,
+                        &element_type,
+                        parent_element_type.as_ref(),
+                        enable_experimental,
+                    ) {
                         return None;
                     }
                     let c = CompletionItem::new_simple(k.into(), ty.to_string());
@@ -2910,6 +2924,35 @@ component Foo {
         // Nothing typed after `implement` at all, cut off at EOF.
         let results = get_completions_experimental("component Foo { implement 🔺").unwrap();
         assert!(results.iter().any(|completion| completion.label == "property"));
+    }
+
+    #[test]
+    fn flex_item_properties_require_experimental() {
+        let source = r#"
+export component Foo {
+    FlexboxLayout {
+        Rectangle {
+            🔺
+        }
+    }
+}
+"#;
+        let results = get_completions_experimental(source).unwrap();
+        // flex-align-self is registered separately from the other four, so check each one.
+        for prop in
+            ["flex-grow", "flex-shrink", "flex-basis", "flex-align-self", "flex-order"].iter()
+        {
+            assert!(
+                results.iter().any(|completion| completion.label == *prop),
+                "no '{prop}' completion with experimental features"
+            );
+        }
+
+        let results = get_completions(source).unwrap();
+        assert!(
+            !results.iter().any(|completion| completion.label.starts_with("flex-")),
+            "flex-* completions offered without experimental features"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Review feedback: per-item layout properties shouldn't be specific to
FlexboxLayout, they should work in the box and grid layouts too and
preferably reuse the existing stretch and min/max/preferred size
properties. Keep flex-grow, flex-shrink, flex-basis, flex-align-self and
flex-order out of the stable API until that design discussion concludes.

Only the language surface is closed: the compiler rejects them unless
experimental features are enabled, and the LSP stops completing them. The
lowering and the runtime are untouched.