### PR TITLE
slint-sc: Fail the build on coverage and traceability gaps

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -200,7 +200,10 @@ jobs:
               run: |
                   COVERAGE_FLAGS=""
                   if [ "${{ inputs['slint-sc-coverage'] }}" = "true" ]; then
-                      COVERAGE_FLAGS="--coverage-json coverage/coverage.json --coverage-html coverage/html --test-results coverage/test-results"
+                      # --fail-on-gaps holds the runtime at complete coverage and
+                      # every requirement paragraph at one test or more. It needs
+                      # the coverage export, so it only applies to these runs.
+                      COVERAGE_FLAGS="--coverage-json coverage/coverage.json --coverage-html coverage/html --test-results coverage/test-results --fail-on-gaps"
                   fi
                   cargo run --release -p slint-doc-generator -- --slint-sc $COVERAGE_FLAGS generate-mdx
             - name: "Compile Slint snippets in Markdown (doctests)"

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -197,6 +197,7 @@ jobs:
                   name: slint-sc-coverage
                   path: coverage
             - name: "Generate SC API reference"
+              id: sc-reference
               run: |
                   COVERAGE_FLAGS=""
                   if [ "${{ inputs['slint-sc-coverage'] }}" = "true" ]; then
@@ -205,7 +206,18 @@ jobs:
                       # the coverage export, so it only applies to these runs.
                       COVERAGE_FLAGS="--coverage-json coverage/coverage.json --coverage-html coverage/html --test-results coverage/test-results --fail-on-gaps"
                   fi
+                  # A gap exits 2 with the chapters written, so record it and let
+                  # the job build and upload the manual. The last step fails the
+                  # run. Any other non-zero exit is a real failure: stop here.
+                  set +e
                   cargo run --release -p slint-doc-generator -- --slint-sc $COVERAGE_FLAGS generate-mdx
+                  status=$?
+                  set -e
+                  if [ $status -eq 2 ]; then
+                      echo "gaps=true" >> "$GITHUB_OUTPUT"
+                  elif [ $status -ne 0 ]; then
+                      exit $status
+                  fi
             - name: "Compile Slint snippets in Markdown (doctests)"
               run: cargo test --manifest-path tests/Cargo.toml -p doctests
             - name: "Build Safety Manual"
@@ -245,6 +257,12 @@ jobs:
               with:
                 name: docs-astro
                 path: artifact
