### PR TITLE
Fixed cubic bezier error on slow animations

### DIFF
--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -97,20 +97,26 @@ mod cubic_bezier {
 
             // Newton's method.
             let mut t = (x - from) / (to - from);
+            let mut degenerate = false;
             for _ in 0..8 {
                 let x2 = self.x(t);
-
-                if S::abs(x2 - x) <= tolerance {
-                    return t;
-                }
-
                 let dx = self.dx(t);
 
                 if dx <= S::EPSILON {
+                    degenerate = true;
                     break;
                 }
 
-                t -= (x2 - x) / dx;
+                let step = (x2 - x) / dx;
+                t -= step;
+
+                if S::abs(step) <= tolerance {
+                    return t.max(t_range.start).min(t_range.end);
+                }
+            }
+
+            if !degenerate {
+                return t.max(t_range.start).min(t_range.end);
             }
 
             // Fall back to binary search.


### PR DESCRIPTION
Closes #12813. Specifically, this fixes the bug where Cubic-bezier curves could produce small jumps for long duration animations (evident in the gallery easing page when duration is 5s).

In `solve_t_for_x`, convergence was checked against Δx, but a fixed x-tolerance corresponds to wildly different precision in t depending on the curve's local slope (dx/dt) which is small on ease endpoints. This let two nearly-identical inputs converge after a different number of iterations, making the result locally non-monotonic. The fix checks Δt instead, since it already divides by dx and is a direct error estimate on the curve.