### PR TITLE
Fix flexbox_repeater_flex_props test, and make sure CI fails if a test is cancelled

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -97,14 +97,16 @@ jobs:
     done:
         # Note: We use `needs` + `if: always()` here to ensure the "done"
         # task is never just "skipped", which would count as success().
-        # Instead, make the task fail depending on whether there is any failure
-        # in the ci workflow.
+        # Instead, make the task fail if any job did not succeed. A cancelled
+        # job (e.g. a GitHub-side abort) must fail the gate too: it is not a
+        # passing result, so treating it as success would let a change land
+        # without that check actually running.
         needs: [ci, files-changed, format_fix, lint_typecheck]
         if: ${{ always() }}
         name: done
         runs-on: ubuntu-latest
         steps:
-            - if: ${{ contains(needs.*.result, 'failure') }}
-              run: echo "A required check failed! 🌋" && false
-            - if: ${{ !contains(needs.*.result, 'failure') }}
+            - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+              run: echo "A required check failed or was cancelled! 🌋" && false
+            - if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
               run: echo "All checks passed. 🎉"

--- a/tests/cases/layout/flexbox_repeater_flex_props.slint
+++ b/tests/cases/layout/flexbox_repeater_flex_props.slint
@@ -1,6 +1,9 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
 // Test that flex item properties (flex-grow, cross-axis-self-alignment, flex-order) work on repeated items.
 
 // Test 1: flex-grow on a repeated item pushes a static item to the right.


### PR DESCRIPTION
The failure was introduced by https://github.com/slint-ui/slint/pull/12816
The CI for that PR was cancelled by github, but was still marked as green, so make sure this doesn't happen anymore.
