### PR TITLE
Remove `panic = "abort"` from the dev profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,8 +176,6 @@ lsp-types = "0.95.0"
 [profile.release]
 panic = "abort"
 
-[profile.dev]
-panic = "abort"
 
 # Always build resvg and its hot-path dependencies with optimizations,
 # as it otherwise causes freezes to load large SVGs in debug builds.

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -39,8 +39,6 @@ version = "1.18.0"
 [profile.release]
 panic = "abort"
 
-[profile.dev]
-panic = "abort"
 
 # Always build resvg and its hot-path dependencies with optimizations,
 # as it otherwise causes freezes to load large SVGs in debug builds.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -79,8 +79,6 @@ wgpu-30 = { package = "wgpu", version = "30", default-features = false }
 [profile.release]
 panic = "abort"
 
-[profile.dev]
-panic = "abort"
 
 # Always build resvg and its hot-path dependencies with optimizations,
 # as it otherwise causes freezes to load large SVGs in debug builds.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -68,8 +68,6 @@ spin_on = { version = "0.1" }
 [profile.release]
 panic = "abort"
 
-[profile.dev]
-panic = "abort"
 
 # Always build resvg and its hot-path dependencies with optimizations,
 # as it otherwise causes freezes to load large SVGs in debug builds.

--- a/ui-libraries/material/Cargo.toml
+++ b/ui-libraries/material/Cargo.toml
@@ -34,8 +34,6 @@ version = "1.17.0"
 [profile.release]
 panic = "abort"
 
-[profile.dev]
-panic = "abort"
 
 # Always build resvg and its hot-path dependencies with optimizations,
 # as it otherwise causes freezes to load large SVGs in debug builds.


### PR DESCRIPTION
Test targets must unwind, so this setting makes cargo build the entire shared
dependency tree twice in every `cargo build` + `cargo test` cycle. Measured on
a cold target dir at master (`SLINT_NO_QT=1`, `--locked`):

| | before | after |
|---|---|---|
| target after `cargo build` + `cargo test --no-run` | 36G | 31G |
| crate compilations | 1632 | 919 |

The 713 eliminated compilations also mean proportionally faster cold builds
and smaller CI caches. The cost: `cargo build` output alone grows ~4%
(7.8G → 8.1G) because unwind artifacts are slightly larger.

The dev abort dates to commit dcd328d01 ("Abort on panic by default"), whose goal was
that a panicking thread takes down the slint-lsp process. Release builds --
what users run -- keep `panic = "abort"`, so shipped behavior is unchanged.

The second commit preserves the fail-fast behavior explicitly for the two
development tools, slint-lsp and slint-viewer: an unconditional panic hook
that aborts after the normal panic output (and after the
`SLINT_LSP_PANIC_LOG_DIR` telemetry log, when the editor enables it).
