### PR TITLE
Route all backend input through dispatch_event_with_result

### DIFF
--- a/api/rs/slint/tests/text_layout_cache.rs
+++ b/api/rs/slint/tests/text_layout_cache.rs
@@ -4,7 +4,6 @@
 mod common;
 
 use i_slint_core::input::{InternalKeyEvent, KeyEventType};
-use i_slint_core::window::WindowInner;
 use slint::platform::software_renderer::{
     MinimalSoftwareWindow, PremultipliedRgbaColor, SoftwareRenderer, TargetPixel,
 };
@@ -488,7 +487,7 @@ fn composition_is_shaped_through_the_cache() {
     event.preedit_text = "WWWWWWWWWW".into();
     // Where the IME puts the cursor: at the end of the composition.
     event.cursor_position = Some(2 + "WWWWWWWWWW".len() as i32);
-    WindowInner::from_pub(ui.window()).process_key_input(event);
+    ui.window().dispatch_event(slint::platform::WindowEvent::internal(event));
 
     // Read the counter before rendering, so it only covers the cursor rect query above, and again
     // afterwards to see what drawing the composition adds.
@@ -637,7 +636,7 @@ fn ime_composition_is_not_served_a_stale_size() {
     let mut event = InternalKeyEvent::default();
     event.event_type = KeyEventType::UpdateComposition;
     event.preedit_text = "WWWWWWWWWW".into();
-    WindowInner::from_pub(ui.window()).process_key_input(event);
+    ui.window().dispatch_event(slint::platform::WindowEvent::internal(event));
 
     window.request_redraw();
     window.draw_if_needed(|renderer| {

--- a/docs/development/input-event-system.md
+++ b/docs/development/input-event-system.md
@@ -115,12 +115,32 @@ pub struct MouseInputState {
 
 ## Event Processing Flow
 
+### Backend Entry Point
+
+Every event a backend delivers goes through `Window::dispatch_event_with_result()`.
+Events that the public `WindowEvent` variants can't express travel as `WindowEvent::Internal(InternalEvent)`,
+a doc-hidden variant that carries the runtime's own `MouseEvent`, `InternalKeyEvent` or touch point.
+The dispatch reports them to the window event hook as the public event they correspond to,
+or not at all when there is none (gestures, touch, input method composition).
+
+`WindowInner::process_mouse_input()`, `process_key_input()` and `process_touch_input()` are crate-private,
+so backends can't bypass that funnel and each event is observed exactly once.
+Drag and drop is the exception: it uses `WindowInner::process_drag_event()`,
+because the backend needs the negotiated `DragAction` back, which the public dispatch result can't express.
+
 ### Mouse Event Flow
 
 ```
 ┌─────────────────┐
 │  Platform       │  (winit, Qt, etc.)
 │  WindowEvent    │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Window::       │  Single entry point for backend input
+│  dispatch_event │  Notifies the window event hook
+│  _with_result() │
 └────────┬────────┘
          │
          ▼
@@ -325,6 +345,9 @@ pub mod key_codes {
 
 ```
 Platform KeyEvent
+       │
+       ▼
+Window::dispatch_event_with_result()
        │
        ▼
 WindowInner::process_key_input()

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -17,7 +17,7 @@ use i_slint_core::api::{
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, TouchPhase};
 use i_slint_core::lengths::PhysicalEdges;
 use i_slint_core::platform::{
-    Key, PointerEventButton, WindowAdapter, WindowEvent, WindowProperties,
+    InternalEvent, Key, PointerEventButton, WindowAdapter, WindowEvent, WindowProperties,
 };
 use i_slint_core::timers::{Timer, TimerMode};
 use i_slint_core::window::{InputMethodRequest, WindowInner};
@@ -345,22 +345,26 @@ impl AndroidWindowAdapter {
                             );
                             self.long_press.replace(Some(LongPressDetection { position, _timer }));
                             if let Some(p) = motion_event.pointers().next() {
-                                WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id(),
-                                    touch_pos(&p),
-                                    TouchPhase::Started,
-                                );
+                                self.window.dispatch_event(WindowEvent::internal(
+                                    InternalEvent::Touch {
+                                        id: p.pointer_id(),
+                                        position: touch_pos(&p),
+                                        phase: TouchPhase::Started,
+                                    },
+                                ));
                             }
                             InputStatus::Handled
                         }
                         MotionAction::Up => {
                             self.long_press.take();
                             if let Some(p) = motion_event.pointers().next() {
-                                WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id(),
-                                    touch_pos(&p),
-                                    TouchPhase::Ended,
-                                );
+                                self.window.dispatch_event(WindowEvent::internal(
+                                    InternalEvent::Touch {
+                                        id: p.pointer_id(),
+                                        position: touch_pos(&p),
+                                        phase: TouchPhase::Ended,
+                                    },
+                                ));
                             }
                             InputStatus::Handled
                         }
@@ -377,13 +381,14 @@ impl AndroidWindowAdapter {
                             }
                             drop(lp);
 
-                            let runtime_window = WindowInner::from_pub(&self.window);
                             for p in motion_event.pointers() {
-                                runtime_window.process_touch_input(
-                                    p.pointer_id(),
-                                    touch_pos(&p),
-                                    TouchPhase::Moved,
-                                );
+                                self.window.dispatch_event(WindowEvent::internal(
+                                    InternalEvent::Touch {
+                                        id: p.pointer_id(),
+                                        position: touch_pos(&p),
+                                        phase: TouchPhase::Moved,
+                                    },
+                                ));
                             }
                             InputStatus::Handled
                         }
@@ -392,22 +397,26 @@ impl AndroidWindowAdapter {
                             self.long_press.take();
                             let idx = motion_event.pointer_index();
                             if let Some(p) = motion_event.pointers().nth(idx) {
-                                WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id(),
-                                    touch_pos(&p),
-                                    TouchPhase::Started,
-                                );
+                                self.window.dispatch_event(WindowEvent::internal(
+                                    InternalEvent::Touch {
+                                        id: p.pointer_id(),
+                                        position: touch_pos(&p),
+                                        phase: TouchPhase::Started,
+                                    },
+                                ));
                             }
                             InputStatus::Handled
                         }
                         MotionAction::PointerUp => {
                             let idx = motion_event.pointer_index();
                             if let Some(p) = motion_event.pointers().nth(idx) {
-                                WindowInner::from_pub(&self.window).process_touch_input(
-                                    p.pointer_id(),
-                                    touch_pos(&p),
-                                    TouchPhase::Ended,
-                                );
+                                self.window.dispatch_event(WindowEvent::internal(
+                                    InternalEvent::Touch {
+                                        id: p.pointer_id(),
+                                        position: touch_pos(&p),
+                                        phase: TouchPhase::Ended,
+                                    },
+                                ));
                             }
                             InputStatus::Handled
                         }
