### PR TITLE
Implement cross-axis-self-alignment for HorizontalLayout and VerticalLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented in this file.
 
  - Added the `FlexboxLayout` element, which arranges its children in rows or columns and wraps them
    to the next line when they don't fit.
+ - Added the per-item `cross-axis-self-alignment` property: the children of a `FlexboxLayout`,
+   `HorizontalLayout`, or `VerticalLayout` can override the container's `cross-axis-alignment`.
 
 ## [1.17.1] - 2026-07-07
 

--- a/docs/astro/src/content/docs/reference/layouts/overview.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/overview.mdx
@@ -20,6 +20,12 @@ See <Link type="GridLayout" />.
 See <Link type="GridLayout" />.
 </SlintProperty>
 
+### cross-axis-self-alignment
+<SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+Overrides the container's `cross-axis-alignment` for this element.
+Valid on the children of a <Link type="HorizontalLayout" />, <Link type="VerticalLayout" />, or `FlexboxLayout`.
+</SlintProperty>
+
 ### horizontal-stretch, vertical-stretch
 <SlintProperty propName="horizontal-stretch, vertical-stretch" typeName="float" propertyVisibility="in-out">
 Specify how much relative space these elements are stretching in a layout. When 0, this means that the

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -434,7 +434,8 @@ macro_rules! for_each_enums {
             }
 
             /// Overrides the container's `cross-axis-alignment` for a single item.
-            /// Used as the `cross-axis-self-alignment` property of the children of a `FlexboxLayout`.
+            /// Used as the `cross-axis-self-alignment` property of the children of a
+            /// `FlexboxLayout`, `HorizontalLayout`, or `VerticalLayout`.
             #[non_exhaustive]
             enum CrossAxisSelfAlignment {
                 /// Use the container's `cross-axis-alignment` value (default).

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2012,6 +2012,15 @@ export component GridLayout {
 /// Places its children next to each other vertically.
 /// The size of elements can either be fixed with the `width` or `height` property, or if they aren't set
 /// they will be computed by the layout respecting the minimum and maximum sizes and the stretch factor.
+/// \footer
+/// ## Cell elements
+/// Cell elements inside a `VerticalLayout` obtain the following new property:
+///
+/// ### cross-axis-self-alignment
+/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+/// Overrides the container's `cross-axis-alignment` for this element.
+/// The default value `auto` uses the container's `cross-axis-alignment`.
+/// </SlintProperty>
 /// \group:layouts
 export component VerticalLayout {
     //! ## Spacing Properties
@@ -2077,6 +2086,15 @@ export component VerticalLayout {
 /// Places its children next to each other horizontally.
 /// The size of elements can either be fixed with the `width` or `height` property, or if they aren't set
 /// they will be computed by the layout respecting the minimum and maximum sizes and the stretch factor.
+/// \footer
+/// ## Cell elements
+/// Cell elements inside a `HorizontalLayout` obtain the following new property:
+///
+/// ### cross-axis-self-alignment
+/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+/// Overrides the container's `cross-axis-alignment` for this element.
+/// The default value `auto` uses the container's `cross-axis-alignment`.
+/// </SlintProperty>
 /// \group:layouts
 export component HorizontalLayout {
     //! ## Spacing Properties

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2877,13 +2877,35 @@ fn generate_layout_item_info_decl(
         || (root_sc.grid_layout_children.is_empty()
             && !llr::has_inner_repeaters(&root_sc.row_child_templates))
     {
+        // The cell's `cross-axis-self-alignment` in a box layout, returned for
+        // the cross axis only, so the main-axis cache stays independent of it.
+        // The aggregate init otherwise leaves the field value-initialized (`Auto`).
+        let statement = match &root_sc.cross_axis_self_alignment_for_repeated {
+            Some((cross_o, expr)) => {
+                let align_self = compile_expression(&expr.borrow(), ctx);
+                let cross_o = match cross_o {
+                    crate::layout::Orientation::Horizontal => "Horizontal",
+                    crate::layout::Orientation::Vertical => "Vertical",
+                };
+                format!(
+                    "[[maybe_unused]] auto self = this; \
+                     return {{ layout_info({{&static_vtable, const_cast<void *>(static_cast<const void *>(this))}}, o), \
+                     (o == slint::cbindgen_private::Orientation::{cross_o}) ? ({align_self}) : slint::cbindgen_private::CrossAxisSelfAlignment::Auto }};"
+                )
+            }
+            None => "return { layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, o), {} };".to_owned(),
+        };
         return Declaration::Function(Function {
             name: "layout_item_info".into(),
             signature: SIGNATURE.to_owned(),
-            statements: Some(vec!["return { layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, o) };".into()]),
+            statements: Some(vec![statement]),
             ..Function::default()
         });
     }
+
+    // Row templates only exist for repeated grid Rows, which cannot carry
+    // cross-axis-self-alignment; the scan below hardcodes `{}` for the field.
+    debug_assert!(root_sc.cross_axis_self_alignment_for_repeated.is_none());
 
     let templates = root_sc.row_child_templates.as_ref().unwrap();
     let n = templates.len();
@@ -2908,7 +2930,7 @@ fn generate_layout_item_info_decl(
                 write!(
                     body,
                     "if (count == index) {{\n\
-                         return {{ (o == slint::cbindgen_private::Orientation::Horizontal) ? ({layout_info_h_code}) : ({layout_info_v_code}) }};\n\
+                         return {{ (o == slint::cbindgen_private::Orientation::Horizontal) ? ({layout_info_h_code}) : ({layout_info_v_code}), {{}} }};\n\
                      }}\n\
                      {advance}",
                 )
@@ -2926,7 +2948,7 @@ fn generate_layout_item_info_decl(
                      if (index >= count && index - count < inner_len) {{\n\
                          if (auto vrc = {inner_rep_id}.instance_at(index - count).lock()) {{\n\
                              auto vref = vrc->borrow();\n\
-                             return {{ vref.vtable->layout_info(vref, o) }};\n\
+                             return {{ vref.vtable->layout_info(vref, o), {{}} }};\n\
                          }}\n\
                      }}\n\
                      {advance}}}\n",
@@ -2938,9 +2960,9 @@ fn generate_layout_item_info_decl(
     body.push_str(
         // Phantom cell: return "unconstrained" info (matches Rust's LayoutInfo::default()).
         // field order: max, max_percent, min, min_percent, preferred, stretch
-        "return { slint::cbindgen_private::LayoutInfo{ std::numeric_limits<float>::max(), 100.f, 0, 0, 0, 0 } };\n\
+        "return { slint::cbindgen_private::LayoutInfo{ std::numeric_limits<float>::max(), 100.f, 0, 0, 0, 0 }, {} };\n\
          }\n\
-         return { layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, o) };",
+         return { layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, o), {} };",
     );
     Declaration::Function(Function {
         name: "layout_item_info".into(),
@@ -5819,8 +5841,8 @@ fn generate_with_flexbox_layout_item_info(
                      auto info_h = sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Horizontal, std::nullopt); \
                      auto info_v = {v_query}; \
                      flex_props_vector.push_back(info_h.props); \
-                     cells_vector_h.push_back({{ info_h.constraint }}); \
-                     cells_vector_v.push_back({{ info_v.constraint }}); }}); \
+                     cells_vector_h.push_back({{ info_h.constraint, {{}} }}); \
+                     cells_vector_v.push_back({{ info_v.constraint, {{}} }}); }}); \
                      auto repeater_len = self->repeater_{repeater_index}.len(); \
                      cells_vector_h.resize(start_offset + repeater_len); \
                      cells_vector_v.resize(start_offset + repeater_len); \

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1742,6 +1742,20 @@ fn generate_sub_component(
             }
         });
 
