### PR TITLE
core: give each SlintContext its own timers, clock and animation driving

### DIFF
--- a/api/rs/slint/tests/context_ambient_timer.rs
+++ b/api/rs/slint/tests/context_ambient_timer.rs
@@ -1,0 +1,49 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! A plain `Timer` — the API that names no context — must land on the context that is
+//! actually driving this thread, including when that context was created directly rather
+//! than installed by `set_platform`.
+//!
+//! Getting this wrong is silent: the timer reports `running()`, but it sits in a list
+//! nothing ticks, so it simply never fires.
+
+use std::rc::Rc;
+
+struct TestPlatform {
+    start: std::time::Instant,
+}
+
+impl slint::platform::Platform for TestPlatform {
+    fn create_window_adapter(
+        &self,
+    ) -> Result<Rc<dyn slint::platform::WindowAdapter>, slint::PlatformError> {
+        Err(slint::PlatformError::Other("this test needs no window".into()))
+    }
+    fn duration_since_start(&self) -> core::time::Duration {
+        self.start.elapsed()
+    }
+}
+
+#[test]
+fn ambient_timer_lands_on_a_directly_created_context() {
+    let ctx = i_slint_core::SlintContext::new(Box::new(TestPlatform {
+        start: std::time::Instant::now(),
+    }));
+
+    let fired = Rc::new(std::cell::Cell::new(0));
+    let fired_ = fired.clone();
+    let timer = slint::Timer::default();
+    timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(10), move || {
+        fired_.set(fired_.get() + 1)
+    });
+
+    assert!(
+        ctx.next_timer_timeout().is_some(),
+        "the timer registered somewhere other than the context driving this thread"
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    ctx.update_timers_and_animations();
+    assert!(fired.get() > 0, "the timer never fired despite its context being driven");
+}

--- a/api/rs/slint/tests/context_event_loop.rs
+++ b/api/rs/slint/tests/context_event_loop.rs
@@ -1,0 +1,47 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! A context that is never installed as the thread's global one still runs: its clock
+//! advances and its event loop drives its own timers.
+//!
+//! This is the shape `examples/safe-ui/simulator` uses — `SlintContext::new` plus
+//! `new_with_context`, without `set_platform`. It used to have a clock frozen at zero, so
+//! nothing it owned ever ticked.
+
+#[test]
+fn non_global_context_drives_its_own_timers() {
+    let Ok(platform) = i_slint_backend_selector::create_backend() else {
+        println!("SKIP: no backend available");
+        return;
+    };
+    let ctx = i_slint_core::SlintContext::new(platform);
+    let Some(proxy) = ctx.event_loop_proxy() else {
+        println!("SKIP: backend provides no event loop proxy");
+        return;
+    };
+
+    let fired = std::rc::Rc::new(std::cell::Cell::new(0));
+    let fired_ = fired.clone();
+    let timer = ctx.new_timer();
+    timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(20), move || {
+        fired_.set(fired_.get() + 1)
+    });
+
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let _ = proxy.quit_event_loop();
+    });
+
+    match ctx.run_event_loop() {
+        Ok(()) => {
+            assert!(
+                fired.get() > 0,
+                "the event loop ran but never drove this context's timers (fired {} times)",
+                fired.get()
+            );
+        }
+        // A headless CI may have a backend but no usable event loop; that is not a failure
+        // of what this test is checking.
+        Err(err) => println!("SKIP: event loop unavailable: {err}"),
+    }
+}

