### PR TITLE
Close an open menu when clicking its menu bar entry again

### DIFF
--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -1071,10 +1071,21 @@ impl ElementHandle {
         mock_drag_window(window_adapter.window(), self.absolute_center(), target, button);
     }
 
+    /// The center of the element in the coordinate system that input events are dispatched in.
+    /// Unlike [`Self::absolute_position()`] this includes the location of an enclosing popup that's
+    /// rendered inside the window, such as a menu.
     fn absolute_center(&self) -> LogicalPosition {
-        let item_pos = self.absolute_position();
-        let item_size = self.size();
-        LogicalPosition::new(item_pos.x + item_size.width / 2., item_pos.y + item_size.height / 2.)
+        let Some(item) = self.item.upgrade() else {
+            return Default::default();
+        };
+        let geometry = item.geometry();
+        let position = i_slint_core::lengths::logical_position_to_api(
+            item.map_to_native_window(geometry.origin),
+        );
+        LogicalPosition::new(
+            position.x + geometry.width() / 2.,
+            position.y + geometry.height() / 2.,
+        )
     }
 
     pub fn scroll(&self, delta_x: f32, delta_y: f32) {

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -32,6 +32,12 @@ pub enum MudaType {
 
 static MUDA_SET_EVENT_HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
 
+/// Returns true when `SLINT_NO_MUDA` is set, in which case the menu bar and the context menus
+/// are rendered by Slint. That's the only way to exercise these code paths on macOS and Windows.
+pub fn is_disabled() -> bool {
+    std::env::var_os("SLINT_NO_MUDA").is_some()
+}
+
 struct MudaPropertyTracker {
     window_adapter_weak: Weak<WinitWindowAdapter>,
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1606,9 +1606,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
 
     #[cfg(muda)]
     fn supports_native_menu_bar(&self) -> bool {
-        // Set SLINT_NO_NATIVE_MENUBAR to render the menu bar inside the window instead.
-        // That's the only way to exercise the non-native menu bar on macOS and Windows.
-        std::env::var_os("SLINT_NO_NATIVE_MENUBAR").is_none()
+        !crate::muda::is_disabled()
     }
 
     #[cfg(muda)]
@@ -1635,6 +1633,10 @@ impl WindowAdapterInternal for WinitWindowAdapter {
         context_menu_item: vtable::VRc<i_slint_core::menus::MenuVTable>,
         position: LogicalPosition,
     ) -> bool {
+        if crate::muda::is_disabled() {
+            return false;
+        }
+
         self.context_menu.replace(Some(context_menu_item));
 
         if let WinitWindowOrNone::HasWindow { context_menu_muda_adapter, .. } =

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1606,7 +1606,9 @@ impl WindowAdapterInternal for WinitWindowAdapter {
 
     #[cfg(muda)]
     fn supports_native_menu_bar(&self) -> bool {
-        true
+        // Set SLINT_NO_NATIVE_MENUBAR to render the menu bar inside the window instead.
+        // That's the only way to exercise the non-native menu bar on macOS and Windows.
+        std::env::var_os("SLINT_NO_NATIVE_MENUBAR").is_none()
     }
 
     #[cfg(muda)]

--- a/internal/compiler/widgets/common/menus.slint
+++ b/internal/compiler/widgets/common/menus.slint
@@ -168,9 +168,15 @@ export component MenuBarImpl {
             entry: entry;
 
             clicked => {
-                last-open-entry-index = idx;
-                context-menu.entries = root.sub-menu(entry);
-                context-menu.show({ x: e.x, y: root.height });
+                if last-open-entry-index == idx && context-menu.is-open() {
+                    // Clicking the entry whose menu is already open closes it again.
+                    last-open-entry-index = -1;
+                    context-menu.close();
+                } else {
+                    last-open-entry-index = idx;
+                    context-menu.entries = root.sub-menu(entry);
+                    context-menu.show({ x: e.x, y: root.height });
+                }
             }
             hovered => {
                 if last-open-entry-index != idx && context-menu.is-open() {

--- a/tests/cases/widgets/menubar.slint
+++ b/tests/cases/widgets/menubar.slint
@@ -82,7 +82,7 @@ export component TestCase inherits Window {
 
 /*
 ```rust
-use slint::{SharedString, platform::{Key}};
+use slint::{SharedString, platform::{Key, PointerEventButton}};
 let instance = TestCase::new().unwrap();
 assert!(instance.get_test());
 
@@ -133,15 +133,17 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"
 assert!(instance.get_checkable_menu_item_checked());
 
 instance.set_result("".into());
-// click on the file menu to open it, and again to close it
-slint_testing::send_mouse_click(&instance, 10., 16.);
-slint_testing::send_mouse_click(&instance, 10., 16.);
-// the menu is closed, so this click doesn't hit the first entry (new)
-slint_testing::send_mouse_click(&instance, 30., 49.);
-assert_eq!(instance.get_result(), "");
+let find_new = || slint_testing::ElementHandle::find_by_accessible_label(&instance, "New").next();
+let file_menu = slint_testing::ElementHandle::find_by_accessible_label(&instance, "File").next().unwrap();
+// click on the file menu to open it
+file_menu.mock_single_click(PointerEventButton::Left);
+assert!(find_new().is_some());
+// click on it again to close it
+file_menu.mock_single_click(PointerEventButton::Left);
+assert!(find_new().is_none());
 // the menu can be opened again
-slint_testing::send_mouse_click(&instance, 10., 16.);
-slint_testing::send_mouse_click(&instance, 30., 49.);
+file_menu.mock_single_click(PointerEventButton::Left);
+find_new().unwrap().mock_single_click(PointerEventButton::Left);
 assert_eq!(instance.get_result(), "New");
 ```
 
@@ -197,12 +199,12 @@ slint_testing::send_keyboard_string_sequence(&instance, "\n");
 assert(instance.get_checkable_menu_item_checked());
 
 instance.set_result("");
-// click on the file menu to open it, and again to close it
+// click on the file menu to open it
 slint_testing::send_mouse_click(&instance, 10., 16.);
+assert_eq(slint::testing::ElementHandle::find_by_accessible_label(handle, "New").size(), 1);
+// click on it again to close it
 slint_testing::send_mouse_click(&instance, 10., 16.);
-// the menu is closed, so this click doesn't hit the first entry (new)
-slint_testing::send_mouse_click(&instance, 30., 49.);
-assert_eq(instance.get_result(), "");
+assert_eq(slint::testing::ElementHandle::find_by_accessible_label(handle, "New").size(), 0);
 // the menu can be opened again
 slint_testing::send_mouse_click(&instance, 10., 16.);
 slint_testing::send_mouse_click(&instance, 30., 49.);

--- a/tests/cases/widgets/menubar.slint
+++ b/tests/cases/widgets/menubar.slint
@@ -199,12 +199,13 @@ slint_testing::send_keyboard_string_sequence(&instance, "\n");
 assert(instance.get_checkable_menu_item_checked());
 
 instance.set_result("");
-// click on the file menu to open it
+// click on the file menu to open it, and again to close it
+// (the element search API isn't used here, it doesn't work in live-preview mode)
 slint_testing::send_mouse_click(&instance, 10., 16.);
-assert_eq(slint::testing::ElementHandle::find_by_accessible_label(handle, "New").size(), 1);
-// click on it again to close it
 slint_testing::send_mouse_click(&instance, 10., 16.);
-assert_eq(slint::testing::ElementHandle::find_by_accessible_label(handle, "New").size(), 0);
+// the menu is closed, so this click doesn't hit the first entry (new)
+slint_testing::send_mouse_click(&instance, 30., 49.);
+assert_eq(instance.get_result(), "");
 // the menu can be opened again
 slint_testing::send_mouse_click(&instance, 10., 16.);
 slint_testing::send_mouse_click(&instance, 30., 49.);

--- a/tests/cases/widgets/menubar.slint
+++ b/tests/cases/widgets/menubar.slint
@@ -131,6 +131,18 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from("\n"));
 // verify that the checked menu item is checked
 assert!(instance.get_checkable_menu_item_checked());
+
+instance.set_result("".into());
+// click on the file menu to open it, and again to close it
+slint_testing::send_mouse_click(&instance, 10., 16.);
+slint_testing::send_mouse_click(&instance, 10., 16.);
+// the menu is closed, so this click doesn't hit the first entry (new)
+slint_testing::send_mouse_click(&instance, 30., 49.);
+assert_eq!(instance.get_result(), "");
+// the menu can be opened again
+slint_testing::send_mouse_click(&instance, 10., 16.);
+slint_testing::send_mouse_click(&instance, 30., 49.);
+assert_eq!(instance.get_result(), "New");
 ```
 
 ```cpp
@@ -184,6 +196,18 @@ slint_testing::send_keyboard_string_sequence(&instance, "\n");
 // verify that the checked menu item is checked
 assert(instance.get_checkable_menu_item_checked());
 
+instance.set_result("");
+// click on the file menu to open it, and again to close it
+slint_testing::send_mouse_click(&instance, 10., 16.);
+slint_testing::send_mouse_click(&instance, 10., 16.);
+// the menu is closed, so this click doesn't hit the first entry (new)
+slint_testing::send_mouse_click(&instance, 30., 49.);
+assert_eq(instance.get_result(), "");
+// the menu can be opened again
+slint_testing::send_mouse_click(&instance, 10., 16.);
+slint_testing::send_mouse_click(&instance, 30., 49.);
+assert_eq(instance.get_result(), "New");
+
 ```
 
 ```js
@@ -235,6 +259,18 @@ slintlib.private_api.send_keyboard_string_sequence(instance, "\u{F701}");
 slintlib.private_api.send_keyboard_string_sequence(instance, "\n");
 // verify that the checked menu item is checked
 assert(instance.checkable_menu_item_checked);
+
+instance.result = "";
+// click on the file menu to open it, and again to close it
+slintlib.private_api.send_mouse_click(instance, 10., 16.);
+slintlib.private_api.send_mouse_click(instance, 10., 16.);
+// the menu is closed, so this click doesn't hit the first entry (new)
+slintlib.private_api.send_mouse_click(instance, 30., 49.);
+assert.equal(instance.result, "");
+// the menu can be opened again
+slintlib.private_api.send_mouse_click(instance, 10., 16.);
+slintlib.private_api.send_mouse_click(instance, 30., 49.);
+assert.equal(instance.result, "New");
 ```
 
 */


### PR DESCRIPTION
The click that opens a menu bar entry's popup is dispatched to the menu
bar item before the popup's close-on-click-outside handling runs, so the
second click reopened the popup instead of leaving it closed. Track
whether the clicked entry is the one that's currently open and close it
in that case.

changelog: MenuBar: Clicking the entry of an open menu now closes it again

Fixes #12855

