### PR TITLE
compiler: Display enum types without the `enum` prefix

### DIFF
--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -324,13 +324,7 @@ fn format_signature(func: &i_slint_compiler::langtype::Function) -> String {
         .iter()
         .zip(func.args.iter())
         .filter(|(_, ty)| !matches!(ty, Type::ElementReference))
-        .map(|(name, ty)| {
-            if name.is_empty() {
-                ty.to_string()
-            } else {
-                format!("{name}: {ty}")
-            }
-        })
+        .map(|(name, ty)| if name.is_empty() { ty.to_string() } else { format!("{name}: {ty}") })
         .collect();
     let ret = if matches!(func.return_type, Type::Void) {
         String::new()

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -293,15 +293,6 @@ fn transform_code_fences(text: &str, counter: &mut ScreenshotCounter) -> String 
 
 // -- Type formatting helpers --
 
-/// Format a type name for documentation output. Same as `Type::Display`
-/// except enumerations omit the `enum` prefix.
-fn format_type_name(ty: &Type) -> String {
-    match ty {
-        Type::Enumeration(e) => e.name.to_string(),
-        _ => ty.to_string(),
-    }
-}
-
 /// Format a default value expression for documentation output.
 fn format_default_expr(expr: &i_slint_compiler::expression_tree::Expression) -> String {
     use i_slint_compiler::expression_tree::Expression;
@@ -335,16 +326,16 @@ fn format_signature(func: &i_slint_compiler::langtype::Function) -> String {
         .filter(|(_, ty)| !matches!(ty, Type::ElementReference))
         .map(|(name, ty)| {
             if name.is_empty() {
-                format_type_name(ty)
+                ty.to_string()
             } else {
-                format!("{name}: {}", format_type_name(ty))
+                format!("{name}: {ty}")
             }
         })
         .collect();
     let ret = if matches!(func.return_type, Type::Void) {
         String::new()
     } else {
-        format!(" -> {}", format_type_name(&func.return_type))
+        format!(" -> {}", func.return_type)
     };
     format!("({}){ret}", params.join(", "))
 }
@@ -456,7 +447,7 @@ fn write_slint_property(
     structs: &HashSet<String>,
     sc: &mut ScreenshotCounter,
 ) -> std::io::Result<()> {
-    let type_name = format_type_name(&info.ty);
+    let type_name = info.ty.to_string();
     let raw_doc = info.docs.as_deref().unwrap_or("");
     let (description, doc_default) = extract_default(raw_doc);
     let mut default_value = match &info.default_value {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -157,7 +157,7 @@ impl Display for Type {
             Type::Easing => write!(f, "easing"),
             Type::MouseCursor => write!(f, "MouseCursor"),
             Type::Brush => write!(f, "brush"),
-            Type::Enumeration(enumeration) => write!(f, "enum {}", enumeration.name),
+            Type::Enumeration(enumeration) => write!(f, "{}", enumeration.name),
             Type::Keys => write!(f, "keys"),
             Type::DataTransfer => write!(f, "data-transfer"),
             Type::UnitProduct(vec) => {

--- a/internal/compiler/tests/syntax/basic/return.slint
+++ b/internal/compiler/tests/syntax/basic/return.slint
@@ -21,7 +21,7 @@ export X := Rectangle {
         key-released(event) => {
             if (!self.visible) {
                 return;
-//              >     <error{Must return a value of type 'enum EventResult'}
+//              >     <error{Must return a value of type 'EventResult'}
             }
             accept
         }

--- a/internal/compiler/tests/syntax/lookup/enum.slint
+++ b/internal/compiler/tests/syntax/lookup/enum.slint
@@ -20,10 +20,10 @@ export TestCase := Text {
     }
 
     vertical_alignment: TextVerticalAlignment.top.right;
-//                                                >   <error{Cannot access the field 'right' of enum TextVerticalAlignment}
+//                                                >   <error{Cannot access the field 'right' of TextVerticalAlignment}
     Text {
         horizontal-alignment: right.foo;
-//                                  > <error{Cannot access the field 'foo' of enum TextHorizontalAlignment}
+//                                  > <error{Cannot access the field 'foo' of TextHorizontalAlignment}
         vertical_alignment: TextVerticalAlignment;
 //                          >                   <error{Cannot take reference to an enum}
     }

--- a/internal/compiler/tests/syntax/match_element/cast.slint
+++ b/internal/compiler/tests/syntax/match_element/cast.slint
@@ -49,6 +49,6 @@ export component Baz {
 //      >                <error{Cannot convert styled-text to string}
 //      >                <^error{Match expressions must be literal values}
         MyEnum.val2 : Rectangle {}
-//      >          <error{Cannot convert enum MyEnum to string}
+//      >          <error{Cannot convert MyEnum to string}
     }
 }

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -995,7 +995,7 @@ pub mod tests {
         // reserved properties:
         assert_eq!(
             &find_property(&result, "accessible-role").unwrap().ty.to_string(),
-            "enum AccessibleRole"
+            "AccessibleRole"
         );
         // Accessible property should not be present since the role is none
         assert!(find_property(&result, "accessible-label").is_none());


### PR DESCRIPTION
`Display for Type` should spell a type the way it is written in the source, like it already does for structs. Drop the `enum ` prefix so diagnostics say `Cannot convert MyEnum to string` and the suggested syntax in the "missing interface member" errors is valid Slint.

This makes the doc generator's `format_type_name`, which existed only to strip that prefix, redundant.