@@ -420,13 +429,14 @@ impl AndroidWindowAdapter {
                         }
                         MotionAction::Cancel | MotionAction::Outside => {
                             self.long_press.take();
-                            let runtime_window = WindowInner::from_pub(&self.window);
                             for p in motion_event.pointers() {
-                                runtime_window.process_touch_input(
-                                    p.pointer_id(),
-                                    touch_pos(&p),
-                                    TouchPhase::Cancelled,
-                                );
+                                self.window.dispatch_event(WindowEvent::internal(
+                                    InternalEvent::Touch {
+                                        id: p.pointer_id(),
+                                        position: touch_pos(&p),
+                                        phase: TouchPhase::Cancelled,
+                                    },
+                                ));
                             }
                             InputStatus::Handled
                         }
@@ -439,7 +449,6 @@ impl AndroidWindowAdapter {
                 }
                 InputEvent::TextEvent(state) => {
                     self.show_cursor_handles.set(false);
-                    let runtime_window = WindowInner::from_pub(&self.window);
                     // remove the pre_edit
                     let event = if let Some(r) = state.compose_region {
                         let adjust =
@@ -473,7 +482,7 @@ impl AndroidWindowAdapter {
                             ..Default::default()
                         }
                     };
-                    runtime_window.process_key_input(event);
+                    self.window.dispatch_event(WindowEvent::internal(event));
                     InputStatus::Handled
                 }
                 _ => InputStatus::Unhandled,

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -596,7 +596,6 @@ fn callback_update_text<'local>(
     i_slint_core::api::invoke_from_event_loop(move || {
         if let Some(adaptor) = CURRENT_WINDOW.with_borrow(|x| x.upgrade()) {
             adaptor.show_cursor_handles.set(false);
-            let runtime_window = i_slint_core::window::WindowInner::from_pub(&adaptor.window);
             let event = if preedit_start != preedit_end {
                 let adjust = |pos| {
                     if pos <= preedit_start {
@@ -634,7 +633,7 @@ fn callback_update_text<'local>(
                     ..Default::default()
                 }
             };
-            runtime_window.process_key_input(event);
+            adaptor.window.dispatch_event(i_slint_core::platform::WindowEvent::internal(event));
         }
     })
     .unwrap();

--- a/internal/backends/linuxkms/calloop_backend/input.rs
+++ b/internal/backends/linuxkms/calloop_backend/input.rs
@@ -20,8 +20,8 @@ use std::rc::Rc;
 
 use i_slint_core::api::LogicalPosition;
 use i_slint_core::lengths::logical_point_from_api;
-use i_slint_core::platform::{PlatformError, PointerEventButton, WindowEvent};
-use i_slint_core::window::{WindowAdapter, WindowInner};
+use i_slint_core::platform::{InternalEvent, PlatformError, PointerEventButton, WindowEvent};
+use i_slint_core::window::WindowAdapter;
 use i_slint_core::{Property, SharedString};
 use input::LibinputInterface;
 use input::event::keyboard::{KeyState, KeyboardEventTrait};
@@ -277,20 +277,20 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                         );
                         let slot = touch_down_event.slot().unwrap_or(0) as i32;
                         set_touch_pos(&mut self.last_touch_positions, slot, pos);
