### PR TITLE
Fix shift+tab and shift+click from text inputs on web

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -99,7 +99,7 @@ muda = { version = "0.19.0", optional = true, default-features = false }
 vtable = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { workspace = true, features = ["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer", "WebGlContextEvent"] }
+web-sys = { workspace = true, features = ["HtmlInputElement", "HtmlCanvasElement", "Window", "Document", "Event", "EventTarget", "FocusEvent", "KeyboardEvent", "InputEvent", "CompositionEvent", "DomStringMap", "ClipboardEvent", "DataTransfer", "Node", "WebGlContextEvent"] }
 wasm-bindgen = { version = "0.2" }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(all(target_vendor = "apple", not(target_os = "macos")))))'.dependencies]

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -149,10 +149,22 @@ impl WasmInputHelper {
         });
 
         let win = window_adapter.clone();
-        h.add_event_listener("blur", move |_: web_sys::Event| {
+        h.add_event_listener("blur", move |e: web_sys::FocusEvent| {
             // Make sure that the window gets marked as unfocused when the focus leaves the input
             if let Some(window_adapter) = win.upgrade() {
-                if !canvas.matches(":focus").unwrap_or(false) {
+                let canvas_receiving_focus = e.related_target().is_some_and(|target| {
+                    // related_target is the element receiving focus, see https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget
+                    target
+                        .dyn_ref::<web_sys::Node>()
+                        .is_some_and(|node| canvas.is_same_node(Some(node)))
+                });
+                // the correct thing to do to see what is focused (or more accurately, *going* to
+                // be focused) during a blur event is to look at relatedTarget. Some old
+                // browsers may not implement relatedTarget correctly, so this falls back to
+                // .matches(), hoping that the browser focuses the target before dispatching
+                // the blur event
+                let canvas_already_focused = canvas.matches(":focus").unwrap_or(false);
+                if !canvas_receiving_focus && !canvas_already_focused {
                     window_adapter.window().dispatch_event(WindowEvent::WindowActiveChanged(false));
                 }
             }


### PR DESCRIPTION
Previously, focus changing between types of elements would cause window unfocused events even though focus was staying inside slint, and this would reset the keyboard modifier state. This happened because elements may not be focused during a blur event, technically we should look at relatedTarget to see whether the user is leaving an element to the canvas or to another window.

I left the old `canvas.matches(":focus")` because claude pointed out https://bugs.webkit.org/show_bug.cgi?id=254655 and https://issues.chromium.org/issues/360758693 and https://bugzilla.mozilla.org/show_bug.cgi?id=962251 to me, I guess it just seems like `relatedTarget` has had questionable support in the past although it works fine for me on all my current browsers.

Closes #7347 and (I think) also closes #8606 as I now seem to be able to shift+tab as expected as well as shift + left click to highlight text.

No test, at least not yet, not sure if there is currently a way to automatically test UIs under wasm?