+            # Last, so the manual is built and uploaded before the run fails.
+            - name: "Fail on slint-sc coverage or traceability gaps"
+              if: ${{ steps.sc-reference.outputs.gaps == 'true' }}
+              run: |
+                echo "The safety manual has gaps. See the \"Generate SC API reference\" step for the list."
+                exit 1
 
     # Job 3: Build Node and Python documentation
     node-python-docs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,26 @@ cargo test -p i-slint-compiler --features display-diagnostics --test syntax_test
 SLINT_SYNTAX_TEST_UPDATE=1 cargo test -p i-slint-compiler --test syntax_tests  # Update expected errors
 ```
 
+### Slint SC (`api/slint-sc`)
+
+The safety-critical runtime is held to complete coverage and full requirement
+traceability, both enforced in CI:
+
+- Every line, function, and code region of the crate must be covered. No
+  exceptions, no exclusion list, so code no test can reach has to go.
+- Every requirement paragraph (a `{#sls.…}` anchor in an `SC: true` page,
+  inside its `<SC>` block) needs at least one test declaring it with a
+  `//#sls.…` comment. Add the test in the same change as the anchor.
+
+```sh
+scripts/slint_sc_test_suite.sh target/slint-sc-coverage   # Run the suites, measure coverage
+cargo llvm-cov report --summary-only                      # Read the coverage back
+scripts/build_safety_manual_coverage.sh                   # Full check: fails on any gap
+```
+
+The gap check is `slint-doc-generator --slint-sc --fail-on-gaps`, which names
+the source locations that never executed and the requirements without a test.
+
 ### Screenshot Tests
 ```sh
 cargo test --manifest-path tests/Cargo.toml -p test-driver-screenshots                    # Compare against references

--- a/docs/safety/src/content/docs/qualification-plan/test-cases.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/test-cases.mdx
@@ -1,9 +1,89 @@
 ---
 title: Test Cases
-description: Test cases for Slint SC.
+description: The test suites that verify Slint SC, how their cases are written, and what they establish.
 ---
-This section describes the safety critical test cases that are run as part of the qualification process.
-Each test should be described in a section here, tagged with appropriate requirement IDs.
+This chapter describes how Slint SC is tested.
+The [Traceability Matrix](/qualification-plan/traceability-matrix/) maps each requirement to the tests that verify it,
+the [Test Results](/qualification-plan/test-results/) chapter lists the outcome of running them,
+and the [Test Coverage](/qualification-plan/test-coverage/) chapter reports the structural coverage they achieve.
+All three are generated from an actual run of the suites described here.
 
-(TODO: Add test cases here)
+## The Suites
 
+Three suites run together, each verifying a different part of the toolchain.
+`scripts/slint_sc_test_suite.sh` runs all of them and collects their reports.
+
+### Compiler Syntax Tests
+
+The syntax tests in `internal/compiler/tests/syntax/slint-sc/` run the compiler in SC mode and assert its diagnostics.
+Each file pins the expected message to the exact source span that produces it:
+
+```slint
+import { Button } from "std-widgets.slint";
+//                     >                 <error{Imports are not supported in Slint SC}
+```
+
+These tests carry the weight of the subset.
+Slint SC is defined as much by what it rejects as by what it accepts,
+so each construct outside the subset has a file asserting that the compiler refuses it with a diagnostic the user can act on.
+
+### Runtime Test Cases
+
+The cases in `api/slint-sc/tests/cases/` are `.slint` files that get compiled and executed.
+For each case, the driver in `api/slint-sc/tests/driver.rs`:
+
+1. Compiles the case with `slint-compiler --slint-sc` into Rust.
+2. Extracts the test body from the fenced `rust` blocks in the case's comments.
+3. Compiles the generated code and that body with `rustc`.
+4. Runs the resulting binary.
+5. Compares any screenshots it took against the PNG references in `api/slint-sc/tests/references/`.
+
+Step 3 is itself a test.
+The runtime is the only `--extern` passed to `rustc`,
+so generated code that reaches for any other crate fails to compile rather than shipping an undeclared dependency.
+
+A block marked `compile_fail` inverts the check: it must fail to compile, with every error named by a `//~ ERROR` line present in the compiler output.
+That's how the API-level negative cases are written, such as a component that isn't exported staying unreachable:
+
+```rust
+let _ = Hidden::new();
+//~ ERROR undeclared type `Hidden`
+```
+
+The `screenshot!` macro renders the component into a fixed 64x64 RGB buffer and writes it out for the driver to compare.
+The comparison is byte for byte against the reference, with no tolerance threshold,
+which the runtime's determinism makes possible: no dynamic allocation, no external dependencies, and a caller-provided frame buffer.
+A single differing pixel fails the case.
+
+### Runtime Unit Tests
+
+The unit tests in the `slint-sc` crate cover its own API surface, such as color encoding and error formatting.
+They're `no_std` like the crate itself.
+
+## Tagging Requirements
+
+A test declares the requirements it verifies with `//#sls.…` comments naming their identifiers:
+
+```slint
+// A source file with a UTF-8 BOM is well-formed.
+//#sls.source.encoding.bom
+//#sls.source.encoding.utf8
+```
+
+Cases, syntax tests, and the Rust sources of the runtime and the compiler are all scanned for these.
+Where a requirement is enforced by Rust code rather than by a `.slint` case, the comment sits at that code.
+An identifier that matches no requirement paragraph fails the build, so a tag can't outlive the paragraph it names.
+
+## What This Establishes
+
+The evidence runs in two directions, and the build enforces both.
+
+From the requirements down, every requirement paragraph in the specification and the API reference is declared by at least one test.
+A paragraph without one fails the build, so the Traceability Matrix can't develop gaps as the subset grows.
+
+From the code up, every line, function, and code region of the runtime is executed by the suites.
+Coverage is measured on the runtime alone, since that's the code that ships in the product, and the build fails below 100% with no exceptions.
+Nothing reaches a product binary unexercised.
+
+Together they close the loop: the first direction shows the specified behavior is tested,
+the second shows there's no behavior in the runtime beyond what those tests reach.

--- a/docs/safety/src/content/docs/qualification-plan/test-cases.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/test-cases.mdx
@@ -36,7 +36,7 @@ For each case, the driver in `api/slint-sc/tests/driver.rs`:
 2. Extracts the test body from the fenced `rust` blocks in the case's comments.
 3. Compiles the generated code and that body with `rustc`.
 4. Runs the resulting binary.