-                        WindowInner::from_pub(window).process_touch_input(
-                            slot,
-                            logical_point_from_api(pos),
-                            i_slint_core::input::TouchPhase::Started,
-                        );
+                        window.dispatch_event(WindowEvent::internal(InternalEvent::Touch {
+                            id: slot,
+                            position: logical_point_from_api(pos),
+                            phase: i_slint_core::input::TouchPhase::Started,
+                        }));
                     }
                     input::event::TouchEvent::Up(touch_up_event) => {
                         let slot = touch_up_event.slot().unwrap_or(0) as i32;
                         let pos = take_touch_pos(&mut self.last_touch_positions, slot);
-                        WindowInner::from_pub(window).process_touch_input(
-                            slot,
-                            logical_point_from_api(pos),
-                            i_slint_core::input::TouchPhase::Ended,
-                        );
+                        window.dispatch_event(WindowEvent::internal(InternalEvent::Touch {
+                            id: slot,
+                            position: logical_point_from_api(pos),
+                            phase: i_slint_core::input::TouchPhase::Ended,
+                        }));
                     }
                     input::event::TouchEvent::Motion(touch_motion_event) => {
                         let pos = LogicalPosition::new(
@@ -299,20 +299,20 @@ impl<'a> calloop::EventSource for LibInputHandler<'a> {
                         );
                         let slot = touch_motion_event.slot().unwrap_or(0) as i32;
                         set_touch_pos(&mut self.last_touch_positions, slot, pos);
-                        WindowInner::from_pub(window).process_touch_input(
-                            slot,
-                            logical_point_from_api(pos),
-                            i_slint_core::input::TouchPhase::Moved,
-                        );
+                        window.dispatch_event(WindowEvent::internal(InternalEvent::Touch {
+                            id: slot,
+                            position: logical_point_from_api(pos),
+                            phase: i_slint_core::input::TouchPhase::Moved,
+                        }));
                     }
                     input::event::TouchEvent::Cancel(touch_cancel_event) => {
                         let slot = touch_cancel_event.slot().unwrap_or(0) as i32;
                         let pos = take_touch_pos(&mut self.last_touch_positions, slot);
-                        WindowInner::from_pub(window).process_touch_input(
-                            slot,
-                            logical_point_from_api(pos),
-                            i_slint_core::input::TouchPhase::Cancelled,
-                        );
+                        window.dispatch_event(WindowEvent::internal(InternalEvent::Touch {
+                            id: slot,
+                            position: logical_point_from_api(pos),
+                            phase: i_slint_core::input::TouchPhase::Cancelled,
+                        }));
                     }
                     _ => {}
                 },

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -346,7 +346,7 @@ cpp! {{
             if (!rust_window)
                 return;
             rust!(Slint_dragLeaveEvent [rust_window: &QtWindow as "void*"] {
-                rust_window.mouse_event(MouseEvent::Exit)
+                rust_window.drag_leave_event()
             });
         }
 
@@ -477,7 +477,6 @@ cpp! {{
             rust!(Slint_inputMethodEvent [rust_window: &QtWindow as "void*", commit_string: qttypes::QString as "QString",
                 preedit_string: qttypes::QString as "QString", replacement_start: i32 as "int", replacement_length: i32 as "int",
                 preedit_cursor: i32 as "int"] {
-                    let runtime_window = WindowInner::from_pub(&rust_window.window);
                     let mut key_event = KeyEvent::default();
                     key_event.text = i_slint_core::format!("{}", commit_string);
                     let event = InternalKeyEvent {
@@ -489,7 +488,7 @@ cpp! {{
                         .then_some(replacement_start..replacement_start+replacement_length),
                         ..Default::default()
                     };
-                    runtime_window.process_key_input(event);
+                    rust_window.window.dispatch_event(WindowEvent::internal(event));
                 });
         }
         static int gesture_phase(Qt::GestureState state) {
@@ -2146,7 +2145,14 @@ impl QtWindow {
     }
 
     fn mouse_event(&self, event: MouseEvent) {
-        WindowInner::from_pub(&self.window).process_mouse_input(event);
+        self.window.dispatch_event(WindowEvent::internal(event));
+        timer_event();
+    }
+
+    /// A drag left the window: tear down the hover state like a pointer exit,
+    /// but off the `dispatch_event` path, so that it isn't observed as the pointer leaving the window.
+    fn drag_leave_event(&self) {
+        WindowInner::from_pub(&self.window).process_drag_event(MouseEvent::Exit);
         timer_event();
     }
 
@@ -2196,12 +2202,9 @@ impl QtWindow {
         } else {
             MouseEvent::DragMove { event: drop_event, allowed: allowed_actions }
         };
-        let chosen = WindowInner::from_pub(&self.window).process_mouse_input(mouse_event);
+        let chosen = WindowInner::from_pub(&self.window).process_drag_event(mouse_event);
         timer_event();
-        chosen
-            .and_then(|r| r.drag_action)
-            .map(slint_drag_action_to_qt)
-            .unwrap_or(key_generated::Qt_DropAction_IgnoreAction)
+        chosen.map(slint_drag_action_to_qt).unwrap_or(key_generated::Qt_DropAction_IgnoreAction)
     }
 
     fn key_event(&self, key: i32, text: qttypes::QString, released: bool, repeat: bool) {

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -10,6 +10,7 @@ pub use i_slint_core::input::MouseEvent;
 pub use i_slint_core::input::TouchPhase;
 use i_slint_core::item_tree::ItemTreeVTable;
 pub use i_slint_core::lengths::LogicalPoint;
+pub use i_slint_core::platform::InternalEvent;
 use i_slint_core::platform::WindowEvent;
 pub use i_slint_core::window::PopupWindowLocation;
 pub use i_slint_core::window::WindowInner;
@@ -144,14 +145,15 @@ pub fn send_pinch_gesture<
     center_y: f32,
     phase: i_slint_core::input::TouchPhase,
 ) {
-    let inner = WindowInner::from_pub(component.window());
-    inner.process_mouse_input(i_slint_core::input::MouseEvent::PinchGesture {
-        position: i_slint_core::lengths::logical_point_from_api(
-            i_slint_core::api::LogicalPosition::new(center_x, center_y),
-        ),
-        delta,
-        phase,
-    });
+    component.window().dispatch_event(WindowEvent::internal(
+        i_slint_core::input::MouseEvent::PinchGesture {
+            position: i_slint_core::lengths::logical_point_from_api(
+                i_slint_core::api::LogicalPosition::new(center_x, center_y),
+            ),
+            delta,
+            phase,
+        },
+    ));
 }
 
 /// Send a rotation gesture event to the component's window.
@@ -168,14 +170,15 @@ pub fn send_rotation_gesture<
     center_y: f32,
     phase: i_slint_core::input::TouchPhase,
 ) {
-    let inner = WindowInner::from_pub(component.window());
-    inner.process_mouse_input(i_slint_core::input::MouseEvent::RotationGesture {
-        position: i_slint_core::lengths::logical_point_from_api(
-            i_slint_core::api::LogicalPosition::new(center_x, center_y),
-        ),
-        delta,
-        phase,
-    });
+    component.window().dispatch_event(WindowEvent::internal(
+        i_slint_core::input::MouseEvent::RotationGesture {
+            position: i_slint_core::lengths::logical_point_from_api(
+                i_slint_core::api::LogicalPosition::new(center_x, center_y),
+            ),
+            delta,
+            phase,
+        },
+    ));
 }
 
 pub fn access_testing_window<R>(

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -1121,14 +1121,18 @@ fn test_accessibility_role_mapping_complete() {
 // `WindowEventDispatchResult` honesty for pointer events: verify that
 // `Window::dispatch_event_with_result` reports `Accepted` only when an item consumed the
 // event, and `Ignored` otherwise. Tests install the window-event hook directly
-// since that's the consumer the public contract is for.
+// since that's the consumer the public contract is for. The same goes for the events the
+// backends deliver in the internal representation: they're reported as the public event they
+// correspond to, or not at all when there is none.
 
 #[cfg(test)]
 mod dispatch_result_tests {
     use i_slint_core::api::LogicalPosition;
     use i_slint_core::api::WindowEventDispatchResult;
+    use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};
     use i_slint_core::items::PointerEventButton;
-    use i_slint_core::platform::WindowEvent;
+    use i_slint_core::lengths::LogicalPoint;
+    use i_slint_core::platform::{InternalEvent, WindowEvent};
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -1170,6 +1174,18 @@ mod dispatch_result_tests {
         let captured = captured.borrow();
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0].1, expected);
+    }
+
+    /// Dispatch `event` to `window` with a recording hook installed and return what the hook
+    /// observed.
+    fn record_dispatch(
+        window: &i_slint_core::api::Window,
+        event: WindowEvent,
+    ) -> Vec<(WindowEvent, WindowEventDispatchResult)> {
+        let (_guard, captured) = capture_hook();
+        window.dispatch_event(event);
+        let recorded = captured.borrow().clone();
+        recorded
     }
 
     #[test]
@@ -1286,6 +1302,131 @@ mod dispatch_result_tests {
             WindowEvent::PointerExited,
             WindowEventDispatchResult::Accepted,
         );
+    }
+
+    #[test]
+    fn backend_pointer_event_is_recorded_as_public_event() {
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+                TouchArea { width: 100%; height: 100%; }
+            }
+        }
+        let app = App::new().unwrap();
+        assert_eq!(
+            record_dispatch(
+                app.window(),
+                WindowEvent::internal(MouseEvent::Pressed {
+                    position: LogicalPoint::new(50.0, 50.0),
+                    button: PointerEventButton::Left,
+                    click_count: 0,
+                    touch_finger_id: 0,
+                })
+            ),
+            vec![(
+                WindowEvent::PointerPressed {
+                    position: LogicalPosition::new(50.0, 50.0),
+                    button: PointerEventButton::Left,
+                },
+                WindowEventDispatchResult::Accepted
+            )]
+        );
+    }
+
+    #[test]
+    fn backend_pointer_exit_is_recorded_as_accepted() {
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+            }
+        }
+        let app = App::new().unwrap();
+        assert_eq!(
+            record_dispatch(app.window(), WindowEvent::internal(MouseEvent::Exit)),
+            vec![(WindowEvent::PointerExited, WindowEventDispatchResult::Accepted)]
+        );
+    }
+
+    #[test]
+    fn backend_key_event_is_recorded_with_its_result() {
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+            }
+        }
+        let app = App::new().unwrap();
+        let text = slint::SharedString::from("x");
+        let mut key_event = KeyEvent::default();
+        key_event.text = text.clone();
+        key_event.repeat = true;
+        assert_eq!(
+            record_dispatch(
+                app.window(),
+                WindowEvent::internal(InternalKeyEvent {
+                    event_type: KeyEventType::KeyPressed,
+                    key_event,
+                    ..Default::default()
+                })
+            ),
+            vec![(WindowEvent::KeyPressRepeated { text }, WindowEventDispatchResult::Ignored)]
+        );
+    }
+
+    #[test]
+    fn composition_events_are_not_recorded() {
+        // The public API can't express input method composition, so there is nothing to report.
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+            }
+        }
+        let app = App::new().unwrap();
+        assert!(
+            record_dispatch(
+                app.window(),
+                WindowEvent::internal(InternalKeyEvent {
+                    event_type: KeyEventType::UpdateComposition,
+                    preedit_text: "abc".into(),
+                    ..Default::default()
+                })
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn touch_events_reach_the_scene_but_are_not_recorded() {
+        // Touch has no public representation either, but it must still be dispatched.
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 200px;
+                height: 200px;
+                out property <bool> touched: touch-area.pressed;
+                touch-area := TouchArea { width: 100%; height: 100%; }
+            }
+        }
+        let app = App::new().unwrap();
+        assert!(
+            record_dispatch(
+                app.window(),
+                WindowEvent::internal(InternalEvent::Touch {
+                    id: 1,
+                    position: LogicalPoint::new(50.0, 50.0),
+                    phase: TouchPhase::Started,
+                })
+            )
+            .is_empty()
+        );
+        assert!(app.get_touched());
     }
 
     #[test]

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -393,10 +393,7 @@ impl TestingWindow {
         } else {
             MouseEvent::DragMove { event, allowed }
         };
