### PR TITLE
fix: don't drop animate-only bindings during alias removal

### DIFF
--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -226,7 +226,9 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                     *b = old_binding;
                 }
             } else {
-                if (same_component || both_global) && old_binding.has_binding() {
+                if (same_component || both_global)
+                    && (old_binding.has_binding() || old_binding.animation.is_some())
+                {
                     to_elem.set_binding(to.name().clone(), old_binding);
                 }
             }

--- a/tests/cases/bindings/issue_4529_spinner_animation.slint
+++ b/tests/cases/bindings/issue_4529_spinner_animation.slint
@@ -1,0 +1,33 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component SpinnerBase {
+    in property <float> progress;
+}
+
+export component Spinner {
+    in property <float> progress <=> base.progress;
+    base := SpinnerBase { }
+}
+
+export component TestCase {
+    spinner := Spinner {
+        animate progress { duration: 200ms; }
+    }
+    public function set() {
+        spinner.progress = 0.5;
+    }
+    out property <float> observed: spinner.progress;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_observed(), 0.0);
+instance.invoke_set();
+slint_testing::mock_elapsed_time(100);
+assert!((instance.get_observed() - 0.25).abs() < 0.01, "got {}", instance.get_observed());
+slint_testing::mock_elapsed_time(100);
+assert!((instance.get_observed() - 0.5).abs() < 0.01, "got {}", instance.get_observed());
+```
+*/


### PR DESCRIPTION
Closes #4529 

When collapsing a two-way-bound property whose only binding is `animate` onto an alias target that has no binding of its own yet, `remove_aliases` gated on`has_binding()` before installing the binding on the target. `has_binding()` only reflects the expression/two-way-bindings, not `animation`, so an animation-only binding was silently discarded instead of being moved onto the target. This matches how `merge_with` already treats animations.