### PR TITLE
Fix panic when instantiating a ContextMenuArea-derived component

### DIFF
--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -253,6 +253,22 @@ fn process_context_menu(
     components: &UsefulMenuComponents,
     diag: &mut BuildDiagnostics,
 ) -> bool {
+    // This pass runs before inlining, so a component inheriting ContextMenuArea is lowered
+    // through its own root element, the only one whose base_type is the builtin. Skip the
+    // elements instantiating such a component, however deep the inheritance chain.
+    if !matches!(&context_menu_elem.borrow().base_type, ElementType::Builtin(_)) {
+        // A Menu declared here would be dropped silently.
+        for c in &context_menu_elem.borrow().children {
+            if matches!(&c.borrow().base_type, ElementType::Builtin(b) if b.name == "Menu") {
+                diag.push_error(
+                    "Menu must be declared inside the component inheriting ContextMenuArea".into(),
+                    &*c.borrow(),
+                );
+            }
+        }
+        return false;
+    }
+
     let is_internal = matches!(&context_menu_elem.borrow().base_type, ElementType::Builtin(b) if b.name == "ContextMenuInternal");
 
     if is_internal && context_menu_elem.borrow().property_declarations.contains_key(ENTRIES) {

--- a/internal/compiler/tests/syntax/elements/contextmenu-subclass.slint
+++ b/internal/compiler/tests/syntax/elements/contextmenu-subclass.slint
@@ -1,0 +1,35 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A component inheriting ContextMenuArea used to panic the compiler (issue #12833)
+
+component Empty inherits ContextMenuArea { }
+//                       >              <error{ContextMenuArea should have a Menu}
+
+component Good inherits ContextMenuArea {
+    Menu {
+        MenuItem { title: "ok"; }
+    }
+}
+
+// Another level of inheritance: the Menu comes from the base of the base
+component Deep inherits Good { }
+
+// The Menu of the base was already lowered, so a further one can't be added
+component LateMenu inherits Good {
+    Menu { MenuItem { title: "nope"; } }
+//  >   <error{Menu must be declared inside the component inheriting ContextMenuArea}
+}
+
+export component A {
+    // The Menu missing in `Empty` is reported once, not at every instantiation
+    Empty { }
+    Empty { }
+    LateMenu { }
+    for _ in 3 : Deep { }
+    if true : Good { }
+    Good {
+        Menu { MenuItem { title: "nope"; } }
+//      >   <error{Menu must be declared inside the component inheriting ContextMenuArea}
+    }
+}

--- a/tests/cases/elements/contextmenu_subclass.slint
+++ b/tests/cases/elements/contextmenu_subclass.slint
@@ -1,0 +1,85 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Probe inherits ContextMenuArea {
+    in property <string> name;
+    in-out property <string> result;
+    Menu {
+        MenuItem {
+            title: "Entry " + root.name;
+            activated => { result += root.name; }
+        }
+    }
+}
+
+// Two levels of inheritance: the Menu comes from the base of the base.
+component DeepProbe inherits Probe {
+    Rectangle { background: yellow; }
+}
+
+export component TestCase inherits Window {
+    in-out property <string> result: probe.result + deep.result;
+    width: 700px;
+    height: 700px;
+    probe := Probe {
+        name: "P";
+        x: 0;
+        y: 0;
+        width: 300px;
+        height: 300px;
+    }
+    deep := DeepProbe {
+        name: "D";
+        x: 350px;
+        y: 0;
+        width: 300px;
+        height: 300px;
+    }
+
+    out property <bool> test: true;
+}
+
+/*
+```rust
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+// right click to open the menu of the derived component
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(15.0, 15.0), button: PointerEventButton::Right });
+// press on the entry
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(25.0, 25.0), button: PointerEventButton::Left });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(25.0, 25.0), button: PointerEventButton::Left });
+assert_eq!(instance.get_result(), "P");
+
+// same with the component that inherits the derived component
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(365.0, 15.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(365.0, 15.0), button: PointerEventButton::Right });
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(375.0, 25.0), button: PointerEventButton::Left });
+instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(375.0, 25.0), button: PointerEventButton::Left });
+assert_eq!(instance.get_result(), "PD");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+
+// right click to open the menu of the derived component
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({15.0, 15.0}), slint::PointerEventButton::Right);
+// press on the entry
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({25.0, 25.0}), slint::PointerEventButton::Left);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({25.0, 25.0}), slint::PointerEventButton::Left);
+assert_eq(instance.get_result(), "P");
+
+// same with the component that inherits the derived component
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({365.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({365.0, 15.0}), slint::PointerEventButton::Right);
+instance.window().dispatch_pointer_press_event(slint::LogicalPosition({375.0, 25.0}), slint::PointerEventButton::Left);
+instance.window().dispatch_pointer_release_event(slint::LogicalPosition({375.0, 25.0}), slint::PointerEventButton::Left);
+assert_eq(instance.get_result(), "PD");
+```
+*/


### PR DESCRIPTION
The lower_menus pass runs before inlining, but it selected the elements to process with builtin_type(), which resolves through a component base. An element instantiating a component that inherits ContextMenuArea therefore matched, and process_context_menu called as_builtin() on its still-Component base_type, which panics. The same hazard for SystemTrayIcon is already guarded a few lines above.

Only process elements whose base_type is directly the builtin. The derived component's own root element is that builtin and is visited separately by visit_all_used_components, so the lowering still happens exactly once.

A Menu written at the instantiation site rather than in the derived component can't be lowered by anyone, so reject it instead of silently dropping it.

Fixes #12833