-        WindowInner::from_pub(target)
-            .process_mouse_input(event)
-            .and_then(|r| r.drag_action)
-            .unwrap_or(DragAction::None)
+        WindowInner::from_pub(target).process_drag_event(event).unwrap_or(DragAction::None)
     }
 }
 

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -136,8 +136,9 @@ impl EventLoopState {
         if let Some((window_id, position)) = self.pending_mouse_move.take()
             && let Some(window) = self.shared_backend_data.window_by_id(window_id)
         {
-            let runtime_window = WindowInner::from_pub(window.window());
-            runtime_window.process_mouse_input(MouseEvent::Moved { position, touch_finger_id: 0 });
+            window.window().dispatch_event(corelib::platform::WindowEvent::internal(
+                MouseEvent::Moved { position, touch_finger_id: 0 },
+            ));
         }
     }
 }
@@ -356,7 +357,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     ..Default::default()
                 };
 
-                runtime_window.process_key_input(event);
+                window.window().dispatch_event(corelib::platform::WindowEvent::internal(event));
             }
             WindowEvent::Ime(winit::event::Ime::Preedit(string, preedit_selection)) => {
                 let event = InternalKeyEvent {
@@ -365,7 +366,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     preedit_selection: preedit_selection.map(|e| e.0 as i32..e.1 as i32),
                     ..Default::default()
                 };
-                runtime_window.process_key_input(event);
+                window.window().dispatch_event(corelib::platform::WindowEvent::internal(event));
             }
             WindowEvent::Ime(winit::event::Ime::Commit(string)) => {
                 let mut key_event = KeyEvent::default();
@@ -375,7 +376,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     key_event,
                     ..Default::default()
                 };
-                runtime_window.process_key_input(event);
+                window.window().dispatch_event(corelib::platform::WindowEvent::internal(event));
             }
             WindowEvent::CursorMoved { position, .. } => {
                 self.current_resize_direction = handle_cursor_move_for_resize(
@@ -397,7 +398,9 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                 // On the html canvas, we don't get the mouse move or release event when outside the canvas. So we have no choice but canceling the event
                 if cfg!(target_arch = "wasm32") || !self.pressed {
                     self.pressed = false;
-                    runtime_window.process_mouse_input(MouseEvent::Exit);
+                    window
+                        .window()
+                        .dispatch_event(corelib::platform::WindowEvent::internal(MouseEvent::Exit));
                 }
             }
             WindowEvent::MouseWheel { delta, phase, .. } => {
@@ -414,12 +417,9 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     winit::event::TouchPhase::Ended => TouchPhase::Ended,
                     winit::event::TouchPhase::Cancelled => TouchPhase::Cancelled,
                 };
-                runtime_window.process_mouse_input(MouseEvent::Wheel {
-                    position: self.cursor_pos,
-                    delta_x,
-                    delta_y,
-                    phase,
-                });
+                window.window().dispatch_event(corelib::platform::WindowEvent::internal(
+                    MouseEvent::Wheel { position: self.cursor_pos, delta_x, delta_y, phase },
+                ));
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 let button = match button {
@@ -460,7 +460,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                         }
                     }
                 };
