### PR TITLE
Share brush-to-gradient resolution between renderers

### DIFF
--- a/internal/core/graphics/brush.rs
+++ b/internal/core/graphics/brush.rs
@@ -7,7 +7,9 @@ This module contains brush related types for the run-time library.
 
 use super::Color;
 use crate::SharedVector;
+use crate::lengths::{PhysicalPx, ScaleFactor};
 use crate::properties::InterpolatedPropertyValue;
+use alloc::borrow::Cow;
 use euclid::default::{Point2D, Size2D};
 
 #[cfg(not(feature = "std"))]
@@ -247,6 +249,11 @@ impl LinearGradientBrush {
         // skip the first fake stop that just contains the angle
         self.0.iter().skip(1)
     }
+
+    /// The color stops as a slice, without the angle header stop.
+    fn stops_slice(&self) -> &[GradientStop] {
+        self.0.as_slice().get(1..).unwrap_or_default()
+    }
 }
 
 /// NaN-aware float equality: two NaNs compare equal (unlike IEEE 754).
@@ -307,6 +314,11 @@ impl RadialGradientBrush {
     /// Returns the color stops of the radial gradient.
     pub fn stops(&self) -> impl Iterator<Item = &GradientStop> {
         self.0.iter().skip(Self::HEADER)
+    }
+
+    /// The color stops as a slice, without the header stops.
+    fn stops_slice(&self) -> &[GradientStop] {
+        self.0.as_slice().get(Self::HEADER..).unwrap_or_default()
     }
 
     /// Sets an explicit center, returning `self` for chaining. `cx` and `cy` are in the
@@ -618,6 +630,11 @@ impl ConicGradientBrush {
         self.0.iter().skip(Self::HEADER)
     }
 
+    /// The color stops as a slice, without the header stops.
+    fn stops_slice(&self) -> &[GradientStop] {
+        self.0.as_slice().get(Self::HEADER..).unwrap_or_default()
+    }
+
     /// Sets an explicit center, returning `self` for chaining. `cx` and `cy` are in the
     /// element's local logical coordinate space.
     pub fn with_center(mut self, cx: f32, cy: f32) -> Self {
@@ -904,6 +921,320 @@ impl InterpolatedPropertyValue for Brush {
             }
         }
     }