+    let cross_axis_self_alignment_for_repeated_fn =
+        component.cross_axis_self_alignment_for_repeated.as_ref().map(|(_, expr)| {
+            let expr = compile_expression(&expr.borrow(), &ctx);
+            quote! {
+                fn cross_axis_self_alignment_for_repeated(
+                    self: ::core::pin::Pin<&Self>,
+                ) -> sp::CrossAxisSelfAlignment {
+                    #![allow(unused)]
+                    let _self = self;
+                    #expr
+                }
+            }
+        });
+
     // FIXME! this is only public because of the ComponentHandle::WeakInner. we should find another way
     let visibility = parent_ctx.is_none().then(|| quote!(pub));
 
@@ -1902,6 +1916,8 @@ fn generate_sub_component(
             #grid_layout_input_for_repeated_fn
 
             #flexbox_layout_item_info_for_repeated_fn
+
+            #cross_axis_self_alignment_for_repeated_fn
 
             fn subtree_range(self: ::core::pin::Pin<&Self>, dyn_index: u32) -> sp::IndexRange {
                 #![allow(unused)]
@@ -2715,9 +2731,27 @@ fn generate_repeated_component(
             }
         }
     } else {
+        // The cell's `cross-axis-self-alignment` in a box layout, filled into the
+        // returned LayoutItemInfo for the cross axis only, so the main-axis cache
+        // stays independent of it; the remaining literals default it to `auto`.
+        let align_self_field =
+            root_sc.cross_axis_self_alignment_for_repeated.as_ref().map(|(cross_o, _)| {
+                let cross_o = match cross_o {
+                    Orientation::Horizontal => quote!(sp::Orientation::Horizontal),
+                    Orientation::Vertical => quote!(sp::Orientation::Vertical),
+                };
+                quote!(cross_axis_self_alignment: if o == #cross_o {
+                    self.as_ref().cross_axis_self_alignment_for_repeated()
+                } else {
+                    ::core::default::Default::default()
+                },)
+            });
         let layout_item_info_fn = root_sc.child_of_layout.then(|| {
             // Generate layout_item_info (from the RepeatedItemTree trait) in terms of ItemTree::layout_info
             if root_sc.is_repeated_row {
+                // Repeated grid Rows cannot carry cross-axis-self-alignment; the
+                // row-scan literals below default the field.
+                debug_assert!(root_sc.cross_axis_self_alignment_for_repeated.is_none());
                 // Create a context with proper global_access for compiling layout info expressions
                 let layout_ctx = EvaluationContext {
                     compilation_unit: unit,
@@ -2756,6 +2790,7 @@ fn generate_repeated_component(
                                                 sp::Orientation::Horizontal => #layout_info_h_code,
                                                 sp::Orientation::Vertical => #layout_info_v_code,
                                             },
+                                            ..::core::default::Default::default()
                                         };
                                     }
                                     #advance
@@ -2773,6 +2808,7 @@ fn generate_repeated_component(
                                             if let Some(inner) = _self.#inner_rep_id.instance_at(index - count) {
                                                 return sp::LayoutItemInfo {
                                                     constraint: inner.as_pin_ref().layout_info(o),
+                                                    ..::core::default::Default::default()
                                                 };
                                             }
                                         }
@@ -2791,12 +2827,12 @@ fn generate_repeated_component(
                             #(#scan_steps)*
                             sp::LayoutItemInfo::default()
                         } else {
-                            sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o) }
+                            sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field ..::core::default::Default::default() }
                         }
                     }
                 } else {
                     quote! {
-                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o) }
+                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field ..::core::default::Default::default() }
                     }
                 };
 
@@ -2816,7 +2852,7 @@ fn generate_repeated_component(
                         o: sp::Orientation,
                         _child_index: sp::Option<usize>,
                     ) -> sp::LayoutItemInfo {
-                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o) }
+                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field ..::core::default::Default::default() }
                     }
                 }
             }