-                runtime_window.process_mouse_input(ev);
+                window.window().dispatch_event(corelib::platform::WindowEvent::internal(ev));
             }
             WindowEvent::Touch(touch) => {
                 let location = touch.location.to_logical(runtime_window.scale_factor() as f64);
@@ -482,11 +482,13 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                     }
                 };
                 if let Some(finger_id) = finger_id {
-                    runtime_window.process_touch_input(
-                        finger_id,
-                        position,
-                        winit_touch_phase(touch.phase),
-                    );
+                    window.window().dispatch_event(corelib::platform::WindowEvent::internal(
+                        corelib::platform::InternalEvent::Touch {
+                            id: finger_id,
+                            position,
+                            phase: winit_touch_phase(touch.phase),
+                        },
+                    ));
                 }
             }
             WindowEvent::ScaleFactorChanged { scale_factor, inner_size_writer: _ } => {
@@ -520,20 +522,24 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
             // known cursor position as the best available approximation. On macOS
             // trackpads, CursorMoved events typically precede gesture events.
             WindowEvent::PinchGesture { delta, phase, .. } => {
-                runtime_window.process_mouse_input(corelib::input::MouseEvent::PinchGesture {
-                    position: self.cursor_pos,
-                    delta: delta as f32,
-                    phase: winit_touch_phase(phase),
-                });
+                window.window().dispatch_event(corelib::platform::WindowEvent::internal(
+                    corelib::input::MouseEvent::PinchGesture {
+                        position: self.cursor_pos,
+                        delta: delta as f32,
+                        phase: winit_touch_phase(phase),
+                    },
+                ));
             }
             WindowEvent::RotationGesture { delta, phase, .. } => {
                 // macOS/winit: positive = counterclockwise. Negate to match
                 // Slint convention (positive = clockwise).
-                runtime_window.process_mouse_input(corelib::input::MouseEvent::RotationGesture {
-                    position: self.cursor_pos,
-                    delta: -delta,
-                    phase: winit_touch_phase(phase),
-                });
+                window.window().dispatch_event(corelib::platform::WindowEvent::internal(
+                    corelib::input::MouseEvent::RotationGesture {
+                        position: self.cursor_pos,
+                        delta: -delta,
+                        phase: winit_touch_phase(phase),
+                    },
+                ));
             }
 
             WindowEvent::AxisMotion { .. } => {

--- a/internal/backends/winit/wasm_input_helper.rs
+++ b/internal/backends/winit/wasm_input_helper.rs
@@ -233,16 +233,14 @@ impl WasmInputHelper {
         let input = h.input.clone();
         h.add_event_listener("compositionend", move |e: web_sys::CompositionEvent| {
             if let (Some(window_adapter), Some(data)) = (win.upgrade(), e.data()) {
-                let window_inner = WindowInner::from_pub(window_adapter.window());
-
                 let mut key_event = KeyEvent::default();
                 key_event.text = data.into();
 
-                window_inner.process_key_input(InternalKeyEvent {
+                window_adapter.window().dispatch_event(WindowEvent::internal(InternalKeyEvent {
                     key_event,
                     event_type: KeyEventType::CommitComposition,
                     ..Default::default()
-                });
+                }));
                 input.set_value("");
             }
         });
@@ -250,12 +248,11 @@ impl WasmInputHelper {
         let win = window_adapter.clone();
         h.add_event_listener("compositionupdate", move |e: web_sys::CompositionEvent| {
             if let (Some(window_adapter), Some(data)) = (win.upgrade(), e.data()) {
-                let window_inner = WindowInner::from_pub(window_adapter.window());
-                window_inner.process_key_input(InternalKeyEvent {
+                window_adapter.window().dispatch_event(WindowEvent::internal(InternalKeyEvent {
                     preedit_text: data.into(),
                     event_type: KeyEventType::UpdateComposition,
                     ..Default::default()
-                });
+                }));
             }
         });
 

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -690,10 +690,16 @@ impl Window {
         event: crate::platform::WindowEvent,
     ) -> Result<WindowEventDispatchResult, PlatformError> {
         // Only clone the event when a hook is installed to avoid allocation on the hot path.
-        let event_for_hook = self
-            .0
-            .try_context()
-            .and_then(|ctx| ctx.0.window_event_hook.borrow().is_some().then(|| event.clone()));
+        // Events a backend delivers in the internal representation are reported as the public
+        // event they correspond to, if there is one.
+        let hook_installed =
+            self.0.try_context().is_some_and(|ctx| ctx.0.window_event_hook.borrow().is_some());
+        let event_for_hook = hook_installed
+            .then(|| match &event {
+                crate::platform::WindowEvent::Internal(event) => event.public_representation(),
+                event => Some(event.clone()),
+            })
+            .flatten();
         let dispatch_result = match event {
             crate::platform::WindowEvent::PointerPressed { position, button } => self
                 .0
@@ -785,6 +791,22 @@ impl Window {
                 self.0.set_active(bool);
                 WindowEventDispatchResult::Accepted
             }
+            crate::platform::WindowEvent::Internal(event) => match event.into_inner() {
+                crate::platform::InternalEvent::Mouse(MouseEvent::Exit) => {
+                    // Teardown event, always accepted like `WindowEvent::PointerExited`.
+                    self.0.process_mouse_input(MouseEvent::Exit);
+                    WindowEventDispatchResult::Accepted
+                }
+                crate::platform::InternalEvent::Mouse(event) => {
+                    self.0.process_mouse_input(event).into()
+                }
+                crate::platform::InternalEvent::Key(event) => {
+                    self.0.process_key_input(event).into()
+                }
+                crate::platform::InternalEvent::Touch { id, position, phase } => {
+                    self.0.process_touch_input(id, position, phase).into()
+                }
+            },
         };
         if let Some(event_for_hook) = event_for_hook
             && let Some(ctx) = self.0.try_context()

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -945,7 +945,7 @@ pub enum KeyEventType {
     CommitComposition = 3,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, PartialEq)]
 /// This struct is used to pass key events to the runtime.
 pub struct InternalKeyEvent {
     /// That's the public type with only public fields

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -424,6 +424,12 @@ pub enum WindowEvent {
     /// The backend should dispatch this event with true when the window gains focus
     /// and false when the window loses focus.
     WindowActiveChanged(bool),
+
+    /// An event that one of Slint's own backends delivers in the runtime's internal representation.
+    ///
+    /// This isn't public API, use [`WindowEvent::internal()`] to construct it.
+    #[doc(hidden)]
+    Internal(InternalEventBox),
 }
 
 impl WindowEvent {
@@ -434,7 +440,184 @@ impl WindowEvent {
             WindowEvent::PointerReleased { position, .. } => Some(*position),
             WindowEvent::PointerMoved { position } => Some(*position),
             WindowEvent::PointerScrolled { position, .. } => Some(*position),
+            WindowEvent::Internal(event) => event.position(),
             _ => None,
+        }
+    }
+
+    /// Wraps an event in the runtime's internal representation,
+    /// for Slint's own backends to deliver via [`Window::dispatch_event_with_result()`](crate::api::Window::dispatch_event_with_result).
+    #[doc(hidden)]
+    pub fn internal(event: impl Into<InternalEvent>) -> Self {
+        Self::Internal(InternalEventBox::new(event.into()))
+    }
+}
+
+/// Owning pointer to an [`InternalEvent`].
+///
+/// The payload lives behind a pointer, so that the size of [`WindowEvent`] and the way the C++
+/// bindings represent it don't depend on the internal event.
+/// It's a dedicated type rather than a `Box`, because a `Box` of an unsized type is two pointers
+/// wide, which the generated C++ struct wouldn't match.
+#[doc(hidden)]
+#[repr(transparent)]
+pub struct InternalEventBox(core::ptr::NonNull<InternalEvent>);
+
+#[allow(unsafe_code)]
+impl InternalEventBox {
+    fn new(event: InternalEvent) -> Self {
+        // Safety: `Box::into_raw` never returns null.
+        Self(unsafe { core::ptr::NonNull::new_unchecked(Box::into_raw(Box::new(event))) })
+    }
+
+    /// Takes the event out of the box.
+    pub(crate) fn into_inner(self) -> InternalEvent {
+        let this = core::mem::ManuallyDrop::new(self);
+        // Safety: the pointer comes from `Box::into_raw` in `new()`, and `ManuallyDrop` keeps
+        // `Drop` from freeing it a second time.
+        *unsafe { Box::from_raw(this.0.as_ptr()) }
+    }
+}
+
+#[allow(unsafe_code)]
+impl Drop for InternalEventBox {
+    fn drop(&mut self) {
+        // Safety: the pointer comes from `Box::into_raw` in `new()` and is freed only here or in
+        // `into_inner()`, which doesn't run this.
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+    }
+}
+
+#[allow(unsafe_code)]
+impl core::ops::Deref for InternalEventBox {
+    type Target = InternalEvent;
+    fn deref(&self) -> &InternalEvent {
+        // Safety: the pointer comes from `Box::into_raw` in `new()` and stays valid until `Drop`.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl Clone for InternalEventBox {
+    fn clone(&self) -> Self {
+        Self::new(InternalEvent::clone(self))
+    }
+}
+
+impl PartialEq for InternalEventBox {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl core::fmt::Debug for InternalEventBox {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        InternalEvent::fmt(self, f)
+    }
+}
+
+/// An event that one of Slint's own backends delivers in the representation the runtime uses internally.
+///
+/// These carry information that the [`WindowEvent`] variants can't express,
+/// such as the touch finger id, the click count, the gesture phase, drag payloads or input method composition.
+/// Backends wrap them with [`WindowEvent::internal()`] and dispatch them like any other event,
+/// so that all input takes the same path into the runtime and is observed by the window event hook.
+///
+/// This isn't public API: the variants and their payload change without notice.
+#[doc(hidden)]
+#[derive(Debug, Clone, PartialEq)]
+pub enum InternalEvent {
+    /// A pointer event, including the ones that have no public representation,
+    /// such as gestures and drag and drop.
+    Mouse(crate::input::MouseEvent),
+    /// A key event, including input method composition updates.
+    Key(crate::input::InternalKeyEvent),
+    /// A touch point update, which the runtime turns into pointer or gesture events.
+    Touch {
+        /// The id of the finger that produced the event.
+        id: i32,
+        /// The position of the finger, in logical coordinates.
+        position: crate::lengths::LogicalPoint,
+        /// Whether the finger was put down, moved, lifted or cancelled.
+        phase: crate::input::TouchPhase,
+    },
+}
+
+impl From<crate::input::MouseEvent> for InternalEvent {
+    fn from(event: crate::input::MouseEvent) -> Self {
+        Self::Mouse(event)
+    }
+}
+
+impl From<crate::input::InternalKeyEvent> for InternalEvent {
+    fn from(event: crate::input::InternalKeyEvent) -> Self {
+        Self::Key(event)
+    }
+}
+
+impl InternalEvent {
+    /// The public event this event corresponds to, if any.
+    ///
+    /// This is what the window event hook observes,
+    /// so that hooks only ever see events they could dispatch themselves.
+    /// Events without a public representation aren't reported:
+    /// gestures, drag and drop, touch and input method composition.
+    pub(crate) fn public_representation(&self) -> Option<WindowEvent> {
+        use crate::input::{KeyEventType, MouseEvent};
+        use crate::lengths::logical_position_to_api;
+
+        match self {
+            Self::Mouse(event) => match event {
+                MouseEvent::Pressed { position, button, .. } => Some(WindowEvent::PointerPressed {
+                    position: logical_position_to_api(*position),
+                    button: *button,
+                }),
+                MouseEvent::Released { position, button, .. } => {
+                    Some(WindowEvent::PointerReleased {
+                        position: logical_position_to_api(*position),
+                        button: *button,
+                    })
+                }
+                MouseEvent::Moved { position, .. } => {
+                    Some(WindowEvent::PointerMoved { position: logical_position_to_api(*position) })
+                }
+                MouseEvent::Wheel { position, delta_x, delta_y, .. } => {
+                    Some(WindowEvent::PointerScrolled {
+                        position: logical_position_to_api(*position),
+                        delta_x: *delta_x as f32,
+                        delta_y: *delta_y as f32,
+                    })
+                }
+                MouseEvent::Exit => Some(WindowEvent::PointerExited),
+                MouseEvent::DragMove { .. }
+                | MouseEvent::Drop { .. }
+                | MouseEvent::PinchGesture { .. }
+                | MouseEvent::RotationGesture { .. } => None,
+            },
+            Self::Key(event) => {
+                let text = event.key_event.text.clone();
+                match event.event_type {
+                    KeyEventType::KeyPressed if event.key_event.repeat => {
+                        Some(WindowEvent::KeyPressRepeated { text })
+                    }
+                    KeyEventType::KeyPressed => Some(WindowEvent::KeyPressed { text }),
+                    KeyEventType::KeyReleased => Some(WindowEvent::KeyReleased { text }),
+                    KeyEventType::UpdateComposition | KeyEventType::CommitComposition => None,
+                }
+            }
+            // There's no public touch event, and the pointer events the runtime synthesizes from
+            // a touch point carry a finger id that `WindowEvent` can't express.
+            Self::Touch { .. } => None,
+        }
+    }
+
+    /// The position of the pointer or finger for this event, if any.
+    fn position(&self) -> Option<LogicalPosition> {
+        match self {
+            Self::Mouse(event) => event.position().map(crate::lengths::logical_position_to_api),
+            Self::Key(_) => None,
+            Self::Touch { position, .. } => {
+                Some(crate::lengths::logical_position_to_api(*position))
+            }
         }
     }
 }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -575,7 +575,7 @@ struct WindowPinnedFields {
 
 /// The outcome of dispatching a [`MouseEvent`] through [`WindowInner::process_mouse_input`].
 #[derive(Copy, Clone, Debug)]
-pub struct MouseDispatchResult {
+pub(crate) struct MouseDispatchResult {
     /// For `MouseEvent::DragMove` / `MouseEvent::Drop` events, the action negotiated with
     /// the accepting `DropArea` (or `None` if no `DropArea` accepted). Always `None` for
     /// other event kinds.
@@ -760,6 +760,11 @@ impl WindowInner {
     /// Receive a mouse event and pass it to the items of the component to
     /// change their state.
     ///
+    /// This is the runtime's entry point for pointer input.
+    /// Backends don't call it directly, they dispatch [`crate::platform::InternalEvent::Mouse`]
+    /// through [`crate::api::Window::dispatch_event_with_result()`],
+    /// so that every event they deliver takes the same path and is observed by the window event hook.
+    ///
     /// Returns `None` when there is no component to dispatch to; otherwise returns a
     /// [`MouseDispatchResult`] carrying:
     /// - `accepted`: whether an item consumed the event, and
@@ -770,7 +775,7 @@ impl WindowInner {
     /// `Drop` (if a `DropArea` had previously accepted the matching `DragMove`) or an
     /// `Exit` (if not). The reported `accepted` reflects the rewritten event, so a
     /// `Released` that completes a drop on a non-accepting target reports `accepted = false`.
-    pub fn process_mouse_input(&self, mut event: MouseEvent) -> Option<MouseDispatchResult> {
+    pub(crate) fn process_mouse_input(&self, mut event: MouseEvent) -> Option<MouseDispatchResult> {
         crate::animations::update_animations(crate::animations::Instant::now(self.context()));
 
         let item_tree = self.try_component()?;
@@ -1082,6 +1087,24 @@ impl WindowInner {
         Some(MouseDispatchResult { drag_action, accepted })
     }
 
+    /// Dispatch a drag and drop event: a `DragMove`, a `Drop`,
+    /// or the `Exit` that ends a drag hovering over the window.
+    /// Returns the action negotiated with the accepting `DropArea`, or `None` when none accepted.
+    ///
+    /// Drag and drop is the one kind of input that backends don't deliver through
+    /// [`crate::api::Window::dispatch_event_with_result()`]:
+    /// they need the negotiated action back, which [`crate::api::WindowEventDispatchResult`] can't express,
+    /// and a drag leaving the window isn't the pointer leaving the window.
+    /// These events have no [`crate::platform::WindowEvent`] representation either,
+    /// so nothing is lost for the window event hook.
+    pub fn process_drag_event(&self, event: MouseEvent) -> Option<crate::items::DragAction> {
+        debug_assert!(matches!(
+            event,
+            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } | MouseEvent::Exit
+        ));
+        self.process_mouse_input(event).and_then(|result| result.drag_action)
+    }
+
     /// Remember (or clear) the in-flight native drag, so a backend can report completion or fall
     /// back, and a drop back onto this window can restore the data. Set by `offer_native_drag`.
     pub(crate) fn set_native_drag(&self, drag: Option<NativePendingDrag>) {
@@ -1137,7 +1160,7 @@ impl WindowInner {
     /// `drag_action` reflects the current drop-target negotiation, not a per-event
     /// verdict to aggregate. For touch sequences that never produce a `DragMove`/`Drop`
     /// (the common case), this stays `None` throughout.
-    pub fn process_touch_input(
+    pub(crate) fn process_touch_input(
         &self,
         id: i32,
         position: LogicalPoint,
@@ -1169,7 +1192,7 @@ impl WindowInner {
     ///
     /// Arguments:
     /// * `event`: The key event received by the windowing system.
-    pub fn process_key_input(
+    pub(crate) fn process_key_input(
         &self,
         mut internal_key_event: InternalKeyEvent,
     ) -> crate::input::KeyEventResult {
@@ -2932,15 +2955,17 @@ pub mod ffi {
     ) {
         unsafe {
             let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-            window_adapter.window().0.process_key_input(InternalKeyEvent {
-                event_type,
-                key_event: crate::items::KeyEvent {
-                    text: text.clone(),
-                    repeat,
+            window_adapter.window().dispatch_event(crate::platform::WindowEvent::internal(
+                InternalKeyEvent {
+                    event_type,
+                    key_event: crate::items::KeyEvent {
+                        text: text.clone(),
+                        repeat,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
-                ..Default::default()
-            });
+            ));
         }
     }
 
@@ -2952,7 +2977,9 @@ pub mod ffi {
     ) {
         unsafe {
             let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-            window_adapter.window().0.process_mouse_input(event.clone());
+            window_adapter
+                .window()
+                .dispatch_event(crate::platform::WindowEvent::internal(event.clone()));
         }
     }
 

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -257,18 +257,18 @@ if !cfg!(target_os = "macos") {
 ```rust
 // Test 2b
 // Standalone wheel move events animate without a synthetic settle callback
+use slint::platform::WindowEvent;
 use slint_testing::{LogicalPoint, MouseEvent, TouchPhase};
 let instance = TestCase::new().unwrap();
 let window = instance.window();
-let inner = slint_testing::WindowInner::from_pub(&window);
 
 assert_eq!(instance.get_flicked(), 0);
-inner.process_mouse_input(MouseEvent::Wheel {
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel {
     position: LogicalPoint::new(175., 175.),
     delta_x: -30.,
     delta_y: -50.,
     phase: TouchPhase::Moved,
-});
+}));
 assert_eq!(instance.get_offset_x(), 0.);
 assert_eq!(instance.get_offset_y(), 0.);
 assert_eq!(instance.get_flicked(), 0);

--- a/tests/cases/elements/flickable_touch_pan.slint
+++ b/tests/cases/elements/flickable_touch_pan.slint
@@ -29,7 +29,7 @@ export component TestCase inherits Window {
 
 ```rust
 use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
-use slint_testing::{LogicalPoint, TouchPhase, WindowInner};
+use slint_testing::{InternalEvent, LogicalPoint, TouchPhase};
 let instance = TestCase::new().unwrap();
 
 // Dragging with the mouse doesn't pan
@@ -54,19 +54,17 @@ instance.set_content_y(0.);
 instance.set_flicked_count(0);
 
 // Dragging with a finger pans
-let window = instance.window();
-let inner = WindowInner::from_pub(&window);
-inner.process_touch_input(7, LogicalPoint::new(300.0, 100.0), TouchPhase::Started);
-inner.process_touch_input(7, LogicalPoint::new(300.0, 100.0), TouchPhase::Moved);
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 7, position: LogicalPoint::new(300.0, 100.0), phase: TouchPhase::Started }));
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 7, position: LogicalPoint::new(300.0, 100.0), phase: TouchPhase::Moved }));
 assert_eq!(instance.get_content_x(), 0.);
 assert_eq!(instance.get_content_y(), 0.);
-inner.process_touch_input(7, LogicalPoint::new(200.0, 50.0), TouchPhase::Moved);
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 7, position: LogicalPoint::new(200.0, 50.0), phase: TouchPhase::Moved }));
 assert_eq!(instance.get_content_x(), -100.);
 assert_eq!(instance.get_content_y(), -50.);
 assert!(instance.get_flicked_count() > 0);
 // Release long after the last move so no fling animation starts
 slint_testing::mock_elapsed_time(1000);
-inner.process_touch_input(7, LogicalPoint::new(200.0, 50.0), TouchPhase::Ended);
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 7, position: LogicalPoint::new(200.0, 50.0), phase: TouchPhase::Ended }));
 slint_testing::mock_elapsed_time(1000);
 assert_eq!(instance.get_content_x(), -100.);
 assert_eq!(instance.get_content_y(), -50.);
@@ -76,10 +74,10 @@ instance.set_flicked_count(0);
 
 // interactive: false disables touch panning too
 instance.set_interactive(false);
-inner.process_touch_input(8, LogicalPoint::new(300.0, 100.0), TouchPhase::Started);
-inner.process_touch_input(8, LogicalPoint::new(300.0, 100.0), TouchPhase::Moved);
-inner.process_touch_input(8, LogicalPoint::new(200.0, 50.0), TouchPhase::Moved);
-inner.process_touch_input(8, LogicalPoint::new(200.0, 50.0), TouchPhase::Ended);
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 8, position: LogicalPoint::new(300.0, 100.0), phase: TouchPhase::Started }));
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 8, position: LogicalPoint::new(300.0, 100.0), phase: TouchPhase::Moved }));
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 8, position: LogicalPoint::new(200.0, 50.0), phase: TouchPhase::Moved }));
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 8, position: LogicalPoint::new(200.0, 50.0), phase: TouchPhase::Ended }));
 slint_testing::mock_elapsed_time(1000);
 assert_eq!(instance.get_content_x(), 0.);
 assert_eq!(instance.get_content_y(), 0.);

