### PR TITLE
FlexboxLayout: fix too-short auto-sized window with a nested flexbox

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -2117,6 +2117,39 @@ pub fn flexbox_layout_info_cross_axis(
     flex_wrap: FlexboxLayoutWrap,
     constraint_size: Coord,
 ) -> LayoutInfo {
+    flexbox_layout_info_cross_axis_with_measure(
+        cells_h,
+        cells_v,
+        flex_props,
+        spacing_h,
+        spacing_v,
+        padding_h,
+        padding_v,
+        direction,
+        flex_wrap,
+        constraint_size,
+        None,
+    )
+}
+
+/// Same as [`flexbox_layout_info_cross_axis`], with a measure callback so
+/// height-for-width cells (e.g. a nested wrapping flexbox) are measured at the
+/// main-axis size taffy actually assigns them, not at the pre-computed cell
+/// size (which was measured at the container width).
+#[allow(clippy::too_many_arguments)]
+pub fn flexbox_layout_info_cross_axis_with_measure(
+    cells_h: Slice<LayoutItemInfo>,
+    cells_v: Slice<LayoutItemInfo>,
+    flex_props: Slice<FlexItemProps>,
+    spacing_h: Coord,
+    spacing_v: Coord,
+    padding_h: &Padding,
+    padding_v: &Padding,
+    direction: FlexboxLayoutDirection,
+    flex_wrap: FlexboxLayoutWrap,
+    constraint_size: Coord,
+    measure: FlexboxMeasureFn<'_>,
+) -> LayoutInfo {
     debug_assert_eq!(cells_h.len(), cells_v.len());
     debug_assert_eq!(cells_h.len(), flex_props.len());
     if cells_h.is_empty() {
@@ -2216,7 +2249,7 @@ pub fn flexbox_layout_info_cross_axis(
         flex_direction: taffy_direction,
         container_width,
         container_height,
-        use_measure_for_cross_axis: false,
+        use_measure_for_cross_axis: measure.is_some(),
     });
 
     let (available_width, available_height) = match direction {
@@ -2228,7 +2261,7 @@ pub fn flexbox_layout_info_cross_axis(
         }
     };
 
-    builder.compute_layout(available_width, available_height, None);
+    builder.compute_layout(available_width, available_height, measure);
 
     let (total_width, total_height) = builder.container_size();
     let cross_size = match direction {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -373,6 +373,12 @@ struct ChildElem {
     /// returns trivial info that doesn't reflect the aggregated
     /// constraints; we read the aggregated property directly.
     has_aggregated_info: bool,
+    /// True for a builtin whose height depends on its width (wrapped Text,
+    /// Image): only those are worth re-measuring through the Item vtable.
+    /// For other builtins the vtable returns trivial info, dropping the
+    /// element-level constraints (e.g. `preferred-height`) already in the
+    /// pre-computed cell.
+    builtin_height_for_width: bool,
     /// For a repeated cell, the instance to query — its constrained
     /// layout-info function lives in the instance's own item tree, not in
     /// the parent `component`. `None` for a static cell.
@@ -405,6 +411,7 @@ fn collect_flexbox_child_elems(
         let has_constrained_layoutinfo_v = qe.inherited_layout_info_v_with_constraint().is_some();
         let has_constrained_layoutinfo_h = qe.inherited_layout_info_h_with_constraint().is_some();
         let has_aggregated_info = qe.layout_info_prop.is_some();
+        let builtin_height_for_width = qe.is_builtin_height_for_width();
         drop(qe);
         if repeated {
             // One entry per instance: each is re-measured through its own item
@@ -416,6 +423,7 @@ fn collect_flexbox_child_elems(
                     has_constrained_layoutinfo_v,
                     has_constrained_layoutinfo_h,
                     has_aggregated_info,
+                    builtin_height_for_width,
                     repeated_instance: Some(instance),
                 }));
             }
@@ -425,6 +433,7 @@ fn collect_flexbox_child_elems(
                 has_constrained_layoutinfo_v,
                 has_constrained_layoutinfo_h,
                 has_aggregated_info,
+                builtin_height_for_width,
                 repeated_instance: None,
             }));
         }
@@ -491,7 +500,8 @@ fn measure_flexbox_cell(
         }
     };
 
