### PR TITLE
Add experimental array.find-index predicate

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -103,6 +103,21 @@ bool model_all(const std::shared_ptr<M> &model, P predicate)
     return true;
 }
 
+template<typename M, typename P>
+int32_t model_find_index(const std::shared_ptr<M> &model, P predicate)
+{
+    long int count = model_length(model);
+
+    for (long int i = 0; i < count; ++i) {
+        auto data = access_array_index(model, i);
+        if (predicate(data)) {
+            return static_cast<int32_t>(i);
+        }
+    }
+
+    return -1;
+}
+
 } // namespace private_api
 
 /// A Model is providing Data for Slint Models or ListView elements of the

--- a/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
@@ -1,9 +1,10 @@
 ---
 title: Array Predicates
-description: Experimental predicate expressions for the array operations any and all.
+description: Experimental predicate expressions for the array operations any, all and find-index.
 ---
 
-The array operations `any` and `all` test the elements of an array against a predicate expression.
+The array operations `any`, `all` and `find-index` test the elements of an array against a
+predicate expression.
 
 > **Note**: Array predicates are experimental and subject to change.
 > Tracking issue: [slint-ui/slint#12777](https://github.com/slint-ui/slint/issues/12777).
@@ -14,16 +15,19 @@ A predicate expression has the form `(name) => condition`.
 It binds `name` to a value and evaluates `condition`, which must be a `bool`.
 The name is in scope only inside `condition`.
 
-Predicates are passed to the array operations `any` and `all`,
+Predicates are passed to the array operations `any`, `all` and `find-index`,
 which supply each element in turn as `name`:
 
 - `array.any((name) => condition)` reads `true` if `condition` holds for at least one element.
 - `array.all((name) => condition)` reads `true` if `condition` holds for every element.
+- `array.find-index((name) => condition)` reads the index of the first element for which
+  `condition` holds, or `-1` if no element matches.
 
 The argument name is available only inside the predicate expression,
 and its type is inferred from the array element type.
 
-`any` returns `false` for an empty array, while `all` returns `true` for an empty array.
+`any` returns `false` for an empty array, `all` returns `true` for an empty array, and
+`find-index` returns `-1` for an empty array.
 
 ## Example
 
@@ -33,13 +37,14 @@ export component Example {
 
     out property <bool> contains-two: list-of-int.any((value) => value == 2);   // true
     out property <bool> all-positive: list-of-int.all((value) => value > 0);    // true
+    out property <int> index-of-two: list-of-int.find-index((value) => value == 2); // 1
 }
 ```
 
 ## Current Limitations
 
 Predicates are the only form of closure in the Slint language, and they are only accepted
-as the argument of `any` and `all`.
+as the argument of `any`, `all` and `find-index`.
 A predicate cannot be stored in a property, passed to a function or callback, or called directly.
-The predicate must be written inline in the call to `any` or `all`;
+The predicate must be written inline in the call to `any`, `all` or `find-index`;
 passing a closure stored in a local variable is rejected with an error.

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -95,6 +95,7 @@ pub enum BuiltinFunction {
     ArrayInsert,
     ArrayAny,
     ArrayAll,
+    ArrayFindIndex,
     Rgb,
     Hsv,
     Oklch,
@@ -288,6 +289,7 @@ declare_builtin_function_types!(
     ArrayInsert: (Type::Model, Type::Int32, Type::InferredProperty) -> Type::Void,
     ArrayAny: (Type::Model, Type::Closure) -> Type::Bool,
     ArrayAll: (Type::Model, Type::Closure) -> Type::Bool,
+    ArrayFindIndex: (Type::Model, Type::Closure) -> Type::Int32,
     Rgb: (Type::Int32, Type::Int32, Type::Int32, Type::Float32) -> Type::Color,
     Hsv: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
     Oklch: (Type::Float32, Type::Float32, Type::Float32, Type::Float32) -> Type::Color,
@@ -447,7 +449,9 @@ impl BuiltinFunction {
             BuiltinFunction::MacosBringAllWindowsToFront => false,
             BuiltinFunction::PathPointAt => true,
             BuiltinFunction::PathAngleAt => true,
-            BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => true,
+            BuiltinFunction::ArrayAny
+            | BuiltinFunction::ArrayAll
+            | BuiltinFunction::ArrayFindIndex => true,
         }
     }
 
@@ -544,7 +548,9 @@ impl BuiltinFunction {
             BuiltinFunction::MacosBringAllWindowsToFront => false,
             BuiltinFunction::PathPointAt => true,
             BuiltinFunction::PathAngleAt => true,
-            BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => true,
+            BuiltinFunction::ArrayAny
+            | BuiltinFunction::ArrayAll
+            | BuiltinFunction::ArrayFindIndex => true,
         }
     }
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5565,6 +5565,13 @@ fn compile_builtin_function_call(
         BuiltinFunction::ArrayAll => {
             format!("slint::private_api::model_all({}, {})", a.next().unwrap(), a.next().unwrap())
         },
+        BuiltinFunction::ArrayFindIndex => {
+            format!(
+                "slint::private_api::model_find_index({}, {})",
+                a.next().unwrap(),
+                a.next().unwrap()
+            )
+        },
     }
 }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5567,6 +5567,13 @@ fn compile_builtin_function_call(
         BuiltinFunction::ArrayAll => {
             format!("slint::private_api::model_all({}, {})", a.next().unwrap(), a.next().unwrap())
         },
+        BuiltinFunction::ArrayFindIndex => {
+            format!(
+                "slint::private_api::model_find_index({}, {})",
+                a.next().unwrap(),
+                a.next().unwrap()
+            )
+        },
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5104,6 +5104,18 @@ fn compile_builtin_function_call(
                 sp::model_all(&arr, |#arg_name| -> bool { #closure_expression })
             })
         }
+        BuiltinFunction::ArrayFindIndex => {
+            let arr_expression = compile_expression_to_value(&arguments[0], ctx);
+            let Expression::Closure { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: ArrayFindIndex expects a closure as second argument")
+            };
+            let arg_name = ident(arg_name);
+            let closure_expression = compile_expression(expression, ctx);
+            quote!({
+                let arr = #arr_expression;
+                sp::model_find_index(&arr, |#arg_name| -> bool { #closure_expression })
+            })
+        }
     }
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5084,6 +5084,18 @@ fn compile_builtin_function_call(
                 sp::model_all(&arr, |#arg_name| -> bool { #closure_expression })
             })
         }
+        BuiltinFunction::ArrayFindIndex => {
+            let arr_expression = compile_expression_to_value(&arguments[0], ctx);
+            let Expression::Closure { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: ArrayFindIndex expects a closure as second argument")
+            };
+            let arg_name = ident(arg_name);
+            let closure_expression = compile_expression(expression, ctx);
+            quote!({
+                let arr = #arr_expression;
+                sp::model_find_index(&arr, |#arg_name| -> bool { #closure_expression })
+            })
+        }
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -186,7 +186,9 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::PathPointAt => isize::MAX,
         BuiltinFunction::PathAngleAt => isize::MAX,
         // Iterating the model and running the closure is unbounded; never inline.
-        BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => isize::MAX,
+        BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll | BuiltinFunction::ArrayFindIndex => {
+            isize::MAX
+        }
     }
 }
 

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -184,7 +184,9 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::PathPointAt => isize::MAX,
         BuiltinFunction::PathAngleAt => isize::MAX,
         // Iterating the model and running the closure is unbounded; never inline.
-        BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => isize::MAX,
+        BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll | BuiltinFunction::ArrayFindIndex => {
+            isize::MAX
+        }
     }
 }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -1218,12 +1218,13 @@ impl LookupObject for ArrayExpression<'_> {
             .or_else(|| f("remove", member_macro(BuiltinMacroFunction::ArrayRemove)))
             .or_else(|| f("insert", member_macro(BuiltinMacroFunction::ArrayInsert)))
             .or_else(|| {
-                // `any` and `all` take a closure argument; closures are experimental.
+                // `any`, `all` and `find-index` take a closure argument; closures are experimental.
                 if !ctx.diag.enable_experimental && !ctx.type_register.expose_internal_types {
                     return None;
                 }
                 f("any", member_function(BuiltinFunction::ArrayAny))
                     .or_else(|| f("all", member_function(BuiltinFunction::ArrayAll)))
+                    .or_else(|| f("find-index", member_function(BuiltinFunction::ArrayFindIndex)))
             })
     }
 }

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1575,9 +1575,10 @@ impl Expression {
             }
             return Self::Invalid;
         };
-        // For `.any(predicate)` / `.all(predicate)` the closure's argument type is
-        // structurally derived from the base array's element type. Compute it here
-        // so we can hand it to the closure when resolving that specific argument.
+        // For `.any(predicate)` / `.all(predicate)` / `.find-index(predicate)` the
+        // closure's argument type is structurally derived from the base array's
+        // element type. Compute it here so we can hand it to the closure when
+        // resolving that specific argument.
         let expected_closure_arg_type = match &function {
             Some(LookupResult::Callable(LookupResultCallable::MemberFunction {
                 base,
@@ -1586,7 +1587,9 @@ impl Expression {
             })) if matches!(
                 **member,
                 LookupResultCallable::Callable(Callable::Builtin(
-                    BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll
+                    BuiltinFunction::ArrayAny
+                        | BuiltinFunction::ArrayAll
+                        | BuiltinFunction::ArrayFindIndex
                 ))
             ) =>
             {
@@ -2122,7 +2125,8 @@ impl Expression {
             && !matches!(expression, Expression::Closure { .. })
         {
             ctx.diag.push_error(
-                "Closures must be written inline as the argument of 'any' or 'all'".into(),
+                "Closures must be written inline as the argument of 'any', 'all' or 'find-index'"
+                    .into(),
                 &node,
             );
             return Expression::Invalid;

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1574,9 +1574,10 @@ impl Expression {
             }
             return Self::Invalid;
         };
-        // For `.any(predicate)` / `.all(predicate)` the closure's argument type is
-        // structurally derived from the base array's element type. Compute it here
-        // so we can hand it to the closure when resolving that specific argument.
+        // For `.any(predicate)` / `.all(predicate)` / `.find-index(predicate)` the
+        // closure's argument type is structurally derived from the base array's
+        // element type. Compute it here so we can hand it to the closure when
+        // resolving that specific argument.
         let expected_closure_arg_type = match &function {
             Some(LookupResult::Callable(LookupResultCallable::MemberFunction {
                 base,
@@ -1585,7 +1586,9 @@ impl Expression {
             })) if matches!(
                 **member,
                 LookupResultCallable::Callable(Callable::Builtin(
-                    BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll
+                    BuiltinFunction::ArrayAny
+                        | BuiltinFunction::ArrayAll
+                        | BuiltinFunction::ArrayFindIndex
                 ))
             ) =>
             {
@@ -2112,7 +2115,8 @@ impl Expression {
             && !matches!(expression, Expression::Closure { .. })
         {
             ctx.diag.push_error(
-                "Closures must be written inline as the argument of 'any' or 'all'".into(),
+                "Closures must be written inline as the argument of 'any', 'all' or 'find-index'"
+                    .into(),
                 &node,
             );
             return Expression::Invalid;

--- a/internal/compiler/tests/syntax/expressions/predicates.slint
+++ b/internal/compiler/tests/syntax/expressions/predicates.slint
@@ -14,16 +14,22 @@ export component Test inherits Window {
 //               ^error{Cannot convert float to closure}
         ints.all(1);
 //               ^error{Cannot convert float to closure}
+        ints.find-index(1);
+//                      ^error{Cannot convert float to closure}
 
         ints.any((x) => 1);
 //                      ^error{Closure body must be of type bool, but is float}
         ints.all((x) => 1);
 //                      ^error{Closure body must be of type bool, but is float}
+        ints.find-index((x) => 1);
+//                             ^error{Closure body must be of type bool, but is float}
 
         ints.any((x) => x);
 //                      ^error{Closure body must be of type bool, but is int}
         ints.all((x) => x);
 //                      ^error{Closure body must be of type bool, but is int}
+        ints.find-index((x) => x);
+//                             ^error{Closure body must be of type bool, but is int}
         debug(x);
 //            ^error{Unknown unqualified identifier 'x'. Did you mean 'self.x'?}
 
@@ -55,9 +61,11 @@ export component Test inherits Window {
         // be a closure written inline.
         let not-useless = (x) => x == 3;
         debug(ints.any(not-useless));
-//                     >         <error{Closures must be written inline as the argument of 'any' or 'all'}
+//                     >         <error{Closures must be written inline as the argument of 'any', 'all' or 'find-index'}
         ints.all((not-useless));
-//               >           <error{Closures must be written inline as the argument of 'any' or 'all'}
+//               >           <error{Closures must be written inline as the argument of 'any', 'all' or 'find-index'}
+        ints.find-index((not-useless));
+//                      >           <error{Closures must be written inline as the argument of 'any', 'all' or 'find-index'}
     }
 
     // Closure as the right-hand side of a non-array property still produces a single

--- a/internal/core/model.rs
+++ b/internal/core/model.rs
@@ -364,6 +364,21 @@ pub fn model_all<T: Default>(
     })
 }
 
+/// Returns the index of the first row for which `predicate` returns `true`, or `-1`
+/// if no row matches.
+pub fn model_find_index<T>(
+    model: &dyn Model<Data = T>,
+    mut predicate: impl FnMut(T) -> bool,
+) -> i32 {
+    model.model_tracker().track_row_count_changes();
+    (0..model.row_count())
+        .find(|index| {
+            model.model_tracker().track_row_data_changes(*index);
+            model.row_data(*index).is_some_and(&mut predicate)
+        })
+        .map_or(-1, |index| index as i32)
+}
+
 /// An iterator over the elements of a model.
 /// This struct is created by the [`Model::iter()`] trait function.
 pub struct ModelIterator<'a, T> {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -214,6 +214,30 @@ fn load_local(instance: &SubComponentInstance, member: &LocalMemberIndex) -> Val
     }
 }
 
+/// Evaluates the predicate of `ArrayAny`/`ArrayAll`/`ArrayFindIndex` against a single row
+/// value, binding `arg_name` to it for the duration of the evaluation and restoring any
+/// shadowed local variable afterwards — like the generated code binds its closure parameter.
+/// Iteration and dependency tracking are left to the `model_any`/`model_all`/
+/// `model_find_index` helpers in [`i_slint_core::model`].
+fn eval_array_row_predicate(
+    arg_name: &SmolStr,
+    predicate: &Expression,
+    ctx: &mut EvalContext,
+    row_value: Value,
+) -> bool {
+    let previous = ctx.locals.insert(arg_name.clone(), row_value);
+    let result = eval_expression(ctx, predicate).try_into().unwrap();
+    match previous {
+        Some(prev) => {
+            ctx.locals.insert(arg_name.clone(), prev);
+        }
+        None => {
+            ctx.locals.remove(arg_name);
+        }
+    }
+    result
+}
+
 /// Set `value` on `prop`, interpolating through `animation` when present.
 fn set_maybe_animated(
     prop: Pin<&i_slint_core::Property<Value>>,
@@ -2242,26 +2266,23 @@ fn call_builtin_function(
             let Expression::Closure { arg_name, expression } = &arguments[1] else {
                 panic!("internal error: Array.any/all expects a closure as second argument")
             };
-            // Bind the closure argument as a local, like the generated code
-            // binds its closure parameter.
-            let mut predicate = |x: Value| -> bool {
-                let previous = ctx.locals.insert(arg_name.clone(), x);
-                let result: bool = eval_expression(ctx, expression).try_into().unwrap();
-                match previous {
-                    Some(prev) => {
-                        ctx.locals.insert(arg_name.clone(), prev);
-                    }
-                    None => {
-                        ctx.locals.remove(arg_name);
-                    }
-                }
-                result
-            };
+            let mut predicate =
+                |row_value| eval_array_row_predicate(arg_name, expression, ctx, row_value);
             Value::Bool(if is_all {
                 i_slint_core::model::model_all(&model, &mut predicate)
             } else {
                 i_slint_core::model::model_any(&model, &mut predicate)
             })
+        }
+        BuiltinFunction::ArrayFindIndex => {
+            let model: i_slint_core::model::ModelRc<Value> =
+                eval_expression(ctx, &arguments[0]).try_into().unwrap();
+            let Expression::Closure { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: Array.find-index expects a closure as second argument")
+            };
+            Value::Number(i_slint_core::model::model_find_index(&model, |row_value| {
+                eval_array_row_predicate(arg_name, expression, ctx, row_value)
+            }) as f64)
         }
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
             // The argument is a `PropertyReference` to a `Native { prop_name: "" }`,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -2000,8 +2000,9 @@ fn call_builtin_function(
             let Expression::Closure { arg_name, expression } = &arguments[1] else {
                 panic!("internal error: Array.any/all expects a closure as second argument")
             };
-            let predicate =
-                |row_value| eval_array_row_predicate(arg_name, expression, local_context, row_value);
+            let predicate = |row_value| {
+                eval_array_row_predicate(arg_name, expression, local_context, row_value)
+            };
             Value::Bool(if matches!(f, BuiltinFunction::ArrayAll) {
                 corelib::model::model_all(&model, predicate)
             } else {

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -185,6 +185,29 @@ impl<'a, 'id> EvalLocalContext<'a, 'id> {
     }
 }
 
+/// Evaluates the predicate of `ArrayAny`/`ArrayAll`/`ArrayFindIndex` against a single row
+/// value, binding `arg_name` to it for the duration of the evaluation and restoring any
+/// shadowed local variable afterwards. Iteration and dependency tracking are left to the
+/// `model_any`/`model_all`/`model_find_index` helpers in [`corelib::model`].
+fn eval_array_row_predicate(
+    arg_name: &SmolStr,
+    predicate: &Expression,
+    local_context: &mut EvalLocalContext,
+    row_value: Value,
+) -> bool {
+    let previous = local_context.local_variables.insert(arg_name.clone(), row_value);
+    let result = eval_expression(predicate, local_context).try_into().unwrap();
+    match previous {
+        Some(prev) => {
+            local_context.local_variables.insert(arg_name.clone(), prev);
+        }
+        None => {
+            local_context.local_variables.remove(arg_name);
+        }
+    }
+    result
+}
+
 /// Evaluate `expression` as a length / number and return the resulting f32.
 /// Caller's responsibility to only pass length-typed expressions.
 fn eval_to_f32(expression: &Expression, local_context: &mut EvalLocalContext) -> f32 {
@@ -1972,31 +1995,28 @@ fn call_builtin_function(
             }
         }
         BuiltinFunction::ArrayAny | BuiltinFunction::ArrayAll => {
-            let is_all = matches!(f, BuiltinFunction::ArrayAll);
             let model: ModelRc<Value> =
                 eval_expression(&arguments[0], local_context).try_into().unwrap();
             let Expression::Closure { arg_name, expression } = &arguments[1] else {
                 panic!("internal error: Array.any/all expects a closure as second argument")
             };
-            model.model_tracker().track_row_count_changes();
-            for row in 0..model.row_count() {
-                let x = model.row_data_tracked(row).unwrap_or_default();
-                let previous = local_context.local_variables.insert(arg_name.clone(), x);
-                let result: bool = eval_expression(expression, local_context).try_into().unwrap();
-                match previous {
-                    Some(prev) => {
-                        local_context.local_variables.insert(arg_name.clone(), prev);
-                    }
-                    None => {
-                        local_context.local_variables.remove(arg_name);
-                    }
-                }
-                // `all` short-circuits on false, `any` short-circuits on true.
-                if result != is_all {
-                    return Value::Bool(!is_all);
-                }
-            }
-            Value::Bool(is_all)
+            let predicate =
+                |row_value| eval_array_row_predicate(arg_name, expression, local_context, row_value);
+            Value::Bool(if matches!(f, BuiltinFunction::ArrayAll) {
+                corelib::model::model_all(&model, predicate)
+            } else {
+                corelib::model::model_any(&model, predicate)
+            })
+        }
+        BuiltinFunction::ArrayFindIndex => {
+            let model: ModelRc<Value> =
+                eval_expression(&arguments[0], local_context).try_into().unwrap();
+            let Expression::Closure { arg_name, expression } = &arguments[1] else {
+                panic!("internal error: Array.find-index expects a closure as second argument")
+            };
+            Value::Number(corelib::model::model_find_index(&model, |row_value| {
+                eval_array_row_predicate(arg_name, expression, local_context, row_value)
+            }) as f64)
         }
     }
 }

--- a/tests/cases/models/array_predicates.slint
+++ b/tests/cases/models/array_predicates.slint
@@ -27,6 +27,7 @@ export component TestCase {
     out property <bool> all-positive: ints.all((x) => x > 0);
     out property <bool> any-above-threshold: ints.any((x) => x > threshold);
     out property <bool> all-above-threshold: ints.all((x) => x > threshold);
+    out property <int> index-above-threshold: ints.find-index((x) => x > threshold);
 
     out property <bool> ints-all-positive: ints.all((x) => x > 0);
     out property <bool> ints-not-all-gt-one: !ints.all((x) => x > 1);
@@ -39,12 +40,17 @@ export component TestCase {
     out property <bool> strings-any-hello: strings.any((s) => s == "hello");
     out property <bool> strings-no-test: !strings.any((s) => s == "test");
     out property <bool> strings-no-empty: !strings.any((s) => s.is-empty);
+    out property <int> strings-find-index-world: strings.find-index((s) => s == "world");
+    out property <int> strings-find-index-missing: strings.find-index((s) => s == "test");
 
     out property <bool> people-all-adults: people.all((p) => p.age > 20);
     out property <bool> people-not-all-under-thirty: !people.all((p) => p.age < 30);
     out property <bool> people-any-alice: people.any((p) => p.name == "Alice");
     out property <bool> people-no-evan: !people.any((p) => p.name == "Evan");
     out property <bool> people-any-under-thirty: people.any((p) => p.age < 30);
+    out property <int> people-find-index-charlie: people.find-index((p) => p.name == "Charlie");
+    // First-match semantics: several people are over 20, index of the first one (Alice) must win.
+    out property <int> people-find-index-first-adult: people.find-index((p) => p.age > 20);
 
     out property <bool> groups-all-over-twenty: groups.all((group) => group.all((person) => person.age > 20));
     out property <bool> groups-not-all-under-thirty: !groups.all((group) => group.all((person) => person.age < 30));
@@ -63,6 +69,9 @@ export component TestCase {
 
     out property <bool> empty-any-false: !empty-ints.any((x) => x == 0);
     out property <bool> empty-all-true: empty-ints.all((x) => x == 0);
+    out property <int> empty-find-index: empty-ints.find-index((x) => x == 0);
+    out property <int> ints-find-index-three: ints.find-index((x) => x == 3);
+    out property <int> ints-find-index-missing: ints.find-index((x) => x == 99);
 
     out property <bool> closure-arg-shadows-local: {
         let x = "hello world";
@@ -92,7 +101,10 @@ export component TestCase {
         && nested-no-all-alice && precedence-and && precedence-or && precedence-all
         && empty-any-false && empty-all-true && closure-arg-shadows-local
         && closure-arg-shadows-same-type-local
-        && nested-closure-arg-shadows;
+        && nested-closure-arg-shadows
+        && empty-find-index == -1 && ints-find-index-three == 2 && ints-find-index-missing == -1
+        && strings-find-index-world == 1 && strings-find-index-missing == -1
+        && people-find-index-charlie == 2 && people-find-index-first-adult == 0;
 }
 
 /*
@@ -132,6 +144,13 @@ assert(instance.get_empty_all_true());
 assert(instance.get_closure_arg_shadows_local());
 assert(instance.get_closure_arg_shadows_same_type_local());
 assert(instance.get_nested_closure_arg_shadows());
+assert(instance.get_empty_find_index() == -1);
+assert(instance.get_ints_find_index_three() == 2);
+assert(instance.get_ints_find_index_missing() == -1);
+assert(instance.get_strings_find_index_world() == 1);
+assert(instance.get_strings_find_index_missing() == -1);
+assert(instance.get_people_find_index_charlie() == 2);
+assert(instance.get_people_find_index_first_adult() == 0);
 ```
 
 ```rust
@@ -171,6 +190,13 @@ assert!(instance.get_empty_all_true());
 assert!(instance.get_closure_arg_shadows_local());
 assert!(instance.get_closure_arg_shadows_same_type_local());
 assert!(instance.get_nested_closure_arg_shadows());
+assert_eq!(instance.get_empty_find_index(), -1);
+assert_eq!(instance.get_ints_find_index_three(), 2);
+assert_eq!(instance.get_ints_find_index_missing(), -1);
+assert_eq!(instance.get_strings_find_index_world(), 1);
+assert_eq!(instance.get_strings_find_index_missing(), -1);
+assert_eq!(instance.get_people_find_index_charlie(), 2);
+assert_eq!(instance.get_people_find_index_first_adult(), 0);
 
 let model: std::rc::Rc<slint::VecModel<i32>> = std::rc::Rc::new(vec![1, 2, 3].into());
 instance.set_ints(slint::ModelRc::from(model.clone()));
@@ -178,30 +204,36 @@ assert!(!instance.get_has_zero());
 assert!(instance.get_all_positive());
 assert!(!instance.get_any_above_threshold());
 assert!(!instance.get_all_above_threshold());
+assert_eq!(instance.get_index_above_threshold(), -1);
 
 instance.set_threshold(1);
 assert!(instance.get_any_above_threshold());
 assert!(!instance.get_all_above_threshold());
+assert_eq!(instance.get_index_above_threshold(), 1);
 
 model.set_row_data(0, 3);
 assert!(instance.get_all_above_threshold());
+assert_eq!(instance.get_index_above_threshold(), 0);
 
 model.set_row_data(1, 0);
 assert!(instance.get_has_zero());
 assert!(!instance.get_all_positive());
 assert!(instance.get_any_above_threshold());
 assert!(!instance.get_all_above_threshold());
+assert_eq!(instance.get_index_above_threshold(), 0);
 
 model.set_row_data(1, 4);
 assert!(!instance.get_has_zero());
 assert!(instance.get_all_positive());
 assert!(instance.get_any_above_threshold());
 assert!(instance.get_all_above_threshold());
+assert_eq!(instance.get_index_above_threshold(), 0);
 
 model.push(0);
 assert!(instance.get_has_zero());
 assert!(!instance.get_all_positive());
 assert!(!instance.get_all_above_threshold());
+assert_eq!(instance.get_index_above_threshold(), 0);
 ```
 
 ```js
@@ -239,5 +271,12 @@ assert(instance.empty_all_true);
 assert(instance.closure_arg_shadows_local);
 assert(instance.closure_arg_shadows_same_type_local);
 assert(instance.nested_closure_arg_shadows);
+assert(instance.empty_find_index == -1);
+assert(instance.ints_find_index_three == 2);
+assert(instance.ints_find_index_missing == -1);
+assert(instance.strings_find_index_world == 1);
+assert(instance.strings_find_index_missing == -1);
+assert(instance.people_find_index_charlie == 2);
+assert(instance.people_find_index_first_adult == 0);
 ```
 */


### PR DESCRIPTION
## Summary

Sibling to the `array.any`/`array.all` predicates (#11989): `array.find-index((name) => condition)` returns the index of the first element for which the closure holds, or `-1` if none match.

Mirrors `any`/`all` end-to-end — parser/lookup, resolving, Rust and C++ codegen, `api/cpp/include/private/slint_models.h`, the interpreter, and `core::model::model_find_index` — reusing the existing `Expression::Closure`/`Type::Closure` plumbing. Same experimental gate as `any`/`all` (tracked by #12777); only usable inline, not stored or passed around, for the same reasons `any`/`all` are restricted that way.

The interpreter's per-row "evaluate the closure against this row" loop is shared with `any`/`all` via a small `eval_array_row_predicate` helper rather than copy-pasted into a third arm — `any`/`all`/`find-index` differ only in what they do with each row's boolean result.

This is part 1 of a 3-PR stack:
1. **This PR** — `array.find-index`, the experimental predicate.
2. #12791 — `array.index-of`, a stable value-based sibling that desugars to `find-index`.
3. #12792 — wires ComboBox's `current-value` writes to `index-of`, closing slint-ui/slint#11970.

## Test plan

- `cargo test -p i-slint-compiler --features display-diagnostics --test syntax_tests`
- `SLINT_TEST_FILTER=array_predicates cargo test --manifest-path tests/Cargo.toml -p test-driver-{interpreter,rust,cpp,nodejs}`