--- a/tests/cases/elements/listview_differing_heights.slint
+++ b/tests/cases/elements/listview_differing_heights.slint
@@ -68,7 +68,6 @@ impl ScrollDirection {
 
 let instance = Test::new().unwrap();
 let window = instance.window();
-let inner = slint_testing::WindowInner::from_pub(&window);
 let scroll_position = LogicalPoint::new(300.0, 300.0);
 
 let send_event = |event| {
@@ -94,12 +93,12 @@ let send_moved_event = |x, y| {
 };
 
 let send_wheel_event = |delta_y, phase| {
-    inner.process_mouse_input(MouseEvent::Wheel {
+    send_event(WindowEvent::internal(MouseEvent::Wheel {
         position: scroll_position,
         delta_x: 0.0,
         delta_y,
         phase,
-    });
+    }));
 };
 
 let probe_index = |direction| {

--- a/tests/cases/elements/listview_scroll_touch_pad.slint
+++ b/tests/cases/elements/listview_scroll_touch_pad.slint
@@ -33,28 +33,28 @@ export component TestCase inherits Window {
 // Testing if the animation is applied to the flickable after mouse release. In this scenario only the y animation is triggered
 // Because we move with the mouse only straight up
 use slint::*;
+use slint::platform::WindowEvent;
 use slint_testing::{MouseEvent, TouchPhase, LogicalPoint};
 
 let instance = TestCase::new().unwrap();
 let window = instance.window();
-let inner =  slint_testing::WindowInner::from_pub(&window);
 
 assert!(instance.get_content_height() > instance.get_height_(), "{} > {} not fulfilled", instance.get_content_height(), instance.get_height_());
 
 // // Scroll down
 let pressed_position = LogicalPoint::new(0., 0.);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(1);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(10000); // No animation shall be triggered
 assert_eq!(instance.get_content_y(), -10.);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Moved }); // To reduce the delta t
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Moved })); // To reduce the delta t
 slint_testing::mock_elapsed_time(5);
 assert_eq!(instance.get_content_y(), -10.);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved }));
 assert_eq!(instance.get_content_y(), -20.);
 slint_testing::mock_elapsed_time(5);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 slint_testing::mock_elapsed_time(10000000); // Let the animation finish
 assert!(instance.get_content_y() < -20., "Received: {}, Desired: smaller than {}", instance.get_content_y(), -20.);
 