-5. Compares any screenshots it took against the PNG references in `api/slint-sc/tests/references/`.
+5. Compares the screenshots the case took, if it took any, against the PNG references in `api/slint-sc/tests/references/`.
 
 Step 3 is itself a test.
 The runtime is the only `--extern` passed to `rustc`,
@@ -50,7 +50,8 @@ let _ = Hidden::new();
 //~ ERROR undeclared type `Hidden`
 ```
 
-The `screenshot!` macro renders the component into a fixed 64x64 RGB buffer and writes it out for the driver to compare.
+A case that verifies what the runtime draws calls the `screenshot!` macro, which renders the component into a fixed 64x64 RGB buffer and writes it out for the driver to compare.
+Others assert in Rust alone and take no screenshot.
 The comparison is byte for byte against the reference, with no tolerance threshold,
 which the runtime's determinism makes possible: no dynamic allocation, no external dependencies, and a caller-provided frame buffer.
 A single differing pixel fails the case.

--- a/docs/slint-doc-generator/coverage.rs
+++ b/docs/slint-doc-generator/coverage.rs
@@ -70,6 +70,9 @@ struct FileCoverage {
     path: String,
     summary: Summary,
     fn_stats: FnStats,
+    /// Start of each code region that never executed, in document order, for
+    /// pointing at the gap rather than only counting it.
+    uncovered_regions: Vec<(u64, u64)>,
 }
 
 /// The llvm-cov HTML report installed under the site's `public/` directory,
@@ -95,7 +98,10 @@ impl DetailReport {
     }
 }
 
-pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
+/// Writes the chapter and returns the gaps it shows: the files that aren't
+/// completely covered. A build without a coverage export measures nothing, so
+/// it reports no gaps.
+pub fn generate(cfg: &Config) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let mut out = cfg.qualification_page(PAGE_FILE)?;
 
     writeln!(
@@ -113,7 +119,10 @@ A function counts as fully tested when every code region in it was executed, as 
     )?;
 
     match &cfg.coverage_json {
-        None => write_placeholder(&mut out)?,
+        None => {
+            write_placeholder(&mut out)?;
+            Ok(Vec::new())
+        }
         Some(json) => {
             let text = std::fs::read_to_string(json)
                 .context(format!("error reading coverage export {json:?}"))?;
@@ -137,9 +146,43 @@ A function counts as fully tested when every code region in it was executed, as 
             }
             let sha = crate::traceability::git_head(&crate::root_dir());
             write_report(&mut out, &files, &sha, detail.as_ref())?;
+            Ok(shortfalls(&files))
         }
     }
-    Ok(())
+}
+
+/// The files that aren't completely covered, one message per file naming the
+/// metrics that fall short and where the code that never executed is. The
+/// qualification plan admits no exceptions, so any shortfall is a gap.
+fn shortfalls(files: &[FileCoverage]) -> Vec<String> {
+    let mut gaps = Vec::new();
+    for f in files {
+        let metrics = [
+            ("line", &f.summary.lines),
+            ("function", &f.summary.functions),
+            ("region", &f.summary.regions),
+        ];
+        let short: Vec<String> = metrics
+            .iter()
+            .filter(|(_, c)| c.covered < c.count)
+            .map(|(name, c)| format!("{name} coverage {}", c.cell()))
+            .collect();
+        if short.is_empty() {
+            continue;
+        }
+        let mut msg = format!("{}: {}", f.path, short.join(", "));
+        if !f.uncovered_regions.is_empty() {
+            let at: Vec<String> = f
+                .uncovered_regions
+                .iter()
+                .map(|(line, col)| format!("{}:{line}:{col}", f.path))
+                .collect();
+            msg.push_str("; never executed at ");
+            msg.push_str(&at.join(", "));
+        }
+        gaps.push(msg);
+    }
+    gaps
 }
 
 /// Body of the chapter in a build without a coverage export, e.g. the
@@ -177,6 +220,7 @@ fn parse_export(text: &str) -> anyhow::Result<Vec<FileCoverage>> {
             path,
             summary: parse_summary(summary)?,
             fn_stats: FnStats::default(),
+            uncovered_regions: Vec::new(),
         });
     }
     anyhow::ensure!(!files.is_empty(), "no repository-relative files in the coverage export");
@@ -221,14 +265,21 @@ fn parse_fn_stats(data: &Value, files: &mut [FileCoverage]) -> anyhow::Result<()
         }
     }
     for ((idx, _), counts) in merged {
-        let stats = &mut files[idx].fn_stats;
+        let file = &mut files[idx];
         if counts.values().all(|c| *c == 0) {
-            stats.untested += 1;
+            file.fn_stats.untested += 1;
         } else if counts.values().all(|c| *c > 0) {
-            stats.full += 1;
+            file.fn_stats.full += 1;
         } else {
-            stats.partial += 1;
+            file.fn_stats.partial += 1;
         }
+        file.uncovered_regions.extend(
+            counts.iter().filter(|(_, c)| **c == 0).map(|((line, col, ..), _)| (*line, *col)),
+        );
+    }
+    for file in files.iter_mut() {
+        file.uncovered_regions.sort_unstable();
+        file.uncovered_regions.dedup();
     }
     Ok(())
 }
@@ -404,6 +455,37 @@ fn write_report(
 }
 
 #[test]
+fn test_shortfalls() {
+    let file = |path: &str, covered: u64, uncovered_regions: &[(u64, u64)]| FileCoverage {
+        path: path.into(),
+        summary: Summary {
+            lines: Counts { count: 10, covered },
+            functions: Counts { count: 2, covered: 2 },
+            regions: Counts { count: 10, covered },
+        },
+        fn_stats: FnStats::default(),
+        uncovered_regions: uncovered_regions.to_vec(),
+    };
+
+    // A completely covered file is no gap.
+    assert!(shortfalls(&[file("api/slint-sc/lib.rs", 10, &[])]).is_empty());
+
+    // A shortfall names the metrics that fall short and where the code that
+    // never executed is; the complete metric isn't mentioned.
+    let gaps = shortfalls(&[file("api/slint-sc/lib.rs", 8, &[(30, 1)])]);
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert_eq!(
+        gaps[0],
+        "api/slint-sc/lib.rs: line coverage 80.0% (8/10), region coverage 80.0% (8/10); \
+         never executed at api/slint-sc/lib.rs:30:1"
+    );
+    assert!(!gaps[0].contains("function coverage"), "{}", gaps[0]);
+
+    // Every incomplete file is reported, not just the first.
+    assert_eq!(shortfalls(&[file("a.rs", 8, &[]), file("b.rs", 9, &[])]).len(), 2);
+}
+
+#[test]
 fn test_cell() {
     assert_eq!(Counts { count: 0, covered: 0 }.cell(), "-");
     assert_eq!(Counts { count: 252, covered: 240 }.cell(), "95.2% (240/252)");
@@ -473,6 +555,10 @@ fn test_parse_export() {
     let stats = files[0].fn_stats;
     assert_eq!((stats.full, stats.partial, stats.untested), (1, 1, 1));
     assert_eq!(fn_stats_sentence(&stats), "1 fully tested, 1 partially tested, 1 untested");
+
+    // `b`'s unexecuted region and `c`, which never ran, are located for the
+    // gap message; `a`'s regions all executed once merged.
+    assert_eq!(files[0].uncovered_regions, [(12, 1), (30, 1)]);
 
     // An export without any repository file is an error, not an empty page.
     let empty = r#"{"data": [{"files": [], "totals": {}}]}"#;

--- a/docs/slint-doc-generator/main.rs
+++ b/docs/slint-doc-generator/main.rs
@@ -44,6 +44,13 @@ struct Cli {
     #[arg(long, value_name = "DIR")]
     test_results: Option<PathBuf>,
 
+    /// Fail instead of only reporting when the safety manual shows a gap: a
+    /// runtime source file below 100% line, function, or region coverage, or a
+    /// requirement paragraph that no test declares. Requires a coverage export
+    /// to check the coverage half against.
+    #[arg(long, action, requires = "coverage_json")]
+    fail_on_gaps: bool,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -92,6 +99,10 @@ pub struct Config {
     /// safety manual's Test Results chapter; without them the chapter is a
     /// placeholder.
     pub test_results: Option<PathBuf>,
+    /// Turn the gaps the generated chapters report into an error, so a change
+    /// can't land while the runtime is below 100% coverage or a requirement
+    /// has no test.
+    pub fail_on_gaps: bool,
 }
 
 /// Path of the generated content root, relative to the site's `src` directory.
@@ -111,6 +122,7 @@ impl Config {
             coverage_json: None,
             coverage_html: None,
             test_results: None,
+            fail_on_gaps: false,
         }
     }
     pub fn safety_manual(include_experimental: bool) -> Self {
@@ -124,6 +136,7 @@ impl Config {
             coverage_json: None,
             coverage_html: None,
             test_results: None,
+            fail_on_gaps: false,
         }
     }
 
@@ -175,6 +188,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cfg.coverage_json = args.coverage_json;
     cfg.coverage_html = args.coverage_html;
     cfg.test_results = args.test_results;
+    cfg.fail_on_gaps = args.fail_on_gaps;
 
     match args.command {
         Some(Command::GenerateMdx) => {

--- a/docs/slint-doc-generator/main.rs
+++ b/docs/slint-doc-generator/main.rs
@@ -44,10 +44,11 @@ struct Cli {
     #[arg(long, value_name = "DIR")]
     test_results: Option<PathBuf>,
 
-    /// Fail instead of only reporting when the safety manual shows a gap: a
+    /// Exit with [`GAPS_EXIT_CODE`] when the safety manual shows a gap: a
     /// runtime source file below 100% line, function, or region coverage, or a
-    /// requirement paragraph that no test declares. Requires a coverage export
-    /// to check the coverage half against.
+    /// requirement paragraph that no test declares. The pages are written and
+    /// the site is built either way. Requires a coverage export to check the
+    /// coverage half against.
     #[arg(long, action, requires = "coverage_json")]
     fail_on_gaps: bool,
 
@@ -99,10 +100,6 @@ pub struct Config {
     /// safety manual's Test Results chapter; without them the chapter is a
     /// placeholder.
     pub test_results: Option<PathBuf>,
-    /// Turn the gaps the generated chapters report into an error, so a change
-    /// can't land while the runtime is below 100% coverage or a requirement
-    /// has no test.
-    pub fail_on_gaps: bool,
 }
 
 /// Path of the generated content root, relative to the site's `src` directory.
@@ -122,7 +119,6 @@ impl Config {
             coverage_json: None,
             coverage_html: None,
             test_results: None,
-            fail_on_gaps: false,
         }
     }
     pub fn safety_manual(include_experimental: bool) -> Self {
@@ -136,7 +132,6 @@ impl Config {
             coverage_json: None,
             coverage_html: None,
             test_results: None,
-            fail_on_gaps: false,
         }
     }
 
@@ -177,7 +172,12 @@ fn build_astro(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// Exit code of a run that found gaps, distinct from the `1` of a run that
+/// failed. Everything is written and built by then, so a caller can publish
+/// the documentation it produced and still fail its build afterwards.
+pub const GAPS_EXIT_CODE: u8 = 2;
+
+fn main() -> Result<std::process::ExitCode, Box<dyn std::error::Error>> {
     let args = Cli::parse();
     let experimental = args.experimental;
     let mut cfg = if args.slint_sc {
@@ -188,11 +188,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cfg.coverage_json = args.coverage_json;
     cfg.coverage_html = args.coverage_html;
     cfg.test_results = args.test_results;
-    cfg.fail_on_gaps = args.fail_on_gaps;
 
+    let mut gaps = Vec::new();
     match args.command {
         Some(Command::GenerateMdx) => {
-            mdx::generate(&cfg)?;
+            gaps = mdx::generate(&cfg)?;
         }
         Some(Command::Screenshots(args)) => {
             screenshots::run(args)?;
@@ -202,7 +202,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         None => {
             // Generate mdx first because screenshots reads them.
-            mdx::generate(&cfg)?;
+            gaps = mdx::generate(&cfg)?;
             if !cfg.skip_screenshots {
                 let docs_folder = cfg.astro_dir.join("src/content");
                 let reference_elements = cfg.astro_dir.join("src/content/docs/reference/elements");
@@ -219,5 +219,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    Ok(())
+    if args.fail_on_gaps && !gaps.is_empty() {
+        eprintln!("error: the safety manual has {} gap(s):", gaps.len());
+        for gap in &gaps {
+            eprintln!("  {gap}");
+        }
+        eprintln!(
+            "the runtime must stay completely covered and every requirement must be declared by a test"
+        );
+        return Ok(std::process::ExitCode::from(GAPS_EXIT_CODE));
+    }
+
+    Ok(std::process::ExitCode::SUCCESS)
 }

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -42,9 +42,22 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if cfg.sc_only {
-        crate::traceability::generate(cfg)?;
-        crate::coverage::generate(cfg)?;
+        // Both chapters are written before any gap is reported, so the failure
+        // lists every gap at once and the generated pages are there to inspect.
+        let mut gaps = crate::traceability::generate(cfg)?;
+        gaps.extend(crate::coverage::generate(cfg)?);
         crate::test_results::generate(cfg)?;
+        if cfg.fail_on_gaps && !gaps.is_empty() {
+            eprintln!("error: the safety manual has {} gap(s):", gaps.len());
+            for gap in &gaps {
+                eprintln!("  {gap}");
+            }
+            return Err(anyhow::anyhow!(
+                "{} gap(s): the runtime must stay completely covered and every requirement must be declared by a test",
+                gaps.len()
+            )
+            .into());
+        }
     }
 
     Ok(())

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -13,8 +13,11 @@ fn is_generated_dir(dir: &std::path::Path, astro_dir: &std::path::Path) -> bool 
     dir.starts_with(astro_dir) && dir.file_name().is_some_and(|name| name == "generated")
 }
 
-/// Generate all markdown/mdx documentation files.
-pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
+/// Generate all markdown/mdx documentation files, and return the gaps the
+/// safety manual shows: the runtime files that aren't completely covered and
+/// the requirement paragraphs that no test declares. Every page is written
+/// first, so a build can publish the manual and act on the gaps afterwards.
+pub fn generate(cfg: &Config) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     // Start from an empty directory: a page left behind by an earlier run
     // (of a version that named or grouped it differently) still renders, and
     // its paragraph ids still count as duplicates of the current ones.
@@ -41,26 +44,14 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         write_builtin_structs_and_enums(cfg, &structs, &enums)?;
     }
 
+    let mut gaps = Vec::new();
     if cfg.sc_only {
-        // Both chapters are written before any gap is reported, so the failure
-        // lists every gap at once and the generated pages are there to inspect.
-        let mut gaps = crate::traceability::generate(cfg)?;
+        gaps = crate::traceability::generate(cfg)?;
         gaps.extend(crate::coverage::generate(cfg)?);
         crate::test_results::generate(cfg)?;
-        if cfg.fail_on_gaps && !gaps.is_empty() {
-            eprintln!("error: the safety manual has {} gap(s):", gaps.len());
-            for gap in &gaps {
-                eprintln!("  {gap}");
-            }
-            return Err(anyhow::anyhow!(
-                "{} gap(s): the runtime must stay completely covered and every requirement must be declared by a test",
-                gaps.len()
-            )
-            .into());
-        }
     }
 
-    Ok(())
+    Ok(gaps)
 }
 
 /// An enum documented on its own type page rather than in the Builtin Enums list.

--- a/docs/slint-doc-generator/traceability.rs
+++ b/docs/slint-doc-generator/traceability.rs
@@ -120,7 +120,9 @@ impl TestRef {
     }
 }
 
-pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
+/// Writes the matrix and returns the gaps it shows: the requirement
+/// paragraphs that no test declares.
+pub fn generate(cfg: &Config) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let root = crate::root_dir();
     let mut spec_pages = scan_spec_pages(&root.join(SPEC_DIR))?;
     spec_pages.extend(scan_property_type_pages(&root)?);
@@ -149,7 +151,28 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    write_matrix(cfg, &root, &spec_pages, &reference_pages, &safety_pages, &tests_by_id)
+    let page_sets: [&[SpecPage]; 3] = [&spec_pages, &reference_pages, &safety_pages];
+    let gaps = uncovered(&page_sets, &tests_by_id);
+    write_matrix(cfg, &root, &spec_pages, &reference_pages, &safety_pages, &tests_by_id)?;
+    Ok(gaps)
+}
+
+/// The requirement paragraphs no test declares -- the ❌ rows of the matrix --
+/// one message per paragraph. Informative paragraphs state no requirement, so
+/// they need no test and don't count.
+fn uncovered(page_sets: &[&[SpecPage]], tests_by_id: &HashMap<&str, Vec<&TestRef>>) -> Vec<String> {
+    let mut gaps = Vec::new();
+    for page in page_sets.iter().flat_map(|set| set.iter()) {
+        for (id, line) in &page.anchors {
+            if !informative(id) && !tests_by_id.contains_key(id.as_str()) {
+                gaps.push(format!(
+                    "{}:{line}: requirement `{id}` is declared by no test; reference it from a test with a `//#{id}` comment",
+                    page.file
+                ));
+            }
+        }
+    }
+    gaps
 }
 
 /// Validate the parsed pages and test references, returning one message per
