### PR TITLE
c++: Update Catch2 and fix panic when invoke_from_event_loop is called first 

### DIFF
--- a/api/cpp/lib.rs
+++ b/api/cpp/lib.rs
@@ -130,6 +130,11 @@ pub unsafe extern "C" fn slint_post_event(
     unsafe impl Send for UserData {}
     let ud = UserData { user_data, drop_user_data };
 
+    // Install the default platform if none is set yet, so that posting events works even
+    // before the event loop runs. From a non-main thread this errors and the platform
+    // installed by another thread provides the event loop proxy below.
+    let _ = with_platform(|_| Ok(()));
+
     i_slint_core::api::invoke_from_event_loop(move || {
         let ud = &ud;
         event(ud.user_data);

--- a/api/cpp/tests/CMakeLists.txt
+++ b/api/cpp/tests/CMakeLists.txt
@@ -5,8 +5,11 @@ include(FetchContent)
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.8.0
+    GIT_TAG v3.15.3
 )
+
+# Some tests assert from worker threads, which plain Catch2 forbids.
+set(CATCH_CONFIG_THREAD_SAFE_ASSERTIONS ON)
 
 FetchContent_MakeAvailable(Catch2)
 


### PR DESCRIPTION
Catch2 assertion are not thread safe and we use them between thread, resulting in flaky CI sometimes.

Update Catch2 revealed a bug because it runs the test in random order, so fix bug when invoke_from_event_loop is called first