### PR TITLE
Detect binding loops going through a two-way bound property

### DIFF
--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -378,10 +378,14 @@ fn analyze_binding(
             }
 
             let span = binding.span.clone().unwrap_or_else(|| elem.to_source_location());
-            if !context.error_on_binding_loop_with_window_layout && has_window_layout {
-                diag.push_warning(format!("The binding for the property '{}' is part of a binding loop ({loop_description}).\nThis was allowed in previous version of Slint, but is deprecated and may cause panic at runtime", p.name()), &span);
-            } else {
-                diag.push_error(format!("The binding for the property '{}' is part of a binding loop ({loop_description})", p.name()), &span);
+            // Skip the properties of synthetic elements (eg. the Flickable's content element):
+            // they have no location in the source. The rest of the loop is still reported.
+            if span.source_file.is_some() {
+                if !context.error_on_binding_loop_with_window_layout && has_window_layout {
+                    diag.push_warning(format!("The binding for the property '{}' is part of a binding loop ({loop_description}).\nThis was allowed in previous version of Slint, but is deprecated and may cause panic at runtime", p.name()), &span);
+                } else {
+                    diag.push_error(format!("The binding for the property '{}' is part of a binding loop ({loop_description})", p.name()), &span);
+                }
             }
             if it == current {
                 break;
@@ -440,6 +444,27 @@ fn analyze_binding(
     recurse_expression(&current.prop.element(), &b.expression, &mut |p, r| {
         process_prop(p, r, context)
     });
+
+    // `remove_aliases` merges two-way bound properties into one, keeping only one of the bindings,
+    // so the expression of a property aliased to this one is a dependency of this binding too.
+    // The other direction is covered by the `two_way_bindings` loop above.
+    let mut aliased_deps = Vec::new();
+    for alias in reverse_aliases.get(&current.prop).into_iter().flatten() {
+        let element = alias.element();
+        let element_borrow = element.borrow();
+        if let Some(alias_binding) = element_borrow.binding(alias.name()) {
+            recurse_expression(&element, &alias_binding.expression, &mut |p, r| {
+                // A reference back to this property is reported as "cannot refer to itself".
+                if !(p.elements.is_empty() && p.prop == current.prop) {
+                    aliased_deps.push((p.clone(), r))
+                }
+            });
+        }
+    }
+    // Process outside of the loop so that the alias binding isn't borrowed while it is analyzed.
+    for (p, r) in &aliased_deps {
+        process_prop(p, *r, context);
+    }
 
     let mut is_const = b.expression.is_constant(Some(context.global_analysis))
         && b.two_way_bindings.iter().all(|n| n.is_constant());

--- a/internal/compiler/tests/syntax/analysis/binding_loop_flickable_viewport.slint
+++ b/internal/compiler/tests/syntax/analysis/binding_loop_flickable_viewport.slint
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #12333: the loop goes through the `viewport-height` alias. The Rectangle fills the
+// Flickable's content element, whose height comes from `flickable.content-height`.
+
+component ScrollView {
+    in-out property <length> viewport-height <=> flickable.content-height;
+
+    flickable := Flickable {
+//               >        <error{The binding for the property 'content-height' is part of a binding loop (flickable.content-height -> flickable-content.height -> cell-info.height -> flickable.content-height)}
+        width: root.width;
+        height: root.height;
+
+        @children
+    }
+}
+
+export component TestCase inherits Window {
+    ScrollView {
+        viewport-height: cell-info.height;
+
+        cell-info := Rectangle { }
+//                   >        <error{The binding for the property 'height' is part of a binding loop (flickable.content-height -> flickable-content.height -> cell-info.height -> flickable.content-height)}
+    }
+}


### PR DESCRIPTION
Two-way bound properties are collapsed into a single property by the remove_aliases pass, which keeps the binding of only one of them. binding_analysis was however visiting each binding in isolation, so a loop closing through the binding of an aliased property was missed, and the resulting self-referential binding panicked at runtime with "Recursion detected".

Also visit the expression of the properties aliased to the one being analyzed. The other direction is already followed by the processing of the two-way bindings.

Don't report the loop on the properties of a synthetic element such as the Flickable's content element, as they have no location in the source.

Fixes #12333
