### PR TITLE
Rename flex-align-self to cross-axis-self-alignment and stabilize it

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/flexbox-item-properties.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/flexbox-item-properties.mdx
@@ -3,14 +3,14 @@ title: Flexbox Item Properties
 description: Experimental per-item properties for FlexboxLayout children.
 ---
 
-The children of a `FlexboxLayout` can set `flex-grow`, `flex-shrink`, `flex-basis`,
-`flex-align-self` and `flex-order` to control how the layout treats them individually.
+The children of a `FlexboxLayout` can set `flex-grow`, `flex-shrink`, `flex-basis`
+and `flex-order` to control how the layout treats them individually.
 
 > **Note**: these properties are experimental and subject to change.
 > Per-item properties shouldn't be specific to `FlexboxLayout` — they should work in
 > `HorizontalLayout`, `VerticalLayout` and `GridLayout` too, and preferably reuse the existing
 > `horizontal-stretch`/`vertical-stretch` and min/max/preferred size properties. That design
-> discussion is still open, which is why these five are not part of the stable API yet.
+> discussion is still open, which is why these four are not part of the stable API yet.
 > Expect them to be renamed, or replaced by the properties the other layouts already use.
 >
 > The Experimental Features overview page explains how to enable them.
@@ -25,13 +25,12 @@ FlexboxLayout {
 Each one behaves like the CSS property of the same name, with the same default, so refer to the CSS
 flexbox documentation for what they do:
 
-| Property          | CSS property  | Default |
-| ----------------- | ------------- | ------- |
-| `flex-grow`       | `flex-grow`   | `0`     |
-| `flex-shrink`     | `flex-shrink` | `1`     |
-| `flex-basis`      | `flex-basis`  | `auto`  |
-| `flex-align-self` | `align-self`  | `auto`  |
-| `flex-order`      | `order`       | `0`     |
+| Property      | CSS property  | Default |
+| ------------- | ------------- | ------- |
+| `flex-grow`   | `flex-grow`   | `0`     |
+| `flex-shrink` | `flex-shrink` | `1`     |
+| `flex-basis`  | `flex-basis`  | `auto`  |
+| `flex-order`  | `order`       | `0`     |
 
 One difference: an `auto` `flex-basis` uses the item's `preferred-width` (row direction) or
 `preferred-height` (column direction), rather than sizing it from its content.

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -227,17 +227,17 @@ export component MainWindow inherits Window {
                     width: 80phx;
                     height: 40phx;
                 }
-                // flex-align-self: orange item overrides the container's cross-axis-alignment
+                // cross-axis-self-alignment: orange item overrides the container's cross-axis-alignment
                 FlexCell {
                     cell_text: "S self:end";
-                    flex-align-self: end;
+                    cross-axis-self-alignment: end;
                     height: 30phx;
                     background: #e67e22;
                 }
 
                 FlexCell {
                     cell_text: "T self:center";
-                    flex-align-self: center;
+                    cross-axis-self-alignment: center;
                     height: 30phx;
                     background: #d35400;
                 }

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -433,9 +433,10 @@ macro_rules! for_each_enums {
                 Center,
             }
 
-            /// Overrides the container's `cross-axis-alignment` for a specific flex item.
+            /// Overrides the container's `cross-axis-alignment` for a single item.
+            /// Used as the `cross-axis-self-alignment` property of the children of a `FlexboxLayout`.
             #[non_exhaustive]
-            enum FlexboxLayoutAlignSelf {
+            enum CrossAxisSelfAlignment {
                 /// Use the container's `cross-axis-alignment` value (default).
                 Auto,
                 /// The item is stretched to fill the line along the cross axis.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2172,6 +2172,15 @@ export component HorizontalLayout {
 /// In row direction, items are placed from left to right. When the available width is exceeded, items automatically wrap to the next row. In column direction, items are placed from top to bottom and wrap to the next column when the available height is exceeded.
 ///
 /// \footer
+/// ## Cell elements
+/// Cell elements inside a `FlexboxLayout` obtain the following new property:
+///
+/// ### cross-axis-self-alignment
+/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+/// Overrides the container's `cross-axis-alignment` for this element. CSS Flexbox calls this "align-self".
+/// The default value `auto` uses the container's `cross-axis-alignment`.
+/// </SlintProperty>
+///
 /// ## Layout Behavior
 ///
 /// The layouting algorithm for FlexboxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3003,7 +3003,7 @@ fn generate_flexbox_layout_item_info_decl(
         // Equivalent of the Rust trait default `layout_item_info(o).into()`, whose
         // props are FlexItemProps::default() (note flex_shrink defaults to 1, not 0).
         "auto base = layout_item_info(o, child_index); \
-         return { base.constraint, { 0.0f, 1.0f, -1.0f, slint::cbindgen_private::FlexboxLayoutAlignSelf::Auto, 0 } };"
+         return { base.constraint, { 0.0f, 1.0f, -1.0f, slint::cbindgen_private::CrossAxisSelfAlignment::Auto, 0 } };"
             .to_owned()
     };
 

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1084,7 +1084,7 @@ struct BoxLayoutDataResult {
 }
 
 fn default_align_self() -> (Type, llr_Expression) {
-    let e = crate::typeregister::BUILTIN.enums.FlexboxLayoutAlignSelf.clone();
+    let e = crate::typeregister::BUILTIN.enums.CrossAxisSelfAlignment.clone();
     (
         Type::Enumeration(e.clone()),
         llr_Expression::EnumerationValue(EnumerationValue {
@@ -1118,7 +1118,7 @@ fn make_flex_props_struct(fp: FlexItemProps) -> llr_Expression {
             ("flex-grow", Type::Float32, fp.grow),
             ("flex-shrink", Type::Float32, fp.shrink),
             ("flex-basis", Type::Float32, fp.basis),
-            ("flex-align-self", align_self_ty, fp.align_self),
+            ("cross-axis-self-alignment", align_self_ty, fp.align_self),
             ("flex-order", Type::Int32, fp.order),
         ],
     )
@@ -1991,7 +1991,7 @@ pub fn get_flexbox_layout_item_info_for_repeated(
     let grow = prop_ref("flex-grow").unwrap_or(llr_Expression::NumberLiteral(0.0));
     let shrink = prop_ref("flex-shrink").unwrap_or(llr_Expression::NumberLiteral(1.0));
     let basis = prop_ref("flex-basis").unwrap_or(llr_Expression::NumberLiteral(-1.0));
-    let align_self = prop_ref("flex-align-self").unwrap_or(align_self_default);
+    let align_self = prop_ref("cross-axis-self-alignment").unwrap_or(align_self_default);
     let order = prop_ref("flex-order").unwrap_or(llr_Expression::NumberLiteral(0.0));
 
     make_struct(

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -692,7 +692,7 @@ fn lower_sub_component(
     if component.root_element.borrow().child_of_flexbox {
         let root_elem = &component.root_element;
         let has_flex_binding =
-            ["flex-grow", "flex-shrink", "flex-basis", "flex-align-self", "flex-order"]
+            ["flex-grow", "flex-shrink", "flex-basis", "cross-axis-self-alignment", "flex-order"]
                 .iter()
                 .any(|name| crate::layout::binding_reference(root_elem, name).is_some());
         let v_constrained =

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -4427,12 +4427,13 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
     // generated on the wrapper the layout actually calls it on.
     if old_root.borrow().child_of_flexbox {
         new_root.borrow_mut().child_of_flexbox = true;
-        // That accessor reads the flex-* properties from the repeated root (now the
+        // That accessor reads the flex item properties from the repeated root (now the
         // wrapper). Link them to the inner element that still carries the bindings
         // (and the FlexboxLayout's captured references keeping them alive), rather
         // than moving them, which would leave those references dangling.
         for prop in
-            ["flex-grow", "flex-shrink", "flex-basis", "flex-order", "flex-align-self"].iter()
+            ["flex-grow", "flex-shrink", "flex-basis", "flex-order", "cross-axis-self-alignment"]
+                .iter()
         {
             if old_root.borrow().binding(prop).is_some() {
                 new_root.borrow_mut().set_binding(

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1890,7 +1890,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
         let flex_grow = crate::layout::binding_reference(actual_elem, "flex-grow");
         let flex_shrink = crate::layout::binding_reference(actual_elem, "flex-shrink");
         let flex_basis = crate::layout::binding_reference(actual_elem, "flex-basis");
-        let align_self = crate::layout::binding_reference(actual_elem, "flex-align-self");
+        let align_self = crate::layout::binding_reference(actual_elem, "cross-axis-self-alignment");
         let order = crate::layout::binding_reference(actual_elem, "flex-order");
         layout.elems.push(crate::layout::FlexboxLayoutItem {
             item: item.item,
@@ -2541,10 +2541,7 @@ fn check_no_layout_properties(
         {
             diag.push_error(format!("{prop} used outside of a GridLayout's cell"), &*expr.borrow());
         }
-        if matches!(
-            prop.as_ref(),
-            "flex-grow" | "flex-shrink" | "flex-basis" | "flex-align-self" | "flex-order"
-        ) {
+        if matches!(prop.as_ref(), "flex-grow" | "flex-shrink" | "flex-basis" | "flex-order") {
             if parent_layout_type.as_deref() != Some("FlexboxLayout") {
                 diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
             } else {
@@ -2552,6 +2549,11 @@ fn check_no_layout_properties(
                 // the properties the other layouts already use is still being discussed.
                 crate::reject_experimental_feature(diag, type_register, prop, &*expr.borrow());
             }
+        }
+        if prop == "cross-axis-self-alignment"
+            && parent_layout_type.as_deref() != Some("FlexboxLayout")
+        {
+            diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
         }
         if parent_layout_type.as_deref() != Some("Dialog")
             && matches!(prop.as_ref(), "dialog-button-role")

--- a/internal/compiler/tests/experimental_flex_item_properties.rs
+++ b/internal/compiler/tests/experimental_flex_item_properties.rs
@@ -3,20 +3,16 @@
 
 //! The per-item `flex-*` properties of a `FlexboxLayout` are not stable API yet, so they are only
 //! accepted with experimental features enabled. The syntax tests can't cover this because they
-//! always enable them.
+//! always enable them. This also hosts the stable-API tests for `cross-axis-self-alignment`,
+//! which needs the same experimental-features control.
 
 use i_slint_compiler::diagnostics::{BuildDiagnostics, DiagnosticLevel};
 use i_slint_compiler::generator::OutputFormat;
 use i_slint_compiler::parser::parse;
 use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
 
-const FLEX_ITEM_PROPERTIES: &[&str] = &[
-    "flex-grow: 1",
-    "flex-shrink: 2",
-    "flex-basis: 100px",
-    "flex-align-self: center",
-    "flex-order: 3",
-];
+const FLEX_ITEM_PROPERTIES: &[&str] =
+    &["flex-grow: 1", "flex-shrink: 2", "flex-basis: 100px", "flex-order: 3"];
 
 /// Compile `source` and return its errors (warnings are not of interest here).
 fn errors(source: String, enable_experimental: bool) -> Vec<String> {
@@ -69,12 +65,20 @@ fn flex_item_properties_accepted_with_experimental() {
     }
 }
 
+/// `cross-axis-self-alignment` is stable API, usable without experimental features.
+#[test]
+fn cross_axis_self_alignment_is_stable() {
+    assert_eq!(in_flexbox("cross-axis-self-alignment: center", false), Vec::<String>::new());
+}
+
 /// Outside of a `FlexboxLayout` the property is wrong regardless of the experimental features, so
 /// only that error is reported: being sent to a construct that would then reject them for another
 /// reason would be confusing.
 #[test]
 fn used_outside_of_a_flexbox_reports_only_that() {
-    for binding in FLEX_ITEM_PROPERTIES {
+    for binding in
+        FLEX_ITEM_PROPERTIES.iter().chain(std::iter::once(&"cross-axis-self-alignment: center"))
+    {
         let source = format!(
             r#"
 export component TestCase inherits Window {{
@@ -106,4 +110,19 @@ export component TestCase inherits Window {{
         );
         assert_eq!(errors(source, false), ["'flex-grow' is an experimental feature"]);
     }
+}
+
+/// The `CrossAxisSelfAlignment` enum is in the stable type register:
+/// nameable as a type and as a qualified value without experimental features.
+#[test]
+fn cross_axis_self_alignment_enum_is_stable() {
+    let source = r#"
+export component TestCase inherits Window {
+    in property <CrossAxisSelfAlignment> a: CrossAxisSelfAlignment.center;
+    FlexboxLayout {
+        Rectangle { cross-axis-self-alignment: root.a; }
+    }
+}
+"#;
+    assert_eq!(errors(source.into(), false), Vec::<String>::new());
 }

--- a/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
@@ -8,7 +8,7 @@ export component X inherits Rectangle {
             flex-grow: 1;
             flex-shrink: 2;
             flex-basis: 100px;
-            flex-align-self: center;
+            cross-axis-self-alignment: center;
             flex-order: 3;
         }
         Rectangle {
@@ -19,8 +19,8 @@ export component X inherits Rectangle {
 //                           ><error{flex-shrink used outside of a FlexboxLayout}
                 flex-basis: 100px;
 //                          >    <error{flex-basis used outside of a FlexboxLayout}
-                flex-align-self: center;
-//                               >     <error{flex-align-self used outside of a FlexboxLayout}
+                cross-axis-self-alignment: center;
+//                                         >     <error{cross-axis-self-alignment used outside of a FlexboxLayout}
                 flex-order: 3;
 //                          ><error{flex-order used outside of a FlexboxLayout}
             }
@@ -35,8 +35,8 @@ export component X inherits Rectangle {
 //                   ><error{flex-shrink used outside of a FlexboxLayout}
         flex-basis: 100px;
 //                  >    <error{flex-basis used outside of a FlexboxLayout}
-        flex-align-self: center;
-//                       >     <error{flex-align-self used outside of a FlexboxLayout}
+        cross-axis-self-alignment: center;
+//                                 >     <error{cross-axis-self-alignment used outside of a FlexboxLayout}
         flex-order: 3;
 //                  ><error{flex-order used outside of a FlexboxLayout}
     }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -48,8 +48,8 @@ pub const RESERVED_GRIDLAYOUT_PROPERTIES: &[(&str, Type)] = &[
     ("rowspan", Type::Int32),
 ];
 
-// Note: flex-align-self is also a flexbox property but is added in reserved_properties()
-// because Type::Enumeration requires a runtime Arc allocation.
+// Note: cross-axis-self-alignment is also a flexbox property but is added in
+// reserved_properties() because Type::Enumeration requires a runtime Arc allocation.
 pub const RESERVED_FLEXBOXLAYOUT_PROPERTIES: &[(&str, Type)] = &[
     ("flex-grow", Type::Float32),
     ("flex-shrink", Type::Float32),
@@ -121,7 +121,7 @@ impl BuiltinTypes {
             BuiltinStruct::LayoutInfo,
         ));
         let enums = BuiltinEnums::new();
-        let flex_align_self_type = Type::Enumeration(enums.FlexboxLayoutAlignSelf.clone());
+        let align_self_type = Type::Enumeration(enums.CrossAxisSelfAlignment.clone());
         // Shared by `flex_item_props_type` and nested as `props` in
         // `flexbox_layout_item_info_type`, so the field list is defined once.
         let flex_item_props_struct = Arc::new(Struct::new(
@@ -129,7 +129,7 @@ impl BuiltinTypes {
                 ("flex-grow".into(), Type::Float32),
                 ("flex-shrink".into(), Type::Float32),
                 ("flex-basis".into(), Type::Float32),
-                ("flex-align-self".into(), flex_align_self_type),
+                ("cross-axis-self-alignment".into(), align_self_type),
                 ("flex-order".into(), Type::Int32),
             ])
             .collect(),
@@ -329,11 +329,11 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
                 .iter()
                 .map(|(k, v)| (*k, v.clone(), PropertyVisibility::Input)),
         )
-        // flex-align-self is a flexbox-layout property but can't be in the const array
-        // because Type::Enumeration requires a runtime Arc allocation.
+        // cross-axis-self-alignment is a flexbox-layout property but can't be in the const
+        // array because Type::Enumeration requires a runtime Arc allocation.
         .chain(std::iter::once((
-            "flex-align-self",
-            Type::Enumeration(BUILTIN.enums.FlexboxLayoutAlignSelf.clone()),
+            "cross-axis-self-alignment",
+            Type::Enumeration(BUILTIN.enums.CrossAxisSelfAlignment.clone()),
             PropertyVisibility::Input,
         )))
         .chain(IntoIterator::into_iter([
@@ -624,9 +624,6 @@ impl TypeRegister {
 
         register.elements.remove("ComponentContainer").unwrap();
         register.types.remove("component-factory").unwrap();
-
-        // Only used by the experimental `flex-align-self`, so don't freeze its name either.
-        register.types.remove("FlexboxLayoutAlignSelf").unwrap();
 
         Rc::new(RefCell::new(register))
     }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,7 +6,7 @@
 // cspell:ignore coord
 
 use crate::items::{
-    CrossAxisAlignment, CrossAxisLineAlignment, DialogButtonRole, FlexboxLayoutAlignSelf,
+    CrossAxisAlignment, CrossAxisLineAlignment, CrossAxisSelfAlignment, DialogButtonRole,
     FlexboxLayoutDirection, FlexboxLayoutWrap, LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
@@ -1184,7 +1184,7 @@ pub struct FlexItemProps {
     /// Flex basis in logical pixels (-1 = auto, meaning use preferred size; default)
     pub flex_basis: Coord,
     /// Per-item cross-axis alignment override (Auto = use container's cross-axis-alignment)
-    pub flex_align_self: FlexboxLayoutAlignSelf,
+    pub cross_axis_self_alignment: CrossAxisSelfAlignment,
     /// Visual ordering of flex items (lower values appear first, default 0)
     pub flex_order: i32,
 }
@@ -1195,7 +1195,7 @@ impl Default for FlexItemProps {
             flex_grow: 0.0,
             flex_shrink: 1.0,
             flex_basis: -1 as Coord,
-            flex_align_self: FlexboxLayoutAlignSelf::Auto,
+            cross_axis_self_alignment: CrossAxisSelfAlignment::Auto,
             flex_order: 0,
         }
     }
@@ -1437,7 +1437,7 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, CrossAxisAlignment, CrossAxisLineAlignment, FlexItemProps, FlexboxLayoutAlignSelf,
+        Coord, CrossAxisAlignment, CrossAxisLineAlignment, CrossAxisSelfAlignment, FlexItemProps,
         FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment, LayoutInfo, LayoutItemInfo,
         Padding, Slice,
     };
@@ -1585,14 +1585,14 @@ mod flexbox_taffy {
                                             // Stretching items get `auto` width so they
                                             // size to their flex *line's* cross size (the
                                             // per-column width when wrapped), not the whole
-                                            // container. A per-item `flex-align-self`
+                                            // container. A per-item `cross-axis-self-alignment`
                                             // overrides the container's alignment.
-                                            let stretches = match flex.flex_align_self {
-                                                FlexboxLayoutAlignSelf::Auto => {
+                                            let stretches = match flex.cross_axis_self_alignment {
+                                                CrossAxisSelfAlignment::Auto => {
                                                     params.cross_axis_alignment
                                                         == CrossAxisAlignment::Stretch
                                                 }
-                                                FlexboxLayoutAlignSelf::Stretch => true,
+                                                CrossAxisSelfAlignment::Stretch => true,
                                                 _ => false,
                                             };
                                             if stretches {
@@ -1640,12 +1640,12 @@ mod flexbox_taffy {
                                 },
                                 flex_grow: flex.flex_grow,
                                 flex_shrink: flex.flex_shrink,
-                                align_self: match flex.flex_align_self {
-                                    FlexboxLayoutAlignSelf::Auto => None,
-                                    FlexboxLayoutAlignSelf::Stretch => Some(AlignSelf::Stretch),
-                                    FlexboxLayoutAlignSelf::Start => Some(AlignSelf::FlexStart),
-                                    FlexboxLayoutAlignSelf::End => Some(AlignSelf::FlexEnd),
-                                    FlexboxLayoutAlignSelf::Center => Some(AlignSelf::Center),
+                                align_self: match flex.cross_axis_self_alignment {
+                                    CrossAxisSelfAlignment::Auto => None,
+                                    CrossAxisSelfAlignment::Stretch => Some(AlignSelf::Stretch),
+                                    CrossAxisSelfAlignment::Start => Some(AlignSelf::FlexStart),
+                                    CrossAxisSelfAlignment::End => Some(AlignSelf::FlexEnd),
+                                    CrossAxisSelfAlignment::Center => Some(AlignSelf::Center),
                                 },
                                 ..Default::default()
                             },

--- a/internal/interpreter/dynamic_item_tree.rs
+++ b/internal/interpreter/dynamic_item_tree.rs
@@ -233,10 +233,11 @@ impl RepeatedItemTree for ErasedItemTreeBox {
             } else {
                 -1.0
             };
-        let flex_align_self = eval::load_property(instance_ref, root_element, "flex-align-self")
-            .ok()
-            .and_then(|v| v.try_into().ok())
-            .unwrap_or(i_slint_core::items::FlexboxLayoutAlignSelf::Auto);
+        let cross_axis_self_alignment =
+            eval::load_property(instance_ref, root_element, "cross-axis-self-alignment")
+                .ok()
+                .and_then(|v| v.try_into().ok())
+                .unwrap_or(i_slint_core::items::CrossAxisSelfAlignment::Auto);
         let flex_order = load_f32("flex-order") as i32;
 
         i_slint_core::layout::FlexboxLayoutItemInfo {
@@ -245,7 +246,7 @@ impl RepeatedItemTree for ErasedItemTreeBox {
                 flex_grow,
                 flex_shrink,
                 flex_basis,
-                flex_align_self,
+                cross_axis_self_alignment,
                 flex_order,
             },
         }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -753,7 +753,7 @@ fn flexbox_layout_data(
                         .try_into()
                         .unwrap()
                 })
-                .unwrap_or(i_slint_core::items::FlexboxLayoutAlignSelf::default());
+                .unwrap_or(i_slint_core::items::CrossAxisSelfAlignment::default());
             let order = layout_elem.order.as_ref().map(expr_eval).unwrap_or(0.0) as i32;
             cells_h.push(core_layout::FlexboxLayoutItemInfo {
                 constraint: layout_info_h,
@@ -761,7 +761,7 @@ fn flexbox_layout_data(
                     flex_grow,
                     flex_shrink,
                     flex_basis,
-                    flex_align_self: align_self,
+                    cross_axis_self_alignment: align_self,
                     flex_order: order,
                 },
             });

--- a/tests/cases/layout/flexbox_column_definite_width_no_stretch.slint
+++ b/tests/cases/layout/flexbox_column_definite_width_no_stretch.slint
@@ -39,7 +39,7 @@ export component TestCase inherits Window {
     out property <bool> no_overflow: b3.x + b3.width <= 300px && b1.x + b1.width <= 300px;
 
     // --- Test 2 -------------------------------------------------------------
-    // Per-item `flex-align-self: stretch` must win even when the container's
+    // Per-item `cross-axis-self-alignment: stretch` must win even when the container's
     // `cross-axis-alignment` is NOT stretch. Here the container aligns items to
     // the start (so plain items keep their preferred 100px width), but s3 opts
     // into stretch and must therefore fill its flex line's cross size, which the
@@ -56,7 +56,7 @@ export component TestCase inherits Window {
 
         s1 := Rectangle { preferred-width: 100px; height: 40px; background: #c33; Text { text: "start"; color: white; } }
         s2 := Rectangle { preferred-width: 100px; height: 40px; background: #3c3; Text { text: "start"; color: white; } }
-        s3 := Rectangle { preferred-width: 100px; height: 40px; flex-align-self: stretch; background: #36c; Text { text: "stretch"; color: white; } }
+        s3 := Rectangle { preferred-width: 100px; height: 40px; cross-axis-self-alignment: stretch; background: #36c; Text { text: "stretch"; color: white; } }
     }
 
     // s1 keeps its preferred width (container start-aligns it); s3 stretches to
@@ -119,7 +119,7 @@ assert(handle->get_test());
 let instance = TestCase::new().unwrap();
 assert!(instance.get_wrapped(), "b3 should wrap to a 2nd column");
 assert!(instance.get_no_overflow(), "column contents overflow the 300px flex");
-assert!(instance.get_align_self_stretches(), "s3 with flex-align-self:stretch should be wider than start-aligned s1");
+assert!(instance.get_align_self_stretches(), "s3 with cross-axis-self-alignment:stretch should be wider than start-aligned s1");
 assert!(instance.get_widths_differ(), "reference heights are equal, so h4w_at_own_width would hold trivially");
 assert!(instance.get_h4w_at_own_width(), "h4w item measured at the container width, not its own");
 assert!(instance.get_test());

--- a/tests/cases/layout/flexbox_cross_axis_self_alignment.slint
+++ b/tests/cases/layout/flexbox_cross_axis_self_alignment.slint
@@ -1,9 +1,9 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test FlexboxLayout align-self per-item property
+// Test the per-item cross-axis-self-alignment property of FlexboxLayout
 
-// Test 1: align-self overrides container cross-axis-alignment
+// Test 1: cross-axis-self-alignment overrides container cross-axis-alignment
 // Container has cross-axis-alignment: start, but r2 overrides to end
 component TestAlignSelfOverride inherits Rectangle {
     width: 300px;
@@ -20,7 +20,7 @@ component TestAlignSelfOverride inherits Rectangle {
         r2 := Rectangle {
             width: 80px;
             height: 30px;
-            flex-align-self: end;
+            cross-axis-self-alignment: end;
             background: green;
         }
         r3 := Rectangle {
@@ -31,14 +31,14 @@ component TestAlignSelfOverride inherits Rectangle {
     }
 
     // r1 and r3: cross-axis-alignment: start → y=0
-    // r2: flex-align-self: end → y=70 (100-30)
+    // r2: cross-axis-self-alignment: end → y=70 (100-30)
     out property <bool> test_r1: r1.y == 0px;
     out property <bool> test_r2: r2.y == 70px;
     out property <bool> test_r3: r3.y == 0px;
     out property <bool> test: test_r1 && test_r2 && test_r3;
 }
 
-// Test 2: flex-align-self: center
+// Test 2: cross-axis-self-alignment: center
 component TestAlignSelfCenter inherits Rectangle {
     width: 300px;
     height: 100px;
@@ -54,7 +54,7 @@ component TestAlignSelfCenter inherits Rectangle {
         r2 := Rectangle {
             width: 80px;
             height: 30px;
-            flex-align-self: center;
+            cross-axis-self-alignment: center;
             background: green;
         }
     }
@@ -66,7 +66,7 @@ component TestAlignSelfCenter inherits Rectangle {
     out property <bool> test: test_r1 && test_r2;
 }
 
-// Test 3: flex-align-self: stretch overrides container's start
+// Test 3: cross-axis-self-alignment: stretch overrides container's start
 component TestAlignSelfStretch inherits Rectangle {
     width: 300px;
     height: 100px;
@@ -81,7 +81,7 @@ component TestAlignSelfStretch inherits Rectangle {
         }
         r2 := Rectangle {
             width: 80px;
-            flex-align-self: stretch;
+            cross-axis-self-alignment: stretch;
             background: green;
         }
     }
@@ -93,7 +93,7 @@ component TestAlignSelfStretch inherits Rectangle {
     out property <bool> test: test_r1 && test_r2;
 }
 
-// Test 4: flex-align-self: auto (default) inherits from container
+// Test 4: cross-axis-self-alignment: auto (default) inherits from container
 component TestAlignSelfAuto inherits Rectangle {
     width: 300px;
     height: 100px;
@@ -104,7 +104,7 @@ component TestAlignSelfAuto inherits Rectangle {
         r1 := Rectangle {
             width: 80px;
             height: 30px;
-            flex-align-self: auto;
+            cross-axis-self-alignment: auto;
             background: red;
         }
         r2 := Rectangle {

--- a/tests/cases/layout/flexbox_repeater_flex_props.slint
+++ b/tests/cases/layout/flexbox_repeater_flex_props.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Test that flex item properties (flex-grow, align-self, order) work on repeated items.
+// Test that flex item properties (flex-grow, cross-axis-self-alignment, flex-order) work on repeated items.
 
 // Test 1: flex-grow on a repeated item pushes a static item to the right.
 // Repeated item with flex-grow:1 before a 60px static item:
@@ -53,7 +53,7 @@ component TestOrderRepeater inherits Rectangle {
     out property <bool> test: r_static.x == 100px;
 }
 
-// Test 3: align-self on static item works when mixed with repeaters.
+// Test 3: cross-axis-self-alignment on static item works when mixed with repeaters.
 component TestAlignSelfWithRepeater inherits Rectangle {
     width: 300px;
     height: 100px;
@@ -64,7 +64,7 @@ component TestAlignSelfWithRepeater inherits Rectangle {
         r_static := Rectangle {
             width: 80px;
             height: 30px;
-            flex-align-self: end;
+            cross-axis-self-alignment: end;
             background: gray;
         }
         for item in [1]: Rectangle {
@@ -74,18 +74,35 @@ component TestAlignSelfWithRepeater inherits Rectangle {
         }
     }
 
-    // Static item: flex-align-self:end → y=70 (100-30)
+    // Static item: cross-axis-self-alignment:end → y=70 (100-30)
     out property <bool> test: r_static.y == 70px;
 }
 
 export component TestCase inherits Window {
     width: 400px;
-    height: 300px;
+    height: 400px;
 
     VerticalLayout {
         t1 := TestFlexGrowRepeater { }
         t2 := TestOrderRepeater { }
         t3 := TestAlignSelfWithRepeater { }
+
+        // Test 4: cross-axis-self-alignment on the repeated item itself.
+        wrap4 := Rectangle {
+            width: 300px;
+            height: 100px;
+            FlexboxLayout {
+                flex-wrap: no-wrap;
+                cross-axis-alignment: start;
+
+                for item in [1, 2]: rep := Rectangle {
+                    width: 80px;
+                    height: 30px;
+                    cross-axis-self-alignment: end;
+                    background: red;
+                }
+            }
+        }
     }
 
     out property <bool> test_flex_grow: t1.test;
@@ -100,6 +117,14 @@ auto handle = TestCase::create();
 assert(handle->get_test_flex_grow());
 assert(handle->get_test_order());
 assert(handle->get_test_align_self());
+
+// The repeated items can't be referenced from slint code; query them by element id.
+auto rep = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::rep");
+assert_eq(rep.size(), 2);
+auto wrap4 = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::wrap4")[0];
+for (auto e : rep) {
+    assert_eq(e.absolute_position().y - wrap4.absolute_position().y, 70.0);
+}
 ```
 
 ```rust
@@ -107,6 +132,14 @@ let instance = TestCase::new().unwrap();
 assert!(instance.get_test_flex_grow());
 assert!(instance.get_test_order());
 assert!(instance.get_test_align_self());
+
+// The repeated items can't be referenced from slint code; query them by element id.
+let rep: Vec<_> = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::rep").collect();
+assert_eq!(rep.len(), 2);
+let wrap4 = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::wrap4").next().unwrap();
+for e in rep {
+    assert_eq!(e.absolute_position().y - wrap4.absolute_position().y, 70.0, "repeated item aligned to the bottom");
+}
 ```
 
 ```js

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -557,9 +557,10 @@ fn is_reserved_prop_valid(
     if name_in(i_slint_compiler::typeregister::RESERVED_GRIDLAYOUT_PROPERTIES) {
         return matches!(parent_name, Some("GridLayout" | "Row"));
     }
-    if prop == "flex-align-self"
-        || name_in(i_slint_compiler::typeregister::RESERVED_FLEXBOXLAYOUT_PROPERTIES)
-    {
+    if prop == "cross-axis-self-alignment" {
+        return parent_name == Some("FlexboxLayout");
+    }
+    if name_in(i_slint_compiler::typeregister::RESERVED_FLEXBOXLAYOUT_PROPERTIES) {
         // Not stable API yet, the compiler only accepts them as an experimental feature.
         return enable_experimental && parent_name == Some("FlexboxLayout");
     }
@@ -1817,7 +1818,7 @@ mod tests {
         assert!(res.iter().any(|ci| ci.label == "spacing-vertical"));
         assert!(res.iter().any(|ci| ci.label == "padding"));
         assert!(!res.iter().any(|ci| ci.label == "flex-grow"));
-        assert!(!res.iter().any(|ci| ci.label == "flex-align-self"));
+        assert!(!res.iter().any(|ci| ci.label == "cross-axis-self-alignment"));
     }
 
     #[test]
@@ -2938,10 +2939,7 @@ export component Foo {
 }
 "#;
         let results = get_completions_experimental(source).unwrap();
-        // flex-align-self is registered separately from the other four, so check each one.
-        for prop in
-            ["flex-grow", "flex-shrink", "flex-basis", "flex-align-self", "flex-order"].iter()
-        {
+        for prop in ["flex-grow", "flex-shrink", "flex-basis", "flex-order"].iter() {
             assert!(
                 results.iter().any(|completion| completion.label == *prop),
                 "no '{prop}' completion with experimental features"
@@ -2952,6 +2950,11 @@ export component Foo {
         assert!(
             !results.iter().any(|completion| completion.label.starts_with("flex-")),
             "flex-* completions offered without experimental features"
+        );
+        // cross-axis-self-alignment is stable, so it completes without experimental features.
+        assert!(
+            results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
+            "no 'cross-axis-self-alignment' completion"
         );
     }
 


### PR DESCRIPTION
Unlike the other per-item flex properties, this one cannot be replaced
by existing concepts: a wrapper element cannot stretch an item to the
flex line's cross size. So it survives as a property, named after the
cross-axis-alignment / cross-axis-line-alignment family, and its enum
becomes CrossAxisSelfAlignment and enters the stable type register.
It stays restricted to FlexboxLayout children for now.