### PR TITLE
language: Reject locale dependent number to string casts in struct field defaults

### DIFF
--- a/docs/astro/src/content/docs/reference/language/structs-and-enums.mdx
+++ b/docs/astro/src/content/docs/reference/language/structs-and-enums.mdx
@@ -85,6 +85,8 @@ export component Example {
 The expression must be a compile-time constant.
 It may combine literals, casts, and operators, but referencing a property, an element, or any runtime value
 is a compile error.
+A number is only converted to a string when the result is the same in every locale:
+`= 42` is fine, while `= 42.1` is a compile error, because the decimal separator depends on the locale.
 
 The default applies whenever an instance of the struct is created without a value for the field:
 in struct literals that omit the field, in properties of that struct type that are never set,

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -1188,6 +1188,13 @@ impl ConstantExpression {
             Expression::BoolLiteral(b) => Self::BoolLiteral(*b),
             Expression::EnumerationValue(e) => Self::EnumerationValue(e.clone()),
             Expression::Cast { from, to } => {
+                // Converting a number to a string depends on the locale's decimal separator.
+                // The constant propagation folds the cases that render the same in every
+                // locale into a string literal, so a cast that's still here isn't constant
+                // (see `Expression::is_constant`).
+                if *to == Type::String {
+                    return None;
+                }
                 Self::Cast { from: Box::new(Self::from_expression(from)?), to: to.clone() }
             }
             Expression::UnaryOp { sub, op } => {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3484,6 +3484,9 @@ fn non_constant_expression_reason(expr: &Expression) -> Option<String> {
                 }
                 Callable::Builtin(_) => Some("functions are not evaluated at compile time".into()),
             },
+            Expression::Cast { to: Type::String, .. } => {
+                Some("the conversion from a number to a string depends on the locale".into())
+            }
             _ => None,
         };
     });

--- a/internal/compiler/tests/syntax/basic/struct_field_defaults.slint
+++ b/internal/compiler/tests/syntax/basic/struct_field_defaults.slint
@@ -50,6 +50,24 @@ struct NotConstantRuntime {
 //           >                     <error{The default value of a struct field must be a constant expression: functions are not evaluated at compile time}
 }
 
+// The conversion of a number that renders the same in every locale folds to a string literal
+struct OkNumberToString {
+    a: string = 42,
+    b: string = "score: \{42}",
+    c: [string] = ["a", 1],
+}
+
+struct NumberToString {
+    a: string = 42.1,
+//              >  <error{The default value of a struct field must be a constant expression: the conversion from a number to a string depends on the locale}
+    b: string = "score: \{42.1}",
+//              >              <error{The default value of a struct field must be a constant expression: the conversion from a number to a string depends on the locale}
+    c: [string] = ["a", 1.5],
+//                >        <error{The default value of a struct field must be a constant expression: the conversion from a number to a string depends on the locale}
+    d: Ok1 = { b: 1.5 },
+//           >        <error{The default value of a struct field must be a constant expression: the conversion from a number to a string depends on the locale}
+}
+
 struct ForwardReference {
     e: LaterEnum = LaterEnum.x,
 //     >        <error{Unknown type 'LaterEnum'}

--- a/tests/cases/types/struct_field_defaults.slint
+++ b/tests/cases/types/struct_field_defaults.slint
@@ -30,9 +30,9 @@ export struct Holder {
 export struct Edge {
     // Folds to infinity; the backends saturate when converting to int
     big: int = 45 / 0,
-    // The number to string conversion respects the locale's decimal separator,
-    // so it stays a runtime conversion instead of a compile time string
-    text: string = 42.1,
+    // A number that renders the same in every locale folds to a string literal.
+    // 42.1 wouldn't, so it's rejected as non-constant.
+    text: string = 42,
     size: length = 44px,
     // No default here, but the field type declares its own defaults
     inner: PlayerWithDefault,
@@ -127,7 +127,7 @@ export component TestCase {
         && score-of({ name: "arg" }) == 42
         && let-player("let").name == "let" && let-player("let").score == 42
         && make-cb().name == "cb" && make-cb().score == 42 && make-cb().rank == Rank.gold
-        && edge.big > 2000000000 && edge.text.starts-with("42") && edge.size == 44px
+        && edge.big > 2000000000 && edge.text == "42" && edge.size == 44px
         && edge.inner.name == "unknown" && edge.inner.score == 42 && edge.inner.alive
         && holder.model.length == 1 && holder.model[0].abc == 45
         && tw-a.name == "tw" && tw-b.name == "tw" && tw-b.score == 42 && tw-b.alive;
@@ -171,7 +171,7 @@ assert_eq!(h2.model.row_count(), 1);
 
 let edge = Edge::default();
 assert_eq!(edge.big, i32::MAX);
-assert!(edge.text.starts_with("42"));
+assert_eq!(edge.text, "42");
 assert_eq!(edge.size, 44.);
 assert_eq!(edge.inner.score, 42);
 assert!(edge.inner.alive);
@@ -220,7 +220,7 @@ assert_eq(h2.model->row_count(), 1);
 
 Edge edge;
 assert_eq(edge.big, std::numeric_limits<int>::max());
-assert(std::string_view(edge.text).starts_with("42"));
+assert_eq(edge.text, "42");
 assert_eq(edge.size, 44.f);
 assert_eq(edge.inner.score, 42);
 assert(edge.inner.alive);
@@ -265,7 +265,7 @@ assert.equal(nested.player.score, 42);
 
 let edge = new slint.Edge();
 assert(edge.big > 2000000000);
-assert(edge.text.startsWith("42"));
+assert.equal(edge.text, "42");
 assert.equal(edge.inner.score, 42);
 
 let from_cb = instance.make_cb();
@@ -295,7 +295,7 @@ assert nested.player.score == 42
 
 edge = Edge()
 assert edge.big > 2000000000
-assert str(edge.text).startswith("42")
+assert edge.text == "42"
 assert edge.inner.score == 42
 assert edge.size == 44
 


### PR DESCRIPTION
Formatting a number as a string uses the locale's decimal separator, so it must not be baked into a struct's default value.

`Expression::is_constant` already treats such a cast as non-constant, but `ConstantExpression::from_expression` accepted any cast. Reject the ones to string there: the constant propagation folds the numbers that render the same in every locale into a string literal, so `= 42` keeps working while `= 42.1` is now reported as non-constant, with the reason spelled out alongside the existing `phx` / `rem` / `@tr()` ones.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