+}
+
+/// A [`Brush`] resolved by [`resolve_brush`]: gradient geometry in physical pixels
+/// plus sanitized color stops, so that all renderers share one interpretation of
+/// the brush model.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResolvedBrush<'a> {
+    /// A plain color fill.
+    SolidColor(Color),
+    /// See [`ResolvedLinearGradient`].
+    LinearGradient(ResolvedLinearGradient<'a>),
+    /// See [`ResolvedRadialGradient`].
+    RadialGradient(ResolvedRadialGradient<'a>),
+    /// See [`ResolvedConicGradient`].
+    ConicGradient(ResolvedConicGradient<'a>),
+}
+
+/// A linear gradient whose stops span the line from `start` to `end`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedLinearGradient<'a> {
+    /// The point stop position 0 lies on.
+    pub start: euclid::Point2D<f32, PhysicalPx>,
+    /// The point stop position 1 lies on.
+    pub end: euclid::Point2D<f32, PhysicalPx>,
+    /// The sanitized color stops.
+    pub stops: Cow<'a, [GradientStop]>,
+}
+
+/// A radial gradient whose stops span from `center` to `radius`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedRadialGradient<'a> {
+    /// The center of the gradient.
+    pub center: euclid::Point2D<f32, PhysicalPx>,
+    /// The radius stop position 1 lies on.
+    pub radius: euclid::Length<f32, PhysicalPx>,
+    /// The sanitized color stops.
+    pub stops: Cow<'a, [GradientStop]>,
+}
+
+/// A conic gradient whose stops run one full clockwise turn around `center`,
+/// starting at 12 o'clock (Slint's 0°).
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedConicGradient<'a> {
+    /// The center of the gradient.
+    pub center: euclid::Point2D<f32, PhysicalPx>,
+    /// The sanitized color stops.
+    pub stops: Cow<'a, [GradientStop]>,
+}
+
+/// Resolves a brush against the shape it fills: `size` is the shape's size in
+/// physical pixels; explicit gradient center and radius values are local logical
+/// lengths converted through `scale_factor`. Returns `None` for a fully
+/// transparent brush.
+///
+/// The returned stops are canonical - sorted, strictly increasing, within [0, 1] -
+/// with out-of-range linear/radial stops folded into the gradient geometry and
+/// conic stops clamped (a conic gradient cannot extend past a full turn), so they
+/// are directly usable by backends that render non-canonical stops incorrectly
+/// (vello draws them as a solid fill of the first color). Already-canonical stops,
+/// which is all the compiler produces, are borrowed rather than copied.
+///
+/// A free function rather than a `Brush` method so that it stays out of the public
+/// API that `Brush` is re-exported into.
+pub fn resolve_brush<'a>(
+    brush: &'a Brush,
+    size: euclid::Size2D<f32, PhysicalPx>,
+    scale_factor: ScaleFactor,
+) -> Option<ResolvedBrush<'a>> {
+    if brush.is_transparent() {
+        return None;
+    }
+    Some(match brush {
+        Brush::SolidColor(color) => ResolvedBrush::SolidColor(*color),
+        Brush::LinearGradient(gradient) => {
+            let (stops, extent) = sanitize_color_stops(gradient.stops_slice(), true);
+            let (start, mut end) = line_for_angle(gradient.angle(), size.to_untyped());
+            if extent != 1.0 {
+                // sanitize_color_stops scaled the offsets down into [0, 1]; scale
+                // the gradient line to match, or the ramp comes out compressed.
+                end = start + (end - start) * extent;
+            }
+            ResolvedBrush::LinearGradient(ResolvedLinearGradient {
+                start: start.cast_unit(),
+                end: end.cast_unit(),
+                stops,
+            })
+        }
+        Brush::RadialGradient(gradient) => {
+            let (stops, extent) = sanitize_color_stops(gradient.stops_slice(), true);
+            let (center_x, center_y) =
+                gradient.center_or_default_scaled(size.width, size.height, scale_factor.get());
+            let radius =
+                gradient.radius_or_default_scaled(size.width, size.height, scale_factor.get())
+                    * extent;
+            ResolvedBrush::RadialGradient(ResolvedRadialGradient {
+                center: euclid::point2(center_x, center_y),
+                radius: euclid::Length::new(radius),
+                stops,
+            })
+        }
+        Brush::ConicGradient(gradient) => {
+            let (stops, _) = sanitize_color_stops(gradient.stops_slice(), false);
+            let (center_x, center_y) =
+                gradient.center_or_default_scaled(size.width, size.height, scale_factor.get());
+            ResolvedBrush::ConicGradient(ResolvedConicGradient {
+                center: euclid::point2(center_x, center_y),
+                stops,
+            })
+        }
+    })
+}
+
+/// Massage gradient color stops into a canonical form (see [`resolve_brush`]).
+/// Stops below 0 are replaced by the interpolated color at 0 (the CSS behavior).
+/// For stops beyond 1: with `can_extend`, all positions are divided by the maximum
+/// and that maximum is returned as the second tuple element, so the caller can grow
+/// the gradient geometry by the same factor; without it, they are clamped to the
+/// interpolated color at 1. Duplicate positions (hard color steps) are separated by
+/// the smallest representable amount.
+fn sanitize_color_stops(
+    stops: &[GradientStop],
+    can_extend: bool,
+) -> (Cow<'_, [GradientStop]>, f32) {
+    /// Plain per-channel interpolation, matching how the gradient ramp itself blends.
+    fn color_at(position: f32, a: &GradientStop, b: &GradientStop) -> Color {
+        let t = if b.position > a.position {
+            ((position - a.position) / (b.position - a.position)).clamp(0., 1.)
+        } else {
+            0.
+        };
+        let (ca, cb) = (a.color.to_argb_u8(), b.color.to_argb_u8());
+        let lerp = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * t) as u8;
+        Color::from_argb_u8(
+            lerp(ca.alpha, cb.alpha),
+            lerp(ca.red, cb.red),
+            lerp(ca.green, cb.green),
+            lerp(ca.blue, cb.blue),
+        )
+    }
+
+    // The compiler always produces canonical stop lists, so this fast path is the
+    // common case. A NaN position fails these comparisons: slow path.
+    if stops.first().is_none_or(|first| first.position >= 0.)
+        && stops.last().is_none_or(|last| last.position <= 1.)
+        && stops.windows(2).all(|pair| pair[0].position < pair[1].position)
+    {
+        return (Cow::Borrowed(stops), 1.0);
+    }
+
+    let mut stops: alloc::vec::Vec<GradientStop> = stops.to_vec();
+    stops.sort_by(|a, b| a.position.total_cmp(&b.position));
+
+    // Replace everything below 0 with the interpolated color at 0.
+    while stops.len() >= 2 && stops[1].position <= 0. {
+        stops.remove(0);
+    }
+    if let [first, second, ..] = stops.as_slice()
+        && first.position < 0.
+    {
+        stops[0] = GradientStop { color: color_at(0., first, second), position: 0. };
+    } else if let [only] = stops.as_slice()
+        && only.position < 0.
+    {
+        stops[0].position = 0.;
+    }
+
+    // Handle stops beyond 1: normalize (the caller extends the geometry) or clamp to
+    // the interpolated color at 1.
+    let mut extent = 1.0f32;
+    if stops.last().is_some_and(|last| last.position > 1.) {
+        if can_extend {
+            extent = stops.last().unwrap().position;
+            for stop in &mut stops {
+                stop.position /= extent;
+            }
+        } else {
+            while stops.len() >= 2 && stops[stops.len() - 2].position >= 1. {
+                stops.pop();
+            }
+            let clamped_last = match stops.as_slice() {
+                [.., second_to_last, last] if last.position > 1. => {
+                    Some(GradientStop { color: color_at(1., second_to_last, last), position: 1. })
+                }
+                [only] if only.position > 1. => {
+                    Some(GradientStop { color: only.color, position: 1. })
+                }
+                _ => None,
+            };
+            if let Some(stop) = clamped_last {
+                *stops.last_mut().unwrap() = stop;
+            }
+        }
+    }
+
+    // Make positions strictly increasing: separate duplicates (hard color steps) by the
+    // smallest representable amount, then push back anything that got nudged past 1.
+    let mut previous = f32::NEG_INFINITY;
+    for stop in &mut stops {
+        if stop.position <= previous {
+            stop.position = previous.next_up();
+        }
+        previous = stop.position;
+    }
+    let mut next = 1.0f32.next_up();
+    for stop in stops.iter_mut().rev() {
+        if stop.position >= next {
+            stop.position = next.next_down();
+        }
+        next = stop.position;
+    }
+
+    (Cow::Owned(stops), extent)
+}
+
+#[test]
+fn test_resolve_sanitizes_out_of_range_stops() {
+    // Stops beyond 1 extend the gradient line instead of being clamped.
+    let brush = Brush::LinearGradient(LinearGradientBrush::new(
+        180.,
+        [
+            GradientStop { position: 0.0, color: Color::from_rgb_u8(255, 0, 0) },
+            GradientStop { position: 2.0, color: Color::from_rgb_u8(0, 0, 255) },
+        ],
+    ));
+    let Some(ResolvedBrush::LinearGradient(gradient)) =
+        resolve_brush(&brush, [100., 50.].into(), ScaleFactor::new(1.0))
+    else {
+        panic!("expected a resolved linear gradient");
+    };
+    assert_eq!(gradient.stops.last().unwrap().position, 1.0);
+    // A 180° gradient runs from the top edge down; the end extends past the shape.
+    assert_eq!(gradient.start.y, 0.);
+    assert_eq!(gradient.end.y, 100.);
+
+    // A conic gradient cannot extend, so out-of-range stops are clamped to the
+    // interpolated color at position 1 instead. Note that ConicGradientBrush::new
+    // already normalizes, so resolving keeps its stops within [0, 1].
+    let brush = Brush::ConicGradient(ConicGradientBrush::new(
+        0.,
+        [
+            GradientStop { position: 0.0, color: Color::from_rgb_u8(255, 0, 0) },
+            GradientStop { position: 2.0, color: Color::from_rgb_u8(0, 0, 255) },
+        ],
+    ));
+    let Some(ResolvedBrush::ConicGradient(gradient)) =
+        resolve_brush(&brush, [100., 50.].into(), ScaleFactor::new(1.0))
+    else {
+        panic!("expected a resolved conic gradient");
+    };
+    assert!(gradient.stops.iter().all(|stop| (0. ..=1.).contains(&stop.position)));
+    assert_eq!(gradient.center, euclid::point2(50., 25.));
+}
+
+#[test]
+fn test_resolve_makes_stops_strictly_increasing() {
+    let brush = Brush::LinearGradient(LinearGradientBrush::new(
+        0.,
+        [
+            GradientStop { position: 0.5, color: Color::from_rgb_u8(255, 0, 0) },
+            GradientStop { position: 0.5, color: Color::from_rgb_u8(0, 255, 0) },
+            GradientStop { position: 0.2, color: Color::from_rgb_u8(0, 0, 255) },
+        ],
+    ));
+    let Some(ResolvedBrush::LinearGradient(gradient)) =
+        resolve_brush(&brush, [100., 100.].into(), ScaleFactor::new(1.0))
+    else {
+        panic!("expected a resolved linear gradient");
+    };
+    // Sorted and strictly increasing: the duplicate hard step is separated minimally.
+    assert!(gradient.stops.windows(2).all(|pair| pair[0].position < pair[1].position));
+    assert_eq!(gradient.stops[0].color, Color::from_rgb_u8(0, 0, 255));
+}
+
+#[test]
+fn test_resolve_replaces_stops_below_zero() {
+    let brush = Brush::LinearGradient(LinearGradientBrush::new(
+        0.,
+        [
+            GradientStop { position: -1.0, color: Color::from_rgb_u8(0, 0, 0) },
+            GradientStop { position: 1.0, color: Color::from_rgb_u8(200, 200, 200) },
+        ],
+    ));
+    let Some(ResolvedBrush::LinearGradient(gradient)) =
+        resolve_brush(&brush, [100., 100.].into(), ScaleFactor::new(1.0))
+    else {
+        panic!("expected a resolved linear gradient");
+    };
+    // The first stop is replaced by the interpolated color at position 0.
+    assert_eq!(gradient.stops[0].position, 0.0);
+    assert_eq!(gradient.stops[0].color, Color::from_rgb_u8(100, 100, 100));
+}
+
+#[test]
+fn test_resolve_transparent_brush() {
+    assert_eq!(resolve_brush(&Brush::default(), [100., 100.].into(), ScaleFactor::new(1.0)), None);
+}
+
+#[test]
+fn test_resolve_borrows_canonical_stops() {
+    // Already canonical stops are borrowed from the brush, not copied.
+    let brush = Brush::LinearGradient(LinearGradientBrush::new(
+        90.,
+        [
+            GradientStop { position: 0.0, color: Color::from_rgb_u8(255, 0, 0) },
+            GradientStop { position: 1.0, color: Color::from_rgb_u8(0, 0, 255) },
+        ],
+    ));
+    let Some(ResolvedBrush::LinearGradient(gradient)) =
+        resolve_brush(&brush, [100., 100.].into(), ScaleFactor::new(1.0))
+    else {
+        panic!("expected a resolved linear gradient");
+    };
+    assert!(matches!(gradient.stops, Cow::Borrowed(_)));
+    assert_eq!(gradient.stops.len(), 2);
 }
 
 #[test]