--- a/internal/backends/android-activity/lib.rs
+++ b/internal/backends/android-activity/lib.rs
@@ -43,6 +43,7 @@ pub struct AndroidPlatform {
     app: AndroidApp,
     window: Rc<AndroidWindowAdapter>,
     event_listener: Option<Box<dyn Fn(&PollEvent<'_>)>>,
+    context: core::cell::OnceCell<i_slint_core::SlintContextWeak>,
 }
 
 impl AndroidPlatform {
@@ -65,7 +66,7 @@ impl AndroidPlatform {
     pub fn new(app: AndroidApp) -> Self {
         let window = AndroidWindowAdapter::new(app.clone());
         CURRENT_WINDOW.set(Rc::downgrade(&window));
-        Self { app, window, event_listener: None }
+        Self { app, window, event_listener: None, context: Default::default() }
     }
 
     /// Instantiate a new Android backend given the [`android_activity::AndroidApp`]
@@ -106,9 +107,14 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
         Ok(self.window.clone())
     }
     fn run_event_loop(&self) -> Result<(), PlatformError> {
+        let ctx = self
+            .context
+            .get()
+            .and_then(|ctx| ctx.upgrade())
+            .expect("the event loop runs inside the context that owns this platform");
         let vsync = vsync::VsyncDriver::new(self.app.create_waker());
         loop {
-            let mut timeout = i_slint_core::platform::duration_until_next_timer_update();
+            let mut timeout = ctx.duration_until_next_timer_update();
             // While animating, the vsync thread wakes this loop at each display refresh
             // so rendering tracks the refresh rate instead of a fixed poll timeout.
             let animating = self.window.window.has_active_animations();
@@ -126,7 +132,7 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
             }
             let mut r = Ok(ControlFlow::Continue(()));
             self.app.poll_events(timeout, |e| {
-                i_slint_core::platform::update_timers_and_animations();
+                ctx.update_timers_and_animations();
                 r = self.window.process_event(&e);
                 if let Some(event_listener) = &self.event_listener {
                     event_listener(&e)
@@ -172,6 +178,7 @@ impl i_slint_core::platform::Platform for AndroidPlatform {
     }
 
     fn bind_context(&self, ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
+        let _ = self.context.set(ctx.clone());
         let ctx = ctx.upgrade().expect("bind_context called while the SlintContext is still alive");
         let color_scheme = match self
             .window

--- a/internal/backends/linuxkms/calloop_backend.rs
+++ b/internal/backends/linuxkms/calloop_backend.rs
@@ -65,6 +65,7 @@ impl i_slint_core::platform::EventLoopProxy for Proxy {
 }
 
 pub struct Backend {
+    context: std::cell::OnceCell<i_slint_core::SlintContextWeak>,
     #[cfg(feature = "libseat")]
     seat: Rc<RefCell<libseat::Seat>>,
     window: RefCell<Option<Rc<FullscreenWindowAdapter>>>,
@@ -140,6 +141,7 @@ impl Backend {
         }
 
         Ok(Backend {
+            context: Default::default(),
             #[cfg(feature = "libseat")]
             seat: Rc::new(RefCell::new(seat)),
             window: Default::default(),
@@ -155,6 +157,10 @@ impl Backend {
 }
 
 impl i_slint_core::platform::Platform for Backend {
+    fn bind_context(&self, ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
+        let _ = self.context.set(ctx);
+    }
+
     fn create_window_adapter(
         &self,
     ) -> Result<std::rc::Rc<dyn i_slint_core::window::WindowAdapter>, PlatformError> {
@@ -258,8 +264,14 @@ impl i_slint_core::platform::Platform for Backend {
 
         quit_loop.store(false, std::sync::atomic::Ordering::Release);
 
+        let ctx = self
+            .context
+            .get()
+            .and_then(|ctx| ctx.upgrade())
+            .expect("the event loop runs inside the context that owns this backend");
+
         while !quit_loop.load(std::sync::atomic::Ordering::Acquire) {
-            i_slint_core::platform::update_timers_and_animations();
+            ctx.update_timers_and_animations();
 
             // Only after updating the animation tick, invoke callbacks from invoke_from_event_loop(). They
             // might set animated properties, which requires an up-to-date start time.
@@ -271,7 +283,7 @@ impl i_slint_core::platform::Platform for Backend {
                 adapter.clone().render_if_needed(mouse_position_property.as_ref())?;
             };
 
-            let next_timeout = i_slint_core::platform::duration_until_next_timer_update();
+            let next_timeout = ctx.duration_until_next_timer_update();
             event_loop
                 .dispatch(next_timeout, &mut loop_data)
                 .map_err(|e| format!("Error dispatch events: {e}"))?;

--- a/internal/backends/qt/lib.rs
+++ b/internal/backends/qt/lib.rs
@@ -396,6 +396,13 @@ impl i_slint_core::platform::Platform for Backend {
 }
 
 #[cfg(not(no_qt))]
+/// `None` when unbound: Qt's timer entry points come from C++ statics whose lifetime is not
+/// tied to the context, so callers skip rather than assert.
+pub(crate) fn context() -> Option<i_slint_core::SlintContext> {
+    QT_CONTEXT.with(|cell| cell.get().and_then(|ctx| ctx.upgrade()))
+}
+
+#[cfg(not(no_qt))]
 fn update_palette_state() {
     use cpp::cpp;
     let dark = cpp! {unsafe [] -> bool as "bool" {

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2847,16 +2847,16 @@ thread_local! {
 
 /// Called by C++'s TimerHandler::timerEvent, or every time a timer might have been started
 pub(crate) fn timer_event() {
-    i_slint_core::platform::update_timers_and_animations();
+    if let Some(ctx) = crate::context() {
+        ctx.update_timers_and_animations();
+    }
     restart_timer();
 }
 
 pub(crate) fn restart_timer() {
-    let timeout = i_slint_core::timers::TimerList::next_timeout().map(|instant| {
-        let now = std::time::Instant::now();
-        let instant: std::time::Instant = instant.into();
-        if instant > now { instant.duration_since(now).as_millis() as i32 } else { 0 }
-    });
+    let timeout = crate::context()
+        .and_then(|ctx| ctx.duration_until_next_timer_update())
+        .map(|d| d.as_millis() as i32);
     if let Some(timeout) = timeout {
         cpp! { unsafe [timeout as "int"] {
             ensure_initialized(true);

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -2098,7 +2098,9 @@ impl QtWindow {
         let runtime_window = WindowInner::from_pub(&self.window);
         let window_adapter = runtime_window.window_adapter();
         runtime_window.draw_contents(|components, post_render| {
-            i_slint_core::animations::update_animations();
+            i_slint_core::animations::update_animations(i_slint_core::animations::Instant::now(
+                runtime_window.context(),
+            ));
 
             let mut renderer = QtItemRenderer {
                 painter,
@@ -2209,7 +2211,9 @@ impl QtWindow {
     }
 
     fn key_event(&self, key: i32, text: qttypes::QString, released: bool, repeat: bool) {
-        i_slint_core::animations::update_animations();
+        i_slint_core::animations::update_animations(i_slint_core::animations::Instant::now(
+            WindowInner::from_pub(&self.window).context(),
+        ));
         let text: String = text.into();
 
         let text = qt_key_to_string(key as key_generated::Qt_Key, text);

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -154,6 +154,7 @@ pub struct TestingBackendOptions {
 }
 
 pub struct TestingBackend {
+    context: std::cell::OnceCell<i_slint_core::SlintContextWeak>,
     clipboard: Mutex<Option<String>>,
     queue: Option<Queue>,
     mock_time: bool,
@@ -166,6 +167,7 @@ pub struct TestingBackend {
 impl TestingBackend {
     pub fn new(options: TestingBackendOptions) -> Self {
         Self {
+            context: Default::default(),
             clipboard: Mutex::default(),
             queue: options.threading.then(|| Queue(Default::default(), std::thread::current())),
             mock_time: options.mock_time,
@@ -178,6 +180,10 @@ impl TestingBackend {
 }
 
 impl i_slint_core::platform::Platform for TestingBackend {
+    fn bind_context(&self, ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
+        let _ = self.context.set(ctx);
+    }
+
     fn create_window_adapter(
         &self,
     ) -> Result<Rc<dyn WindowAdapter>, i_slint_core::platform::PlatformError> {
@@ -239,13 +245,17 @@ impl i_slint_core::platform::Platform for TestingBackend {
 
         loop {
             let e = queue.0.lock().unwrap().pop_front();
+            let ctx =
+                self.context.get().and_then(|ctx| ctx.upgrade()).expect(
+                    "the testing backend's event loop runs inside the context that owns it",
+                );
             if !self.mock_time {
-                i_slint_core::platform::update_timers_and_animations();
+                ctx.update_timers_and_animations();
             }
             match e {
                 Some(Event::Quit) => break Ok(()),
                 Some(Event::Event(e)) => e(),
-                None => match i_slint_core::platform::duration_until_next_timer_update() {
+                None => match ctx.duration_until_next_timer_update() {
                     Some(duration) if !self.mock_time => std::thread::park_timeout(duration),
                     _ => std::thread::park(),
                 },

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -612,7 +612,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
 
         event_loop.set_control_flow(ControlFlow::Wait);
 
-        corelib::platform::update_timers_and_animations();
+        self.shared_backend_data.context().update_timers_and_animations();
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
@@ -646,7 +646,8 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
         }
 
         if event_loop.control_flow() == ControlFlow::Wait
-            && let Some(next_timer) = corelib::platform::duration_until_next_timer_update()
+            && let Some(next_timer) =
+                self.shared_backend_data.context().duration_until_next_timer_update()
         {
             event_loop.set_control_flow(ControlFlow::wait_duration(next_timer));
         }

--- a/internal/backends/winit/frame_throttle/apple_display_link.rs
+++ b/internal/backends/winit/frame_throttle/apple_display_link.rs
@@ -32,19 +32,23 @@ define_class!(
     impl DisplayLinkTarget {
         #[unsafe(method(tick:))]
         fn tick(&self, display_link: &CADisplayLink) {
-            corelib::platform::update_timers_and_animations();
-            if let Some(adapter) = self.ivars().window_adapter.upgrade() {
-                // Call draw() directly rather than request_redraw(), because
-                // during modal tracking loops (e.g. context menus) winit's
-                // event loop is blocked and would never process RedrawRequested.
-                if let Err(e) = adapter.draw() {
-                    i_slint_core::debug_log!("Error rendering during modal loop: {e}");
-                    display_link.setPaused(true);
-                    return;
-                }
-                if !adapter.window().has_active_animations() && !adapter.pending_redraw() {
-                    display_link.setPaused(true);
-                }
+            let Some(adapter) = self.ivars().window_adapter.upgrade() else {
+                // The window is gone, so there is nothing for this display link to drive.
+                return;
+            };
+            corelib::window::WindowInner::from_pub(adapter.window())
+                .context()
+                .update_timers_and_animations();
+            // Call draw() directly rather than request_redraw(), because
+            // during modal tracking loops (e.g. context menus) winit's
+            // event loop is blocked and would never process RedrawRequested.
+            if let Err(e) = adapter.draw() {
+                i_slint_core::debug_log!("Error rendering during modal loop: {e}");
+                display_link.setPaused(true);
+                return;
+            }
+            if !adapter.window().has_active_animations() && !adapter.pending_redraw() {
+                display_link.setPaused(true);
             }
         }
     }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -16,6 +16,7 @@ use i_slint_core::graphics::RequestedGraphicsAPI;
 use i_slint_core::platform::{EventLoopProxy, PlatformError};
 use i_slint_core::window::WindowAdapter;
 use renderer::WinitCompatibleRenderer;
+use std::cell::OnceCell;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -396,6 +397,7 @@ impl BackendBuilder {
 }
 
 pub(crate) struct SharedBackendData {
+    context: OnceCell<i_slint_core::SlintContextWeak>,
     /// Allow fallback if the desired renderer is not found
     allow_fallback: bool,
     renderer_name: Option<String>,
@@ -423,6 +425,14 @@ pub(crate) struct SharedBackendData {
 }
 
 impl SharedBackendData {
+    /// Panics if the backend is not bound: an event loop only runs inside a live context.
+    pub(crate) fn context(&self) -> i_slint_core::SlintContext {
+        self.context
+            .get()
+            .and_then(|ctx| ctx.upgrade())
+            .expect("the winit event loop runs inside the context that owns this backend")
+    }
+
     fn new(
         mut builder: EventLoopBuilder,
         renderer_name: Option<String>,
@@ -491,6 +501,7 @@ impl SharedBackendData {
                 .map_err(|display_err| PlatformError::OtherError(display_err.into()))?,
         );
         Ok(Self {
+            context: Default::default(),
             allow_fallback,
             renderer_name,
             requested_graphics_api,
@@ -736,6 +747,7 @@ impl Drop for Backend {
 
 impl i_slint_core::platform::Platform for Backend {
     fn bind_context(&self, _ctx: i_slint_core::SlintContextWeak, _: i_slint_core::InternalToken) {
+        let _ = self.shared_data.context.set(_ctx.clone());
         #[cfg(xdg_desktop_settings)]
         {
             *self.xdg_watcher.borrow_mut() =

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -353,6 +353,20 @@ fn generate_public_component(
         &ctx,
     );
 
+    // The SystemTrayIcon native item sits as item 0 of the root sub-component when the
+    // public component inherits SystemTrayIcon.
+    let tray_field =
+        matches!(llr.top_level_type, llr::TopLevelComponentType::SystemTrayIcon).then(|| {
+            let tray_item =
+                &unit.sub_components[llr.item_tree.root].items[llr::ItemInstanceIdx::from(0usize)];
+            debug_assert_eq!(
+                tray_item.ty.class_name.as_str(),
+                "SystemTrayIcon",
+                "TopLevelComponentType::SystemTrayIcon expects the root item to be a SystemTrayIcon"
+            );
+            ident(&tray_item.name)
+        });
+
     // SystemTrayIcon-rooted components don't have a `WindowAdapter`. Skip the
     // eager creation calls in `new` / `new_with_context` so instantiating
     // a tray doesn't spin up a hidden window adapter as a side effect.
@@ -372,7 +386,20 @@ fn generate_public_component(
                 sp::WindowInner::from_pub(window.window()).ensure_tree_instantiated();
             )),
         ),
-        llr::TopLevelComponentType::SystemTrayIcon => (None, quote!(let _ = ctx;), None),
+        llr::TopLevelComponentType::SystemTrayIcon => {
+            let tray_field = tray_field.as_ref().unwrap();
+            (
+                None,
+                // A tray has no window to reach a context through, so hand it over here.
+                quote!(
+                    #inner_component_id::FIELD_OFFSETS
+                        .#tray_field()
+                        .apply_pin(sp::VRc::as_pin_ref(&inner))
+                        .set_context(&ctx);
+                ),
+                None,
+            )
+        }
     };
 
     #[cfg(feature = "bundle-translations")]
@@ -450,16 +477,7 @@ fn generate_public_component(
                 )
             }
             llr::TopLevelComponentType::SystemTrayIcon => {
-                // Look up the SystemTrayIcon native item — it sits as item 0 of the
-                // root sub-component when the public component inherits SystemTrayIcon.
-                let root_sub = &unit.sub_components[llr.item_tree.root];
-                let tray_item = &root_sub.items[llr::ItemInstanceIdx::from(0usize)];
-                debug_assert_eq!(
-                    tray_item.ty.class_name.as_str(),
-                    "SystemTrayIcon",
-                    "TopLevelComponentType::SystemTrayIcon expects the root item to be a SystemTrayIcon"
-                );
-                let tray_field = ident(&tray_item.name);
+                let tray_field = tray_field.as_ref().unwrap();
                 let common = common(quote!(pub));
                 // No `run()`: a tray icon doesn't drive the event loop. `show`/`hide`
                 // toggle the `visible` property; the platform side of the change

--- a/internal/core/animations.rs
+++ b/internal/core/animations.rs
@@ -211,14 +211,12 @@ impl Instant {
 
     /// Wrapper around [`std::time::Instant::now()`] that delegates to the backend
     /// and allows working in no_std environments.
-    pub fn now() -> Self {
-        Self(Self::duration_since_start().as_millis() as u64)
-    }
-
-    fn duration_since_start() -> core::time::Duration {
-        crate::context::GLOBAL_CONTEXT
-            .with(|p| p.get().map(|p| p.platform().duration_since_start()))
-            .unwrap_or_default()
+    ///
+    /// Takes the context rather than reaching for an ambient one because the origin is the
+    /// platform's start time: instants from different contexts are not comparable, so the
+    /// caller has to say which clock it means.
+    pub fn now(ctx: &crate::SlintContext) -> Self {
+        Self(ctx.platform().duration_since_start().as_millis() as u64)
     }
 
     /// Return the number of milliseconds this `Instant` is after the backend has started
@@ -411,11 +409,16 @@ fn easing_test() {
 }
 */
 
-/// Update the global animation time to the current time
-pub fn update_animations() {
+/// Update the global animation time to `now`.
+///
+/// The driver is per-thread while `now` comes from whichever context is driving it, so a
+/// thread running several contexts with different clock origins would see the tick jump.
+/// Per-context animation drivers would mean reaching a context from every binding
+/// evaluation, which is a much larger change.
+pub fn update_animations(now: Instant) {
     CURRENT_ANIMATION_DRIVER.with(|driver| {
         #[allow(unused_mut)]
-        let mut duration = Instant::duration_since_start().as_millis() as u64;
+        let mut duration = now.0;
         #[cfg(feature = "std")]
         if let Ok(val) = std::env::var("SLINT_SLOW_ANIMATIONS") {
             let factor = val.parse().unwrap_or(2).max(1);

--- a/internal/core/animations/physics_simulation.rs
+++ b/internal/core/animations/physics_simulation.rs
@@ -257,7 +257,7 @@ mod tests {
         const DECELERATION: f32 = 20.;
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
-        let time = Instant::now();
+        let time = Instant::default();
         let mut simulation = ConstantDeceleration::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -281,7 +281,7 @@ mod tests {
         const DECELERATION: f32 = 20.;
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDeceleration::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -326,7 +326,7 @@ mod tests {
         const DECELERATION: f32 = 20.;
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDeceleration::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -354,7 +354,7 @@ mod tests {
 
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDeceleration::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -401,7 +401,7 @@ mod tests {
         const DECELERATION: f32 = 20.;
         let parameters = ConstantDecelerationParameters::new(INITIAL_VELOCITY, DECELERATION);
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDeceleration::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -736,7 +736,7 @@ mod tests_spring_damper {
         );
 
         assert_eq!(START_VALUE, LIMIT_VALUE);
-        let time = Instant::now();
+        let time = Instant::default();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -763,7 +763,7 @@ mod tests_spring_damper {
             HALF_PERIOD_TIME,
         );
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             10.,
             test_limit_property(2000.),
@@ -815,7 +815,7 @@ mod tests_spring_damper {
             HALF_PERIOD_TIME,
         );
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -867,7 +867,7 @@ mod tests_spring_damper {
             HALF_PERIOD_TIME,
         );
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),
@@ -912,7 +912,7 @@ mod tests_spring_damper {
             HALF_PERIOD_TIME,
         );
 
-        let mut time = Instant::now();
+        let mut time = Instant::default();
         let mut simulation = ConstantDecelerationSpringDamper::new_internal(
             START_VALUE,
             test_limit_property(LIMIT_VALUE),

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -188,6 +188,30 @@ impl SlintContext {
         crate::timers::Timer::with_list(&self.0.timers)
     }
 
+    /// Advances this context's animations and timers to its own clock, and runs any change
+    /// handlers that fall out of it.
+    ///
+    /// This is what an event loop driving this context should call at the top of each
+    /// iteration. [`crate::platform::update_timers_and_animations`] is the same thing for
+    /// whichever context is this thread's global one.
+    pub fn update_timers_and_animations(&self) {
+        let now = crate::animations::Instant::now(self);
+        crate::animations::update_animations(now);
+        self.maybe_activate_timers(now);
+        crate::properties::ChangeTracker::run_change_handlers();
+    }
+
+    /// How long this context can go to sleep before its next timer is due, or `None` when it
+    /// has no active timer.
+    ///
+    /// The deadline and the clock it is measured against both come from this context, so
+    /// they cannot disagree.
+    pub fn duration_until_next_timer_update(&self) -> Option<core::time::Duration> {
+        let timeout = self.next_timer_timeout()?;
+        let now = crate::animations::Instant::now(self);
+        Some(core::time::Duration::from_millis(timeout.0.saturating_sub(now.0)))
+    }
+
     /// Fires the callbacks of this context's timers that have expired by `now`, and returns
     /// whether any of them was activated.
     pub fn maybe_activate_timers(&self, now: crate::animations::Instant) -> bool {

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -188,6 +188,14 @@ impl SlintContext {
         crate::timers::Timer::with_list(&self.0.timers)
     }
 
+    /// Runs `callback` once, `duration` from now, on this context.
+    ///
+    /// The context-bound counterpart of [`Timer::single_shot`](crate::timers::Timer::single_shot),
+    /// which registers on whichever context is current instead.
+    pub fn single_shot(&self, duration: core::time::Duration, callback: impl FnOnce() + 'static) {
+        crate::timers::single_shot_on(&self.0.timers, duration, callback);
+    }
+
     /// Advances this context's animations and timers to its own clock, and runs any change
     /// handlers that fall out of it.
     ///

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -132,6 +132,10 @@ impl SlintContext {
         // The list's deadlines are measured on this context's clock from now on. Done after
         // construction because it needs a handle to the context that owns it.
         crate::timers::set_owning_context(&this.0.timers, &this);
+        // Every context tells its platform which context it belongs to, not just the one
+        // that becomes this thread's global: a platform is owned by exactly one context, and
+        // a backend driving a context needs to be able to find it.
+        this.platform().bind_context(this.downgrade(), crate::InternalToken);
         this
     }
 

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -87,7 +87,7 @@ impl SlintContext {
         #[cfg(feature = "shared-parley")]
         let collection = i_slint_common::sharedfontique::create_collection(true);
 
-        Self(Rc::pin(SlintContextInner {
+        let this = Self(Rc::pin(SlintContextInner {
             platform,
             window_count: 0.into(),
 
@@ -128,7 +128,11 @@ impl SlintContext {
             // list; take it over so those timers keep working. It is the very list they
             // hold a `Weak` to, so nothing needs fixing up.
             timers: crate::timers::take_pending_timers(),
-        }))
+        }));
+        // The list's deadlines are measured on this context's clock from now on. Done after
+        // construction because it needs a handle to the context that owns it.
+        crate::timers::set_owning_context(&this.0.timers, &this);
+        this
     }
 
     /// Return a reference to the platform abstraction

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -69,6 +69,10 @@ pub(crate) struct SlintContextInner {
     #[cfg(feature = "shared-swash")]
     pub(crate) swash_scale_context: core::cell::RefCell<swash::scale::ScaleContext>,
     pub(crate) modifiers: Cell<InternalKeyboardModifierState>,
+
+    /// The timers registered on this context. Shared, so that `Timer` handles can hold a
+    /// `Weak` to the list they registered in without knowing which context owns it.
+    pub(crate) timers: crate::timers::TimerListRc,
 }
 
 /// This context is meant to hold the state and the backend.
@@ -120,6 +124,10 @@ impl SlintContext {
             #[cfg(feature = "shared-swash")]
             swash_scale_context: core::cell::RefCell::new(swash::scale::ScaleContext::new()),
             modifiers: Cell::new(Default::default()),
+            // Timers started before this thread had a context registered in the pending
+            // list; take it over so those timers keep working. It is the very list they
+            // hold a `Weak` to, so nothing needs fixing up.
+            timers: crate::timers::take_pending_timers(),
         }))
     }
 

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -82,7 +82,13 @@ pub(crate) struct SlintContextInner {
 pub struct SlintContext(pub(crate) core::pin::Pin<Rc<SlintContextInner>>);
 
 impl SlintContext {
-    /// Create a new context with a given platform
+    /// Create a new context with a given platform.
+    ///
+    /// If this thread has no context yet, the new one becomes it — first come, first
+    /// served. That is what the ambient APIs resolve to: [`crate::timers::Timer`],
+    /// `spawn_local`, `quit_event_loop` and friends. Contexts created afterwards are
+    /// perfectly usable, but are not the thread's current one, so code holding such a
+    /// context has to be explicit about it (e.g. [`Self::new_timer`]).
     pub fn new(platform: Box<dyn Platform + 'static>) -> Self {
         #[cfg(feature = "shared-parley")]
         let collection = i_slint_common::sharedfontique::create_collection(true);
@@ -132,6 +138,12 @@ impl SlintContext {
         // The list's deadlines are measured on this context's clock from now on. Done after
         // construction because it needs a handle to the context that owns it.
         crate::timers::set_owning_context(&this.0.timers, &this);
+        // Claim this thread's context slot if it is still free, so that the ambient APIs
+        // resolve here rather than to a list nothing drives. Fails harmlessly when the
+        // thread already has a context: that one stays current.
+        GLOBAL_CONTEXT.with(|slot| {
+            let _ = slot.set(this.clone());
+        });
         // Every context tells its platform which context it belongs to, not just the one
         // that becomes this thread's global: a platform is owned by exactly one context, and
         // a backend driving a context needs to be able to find it.

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -169,6 +169,28 @@ impl SlintContext {
         self.0.platform.run_event_loop()
     }
 
+    /// Creates a [`Timer`](crate::timers::Timer) that registers on this context rather than
+    /// on whichever one is current when it is started.
+    ///
+    /// For the context that a thread runs its event loop on this is the same as
+    /// `Timer::default()`, and the event loop activates the timer as usual. A context that
+    /// isn't the current one has no event loop driving it, so its owner is responsible for
+    /// calling [`Self::maybe_activate_timers`].
+    pub fn new_timer(&self) -> crate::timers::Timer {
+        crate::timers::Timer::with_list(&self.0.timers)
+    }
+
+    /// Fires the callbacks of this context's timers that have expired by `now`, and returns
+    /// whether any of them was activated.
+    pub fn maybe_activate_timers(&self, now: crate::animations::Instant) -> bool {
+        crate::timers::TimerList::activate_expired(&self.0.timers, now)
+    }
+
+    /// Returns when this context's next timer is due, or `None` if it has no active timer.
+    pub fn next_timer_timeout(&self) -> Option<crate::animations::Instant> {
+        self.0.timers.borrow().first_timeout()
+    }
+
     /// Returns the effective color scheme for the given component root, or the
     /// process-wide scheme when `root` is `None`. A `SystemTrayIcon`-rooted
     /// component resolves against the tray's own scheme first, falling back to

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -61,15 +61,6 @@ pub struct RenderingMetricsCollector {
     output_overlay: bool,
 }
 
-/// The instant used to stamp frames.
-///
-/// This collector only ever compares its own timestamps against each other, and is enabled
-/// by `SLINT_DEBUG_PERFORMANCE` alone, so it reads the global context's clock rather than
-/// threading a context through every renderer's render path.
-fn now() -> Instant {
-    crate::context::GLOBAL_CONTEXT.with(|ctx| ctx.get().map(Instant::now)).unwrap_or_default()
-}
-
 impl RenderingMetricsCollector {
     /// Returns a new instance of the counter if requested by the user (via `SLINT_DEBUG_PERFORMANCE` environment variable).
     /// The environment variable holds a comma separated list of options:
@@ -127,9 +118,21 @@ impl RenderingMetricsCollector {
 
         debug_log!("Slint: Build config: {}; Backend: {}", build_config, winsys_info);
 
-        let self_weak = Rc::downgrade(&collector);
-        collector.update_timer.stop();
-        collector.update_timer.start(
+        Some(collector)
+    }
+
+    /// Starts the once-a-second report, on the context of the window being rendered.
+    ///
+    /// Deferred until the first frame because construction happens before any window
+    /// exists: the software renderer builds its collector in `Default::default()`.
+    fn ensure_reporting(self: &Rc<Self>, ctx: &crate::SlintContext) {
+        if self.update_timer.running() {
+            return;
+        }
+        let self_weak = Rc::downgrade(self);
+        let ctx_weak = ctx.downgrade();
+        self.update_timer.start_on(
+            ctx,
             TimerMode::Repeated,
             core::time::Duration::from_secs(1),
             move || {
@@ -137,7 +140,8 @@ impl RenderingMetricsCollector {
                     Some(this) => this,
                     None => return,
                 };
-                this.trim_frame_data_to_second_boundary();
+                let Some(ctx) = ctx_weak.upgrade() else { return };
+                this.trim_frame_data_to_second_boundary(Instant::now(&ctx));
 
                 let mut last_frame_details = String::new();
                 if let Some(last_frame_data) =
@@ -160,13 +164,10 @@ impl RenderingMetricsCollector {
                 }
             },
         );
-
-        Some(collector)
     }
 
-    fn trim_frame_data_to_second_boundary(self: &Rc<Self>) {
+    fn trim_frame_data_to_second_boundary(self: &Rc<Self>, now: Instant) {
         let mut frame_times = self.collected_frame_data_since_second_ago.borrow_mut();
-        let now = now();
         frame_times.retain(|frame| {
             now.duration_since(frame.timestamp) <= core::time::Duration::from_secs(1)
         });
@@ -179,14 +180,17 @@ impl RenderingMetricsCollector {
         renderer: &mut dyn crate::item_rendering::ItemRenderer,
         metrics: RenderingMetrics,
     ) {
+        let ctx = renderer.window().context().clone();
+        self.ensure_reporting(&ctx);
+        let now = Instant::now(&ctx);
         self.collected_frame_data_since_second_ago
             .borrow_mut()
-            .push(FrameData { timestamp: now(), metrics });
+            .push(FrameData { timestamp: now, metrics });
         if matches!(self.refresh_mode, RefreshMode::FullSpeed) {
             crate::animations::CURRENT_ANIMATION_DRIVER
                 .with(|driver| driver.set_has_active_animations());
         }
-        self.trim_frame_data_to_second_boundary();
+        self.trim_frame_data_to_second_boundary(now);
 
         if self.output_overlay {
             renderer.draw_string(

--- a/internal/core/graphics/rendering_metrics_collector.rs
+++ b/internal/core/graphics/rendering_metrics_collector.rs
@@ -61,6 +61,15 @@ pub struct RenderingMetricsCollector {
     output_overlay: bool,
 }
 
+/// The instant used to stamp frames.
+///
+/// This collector only ever compares its own timestamps against each other, and is enabled
+/// by `SLINT_DEBUG_PERFORMANCE` alone, so it reads the global context's clock rather than
+/// threading a context through every renderer's render path.
+fn now() -> Instant {
+    crate::context::GLOBAL_CONTEXT.with(|ctx| ctx.get().map(Instant::now)).unwrap_or_default()
+}
+
 impl RenderingMetricsCollector {
     /// Returns a new instance of the counter if requested by the user (via `SLINT_DEBUG_PERFORMANCE` environment variable).
     /// The environment variable holds a comma separated list of options:
@@ -157,7 +166,7 @@ impl RenderingMetricsCollector {
 
     fn trim_frame_data_to_second_boundary(self: &Rc<Self>) {
         let mut frame_times = self.collected_frame_data_since_second_ago.borrow_mut();
-        let now = Instant::now();
+        let now = now();
         frame_times.retain(|frame| {
             now.duration_since(frame.timestamp) <= core::time::Duration::from_secs(1)
         });
@@ -172,7 +181,7 @@ impl RenderingMetricsCollector {
     ) {
         self.collected_frame_data_since_second_ago
             .borrow_mut()
-            .push(FrameData { timestamp: Instant::now(), metrics });
+            .push(FrameData { timestamp: now(), metrics });
         if matches!(self.refresh_mode, RefreshMode::FullSpeed) {
             crate::animations::CURRENT_ANIMATION_DRIVER
                 .with(|driver| driver.set_has_active_animations());

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -15,7 +15,6 @@ use crate::items::{
 };
 pub use crate::items::{FocusReason, KeyEvent, KeyboardModifiers, PointerEventButton};
 use crate::lengths::{ItemTransform, LogicalPoint, LogicalVector};
-use crate::timers::Timer;
 use crate::window::{WindowAdapter, WindowInner};
 use crate::{Coord, Property, SharedString};
 use alloc::rc::Rc;
@@ -1688,7 +1687,7 @@ fn send_mouse_event_to_item(
         InputEventFilterResult::Intercept => (false, false),
         InputEventFilterResult::DelayForwarding(_) if ignore_delays => (true, false),
         InputEventFilterResult::DelayForwarding(duration) => {
-            let timer = Timer::default();
+            let timer = WindowInner::from_pub(window_adapter.window()).context().new_timer();
             let w = Rc::downgrade(window_adapter);
             timer.start(
                 crate::timers::TimerMode::SingleShot,
@@ -1825,11 +1824,12 @@ impl TextCursorBlinker {
     pub fn set_binding(
         instance: Pin<Rc<TextCursorBlinker>>,
         prop: &Property<bool>,
+        ctx: &crate::SlintContext,
         cycle_duration: Duration,
     ) {
         instance.as_ref().cursor_visible.set(true);
         // Re-start timer, in case.
-        Self::start(&instance, cycle_duration);
+        Self::start(&instance, ctx, cycle_duration);
         prop.set_binding(move || {
             TextCursorBlinker::FIELD_OFFSETS.cursor_visible().apply_pin(instance.as_ref()).get()
         });
@@ -1837,7 +1837,7 @@ impl TextCursorBlinker {
 
     /// Starts the blinking cursor timer that will toggle the cursor and update all bindings that
     /// were installed on properties with set_binding call.
-    pub fn start(self: &Pin<Rc<Self>>, cycle_duration: Duration) {
+    pub fn start(self: &Pin<Rc<Self>>, ctx: &crate::SlintContext, cycle_duration: Duration) {
         if self.cursor_blink_timer.running() {
             self.cursor_blink_timer.restart();
         } else {
@@ -1854,7 +1854,8 @@ impl TextCursorBlinker {
                 }
             };
             if !cycle_duration.is_zero() {
-                self.cursor_blink_timer.start(
+                self.cursor_blink_timer.start_on(
+                    ctx,
                     crate::timers::TimerMode::Repeated,
                     cycle_duration / 2,
                     toggle_cursor,

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1179,9 +1179,14 @@ pub struct ClickState {
 
 impl ClickState {
     /// Resets the timer and count.
-    fn restart(&self, position: LogicalPoint, button: PointerEventButton) {
+    fn restart(
+        &self,
+        position: LogicalPoint,
+        button: PointerEventButton,
+        now: crate::animations::Instant,
+    ) {
         self.click_count.set(0);
-        self.click_count_time_stamp.set(Some(crate::animations::Instant::now()));
+        self.click_count_time_stamp.set(Some(now));
         self.click_position.set(position);
         self.click_button.set(button);
     }
@@ -1193,10 +1198,13 @@ impl ClickState {
     }
 
     /// Check if the click is repeated.
-    pub fn check_repeat(&self, mouse_event: MouseEvent, click_interval: Duration) -> MouseEvent {
+    /// Takes the context rather than just the interval: the timestamps it compares have to
+    /// come from the same clock, which only the context can name.
+    pub fn check_repeat(&self, mouse_event: MouseEvent, ctx: &crate::SlintContext) -> MouseEvent {
+        let click_interval = ctx.platform().click_interval();
         match mouse_event {
             MouseEvent::Pressed { position, button, touch_finger_id, .. } => {
-                let instant_now = crate::animations::Instant::now();
+                let instant_now = crate::animations::Instant::now(ctx);
 
                 if let Some(click_count_time_stamp) = self.click_count_time_stamp.get() {
                     if instant_now - click_count_time_stamp < click_interval
@@ -1206,10 +1214,10 @@ impl ClickState {
                         self.click_count.set(self.click_count.get().wrapping_add(1));
                         self.click_count_time_stamp.set(Some(instant_now));
                     } else {
-                        self.restart(position, button);
+                        self.restart(position, button, instant_now);
                     }
                 } else {
-                    self.restart(position, button);
+                    self.restart(position, button, instant_now);
                 }
 
                 return MouseEvent::Pressed {

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -1628,12 +1628,11 @@ impl Item for ContextMenu {
             MouseEvent::Pressed { position, button: PointerEventButton::Left, .. } => {
                 let self_weak = _self_rc.downgrade();
                 let position = *position;
-                self.long_press_timer.start(
+                let ctx = WindowInner::from_pub(_window_adapter.window()).context();
+                self.long_press_timer.start_on(
+                    ctx,
                     crate::timers::TimerMode::SingleShot,
-                    WindowInner::from_pub(_window_adapter.window())
-                        .context()
-                        .platform()
-                        .long_press_interval(crate::InternalToken),
+                    ctx.platform().long_press_interval(crate::InternalToken),
                     move || {
                         let Some(self_rc) = self_weak.upgrade() else { return };
                         let Some(self_) = self_rc.downcast::<ContextMenu>() else { return };
@@ -2116,7 +2115,12 @@ impl TooltipArea {
         }
 
         let self_weak = self_rc.downgrade();
-        self.timer.start(
+        // Start on the context this item's window belongs to, not on whichever one is
+        // current: a component built with `new_with_context` must keep its timers there.
+        let Some(window_adapter) = self_rc.window_adapter() else { return };
+        let ctx = crate::window::WindowInner::from_pub(window_adapter.window()).context();
+        self.timer.start_on(
+            ctx,
             crate::timers::TimerMode::SingleShot,
             Duration::from_millis(delay_ms),
             move || {

--- a/internal/core/items/flickable/data_ringbuffer.rs
+++ b/internal/core/items/flickable/data_ringbuffer.rs
@@ -22,7 +22,8 @@ pub(crate) struct VelocityRingBuffer<const N: usize> {
 
 impl<const N: usize> Default for VelocityRingBuffer<N> {
     fn default() -> Self {
-        Self { curr_index: 0, full: false, values: [(Instant::now(), Vector2D::default()); N] }
+        // Placeholder timestamps; `curr_index`/`full` track which entries are real.
+        Self { curr_index: 0, full: false, values: [(Instant::default(), Vector2D::default()); N] }
     }
 }
 
@@ -103,7 +104,7 @@ mod tests {
     #[test]
     fn test_push_single_element() {
         let mut buffer: VelocityRingBuffer<5> = VelocityRingBuffer::default();
-        let time = Instant::now();
+        let time = Instant::default();
         let delta = Vector2D::new(10.0, 20.0);
 
         buffer.push(time, delta);
@@ -120,7 +121,7 @@ mod tests {
     #[test]
     fn test_push_two_elements() {
         let mut buffer: VelocityRingBuffer<5> = VelocityRingBuffer::default();
-        let time = Instant::now();
+        let time = Instant::default();
 
         buffer.push(time, Vector2D::new(10.0, 20.0));
         buffer.push(time + Duration::from_millis(100), Vector2D::new(13.0, -5.0));
@@ -137,7 +138,7 @@ mod tests {
     #[test]
     fn test_push_until_full() {
         let mut buffer: VelocityRingBuffer<5> = VelocityRingBuffer::default();
-        let base_time = Instant::now();
+        let base_time = Instant::default();
 
         // Push elements to fill the buffer
         for i in 0..5 {
@@ -158,7 +159,7 @@ mod tests {
     fn test_push_beyond_capacity() {
         const CAP: usize = 5;
         let mut buffer: VelocityRingBuffer<CAP> = VelocityRingBuffer::default();
-        let base_time = Instant::now();
+        let base_time = Instant::default();
 
         // Push more than capacity
         for i in 0..(CAP + 2) {
@@ -179,7 +180,7 @@ mod tests {
     fn test_push_beyond_capacity_wrap_back() {
         const CAP: usize = 5;
         let mut buffer: VelocityRingBuffer<CAP> = VelocityRingBuffer::default();
-        let base_time = Instant::now();
+        let base_time = Instant::default();
 
         // Push more than capacity
         for i in 0..CAP {

--- a/internal/core/items/system_tray.rs
+++ b/internal/core/items/system_tray.rs
@@ -175,6 +175,8 @@ struct MenuDirtyHandler {
 impl crate::properties::PropertyDirtyHandler for MenuDirtyHandler {
     fn notify(self: Pin<&Self>) {
         let self_weak = self.self_weak.clone();
+        // A tray icon has no window, so there is no context to reach from the item: this
+        // one deliberately registers on whichever context is current.
         crate::timers::Timer::single_shot(Default::default(), move || {
             let Some(item_rc) = self_weak.upgrade() else { return };
             let Some(tray) = item_rc.downcast::<SystemTrayIcon>() else { return };

--- a/internal/core/items/system_tray.rs
+++ b/internal/core/items/system_tray.rs
@@ -150,12 +150,27 @@ pub struct SystemTrayIconData {
     /// so that a re-fired tracker can't double-increment.
     keepalive_live: core::cell::Cell<bool>,
     menu: core::cell::RefCell<Option<MenuState>>,
+    /// The context of the component this tray belongs to, handed over by the generated
+    /// code. A tray has no window, so this is the only way it can tell which context it
+    /// is part of. Empty for a component built with `new()`, which uses the thread's.
+    context: core::cell::OnceCell<crate::SlintContextWeak>,
+}
+
+impl SystemTrayIconData {
+    /// The context this tray belongs to: the one its component was built with, falling
+    /// back to the thread's for a component built with `new()`.
+    fn context(&self) -> Option<crate::SlintContext> {
+        match self.context.get() {
+            Some(ctx) => ctx.upgrade(),
+            None => crate::context::GLOBAL_CONTEXT.with(|p| p.get().cloned()),
+        }
+    }
 }
 
 impl Drop for SystemTrayIconData {
     fn drop(&mut self) {
         if self.keepalive_live.get()
-            && let Some(ctx) = crate::context::GLOBAL_CONTEXT.with(|p| p.get().cloned())
+            && let Some(ctx) = self.context()
         {
             ctx.release_keepalive();
         }
@@ -175,9 +190,10 @@ struct MenuDirtyHandler {
 impl crate::properties::PropertyDirtyHandler for MenuDirtyHandler {
     fn notify(self: Pin<&Self>) {
         let self_weak = self.self_weak.clone();
-        // A tray icon has no window, so there is no context to reach from the item: this
-        // one deliberately registers on whichever context is current.
-        crate::timers::Timer::single_shot(Default::default(), move || {
+        let Some(item_rc) = self_weak.upgrade() else { return };
+        let Some(tray) = item_rc.downcast::<SystemTrayIcon>() else { return };
+        let Some(ctx) = tray.as_pin_ref().data.context() else { return };
+        ctx.single_shot(Default::default(), move || {
             let Some(item_rc) = self_weak.upgrade() else { return };
             let Some(tray) = item_rc.downcast::<SystemTrayIcon>() else { return };
             tray.as_pin_ref().rebuild_menu();
@@ -200,6 +216,13 @@ pub struct SystemTrayIcon {
 }
 
 impl SystemTrayIcon {
+    /// Called from a tray-rooted component's `new_with_context` to tell the item which
+    /// context it belongs to. Without it the item would fall back to the thread's context,
+    /// which is the wrong one when the component was built on another.
+    pub fn set_context(self: Pin<&Self>, ctx: &crate::SlintContext) {
+        let _ = self.data.context.set(ctx.downgrade());
+    }
+
     /// Called from generated code (via the `SetupSystemTrayIcon` builtin) to hand off the
     /// lowered menu's `VRc<MenuVTable>` to the native item. The item walks the menu via
     /// this vtable inside its own `PropertyTracker`, so property changes inside the menu
@@ -246,7 +269,7 @@ impl SystemTrayIcon {
         if want_live == was_live {
             return;
         }
-        let Some(ctx) = crate::context::GLOBAL_CONTEXT.with(|p| p.get().cloned()) else {
+        let Some(ctx) = self.data.context() else {
             return;
         };
         if want_live {
@@ -274,13 +297,7 @@ impl Item for SystemTrayIcon {
                 if !*has_icon {
                     return;
                 }
-                // The platform is set before any item's `init` runs (the public
-                // component's `new` calls `ensure_backend()` first), so the
-                // global context is populated by the time this tracker fires
-                // from the event loop. SystemTrayIcon has no `WindowAdapter` of
-                // its own, so we read the context directly rather than going
-                // through `tray_rc.window_adapter()`.
-                let Some(ctx) = crate::context::GLOBAL_CONTEXT.with(|p| p.get().cloned()) else {
+                let Some(ctx) = tray.as_pin_ref().data.context() else {
                     return;
                 };
                 let tray = tray.as_pin_ref();

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -271,10 +271,10 @@ pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), SetPlat
                 *EVENTLOOP_PROXY.lock().unwrap() = Some(proxy);
             }
         }
-        instance
-            .set(crate::SlintContext::new(platform))
-            .map_err(|_| SetPlatformError::AlreadySet)
-            .unwrap();
+        // The slot is free, so this claims it. The returned handle is dropped here; the
+        // context stays alive because the slot holds it.
+        drop(crate::SlintContext::new(platform));
+        debug_assert!(instance.get().is_some(), "SlintContext::new claims a free slot");
         // Ensure a sane starting point for the animation tick.
         update_timers_and_animations();
         Ok(())

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -65,11 +65,13 @@ pub trait Platform {
         Err(PlatformError::NoEventLoopProvider)
     }
 
-    /// Called once by `set_platform` immediately after the [`crate::SlintContext`]
-    /// has been constructed, to give the platform a weak handle to its own context.
-    /// Platforms can stash the handle and later use it to spawn futures or write
-    /// process-wide state without going through a window adapter. The default impl
-    /// drops the handle.
+    /// Called once by [`crate::SlintContext::new`], as the context that owns this platform
+    /// finishes construction, to give the platform a weak handle to it. Platforms can stash
+    /// the handle and later use it to spawn futures or write context-wide state without
+    /// going through a window adapter. The default impl drops the handle.
+    ///
+    /// Every context binds its own platform, not only the one installed as the thread's
+    /// global context, so a backend driving a context can always find it.
     #[doc(hidden)]
     fn bind_context(&self, _ctx: crate::SlintContextWeak, _: crate::InternalToken) {}
 
@@ -273,8 +275,6 @@ pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), SetPlat
             .set(crate::SlintContext::new(platform))
             .map_err(|_| SetPlatformError::AlreadySet)
             .unwrap();
-        let ctx = instance.get().unwrap();
-        ctx.platform().bind_context(ctx.downgrade(), crate::InternalToken);
         // Ensure a sane starting point for the animation tick.
         update_timers_and_animations();
         Ok(())

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -287,8 +287,13 @@ pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), SetPlat
 /// This function should be called before rendering or processing input event, at the
 /// beginning of each event loop iteration.
 pub fn update_timers_and_animations() {
-    crate::animations::update_animations();
-    crate::timers::TimerList::maybe_activate_timers(crate::animations::Instant::now());
+    // The zero fallback keeps the pre-platform behaviour: without a context there is no
+    // clock, so only zero-duration timers are due.
+    let now = crate::context::GLOBAL_CONTEXT
+        .with(|ctx| ctx.get().map(crate::animations::Instant::now))
+        .unwrap_or_default();
+    crate::animations::update_animations(now);
+    crate::timers::TimerList::maybe_activate_timers(now);
     crate::properties::ChangeTracker::run_change_handlers();
 }
 

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -287,14 +287,16 @@ pub fn set_platform(platform: Box<dyn Platform + 'static>) -> Result<(), SetPlat
 /// This function should be called before rendering or processing input event, at the
 /// beginning of each event loop iteration.
 pub fn update_timers_and_animations() {
-    // The zero fallback keeps the pre-platform behaviour: without a context there is no
-    // clock, so only zero-duration timers are due.
-    let now = crate::context::GLOBAL_CONTEXT
-        .with(|ctx| ctx.get().map(crate::animations::Instant::now))
-        .unwrap_or_default();
-    crate::animations::update_animations(now);
-    crate::timers::TimerList::maybe_activate_timers(now);
-    crate::properties::ChangeTracker::run_change_handlers();
+    match crate::context::GLOBAL_CONTEXT.with(|ctx| ctx.get().cloned()) {
+        Some(ctx) => ctx.update_timers_and_animations(),
+        None => {
+            // Pre-platform behavior: with no context there is no clock either, so only
+            // zero-duration timers in the pending list are due.
+            crate::animations::update_animations(Default::default());
+            crate::timers::TimerList::maybe_activate_timers(Default::default());
+            crate::properties::ChangeTracker::run_change_handlers();
+        }
+    }
 }
 
 /// Returns the duration before the next timer is expected to be activated. This is the
@@ -307,14 +309,12 @@ pub fn update_timers_and_animations() {
 /// Only go to sleep if [`Window::has_active_animations()`](crate::api::Window::has_active_animations())
 /// returns false.
 pub fn duration_until_next_timer_update() -> Option<core::time::Duration> {
-    crate::timers::TimerList::next_timeout().map(|timeout| {
-        let duration_since_start = crate::context::GLOBAL_CONTEXT
-            .with(|p| p.get().map(|p| p.platform().duration_since_start()))
-            .unwrap_or_default();
-        core::time::Duration::from_millis(
-            timeout.0.saturating_sub(duration_since_start.as_millis() as u64),
-        )
-    })
+    match crate::context::GLOBAL_CONTEXT.with(|ctx| ctx.get().cloned()) {
+        Some(ctx) => ctx.duration_until_next_timer_update(),
+        // No context, hence no clock: the deadline is measured from a zero origin.
+        None => crate::timers::TimerList::next_timeout()
+            .map(|timeout| core::time::Duration::from_millis(timeout.0)),
+    }
 }
 
 // reexport key enum to the public api

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -182,6 +182,14 @@ impl Timer {
             .unwrap_or_default()
     }
 
+    /// A timer that will register in `timers` when started, rather than in whichever list
+    /// is current at that point. Backs [`SlintContext::new_timer`](crate::SlintContext::new_timer).
+    pub(crate) fn with_list(timers: &TimerListRc) -> Self {
+        let timer = Self::default();
+        timer.set_ids(list_handle(timers), None);
+        timer
+    }
+
     /// Decodes `id` into the list this timer belongs to and its slot in that list.
     ///
     /// `None` when the timer has no list at all, or when that list has gone away with the
@@ -277,7 +285,7 @@ impl TimerList {
 
     /// The timeout of the timer in this list that should fire the soonest, or None if
     /// none is active.
-    fn first_timeout(&self) -> Option<Instant> {
+    pub(crate) fn first_timeout(&self) -> Option<Instant> {
         self.active_timers.first().map(|first_active_timer| first_active_timer.timeout)
     }
 
@@ -286,7 +294,7 @@ impl TimerList {
     ///
     /// Takes the list by `&RefCell` rather than `&mut self` because the borrow has to be
     /// released around every callback: a callback may start, stop or drop timers.
-    fn activate_expired(timers: &RefCell<Self>, now: Instant) -> bool {
+    pub(crate) fn activate_expired(timers: &RefCell<Self>, now: Instant) -> bool {
         // Shortcut: Is there any timer worth activating?
         if timers.borrow().first_timeout().map(|timeout| now < timeout).unwrap_or(false) {
             return false;
@@ -1316,3 +1324,93 @@ assert_eq!(CALL2_COUNT.load(std::sync::atomic::Ordering::SeqCst), 1);
  */
 #[cfg(doctest)]
 const _TIMER_AT_EXIT: () = ();
+
+/**
+ * A timer created from a context registers on that context: driving the current (global)
+ * context leaves it alone, and driving its own fires it.
+```rust
+use i_slint_core::platform::*;
+struct DummyBackend;
+impl Platform for DummyBackend {
+    fn create_window_adapter(&self) -> Result<std::rc::Rc<dyn WindowAdapter>, PlatformError> {
+        Err(PlatformError::Other("not implemented".into()))
+    }
+    fn duration_since_start(&self) -> core::time::Duration {
+        core::time::Duration::from_millis(0)
+    }
+}
+
+// Establishes the *global* context for this thread.
+i_slint_backend_testing::init_no_event_loop();
+// ... and a second one, which never becomes current.
+let ctx = i_slint_core::SlintContext::new(Box::new(DummyBackend));
+
+let fired = std::rc::Rc::new(std::cell::Cell::new(0));
+let fired_ = fired.clone();
+let timer = ctx.new_timer();
+timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(10), move || {
+    fired_.set(fired_.get() + 1);
+});
+
+// It is not in the global context's list, so driving that one does nothing...
+i_slint_backend_testing::mock_elapsed_time(500);
+assert_eq!(fired.get(), 0);
+assert_eq!(i_slint_core::timers::TimerList::next_timeout(), None);
+
+// ... while driving its own context fires it.
+assert!(ctx.next_timer_timeout().is_some());
+assert!(ctx.maybe_activate_timers(i_slint_core::animations::Instant(10_000)));
+assert_eq!(fired.get(), 1);
+```
+ */
+#[cfg(doctest)]
+const _TIMER_ON_ITS_OWN_CONTEXT: () = ();
+
+/**
+ * A timer outliving its context goes inert rather than indexing a list that no longer
+ * exists, and can be restarted onto the current context afterwards.
+```rust
+use i_slint_core::platform::*;
+struct DummyBackend;
+impl Platform for DummyBackend {
+    fn create_window_adapter(&self) -> Result<std::rc::Rc<dyn WindowAdapter>, PlatformError> {
+        Err(PlatformError::Other("not implemented".into()))
+    }
+    fn duration_since_start(&self) -> core::time::Duration {
+        core::time::Duration::from_millis(0)
+    }
+}
+i_slint_backend_testing::init_no_event_loop();
+
+let fired = std::rc::Rc::new(std::cell::Cell::new(0));
+let fired_ = fired.clone();
+let timer = {
+    let ctx = i_slint_core::SlintContext::new(Box::new(DummyBackend));
+    let timer = ctx.new_timer();
+    timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(10), move || {
+        fired_.set(fired_.get() + 1);
+    });
+    assert!(timer.running());
+    timer
+}; // the context, and with it the list holding the callback, is dropped here
+
+assert!(!timer.running());
+assert_eq!(timer.interval(), std::time::Duration::default());
+timer.stop();
+timer.restart();
+i_slint_backend_testing::mock_elapsed_time(500);
+assert_eq!(fired.get(), 0);
+
+// Starting it again moves it to the current context.
+let fired_ = fired.clone();
+timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(10), move || {
+    fired_.set(fired_.get() + 1);
+});
+i_slint_backend_testing::mock_elapsed_time(50);
+assert_eq!(fired.get(), 1);
+
+drop(timer); // must not panic
+```
+ */
+#[cfg(doctest)]
+const _TIMER_OUTLIVING_ITS_CONTEXT: () = ();

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -112,6 +112,24 @@ impl Timer {
         self.set_ids(handle, Some(slot));
     }
 
+    /// Starts the timer on `ctx` rather than on whichever context happens to be current.
+    ///
+    /// A timer that already belongs to a live context keeps firing on that one; this only
+    /// decides where a timer that has never been started registers. Used by items, which
+    /// own their `Timer` as a field but can reach their window's context when they start it.
+    pub(crate) fn start_on(
+        &self,
+        ctx: &crate::SlintContext,
+        mode: TimerMode,
+        interval: core::time::Duration,
+        callback: impl FnMut() + 'static,
+    ) {
+        if self.resolve().is_none() {
+            self.set_ids(list_handle(&ctx.0.timers), None);
+        }
+        self.start(mode, interval, callback);
+    }
+
     /// Starts the timer with the duration and the callback to called when the
     /// timer fires. It is fired only once and then deleted.
     ///
@@ -215,6 +233,21 @@ impl Timer {
         debug_assert!(list <= usize::MAX >> LIST_SHIFT, "too many timer lists");
         self.id.set(NonZeroUsize::new((list << LIST_SHIFT) | slot));
     }
+}
+
+/// Registers a single-shot timer in `timers` rather than in whichever list is current.
+/// Backs [`SlintContext::single_shot`](crate::SlintContext::single_shot).
+pub(crate) fn single_shot_on(
+    timers: &TimerListRc,
+    duration: core::time::Duration,
+    callback: impl FnOnce() + 'static,
+) {
+    timers.borrow_mut().start_or_restart_timer(
+        None,
+        TimerMode::SingleShot,
+        duration,
+        CallbackVariant::SingleShot(Box::new(callback)),
+    );
 }
 
 impl Drop for Timer {

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -241,108 +241,115 @@ impl TimerList {
     /// Returns the timeout of the timer that should fire the soonest, or None if there
     /// is no timer active.
     pub fn next_timeout() -> Option<Instant> {
-        CURRENT_TIMERS.with(|timers| {
-            timers
-                .borrow()
-                .active_timers
-                .first()
-                .map(|first_active_timer| first_active_timer.timeout)
-        })
+        CURRENT_TIMERS.with(|timers| timers.borrow().first_timeout())
     }
 
     /// Activates any expired timers by calling their callback function. Returns true if any timers were
     /// activated; false otherwise.
     pub fn maybe_activate_timers(now: Instant) -> bool {
+        CURRENT_TIMERS.with(|timers| Self::activate_expired(timers, now))
+    }
+
+    /// The timeout of the timer in this list that should fire the soonest, or None if
+    /// none is active.
+    fn first_timeout(&self) -> Option<Instant> {
+        self.active_timers.first().map(|first_active_timer| first_active_timer.timeout)
+    }
+
+    /// Activates the timers in `timers` that have expired by `now`. Returns true if any
+    /// timer was activated; false otherwise.
+    ///
+    /// Takes the list by `&RefCell` rather than `&mut self` because the borrow has to be
+    /// released around every callback: a callback may start, stop or drop timers.
+    fn activate_expired(timers: &RefCell<Self>, now: Instant) -> bool {
         // Shortcut: Is there any timer worth activating?
-        if TimerList::next_timeout().map(|timeout| now < timeout).unwrap_or(false) {
+        if timers.borrow().first_timeout().map(|timeout| now < timeout).unwrap_or(false) {
             return false;
         }
 
-        CURRENT_TIMERS.with(|timers| {
-            assert!(timers.borrow().callback_active.is_none(), "Recursion in timer code");
+        assert!(timers.borrow().callback_active.is_none(), "Recursion in timer code");
 
-            // Re-register all timers that expired but are repeating, as well as all that haven't expired yet. This is
-            // done in one shot to ensure a consistent state by the time the callbacks are invoked.
-            let expired_timers = {
-                let mut timers = timers.borrow_mut();
+        // Re-register all timers that expired but are repeating, as well as all that haven't expired yet. This is
+        // done in one shot to ensure a consistent state by the time the callbacks are invoked.
+        let expired_timers = {
+            let mut timers = timers.borrow_mut();
 
-                // Empty active_timers and rebuild it, to preserve insertion order across expired and not expired timers.
-                let mut active_timers = core::mem::take(&mut timers.active_timers);
+            // Empty active_timers and rebuild it, to preserve insertion order across expired and not expired timers.
+            let mut active_timers = core::mem::take(&mut timers.active_timers);
 
-                let expired_vs_remaining_timers_partition_point =
-                    active_timers.partition_point(|active_timer| active_timer.timeout <= now);
+            let expired_vs_remaining_timers_partition_point =
+                active_timers.partition_point(|active_timer| active_timer.timeout <= now);
 
-                let (expired_timers, timers_not_activated_this_time) =
-                    active_timers.split_at(expired_vs_remaining_timers_partition_point);
+            let (expired_timers, timers_not_activated_this_time) =
+                active_timers.split_at(expired_vs_remaining_timers_partition_point);
 
-                for expired_timer in expired_timers {
-                    let timer = &mut timers.timers[expired_timer.id];
-                    assert!(!timer.being_activated);
-                    timer.being_activated = true;
+            for expired_timer in expired_timers {
+                let timer = &mut timers.timers[expired_timer.id];
+                assert!(!timer.being_activated);
+                timer.being_activated = true;
 
-                    if matches!(timers.timers[expired_timer.id].mode, TimerMode::Repeated) {
-                        timers.activate_timer(expired_timer.id);
-                    } else {
-                        timers.timers[expired_timer.id].running = false;
-                    }
-                }
-
-                for future_timer in timers_not_activated_this_time.iter() {
-                    timers.register_active_timer(*future_timer);
-                }
-
-                // turn `expired_timers` slice into a truncated vec.
-                active_timers.truncate(expired_vs_remaining_timers_partition_point);
-                active_timers
-            };
-
-            let any_activated = !expired_timers.is_empty();
-
-            for active_timer in expired_timers.into_iter() {
-                let mut callback = {
-                    let mut timers = timers.borrow_mut();
-
-                    timers.callback_active = Some(active_timer.id);
-
-                    // have to release the borrow on `timers` before invoking the callback,
-                    // so here we temporarily move the callback out of its permanent place
-                    core::mem::replace(
-                        &mut timers.timers[active_timer.id].callback,
-                        CallbackVariant::Empty,
-                    )
-                };
-
-                match callback {
-                    CallbackVariant::Empty => (),
-                    CallbackVariant::MultiFire(ref mut cb) => cb(),
-                    CallbackVariant::SingleShot(cb) => {
-                        cb();
-                        timers.borrow_mut().callback_active = None;
-                        timers.borrow_mut().timers.remove(active_timer.id);
-                        continue;
-                    }
-                };
-
-                let mut timers = timers.borrow_mut();
-
-                let callback_register = &mut timers.timers[active_timer.id].callback;
-
-                // only emplace back the callback if its permanent store is still Empty:
-                // if not, it means the invoked callback has restarted its own timer with a new callback
-                if matches!(callback_register, CallbackVariant::Empty) {
-                    *callback_register = callback;
-                }
-
-                timers.callback_active = None;
-                let t = &mut timers.timers[active_timer.id];
-                if t.removed {
-                    timers.timers.remove(active_timer.id);
+                if matches!(timers.timers[expired_timer.id].mode, TimerMode::Repeated) {
+                    timers.activate_timer(expired_timer.id);
                 } else {
-                    t.being_activated = false;
+                    timers.timers[expired_timer.id].running = false;
                 }
             }
-            any_activated
-        })
+
+            for future_timer in timers_not_activated_this_time.iter() {
+                timers.register_active_timer(*future_timer);
+            }
+
+            // turn `expired_timers` slice into a truncated vec.
+            active_timers.truncate(expired_vs_remaining_timers_partition_point);
+            active_timers
+        };
+
+        let any_activated = !expired_timers.is_empty();
+
+        for active_timer in expired_timers.into_iter() {
+            let mut callback = {
+                let mut timers = timers.borrow_mut();
+
+                timers.callback_active = Some(active_timer.id);
+
+                // have to release the borrow on `timers` before invoking the callback,
+                // so here we temporarily move the callback out of its permanent place
+                core::mem::replace(
+                    &mut timers.timers[active_timer.id].callback,
+                    CallbackVariant::Empty,
+                )
+            };
+
+            match callback {
+                CallbackVariant::Empty => (),
+                CallbackVariant::MultiFire(ref mut cb) => cb(),
+                CallbackVariant::SingleShot(cb) => {
+                    cb();
+                    timers.borrow_mut().callback_active = None;
+                    timers.borrow_mut().timers.remove(active_timer.id);
+                    continue;
+                }
+            };
+
+            let mut timers = timers.borrow_mut();
+
+            let callback_register = &mut timers.timers[active_timer.id].callback;
+
+            // only emplace back the callback if its permanent store is still Empty:
+            // if not, it means the invoked callback has restarted its own timer with a new callback
+            if matches!(callback_register, CallbackVariant::Empty) {
+                *callback_register = callback;
+            }
+
+            timers.callback_active = None;
+            let t = &mut timers.timers[active_timer.id];
+            if t.removed {
+                timers.timers.remove(active_timer.id);
+            } else {
+                t.being_activated = false;
+            }
+        }
+        any_activated
     }
 
     fn start_or_restart_timer(

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -60,10 +60,21 @@ pub enum TimerMode {
 /// ```
 #[derive(Default)]
 pub struct Timer {
+    /// Identifies both the list this timer belongs to and its slot in that list, packed
+    /// into one word. See [`Timer::resolve`] for the encoding.
     id: Cell<Option<NonZeroUsize>>,
     /// The timer cannot be moved between treads
     _phantom: core::marker::PhantomData<*mut ()>,
 }
+
+/// `Timer` must stay exactly one pointer wide: the C++ `slint::Timer` mirrors it by hand as
+/// a single `uintptr_t` (see `api/cpp/include/private/slint_timer.h`), and native items such
+/// as `TooltipArea` and `ContextMenu` embed it in structs that C++ lays out. Widening it
+/// silently corrupts those items rather than failing to build, so pin the size here.
+const _: () = assert!(
+    core::mem::size_of::<Timer>() == core::mem::size_of::<usize>(),
+    "Timer must stay one word wide to match the hand-written C++ slint::Timer"
+);
 
 impl Timer {
     /// Starts the timer with the given mode and interval, in order for the callback to called when the
@@ -81,15 +92,24 @@ impl Timer {
         interval: core::time::Duration,
         callback: impl FnMut() + 'static,
     ) {
-        if let Some(timers) = current_timers() {
-            let id = timers.borrow_mut().start_or_restart_timer(
-                self.id(),
-                mode,
-                interval,
-                CallbackVariant::MultiFire(Box::new(callback)),
-            );
-            self.set_id(Some(id));
-        }
+        // Keep firing on the list this timer already belongs to. Only a timer that was
+        // never started, or whose list went away with its context, picks a new one.
+        let (timers, slot) = match self.resolve() {
+            Some(resolved) => resolved,
+            None => {
+                let Some(timers) = current_timers() else { return };
+                (timers, None)
+            }
+        };
+
+        let handle = list_handle(&timers);
+        let slot = timers.borrow_mut().start_or_restart_timer(
+            slot,
+            mode,
+            interval,
+            CallbackVariant::MultiFire(Box::new(callback)),
+        );
+        self.set_ids(handle, Some(slot));
     }
 
     /// Starts the timer with the duration and the callback to called when the
@@ -120,10 +140,8 @@ impl Timer {
 
     /// Stops the previously started timer. Does nothing if the timer has never been started.
     pub fn stop(&self) {
-        if let Some(id) = self.id() {
-            if let Some(timers) = current_timers() {
-                timers.borrow_mut().deactivate_timer(id);
-            }
+        if let Some((timers, slot)) = self.started() {
+            timers.borrow_mut().deactivate_timer(slot);
         }
     }
 
@@ -133,21 +151,15 @@ impl Timer {
     ///
     /// Does nothing if the timer was never started.
     pub fn restart(&self) {
-        if let Some(id) = self.id() {
-            if let Some(timers) = current_timers() {
-                timers.borrow_mut().deactivate_timer(id);
-                timers.borrow_mut().activate_timer(id);
-            }
+        if let Some((timers, slot)) = self.started() {
+            timers.borrow_mut().deactivate_timer(slot);
+            timers.borrow_mut().activate_timer(slot);
         }
     }
 
     /// Returns true if the timer is running; false otherwise.
     pub fn running(&self) -> bool {
-        self.id()
-            .and_then(|timer_id| {
-                current_timers().map(|timers| timers.borrow().timers[timer_id].running)
-            })
-            .unwrap_or(false)
+        self.started().is_some_and(|(timers, slot)| timers.borrow().timers[slot].running)
     }
 
     /// Change the duration of timer. If the timer was is running (see [`Self::running()`]),
@@ -158,45 +170,57 @@ impl Timer {
     /// * `interval`: The duration from now until when the timer should fire. And the period of that timer
     ///   for [`Repeated`](TimerMode::Repeated) timers.
     pub fn set_interval(&self, interval: core::time::Duration) {
-        if let Some(id) = self.id() {
-            if let Some(timers) = current_timers() {
-                timers.borrow_mut().set_interval(id, interval);
-            }
+        if let Some((timers, slot)) = self.started() {
+            timers.borrow_mut().set_interval(slot, interval);
         }
     }
 
     /// Returns the interval of the timer. If the timer was never started, the returned duration is 0ms.
     pub fn interval(&self) -> core::time::Duration {
-        self.id()
-            .and_then(|timer_id| {
-                current_timers().map(|timers| timers.borrow().timers[timer_id].duration)
-            })
+        self.started()
+            .map(|(timers, slot)| timers.borrow().timers[slot].duration)
             .unwrap_or_default()
     }
 
-    fn id(&self) -> Option<usize> {
-        self.id.get().map(|v| usize::from(v) - 1)
+    /// Decodes `id` into the list this timer belongs to and its slot in that list.
+    ///
+    /// `None` when the timer has no list at all, or when that list has gone away with the
+    /// context owning it — in which case the slot it names no longer means anything, and
+    /// every operation but [`Self::start`] does nothing. The inner `Option` is `None` for a
+    /// timer that has a list but was never started, as [`Self::with_list`] produces.
+    fn resolve(&self) -> Option<(TimerListRc, Option<usize>)> {
+        let id = usize::from(self.id.get()?);
+        let timers = list_from_handle(id >> LIST_SHIFT)?;
+        Some((timers, (id & SLOT_MASK).checked_sub(1)))
     }
 
-    fn set_id(&self, id: Option<usize>) {
-        self.id.set(id.and_then(|v| NonZeroUsize::new(v + 1)));
+    /// The list and slot of a timer that has been started and whose list is still alive.
+    /// `None` in every other case, which is what all operations but [`Self::start`] want.
+    fn started(&self) -> Option<(TimerListRc, usize)> {
+        let (timers, slot) = self.resolve()?;
+        Some((timers, slot?))
+    }
+
+    fn set_ids(&self, list: usize, slot: Option<usize>) {
+        let slot = slot.map_or(0, |slot| slot + 1);
+        debug_assert!(slot <= SLOT_MASK, "too many timers in one list");
+        debug_assert!(list <= usize::MAX >> LIST_SHIFT, "too many timer lists");
+        self.id.set(NonZeroUsize::new((list << LIST_SHIFT) | slot));
     }
 }
 
 impl Drop for Timer {
     fn drop(&mut self) {
-        if let Some(id) = self.id() {
-            if let Some(timers) = current_timers() {
-                #[cfg(target_os = "android")]
-                if timers.borrow().timers.is_empty() {
-                    // There seems to be a bug in android thread_local where try_with recreates the already thread local.
-                    // But we are called from the drop of another thread local, just ignore the drop then
-                    return;
-                }
-                let callback = timers.borrow_mut().remove_timer(id);
-                // drop the callback without having the list borrowed
-                drop(callback);
+        if let Some((timers, slot)) = self.started() {
+            #[cfg(target_os = "android")]
+            if timers.borrow().timers.is_empty() {
+                // There seems to be a bug in android thread_local where try_with recreates the already thread local.
+                // But we are called from the drop of another thread local, just ignore the drop then
+                return;
             }
+            let callback = timers.borrow_mut().remove_timer(slot);
+            // drop the callback without having the list borrowed
+            drop(callback);
         }
     }
 }
@@ -233,6 +257,9 @@ pub struct TimerList {
     active_timers: Vec<ActiveTimer>,
     /// If a callback is currently running, this is the id of the currently running callback
     callback_active: Option<usize>,
+    /// This list's index in [`ThreadTimers::lists`], assigned the first time a timer id naming it
+    /// is handed out. Cached here so encoding an id doesn't have to search the registry.
+    handle: Option<usize>,
 }
 
 impl TimerList {
@@ -434,7 +461,62 @@ impl TimerList {
 /// without needing to know who owns it.
 pub(crate) type TimerListRc = alloc::rc::Rc<RefCell<TimerList>>;
 
-crate::thread_local!(static PENDING_TIMERS : RefCell<Option<TimerListRc>> = RefCell::default());
+/// How a [`Timer`]'s `id` splits into the list it belongs to and its slot in that list.
+///
+/// The high part is the list's index in [`ThreadTimers::lists`] plus one, so the whole word
+/// is never zero; the low part is the slot plus one, or zero for a timer that has a list but
+/// hasn't been started. Packing both into the existing word is what keeps `Timer` one
+/// pointer wide, which the C++ ABI requires — see the assertion next to the struct.
+const LIST_SHIFT: u32 = if usize::BITS >= 64 { 32 } else { 20 };
+const SLOT_MASK: usize = (1 << LIST_SHIFT) - 1;
+
+/// This thread's timer bookkeeping: which list a handle names, and who owns the list that
+/// no context has taken over yet.
+#[derive(Default)]
+struct ThreadTimers {
+    /// The lists this thread has handed out ids for, weakly so that a context's list dies
+    /// with it. Slots are never reused: a stale id must resolve to nothing rather than to
+    /// some later list that happens to sit at the same index. Dead entries are emptied in
+    /// [`list_handle`] so they don't pin the allocation of a list that is already gone.
+    lists: Vec<alloc::rc::Weak<RefCell<TimerList>>>,
+    /// Owns the list that timers register in before this thread has a context, until the
+    /// first context adopts it. Nothing else would keep it alive: `lists` is weak, and a
+    /// `Timer` holds an id rather than a reference.
+    pending: Option<TimerListRc>,
+}
+
+crate::thread_local!(static TIMERS : RefCell<ThreadTimers> = RefCell::default());
+
+/// The handle identifying `timers` in an id, registering it on first use. Handles are the
+/// registry index plus one, so that the high part of an id is never zero.
+fn list_handle(timers: &TimerListRc) -> usize {
+    *timers.borrow_mut().handle.get_or_insert_with(|| {
+        TIMERS.with(|thread_timers| {
+            let lists = &mut thread_timers.borrow_mut().lists;
+            // A `Weak` to a list whose context is gone keeps that list's allocation alive
+            // even though its contents were dropped with the context. Registering happens
+            // once per context, so take the opportunity to release those. The slots stay
+            // occupied: reusing an index would let a stale id name a different list.
+            for entry in lists.iter_mut() {
+                if entry.strong_count() == 0 {
+                    *entry = alloc::rc::Weak::new();
+                }
+            }
+            lists.push(alloc::rc::Rc::downgrade(timers));
+            lists.len()
+        })
+    })
+}
+
+/// The list a handle refers to, or `None` once it has been dropped.
+fn list_from_handle(handle: usize) -> Option<TimerListRc> {
+    TIMERS
+        .try_with(|thread_timers| {
+            thread_timers.borrow().lists.get(handle - 1).and_then(alloc::rc::Weak::upgrade)
+        })
+        .ok()
+        .flatten()
+}
 
 /// The list that timers started on this thread register in: this thread's context's list,
 /// or the pending one when there is no context yet.
@@ -448,8 +530,10 @@ fn current_timers() -> Option<TimerListRc> {
     if on_context.is_some() {
         return on_context;
     }
-    PENDING_TIMERS
-        .try_with(|pending| pending.borrow_mut().get_or_insert_with(Default::default).clone())
+    TIMERS
+        .try_with(|thread_timers| {
+            thread_timers.borrow_mut().pending.get_or_insert_with(Default::default).clone()
+        })
         .ok()
 }
 
@@ -458,8 +542,8 @@ fn current_timers() -> Option<TimerListRc> {
 ///
 /// The next context to be created starts from an empty list.
 pub(crate) fn take_pending_timers() -> TimerListRc {
-    PENDING_TIMERS
-        .try_with(|pending| pending.borrow_mut().take())
+    TIMERS
+        .try_with(|thread_timers| thread_timers.borrow_mut().pending.take())
         .ok()
         .flatten()
         .unwrap_or_default()
@@ -471,6 +555,23 @@ pub(crate) mod ffi {
 
     use super::*;
     use core::ffi::c_void;
+
+    /// A handle to the timer `id`, which names both its list and its slot. An id of 0 means
+    /// "no timer yet", so C++ can pass one straight back to `slint_timer_start`.
+    fn timer_from_id(id: usize) -> Timer {
+        let timer = Timer::default();
+        timer.id.set(NonZeroUsize::new(id));
+        timer
+    }
+
+    /// Runs `f` on the timer `id` names, without unregistering it when the borrowed handle
+    /// goes away: C++ owns the timer and calls `slint_timer_destroy` in its destructor.
+    fn with_timer<R>(id: usize, f: impl FnOnce(&Timer) -> R) -> R {
+        let timer = timer_from_id(id);
+        let result = f(&timer);
+        timer.id.take();
+        result
+    }
 
     struct WrapFn {
         callback: extern "C" fn(*mut c_void),
@@ -506,10 +607,7 @@ pub(crate) mod ffi {
         drop_user_data: Option<extern "C" fn(*mut c_void)>,
     ) -> usize {
         let wrap = WrapFn { callback, user_data, drop_user_data };
-        let timer = Timer::default();
-        if id != 0 {
-            timer.id.set(NonZeroUsize::new(id));
-        }
+        let timer = timer_from_id(id);
         if duration > i64::MAX as u64 {
             // negative duration? stop the timer
             timer.stop();
@@ -534,57 +632,31 @@ pub(crate) mod ffi {
     /// Stop a timer and free its raw data
     #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_destroy(id: usize) {
-        if id == 0 {
-            return;
-        }
-        let timer = Timer { id: Cell::new(NonZeroUsize::new(id)), _phantom: Default::default() };
-        drop(timer);
+        drop(timer_from_id(id));
     }
 
     /// Stop a timer
     #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_stop(id: usize) {
-        if id == 0 {
-            return;
-        }
-        let timer = Timer { id: Cell::new(NonZeroUsize::new(id)), _phantom: Default::default() };
-        timer.stop();
-        timer.id.take(); // Make sure that dropping the Timer doesn't unregister it. C++ will call destroy() in the destructor.
+        with_timer(id, Timer::stop)
     }
 
     /// Restart a repeated timer
     #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_restart(id: usize) {
-        if id == 0 {
-            return;
-        }
-        let timer = Timer { id: Cell::new(NonZeroUsize::new(id)), _phantom: Default::default() };
-        timer.restart();
-        timer.id.take(); // Make sure that dropping the Timer doesn't unregister it. C++ will call destroy() in the destructor.
+        with_timer(id, Timer::restart)
     }
 
     /// Returns true if the timer is running; false otherwise.
     #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_running(id: usize) -> bool {
-        if id == 0 {
-            return false;
-        }
-        let timer = Timer { id: Cell::new(NonZeroUsize::new(id)), _phantom: Default::default() };
-        let running = timer.running();
-        timer.id.take(); // Make sure that dropping the Timer doesn't unregister it. C++ will call destroy() in the destructor.
-        running
+        with_timer(id, Timer::running)
     }
 
     /// Returns the interval in milliseconds. 0 when the timer was never started.
     #[unsafe(no_mangle)]
     pub extern "C" fn slint_timer_interval(id: usize) -> u64 {
-        if id == 0 {
-            return 0;
-        }
-        let timer = Timer { id: Cell::new(NonZeroUsize::new(id)), _phantom: Default::default() };
-        let val = timer.interval().as_millis() as u64;
-        timer.id.take(); // Make sure that dropping the Timer doesn't unregister it. C++ will call destroy() in the destructor.
-        val
+        with_timer(id, |timer| timer.interval().as_millis() as u64)
     }
 }
 

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -81,16 +81,15 @@ impl Timer {
         interval: core::time::Duration,
         callback: impl FnMut() + 'static,
     ) {
-        let _ = CURRENT_TIMERS.try_with(|timers| {
-            let mut timers = timers.borrow_mut();
-            let id = timers.start_or_restart_timer(
+        if let Some(timers) = current_timers() {
+            let id = timers.borrow_mut().start_or_restart_timer(
                 self.id(),
                 mode,
                 interval,
                 CallbackVariant::MultiFire(Box::new(callback)),
             );
             self.set_id(Some(id));
-        });
+        }
     }
 
     /// Starts the timer with the duration and the callback to called when the
@@ -109,23 +108,22 @@ impl Timer {
     /// });
     /// ```
     pub fn single_shot(duration: core::time::Duration, callback: impl FnOnce() + 'static) {
-        let _ = CURRENT_TIMERS.try_with(|timers| {
-            let mut timers = timers.borrow_mut();
-            timers.start_or_restart_timer(
+        if let Some(timers) = current_timers() {
+            timers.borrow_mut().start_or_restart_timer(
                 None,
                 TimerMode::SingleShot,
                 duration,
                 CallbackVariant::SingleShot(Box::new(callback)),
             );
-        });
+        }
     }
 
     /// Stops the previously started timer. Does nothing if the timer has never been started.
     pub fn stop(&self) {
         if let Some(id) = self.id() {
-            let _ = CURRENT_TIMERS.try_with(|timers| {
+            if let Some(timers) = current_timers() {
                 timers.borrow_mut().deactivate_timer(id);
-            });
+            }
         }
     }
 
@@ -136,10 +134,10 @@ impl Timer {
     /// Does nothing if the timer was never started.
     pub fn restart(&self) {
         if let Some(id) = self.id() {
-            let _ = CURRENT_TIMERS.try_with(|timers| {
+            if let Some(timers) = current_timers() {
                 timers.borrow_mut().deactivate_timer(id);
                 timers.borrow_mut().activate_timer(id);
-            });
+            }
         }
     }
 
@@ -147,7 +145,7 @@ impl Timer {
     pub fn running(&self) -> bool {
         self.id()
             .and_then(|timer_id| {
-                CURRENT_TIMERS.try_with(|timers| timers.borrow().timers[timer_id].running).ok()
+                current_timers().map(|timers| timers.borrow().timers[timer_id].running)
             })
             .unwrap_or(false)
     }
@@ -161,9 +159,9 @@ impl Timer {
     ///   for [`Repeated`](TimerMode::Repeated) timers.
     pub fn set_interval(&self, interval: core::time::Duration) {
         if let Some(id) = self.id() {
-            let _ = CURRENT_TIMERS.try_with(|timers| {
+            if let Some(timers) = current_timers() {
                 timers.borrow_mut().set_interval(id, interval);
-            });
+            }
         }
     }
 
@@ -171,7 +169,7 @@ impl Timer {
     pub fn interval(&self) -> core::time::Duration {
         self.id()
             .and_then(|timer_id| {
-                CURRENT_TIMERS.try_with(|timers| timers.borrow().timers[timer_id].duration).ok()
+                current_timers().map(|timers| timers.borrow().timers[timer_id].duration)
             })
             .unwrap_or_default()
     }
@@ -188,7 +186,7 @@ impl Timer {
 impl Drop for Timer {
     fn drop(&mut self) {
         if let Some(id) = self.id() {
-            let _ = CURRENT_TIMERS.try_with(|timers| {
+            if let Some(timers) = current_timers() {
                 #[cfg(target_os = "android")]
                 if timers.borrow().timers.is_empty() {
                     // There seems to be a bug in android thread_local where try_with recreates the already thread local.
@@ -196,9 +194,9 @@ impl Drop for Timer {
                     return;
                 }
                 let callback = timers.borrow_mut().remove_timer(id);
-                // drop the callback without having CURRENT_TIMERS borrowed
+                // drop the callback without having the list borrowed
                 drop(callback);
-            });
+            }
         }
     }
 }
@@ -241,13 +239,13 @@ impl TimerList {
     /// Returns the timeout of the timer that should fire the soonest, or None if there
     /// is no timer active.
     pub fn next_timeout() -> Option<Instant> {
-        CURRENT_TIMERS.with(|timers| timers.borrow().first_timeout())
+        current_timers().and_then(|timers| timers.borrow().first_timeout())
     }
 
     /// Activates any expired timers by calling their callback function. Returns true if any timers were
     /// activated; false otherwise.
     pub fn maybe_activate_timers(now: Instant) -> bool {
-        CURRENT_TIMERS.with(|timers| Self::activate_expired(timers, now))
+        current_timers().is_some_and(|timers| Self::activate_expired(&timers, now))
     }
 
     /// The timeout of the timer in this list that should fire the soonest, or None if
@@ -432,7 +430,40 @@ impl TimerList {
     }
 }
 
-crate::thread_local!(static CURRENT_TIMERS : RefCell<TimerList> = RefCell::default());
+/// A timer list, shared so that [`Timer`] handles can point at the one they registered in
+/// without needing to know who owns it.
+pub(crate) type TimerListRc = alloc::rc::Rc<RefCell<TimerList>>;
+
+crate::thread_local!(static PENDING_TIMERS : RefCell<Option<TimerListRc>> = RefCell::default());
+
+/// The list that timers started on this thread register in: this thread's context's list,
+/// or the pending one when there is no context yet.
+///
+/// Returns `None` only when thread-local storage is already being torn down, hence the
+/// `try_with`: `Timer::drop` runs during thread exit.
+fn current_timers() -> Option<TimerListRc> {
+    let on_context = crate::context::GLOBAL_CONTEXT
+        .try_with(|ctx| ctx.get().map(|ctx| ctx.0.timers.clone()))
+        .ok()?;
+    if on_context.is_some() {
+        return on_context;
+    }
+    PENDING_TIMERS
+        .try_with(|pending| pending.borrow_mut().get_or_insert_with(Default::default).clone())
+        .ok()
+}
+
+/// Hands the pending list over to a context being constructed, so that timers started
+/// before this thread had one keep working — they hold a `Weak` to this very list.
+///
+/// The next context to be created starts from an empty list.
+pub(crate) fn take_pending_timers() -> TimerListRc {
+    PENDING_TIMERS
+        .try_with(|pending| pending.borrow_mut().take())
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+}
 
 #[cfg(feature = "ffi")]
 pub(crate) mod ffi {

--- a/internal/core/timers.rs
+++ b/internal/core/timers.rs
@@ -268,6 +268,10 @@ pub struct TimerList {
     /// This list's index in [`ThreadTimers::lists`], assigned the first time a timer id naming it
     /// is handed out. Cached here so encoding an id doesn't have to search the registry.
     handle: Option<usize>,
+    /// The context this list belongs to, so that a deadline is computed on the same clock it
+    /// is later compared against. `None` until a context takes the list over — the origin is
+    /// the platform's start time, and without a platform there is no origin.
+    context: Option<crate::SlintContextWeak>,
 }
 
 impl TimerList {
@@ -281,6 +285,16 @@ impl TimerList {
     /// activated; false otherwise.
     pub fn maybe_activate_timers(now: Instant) -> bool {
         current_timers().is_some_and(|timers| Self::activate_expired(&timers, now))
+    }
+
+    /// The current instant on this list's clock, or the zero origin while no context owns
+    /// it — the same origin the deadlines of any timer started that early were computed
+    /// against, so they stay consistent until a context adopts them.
+    fn now(&self) -> Instant {
+        self.context
+            .as_ref()
+            .and_then(|ctx| ctx.upgrade())
+            .map_or_else(Instant::default, |ctx| Instant::now(&ctx))
     }
 
     /// The timeout of the timer in this list that should fire the soonest, or None if
@@ -429,7 +443,7 @@ impl TimerList {
     fn activate_timer(&mut self, id: usize) {
         self.register_active_timer(ActiveTimer {
             id,
-            timeout: Instant::now() + self.timers[id].duration,
+            timeout: self.now() + self.timers[id].duration,
         });
     }
 
@@ -549,6 +563,12 @@ fn current_timers() -> Option<TimerListRc> {
 /// before this thread had one keep working — they hold a `Weak` to this very list.
 ///
 /// The next context to be created starts from an empty list.
+/// Points `timers` at the context that now owns it, so its deadlines are measured on that
+/// context's clock.
+pub(crate) fn set_owning_context(timers: &TimerListRc, ctx: &crate::SlintContext) {
+    timers.borrow_mut().context = Some(ctx.downgrade());
+}
+
 pub(crate) fn take_pending_timers() -> TimerListRc {
     TIMERS
         .try_with(|thread_timers| thread_timers.borrow_mut().pending.take())

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -762,7 +762,7 @@ impl WindowInner {
     /// `Exit` (if not). The reported `accepted` reflects the rewritten event, so a
     /// `Released` that completes a drop on a non-accepting target reports `accepted = false`.
     pub fn process_mouse_input(&self, mut event: MouseEvent) -> Option<MouseDispatchResult> {
-        crate::animations::update_animations();
+        crate::animations::update_animations(crate::animations::Instant::now(self.context()));
 
         let item_tree = self.try_component()?;
         self.ensure_tree_instantiated();
@@ -776,7 +776,7 @@ impl WindowInner {
         }
 
         // handle multiple press release
-        event = self.click_state.check_repeat(event, self.context().platform().click_interval());
+        event = self.click_state.check_repeat(event, self.context());
 
         let window_adapter = self.window_adapter();
         let mut mouse_input_state = self.mouse_input_state.take();
@@ -1014,7 +1014,7 @@ impl WindowInner {
 
         if last_top_item != mouse_input_state.top_item_including_delayed() {
             self.click_state.reset();
-            self.click_state.check_repeat(event, self.context().platform().click_interval());
+            self.click_state.check_repeat(event, self.context());
         }
 
         if !had_delay && mouse_input_state.has_delayed_event() {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -457,11 +457,15 @@ struct WindowPropertiesTracker {
 impl crate::properties::PropertyDirtyHandler for WindowPropertiesTracker {
     fn notify(self: Pin<&Self>) {
         let win = self.window_adapter_weak.clone();
-        crate::timers::Timer::single_shot(Default::default(), move || {
-            if let Some(window_adapter) = win.upgrade() {
-                WindowInner::from_pub(window_adapter.window()).update_window_properties();
-            };
-        })
+        let Some(adapter) = win.upgrade() else { return };
+        WindowInner::from_pub(adapter.window()).context().single_shot(
+            Default::default(),
+            move || {
+                if let Some(window_adapter) = win.upgrade() {
+                    WindowInner::from_pub(window_adapter.window()).update_window_properties();
+                };
+            },
+        )
     }
 }
 
@@ -476,13 +480,18 @@ impl crate::properties::PropertyDirtyHandler for PopupWindowPropertiesTracker {
     fn notify(self: Pin<&Self>) {
         let parent = self.parent_window_adapter_weak.clone();
         let popup_id = self.popup_id;
+        let Some(parent_adapter) = parent.upgrade() else { return };
         // Use a timer here, so if we change multiple properties at the same time not multiple notifications are send
         // This timer will delay for the next evaluation
-        crate::timers::Timer::single_shot(Default::default(), move || {
-            if let Some(parent_adapter) = parent.upgrade() {
-                WindowInner::from_pub(parent_adapter.window()).update_popup_properties(popup_id);
-            }
-        });
+        WindowInner::from_pub(parent_adapter.window()).context().single_shot(
+            Default::default(),
+            move || {
+                if let Some(parent_adapter) = parent.upgrade() {
+                    WindowInner::from_pub(parent_adapter.window())
+                        .update_popup_properties(popup_id);
+                }
+            },
+        );
     }
 }
 
@@ -701,7 +710,7 @@ impl WindowInner {
         self.set_window_item_safe_area(inset.to_logical(scale_factor));
         window_adapter.request_redraw();
         let weak = Rc::downgrade(&window_adapter);
-        crate::timers::Timer::single_shot(Default::default(), move || {
+        self.context().single_shot(Default::default(), move || {
             if let Some(window_adapter) = weak.upgrade() {
                 WindowInner::from_pub(window_adapter.window()).update_window_properties();
             }
@@ -1357,11 +1366,8 @@ impl WindowInner {
             new_blinker
         });
 
-        TextCursorBlinker::set_binding(
-            blinker,
-            prop,
-            self.context().platform().cursor_flash_cycle(),
-        );
+        let ctx = self.context();
+        TextCursorBlinker::set_binding(blinker, prop, ctx, ctx.platform().cursor_flash_cycle());
     }
 
     /// Sets the focus to the item pointed to by item_ptr. This will remove the focus from any


### PR DESCRIPTION
Timers and the clock were resolved through a thread-local rather than through the context they belong to, so on a `SlintContext` created with `SlintContext::new` instead of `set_platform`, timers never fired and animations never advanced.

- The timer list moves onto `SlintContext`; a `Timer` is bound to the list it registered in.
- `Instant::now` takes a `&SlintContext`.
- Every context binds its own platform, and each backend's event loop ticks the context it was bound to.
- Internal timers (tooltip, cursor blink, delayed input) register on their window's context; the tray icon gets one via generated `new_with_context`.
- A new context claims the thread's slot if it is free, so ambient APIs still resolve to a context whose timers are actually ticked. `SlintContext::new_timer` and `single_shot` register explicitly.

Tests: `context_ambient_timer.rs`, `context_event_loop.rs`, and doctests for a timer on its own context and one outliving it.