### PR TITLE
Fix Tree-Sitter Grammar for import statements

### DIFF
--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -12,7 +12,7 @@ module.exports = grammar({
     [$.assignment_block],
     // Caused by accepting arbitrary expressions in the radial-gradient/conical-gradient without a separator!
     [$.unary_prec_operator, $.add_prec_operator]
-],
+  ],
 
   externals: ($) => [$.block_comment],
 
@@ -53,7 +53,7 @@ module.exports = grammar({
     export_statement: ($) => seq(
       "export",
       "{", commaSep($.export_type), optional(","), "}",
-      optional(seq("from", field("from", $.string_value), ";"))
+      optional(seq("from", field("from", alias($._import_string, $.string_value)), ";"))
     ),
 
     _rust_attr_args: ($) => seq("(", repeat(choice(/[^()"]+/, $.string_value, $._rust_attr_args)), ")"),
@@ -64,7 +64,7 @@ module.exports = grammar({
       seq(
         "import",
         optional(seq("{", commaSep($.import_type), optional(","), "}", "from")),
-        $.string_value,
+        alias($._import_string, $.string_value),
         ";",
       ),
 
@@ -833,22 +833,41 @@ module.exports = grammar({
     _unescaped_string_fragment: (_) => token.immediate(prec(1, /[^"\\]+/)),
 
     escape_sequence: ($) =>
-      seq(
-        "\\",
-        choice(
-          /u\{[0-9a-fA-F]+\}/,
-          "n",
-          "\\",
-          '"',
-          seq("{", $.expression, "}"),
-          // The lexer accepts a backslash before any character; an escape it
-          // doesn't recognize is a semantic error, not a syntax one. Keeping
-          // such a backslash lets it act as a path separator in an import or
-          // @image-url address. The already-handled characters are excluded so
-          // this doesn't compete with them.
-          /[^"n{\\]/,
+      choice(
+        // A single token, so the longest match decides between the three
+        // alternatives here and no whitespace can sneak in after the backslash.
+        token.immediate(
+          seq("\\", choice(/u\{[0-9a-fA-F]+\}/, "n", "\\", '"')),
         ),
+        // The "}" is not immediate: the expression may be followed by
+        // whitespace, as in "\{ 1 + 2 }".
+        seq(token.immediate("\\{"), $.expression, "}"),
+        // A backslash that starts no known escape is a semantic error, not a
+        // syntax one. Keeping it a node rather than an ERROR avoids wrecking
+        // the tree while an escape is still being typed.
+        token.immediate("\\"),
       ),
+
+    // Strings in import statements are special.
+    // Even though the escape sequences are respected at lexing time, they
+    // are then later ignored, so \" does not close the string, but actually produces
+    // \" and not ".
+    //
+    // e.g.:
+    //
+    // import {Foo} from "\"x";
+    //
+    // Actually imports from the file \"x
+    _import_string: ($) => seq(
+      '"',
+      repeat(choice(
+        $._unescaped_string_fragment,
+        token.immediate("\\\\"),
+        token.immediate("\\\""),
+        token.immediate("\\"))),
+      '"',
+    ),
+
     /////////////////////////////////////////////////////////////////////
 
     property_visibility: (_) => choice("private", "in", "out", "in-out", "in_out"),

--- a/editors/tree-sitter-slint/test/corpus/string_escape.txt
+++ b/editors/tree-sitter-slint/test/corpus/string_escape.txt
@@ -1,0 +1,243 @@
+================================================================================
+Recognized escape sequences
+================================================================================
+
+export component X {
+    a: "back\\slash";
+    b: "new\nline";
+    c: "quo\"te";
+    d: "uni\u{1F600}code";
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (exported_definition
+    (component_definition
+      (user_type_identifier)
+      (block
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))))))
+
+================================================================================
+String interpolation
+================================================================================
+
+export component X {
+    a: "sum\{1+2}end";
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (exported_definition
+    (component_definition
+      (user_type_identifier)
+      (block
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence
+                  (expression
+                    (binary_expression
+                      (expression
+                        (value
+                          (int_value)))
+                      (add_prec_operator)
+                      (expression
+                        (value
+                          (int_value))))))))))))))
+
+================================================================================
+String interpolation with whitespace around the expression
+================================================================================
+
+export component X {
+    a: "sum\{ 1 + 2 }end";
+    b: "sum\{
+        1 + 2
+    }end";
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (exported_definition
+    (component_definition
+      (user_type_identifier)
+      (block
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence
+                  (expression
+                    (binary_expression
+                      (expression
+                        (value
+                          (int_value)))
+                      (add_prec_operator)
+                      (expression
+                        (value
+                          (int_value))))))))))
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence
+                  (expression
+                    (binary_expression
+                      (expression
+                        (value
+                          (int_value)))
+                      (add_prec_operator)
+                      (expression
+                        (value
+                          (int_value))))))))))))))
+
+================================================================================
+A backslash that starts no known escape is a lone escape sequence
+================================================================================
+
+export component X {
+    a: "stray\xbackslash";
+    b: "path\to\file";
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (exported_definition
+    (component_definition
+      (user_type_identifier)
+      (block
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)
+                (escape_sequence)))))))))
+
+================================================================================
+Whitespace after a backslash is not part of an escape sequence
+================================================================================
+
+export component X {
+    a: "sp\ n";
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (exported_definition
+    (component_definition
+      (user_type_identifier)
+      (block
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))))))
+
+================================================================================
+A malformed unicode escape is a lone escape sequence
+================================================================================
+
+export component X {
+    a: "malformed\u{ZZZ}tail";
+    b: "bare\utail";
+}
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (exported_definition
+    (component_definition
+      (user_type_identifier)
+      (block
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))
+        (property_assignment
+          (simple_identifier)
+          (expression
+            (value
+              (string_value
+                (escape_sequence)))))))))
+
+================================================================================
+Backslashes in an import path are not escape sequences
+================================================================================
+
+import { A } from "path\to\file.slint";
+import { B } from "\"x";
+import { C } from "p\\q";
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (import_statement
+    (import_type
+      (user_type_identifier))
+    (string_value))
+  (import_statement
+    (import_type
+      (user_type_identifier))
+    (string_value))
+  (import_statement
+    (import_type
+      (user_type_identifier))
+    (string_value)))
+
+================================================================================
+Backslashes in a re-export path are not escape sequences
+================================================================================
+
+export { A } from "path\to\file.slint";
+export { B } from "\"x";
+export { C } from "p\\q";
+--------------------------------------------------------------------------------
+
+(sourcefile
+  (export_statement
+    (export_type
+      (user_type_identifier))
+    (string_value))
+  (export_statement
+    (export_type
+      (user_type_identifier))
+    (string_value))
+  (export_statement
+    (export_type
+      (user_type_identifier))
+    (string_value)))


### PR DESCRIPTION
The string in the import and export statements in Slint behaves a bit
strangely. It actually Lexes as if it had escape sequences, but then
ignores them.

The Tree-sitter grammar now reflects this by not adding escape sequence
nodes in import statements and export statements. Also, a single \ in a
string literal is now accepted by the Tree-sitter grammar. That prevents
emitting error nodes when users start typing an escape sequence.