@@ -62,14 +62,14 @@ let content_y = instance.get_content_y();
 println!("Viewport y: {}", content_y);
 
 // // Scroll up again until the limit
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(1);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 10., phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 10., phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(10000); // No animation shall be triggered
 assert!(instance.get_content_y() == content_y + 10., "Received: {}, Desired: {}", instance.get_content_y(),content_y + 10.);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 100., phase: TouchPhase::Moved }); // To reduce the delta t
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 100., phase: TouchPhase::Moved })); // To reduce the delta t
 slint_testing::mock_elapsed_time(1);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 slint_testing::mock_elapsed_time(10000); // Let the animation finish
 assert!(instance.get_content_y() == 0., "Received: {}, Desired: {}", instance.get_content_y(), 0.);
 ```
@@ -82,38 +82,37 @@ use slint::{platform::WindowEvent, LogicalPosition};
 
 let instance = TestCase::new().unwrap();
 let window = instance.window();
-let inner =  slint_testing::WindowInner::from_pub(&window);
 
 assert!(instance.get_content_height() > instance.get_height_(), "{} > {} not fulfilled", instance.get_content_height(), instance.get_height_());
 
 // Scroll down
 let pressed_position = LogicalPoint::new(0., 0.);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(12);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -47.164063, phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -47.164063, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(14);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -43.35547, phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -43.35547, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(8);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.625, phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.625, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(21);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -37.003906, phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -37.003906, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(0);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.441406, phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.441406, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(4);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -38.45703, phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -38.45703, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(34);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -19.953125, phase: TouchPhase::Moved });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -19.953125, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(0);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 
 slint_testing::mock_elapsed_time(362);
 
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(300.0, 100.0) }); // This move is required to trigger a ensure_updated_listview()
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(12);
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 42.085938, phase: TouchPhase::Moved }); // Going up again
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 42.085938, phase: TouchPhase::Moved })); // Going up again
 slint_testing::mock_elapsed_time(10000); // No animation shall be triggered
-inner.process_mouse_input(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended });
+window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(300.0, 100.0) });
 // No crash
 ```

