### PR TITLE
compiler: fix escape sequences in paths

### DIFF
--- a/docs/astro/src/content/docs/reference/language/imports.mdx
+++ b/docs/astro/src/content/docs/reference/language/imports.mdx
@@ -63,6 +63,10 @@ An import path is a double-quoted string literal. \{#sls.import.path-literal}
 <OnlyInSC>
 The path is resolved relative to the directory of the importing source file. \{#sls.import.path-relative}
 </OnlyInSC>
+
+The characters between the quotes are taken verbatim: escape sequences aren't decoded.
+Both `/` and `\` are directory separators,
+so a backslash separates directories rather than escaping the next character. \{#sls.import.path-verbatim}
 </SC>
 
 If the path begins with the character `@`, it is a *library import*:

--- a/docs/astro/src/content/docs/reference/property-types/images.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/images.mdx
@@ -19,6 +19,10 @@ In Slint, an image can be loaded from a file with the `@image-url("...")` constr
 The address within the `@image-url` function must be a string literal and the image is resolved at compile time.
 An empty string produces an empty image.
 
+Unlike an [import path](../../language/imports/#import-paths),
+the address decodes the [escape sequences](../strings/#string) `\"`, `\\`, `\n`, and `\u{...}`,
+so a literal backslash must be written as `\\`.
+
 Slint looks for images in the following places:
 
 1. The absolute path or the path relative to the current `.slint` file.

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -841,6 +841,12 @@ module.exports = grammar({
           "\\",
           '"',
           seq("{", $.expression, "}"),
+          // The lexer accepts a backslash before any character; an escape it
+          // doesn't recognize is a semantic error, not a syntax one. Keeping
+          // such a backslash lets it act as a path separator in an import or
+          // @image-url address. The already-handled characters are excluded so
+          // this doesn't compete with them.
+          /[^"n{\\]/,
         ),
       ),
     /////////////////////////////////////////////////////////////////////

--- a/internal/compiler/pathutils.rs
+++ b/internal/compiler/pathutils.rs
@@ -466,17 +466,17 @@ pub fn dirname(path: &Path) -> PathBuf {
 /// The result will be a `clean_path(...)`.
 pub fn join(base: &Path, path: &Path) -> Option<PathBuf> {
     if is_absolute(path) {
-        return Some(path.to_owned());
+        return Some(clean_path(path));
     }
 
     let Some(base_str) = base.to_str() else {
-        return Some(path.to_owned());
+        return Some(clean_path(path));
     };
     let Some(path_str) = path.to_str() else {
-        return Some(path.to_owned());
+        return Some(clean_path(path));
     };
     if base_str.is_empty() {
-        return Some(path.to_owned());
+        return Some(clean_path(path));
     }
 
     let path_separator = find_path_separator(path_str);
@@ -532,4 +532,15 @@ fn test_join() {
     th("some/relative", "hello.txt", Some("some/relative/hello.txt"));
     th("", "foo/hello.txt", Some("foo/hello.txt"));
     th("some/relative", "/foo/hello.txt", Some("/foo/hello.txt"));
+
+    // An absolute `path` ignores `base`, but is still cleaned up (#12798): a stray
+    // backslash used to be returned verbatim, which then mismatched the cleaned
+    // path used to look the document up again, panicking the type loader.
+    th("some/base", "/ddd\\\"dd", Some("/ddd/\"dd"));
+    th("some/base", "/a/../b", Some("/b"));
+    th("some/base", "/a\\b\\c", Some("/a/b/c"));
+    // Windows drive-absolute paths keep their backslashes.
+    th("some/base", "C:\\a\\b", Some("C:\\a\\b"));
+    // An empty base also cleans the path instead of returning it raw.
+    th("", "a/../b", Some("b"));
 }

--- a/internal/compiler/tests/syntax/expressions/image_url_escape.slint
+++ b/internal/compiler/tests/syntax/expressions/image_url_escape.slint
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The @image-url path is a string literal whose escapes are decoded (unlike an
+// import path), so a lone backslash is an unknown escape rather than a separator.
+export component Test {
+    in property <image> i: @image-url("images\icon.png");
+//                                           ><error{Unknown escape sequence. Use '\\' to escape a literal backslash}
+}

--- a/internal/compiler/tests/syntax/imports/bug_12798.slint
+++ b/internal/compiler/tests/syntax/imports/bug_12798.slint
@@ -1,0 +1,11 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A backslash is a directory separator, not an escape, so it stays in the path.
+// An absolute path with one cleans to a different string; the type loader must
+// not panic looking it up (#12798). A character that can't appear in a file name
+// is reported as missing rather than as a raw OS error.
+import { XX } from "/ddd\dd.slint";
+//                 >             <error{Cannot find requested import "/ddd\dd.slint" in the include search path}
+import { XX as Q } from "/foo\"bar.slint";
+//                      >               <error{Cannot find requested import "/foo\"bar.slint" in the include search path}

--- a/internal/compiler/tests/syntax/imports/import_path_interpolation.slint
+++ b/internal/compiler/tests/syntax/imports/import_path_interpolation.slint
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// An import path must be a plain string literal, so `\{...}` interpolation is rejected.
+import { XX } from "foo\{1 + 1}.slint";
+//                 >    <error{Expected plain string literal}

--- a/internal/compiler/tests/syntax/slint-sc/import_paths.slint
+++ b/internal/compiler/tests/syntax/slint-sc/import_paths.slint
@@ -24,6 +24,12 @@ import { XX } from "/etc/hosts";
 import { XX } from "C:/Windows/win.ini";
 //                 >                  <error{Absolute import paths are not supported in Slint SC}
 
+// The path is taken verbatim: a backslash is a directory separator, not an
+// escape, so this names sub/comp.slint and reports it missing.
+//#sls.import.path-verbatim
+import { XX } from "sub\comp.slint";
+//                 >              <error{Cannot find requested import "sub\comp.slint" in the include search path}
+
 //#sls.import.path-relative
 import { Button } from "std-widgets.slint";
 //                     >                 <error{Importing the builtin file 'std-widgets.slint' is not supported in Slint SC}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1458,7 +1458,15 @@ impl TypeLoader {
                 )),
                 Err(err)
                     if !resolved
-                        && matches!(err.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) =>
+                        && matches!(
+                            err.kind(),
+                            // A path that can't name a file (e.g. one with a character
+                            // Windows forbids) can't be found either, so report it the
+                            // same way rather than leaking the raw OS error.
+                            ErrorKind::NotFound
+                                | ErrorKind::NotADirectory
+                                | ErrorKind::InvalidFilename
+                        ) =>
                 {
                     let import_kind =
                         if file_to_import.starts_with('@') { "library" } else { "include" };
@@ -1808,6 +1816,8 @@ impl TypeLoader {
                         return None;
                     }
                 };
+                // The path is taken verbatim: escape sequences aren't decoded, so a
+                // backslash stays a directory separator rather than an escape.
                 let path_to_import = import_uri.text().to_string();
                 let path_to_import = path_to_import.trim_matches('\"').to_string();
 
@@ -2075,6 +2085,58 @@ fn test_dependency_loading_from_rust() {
     assert!(build_diagnostics.is_empty()); // also no warnings
     assert_eq!(foreign_imports.len(), 3);
     assert!(foreign_imports.iter().all(|x| matches!(x.import_kind, ImportKind::ImportList(..))));
+}
+
+#[test]
+fn test_import_path_verbatim() {
+    // The import path is taken verbatim, not unescaped: a literal Unicode or emoji
+    // file name is used as written, and a backslash is a directory separator rather
+    // than an escape, so `sub\comp.slint` names `sub/comp.slint`. An absolute path
+    // with a backslash cleans to a different string, so it must be registered and
+    // looked up under that cleaned path or the type loader panics (#12798).
+    let requested = Rc::new(RefCell::new(Vec::<String>::new()));
+    let requested_ = requested.clone();
+
+    let mut compiler_config =
+        CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
+    compiler_config.style = Some("fluent".into());
+    compiler_config.open_import_callback = Some(Rc::new(move |path| {
+        let requested_ = requested_.clone();
+        Box::pin(async move {
+            requested_.borrow_mut().push(path);
+            Some(Ok("export XX := Rectangle {} ".to_owned()))
+        })
+    }));
+
+    let mut test_diags = crate::diagnostics::BuildDiagnostics::default();
+    let doc_node = crate::parser::parse(
+        r#"
+import { XX as A } from "naïve.slint";
+import { XX as B } from "party🎉.slint";
+import { XX as C } from "sub\comp.slint";
+import { XX as D } from "/ddd\dd.slint";
+export component X { A {} B {} C {} D {} }
+"#
+        .into(),
+        Some(std::path::Path::new("HELLO")),
+        &mut test_diags,
+    );
+
+    let doc_node: syntax_nodes::Document = doc_node.into();
+    let mut build_diagnostics = BuildDiagnostics::default();
+    let mut loader = TypeLoader::new(compiler_config, &mut build_diagnostics);
+    let registry = Rc::new(RefCell::new(TypeRegister::new(&loader.global_type_registry)));
+    spin_on::spin_on(loader.load_dependencies_recursively(
+        &doc_node,
+        &mut build_diagnostics,
+        &registry,
+    ));
+    assert!(!test_diags.has_errors());
+    assert!(!build_diagnostics.has_errors(), "{:?}", build_diagnostics.to_string_vec());
+    let mut requested = requested.borrow().clone();
+    requested.sort();
+    // Unicode names are kept as written; a backslash is normalized to a slash.
+    assert_eq!(requested, ["/ddd/dd.slint", "naïve.slint", "party🎉.slint", "sub/comp.slint"]);
 }
 
 #[test]

--- a/tests/cases/imports/backslash_path.slint
+++ b/tests/cases/imports/backslash_path.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Python is ignored because include paths aren't forwarded in the generated stubs.
+//ignore: pyi
+
+// A backslash in an import path is a directory separator, not an escape, so this
+// resolves to helper_components/imported_via_backslash.slint on every platform.
+//include_path: ../..
+import { BackslashHelper } from "helper_components\imported_via_backslash.slint";
+
+export component TestCase inherits Rectangle {
+    h := BackslashHelper {}
+    out property <bool> test: h.value == 42;
+}

--- a/tests/cases/imports/unicode_paths.slint
+++ b/tests/cases/imports/unicode_paths.slint
@@ -1,0 +1,16 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Python is ignored because include paths aren't forwarded in the generated stubs.
+//ignore: pyi
+
+// A Unicode or emoji file name is taken verbatim and loads the matching file.
+//include_path: ../../helper_components
+import { UnicodeHelper } from "café.slint";
+import { EmojiHelper } from "party🎉.slint";
+
+export component TestCase inherits Rectangle {
+    u := UnicodeHelper {}
+    p := EmojiHelper {}
+    out property <bool> test: u.value == 2 && p.value == 3;
+}

--- a/tests/cases/types/image_url_escapes.slint
+++ b/tests/cases/types/image_url_escapes.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//include_path: ../../../demos/printerdemo/ui/images/
+
+// The @image-url path is unescaped: a `\u{...}` escape is decoded (`\u{63}` is
+// `c`, so this names cat.jpg), and a `\\` decodes to a `\`, which resolves as a
+// directory separator just like `/`.
+export component TestCase inherits Rectangle {
+    in-out property <image> escaped: @image-url("\u{63}at.jpg");
+    in-out property <image> backslash: @image-url("..\\images\\cat.jpg");
+    in-out property <image> forward: @image-url("../images/cat.jpg");
+
+    out property <bool> test:
+        escaped.width == 320 && escaped.height == 480
+        && backslash.width == 320 && backslash.height == 480
+        && backslash.width == forward.width && backslash.height == forward.height;
+}

--- a/tests/helper_components/café.slint
+++ b/tests/helper_components/café.slint
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component UnicodeHelper inherits Rectangle {
+    in-out property <int> value: 2;
+}

--- a/tests/helper_components/imported_via_backslash.slint
+++ b/tests/helper_components/imported_via_backslash.slint
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component BackslashHelper inherits Rectangle {
+    in-out property <int> value: 42;
+}

--- a/tests/helper_components/party🎉.slint
+++ b/tests/helper_components/party🎉.slint
@@ -1,0 +1,6 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component EmojiHelper inherits Rectangle {
+    in-out property <int> value: 3;
+}


### PR DESCRIPTION
Fixes: https://github.com/slint-ui/slint/issues/12798