### PR TITLE
FlexboxLayout: name the measure-cell type instead of using Either

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4666,7 +4666,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 let mut v_cases = String::new();
                 let mut h_cases = String::new();
                 for (i, item) in measure_cells.iter().enumerate() {
-                    if let Either::Left((h_info, v_info)) = item {
+                    if let llr::FlexboxMeasureCellKind::Static { h_info, v_info } = &item.kind {
                         let v = compile_expression(v_info, ctx);
                         let h = compile_expression(h_info, ctx);
                         v_cases.push_str(&format!(
@@ -4685,8 +4685,8 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 let mut v_steps = String::new();
                 let mut h_steps = String::new();
                 for item in measure_cells {
-                    match item {
-                        Either::Left((h_info, v_info)) => {
+                    match &item.kind {
+                        llr::FlexboxMeasureCellKind::Static { h_info, v_info } => {
                             let v = compile_expression(v_info, ctx);
                             let h = compile_expression(h_info, ctx);
                             v_steps.push_str(&format!(
@@ -4698,7 +4698,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                                  cursor += 1;\n"
                             ));
                         }
-                        Either::Right(repeater) => {
+                        llr::FlexboxMeasureCellKind::Repeated(repeater) => {
                             let i = usize::from(repeater.repeater_index);
                             v_steps.push_str(&format!(
                                 "{{ auto len = self->repeater_{i}.len(); \

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5610,7 +5610,7 @@ fn generate_with_flexbox_layout_item_info(
 fn generate_solve_flexbox_layout_with_measure(
     data: &Expression,
     repeater_indices: &Expression,
-    measure_cells: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
+    measure_cells: &[llr::FlexboxMeasureCell],
     default_cells: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
     cells_variables: Option<&(SmolStr, SmolStr)>,
     ctx: &EvaluationContext,
@@ -5630,7 +5630,7 @@ fn generate_solve_flexbox_layout_with_measure(
         let mut v_arms = Vec::new();
         let mut h_arms = Vec::new();
         for (i, item) in measure_cells.iter().enumerate() {
-            if let Either::Left((h_info, v_info)) = item {
+            if let llr::FlexboxMeasureCellKind::Static { h_info, v_info } = &item.kind {
                 let idx = proc_macro2::Literal::usize_unsuffixed(i);
                 let v = compile_expression(v_info, ctx);
                 let h = compile_expression(h_info, ctx);
@@ -5643,8 +5643,8 @@ fn generate_solve_flexbox_layout_with_measure(
         let mut v_steps = Vec::new();
         let mut h_steps = Vec::new();
         for item in measure_cells {
-            match item {
-                Either::Left((h_info, v_info)) => {
+            match &item.kind {
+                llr::FlexboxMeasureCellKind::Static { h_info, v_info } => {
                     let v = compile_expression(v_info, ctx);
                     let h = compile_expression(h_info, ctx);
                     v_steps.push(quote!(
@@ -5656,7 +5656,7 @@ fn generate_solve_flexbox_layout_with_measure(
                         cursor += 1;
                     ));
                 }
-                Either::Right(repeater) => {
+                llr::FlexboxMeasureCellKind::Repeated(repeater) => {
                     let repeater_id =
                         format_ident!("repeater{}", usize::from(repeater.repeater_index));
                     v_steps.push(quote!(

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -23,6 +23,25 @@ pub enum ArrayOutput {
 
 pub use crate::expression_tree::MouseCursorInner;
 
+/// One cell of a generated flexbox measure callback: how to re-measure it at a
+/// taffy-assigned size. See [`Expression::SolveFlexboxLayoutWithMeasure`].
+#[derive(Debug, Clone)]
+pub struct FlexboxMeasureCell {
+    pub kind: FlexboxMeasureCellKind,
+}
+
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum FlexboxMeasureCellKind {
+    /// A static cell, with its `LayoutInfo`-typed expressions reading the
+    /// `measure_known_h` / `measure_known_w` locals as their cross-axis
+    /// constraint.
+    Static { h_info: Expression, v_info: Expression },
+    /// A repeater: its instances are only known at run time, so the generated
+    /// callback queries the instance directly.
+    Repeated(LayoutRepeatedElement),
+}
+
 #[derive(Debug, Clone)]
 pub enum Expression {
     /// A string literal. The .0 is the content of the string, without the quotes
@@ -257,22 +276,22 @@ pub enum Expression {
     /// callback so the cross-axis size of height-for-width cells is recomputed
     /// at the width/height taffy actually assigns (rather than the cell's
     /// preferred size). `data` is the `FlexboxLayoutData`. For each static cell,
-    /// `measure_cells[i]` is `(h_info_given_known_h, v_info_given_known_w)`,
+    /// `measure_cells[i]` carries `(h_info_given_known_h, v_info_given_known_w)`,
     /// each a `LayoutInfo`-typed expression that reads
     /// `ReadLocalVariable("measure_known_w" / "measure_known_h")` (a `Float32`)
     /// as its cross-axis constraint. `default_cells[i]` is the cell's
     /// `(h_info, v_info)` at the default constraint (matching `data`'s cells);
     /// it provides the preferred size returned when taffy asks for a dimension
     /// without a known cross-axis size (mirroring the plain `solve_flexbox_layout`
-    /// measure). A repeater cell (the `Right` case) is measured by calling the
-    /// matching cross-axis accessor (`flexbox_layout_item_info_at_cross_width` or
-    /// `_at_cross_height`) on the instance taffy asks for.
+    /// measure). A repeater cell is measured by calling the matching cross-axis
+    /// accessor (`flexbox_layout_item_info_at_cross_width` or `_at_cross_height`)
+    /// on the instance taffy asks for.
     SolveFlexboxLayoutWithMeasure {
         /// The `FlexboxLayoutData` (built inline with the cell arrays, so its
         /// temporaries live for the duration of the solve call).
         data: Box<Expression>,
         repeater_indices: Box<Expression>,
-        measure_cells: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
+        measure_cells: Vec<FlexboxMeasureCell>,
         /// Only used when `cells_variables` is `None`; empty otherwise.
         default_cells: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
         /// Names of the flat `(cells_h, cells_v)` locals set up by the enclosing
@@ -621,9 +640,15 @@ macro_rules! visit_impl {
             } => {
                 $visitor(data);
                 $visitor(repeater_indices);
-                measure_cells.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
-                    $visitor(h);
-                    $visitor(v);
+                measure_cells.$iter().for_each(|x| {
+                    if let FlexboxMeasureCell {
+                        kind: FlexboxMeasureCellKind::Static { h_info, v_info },
+                        ..
+                    } = x
+                    {
+                        $visitor(h_info);
+                        $visitor(v_info);
+                    }
                 });
                 default_cells.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
                     $visitor(h);

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -14,6 +14,7 @@ use crate::langtype::{BuiltinStruct, EnumerationValue, Struct, Type};
 use crate::layout::{FlexboxAxisRelation, GridLayoutCell, Orientation, RowColExpr};
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
+use crate::llr::{FlexboxMeasureCell, FlexboxMeasureCellKind};
 use crate::namedreference::NamedReference;
 use crate::object_tree::ElementRc;
 
@@ -516,12 +517,12 @@ pub(super) fn solve_flexbox_layout(
 /// Per-element measure inputs for `SolveFlexboxLayoutWithMeasure`: the cell's
 /// `(h_info, v_info)` measured at the dimension taffy assigns, read from the
 /// `measure_known_w` / `measure_known_h` locals. A repeated element becomes a
-/// `Right`: its instances are only known at solve time, so the generated
-/// callback queries the instance directly.
+/// `FlexboxMeasureCellKind::Repeated`: its instances are only known at solve
+/// time, so the generated callback queries the instance directly.
 fn measure_cells_for(
     layout: &crate::layout::FlexboxLayout,
     ctx: &mut ExpressionLoweringCtx,
-) -> Vec<Either<(llr_Expression, llr_Expression), LayoutRepeatedElement>> {
+) -> Vec<FlexboxMeasureCell> {
     layout
         .elems
         .iter()
@@ -533,10 +534,12 @@ fn measure_cells_for(
                         LoweredElement::Repeated { repeated_index } => *repeated_index,
                         _ => panic!("repeated flexbox element not lowered as Repeated"),
                     };
-                return Either::Right(LayoutRepeatedElement {
-                    repeater_index,
-                    row_child_templates: None,
-                });
+                return FlexboxMeasureCell {
+                    kind: FlexboxMeasureCellKind::Repeated(LayoutRepeatedElement {
+                        repeater_index,
+                        row_child_templates: None,
+                    }),
+                };
             }
             let v_constraint = is_height_for_width_cell(elem).then(|| {
                 crate::expression_tree::Expression::ReadLocalVariable {
@@ -565,7 +568,7 @@ fn measure_cells_for(
                 Orientation::Horizontal,
                 h_constraint,
             );
-            Either::Left((h_info, v_info))
+            FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Static { h_info, v_info } }
         })
         .collect()
 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -6,7 +6,7 @@
 
 use crate::Value;
 use crate::eval::{EvalContext, eval_expression};
-use i_slint_compiler::llr::Expression;
+use i_slint_compiler::llr::{Expression, FlexboxMeasureCellKind};
 use i_slint_core::SharedVector;
 use i_slint_core::layout::{
     BoxLayoutData, FlexboxLayoutData, FlexboxLayoutItemInfo, GridLayoutData, GridLayoutInputData,
@@ -386,11 +386,11 @@ pub(crate) fn solve_flexbox_layout_with_measure(ctx: &mut EvalContext, expr: &Ex
     }
     let mut flat: Vec<FlatCell> = Vec::with_capacity(measure_cells.len());
     for item in measure_cells {
-        match item {
-            itertools::Either::Left((h_info, v_info)) => {
+        match &item.kind {
+            FlexboxMeasureCellKind::Static { h_info, v_info } => {
                 flat.push(FlatCell::Static(h_info, v_info))
             }
-            itertools::Either::Right(repeater) => {
+            FlexboxMeasureCellKind::Repeated(repeater) => {
                 if let Some(current) = ctx.current.as_ref() {
                     let rep = &current.repeaters[repeater.repeater_index];
                     rep.track_instance_changes();


### PR DESCRIPTION
Port measure_cells from Either<(Expression, Expression), LayoutRepeatedElement> to a FlexboxMeasureCell struct with a Static/Repeated kind enum. No behavior change; an upcoming change adds a per-cell flag to the struct.

Clippy: the size imbalance between the variants predates the port (a tuple of two Expressions vs. a repeater index), but only a named enum gets clippy's large_enum_variant lint; allow it like the compiler's other expression-sized enums do.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
