### PR TITLE
docs: fix doubled path in weather-demo README links

### DIFF
--- a/demos/weather-demo/README.md
+++ b/demos/weather-demo/README.md
@@ -5,7 +5,7 @@ A simple, cross-platform (Desktop, Android, Wasm) weather application using real
 
 | `.slint` Design | Rust Source (Desktop) | Rust Source (Android / Wasm) | Online wasm Preview | Open in SlintPad |
 | --- | --- | --- | --- | --- |
-| [`main.slint`](./weather-demo/ui/main.slint) | [`main.rs`](./weather-demo/src/main.rs) | [`lib.rs`](./weather-demo/src/lib.rs) | [Online simulation](https://slint.dev/snapshots/master/demos/weather-demo/) | [Preview in Online Code Editor](https://slint.dev/snapshots/master/editor?load_url=https://raw.githubusercontent.com/slint-ui/slint/master/demos/weather-demo/ui/main.slint) |
+| [`main.slint`](./ui/main.slint) | [`main.rs`](./src/main.rs) | [`lib.rs`](./src/lib.rs) | [Online simulation](https://slint.dev/snapshots/master/demos/weather-demo/) | [Preview in Online Code Editor](https://slint.dev/snapshots/master/editor?load_url=https://raw.githubusercontent.com/slint-ui/slint/master/demos/weather-demo/ui/main.slint) |
 
 Weather Demo is a weather application made by [Felgo](https://felgo.com/).
 


### PR DESCRIPTION
The source-file cells in `demos/weather-demo/README.md` link with a doubled path, e.g. `[main.slint](./weather-demo/ui/main.slint)`. Since the README is already in `demos/weather-demo/`, those resolve to `demos/weather-demo/weather-demo/...` and 404 on GitHub. The files are at `demos/weather-demo/ui/main.slint`, `demos/weather-demo/src/main.rs`, and `demos/weather-demo/src/lib.rs`. The "Preview in Online Code Editor" link in the same row already uses the correct path. This drops the extra `weather-demo/` segment.