--- a/tests/cases/input/altgr.slint
+++ b/tests/cases/input/altgr.slint
@@ -90,33 +90,32 @@ Ideally we should only remove the Ctrl+Alt modifiers if they actually caused a d
     use i_slint_core::input::KeyEventType;
     use i_slint_core::items::KeyEvent;
 
-    let inner = i_slint_core::window::WindowInner::from_pub(instance.window());
     // If the text_without_modifiers is "@", then we know that this layout doesn't
     // have AltGr behavior to produce an `@`, and we can trigger the Ctrl+Alt+@ shortcut
     let mut key_event = KeyEvent::default();
     key_event.text = "@".into();
-    inner.process_key_input(
+    instance.window().dispatch_event(WindowEvent::internal(
         InternalKeyEvent {
             event_type: KeyEventType::KeyPressed,
             key_event,
             text_without_modifiers: "@".into(),
             ..Default::default()
         }
-    );
+    ));
     assert_matched("Ctrl+Alt+@");
 
     // But if the text_without_modifiers is "q", then we know that this layout produces
     // an `@` when AltGr is pressed, and Ctrl+Alt+@ should just be interpreted as `@`
     let mut key_event = KeyEvent::default();
     key_event.text = "@".into();
-    inner.process_key_input(
+    instance.window().dispatch_event(WindowEvent::internal(
         InternalKeyEvent {
             event_type: KeyEventType::KeyPressed,
             key_event,
             text_without_modifiers: "q".into(),
             ..Default::default()
         }
-    );
+    ));
     assert_matched("@");
 }
 

--- a/tests/cases/widgets/scrollview.slint
+++ b/tests/cases/widgets/scrollview.slint
@@ -81,7 +81,7 @@ assert!(instance.get_content_y() != -200.0);
 ```rust
 // Panning the content: touch pans, mouse dragging doesn't (mouse-drag-pan-enabled defaults to false)
 use slint::{LogicalPosition, platform::{WindowEvent, PointerEventButton}};
-use slint_testing::{LogicalPoint, TouchPhase, WindowInner};
+use slint_testing::{InternalEvent, LogicalPoint, TouchPhase};
 
 let instance = TestCase::new().unwrap();
 
@@ -97,16 +97,14 @@ assert_eq!(instance.get_content_x(), 0.);
 assert_eq!(instance.get_content_y(), 0.);
 
 // Drag the content with a finger
-let window = instance.window();
-let inner = WindowInner::from_pub(&window);
-inner.process_touch_input(3, LogicalPoint::new(50.0, 50.0), TouchPhase::Started);
-inner.process_touch_input(3, LogicalPoint::new(50.0, 50.0), TouchPhase::Moved);
-inner.process_touch_input(3, LogicalPoint::new(20.0, 30.0), TouchPhase::Moved);
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 3, position: LogicalPoint::new(50.0, 50.0), phase: TouchPhase::Started }));
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 3, position: LogicalPoint::new(50.0, 50.0), phase: TouchPhase::Moved }));
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 3, position: LogicalPoint::new(20.0, 30.0), phase: TouchPhase::Moved }));
 assert_eq!(instance.get_content_x(), -30.);
 assert_eq!(instance.get_content_y(), -20.);
 // Release long after the last move so no fling animation starts
 slint_testing::mock_elapsed_time(1000);
-inner.process_touch_input(3, LogicalPoint::new(20.0, 30.0), TouchPhase::Ended);
+instance.window().dispatch_event(WindowEvent::internal(InternalEvent::Touch { id: 3, position: LogicalPoint::new(20.0, 30.0), phase: TouchPhase::Ended }));
 slint_testing::mock_elapsed_time(1000);
 assert_eq!(instance.get_content_x(), -30.);
 assert_eq!(instance.get_content_y(), -20.);


### PR DESCRIPTION
Backends called `WindowInner::process_mouse_input`, `process_key_input` and `process_touch_input` directly, so the window event hook only saw the events that were dispatched through the public API.

Add a doc-hidden `WindowEvent::Internal` variant that carries the runtime's own event representation, and make the `process_*` functions crate private. Every event a backend delivers now takes the same path and is reported to the hook exactly once, as the public event it corresponds to, or not at all when there is none. Drag and drop keeps a separate entry point, since the backend needs the negotiated `DragAction` back.

This is an alternative to #12720, which maps and reports the events in each backend instead.