### PR TITLE
Match Optimization Improvements

### DIFF
--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -164,6 +164,14 @@ fn resolve_match_elements(
             match_element.cases.iter().map(|case| CaseValue::new(&case.value)).collect();
         check_duplicate_cases(&match_element.cases, &values, diag);
         check_exhaustiveness(match_element, &values, diag);
+
+        let subject_ref = crate::layout::create_new_prop(elem, "match-subject".into(), case_type);
+        let subject = std::mem::replace(
+            &mut match_element.subject,
+            Expression::PropertyReference(subject_ref.clone()),
+        );
+        elem.borrow_mut().set_binding(subject_ref.name().clone(), subject.into());
+
         match_element.lower_to_conditional_elements();
     }
 }

--- a/tests/cases/match_element/multiple_subjects.slint
+++ b/tests/cases/match_element/multiple_subjects.slint
@@ -1,0 +1,117 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nicholas Turner <nicholas.turner@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component TestCase inherits Window {
+    in-out property <int> var1: 1;
+    in-out property <int> var2: 2;
+
+    pure callback a() -> int;
+    pure callback b() -> int;
+
+    match a() {
+        0: TouchArea {
+            x: 0px;
+            y: 100px;
+            width: 100px;
+            height: 100px;
+            clicked => {
+                var1 += 1;
+            }
+        }
+        1: TouchArea {
+            x: 150px;
+            y: 100px;
+            width: 100px;
+            height: 100px;
+            clicked => {
+                var1 += 1;
+            }
+        }
+        2: TouchArea {
+            x: 300px;
+            y: 100px;
+            width: 100px;
+            height: 100px;
+            clicked => {
+                var1 += 1;
+            }
+        }
+        *: { }
+    }
+
+    match b() {
+        0: TouchArea {
+            x: 450px;
+            y: 100px;
+            width: 100px;
+            height: 100px;
+            clicked => {
+                var2 += 1;
+            }
+        }
+        1: TouchArea {
+            x: 600px;
+            y: 100px;
+            width: 100px;
+            height: 100px;
+            clicked => {
+                var2 += 1;
+            }
+        }
+        2: TouchArea {
+            x: 750px;
+            y: 100px;
+            width: 100px;
+            height: 100px;
+            clicked => {
+                var2 += 1;
+            }
+        }
+        *: { }
+    }
+
+
+    in-out property <bool> test: var1 == 1 && var2 == 2;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+auto a_count = std::make_shared<int>(0);
+auto b_count = std::make_shared<int>(0);
+instance.on_a([a_count] { (*a_count)++; return 1; });
+instance.on_b([b_count] { (*b_count)++; return 1; });
+
+slint_testing::send_mouse_click(&instance, 200., 150.);
+assert_eq(instance.get_var1(), 2);
+assert_eq(*a_count, 1);
+assert_eq(*b_count, 1);
+
+slint_testing::send_mouse_click(&instance, 650., 150.);
+assert_eq(instance.get_var2(), 3);
+assert_eq(*a_count, 1);
+assert_eq(*b_count, 1);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+let a_count = std::rc::Rc::new(std::cell::Cell::new(0));
+let b_count = std::rc::Rc::new(std::cell::Cell::new(0));
+let a_count_cpy = a_count.clone();
+let b_count_cpy = b_count.clone();
+instance.on_a(move || { a_count_cpy.set(a_count_cpy.get() + 1); 1 });
+instance.on_b(move || { b_count_cpy.set(b_count_cpy.get() + 1); 1 });
+
+slint_testing::send_mouse_click(&instance, 200., 150.);
+assert_eq!(instance.get_var1(), 2);
+assert_eq!(a_count.get(), 1);
+assert_eq!(b_count.get(), 1);
+
+slint_testing::send_mouse_click(&instance, 650., 150.);
+assert_eq!(instance.get_var2(), 3);
+assert_eq!(a_count.get(), 1);
+assert_eq!(b_count.get(), 1);
+```
+*/

--- a/tools/lsp/language/semantic_tokens.rs
+++ b/tools/lsp/language/semantic_tokens.rs
@@ -49,6 +49,7 @@ pub fn get_semantic_tokens(
                 SyntaxKind::RepeatedElement => Some((self::KEYWORD, 0)),
                 SyntaxKind::RepeatedIndex => Some((self::VARIABLE, 1 << self::DEFINITION)),
                 SyntaxKind::ConditionalElement => Some((self::KEYWORD, 0)),
+                SyntaxKind::MatchElement => Some((self::KEYWORD, 0)),
                 SyntaxKind::CallbackDeclaration => Some((self::KEYWORD, 0)),
                 SyntaxKind::CallbackConnection => Some((self::FUNCTION, 0)),
                 SyntaxKind::PropertyDeclaration => Some((self::KEYWORD, 0)),


### PR DESCRIPTION
Builds off of [PR #12680](https://github.com/slint-ui/slint/pull/12680) to further optimize experimental match elements as requested in [issue #1307](https://github.com/slint-ui/slint/issues/1307#issue-1257855957)

## Updated Expression Resolution
Updated the evaluation of the match subject to only occur once, reducing time spent for expensive calculations.

``` slint no-test
match expensive_calculation() {
    0: Rectangle { }
    1: Rectangle { }
    *: Rectangle { }
}
```

## Updated LSP to Recognize `match` as a Keyword
`match` now receives keyword syntactic highlighting.


<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