@@ -754,6 +777,33 @@ fn test_check_reports_all_errors() {
     let errors = check(&[&clean_pages, &reference], &[test_ref("sls.ref.covered", "t.slint", 1)]);
     assert_eq!(errors.len(), 1);
     assert!(errors[0].contains("{#sls.one}"), "{}", errors[0]);
+}
+
+#[test]
+fn test_uncovered() {
+    let page = SpecPage {
+        file: "spec/chapter.md".into(),
+        title: String::new(),
+        base: String::new(),
+        top_level: false,
+        anchors: [("sls.tested", 5), ("sls.untested", 9), ("sls.meta.note", 12)]
+            .map(|(id, line)| (id.to_string(), line))
+            .into(),
+        draft: false,
+        sc: false,
+        normative: true,
+    };
+    let test_ref =
+        TestRef { id: "sls.tested".into(), file: "t.slint".into(), line: 1, kind: &TEST_ROOTS[0] };
+    let tests_by_id = HashMap::from([("sls.tested", vec![&test_ref])]);
+
+    // The informative paragraph needs no test, so only `sls.untested` is a gap.
+    let gaps = uncovered(&[&[page]], &tests_by_id);
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("spec/chapter.md:9"), "{}", gaps[0]);
+    assert!(gaps[0].contains("sls.untested"), "{}", gaps[0]);
+
+    assert!(uncovered(&[], &tests_by_id).is_empty());
 }
 
 #[test]