@@ -5556,8 +5592,8 @@ fn generate_with_flexbox_layout_item_info(
                         let info_h = sub_comp.as_pin_ref().flexbox_layout_item_info(sp::Orientation::Horizontal, None);
                         let info_v = #v_query;
                         items_vec_flex.push(info_h.props);
-                        items_vec_h.push(sp::LayoutItemInfo { constraint: info_h.constraint });
-                        items_vec_v.push(sp::LayoutItemInfo { constraint: info_v.constraint });
+                        items_vec_h.push(sp::LayoutItemInfo { constraint: info_h.constraint, ..::core::default::Default::default() });
+                        items_vec_v.push(sp::LayoutItemInfo { constraint: info_v.constraint, ..::core::default::Default::default() });
                     } else {
                         // Not-yet-instantiated slot: push placeholder cells so the cell
                         // count stays in sync with the repeater length written above.

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -78,6 +78,9 @@ impl Layout {
 pub struct LayoutItem {
     pub element: ElementRc,
     pub constraints: LayoutConstraints,
+    /// The `cross-axis-self-alignment` property, if set.
+    /// Used by box layouts and FlexboxLayout; always `None` in a GridLayout.
+    pub cross_axis_self_alignment: Option<NamedReference>,
 }
 
 /// A FlexboxLayout child item, wrapping a LayoutItem with flex-specific properties.
@@ -87,7 +90,6 @@ pub struct FlexboxLayoutItem {
     pub flex_grow: Option<NamedReference>,
     pub flex_shrink: Option<NamedReference>,
     pub flex_basis: Option<NamedReference>,
-    pub align_self: Option<NamedReference>,
     pub order: Option<NamedReference>,
 }
 
@@ -741,6 +743,9 @@ impl BoxLayout {
     pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
         for cell in &mut self.elems {
             cell.constraints.visit_named_references(visitor);
+            if let Some(e) = cell.cross_axis_self_alignment.as_mut() {
+                visitor(&mut *e);
+            }
         }
         self.geometry.visit_named_references(visitor);
         if let Some(e) = self.cross_alignment.as_mut() {
@@ -839,7 +844,7 @@ impl FlexboxLayout {
             if let Some(e) = cell.flex_basis.as_mut() {
                 visitor(&mut *e)
             }
-            if let Some(e) = cell.align_self.as_mut() {
+            if let Some(e) = cell.item.cross_axis_self_alignment.as_mut() {
                 visitor(&mut *e)
             }
             if let Some(e) = cell.order.as_mut() {

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -528,6 +528,12 @@ pub struct SubComponent {
     /// Expression that builds a FlexboxLayoutItemInfo for a repeated element in a FlexboxLayout.
     /// Contains property references to flex-grow, flex-shrink, flex-basis, align-self, order.
     pub flexbox_layout_item_info_for_repeated: Option<MutExpression>,
+    /// The root's `cross-axis-self-alignment` for a repeated element in a box
+    /// layout, returned by the generated `layout_item_info` for the given
+    /// (cross-axis) orientation only, so the main-axis cache stays independent
+    /// of it. The cross-axis layout-info pass shares that accessor and so also
+    /// evaluates it, unlike static cells (`box_layout_info_ortho` ignores it).
+    pub cross_axis_self_alignment_for_repeated: Option<(crate::layout::Orientation, MutExpression)>,
     /// Vertical `LayoutInfo` for a repeated element, computed with a width
     /// constraint (its preferred width) so a height-for-width instance in a
     /// column FlexboxLayout doesn't read `self.width` and recurse through the
@@ -743,6 +749,9 @@ impl CompilationUnit {
                 visitor(e, ctx);
             }
             if let Some(e) = &sc.flexbox_layout_item_info_for_repeated {
+                visitor(e, ctx);
+            }
+            if let Some((_, e)) = &sc.cross_axis_self_alignment_for_repeated {
                 visitor(e, ctx);
             }
             if let Some(e) = &sc.layout_info_v_constrained_for_repeated {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -91,7 +91,7 @@ pub(super) fn compute_box_layout_info(
     let (padding, spacing) = generate_layout_padding_and_spacing(&layout.geometry, o, ctx);
     let adjusted_override = cross_axis_size_override
         .map(|o_expr| subtract_padding(o_expr.clone(), &layout.geometry, o.orthogonal()));
-    let bld = box_layout_data(layout, o, ctx, adjusted_override.as_ref(), None);
+    let bld = box_layout_data(layout, o, ctx, adjusted_override.as_ref(), None, false);
     let sub_expression = if o == layout.orientation {
         llr_Expression::ExtraBuiltinFunctionCall {
             function: "box_layout_info".into(),
@@ -267,7 +267,7 @@ pub(super) fn solve_box_layout(
     // gets its natural single-line size instead of the compact sqrt preferred.
     let cross_clamp =
         (o != layout.orientation).then(|| layout_cross_content_size(layout)).flatten();
-    let bld = box_layout_data(layout, o, ctx, cross_override.as_ref(), cross_clamp.as_ref());
+    let bld = box_layout_data(layout, o, ctx, cross_override.as_ref(), cross_clamp.as_ref(), true);
     let size = layout_geometry_size(&layout.geometry.rect, o, ctx);
     let (data, function) = if o == layout.orientation {
         let data = make_struct(
@@ -884,7 +884,8 @@ fn flexbox_layout_data(
                     .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
                     .unwrap_or(llr_Expression::NumberLiteral(-1.0)),
                 align_self: li
-                    .align_self
+                    .item
+                    .cross_axis_self_alignment
                     .as_ref()
                     .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
                     .unwrap_or(default_align_self().1),
@@ -953,7 +954,7 @@ fn flexbox_layout_data(
                         Orientation::Horizontal,
                         constraint,
                     );
-                    make_layout_cell_data_struct(layout_info_h)
+                    make_layout_cell_data_struct(layout_info_h, None)
                 })
                 .collect(),
             element_ty: cell_ty.clone(),
@@ -976,7 +977,7 @@ fn flexbox_layout_data(
                         Orientation::Vertical,
                         constraint,
                     );
-                    make_layout_cell_data_struct(layout_info_v)
+                    make_layout_cell_data_struct(layout_info_v, None)
                 })
                 .collect(),
             element_ty: cell_ty,
@@ -1038,8 +1039,8 @@ fn flexbox_layout_data(
                     constraint,
                 );
                 elements.push(Either::Left((
-                    make_layout_cell_data_struct(layout_info_h),
-                    make_layout_cell_data_struct(layout_info_v),
+                    make_layout_cell_data_struct(layout_info_h, None),
+                    make_layout_cell_data_struct(layout_info_v, None),
                     make_flex_props_struct(flex_prop(item, ctx)),
                 )));
             }
@@ -1094,11 +1095,20 @@ fn default_align_self() -> (Type, llr_Expression) {
     )
 }
 
-fn make_layout_cell_data_struct(layout_info: llr_Expression) -> llr_Expression {
-    make_struct(
-        BuiltinStruct::LayoutItemInfo,
-        [("constraint", crate::typeregister::layout_info_type().into(), layout_info)],
-    )
+/// Build a LayoutItemInfo struct expression with the canonical (full) field
+/// list as its type, so the generators default the fields that are not set.
+/// `align_self` is only set for a box layout's cross-axis cells.
+fn make_layout_cell_data_struct(
+    layout_info: llr_Expression,
+    align_self: Option<llr_Expression>,
+) -> llr_Expression {
+    let Type::Struct(ty) = crate::typeregister::layout_item_info_type() else { unreachable!() };
+    let mut values = BTreeMap::<SmolStr, llr_Expression>::new();
+    values.insert("constraint".into(), layout_info);
+    if let Some(align_self) = align_self {
+        values.insert("cross-axis-self-alignment".into(), align_self);
+    }
+    llr_Expression::Struct { ty, values }
 }
 
 #[derive(Clone)]
@@ -1130,6 +1140,7 @@ fn box_layout_data(
     ctx: &mut ExpressionLoweringCtx,
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
     cross_clamp: Option<&crate::expression_tree::Expression>,
+    for_solve: bool,
 ) -> BoxLayoutDataResult {
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
@@ -1146,6 +1157,17 @@ fn box_layout_data(
 
     let element_ty = crate::typeregister::layout_item_info_type();
 
+    // The per-item alignment only matters to the cross-axis solve. Leaving it
+    // out of the main-axis cells keeps that cache independent of it, and out of
+    // the layout-info cells because `box_layout_info_ortho` ignores it.
+    // This covers static cells only: repeated cells go through the generated
+    // `layout_item_info`, which is guarded on the orientation alone.
+    let cell_align_self = |li: &crate::layout::LayoutItem, ctx: &mut ExpressionLoweringCtx| {
+        li.cross_axis_self_alignment
+            .as_ref()
+            .filter(|_| for_solve && orientation != layout.orientation)
+            .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
+    };
     if repeater_count == 0 {
         let cells = llr_Expression::Array {
             values: layout
@@ -1160,7 +1182,8 @@ fn box_layout_data(
                         cross_axis_size_override,
                         cross_clamp,
                     );
-                    make_layout_cell_data_struct(layout_info)
+                    let align_self = cell_align_self(li, ctx);
+                    make_layout_cell_data_struct(layout_info, align_self)
                 })
                 .collect(),
             element_ty,
@@ -1189,7 +1212,8 @@ fn box_layout_data(
                     cross_axis_size_override,
                     cross_clamp,
                 );
-                elements.push(Either::Left(make_layout_cell_data_struct(layout_info)));
+                let align_self = cell_align_self(item, ctx);
+                elements.push(Either::Left(make_layout_cell_data_struct(layout_info, align_self)));
             }
         }
         let cells = llr_Expression::ReadLocalVariable {
@@ -1459,7 +1483,7 @@ fn grid_layout_cell_constraints(
                         cross_axis_size_override,
                         None,
                     );
-                    make_layout_cell_data_struct(layout_info)
+                    make_layout_cell_data_struct(layout_info, None)
                 })
                 .collect(),
             output: llr_ArrayOutput::Slice,
@@ -1492,7 +1516,7 @@ fn grid_layout_cell_constraints(
                     cross_axis_size_override,
                     None,
                 );
-                elements.push(Either::Left(make_layout_cell_data_struct(layout_info)));
+                elements.push(Either::Left(make_layout_cell_data_struct(layout_info, None)));
             }
         }
         let cells = llr_Expression::ReadLocalVariable {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -319,6 +319,7 @@ fn lower_sub_component(
         child_of_layout: component.root_element.borrow().child_of_layout,
         grid_layout_input_for_repeated: None,
         flexbox_layout_item_info_for_repeated: None,
+        cross_axis_self_alignment_for_repeated: None,
         layout_info_v_constrained_for_repeated: None,
         layout_info_v_at_cross_width_for_repeated: None,
         layout_info_h_constrained_for_repeated: None,
@@ -734,6 +735,19 @@ fn lower_sub_component(
                 &component.root_constraints.borrow(),
             )
             .map(Into::into);
+    } else if let Some(box_orientation) =
+        component.root_element.borrow().parent_box_layout_orientation
+    {
+        // A repeated element in a box layout returns its `cross-axis-self-alignment`
+        // through the generated `layout_item_info`, on the cross axis only.
+        if let Some(nr) =
+            crate::layout::binding_reference(&component.root_element, "cross-axis-self-alignment")
+        {
+            sub_component.cross_axis_self_alignment_for_repeated = Some((
+                box_orientation.orthogonal(),
+                super::Expression::PropertyReference(ctx.map_property_reference(&nr)).into(),
+            ));
+        }
     }
 
     if let Some(grid_layout_cell) = component.root_element.borrow().grid_layout_cell.as_ref() {

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -80,6 +80,9 @@ pub fn count_property_use(root: &CompilationUnit) {
         if let Some(e) = &sc.flexbox_layout_item_info_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }
+        if let Some((_, e)) = &sc.cross_axis_self_alignment_for_repeated {
+            e.borrow().visit_property_references(ctx, &mut visit_property);
+        }
         if let Some(e) = &sc.layout_info_v_constrained_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -306,6 +306,7 @@ mod visitor {
             child_of_layout: _,
             grid_layout_input_for_repeated,
             flexbox_layout_item_info_for_repeated,
+            cross_axis_self_alignment_for_repeated,
             layout_info_v_constrained_for_repeated,
             layout_info_v_at_cross_width_for_repeated,
             layout_info_h_constrained_for_repeated,
@@ -405,6 +406,9 @@ mod visitor {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some(e) = flexbox_layout_item_info_for_repeated {
+            visit_expression(e.get_mut(), &scope, state, visitor);
+        }
+        if let Some((_, e)) = cross_axis_self_alignment_for_repeated {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some(e) = layout_info_v_constrained_for_repeated {

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -185,6 +185,14 @@ impl PrettyPrinter<'_> {
                 DisplayExpression(&e.borrow(), &ctx)
             )?
         }
+        if let Some((cross_o, e)) = &sc.cross_axis_self_alignment_for_repeated {
+            self.indent()?;
+            writeln!(
+                self.writer,
+                "cross-axis-self-alignment-for-repeated ({cross_o:?}): {};",
+                DisplayExpression(&e.borrow(), &ctx)
+            )?
+        }
         for (i, c) in sc.grid_layout_children.iter_enumerated() {
             self.indent()?;
             writeln!(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1047,6 +1047,11 @@ pub struct Element {
     /// than `child_of_layout`: only flexbox cells need the per-repeater
     /// `flexbox_layout_item_info` accessor.
     pub child_of_flexbox: bool,
+    /// The orientation of the box layout this element is a repeated cell of.
+    /// Only set when the cell also binds `cross-axis-self-alignment`; lets the
+    /// generated `layout_item_info` return that value only for the cross axis,
+    /// so the main-axis cache stays independent of it.
+    pub parent_box_layout_orientation: Option<Orientation>,
     /// The property pointing to the layout info. `(horizontal, vertical)`
     pub layout_info_prop: Option<(NamedReference, NamedReference)>,
     /// `pure function layoutinfo-v-with-constraint(width: length) -> LayoutInfo`
@@ -4425,22 +4430,25 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
     // generated on the wrapper the layout actually calls it on.
     if old_root.borrow().child_of_flexbox {
         new_root.borrow_mut().child_of_flexbox = true;
-        // That accessor reads the flex item properties from the repeated root (now the
-        // wrapper). Link them to the inner element that still carries the bindings
-        // (and the FlexboxLayout's captured references keeping them alive), rather
-        // than moving them, which would leave those references dangling.
-        for prop in
-            ["flex-grow", "flex-shrink", "flex-basis", "flex-order", "cross-axis-self-alignment"]
-                .iter()
-        {
-            if old_root.borrow().binding(prop).is_some() {
-                new_root.borrow_mut().set_binding(
-                    SmolStr::new_static(prop),
-                    BindingExpression::new_two_way(
-                        NamedReference::new(old_root, SmolStr::new_static(prop)).into(),
-                    ),
-                );
-            }
+    }
+    new_root.borrow_mut().parent_box_layout_orientation =
+        old_root.borrow().parent_box_layout_orientation;
+    // The item-info accessors read the per-item layout properties from the repeated
+    // root (now the wrapper). Link them to the inner element that still carries the
+    // bindings (and the layout's captured references keeping them alive), rather
+    // than moving them, which would leave those references dangling.
+    // cross-axis-self-alignment is read by both the flexbox and the box layout
+    // accessor; the flex-* properties only by the flexbox one.
+    for prop in
+        ["flex-grow", "flex-shrink", "flex-basis", "flex-order", "cross-axis-self-alignment"].iter()
+    {
+        if old_root.borrow().binding(prop).is_some() {
+            new_root.borrow_mut().set_binding(
+                SmolStr::new_static(prop),
+                BindingExpression::new_two_way(
+                    NamedReference::new(old_root, SmolStr::new_static(prop)).into(),
+                ),
+            );
         }
     }
     let layout_info_prop = old_root.borrow().layout_info_prop.clone().or_else(|| {

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -635,12 +635,17 @@ fn recurse_expression(
             }
             visit_layout_items_dependencies(l.elems.iter(), *o, vis);
 
-            // The orthogonal solve depends on `cross-axis-alignment`.
-            if matches!(expr, Expression::SolveBoxLayout(..))
-                && *o != l.orientation
-                && let Some(nr) = l.cross_alignment.as_ref()
-            {
-                vis(&nr.clone().into(), P);
+            // The orthogonal solve depends on `cross-axis-alignment` and on the
+            // cells' `cross-axis-self-alignment`.
+            if matches!(expr, Expression::SolveBoxLayout(..)) && *o != l.orientation {
+                if let Some(nr) = l.cross_alignment.as_ref() {
+                    vis(&nr.clone().into(), P);
+                }
+                for cell in l.elems.iter() {
+                    if let Some(nr) = cell.cross_axis_self_alignment.as_ref() {
+                        vis(&nr.clone().into(), P);
+                    }
+                }
             }
 
             let mut g = l.geometry.clone();

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -596,6 +596,7 @@ fn duplicate_element_with_mapping(
             .collect(),
         child_of_layout: elem.child_of_layout,
         child_of_flexbox: elem.child_of_flexbox,
+        parent_box_layout_orientation: elem.parent_box_layout_orientation,
         layout_info_prop: elem.layout_info_prop.clone(),
         layout_info_v_with_constraint: elem.layout_info_v_with_constraint.clone(),
         layout_info_h_with_constraint: elem.layout_info_h_with_constraint.clone(),

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1674,13 +1674,6 @@ fn lower_box_layout(
         cross_alignment: binding_reference(layout_element, "cross-axis-alignment"),
     };
 
-    let layout_cache_ortho_prop = layout.cross_alignment.is_some().then(|| {
-        create_new_prop(
-            layout_element,
-            SmolStr::new_static("layout-cache-ortho"),
-            Type::LayoutCache,
-        )
-    });
     let layout_info_prop_v = create_new_prop(
         layout_element,
         SmolStr::new_static("layoutinfo-v"),
@@ -1693,6 +1686,33 @@ fn lower_box_layout(
     );
 
     let layout_children = std::mem::take(&mut layout_element.borrow_mut().children);
+
+    // Collect the items before wiring anything: the ortho-cache decision below
+    // needs to know whether any cell sets `cross-axis-self-alignment`.
+    let items: Vec<_> =
+        layout_children.iter().map(|child| create_layout_item(child, diag)).collect();
+    // A repeated cell with `cross-axis-self-alignment` returns that value through
+    // the generated `layout_item_info`, which needs the layout's orientation to
+    // restrict it to the cross axis.
+    for item in &items {
+        if item.repeater_index.is_some() && item.item.cross_axis_self_alignment.is_some() {
+            item.elem.borrow_mut().parent_box_layout_orientation = Some(orientation);
+        }
+    }
+
+    // A per-item `cross-axis-self-alignment` needs the ortho solver too, even
+    // when the container itself has no `cross-axis-alignment`.
+    let any_cell_align_self =
+        items.iter().any(|item| item.item.cross_axis_self_alignment.is_some());
+
+    let layout_cache_ortho_prop =
+        (layout.cross_alignment.is_some() || any_cell_align_self).then(|| {
+            create_new_prop(
+                layout_element,
+                SmolStr::new_static("layout-cache-ortho"),
+                Type::LayoutCache,
+            )
+        });
 
     let (pos, size, pad, ortho) = match orientation {
         Orientation::Horizontal => ("x", "width", "y", "height"),
@@ -1708,8 +1728,7 @@ fn lower_box_layout(
         (pad_expr, size_minus_padding(layout_element, ortho, pads))
     });
 
-    for layout_child in &layout_children {
-        let item = create_layout_item(layout_child, diag);
+    for item in items {
         let index = layout.elems.len() * BOX_LAYOUT_CACHE_ENTRIES_PER_CELL;
         let rep_idx = &item.repeater_index;
         let (fixed_size, fixed_ortho) = match orientation {
@@ -1890,14 +1909,12 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
         let flex_grow = crate::layout::binding_reference(actual_elem, "flex-grow");
         let flex_shrink = crate::layout::binding_reference(actual_elem, "flex-shrink");
         let flex_basis = crate::layout::binding_reference(actual_elem, "flex-basis");
-        let align_self = crate::layout::binding_reference(actual_elem, "cross-axis-self-alignment");
         let order = crate::layout::binding_reference(actual_elem, "flex-order");
         layout.elems.push(crate::layout::FlexboxLayoutItem {
             item: item.item,
             flex_grow,
             flex_shrink,
             flex_basis,
-            align_self,
             order,
         });
     }
@@ -2268,8 +2285,10 @@ fn create_layout_item(
     };
 
     let constraints = LayoutConstraints::new(&actual_elem, Some((diag, DiagnosticLevel::Error)));
+    let cross_axis_self_alignment =
+        crate::layout::binding_reference(&actual_elem, "cross-axis-self-alignment");
     CreateLayoutItemResult {
-        item: LayoutItem { element: item_element.clone(), constraints },
+        item: LayoutItem { element: item_element.clone(), constraints, cross_axis_self_alignment },
         elem: actual_elem,
         repeater_index,
     }
@@ -2551,9 +2570,17 @@ fn check_no_layout_properties(
             }
         }
         if prop == "cross-axis-self-alignment"
-            && parent_layout_type.as_deref() != Some("FlexboxLayout")
+            && !matches!(
+                parent_layout_type.as_deref(),
+                Some("FlexboxLayout" | "HorizontalLayout" | "VerticalLayout")
+            )
         {
-            diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
+            diag.push_error(
+                format!(
+                    "{prop} used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout"
+                ),
+                &*expr.borrow(),
+            );
         }
         if parent_layout_type.as_deref() != Some("Dialog")
             && matches!(prop.as_ref(), "dialog-button-role")

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -54,6 +54,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 transitions: std::mem::take(&mut original_elem.transitions),
                 child_of_layout: original_elem.child_of_layout || is_listview.is_some(),
                 child_of_flexbox: original_elem.child_of_flexbox,
+                parent_box_layout_orientation: original_elem.parent_box_layout_orientation,
                 layout_info_prop: original_elem.layout_info_prop.take(),
                 layout_info_v_with_constraint: original_elem.layout_info_v_with_constraint.take(),
                 layout_info_h_with_constraint: original_elem.layout_info_h_with_constraint.take(),

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -53,6 +53,7 @@ pub fn ensure_window(
         transitions: Default::default(),
         child_of_layout: false,
         child_of_flexbox: false,
+        parent_box_layout_orientation: None,
         has_popup_child: false,
         layout_info_prop: Default::default(),
         layout_info_v_with_constraint: Default::default(),

--- a/internal/compiler/tests/experimental_flex_item_properties.rs
+++ b/internal/compiler/tests/experimental_flex_item_properties.rs
@@ -65,10 +65,41 @@ fn flex_item_properties_accepted_with_experimental() {
     }
 }
 
-/// `cross-axis-self-alignment` is stable API, usable without experimental features.
+/// `cross-axis-self-alignment` is stable API, usable without experimental features
+/// in a FlexboxLayout and in the box layouts.
 #[test]
 fn cross_axis_self_alignment_is_stable() {
     assert_eq!(in_flexbox("cross-axis-self-alignment: center", false), Vec::<String>::new());
+    for layout in ["HorizontalLayout", "VerticalLayout"] {
+        let source = format!(
+            r#"
+export component TestCase inherits Window {{
+    {layout} {{
+        Rectangle {{ cross-axis-self-alignment: center; }}
+    }}
+}}
+"#
+        );
+        assert_eq!(errors(source, false), Vec::<String>::new());
+    }
+}
+
+/// In a GridLayout (or outside of any layout) the property is rejected.
+#[test]
+fn cross_axis_self_alignment_rejected_in_grid() {
+    let source = r#"
+export component TestCase inherits Window {
+    GridLayout {
+        Rectangle { cross-axis-self-alignment: center; }
+    }
+}
+"#;
+    assert_eq!(
+        errors(source.into(), false),
+        [
+            "cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout"
+        ]
+    );
 }
 
 /// Outside of a `FlexboxLayout` the property is wrong regardless of the experimental features, so
@@ -76,9 +107,7 @@ fn cross_axis_self_alignment_is_stable() {
 /// reason would be confusing.
 #[test]
 fn used_outside_of_a_flexbox_reports_only_that() {
-    for binding in
-        FLEX_ITEM_PROPERTIES.iter().chain(std::iter::once(&"cross-axis-self-alignment: center"))
-    {
+    for binding in FLEX_ITEM_PROPERTIES {
         let source = format!(
             r#"
 export component TestCase inherits Window {{

--- a/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
@@ -20,7 +20,7 @@ export component X inherits Rectangle {
                 flex-basis: 100px;
 //                          >    <error{flex-basis used outside of a FlexboxLayout}
                 cross-axis-self-alignment: center;
-//                                         >     <error{cross-axis-self-alignment used outside of a FlexboxLayout}
+//                                         >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
                 flex-order: 3;
 //                          ><error{flex-order used outside of a FlexboxLayout}
             }
@@ -36,7 +36,7 @@ export component X inherits Rectangle {
         flex-basis: 100px;
 //                  >    <error{flex-basis used outside of a FlexboxLayout}
         cross-axis-self-alignment: center;
-//                                 >     <error{cross-axis-self-alignment used outside of a FlexboxLayout}
+//                                 >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
         flex-order: 3;
 //                  ><error{flex-order used outside of a FlexboxLayout}
     }
@@ -45,6 +45,8 @@ export component X inherits Rectangle {
         Text {
             flex-grow: 1;
 //                     ><error{flex-grow used outside of a FlexboxLayout}
+            cross-axis-self-alignment: center;
+//                                     >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
         }
     }
 
@@ -54,6 +56,15 @@ export component X inherits Rectangle {
 //                     ><error{flex-grow used outside of a FlexboxLayout}
             flex-order: 5;
 //                      ><error{flex-order used outside of a FlexboxLayout}
+            // valid in a box layout
+            cross-axis-self-alignment: center;
+        }
+    }
+
+    VerticalLayout {
+        Text {
+            // valid in a box layout
+            cross-axis-self-alignment: end;
         }
     }
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -48,8 +48,8 @@ pub const RESERVED_GRIDLAYOUT_PROPERTIES: &[(&str, Type)] = &[
     ("rowspan", Type::Int32),
 ];
 
-// Note: cross-axis-self-alignment is also a flexbox property but is added in
-// reserved_properties() because Type::Enumeration requires a runtime Arc allocation.
+// Note: the per-item cross-axis-self-alignment (flexbox and box layouts) is added
+// in reserved_properties() because Type::Enumeration requires a runtime Arc allocation.
 pub const RESERVED_FLEXBOXLAYOUT_PROPERTIES: &[(&str, Type)] = &[
     ("flex-grow", Type::Float32),
     ("flex-shrink", Type::Float32),
@@ -136,7 +136,6 @@ impl BuiltinTypes {
             BuiltinStruct::FlexItemProps,
         ));
         Self {
-            enums,
             logical_point_type: Arc::new(Struct::new(
                 IntoIterator::into_iter([
                     (SmolStr::new_static("x"), Type::LogicalLength),
@@ -193,8 +192,14 @@ impl BuiltinTypes {
                 BuiltinStruct::PathElement,
             ))),
             layout_item_info_type: Type::Struct(Arc::new(Struct::new(
-                IntoIterator::into_iter([("constraint".into(), layout_info_type.clone().into())])
-                    .collect(),
+                IntoIterator::into_iter([
+                    ("constraint".into(), layout_info_type.clone().into()),
+                    (
+                        "cross-axis-self-alignment".into(),
+                        Type::Enumeration(enums.CrossAxisSelfAlignment.clone()),
+                    ),
+                ])
+                .collect(),
                 BuiltinStruct::LayoutItemInfo,
             ))),
             flexbox_layout_item_info_type: Type::Struct(Arc::new(Struct::new(
@@ -216,6 +221,8 @@ impl BuiltinTypes {
                 .collect(),
                 BuiltinStruct::GridLayoutInputData,
             ))),
+            // Last: the field initializers above still borrow from it.
+            enums,
         }
     }
 }
@@ -329,8 +336,8 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
                 .iter()
                 .map(|(k, v)| (*k, v.clone(), PropertyVisibility::Input)),
         )
-        // cross-axis-self-alignment is a flexbox-layout property but can't be in the const
-        // array because Type::Enumeration requires a runtime Arc allocation.
+        // The per-item cross-axis-self-alignment (flexbox and box layouts) can't be in a
+        // const array because Type::Enumeration requires a runtime Arc allocation.
         .chain(std::iter::once((
             "cross-axis-self-alignment",
             Type::Enumeration(BUILTIN.enums.CrossAxisSelfAlignment.clone()),

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1167,6 +1167,9 @@ pub struct FlexboxLayoutData<'a> {
 /// The information about a single item in a box or grid layout
 pub struct LayoutItemInfo {
     pub constraint: LayoutInfo,
+    /// Per-item cross-axis alignment override for box layouts
+    /// (`Auto` = use the container's `cross-axis-alignment`)
+    pub cross_axis_self_alignment: CrossAxisSelfAlignment,
 }
 
 /// The per-item flex properties of a FlexboxLayout cell.
@@ -1261,7 +1264,13 @@ pub struct FlexboxLayoutItemInfo {
 
 impl From<LayoutItemInfo> for FlexboxLayoutItemInfo {
     fn from(info: LayoutItemInfo) -> Self {
-        Self { constraint: info.constraint, ..Default::default() }
+        Self {
+            constraint: info.constraint,
+            props: FlexItemProps {
+                cross_axis_self_alignment: info.cross_axis_self_alignment,
+                ..Default::default()
+            },
+        }
     }
 }
 
@@ -1364,17 +1373,24 @@ pub fn solve_box_layout_ortho(
     let size_without_padding = data.size - data.padding.begin - data.padding.end;
     let mut generator = LayoutCacheGenerator::new(&repeater_indices, &mut result);
     for c in data.cells.iter() {
+        let alignment = match c.cross_axis_self_alignment {
+            CrossAxisSelfAlignment::Auto => data.cross_axis_alignment,
+            CrossAxisSelfAlignment::Stretch => CrossAxisAlignment::Stretch,
+            CrossAxisSelfAlignment::Start => CrossAxisAlignment::Start,
+            CrossAxisSelfAlignment::End => CrossAxisAlignment::End,
+            CrossAxisSelfAlignment::Center => CrossAxisAlignment::Center,
+        };
         let min =
             c.constraint.min.max(c.constraint.min_percent * size_without_padding / 100 as Coord);
         let max =
             c.constraint.max.min(c.constraint.max_percent * size_without_padding / 100 as Coord);
-        let size = match data.cross_axis_alignment {
+        let size = match alignment {
             CrossAxisAlignment::Stretch => size_without_padding,
             _ => c.constraint.preferred,
         }
         .min(max)
         .max(min);
-        let pos = match data.cross_axis_alignment {
+        let pos = match alignment {
             CrossAxisAlignment::Stretch | CrossAxisAlignment::Start => data.padding.begin,
             CrossAxisAlignment::End => data.padding.begin + size_without_padding - size,
             CrossAxisAlignment::Center => {
@@ -3081,7 +3097,13 @@ mod tests {
         /// arrays the runtime takes.
         fn split(cells: &[FlexboxLayoutItemInfo]) -> (Vec<LayoutItemInfo>, Vec<FlexItemProps>) {
             (
-                cells.iter().map(|c| LayoutItemInfo { constraint: c.constraint.clone() }).collect(),
+                cells
+                    .iter()
+                    .map(|c| LayoutItemInfo {
+                        constraint: c.constraint.clone(),
+                        ..Default::default()
+                    })
+                    .collect(),
                 cells.iter().map(|c| c.props).collect(),
             )
         }
@@ -3095,6 +3117,7 @@ mod tests {
                 .iter()
                 .map(|_| LayoutItemInfo {
                     constraint: LayoutInfo { max: Coord::MAX, ..Default::default() },
+                    ..Default::default()
                 })
                 .collect();
             let cells_h = Slice::from_slice(&main);
@@ -3197,6 +3220,7 @@ mod tests {
                 .iter()
                 .map(|_| LayoutItemInfo {
                     constraint: LayoutInfo { max: Coord::MAX, ..Default::default() },
+                    ..Default::default()
                 })
                 .collect();
             let cells_h = Slice::from_slice(&h);
@@ -3303,6 +3327,7 @@ mod tests {
                 max: Coord::MAX,
                 ..Default::default()
             },
+            ..Default::default()
         }];
         let cells_v = [LayoutItemInfo {
             constraint: LayoutInfo {
@@ -3310,6 +3335,7 @@ mod tests {
                 max: Coord::MAX,
                 ..Default::default()
             },
+            ..Default::default()
         }];
         let flex_props = [FlexItemProps::default()];
         let pad = Padding::default();

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1089,6 +1089,17 @@ fn push_repeater_layout_items(
     let push_cell = |cells: &mut Vec<Value>, info: i_slint_core::layout::LayoutItemInfo| {
         let mut struct_value = crate::api::Struct::default();
         struct_value.set_field("constraint".to_string(), info.constraint.into());
+        // The cell's `cross-axis-self-alignment` in a box layout; `to_cells`
+        // reads it back on the cross-axis solve, an absent field means `auto`.
+        if info.cross_axis_self_alignment != i_slint_core::items::CrossAxisSelfAlignment::Auto {
+            struct_value.set_field(
+                "cross-axis-self-alignment".to_string(),
+                Value::EnumerationValue(
+                    "CrossAxisSelfAlignment".to_string(),
+                    info.cross_axis_self_alignment.to_string(),
+                ),
+            );
+        }
         cells.push(Value::Struct(struct_value));
     };
     let step = match row_child_templates {
@@ -1146,7 +1157,7 @@ fn total_row_child_count(
     total
 }
 
-fn llr_to_core_orientation(
+pub(crate) fn llr_to_core_orientation(
     o: i_slint_compiler::layout::Orientation,
 ) -> i_slint_core::items::Orientation {
     match o {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -46,7 +46,14 @@ fn to_cells(v: &Value) -> Vec<LayoutItemInfo> {
         .filter_map(|i| {
             let Value::Struct(s) = m.row_data(i)? else { return None };
             let c = s.get_field("constraint")?;
-            Some(LayoutItemInfo { constraint: c.clone().try_into().unwrap_or_default() })
+            Some(LayoutItemInfo {
+                constraint: c.clone().try_into().unwrap_or_default(),
+                // Only set for a box layout's cross-axis cells; absent means `auto`.
+                cross_axis_self_alignment: s
+                    .get_field("cross-axis-self-alignment")
+                    .map(to_enum)
+                    .unwrap_or_default(),
+            })
         })
         .collect()
 }

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -1111,7 +1111,19 @@ impl i_slint_core::model::RepeatedItemTree for Instance {
         let mut ctx = crate::eval::EvalContext::new(this.root_sub_component.clone());
         let constraint =
             crate::eval::eval_expression(&mut ctx, &expr).try_into().unwrap_or_default();
-        i_slint_core::layout::LayoutItemInfo { constraint }
+        // The cell's `cross-axis-self-alignment` in a box layout, returned for
+        // the cross axis only, so the main-axis cache stays independent of it.
+        let cross_axis_self_alignment = match &sc.cross_axis_self_alignment_for_repeated {
+            Some((cross_o, align_expr))
+                if crate::eval::llr_to_core_orientation(*cross_o) == orientation =>
+            {
+                crate::eval::eval_expression(&mut ctx, &align_expr.borrow())
+                    .try_into()
+                    .unwrap_or_default()
+            }
+            _ => Default::default(),
+        };
+        i_slint_core::layout::LayoutItemInfo { constraint, cross_axis_self_alignment }
     }
 
     fn flexbox_layout_item_info(
@@ -1249,7 +1261,10 @@ fn row_child_layout_item_info(
                     let constraint = crate::eval::eval_expression(&mut ctx, &expr)
                         .try_into()
                         .unwrap_or_default();
-                    return i_slint_core::layout::LayoutItemInfo { constraint };
+                    return i_slint_core::layout::LayoutItemInfo {
+                        constraint,
+                        ..Default::default()
+                    };
                 }
                 index -= 1;
             }

--- a/tests/cases/layout/boxlayout_cross_axis_self_alignment.slint
+++ b/tests/cases/layout/boxlayout_cross_axis_self_alignment.slint
@@ -1,0 +1,501 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// C++ live preview: no element search (wrapper has no item tree)
+//ignore: cpp-live-preview
+
+// Test the per-item cross-axis-self-alignment property of HorizontalLayout and VerticalLayout
+//
+// Reading the rendered window: each gray-outlined band is one layout. Blue
+// cells carry a cross-axis-self-alignment (their label is its value), gray
+// cells don't and follow the container. The caption above each band says where
+// the cells must sit.
+//
+// The cells keep their exact geometry: the labels set `x` so they stay out of
+// their parent's layout-info (see gen_layout_info_prop in default_geometry.rs),
+// and the captions live outside the bands. The assertions are unchanged.
+
+// Test 1: overrides in a HorizontalLayout without cross-axis-alignment (default: stretch).
+// The per-item property alone must switch the layout to the ortho solver.
+component TestDefaultContainer inherits Rectangle {
+    width: 520px;
+    height: 130px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Text { text: "container stretches by default: end → bottom, center → middle, no override → top / fills"; font-size: 11px; }
+        Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                r1 := Rectangle {
+                    width: 60px;
+                    height: 30px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "fixed 30"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                r2 := Rectangle {
+                    width: 60px;
+                    height: 30px;
+                    cross-axis-self-alignment: end;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "end"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                r3 := Rectangle {
+                    width: 60px;
+                    height: 30px;
+                    cross-axis-self-alignment: center;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "center"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                r4 := Rectangle {
+                    width: 60px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "fills"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+    }
+
+    // r1: no override, fixed height → y=0
+    // r2: end → y=70 (100-30), r3: center → y=35
+    // r4: no override, no fixed height → stretches to 100
+    out property <bool> test_r1: r1.y == 0px;
+    out property <bool> test_r2: r2.y == 70px;
+    out property <bool> test_r3: r3.y == 35px;
+    out property <bool> test_r4: r4.height == 100px;
+    out property <bool> test: test_r1 && test_r2 && test_r3 && test_r4;
+}
+
+// Test 2: stretch override under a non-stretching container:
+// a separator fills the height while the other items stay centered.
+component TestStretchOverride inherits Rectangle {
+    width: 520px;
+    height: 130px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Text { text: "container centers everything; the 2px separator overrides with stretch and fills the height"; font-size: 11px; }
+        Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                cross-axis-alignment: center;
+
+                s1 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "centered"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                s2 := Rectangle {
+                    width: 2px;
+                    cross-axis-self-alignment: stretch;
+                    background: #5b8db8;
+                }
+                s3 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: auto;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "auto"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+    }
+
+    // s1: centered → height 30, y=35; s2: stretch → height 100, y=0
+    // s3: auto inherits center → y=35
+    out property <bool> test_s1: s1.height == 30px && s1.y == 35px;
+    out property <bool> test_s2: s2.height == 100px && s2.y == 0px;
+    out property <bool> test_s3: s3.y == 35px;
+    out property <bool> test: test_s1 && test_s2 && test_s3;
+}
+
+// Test 3: VerticalLayout, the cross axis is horizontal.
+component TestVertical inherits Rectangle {
+    width: 520px;
+    height: 150px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Text { text: "VerticalLayout, cross axis is horizontal, container aligns start: end → right, center → middle"; font-size: 11px; }
+        Rectangle {
+            width: 100px;
+            height: 120px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            VerticalLayout {
+                cross-axis-alignment: start;
+
+                v1 := Rectangle {
+                    height: 40px;
+                    width: 30px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "left"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                v2 := Rectangle {
+                    height: 40px;
+                    width: 30px;
+                    cross-axis-self-alignment: end;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "end"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                v3 := Rectangle {
+                    height: 40px;
+                    width: 30px;
+                    cross-axis-self-alignment: center;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "center"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+    }
+
+    // v1: start → x=0; v2: end → x=70 (100-30); v3: center → x=35
+    out property <bool> test_v1: v1.x == 0px;
+    out property <bool> test_v2: v2.x == 70px;
+    out property <bool> test_v3: v3.x == 35px;
+    out property <bool> test: test_v1 && test_v2 && test_v3;
+}
+
+export component TestCase inherits Window {
+
+    in property <bool> show-conditional: true;
+    in property <bool> flip: false;
+
+    VerticalLayout {
+        alignment: start;
+        spacing: 8px;
+        padding: 8px;
+        Text {
+            text: "blue = cell with a cross-axis-self-alignment (label = its value)\ngray = cell without one, it follows the container; gray outline = the layout's area";
+            font-size: 11px;
+            color: #555555;
+        }
+        t1 := TestDefaultContainer { }
+        t2 := TestStretchOverride { }
+        t3 := TestVertical { }
+
+        // Test 4: repeated cells carry the property through the item-info accessor.
+        Text { text: "repeated cells: end → bottom; the static center cell sits in the middle"; font-size: 11px; }
+        wrap4 := Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                // end → not stretched: height stays at the preferred 30px
+                for i in [0, 1]: rep-end := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: end;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "end"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                // A static item mixed with repeaters uses the same solve.
+                anchor4 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: center;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "center"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+
+        // Test 5: repeated cell stretches while the container doesn't.
+        Text { text: "container aligns start; the repeated cell overrides with stretch and fills"; font-size: 11px; }
+        wrap5 := Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                cross-axis-alignment: start;
+                for i in [0]: reps := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: stretch;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "stretch"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                anchor5 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "top"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+
+        // Test 6: a repeated cell is the only reason to run the ortho solver:
+        // no container cross-axis-alignment, no static cell with the property.
+        Text { text: "a repeated cell is the only override: bottom; its plain sibling still fills"; font-size: 11px; }
+        wrap6 := Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                for i in [0]: repo := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: end;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "end"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                anchor6 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "fills"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+
+        // Test 7: conditional cell with the property.
+        Text { text: "conditional cell overrides with stretch and fills; the plain sibling stays at the top"; font-size: 11px; }
+        wrap7 := Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                cross-axis-alignment: start;
+                if show-conditional: conditional := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: stretch;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "stretch"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                anchor7 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "top"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+
+        // Test 8: dynamic alignment bindings, toggled at runtime by the drivers.
+        Text { text: "dynamic: setting 'flip' moves both cells from the top to the bottom (the drivers toggle it)"; font-size: 11px; }
+        wrap8 := Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                dyn1 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: root.flip ? CrossAxisSelfAlignment.end : CrossAxisSelfAlignment.start;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: root.flip ? "end" : "start"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                for i in [0]: rep-dyn := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    cross-axis-self-alignment: root.flip ? CrossAxisSelfAlignment.end : CrossAxisSelfAlignment.start;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: root.flip ? "end" : "start"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+
+        // Test 9: `opacity` wraps the repeated cell in an injected element; the
+        // property must be linked onto that wrapper to reach the solver.
+        Text { text: "repeated translucent cell: the injected opacity wrapper forwards end → bottom"; font-size: 11px; }
+        wrap9 := Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                for i in [0]: rep-wrapped := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    opacity: 0.5;
+                    cross-axis-self-alignment: end;
+                    background: #cce6ff;
+                    border-width: 1px;
+                    border-color: #5b8db8;
+                    Text { x: 0px; width: 100%; height: 100%; text: "end"; font-size: 10px; color: #003366;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+                anchor9 := Rectangle {
+                    width: 60px;
+                    preferred-height: 30px;
+                    background: #dcdcdc;
+                    border-width: 1px;
+                    border-color: #a0a0a0;
+                    Text { x: 0px; width: 100%; height: 100%; text: "fills"; font-size: 10px; color: #333333;
+                        horizontal-alignment: center; vertical-alignment: center; }
+                }
+            }
+        }
+    }
+
+    out property <bool> test_anchor4: anchor4.y == 35px && anchor4.height == 30px;
+    out property <bool> test_anchor5: anchor5.y == 0px && anchor5.height == 30px;
+    // anchor6 has no override: it still stretches under the repeated-only trigger.
+    out property <bool> test_anchor6: anchor6.y == 0px && anchor6.height == 100px;
+    out property <bool> test_anchor7: anchor7.y == 0px && anchor7.height == 30px;
+    out property <length> dyn1_y: dyn1.y;
+    out property <bool> test_anchor9: anchor9.y == 0px && anchor9.height == 100px;
+    out property <bool> test: t1.test && t2.test && t3.test
+        && test_anchor4 && test_anchor5 && test_anchor6 && test_anchor7 && test_anchor9
+        && dyn1_y == 0px && dyn1.height == 30px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+// The repeated cells can't be referenced from slint code; query them by element id.
+auto rep_end = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::rep-end");
+assert_eq(rep_end.size(), 2);
+auto wrap4 = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::wrap4")[0];
+for (auto e : rep_end) {
+    assert_eq(e.size().height, 30.0);
+    assert_eq(e.absolute_position().y - wrap4.absolute_position().y, 70.0);
+}
+auto reps = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::reps")[0];
+assert_eq(reps.size().height, 100.0);
+
+// A repeated cell alone triggers the ortho solver.
+auto repo = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::repo")[0];
+auto wrap6 = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::wrap6")[0];
+assert_eq(repo.size().height, 30.0);
+assert_eq(repo.absolute_position().y - wrap6.absolute_position().y, 70.0);
+
+// Conditional cell stretches while the container doesn't.
+auto conditional = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::conditional")[0];
+assert_eq(conditional.size().height, 100.0);
+
+// The property reaches the solver through the injected opacity wrapper.
+auto rep_wrapped = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::rep-wrapped")[0];
+auto wrap9 = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::wrap9")[0];
+assert_eq(rep_wrapped.size().height, 30.0);
+assert_eq(rep_wrapped.absolute_position().y - wrap9.absolute_position().y, 70.0);
+
+// Dynamic alignment bindings re-solve on change.
+auto wrap8 = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::wrap8")[0];
+auto rep_dyn = slint::testing::ElementHandle::find_by_element_id(handle, "TestCase::rep-dyn")[0];
+assert_eq(rep_dyn.absolute_position().y - wrap8.absolute_position().y, 0.0);
+instance.set_flip(true);
+assert_eq(instance.get_dyn1_y(), 70.0);
+assert_eq(rep_dyn.absolute_position().y - wrap8.absolute_position().y, 70.0);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+// The repeated cells can't be referenced from slint code; query them by element id.
+let rep_end: Vec<_> = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::rep-end").collect();
+assert_eq!(rep_end.len(), 2);
+let wrap4 = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::wrap4").next().unwrap();
+for e in rep_end {
+    assert_eq!(e.size().height, 30.0, "repeated end-aligned cell keeps its preferred height");
+    assert_eq!(e.absolute_position().y - wrap4.absolute_position().y, 70.0, "repeated cell aligned to the bottom");
+}
+let reps = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::reps").next().unwrap();
+assert_eq!(reps.size().height, 100.0, "repeated stretch cell fills the height of a non-stretching container");
+
+// A repeated cell alone triggers the ortho solver.
+let repo = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::repo").next().unwrap();
+let wrap6 = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::wrap6").next().unwrap();
+assert_eq!(repo.size().height, 30.0, "repeated cell must not stretch");
+assert_eq!(repo.absolute_position().y - wrap6.absolute_position().y, 70.0, "repeated cell aligned to the bottom");
+
+// Conditional cell stretches while the container doesn't.
+let conditional = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::conditional").next().unwrap();
+assert_eq!(conditional.size().height, 100.0, "conditional stretch cell fills the height");
+
+// The property reaches the solver through the injected opacity wrapper.
+let rep_wrapped = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::rep-wrapped").next().unwrap();
+let wrap9 = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::wrap9").next().unwrap();
+assert_eq!(rep_wrapped.size().height, 30.0, "wrapped repeated cell must not stretch");
+assert_eq!(rep_wrapped.absolute_position().y - wrap9.absolute_position().y, 70.0, "wrapped repeated cell aligned to the bottom");
+
+// Dynamic alignment bindings re-solve on change.
+let wrap8 = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::wrap8").next().unwrap();
+let rep_dyn = slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::rep-dyn").next().unwrap();
+assert_eq!(rep_dyn.absolute_position().y - wrap8.absolute_position().y, 0.0);
+instance.set_flip(true);
+assert_eq!(instance.get_dyn1_y(), 70.0, "static cell moved to the bottom after the toggle");
+assert_eq!(rep_dyn.absolute_position().y - wrap8.absolute_position().y, 70.0, "repeated cell moved to the bottom after the toggle");
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+instance.flip = true;
+assert.equal(instance.dyn1_y, 70);
+```
+*/

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -558,7 +558,10 @@ fn is_reserved_prop_valid(
         return matches!(parent_name, Some("GridLayout" | "Row"));
     }
     if prop == "cross-axis-self-alignment" {
-        return parent_name == Some("FlexboxLayout");
+        return matches!(
+            parent_name,
+            Some("FlexboxLayout" | "HorizontalLayout" | "VerticalLayout")
+        );
     }
     if name_in(i_slint_compiler::typeregister::RESERVED_FLEXBOXLAYOUT_PROPERTIES) {
         // Not stable API yet, the compiler only accepts them as an experimental feature.
@@ -2956,6 +2959,28 @@ export component Foo {
             results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
             "no 'cross-axis-self-alignment' completion"
         );
+    }
+
+    #[test]
+    fn cross_axis_self_alignment_in_box_layouts() {
+        for layout in ["HorizontalLayout", "VerticalLayout"] {
+            let source = format!(
+                r#"
+component Foo {{
+    {layout} {{
+        Rectangle {{
+            🔺
+        }}
+    }}
+}}
+"#
+            );
+            let results = get_completions(&source).unwrap();
+            assert!(
+                results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
+                "no 'cross-axis-self-alignment' completion in a {layout}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
The per-cell reference moves from FlexboxLayoutItem to LayoutItem so all
layouts collect it in create_layout_item, and the runtime LayoutItemInfo
carries the value into solve_box_layout_ortho, which resolves it against
the container's cross-axis-alignment. A cell with the property switches
the layout to the ortho solver even when the container itself has no
cross-axis-alignment. Repeated cells return the value through the
generated layout_item_info.

As discussed in #12795