-    if known_w.is_some() && known_h.is_none() {
+    // Compute the cell's vertical info at the width `w`.
+    let measure_height = || -> (f32, f32) {
         if use_property_lookup {
             let v_info = query(Orientation::Vertical, ce.has_constrained_layoutinfo_v.then_some(w));
             return (w, v_info.preferred_bounded());
@@ -502,9 +512,7 @@ fn measure_flexbox_cell(
         // repeated cell (which lives in its own instance): a
         // height-for-width repeated cell takes the `query` path above, and a
         // non-height-for-width one keeps its width-independent default `h`.
-        if let Some(item_within) = ce
-            .repeated_instance
-            .is_none()
+        if let Some(item_within) = (ce.repeated_instance.is_none() && ce.builtin_height_for_width)
             .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
             .flatten()
         {
@@ -519,36 +527,39 @@ fn measure_flexbox_cell(
             );
             return (w, v_info.preferred_bounded());
         }
-        return (w, h);
-    }
-    if known_h.is_some() && known_w.is_none() {
+        (w, h)
+    };
+    // Compute the cell's horizontal info at the height `h`.
+    let measure_width = || -> (f32, f32) {
         if use_property_lookup {
             let h_info =
                 query(Orientation::Horizontal, ce.has_constrained_layoutinfo_h.then_some(h));
             return (h_info.preferred_bounded(), h);
         }
-        // Builtin path, symmetric to the known-w branch above: parent-tree
-        // lookup only, so it is skipped for a repeated cell.
-        if let Some(item_within) = ce
-            .repeated_instance
-            .is_none()
-            .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
-            .flatten()
-        {
-            let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
-            let item_rc = ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
-            let item = unsafe { item_within.item_from_item_tree(component.as_ptr()) };
-            let h_info = item.as_ref().layout_info(
-                to_runtime(Orientation::Horizontal),
-                h,
-                window_adapter,
-                &item_rc,
-            );
-            return (h_info.preferred_bounded(), h);
+        // No builtin path here, unlike measure_height: no builtin derives its
+        // width from its height (even Image's horizontal layout_info ignores
+        // the cross-axis constraint), so the Item vtable could only return
+        // trivial info and drop element-level constraints like
+        // `preferred-width`. Keep the pre-computed default.
+        (w, h)
+    };
+
+    match (known_w, known_h) {
+        (Some(_), Some(_)) => (w, h),
+        (Some(_), None) => measure_height(),
+        (None, Some(_)) => measure_width(),
+        // A (None, None) call asks for the content size. The returned pair
+        // must be self-consistent — the height must be the height *at the
+        // returned width* — because taffy caches the result and reuses the
+        // height for a later query with that width known. So measure the free
+        // axis at the returned default size: the vertical axis for a
+        // height-for-width cell, or the horizontal one for a
+        // width-for-height-only cell (a vertical measure couldn't help it).
+        (None, None) => {
+            let w4h_only = ce.has_constrained_layoutinfo_h && !ce.has_constrained_layoutinfo_v;
+            if w4h_only { measure_width() } else { measure_height() }
         }
-        return (w, h);
     }
-    (w, h)
 }
 
 fn flexbox_layout_direction(
@@ -669,7 +680,27 @@ pub(crate) fn compute_flexbox_layout_info(
                 width_ref.as_ref().map(&expr_eval).unwrap_or(0.)
             }
         });
-        core_layout::flexbox_layout_info_cross_axis(
+        // Re-measure height-for-width cells at the main-axis size taffy
+        // assigns them, not at the container width the cells were
+        // pre-measured at: e.g. a nested wrapping flexbox laid out at its
+        // preferred width can be taller than when given the full container
+        // width.
+        let window_adapter = component.window_adapter();
+        let child_elems = collect_flexbox_child_elems(flexbox_layout, component);
+        let mut measure =
+            |child_index: usize, known_w: Option<f32>, known_h: Option<f32>| -> (f32, f32) {
+                measure_flexbox_cell(
+                    &child_elems,
+                    component,
+                    &window_adapter,
+                    &cells_h,
+                    &cells_v,
+                    child_index,
+                    known_w,
+                    known_h,
+                )
+            };
+        core_layout::flexbox_layout_info_cross_axis_with_measure(
             Slice::from(cells_h.as_slice()),
             Slice::from(cells_v.as_slice()),
             Slice::from(flex_props.as_slice()),
@@ -680,6 +711,7 @@ pub(crate) fn compute_flexbox_layout_info(
             direction,
             flex_wrap,
             constraint_size,
+            Some(&mut measure),
         )
         .into()
     }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -343,31 +343,50 @@ pub(crate) fn solve_flexbox_layout(
 
     let window_adapter = component.window_adapter();
 
-    // Build measure callback that computes constrained layout_info for items
-    // that support height-for-width (Text with wrap, Image with aspect ratio,
-    // and component instances with a synthesized
-    // `layoutinfo-{v,h}-with-constraint`).
-    //
-    // Collect `(element, has_constrained_layoutinfo_{v,h})` so we can
-    // dispatch component instances through the parametrized layout-info
-    // function rather than through the Item vtable (which returns trivial
-    // info for the Empty wrapper of a sub-component instance).
-    struct ChildElem {
-        elem: ElementRc,
-        has_constrained_layoutinfo_v: bool,
-        has_constrained_layoutinfo_h: bool,
-        /// True when the cell aggregates layoutinfo from its own subtree
-        /// (set by `default_geometry::gen_layout_info_prop`) — typical for
-        /// component-wrappers like a Rectangle containing a layout. In
-        /// that case the Item vtable's `layout_info` on the wrapper item
-        /// returns trivial info that doesn't reflect the aggregated
-        /// constraints; we read the aggregated property directly.
-        has_aggregated_info: bool,
-        /// For a repeated cell, the instance to query — its constrained
-        /// layout-info function lives in the instance's own item tree, not in
-        /// the parent `component`. `None` for a static cell.
-        repeated_instance: Option<crate::dynamic_item_tree::DynamicComponentVRc>,
-    }
+    let child_elems = collect_flexbox_child_elems(flexbox_layout, component);
+    let mut measure =
+        |child_index: usize, known_w: Option<f32>, known_h: Option<f32>| -> (f32, f32) {
+            measure_flexbox_cell(
+                &child_elems,
+                component,
+                &window_adapter,
+                &cells_h,
+                &cells_v,
+                child_index,
+                known_w,
+                known_h,
+            )
+        };
+
+    core_layout::solve_flexbox_layout_with_measure(&data, ri, Some(&mut measure)).into()
+}
+
+/// One flexbox cell as seen by the measure callback.
+struct ChildElem {
+    elem: ElementRc,
+    has_constrained_layoutinfo_v: bool,
+    has_constrained_layoutinfo_h: bool,
+    /// True when the cell aggregates layoutinfo from its own subtree
+    /// (set by `default_geometry::gen_layout_info_prop`) — typical for
+    /// component-wrappers like a Rectangle containing a layout. In
+    /// that case the Item vtable's `layout_info` on the wrapper item
+    /// returns trivial info that doesn't reflect the aggregated
+    /// constraints; we read the aggregated property directly.
+    has_aggregated_info: bool,
+    /// For a repeated cell, the instance to query — its constrained
+    /// layout-info function lives in the instance's own item tree, not in
+    /// the parent `component`. `None` for a static cell.
+    repeated_instance: Option<crate::dynamic_item_tree::DynamicComponentVRc>,
+}
+
+/// Collect `(element, has_constrained_layoutinfo_{v,h})` so we can
+/// dispatch component instances through the parametrized layout-info
+/// function rather than through the Item vtable (which returns trivial
+/// info for the Empty wrapper of a sub-component instance).
+fn collect_flexbox_child_elems(
+    flexbox_layout: &i_slint_compiler::layout::FlexboxLayout,
+    component: InstanceRef,
+) -> Vec<Option<ChildElem>> {
     let mut child_elems: Vec<Option<ChildElem>> = Vec::new();
     for layout_elem in &flexbox_layout.elems {
         let placeholder = layout_elem.item.element.borrow();
@@ -410,121 +429,126 @@ pub(crate) fn solve_flexbox_layout(
             }));
         }
     }
+    child_elems
+}
 