--- a/scripts/build_safety_manual_coverage.sh
+++ b/scripts/build_safety_manual_coverage.sh
@@ -9,6 +9,9 @@
 # manual's content, and builds the site into docs/safety/dist/.
 # An HTML report with per-line detail is also written for local inspection.
 #
+# Fails when the runtime isn't completely covered or a requirement paragraph
+# is declared by no test, so run this before pushing a change to slint-sc.
+#
 # Requires cargo-llvm-cov, the llvm-tools-preview rustup component, and pnpm.
 
 set -euo pipefail
@@ -22,6 +25,7 @@ cargo run -p slint-doc-generator -- --slint-sc \
     --coverage-json "$coverage_dir/coverage.json" \
     --coverage-html "$coverage_dir/html" \
     --test-results "$coverage_dir/test-results" \
+    --fail-on-gaps \
     generate-mdx
 
 pnpm install --frozen-lockfile --ignore-scripts

--- a/scripts/build_safety_manual_coverage.sh
+++ b/scripts/build_safety_manual_coverage.sh
@@ -21,15 +21,28 @@ coverage_dir=target/slint-sc-coverage
 
 scripts/slint_sc_test_suite.sh "$coverage_dir"
 
+# A gap exits 2 with the chapters written, so build the manual before failing:
+# the reports of the run that found the gap are then there to look at.
+set +e
 cargo run -p slint-doc-generator -- --slint-sc \
     --coverage-json "$coverage_dir/coverage.json" \
     --coverage-html "$coverage_dir/html" \
     --test-results "$coverage_dir/test-results" \
     --fail-on-gaps \
     generate-mdx
+status=$?
+set -e
+if [ $status -ne 0 ] && [ $status -ne 2 ]; then
+    exit $status
+fi
 
 pnpm install --frozen-lockfile --ignore-scripts
 pnpm -C docs/safety build
 
 echo "Safety manual built in docs/safety/dist/"
 echo "Detailed HTML coverage report in $coverage_dir/html/"
+
+if [ $status -eq 2 ]; then
+    echo "The safety manual has gaps; see the generator output above." >&2
+    exit 1
+fi


### PR DESCRIPTION
The safety manual reported the runtime's code coverage and the requirement traceability, but nothing acted on either. A drop below complete coverage, or a requirement paragraph that no test declares, only showed up as a number or a marker in the published manual.

slint-doc-generator --slint-sc --fail-on-gaps now turns both into errors, naming the source locations that never executed and the requirements without a test. The docs CI job and scripts/build_safety_manual_coverage.sh pass the flag whenever they measure coverage, so a change to the runtime can't land while it's below 100% line, function, and region coverage, or while the traceability matrix has a gap.

The Test Cases chapter of the qualification plan replaces its placeholder with a description of the three test suites, how their cases are written, and what they establish.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
