### PR TITLE
Throw an error when a callback is aliased with multiple declarations

### DIFF
--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -98,6 +98,10 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
     // collect all sets that are linked together
     let mut property_sets = PropertySets::default();
 
+    // Track how many distinct declarations alias into the same target
+    // target -> [aliases]
+    let mut callback_aliases: HashMap<NamedReference, Vec<NamedReference>> = HashMap::new();
+
     let mut process_element = |e: &ElementRc| {
         'bindings: for (name, binding) in e.borrow().real_bindings() {
             for twb in &binding.borrow().two_way_bindings {
@@ -114,7 +118,14 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
                         );
                         continue 'bindings;
                     }
-                    property_sets.add_link(NamedReference::new(e, name.clone()), property.clone());
+                    let source = NamedReference::new(e, name.clone());
+                    if matches!(source.ty(), Type::Callback(..)) {
+                        let bucket = callback_aliases.entry(property.clone()).or_default();
+                        if !bucket.contains(&source) {
+                            bucket.push(source.clone());
+                        }
+                    }
+                    property_sets.add_link(source, property.clone());
                 }
             }
         }
@@ -123,6 +134,43 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
     doc.visit_all_used_components(|component| {
         recurse_elem_including_sub_components(component, &(), &mut |e, &()| process_element(e))
     });
+
+    for (target, sources) in &callback_aliases {
+        if sources.len() < 2 {
+            continue;
+        }
+        // if a callback has an implementation, the rest are alternate names for invoking it
+        let has_implementation = property_sets.map.get(target).is_some_and(|set_rc| {
+            set_rc.borrow().iter().any(|nr| {
+                let elem = nr.element();
+                let elem = elem.borrow();
+                elem.binding(nr.name())
+                    .is_some_and(|b| !matches!(b.value_expression(), Expression::Invalid))
+            })
+        });
+        if has_implementation {
+            continue;
+        }
+        for nr in sources {
+            let other_names = sources
+                .iter()
+                .filter(|other| *other != nr)
+                .map(|other| format!("'{}'", other.name()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let elem = nr.element();
+            let elem = elem.borrow();
+            if let Some(b) = elem.binding(nr.name()) {
+                diag.push_error(
+                    format!(
+                        "Callback '{}' shares a handler slot with {other_names}, so only one of them can have an implementation",
+                        nr.name()
+                    ),
+                    &*b,
+                );
+            }
+        }
+    }
 
     // The key will be removed and replaced by the named reference
     let mut aliases_to_remove = Mapping::new();

--- a/internal/compiler/tests/syntax/lookup/callback_alias_multiple_names.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias_multiple_names.slint
@@ -1,0 +1,11 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Xxx inherits Window {
+    callback clicked-b <=> button.clicked;
+//                     >                <error{Callback 'clicked-b' shares a handler slot with 'clicked-a', so only one of them can have an implementation}
+    callback clicked-a <=> button.clicked;
+//                     >                <error{Callback 'clicked-a' shares a handler slot with 'clicked-b', so only one of them can have an implementation}
+
+    button := TouchArea {}
+}


### PR DESCRIPTION
Closes #3966 

Error when two callbacks alias to the same target as there could only be one handler at runtime. The check only fires when none of the aliased names has a real implementation.