### PR TITLE
slint-sc: add the int type

### DIFF
--- a/api/slint-sc/tests/cases/component/properties.slint
+++ b/api/slint-sc/tests/cases/component/properties.slint
@@ -8,6 +8,8 @@ export component TestCase inherits Window {
     out property <color> shade: #12345678;
     in-out property <length> offset;
     property <color> internal: #ff0000;
+    in property <int> count: 42;
+    in-out property <int> counter;
 }
 
 /*
@@ -39,6 +41,15 @@ assert_eq!(x.get_offset(), 7);
 x.set_tint(slint_sc::Color::from_rgb_u8(1, 2, 3));
 let tint = x.get_tint();
 assert_eq!((tint.red(), tint.green(), tint.blue(), tint.alpha()), (1, 2, 3, 0xff));
+
+// A whole number without a unit is an `int` literal; the default `int` is zero.
+//#sls.type.int
+//#sls.expr.int.form
+//#sls.expr.int.type
+assert_eq!(x.get_count(), 42);
+assert_eq!(x.get_counter(), 0);
+x.set_counter(9);
+assert_eq!(x.get_counter(), 9);
 ```
 
 An out property has no setter:

--- a/docs/astro/src/content/docs/reference/language/expressions.mdx
+++ b/docs/astro/src/content/docs/reference/language/expressions.mdx
@@ -8,7 +8,7 @@ import SC from '@slint/common-files/src/components/SC.astro';
 import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
 
 <OnlyInSC>
-An expression is a color literal, a length literal, or a property reference. \{#sls.expr.forms}
+An expression is a color literal, a length literal, an integer literal, or a property reference. \{#sls.expr.forms}
 </OnlyInSC>
 
 An expression produces a value.
@@ -55,7 +55,7 @@ export component Example inherits Window {
 The number shall be integral: `10.5px` is an error. \{#sls.expr.length.integral}
 
 `px` is the only unit.
-A number literal with another unit, or without a unit, is an error. \{#sls.expr.length.px-only}
+A number literal with another unit is an error. \{#sls.expr.length.px-only}
 </OnlyInSC>
 
 The number may be fractional, as in `10.5px`.
@@ -63,6 +63,16 @@ Length units include `px`, `phx`, `cm`, `mm`, `in`, `pt`, and `rem`.
 
 <SC>
 A length literal evaluates to a value of type `length`. \{#sls.expr.length.type}
+
+## Integer Literals
+
+An integer literal is a whole number written without a unit, for example `42`. \{#sls.expr.int.form}
+
+An integer literal evaluates to a value of type `int`. \{#sls.expr.int.type}
+
+<OnlyInSC>
+A number with a fractional part but no unit is an error. \{#sls.expr.int.fractional}
+</OnlyInSC>
 
 ## References
 

--- a/docs/astro/src/content/docs/reference/language/properties.mdx
+++ b/docs/astro/src/content/docs/reference/language/properties.mdx
@@ -54,7 +54,7 @@ Properties can be declared on any element.
 
 <SC>
 <OnlyInSC>
-The declared type shall be `length` or `color`. \{#sls.prop.decl.types}
+The declared type shall be `int`, `length`, or `color`. \{#sls.prop.decl.types}
 </OnlyInSC>
 </SC>
 

--- a/docs/astro/src/content/docs/reference/property-types/numeric-types.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/numeric-types.mdx
@@ -67,12 +67,14 @@ for example `(-10).abs()` or `x.round()`.
 
 Returns a string representation of the number but not localized. This means the decimal separator will always be a dot.
 
+<SC>
+
 ### int
 <SlintProperty propName="int" typeName="int" defaultValue='0'>
 Signed integral number.
 </SlintProperty>
 
-<SC>
+The default `int` is zero. \{#sls.type.int}
 
 ### length
 <SlintProperty propName="length" typeName="length" defaultValue='0px'>

--- a/docs/safety/src/content/docs/reference/generated-code.mdx
+++ b/docs/safety/src/content/docs/reference/generated-code.mdx
@@ -78,5 +78,6 @@ The Rust type `T` of a property maps from its Slint type:
 
 | Slint type | Rust type |
 | --- | --- |
+| `int` | `i32` |
 | `color` | `slint_sc::Color` |
 | `length` | `i32` |

--- a/internal/compiler/generator/slint_sc.rs
+++ b/internal/compiler/generator/slint_sc.rs
@@ -176,7 +176,7 @@ fn declared_properties(root: &ElementRc) -> Vec<DeclaredProperty> {
 /// The Rust type holding a value of the given Slint type.
 fn rust_type(ty: &Type) -> TokenStream {
     match ty {
-        Type::LogicalLength => quote!(i32),
+        Type::Int32 | Type::LogicalLength => quote!(i32),
         Type::Color => quote!(slint_sc::Color),
         // brush is not a declarable property type, and every other type was
         // rejected by the compiler
@@ -187,7 +187,7 @@ fn rust_type(ty: &Type) -> TokenStream {
 /// The Rust value a property of the given type defaults to.
 fn default_value(ty: &Type) -> TokenStream {
     match ty {
-        Type::LogicalLength => quote!(0i32),
+        Type::Int32 | Type::LogicalLength => quote!(0i32),
         Type::Color => quote!(slint_sc::Color::default()),
         _ => unreachable!(),
     }
@@ -210,6 +210,9 @@ fn compile_expression(expr: &Expression, root: &ElementRc) -> TokenStream {
             }
             from => compile_expression(from, root),
         },
+        // A unit-less literal is `float`-typed and cast to `int` where an `int`
+        // is expected; it lowers to the same `i32`.
+        Expression::Cast { from, to: Type::Int32 } => compile_expression(from, root),
         Expression::PropertyReference(nr) => {
             // An unbound property has its type's default value.
             compile_property_reference(nr, root).unwrap_or_else(|| default_value(&nr.ty()))

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -195,7 +195,7 @@ impl Type {
     /// Whether the type is part of the Slint SC subset
     #[cfg(feature = "slint-sc")]
     pub fn is_slint_sc(&self) -> bool {
-        matches!(self, Self::LogicalLength | Self::Color)
+        matches!(self, Self::Int32 | Self::LogicalLength | Self::Color)
     }
 
     /// valid type for properties

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -571,10 +571,12 @@ impl Expression {
                                             .diag
                                             .slint_sc_error("Non-integral lengths are", &token),
                                         WrittenUnit::Px => {}
-                                        WrittenUnit::None => ctx.diag.slint_sc_error(
-                                            "Number literals without a unit are",
-                                            &token,
-                                        ),
+                                        // A unit-less integer is an `int` literal; a
+                                        // fractional one would be a `float`.
+                                        WrittenUnit::None if value.fract() != 0. => ctx
+                                            .diag
+                                            .slint_sc_error("Non-integral numbers are", &token),
+                                        WrittenUnit::None => {}
                                         _ => ctx.diag.slint_sc_error(
                                             &format!("Number literals with the unit '{unit}' are"),
                                             &token,

--- a/internal/compiler/tests/syntax/slint-sc/animations.slint
+++ b/internal/compiler/tests/syntax/slint-sc/animations.slint
@@ -5,7 +5,6 @@
 
 export component Test inherits Window {
     in-out property <int> val;
-//                   > <error{The type 'int' is not supported in Slint SC}
     animate val { duration: 100ms; }
 //  >                              <error{Animations are not supported in Slint SC}
 //                >      <^error{The property 'duration' is not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/bindings.slint
@@ -12,7 +12,6 @@ export component Test inherits Window {
         width: 100px;
         opacity: 1.0;
 //      >     <error{The property 'opacity' is not supported in Slint SC}
-//               > <^error{Number literals without a unit are not supported in Slint SC}
         //#sls.expr.forms
         background: red;
 //                  > <error{Identifier references are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
+++ b/internal/compiler/tests/syntax/slint-sc/change_callbacks.slint
@@ -5,8 +5,6 @@
 
 export component Test inherits Window {
     in-out property <int> val: 0;
-//                   > <error{The type 'int' is not supported in Slint SC}
-//                             ^^error{Number literals without a unit are not supported in Slint SC}
     changed val => { }
 //  >error{Change callbacks are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/expressions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/expressions.slint
@@ -1,32 +1,22 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// All expressions are rejected in Slint SC mode.
+// The expression forms outside the Slint SC subset are rejected; the literals
+// and property references they contain are accepted.
 
 export component Test inherits Window {
-    // number literals
     property <int> a: 42;
-//            > <error{The type 'int' is not supported in Slint SC}
-//                    ><^error{Number literals without a unit are not supported in Slint SC}
     // binary expressions and identifier references
     property <int> b: a + 1;
-//            > <error{The type 'int' is not supported in Slint SC}
-//                    >   <^error{Binary expressions are not supported in Slint SC}
-//                    ><^^error{Identifier references are not supported in Slint SC}
-//                        ^^^^error{Number literals without a unit are not supported in Slint SC}
+//                    >   <error{Binary expressions are not supported in Slint SC}
     // comparison
     property <bool> c: a > 0;
 //            >  <error{The type 'bool' is not supported in Slint SC}
 //                     >   <^error{Binary expressions are not supported in Slint SC}
-//                     ><^^error{Identifier references are not supported in Slint SC}
-//                         ^^^^error{Number literals without a unit are not supported in Slint SC}
     // conditional (ternary)
     property <int> d: c ? 1 : 0;
-//            > <error{The type 'int' is not supported in Slint SC}
-//                    >       <^error{Conditional expressions are not supported in Slint SC}
-//                    ><^^error{Identifier references are not supported in Slint SC}
-//                        ^^^^error{Number literals without a unit are not supported in Slint SC}
-//                            ^^^^^error{Number literals without a unit are not supported in Slint SC}
+//                    >       <error{Conditional expressions are not supported in Slint SC}
+//                    ><^error{Identifier references are not supported in Slint SC}
     // string literals
     property <string> e: "hello";
 //            >    <error{The type 'string' is not supported in Slint SC}
@@ -35,14 +25,11 @@ export component Test inherits Window {
     property <string> f: "val: \{a}";
 //            >    <error{The type 'string' is not supported in Slint SC}
 //                       >         <^error{String interpolation expressions are not supported in Slint SC}
-//                               ^^^error{Identifier references are not supported in Slint SC}
     // color literals
     property <color> g: #ff0000;
     // unary expressions
     property <int> h: -a;
-//            > <error{The type 'int' is not supported in Slint SC}
-//                    ><^error{Unary expressions are not supported in Slint SC}
-//                     ^^^error{Identifier references are not supported in Slint SC}
+//                    ><error{Unary expressions are not supported in Slint SC}
     // @image-url
     property <image> i: @image-url("");
 //            >   <error{The type 'image' is not supported in Slint SC}
@@ -61,38 +48,22 @@ export component Test inherits Window {
     // array expression
     property <[int]> l: [1, 2, 3];
 //            >   <error{Array types are not supported in Slint SC}
-//             > <^error{The type 'int' is not supported in Slint SC}
-//                      >       <^^error{Array expressions are not supported in Slint SC}
-//                       ^^^^error{Number literals without a unit are not supported in Slint SC}
-//                          ^^^^^error{Number literals without a unit are not supported in Slint SC}
-//                             ^^^^^^error{Number literals without a unit are not supported in Slint SC}
+//                      >       <^error{Array expressions are not supported in Slint SC}
     // object literal
     property <{x: int, y: int}> m: { x: 1, y: 2 };
 //            >              <error{Inline struct types are not supported in Slint SC}
-//                > <^error{The type 'int' is not supported in Slint SC}
-//                        > <^^error{The type 'int' is not supported in Slint SC}
-//                                 >            <^^^error{Object literal expressions are not supported in Slint SC}
-//                                      ^^^^^error{Number literals without a unit are not supported in Slint SC}
-//                                            ^^^^^^error{Number literals without a unit are not supported in Slint SC}
+//                                 >            <^error{Object literal expressions are not supported in Slint SC}
     // member access
     property <int> n: m.x;
-//            > <error{The type 'int' is not supported in Slint SC}
-//                    > <^error{Identifier references are not supported in Slint SC}
+//                    > <error{Identifier references are not supported in Slint SC}
     // self-assignment (via callback handler context)
     // index expression
     property <int> o: l[0];
-//            > <error{The type 'int' is not supported in Slint SC}
-//                    >  <^error{Index expressions are not supported in Slint SC}
-//                    ^^^error{Identifier references are not supported in Slint SC}
-//                      ^^^^error{Number literals without a unit are not supported in Slint SC}
+//                    >  <error{Index expressions are not supported in Slint SC}
+//                    ^^error{Identifier references are not supported in Slint SC}
     // function call
     property <int> p: Math.max(1, 2);
-//            > <error{The type 'int' is not supported in Slint SC}
-//                    >            <^error{Function calls are not supported in Slint SC}
-//                             ^^^error{Number literals without a unit are not supported in Slint SC}
-//                                ^^^^error{Number literals without a unit are not supported in Slint SC}
+//                    >            <error{Function calls are not supported in Slint SC}
     // code block
     property <int> q: { 42 };
-//            > <error{The type 'int' is not supported in Slint SC}
-//                      ><^error{Number literals without a unit are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
+++ b/internal/compiler/tests/syntax/slint-sc/for_and_if.slint
@@ -9,9 +9,6 @@ export component Test inherits Window {
     for i in [1, 2, 3]: Rectangle { }
 //  >                               <error{Repeated elements (for-in) are not supported in Slint SC}
 //           >       <^error{Array expressions are not supported in Slint SC}
-//            ^^^error{Number literals without a unit are not supported in Slint SC}
-//               ^^^^error{Number literals without a unit are not supported in Slint SC}
-//                  ^^^^^error{Number literals without a unit are not supported in Slint SC}
 
     if true: Rectangle { }
 //  >                    <error{Conditional elements (if) are not supported in Slint SC}

--- a/internal/compiler/tests/syntax/slint-sc/functions.slint
+++ b/internal/compiler/tests/syntax/slint-sc/functions.slint
@@ -6,6 +6,4 @@
 export component Test inherits Window {
     public function my-func() -> int { return 42; }
 //  >                                             <error{Function declarations are not supported in Slint SC}
-//                               >  <^error{The type 'int' is not supported in Slint SC}
-//                                            ><^^error{Number literals without a unit are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/globals.slint
+++ b/internal/compiler/tests/syntax/slint-sc/globals.slint
@@ -7,8 +7,6 @@
 global MyGlobal {
 //     >      <error{Globals are not supported in Slint SC}
     in-out property <int> value: 42;
-//                   > <error{The type 'int' is not supported in Slint SC}
-//                               ><^error{Number literals without a unit are not supported in Slint SC}
 }
 
 export component Test inherits Window {

--- a/internal/compiler/tests/syntax/slint-sc/int_literal.slint
+++ b/internal/compiler/tests/syntax/slint-sc/int_literal.slint
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// An integer literal is a whole number written without a unit. A fractional
+// number without a unit would be a float, which is not in the subset.
+
+export component Test inherits Window {
+    // A whole number without a unit is an int literal.
+    //#sls.expr.int.form
+    property <int> a: 42;
+
+    // A number with a fractional part but no unit is an error.
+    //#sls.expr.int.fractional
+    property <int> b: 42.5;
+//                    >  <error{Non-integral numbers are not supported in Slint SC}
+}

--- a/internal/compiler/tests/syntax/slint-sc/properties.slint
+++ b/internal/compiler/tests/syntax/slint-sc/properties.slint
@@ -13,7 +13,6 @@ export component Test inherits Window {
     private property <length> e;
     //#sls.prop.decl.types
     in property <int> f;
-//               > <error{The type 'int' is not supported in Slint SC}
     in property <string> g;
 //               >    <error{The type 'string' is not supported in Slint SC}
     in property <brush> h;

--- a/internal/compiler/tests/syntax/slint-sc/structs.slint
+++ b/internal/compiler/tests/syntax/slint-sc/structs.slint
@@ -7,9 +7,7 @@
 struct MyStruct {
 //     >      <error{Struct declarations are not supported in Slint SC}
     x: int,
-//     > <error{The type 'int' is not supported in Slint SC}
     y: int,
-//     > <error{The type 'int' is not supported in Slint SC}
 }
 
 export component Test inherits Window {

--- a/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
+++ b/internal/compiler/tests/syntax/slint-sc/two_way_bindings.slint
@@ -5,9 +5,6 @@
 
 export component Test inherits Window {
     in-out property <int> a: 1;
-//                   > <error{The type 'int' is not supported in Slint SC}
-//                           ^^error{Number literals without a unit are not supported in Slint SC}
     in-out property <int> b <=> a;
-//                   > <error{The type 'int' is not supported in Slint SC}
-//                          >    <^error{Two-way bindings are not supported in Slint SC}
+//                          >    <error{Two-way bindings are not supported in Slint SC}
 }

--- a/internal/compiler/tests/syntax/slint-sc/types.slint
+++ b/internal/compiler/tests/syntax/slint-sc/types.slint
@@ -9,7 +9,6 @@ export component Test inherits Window {
 //             >    <^error{The type 'string' is not supported in Slint SC}
     property <{foo: int, bar: color}> b;
 //            >                    <error{Inline struct types are not supported in Slint SC}
-//                  > <^error{The type 'int' is not supported in Slint SC}
     property <bool> c;
 //            >  <error{The type 'bool' is not supported in Slint SC}
     property <float> d;

--- a/internal/compiler/tests/syntax/slint-sc/units.slint
+++ b/internal/compiler/tests/syntax/slint-sc/units.slint
@@ -20,8 +20,7 @@ export component Test inherits Window {
     //#sls.expr.length.px-only
     Rectangle {
         x: 123;
-//         > <error{Number literals without a unit are not supported in Slint SC}
-//         >  <^error{Cannot convert float to length. Use an unit, or multiply by 1px to convert explicitly}
+//         >  <error{Cannot convert float to length. Use an unit, or multiply by 1px to convert explicitly}
         y: 50%;
 //         > <error{Number literals with the unit '%' are not supported in Slint SC}
 //         >  <^error{Automatic conversion from percentage to length is only possible for the following properties: width, height, preferred-width, preferred-height}


### PR DESCRIPTION
A property can be declared `int`, and a whole number without a unit is an int literal. int maps to i32; a fractional number without a unit is rejected.