-    let mut measure = |child_index: usize,
-                       known_w: Option<f32>,
-                       known_h: Option<f32>|
-     -> (f32, f32) {
-        let default_w = cells_h.get(child_index).map_or(0., |c| c.constraint.preferred_bounded());
-        let default_h = cells_v.get(child_index).map_or(0., |c| c.constraint.preferred_bounded());
-        let w = known_w.unwrap_or(default_w);
-        let h = known_h.unwrap_or(default_h);
+/// Measure callback body: compute constrained layout_info for cells that
+/// support height-for-width (Text with wrap, Image with aspect ratio, and
+/// component instances with a synthesized `layoutinfo-{v,h}-with-constraint`).
+fn measure_flexbox_cell(
+    child_elems: &[Option<ChildElem>],
+    component: InstanceRef,
+    window_adapter: &Rc<dyn WindowAdapter>,
+    cells_h: &[core_layout::LayoutItemInfo],
+    cells_v: &[core_layout::LayoutItemInfo],
+    child_index: usize,
+    known_w: Option<f32>,
+    known_h: Option<f32>,
+) -> (f32, f32) {
+    let default_w = cells_h.get(child_index).map_or(0., |c| c.constraint.preferred_bounded());
+    let default_h = cells_v.get(child_index).map_or(0., |c| c.constraint.preferred_bounded());
+    let w = known_w.unwrap_or(default_w);
+    let h = known_h.unwrap_or(default_h);
 
-        let ce = match child_elems.get(child_index) {
-            Some(Some(c)) => c,
-            _ => return (w, h),
-        };
-
-        // Cells whose layoutinfo aggregates from a sub-tree (set by
-        // default_geometry) or that have a parametrized layout-info
-        // function need to be queried by NamedReference. The Item
-        // vtable's `layout_info` on the wrapper item returns trivial
-        // info that ignores the aggregated children.
-        let use_property_lookup = ce.has_aggregated_info
-            || ce.has_constrained_layoutinfo_v
-            || ce.has_constrained_layoutinfo_h;
-
-        // Query the cell's constrained layout-info. A repeated cell lives in
-        // its own instance's item tree (where its `layoutinfo-*-with-constraint`
-        // function is), so re-measure it there at the assigned cross size; a
-        // static cell is queried through the parent `component`.
-        let query = |orientation, constraint: Option<f32>| -> core_layout::LayoutInfo {
-            match &ce.repeated_instance {
-                Some(instance) => {
-                    generativity::make_guard!(guard);
-                    let unerased = instance.unerase(guard);
-                    get_layout_info_with_constraint(
-                        &ce.elem,
-                        unerased.borrow_instance(),
-                        &window_adapter,
-                        orientation,
-                        constraint,
-                    )
-                }
-                None => get_layout_info_with_constraint(
-                    &ce.elem,
-                    component,
-                    &window_adapter,
-                    orientation,
-                    constraint,
-                ),
-            }
-        };
-
-        if known_w.is_some() && known_h.is_none() {
-            if use_property_lookup {
-                let v_info =
-                    query(Orientation::Vertical, ce.has_constrained_layoutinfo_v.then_some(w));
-                return (w, v_info.preferred_bounded());
-            }
-            // Builtin path (Text, Image): use the Item vtable's layout_info,
-            // which honors the cross-axis constraint. This resolves the item in
-            // the parent `component`'s item tree, so it does not apply to a
-            // repeated cell (which lives in its own instance): a
-            // height-for-width repeated cell takes the `query` path above, and a
-            // non-height-for-width one keeps its width-independent default `h`.
-            if let Some(item_within) = ce
-                .repeated_instance
-                .is_none()
-                .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
-                .flatten()
-            {
-                let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
-                let item_rc =
-                    ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
-                let item = unsafe { item_within.item_from_item_tree(component.as_ptr()) };
-                let v_info = item.as_ref().layout_info(
-                    to_runtime(Orientation::Vertical),
-                    w,
-                    &window_adapter,
-                    &item_rc,
-                );
-                return (w, v_info.preferred_bounded());
-            }
-            return (w, h);
-        }
-        if known_h.is_some() && known_w.is_none() {
-            if use_property_lookup {
-                let h_info =
-                    query(Orientation::Horizontal, ce.has_constrained_layoutinfo_h.then_some(h));
-                return (h_info.preferred_bounded(), h);
-            }
-            // Builtin path, symmetric to the known-w branch above: parent-tree
-            // lookup only, so it is skipped for a repeated cell.
-            if let Some(item_within) = ce
-                .repeated_instance
-                .is_none()
-                .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
-                .flatten()
-            {
-                let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
-                let item_rc =
-                    ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
-                let item = unsafe { item_within.item_from_item_tree(component.as_ptr()) };
-                let h_info = item.as_ref().layout_info(
-                    to_runtime(Orientation::Horizontal),
-                    h,
-                    &window_adapter,
-                    &item_rc,
-                );
-                return (h_info.preferred_bounded(), h);
-            }
-            return (w, h);
-        }
-        (w, h)
+    let ce = match child_elems.get(child_index) {
+        Some(Some(c)) => c,
+        _ => return (w, h),
     };
 
-    core_layout::solve_flexbox_layout_with_measure(&data, ri, Some(&mut measure)).into()
+    // Cells whose layoutinfo aggregates from a sub-tree (set by
+    // default_geometry) or that have a parametrized layout-info
+    // function need to be queried by NamedReference. The Item
+    // vtable's `layout_info` on the wrapper item returns trivial
+    // info that ignores the aggregated children.
+    let use_property_lookup = ce.has_aggregated_info
+        || ce.has_constrained_layoutinfo_v
+        || ce.has_constrained_layoutinfo_h;
+
+    // Query the cell's constrained layout-info. A repeated cell lives in
+    // its own instance's item tree (where its `layoutinfo-*-with-constraint`
+    // function is), so re-measure it there at the assigned cross size; a
+    // static cell is queried through the parent `component`.
+    let query = |orientation, constraint: Option<f32>| -> core_layout::LayoutInfo {
+        match &ce.repeated_instance {
+            Some(instance) => {
+                generativity::make_guard!(guard);
+                let unerased = instance.unerase(guard);
+                get_layout_info_with_constraint(
+                    &ce.elem,
+                    unerased.borrow_instance(),
+                    window_adapter,
+                    orientation,
+                    constraint,
+                )
+            }
+            None => get_layout_info_with_constraint(
+                &ce.elem,
+                component,
+                window_adapter,
+                orientation,
+                constraint,
+            ),
+        }
+    };
+
+    if known_w.is_some() && known_h.is_none() {
+        if use_property_lookup {
+            let v_info = query(Orientation::Vertical, ce.has_constrained_layoutinfo_v.then_some(w));
+            return (w, v_info.preferred_bounded());
+        }
+        // Builtin path (Text, Image): use the Item vtable's layout_info,
+        // which honors the cross-axis constraint. This resolves the item in
+        // the parent `component`'s item tree, so it does not apply to a
+        // repeated cell (which lives in its own instance): a
+        // height-for-width repeated cell takes the `query` path above, and a
+        // non-height-for-width one keeps its width-independent default `h`.
+        if let Some(item_within) = ce
+            .repeated_instance
+            .is_none()
+            .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
+            .flatten()
+        {
+            let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
+            let item_rc = ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
+            let item = unsafe { item_within.item_from_item_tree(component.as_ptr()) };
+            let v_info = item.as_ref().layout_info(
+                to_runtime(Orientation::Vertical),
+                w,
+                window_adapter,
+                &item_rc,
+            );
+            return (w, v_info.preferred_bounded());
+        }
+        return (w, h);
+    }
+    if known_h.is_some() && known_w.is_none() {
+        if use_property_lookup {
+            let h_info =
+                query(Orientation::Horizontal, ce.has_constrained_layoutinfo_h.then_some(h));
+            return (h_info.preferred_bounded(), h);
+        }
+        // Builtin path, symmetric to the known-w branch above: parent-tree
+        // lookup only, so it is skipped for a repeated cell.
+        if let Some(item_within) = ce
+            .repeated_instance
+            .is_none()
+            .then(|| component.description.items.get(ce.elem.borrow().id.as_str()))
+            .flatten()
+        {
+            let item_comp = component.self_weak().get().unwrap().upgrade().unwrap();
+            let item_rc = ItemRc::new(vtable::VRc::into_dyn(item_comp), item_within.item_index());
+            let item = unsafe { item_within.item_from_item_tree(component.as_ptr()) };
+            let h_info = item.as_ref().layout_info(
+                to_runtime(Orientation::Horizontal),
+                h,
+                window_adapter,
+                &item_rc,
+            );
+            return (h_info.preferred_bounded(), h);
+        }
+        return (w, h);
+    }
+    (w, h)
 }
 
 fn flexbox_layout_direction(

--- a/tests/cases/layout/flexbox_hforw_at_assigned_width.slint
+++ b/tests/cases/layout/flexbox_hforw_at_assigned_width.slint
@@ -1,0 +1,185 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A height-for-width cell of a row flexbox must be measured at the width taffy
+// assigns it (its preferred width when it doesn't grow), not at the container
+// width. Here the inner flexbox's preferred width is the wrapping "square"
+// estimate (two texts per line), so it wraps to two lines even though it would
+// fit on one line at the full container width. The outer flexbox's reported
+// height must include that second line — this is what sizes an auto-sized
+// window.
+//
+// TODO: the generated-code info path doesn't use the measure callback yet;
+// remove the ignores once it does.
+//ignore: rust,cpp
+
+component ReportedCard inherits Rectangle {
+    FlexboxLayout {
+        padding: 10px;
+        spacing: 30px;
+        Text { text: "Button1"; }
+        FlexboxLayout {
+            spacing: 10px;
+            Text { text: "Button2"; }
+            Text { text: "Button3"; }
+            Text { text: "Button4"; }
+        }
+    }
+}
+
+// Mirror of ReportedCard with column direction, for the width-for-height case.
+// All labels use the same string: the width assertion compares against the
+// reference text's width, so the cells must not depend on every "ButtonN"
+// happening to render equally wide.
+component ReportedCardColumn inherits Rectangle {
+    FlexboxLayout {
+        flex-direction: column;
+        padding: 10px;
+        spacing: 30px;
+        Text { text: "Button1"; }
+        FlexboxLayout {
+            flex-direction: column;
+            spacing: 10px;
+            Text { text: "Button1"; }
+            Text { text: "Button1"; }
+            Text { text: "Button1"; }
+        }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 800px;
+    height: 500px;
+
+    // Single-line reference, so the assertions stay font-independent
+    // (the nodejs backend has no test fonts).
+    refLine := Text { x: -3000px; text: "Button1"; wrap: no-wrap; }
+    out property <length> line-height: refLine.height;
+    property <length> t: refLine.width;
+
+    // Wide enough for one outer line: Button1 + spacing 30 + inner at its
+    // preferred width (2 texts + spacing 10), plus padding 20 and slack.
+    property <length> w: 3 * t + 80px;
+
+    // Inner flexbox wraps at its preferred width: two lines.
+    wrapped := VerticalLayout {
+        x: 0; y: 0; width: w; height: 450px;
+        alignment: start;
+        wrappedCell := Rectangle {
+            FlexboxLayout {
+                padding: 10px;
+                spacing: 30px;
+                Text { text: "Button1"; }
+                FlexboxLayout {
+                    spacing: 10px;
+                    Text { text: "Button2"; }
+                    Text { text: "Button3"; }
+                    Text { text: "Button4"; }
+                }
+            }
+        }
+    }
+
+    // no-wrap reference: the inner flexbox's preferred width is its full
+    // single-line width, so everything stays on one line.
+    nowrap := VerticalLayout {
+        x: 400px; y: 0; width: 4 * t + 100px; height: 450px;
+        alignment: start;
+        nowrapCell := Rectangle {
+            FlexboxLayout {
+                padding: 10px;
+                spacing: 30px;
+                Text { text: "Button1"; }
+                FlexboxLayout {
+                    spacing: 10px;
+                    flex-wrap: no-wrap;
+                    Text { text: "Button2"; }
+                    Text { text: "Button3"; }
+                    Text { text: "Button4"; }
+                }
+            }
+        }
+    }
+
+    // Same content as `wrapped`, but measured through the *constrained*
+    // layout-info function (`layoutinfo-v-with-constraint`): a
+    // height-for-width cell of a wrapping flexbox is measured that way at its
+    // assigned width — like an auto-sized window is. On that path the cells
+    // are pre-measured at the container width, so the taffy measure callback
+    // must return self-consistent (width, height-at-that-width) pairs, or
+    // taffy's measure cache serves the pre-measured height for the inner
+    // flexbox and drops its second line.
+    FlexboxLayout {
+        x: 0; y: 200px; width: w; height: 250px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        cross-axis-line-alignment: start;
+        cross-axis-alignment: start;
+        ReportedCard { flex-shrink: 0; flex-basis: w; }
+        anchor := Rectangle { width: w; height: 5px; }
+    }
+
+    // Width-for-height mirror of the case above: a column-direction card as the
+    // cell of a wrapping column flexbox, measured at its assigned height. The
+    // inner column flexbox's preferred height is the wrapping estimate (two
+    // texts per column), so it wraps into a second column that the reported
+    // width must include.
+    property <length> column-height: 3 * line-height + 80px;
+    FlexboxLayout {
+        x: 400px; y: 200px; width: 380px; height: column-height;
+        flex-direction: column;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        cross-axis-line-alignment: start;
+        cross-axis-alignment: start;
+        ReportedCardColumn { flex-shrink: 0; flex-basis: column-height; }
+        colAnchor := Rectangle { width: 5px; height: column-height; }
+    }
+
+    out property <length> wrapped-h: wrappedCell.height;
+    out property <length> nowrap-h: nowrapCell.height;
+    out property <length> constrained-h: anchor.y;
+    out property <length> constrained-w: colAnchor.x;
+
+    // Inner wraps to two lines (spacing 10) + outer padding 20.
+    out property <bool> wrapped-ok: abs(wrapped-h - (2 * line-height + 10px + 20px)) < 1px;
+    // Single line + outer padding 20.
+    out property <bool> nowrap-ok: abs(nowrap-h - (line-height + 20px)) < 1px;
+    out property <bool> constrained-ok: abs(constrained-h - (2 * line-height + 10px + 20px)) < 1px;
+    // Inner wraps into two columns (spacing 10) + outer padding 20.
+    out property <bool> constrained-w-ok: abs(constrained-w - (2 * t + 10px + 20px)) < 1px;
+
+    out property <bool> test: wrapped-ok && nowrap-ok && constrained-ok && constrained-w-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_nowrap_ok(), "no-wrap cell height wrong: {} for line height {}",
+    instance.get_nowrap_h(), instance.get_line_height());
+assert!(instance.get_wrapped_ok(), "wrapped cell height wrong: {} for line height {}",
+    instance.get_wrapped_h(), instance.get_line_height());
+assert!(instance.get_constrained_ok(), "constrained-path cell height wrong: {} for line height {}",
+    instance.get_constrained_h(), instance.get_line_height());
+assert!(instance.get_constrained_w_ok(), "constrained-path cell width wrong: {}",
+    instance.get_constrained_w());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_nowrap_ok());
+assert(instance.get_wrapped_ok());
+assert(instance.get_constrained_ok());
+assert(instance.get_constrained_w_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.nowrap_ok);
+assert(instance.wrapped_ok);
+assert(instance.constrained_ok);
+assert(instance.constrained_w_ok);
+```
+*/


### PR DESCRIPTION
FlexboxLayout: fix too-short auto-sized window with a nested flexbox

The window height comes from the root's vertical layout info at the
preferred width. That cross-axis info path ran taffy without a measure
callback, so a nested wrapping flexbox cell kept the height pre-measured
at the container width instead of the width taffy assigns it (its own
preferred width, where it wraps to more lines).

- add flexbox_layout_info_cross_axis_with_measure and pass the same
  measure callback the solve path uses (interpreter only for now)
- a (None, None) measure must return a self-consistent pair (the height
  at the returned width): taffy passes the assigned width in a later
  query, but serves it from its measure cache when the width matches the
  earlier probe's result, reusing the probe's stale height
- only re-measure height-for-width builtins through the Item vtable;
  for others it returns trivial info and would drop element-level
  constraints like preferred-height

The generated-code info path has no measure callback yet, so the new test is ignored for rust and cpp
(will be fixed in a followup PR).

Easier to review the two commits separately, the first one is a no-op refactoring for code reuse.