### PR TITLE
compiler: Reject imports that name an embedded file

### DIFF
--- a/internal/compiler/tests/syntax/imports/import_builtin.slint
+++ b/internal/compiler/tests/syntax/imports/import_builtin.slint
@@ -11,3 +11,12 @@ import { Button } from "std-widgets-impl.slint";
 //                     >                      <error{Cannot find requested import "std-widgets-impl.slint" in the include search path}
 import { NotAThing } from "std-widgets-impl.slint";
 //                        >                      <error{Cannot find requested import "std-widgets-impl.slint" in the include search path}
+
+// Naming the embedded path doesn't reach them either: not the implementation
+// files, and not a style other than the configured one.
+import { StyleMetrics } from "builtin:/fluent/std-widgets-impl.slint";
+//                           >                                      <error{Cannot import "builtin:/fluent/std-widgets-impl.slint": the files built into the compiler are internal. Import the widgets from "std-widgets.slint"}
+import { Button } from "builtin:/fluent/button.slint";
+//                     >                            <error{Cannot import "builtin:/fluent/button.slint": the files built into the compiler are internal. Import the widgets from "std-widgets.slint"}
+import { Button as C } from "builtin:/cupertino/std-widgets.slint";
+//                          >                                    <error{Cannot import "builtin:/cupertino/std-widgets.slint": the files built into the compiler are internal. Import the widgets from "std-widgets.slint"}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -1081,6 +1081,21 @@ impl TypeLoader {
         let mut imports = Vec::new();
         let mut dependencies_futures = Vec::new();
         for mut import in Self::collect_dependencies(state, doc) {
+            // The embedded files import each other by that path, so only a
+            // document outside them is rejected.
+            if import.file.starts_with("builtin:")
+                && !import.import_uri_token.source_file.path().starts_with("builtin:")
+            {
+                state.borrow_mut().diag.push_error(
+                    format!(
+                        "Cannot import \"{}\": the files built into the compiler are internal. Import the widgets from \"std-widgets.slint\"",
+                        import.file
+                    ),
+                    &import.import_uri_token,
+                );
+                continue;
+            }
+
             // The path shapes that don't resolve relative to the importing
             // file. Rejecting them here, before any search path is consulted,
             // keeps the Slint SC error the only diagnostic and leaves the
@@ -1193,9 +1208,11 @@ impl TypeLoader {
                 };
 
                 // The widget library and the styles are built into the
-                // compiler and aren't part of the subset. Their own imports
-                // reach this too, but the error is suppressed for a builtin
-                // referencing file.
+                // compiler and aren't part of the subset. This catches the
+                // "std-widgets.slint" spelling, which only becomes a builtin
+                // path here; naming the embedded path is rejected earlier, for
+                // every mode. Their own imports reach this too, but the error
+                // is suppressed for a builtin referencing file.
                 #[cfg(feature = "slint-sc")]
                 if doc_path.starts_with("builtin:") {
                     state.diag.slint_sc_error(


### PR DESCRIPTION
A path starting with `builtin:` bypassed the include path and loaded any file built into the compiler, reaching the widget implementations and the styles. The widgets stay importable from "std-widgets.slint".

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
