### PR TITLE
doc: Restructure the desktop pages

### DIFF
--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -36,9 +36,9 @@ export default defineConfig({
     site: `${BASE_URL}${BASE_PATH}`,
     base: BASE_PATH,
     trailingSlash: SLINT_STARLIGHT_TRAILING_SLASH,
-    // Pages that moved into the language reference. Astro serves the source
-    // routes under the base path but uses the destinations verbatim, so they
-    // need the prefix.
+    // Pages that moved elsewhere in the tree. Astro serves the source routes
+    // under the base path but uses the destinations verbatim, so they need the
+    // prefix.
     redirects: {
         "/reference/primitive-types/": `${BASE_PATH}reference/property-types/numeric-types/`,
         "/reference/colors-and-brushes/": `${BASE_PATH}reference/property-types/colors-and-brushes/`,
@@ -48,6 +48,9 @@ export default defineConfig({
         "/reference/language/colors-and-brushes/": `${BASE_PATH}reference/property-types/colors-and-brushes/`,
         "/reference/language/arrays-and-models/": `${BASE_PATH}reference/property-types/arrays-and-models/`,
         "/reference/global-structs-enums/": `${BASE_PATH}reference/property-types/builtin-structs/`,
+        "/guide/platforms/desktop/": `${BASE_PATH}guide/platforms/desktop/general/`,
+        "/guide/platforms/other/": `${BASE_PATH}guide/platforms/desktop/general/`,
+        "/guide/platforms/packaging/windows-packaging/": `${BASE_PATH}guide/platforms/desktop/windows/packaging/`,
     },
     markdown: {
         gfm: true,
@@ -205,12 +208,24 @@ export default defineConfig({
                                 label: "Platforms",
                                 collapsed: true,
                                 items: [
-                                    "guide/platforms/desktop",
                                     {
-                                        label: "Packaging",
+                                        label: "Desktop",
                                         collapsed: true,
                                         items: [
-                                            "guide/platforms/packaging/windows-packaging",
+                                            "guide/platforms/desktop/general",
+                                            {
+                                                label: "Windows",
+                                                collapsed: true,
+                                                items: [
+                                                    {
+                                                        label: "Overview",
+                                                        slug: "guide/platforms/desktop/windows/general",
+                                                    },
+                                                    "guide/platforms/desktop/windows/packaging",
+                                                ],
+                                            },
+                                            "guide/platforms/desktop/macos",
+                                            "guide/platforms/desktop/linux",
                                         ],
                                     },
                                     "guide/platforms/embedded",
@@ -224,7 +239,6 @@ export default defineConfig({
                                         ],
                                     },
                                     "guide/platforms/web",
-                                    "guide/platforms/other",
                                 ],
                             },
                             {

--- a/docs/astro/src/content/docs/guide/platforms/desktop/general.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop/general.mdx
@@ -1,0 +1,10 @@
+---
+title: General Desktop Development
+description: Desktop platforms on which Slint has been tested
+---
+
+Slint runs on Windows, macOS, and popular Linux distributions.
+The following pages list the versions we specifically test.
+We aim to support every operating system version that its vendor still supports at the time of a Slint release.
+
+[Contact us](https://slint.dev/contact) if you want to use Slint on other platforms/versions.

--- a/docs/astro/src/content/docs/guide/platforms/desktop/linux.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop/linux.mdx
@@ -1,0 +1,9 @@
+---
+title: Linux
+description: Linux Platform Guide
+---
+
+Linux desktop distributions present a diverse landscape, and Slint should run on any of them,
+provided that they are using Wayland or X-Windows, glibc, and d-bus.
+If a Linux distribution provides Long Term Support (LTS),
+Slint should run on the most recent LTS or newer, at the time of a Slint version release.

--- a/docs/astro/src/content/docs/guide/platforms/desktop/macos.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop/macos.mdx
@@ -1,0 +1,12 @@
+---
+title: macOS
+description: macOS Platform Guide
+---
+
+We test Slint on these macOS versions and architectures:
+
+| Operating System  | Architecture    |
+| ----------------- | --------------- |
+| macOS 14 Sonoma   | aarch64 |
+| macOS 15 Sequoia  | aarch64 |
+| macOS 26          | aarch64 |

--- a/docs/astro/src/content/docs/guide/platforms/desktop/windows/general.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop/windows/general.mdx
@@ -1,24 +1,18 @@
 ---
-title: Desktop
-description: Desktop platforms on which Slint has been tested
+title: Windows
+description: Windows Platform Guide
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Generally, Slint runs on Windows, macOS, and popular Linux distributions. The following tables
-cover versions that we specifically test. The general objective is to support the operating systems that
-are supported by their vendors at the time of a Slint version release.
-
-
-<Tabs syncKey="dev-platform">
-<TabItem label="Windows" icon="seti:windows">
+We test Slint on these Windows versions and architectures:
 
 | Operating System | Architecture    |
 | ---------------- | --------------- |
 | Windows 10       | x86-64          |
 | Windows 11       | x86-64, aarch64 |
 
-### Handle the Console Window
+## Handle the Console Window
 
 When you running an application a console window will show by [default](https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170).
 
@@ -63,7 +57,7 @@ your Python script.
 
 </Tabs>
 
-### Rust: Stack Overflows
+## Rust: Stack Overflows
 
 When developing Rust applications on Windows, you might sooner or later observe the program aborting with `STATUS_STACK_OVERFLOW`,
 especially in debug builds. This is a known issue that's a combination of a high demand for stack space and MSVC defaulting to
@@ -82,25 +76,3 @@ rustflags = ["-C", "link-arg=/STACK:8000000"]
 # space in debug builds. The size matches Linux's default.
 rustflags = ["-C", "link-arg=/STACK:8000000"]
 ```
-
-</TabItem>
-<TabItem label="macOS" icon="apple">
-
-| Operating System  | Architecture    |
-| ----------------- | --------------- |
-| macOS 14 Sonoma   | aarch64 |
-| macOS 15 Sequoia  | aarch64 |
-| macOS 26          | aarch64 |
-
-</TabItem>
-<TabItem label="Linux" icon="linux">
-
-
-Linux desktop distribution present a diverse landscape, and Slint should run on any of them, provided that they
-are using Wayland or X-Windows, glibc, and d-bus. If a Linux distribution provides Long Term Support (LTS),
-Slint should run on the most recent LTS or newer, at the time of a Slint version release.
-</TabItem>
-</Tabs>
-
-## Other Platforms
-[Contact us](https://slint.dev/contact) if you want to use Slint on other platforms/versions.

--- a/docs/astro/src/content/docs/guide/platforms/desktop/windows/packaging.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/desktop/windows/packaging.mdx
@@ -1,5 +1,5 @@
 ---
-title: Windows
+title: Packaging
 description: Package a desktop Slint app for distribution on Windows, using MSIX
 ---
 

--- a/docs/astro/src/content/docs/guide/platforms/other.mdx
+++ b/docs/astro/src/content/docs/guide/platforms/other.mdx
@@ -1,6 +1,0 @@
----
-title: Other Platforms
-description: Contact Us for Additional Platform Support
----
-
-[Contact us](https://slint.dev/contact) if you want to use Slint on other platforms/versions.

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -10,7 +10,7 @@ This document describes the Slint release process
   - Tree sitter: in `.github/workflows/ci.yaml` for the `tree-sitter` job, bump the `tag`
     to the latest release as per https://github.com/tree-sitter/tree-sitter/releases
 
-* Verify that the list of supported platforms in docs/astro/src/content/docs/guide/platforms/desktop.mdx matches what we * Publish the helper_crates, if needed
+* Verify that the list of supported platforms in docs/astro/src/content/docs/guide/platforms/desktop/ matches what we * Publish the helper_crates, if needed
 
 * Update version number in the documentation  (Only for major release)
   - Crate documentation have sample .toml files (api/rs/lib.rs, api/rs/build/lib.rs, api/rs/README)


### PR DESCRIPTION
Desktop gets its own per-OS sub-section, and for Windows the packaging guide goes under there. macOS and Linux will get their own packaging guide.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