--- a/internal/renderers/anyrender/itemrenderer.rs
+++ b/internal/renderers/anyrender/itemrenderer.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyrender::PaintScene;
+use i_slint_core::graphics::ResolvedBrush;
 use i_slint_core::graphics::adjust_rect_and_border_for_inner_drawing;
 use i_slint_core::graphics::euclid;
 use i_slint_core::graphics::{Image, ImageCacheKey, IntRect, SharedImageBuffer, SharedPixelBuffer};
@@ -20,7 +21,7 @@ use i_slint_core::lengths::{
 use i_slint_core::textlayout::sharedparley::{self, GlyphRenderer, fontique, parley};
 use i_slint_core::{Brush, Color, ImageInner, SharedString};
 
-use super::{PhysicalLength, PhysicalRect, PhysicalSize};
+use super::{PhysicalLength, PhysicalPoint, PhysicalRect, PhysicalSize};
 
 /// anyrender's `push_layer` always clips; there is no "no clip", so layers
 /// that should not clip use a rectangle larger than any real scene.
@@ -121,7 +122,7 @@ impl<'a, S: PaintScene> ItemRenderer for AnyrenderItemRenderer<'a, S> {
         let shape = self.rect(LogicalRect::from_size(size));
         self.fill_with_brush(
             rect.background(),
-            self.size(size),
+            size * self.scale_factor,
             self.current_state.transform,
             peniko::Fill::default(),
             &shape,
@@ -144,7 +145,7 @@ impl<'a, S: PaintScene> ItemRenderer for AnyrenderItemRenderer<'a, S> {
         // model positions gradients relative to the border box (full element),
         // but adjust_rect_and_border_for_inner_drawing shrinks the geometry,
         // which would shift the gradient center inward.
-        let brush_size = to_kurbo_size(geometry.size);
+        let brush_size = geometry.size;
 
         let border_color = rect.border_color();
         let opaque_border = border_color.is_opaque();
@@ -216,7 +217,7 @@ impl<'a, S: PaintScene> ItemRenderer for AnyrenderItemRenderer<'a, S> {
         let shape = self.rect(LogicalRect::from_size(size));
         self.fill_with_brush(
             background,
-            self.size(size),
+            size * self.scale_factor,
             self.current_state.transform,
             peniko::Fill::default(),
             &shape,
@@ -412,7 +413,7 @@ impl<'a, S: PaintScene> ItemRenderer for AnyrenderItemRenderer<'a, S> {
             // Apply colorize: push a SrcIn layer and fill with the colorize brush.
             // SrcIn keeps the image's alpha but replaces the color.
             let src_in_blend = peniko::BlendMode::new(peniko::Mix::Normal, peniko::Compose::SrcIn);
-            if let Some((brush, brush_transform)) = self.brush(colorize_brush, dest_rect.size()) {
+            if let Some((brush, brush_transform)) = self.brush(colorize_brush, dest_size) {
                 self.scene.push_layer(
                     src_in_blend,
                     1.0,
@@ -500,7 +501,7 @@ impl<'a, S: PaintScene> ItemRenderer for AnyrenderItemRenderer<'a, S> {
             .transform
             .then_translate(kurbo::Vec2::new(phys_offset.x as f64, phys_offset.y as f64));
 
-        let brush_size = to_kurbo_size(size * sf);
+        let brush_size = size * sf;
 
         let fill_rule = match path.fill_rule() {
             FillRule::Evenodd => peniko::Fill::EvenOdd,
@@ -765,7 +766,7 @@ impl<'a, S: PaintScene> GlyphRenderer for AnyrenderItemRenderer<'a, S> {
         brush: Brush,
         size: LogicalSize,
     ) -> Option<Self::PlatformBrush> {
-        let (peniko_brush, brush_transform) = self.brush(brush, self.size(size))?;
+        let (peniko_brush, brush_transform) = self.brush(brush, size * self.scale_factor)?;
         Some(GlyphBrush {
             peniko_brush,
             brush_transform,
@@ -786,7 +787,7 @@ impl<'a, S: PaintScene> GlyphRenderer for AnyrenderItemRenderer<'a, S> {
         physical_stroke_width: f32,
         size: LogicalSize,
     ) -> Option<Self::PlatformBrush> {
-        let (peniko_brush, brush_transform) = self.brush(stroke_brush, self.size(size))?;
+        let (peniko_brush, brush_transform) = self.brush(stroke_brush, size * self.scale_factor)?;
 
         Some(GlyphBrush {
             peniko_brush,
@@ -925,7 +926,7 @@ impl<'a, S: PaintScene> AnyrenderItemRenderer<'a, S> {
     fn fill_with_brush(
         &mut self,
         brush: Brush,
-        brush_size: kurbo::Size,
+        brush_size: PhysicalSize,
         transform: kurbo::Affine,
         style: peniko::Fill,
         shape: &impl kurbo::Shape,
@@ -946,7 +947,7 @@ impl<'a, S: PaintScene> AnyrenderItemRenderer<'a, S> {
     fn stroke_with_brush(
         &mut self,
         brush: Brush,
-        brush_size: kurbo::Size,
+        brush_size: PhysicalSize,
         transform: kurbo::Affine,
         stroke: &kurbo::Stroke,
         shape: &impl kurbo::Shape,
@@ -995,86 +996,45 @@ impl<'a, S: PaintScene> AnyrenderItemRenderer<'a, S> {
         to_kurbo_rect(rect * self.scale_factor)
     }
 
-    fn size(&self, size: LogicalSize) -> kurbo::Size {
-        to_kurbo_size(size * self.scale_factor)
-    }
-
     fn brush(
         &self,
         brush: Brush,
-        shape_size: kurbo::Size,
+        shape_size: PhysicalSize,
     ) -> Option<(peniko::Brush, Option<kurbo::Affine>)> {
-        if brush.is_transparent() {
-            return None;
-        }
+        let resolved =
+            i_slint_core::graphics::resolve_brush(&brush, shape_size, self.scale_factor)?;
 
-        Some(match brush {
-            Brush::SolidColor(color) => (to_peniko_color(color).into(), None),
-            Brush::LinearGradient(gradient) => {
-                let (stops, extent) = sanitize_color_stops(gradient.stops(), true);
-                let (start, end) = i_slint_core::graphics::line_for_angle(
-                    gradient.angle(),
-                    [shape_size.width as f32, shape_size.height as f32].into(),
+        Some(match resolved {
+            ResolvedBrush::SolidColor(color) => (to_peniko_color(color).into(), None),
+            ResolvedBrush::LinearGradient(gradient) => {
+                let mut peniko_gradient = peniko::Gradient::new_linear(
+                    to_kurbo_point(gradient.start),
+                    to_kurbo_point(gradient.end),
                 );
-                let start = to_kurbo_point(start);
-                let mut end = to_kurbo_point(end);
-                if extent != 1.0 {
-                    // sanitize_color_stops scaled the offsets down into [0, 1],
-                    // so scale the gradient line to match,
-                    // or the ramp comes out compressed.
-                    end = start + (end - start) * extent as f64;
-                }
-
-                let mut peniko_gradient = peniko::Gradient::new_linear(start, end);
-                peniko_gradient.stops = stops;
+                peniko_gradient.stops = to_peniko_stops(&gradient.stops);
 
                 (peniko_gradient.into(), None)
             }
-            Brush::RadialGradient(gradient) => {
-                let (stops, extent) = sanitize_color_stops(gradient.stops(), true);
-                let (center_x, center_y) = gradient.center_or_default_scaled(
-                    shape_size.width as f32,
-                    shape_size.height as f32,
-                    self.scale_factor.get(),
-                );
-                let radius = gradient.radius_or_default_scaled(
-                    shape_size.width as f32,
-                    shape_size.height as f32,
-                    self.scale_factor.get(),
-                );
-                // Same compensation as for the linear gradient line.
-                // It's visible where the shape reaches past the circle,
-                // like the corners of a rectangle.
-                let radius = radius * extent;
-
+            ResolvedBrush::RadialGradient(gradient) => {
                 let mut peniko_gradient =
                     peniko::Gradient::new_radial(kurbo::Point::new(0., 0.), 1.0);
-                peniko_gradient.stops = stops;
+                peniko_gradient.stops = to_peniko_stops(&gradient.stops);
 
                 // A unit circle at the origin, scaled to the radius and moved
                 // to the center, so the color stops span [0, radius].
                 (
                     peniko_gradient.into(),
-                    Some(
-                        kurbo::Affine::scale(radius as f64)
-                            .then_translate(kurbo::Vec2::new(center_x as f64, center_y as f64)),
-                    ),
+                    Some(kurbo::Affine::scale(gradient.radius.get() as f64).then_translate(
+                        kurbo::Vec2::new(gradient.center.x as f64, gradient.center.y as f64),
+                    )),
                 )
             }
-            Brush::ConicGradient(gradient) => {
-                // A sweep gradient's angular range cannot be extended beyond a
-                // full turn, so out-of-range stops are clamped instead.
-                let (stops, _) = sanitize_color_stops(gradient.stops(), false);
-                let (center_x, center_y) = gradient.center_or_default_scaled(
-                    shape_size.width as f32,
-                    shape_size.height as f32,
-                    self.scale_factor.get(),
-                );
-                let center = kurbo::Point::new(center_x as f64, center_y as f64);
+            ResolvedBrush::ConicGradient(gradient) => {
+                let center = kurbo::Point::new(gradient.center.x as f64, gradient.center.y as f64);
 
                 let mut peniko_gradient =
                     peniko::Gradient::new_sweep(center, 0., 360f32.to_radians());
-                peniko_gradient.stops = stops;
+                peniko_gradient.stops = to_peniko_stops(&gradient.stops);
 
                 // Sweep gradients start at 3 o'clock (east); Slint's 0° is at
                 // 12 o'clock, so rotate the brush by -90° around the center.
@@ -1083,119 +1043,12 @@ impl<'a, S: PaintScene> AnyrenderItemRenderer<'a, S> {
                     Some(kurbo::Affine::rotate_about(-std::f64::consts::FRAC_PI_2, center)),
                 )
             }
-            _ => return None,
         })
     }
 }
 
-/// Massage gradient color stops into the form vello accepts: sorted,
-/// strictly increasing, and with offsets in [0, 1]. vello renders gradients
-/// with out-of-range or non-increasing stop offsets as a solid fill of the
-/// first color instead.
-///
-/// Stops below 0 are replaced by the interpolated color at 0 (the CSS
-/// behavior). For stops beyond 1: with `can_extend`, all offsets are divided
-/// by the maximum and that maximum is returned as the second tuple element,
-/// so the caller can grow the gradient geometry (radius, line) by the same
-/// factor; without it, they are clamped to the interpolated color at 1.
-/// Duplicate offsets (hard color steps) are separated by the smallest
-/// representable amount.
-fn sanitize_color_stops<'a>(
-    stops: impl Iterator<Item = &'a i_slint_core::graphics::GradientStop>,
-    can_extend: bool,
-) -> (peniko::ColorStops, f32) {
-    /// Plain per-channel interpolation between the colors of `a` and `b` at
-    /// `position`, matching how the gradient ramp itself blends.
-    fn color_at(
-        position: f32,
-        a: &i_slint_core::graphics::GradientStop,
-        b: &i_slint_core::graphics::GradientStop,
-    ) -> Color {
-        let t = if b.position > a.position {
-            ((position - a.position) / (b.position - a.position)).clamp(0., 1.)
-        } else {
-            0.
-        };
-        let (ca, cb) = (a.color.to_argb_u8(), b.color.to_argb_u8());
-        let lerp = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * t) as u8;
-        Color::from_argb_u8(
-            lerp(ca.alpha, cb.alpha),
-            lerp(ca.red, cb.red),
-            lerp(ca.green, cb.green),
-            lerp(ca.blue, cb.blue),
-        )
-    }
-
-    let mut stops: Vec<i_slint_core::graphics::GradientStop> = stops.cloned().collect();
-    stops.sort_by(|a, b| a.position.total_cmp(&b.position));
-
-    // Replace everything below 0 with the interpolated color at 0.
-    while stops.len() >= 2 && stops[1].position <= 0. {
-        stops.remove(0);
-    }
-    if let [first, second, ..] = stops.as_slice()
-        && first.position < 0.
-    {
-        stops[0] = i_slint_core::graphics::GradientStop {
-            color: color_at(0., first, second),
-            position: 0.,
-        };
-    } else if let [only] = stops.as_slice()
-        && only.position < 0.
-    {
-        stops[0].position = 0.;
-    }
-
-    // Handle stops beyond 1: normalize (the caller extends the geometry) or
-    // clamp to the interpolated color at 1.
-    let mut extent = 1.0f32;
-    if stops.last().is_some_and(|last| last.position > 1.) {
-        if can_extend {
-            extent = stops.last().unwrap().position;
-            for stop in &mut stops {
-                stop.position /= extent;
-            }
-        } else {
-            while stops.len() >= 2 && stops[stops.len() - 2].position >= 1. {
-                stops.pop();
-            }
-            let clamped_last = match stops.as_slice() {
-                [.., second_to_last, last] if last.position > 1. => {
-                    Some(i_slint_core::graphics::GradientStop {
-                        color: color_at(1., second_to_last, last),
-                        position: 1.,
-                    })
-                }
-                [only] if only.position > 1. => {
-                    Some(i_slint_core::graphics::GradientStop { color: only.color, position: 1. })
-                }
-                _ => None,
-            };
-            if let Some(stop) = clamped_last {
-                *stops.last_mut().unwrap() = stop;
-            }
-        }
-    }
-
-    // Make offsets strictly increasing: separate duplicates (hard color
-    // steps) by the smallest representable amount, then push back anything
-    // that got nudged past 1.
-    let mut previous = f32::NEG_INFINITY;
-    for stop in &mut stops {
-        if stop.position <= previous {
-            stop.position = previous.next_up();
-        }
-        previous = stop.position;
-    }
-    let mut next = 1.0f32.next_up();
-    for stop in stops.iter_mut().rev() {
-        if stop.position >= next {
-            stop.position = next.next_down();
-        }
-        next = stop.position;
-    }
-
-    let stops = peniko::ColorStops(
+fn to_peniko_stops(stops: &[i_slint_core::graphics::GradientStop]) -> peniko::ColorStops {
+    peniko::ColorStops(
         stops
             .iter()
             .map(|stop| peniko::ColorStop {
@@ -1203,13 +1056,10 @@ fn sanitize_color_stops<'a>(
                 color: peniko::color::DynamicColor::from_alpha_color(to_peniko_color(stop.color)),
             })
             .collect(),
-    );
-    (stops, extent)
+    )
 }
 
-/// Untyped because that is what [`i_slint_core::graphics::line_for_angle`]
-/// returns; its points are in the brush's device pixel coordinate space.
-fn to_kurbo_point(p: euclid::default::Point2D<f32>) -> kurbo::Point {
+fn to_kurbo_point(p: PhysicalPoint) -> kurbo::Point {
     (p.x, p.y).into()
 }
 

--- a/internal/renderers/anyrender/lib.rs
+++ b/internal/renderers/anyrender/lib.rs
@@ -43,6 +43,7 @@ use i_slint_core::textlayout::sharedparley;
 use i_slint_core::window::{WindowAdapter, WindowInner};
 
 pub(crate) type PhysicalLength = euclid::Length<f32, PhysicalPx>;
+pub(crate) type PhysicalPoint = euclid::Point2D<f32, PhysicalPx>;
 pub(crate) type PhysicalRect = euclid::Rect<f32, PhysicalPx>;
 pub(crate) type PhysicalSize = euclid::Size2D<f32, PhysicalPx>;
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use euclid::approxeq::ApproxEq;
 use femtovg::Transform2D;
+use i_slint_core::graphics::ResolvedBrush;
 use i_slint_core::graphics::adjust_rect_and_border_for_inner_drawing;
 use i_slint_core::graphics::boxshadowcache::BoxShadowCache;
 use i_slint_core::graphics::euclid::num::Zero;
@@ -209,7 +210,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         }
         // TODO: cache path in item to avoid re-tesselation
         let path = rect_to_path(geometry);
-        let paint = match self.brush_to_paint(rect.background(), &path) {
+        let paint = match self.brush_to_paint(rect.background(), geometry.size) {
             Some(paint) => paint,
             None => return,
         }
@@ -233,6 +234,10 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         if self.global_alpha_transparent() {
             return;
         }
+
+        // Gradients are positioned on the border box, before the geometry is shrunk
+        // below for inner border drawing.
+        let brush_size = geometry.size;
 
         let border_color = rect.border_color();
         let opaque_border = border_color.is_opaque();
@@ -275,17 +280,12 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
             (background_path, Some(border_path))
         };
 
-        let fill_paint = self.brush_to_paint(rect.background(), &background_path);
+        let fill_paint = self.brush_to_paint(rect.background(), brush_size);
 
-        let border_paint = self
-            .brush_to_paint(
-                rect.border_color(),
-                maybe_border_path.as_ref().unwrap_or(&background_path),
-            )
-            .map(|mut paint| {
-                paint.set_line_width(border_width.get());
-                paint
-            });
+        let border_paint = self.brush_to_paint(rect.border_color(), brush_size).map(|mut paint| {
+            paint.set_line_width(border_width.get());
+            paint
+        });
 
         let mut canvas = self.canvas.borrow_mut();
         if let Some(paint) = fill_paint {
@@ -347,7 +347,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         sharedparley::draw_text_input(self, text_input, self_rc, size, self.text_layout_cache);
     }
 
-    fn draw_path(&mut self, path: Pin<&items::Path>, item_rc: &ItemRc, _size: LogicalSize) {
+    fn draw_path(&mut self, path: Pin<&items::Path>, item_rc: &ItemRc, size: LogicalSize) {
         if self.global_alpha_transparent() {
             return;
         }
@@ -433,31 +433,33 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
 
         let anti_alias = path.anti_alias();
 
-        let fill_paint = self.brush_to_paint(path.fill(), &femtovg_path).map(|mut fill_paint| {
-            fill_paint.set_fill_rule(match path.fill_rule() {
-                FillRule::Evenodd => femtovg::FillRule::EvenOdd,
-                FillRule::Nonzero | _ => femtovg::FillRule::NonZero,
+        let fill_paint =
+            self.brush_to_paint(path.fill(), size * self.scale_factor).map(|mut fill_paint| {
+                fill_paint.set_fill_rule(match path.fill_rule() {
+                    FillRule::Evenodd => femtovg::FillRule::EvenOdd,
+                    FillRule::Nonzero | _ => femtovg::FillRule::NonZero,
+                });
+                fill_paint.set_anti_alias(anti_alias);
+                fill_paint
             });
-            fill_paint.set_anti_alias(anti_alias);
-            fill_paint
-        });
 
-        let border_paint = self.brush_to_paint(path.stroke(), &femtovg_path).map(|mut paint| {
-            paint.set_line_width((path.stroke_width() * self.scale_factor).get());
-            paint.set_line_cap(match path.stroke_line_cap() {
-                items::LineCap::Round => femtovg::LineCap::Round,
-                items::LineCap::Square => femtovg::LineCap::Square,
-                items::LineCap::Butt | _ => femtovg::LineCap::Butt,
+        let border_paint =
+            self.brush_to_paint(path.stroke(), size * self.scale_factor).map(|mut paint| {
+                paint.set_line_width((path.stroke_width() * self.scale_factor).get());
+                paint.set_line_cap(match path.stroke_line_cap() {
+                    items::LineCap::Round => femtovg::LineCap::Round,
+                    items::LineCap::Square => femtovg::LineCap::Square,
+                    items::LineCap::Butt | _ => femtovg::LineCap::Butt,
+                });
+                paint.set_line_join(match path.stroke_line_join() {
+                    items::LineJoin::Round => femtovg::LineJoin::Round,
+                    items::LineJoin::Bevel => femtovg::LineJoin::Bevel,
+                    items::LineJoin::Miter | _ => femtovg::LineJoin::Miter,
+                });
+                paint.set_miter_limit(path.stroke_miter_limit());
+                paint.set_anti_alias(anti_alias);
+                paint
             });
-            paint.set_line_join(match path.stroke_line_join() {
-                items::LineJoin::Round => femtovg::LineJoin::Round,
-                items::LineJoin::Bevel => femtovg::LineJoin::Bevel,
-                items::LineJoin::Miter | _ => femtovg::LineJoin::Miter,
-            });
-            paint.set_miter_limit(path.stroke_miter_limit());
-            paint.set_anti_alias(anti_alias);
-            paint
-        });
 
         self.canvas.borrow_mut().save_with(|canvas| {
             canvas.translate(offset.x, offset.y);
@@ -945,8 +947,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GlyphRenderer for GLItemRendere
         brush: Brush,
         size: LogicalSize,
     ) -> Option<Self::PlatformBrush> {
-        let text_path = rect_to_path((size * self.scale_factor).into());
-        self.brush_to_paint(brush, &text_path).map(GlyphBrush::Fill)
+        self.brush_to_paint(brush, size * self.scale_factor).map(GlyphBrush::Fill)
     }
 
     fn platform_brush_for_color(
@@ -966,8 +967,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GlyphRenderer for GLItemRendere
         physical_stroke_width: f32,
         size: LogicalSize,
     ) -> Option<Self::PlatformBrush> {
-        let text_path = rect_to_path((size * self.scale_factor).into());
-        match self.brush_to_paint(stroke_brush.clone(), &text_path) {
+        match self.brush_to_paint(stroke_brush.clone(), size * self.scale_factor) {
             Some(mut paint) => {
                 paint.set_line_width(physical_stroke_width);
                 Some(GlyphBrush::Stroke(paint))
@@ -1259,10 +1259,11 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         image_rect.rect(0., 0., image_size.width, image_size.height);
 
         // We fill the entire image, there is no need to apply anti-aliasing around the edges
-        let brush_paint = match self.brush_to_paint(colorize_brush, &image_rect) {
-            Some(paint) => paint.with_anti_alias(false),
-            None => return original_cache_entry,
-        };
+        let brush_paint =
+            match self.brush_to_paint(colorize_brush, PhysicalSize::from_untyped(image_size)) {
+                Some(paint) => paint.with_anti_alias(false),
+                None => return original_cache_entry,
+            };
 
         self.canvas.borrow_mut().save_with(|canvas| {
             canvas.reset();
@@ -1505,94 +1506,49 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         }
     }
 
-    fn brush_to_paint(&self, brush: Brush, path: &femtovg::Path) -> Option<femtovg::Paint> {
-        if brush.is_transparent() {
-            return None;
-        }
-        Some(match brush {
-            Brush::SolidColor(color) => femtovg::Paint::color(to_femtovg_color(&color)),
-            Brush::LinearGradient(gradient) => {
-                let path_bounds = path_bounding_box(&self.canvas, path);
-
-                let path_width = path_bounds.width();
-                let path_height = path_bounds.height();
-
-                let (start, end) = i_slint_core::graphics::line_for_angle(
-                    gradient.angle(),
-                    [path_width, path_height].into(),
-                );
-
-                let mut stops: Vec<_> = gradient
-                    .stops()
-                    .map(|stop| (stop.position, to_femtovg_color(&stop.color)))
-                    .collect();
-
-                // Add an extra stop at 1.0 with the same color as the last stop
-                if let Some(last_stop) = stops.last().cloned()
-                    && last_stop.0 != 1.0
-                {
-                    stops.push((1.0, last_stop.1));
-                }
-
-                femtovg::Paint::linear_gradient_stops(start.x, start.y, end.x, end.y, stops)
-            }
-            Brush::RadialGradient(gradient) => {
-                let path_bounds = path_bounding_box(&self.canvas, path);
-
-                let path_width = path_bounds.width();
-                let path_height = path_bounds.height();
-
-                let (cx, cy) = gradient.center_or_default_scaled(
-                    path_width,
-                    path_height,
-                    self.scale_factor.get(),
-                );
-                let radius = gradient.radius_or_default_scaled(
-                    path_width,
-                    path_height,
-                    self.scale_factor.get(),
-                );
-
-                let mut stops: Vec<_> = gradient
-                    .stops()
-                    .map(|stop| (stop.position, to_femtovg_color(&stop.color)))
-                    .collect();
-
-                // Add an extra stop at 1.0 with the same color as the last stop
-                if let Some(last_stop) = stops.last().cloned()
-                    && last_stop.0 != 1.0
-                {
-                    stops.push((1.0, last_stop.1));
-                }
-
-                femtovg::Paint::radial_gradient_stops(cx, cy, 0., radius, stops)
-            }
-            Brush::ConicGradient(gradient) => {
-                let path_bounds = path_bounding_box(&self.canvas, path);
-
-                let path_width = path_bounds.width();
-                let path_height = path_bounds.height();
-
-                let (cx, cy) = gradient.center_or_default_scaled(
-                    path_width,
-                    path_height,
-                    self.scale_factor.get(),
-                );
-
-                let stops: Vec<_> = gradient
-                    .stops()
-                    .map(|stop| (stop.position, to_femtovg_color(&stop.color)))
-                    .collect();
-
-                femtovg::Paint::conic_gradient_stops(cx, cy, stops)
-            }
-            _ => return None,
+    /// Converts the brush into a femtovg paint, with gradients resolved against the
+    /// `size` of the shape's geometry.
+    fn brush_to_paint(&self, brush: Brush, size: PhysicalSize) -> Option<femtovg::Paint> {
+        let resolved = i_slint_core::graphics::resolve_brush(&brush, size, self.scale_factor)?;
+        Some(match resolved {
+            ResolvedBrush::SolidColor(color) => femtovg::Paint::color(to_femtovg_color(&color)),
+            ResolvedBrush::LinearGradient(gradient) => femtovg::Paint::linear_gradient_stops(
+                gradient.start.x,
+                gradient.start.y,
+                gradient.end.x,
+                gradient.end.y,
+                to_femtovg_stops(&gradient.stops),
+            ),
+            ResolvedBrush::RadialGradient(gradient) => femtovg::Paint::radial_gradient_stops(
+                gradient.center.x,
+                gradient.center.y,
+                0.,
+                gradient.radius.get(),
+                to_femtovg_stops(&gradient.stops),
+            ),
+            ResolvedBrush::ConicGradient(gradient) => femtovg::Paint::conic_gradient_stops(
+                gradient.center.x,
+                gradient.center.y,
+                to_femtovg_stops(&gradient.stops),
+            ),
         })
     }
 
     fn current_render_target(&self) -> femtovg::RenderTarget {
         self.state.last().unwrap().current_render_target
     }
+}
+
+fn to_femtovg_stops(stops: &[i_slint_core::graphics::GradientStop]) -> Vec<(f32, femtovg::Color)> {
+    let mut stops: Vec<_> =
+        stops.iter().map(|stop| (stop.position, to_femtovg_color(&stop.color))).collect();
+    // Add an extra stop at 1.0 with the same color as the last stop
+    if let Some(last_stop) = stops.last().cloned()
+        && last_stop.0 != 1.0
+    {
+        stops.push((1.0, last_stop.1));
+    }
+    stops
 }
 
 pub fn to_femtovg_color(col: &Color) -> femtovg::Color {

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 use super::{PhysicalBorderRadius, PhysicalLength, PhysicalPoint, PhysicalRect, PhysicalSize};
 use i_slint_core::graphics::ApproxEq;
+use i_slint_core::graphics::ResolvedBrush;
 use i_slint_core::graphics::adjust_rect_and_border_for_inner_drawing;
 use i_slint_core::graphics::boxshadowcache::BoxShadowCache;
 use i_slint_core::graphics::euclid::num::Zero;
@@ -221,7 +222,7 @@ impl<'a> SkiaItemRenderer<'a> {
             brush,
             width,
             height,
-            self.scale_factor.get(),
+            self.scale_factor,
         )?;
         paint.set_shader(Some(shader));
 
@@ -233,92 +234,74 @@ impl<'a> SkiaItemRenderer<'a> {
         brush: Brush,
         width: PhysicalLength,
         height: PhysicalLength,
-        scale_factor: f32,
+        scale_factor: ScaleFactor,
     ) -> Option<(skia_safe::Paint, skia_safe::Shader)> {
-        if brush.is_transparent() {
-            return None;
+        let resolved = i_slint_core::graphics::resolve_brush(
+            &brush,
+            euclid::Size2D::from_lengths(width, height),
+            scale_factor,
+        )?;
+
+        fn gradient<'g>(
+            colors: &'g [skia_safe::Color4f],
+            pos: &'g [f32],
+            in_premul: skia_safe::gradient::interpolation::InPremul,
+        ) -> skia_safe::gradient::Gradient<'g> {
+            skia_safe::gradient::Gradient::new(
+                crate::gradient_colors(colors, pos),
+                skia_safe::gradient::Interpolation {
+                    in_premul,
+                    color_space: skia_safe::gradient::interpolation::ColorSpace::SRGB,
+                    ..Default::default()
+                },
+            )
         }
 
-        match brush {
-            Brush::SolidColor(color) => Some(crate::color_shader(&color)),
+        match resolved {
+            ResolvedBrush::SolidColor(color) => Some(crate::color_shader(&color)),
 
-            Brush::LinearGradient(g) => {
-                let (start, end) = i_slint_core::graphics::line_for_angle(
-                    g.angle(),
-                    [width.get(), height.get()].into(),
-                );
-                let (colors, pos): (Vec<skia_safe::Color4f>, Vec<_>) =
-                    g.stops().map(|s| (to_skia_color4f(&s.color), s.position)).unzip();
+            ResolvedBrush::LinearGradient(g) => {
+                let (colors, pos) = to_skia_stops(&g.stops);
 
                 paint.set_dither(true);
 
-                let gradient_colors = crate::gradient_colors(&colors, &pos);
-                let gradient = skia_safe::gradient::Gradient::new(
-                    gradient_colors,
-                    skia_safe::gradient::Interpolation {
-                        in_premul: skia_safe::gradient::interpolation::InPremul::Yes,
-                        color_space: skia_safe::gradient::interpolation::ColorSpace::SRGB,
-                        ..Default::default()
-                    },
-                );
                 skia_safe::gradient::shaders::linear_gradient(
-                    (skia_safe::Point::new(start.x, start.y), skia_safe::Point::new(end.x, end.y)),
-                    &gradient,
+                    (
+                        skia_safe::Point::new(g.start.x, g.start.y),
+                        skia_safe::Point::new(g.end.x, g.end.y),
+                    ),
+                    &gradient(&colors, &pos, skia_safe::gradient::interpolation::InPremul::Yes),
                     None,
                 )
             }
-            Brush::RadialGradient(g) => {
-                let (colors, pos): (Vec<skia_safe::Color4f>, Vec<_>) =
-                    g.stops().map(|s| (to_skia_color4f(&s.color), s.position)).unzip();
-                let (cx, cy) = g.center_or_default_scaled(width.get(), height.get(), scale_factor);
-                let circle_scale =
-                    g.radius_or_default_scaled(width.get(), height.get(), scale_factor);
+            ResolvedBrush::RadialGradient(g) => {
+                let (colors, pos) = to_skia_stops(&g.stops);
 
                 paint.set_dither(true);
 
-                let gradient_colors = crate::gradient_colors(&colors, &pos);
-                let gradient = skia_safe::gradient::Gradient::new(
-                    gradient_colors,
-                    skia_safe::gradient::Interpolation {
-                        in_premul: skia_safe::gradient::interpolation::InPremul::Yes,
-                        color_space: skia_safe::gradient::interpolation::ColorSpace::SRGB,
-                        ..Default::default()
-                    },
-                );
-                let mut local_matrix = skia_safe::Matrix::scale((circle_scale, circle_scale));
-                local_matrix.post_translate((cx, cy));
+                let mut local_matrix = skia_safe::Matrix::scale((g.radius.get(), g.radius.get()));
+                local_matrix.post_translate((g.center.x, g.center.y));
                 skia_safe::gradient::shaders::radial_gradient(
                     (skia_safe::Point::new(0., 0.), 1.),
-                    &gradient,
+                    &gradient(&colors, &pos, skia_safe::gradient::interpolation::InPremul::Yes),
                     &local_matrix,
                 )
             }
-            Brush::ConicGradient(g) => {
-                let (colors, pos): (Vec<skia_safe::Color4f>, Vec<_>) =
-                    g.stops().map(|s| (to_skia_color4f(&s.color), s.position)).unzip();
-                let (cx, cy) = g.center_or_default_scaled(width.get(), height.get(), scale_factor);
+            ResolvedBrush::ConicGradient(g) => {
+                let (colors, pos) = to_skia_stops(&g.stops);
 
                 paint.set_dither(true);
 
                 // Skia's sweep gradient uses 0 degrees at 3 o'clock (east)
                 // We want 0 degrees at 12 o'clock (north), so we need to rotate by -90 degrees
-                let center = skia_safe::Point::new(cx, cy);
-                let gradient_colors = crate::gradient_colors(&colors, &pos);
-                let gradient = skia_safe::gradient::Gradient::new(
-                    gradient_colors,
-                    skia_safe::gradient::Interpolation {
-                        color_space: skia_safe::gradient::interpolation::ColorSpace::SRGB,
-                        ..Default::default()
-                    },
-                );
+                let center = skia_safe::Point::new(g.center.x, g.center.y);
                 skia_safe::gradient::shaders::sweep_gradient(
                     center,
                     (0.0, 360.0),
-                    &gradient,
+                    &gradient(&colors, &pos, skia_safe::gradient::interpolation::InPremul::No),
                     &skia_safe::Matrix::rotate_deg_pivot(-90.0, center),
                 )
             }
-            _ => None,
         }
         .map(|shader| (paint, shader))
     }
@@ -339,7 +322,7 @@ impl<'a> SkiaItemRenderer<'a> {
             colorize_brush,
             PhysicalLength::new(image.width() as f32),
             PhysicalLength::new(image.height() as f32),
-            self.scale_factor.get(),
+            self.scale_factor,
         )
         .map(|(mut paint, colorize_shader)| {
             let mut surface = self.canvas.new_surface(&image_info, None)?;
@@ -773,7 +756,7 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
                 path.fill(),
                 PhysicalLength::new(viewbox_width),
                 PhysicalLength::new(viewbox_height),
-                1.0,
+                ScaleFactor::new(1.0),
             ) {
                 // Apply the viewbox transformation to the shader
                 let transform = skia_safe::Matrix::scale((scale_x, scale_y));
@@ -1255,6 +1238,12 @@ pub fn to_skia_size(size: &PhysicalSize) -> skia_safe::Size {
 }
 
 /// The result is gamma encoded sRGB, like the `slint::Color` it comes from.
+fn to_skia_stops(
+    stops: &[i_slint_core::graphics::GradientStop],
+) -> (Vec<skia_safe::Color4f>, Vec<f32>) {
+    stops.iter().map(|s| (to_skia_color4f(&s.color), s.position)).unzip()
+}
+
 pub fn to_skia_color(col: &Color) -> skia_safe::Color {
     skia_safe::Color::from_argb(col.alpha(), col.red(), col.green(), col.blue())
 }


### PR DESCRIPTION
Each renderer turned a `Brush` into gradient geometry on its own, with its own handling of out-of-range color stops, and femtovg positioned gradients on the femtovg path's bounding box instead of the element geometry.

Add `i_slint_core::graphics::resolve_brush` (a free function, so `Brush`'s public API is unchanged): gradient geometry in typed physical units plus canonical stops, borrowed from the brush when already canonical — the compiler-produced case — so the common path doesn't allocate.

One commit per renderer. core+anyrender and skia are behavior-neutral (goldens unchanged). femtovg changes behavior: gradients are now positioned on the border box respectively element size, matching the other renderers (fixes #6966).