### PR TITLE
FlexboxLayout: resolve measure-callback defaults in core

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -229,10 +229,23 @@ inline SharedVector<float> solve_flexbox_layout(const cbindgen_private::FlexboxL
     return result;
 }
 
-// Like `solve_flexbox_layout`, but with a measure callback used for
-// height-for-width: `measure(index, known_w, known_h)` returns `{width,
-// height}`; an absent optional means "compute it". A negative value over the C
-// ABI denotes an absent dimension.
+// C thunk for the flexbox measure callbacks: unpack the type-erased functor
+// and forward. `measure(index, w, h, known_w, known_h)` returns `{width,
+// height}`; a dimension taffy has not determined (`known_* == false`) arrives
+// pre-resolved to the cell's preferred size.
+template<typename MeasureFn>
+inline void flexbox_measure_thunk(void *user_data, uintptr_t child_index, float width, float height,
+                                  bool known_width, bool known_height, float *out_width,
+                                  float *out_height)
+{
+    auto *f = reinterpret_cast<MeasureFn *>(user_data);
+    auto wh = (*f)(child_index, width, height, known_width, known_height);
+    *out_width = wh.first;
+    *out_height = wh.second;
+}
+
+// Like `solve_flexbox_layout`, but with a measure callback (see
+// `flexbox_measure_thunk`) used for height-for-width.
 template<typename MeasureFn>
 inline SharedVector<float>
 solve_flexbox_layout_with_measure(const cbindgen_private::FlexboxLayoutData &data,
@@ -241,19 +254,9 @@ solve_flexbox_layout_with_measure(const cbindgen_private::FlexboxLayoutData &dat
     SharedVector<float> result;
     cbindgen_private::Slice<uint32_t> ri =
             make_slice(reinterpret_cast<uint32_t *>(repeater_indices.ptr), repeater_indices.len);
-    auto thunk = [](void *user_data, uintptr_t child_index, float known_width, float known_height,
-                    float *out_width, float *out_height) {
-        auto *f = reinterpret_cast<MeasureFn *>(user_data);
-        auto wh = (*f)(
-                child_index,
-                known_width < 0 ? std::optional<float> {} : std::optional<float> { known_width },
-                known_height < 0 ? std::optional<float> {} : std::optional<float> { known_height });
-        *out_width = wh.first;
-        *out_height = wh.second;
-    };
-    cbindgen_private::slint_solve_flexbox_layout(&data, ri, &result,
-                                                 reinterpret_cast<const void *>(+thunk),
-                                                 reinterpret_cast<void *>(&measure));
+    cbindgen_private::slint_solve_flexbox_layout(
+            &data, ri, &result, reinterpret_cast<const void *>(&flexbox_measure_thunk<MeasureFn>),
+            reinterpret_cast<void *>(&measure));
     return result;
 }
 

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4667,149 +4667,12 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             sub_expression,
             ctx,
         ),
-        Expression::SolveFlexboxLayoutWithMeasure {
-            data,
-            repeater_indices,
-            measure_cells,
-            default_cells,
-            cells_variables,
-        } => {
+        Expression::SolveFlexboxLayoutWithMeasure { data, repeater_indices, measure_cells } => {
             let data = compile_expression(data, ctx);
             let repeater_indices = compile_expression(repeater_indices, ctx);
-            // cbindgen does not expose `LayoutInfo::preferred_bounded()`, so
-            // inline it: preferred_bounded = max(min(preferred, max), min).
-            const BOUNDED: &str = "std::max(std::min(li.preferred, li.max), li.min)";
-            // Without a repeater the cell index is known at compile time, so switch
-            // on it (O(1) dispatch). With a repeater the count is only known at
-            // runtime: walk the elements, advancing `cursor` by 1 per static cell
-            // and by the repeater's instance count per repeater, until `index`'s
-            // range is found.
-            let (v_body, h_body) = if cells_variables.is_none() {
-                let mut v_cases = String::new();
-                let mut h_cases = String::new();
-                for (i, item) in measure_cells.iter().enumerate() {
-                    if let llr::FlexboxMeasureCellKind::Static { h_info, v_info } = &item.kind {
-                        let v = compile_expression(v_info, ctx);
-                        let h = compile_expression(h_info, ctx);
-                        v_cases.push_str(&format!(
-                            "case {i}: {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n"
-                        ));
-                        h_cases.push_str(&format!(
-                            "case {i}: {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n"
-                        ));
-                    }
-                }
-                (
-                    format!("switch (index) {{\n{v_cases}default: break;\n}}\n"),
-                    format!("switch (index) {{\n{h_cases}default: break;\n}}\n"),
-                )
-            } else {
-                let mut v_steps = String::new();
-                let mut h_steps = String::new();
-                for item in measure_cells {
-                    match &item.kind {
-                        llr::FlexboxMeasureCellKind::Static { h_info, v_info } => {
-                            let v = compile_expression(v_info, ctx);
-                            let h = compile_expression(h_info, ctx);
-                            v_steps.push_str(&format!(
-                                "if (index == cursor) {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n\
-                                 cursor += 1;\n"
-                            ));
-                            h_steps.push_str(&format!(
-                                "if (index == cursor) {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n\
-                                 cursor += 1;\n"
-                            ));
-                        }
-                        llr::FlexboxMeasureCellKind::Repeated(repeater) => {
-                            let i = usize::from(repeater.repeater_index);
-                            v_steps.push_str(&format!(
-                                "{{ auto len = self->repeater_{i}.len(); \
-                                 if (index >= cursor && index < cursor + len) {{ \
-                                     if (auto *sub_comp = self->repeater_{i}.typed_instance_at(index - cursor)) {{ \
-                                         auto li = sub_comp->flexbox_layout_item_info_at_cross_width(w).constraint; \
-                                         return {{ w, {BOUNDED} }}; }} \
-                                     return {{ w, h }}; }} \
-                                 cursor += len; }}\n"
-                            ));
-                            h_steps.push_str(&format!(
-                                "{{ auto len = self->repeater_{i}.len(); \
-                                 if (index >= cursor && index < cursor + len) {{ \
-                                     if (auto *sub_comp = self->repeater_{i}.typed_instance_at(index - cursor)) {{ \
-                                         auto li = sub_comp->flexbox_layout_item_info_at_cross_height(h).constraint; \
-                                         return {{ {BOUNDED}, h }}; }} \
-                                     return {{ w, h }}; }} \
-                                 cursor += len; }}\n"
-                            ));
-                        }
-                    }
-                }
-                (
-                    format!("[[maybe_unused]] uintptr_t cursor = 0;\n{v_steps}"),
-                    format!("[[maybe_unused]] uintptr_t cursor = 0;\n{h_steps}"),
-                )
-            };
-            // Preferred size per cell, returned when taffy asks for a dimension
-            // without a known cross-axis size. With a repeater the cell count is
-            // only known at runtime, so read the flat cell arrays the enclosing
-            // `WithFlexboxLayoutItemInfo` built; otherwise inline the constants.
-            let (defaults_decl, default_w, default_h) = match cells_variables {
-                Some((cells_h, cells_v)) => {
-                    let (cells_h, cells_v) = (ident(cells_h), ident(cells_v));
-                    (
-                        String::new(),
-                        format!(
-                            "index < {cells_h}.len ? [&]{{ auto li = {cells_h}.ptr[index].constraint; return {BOUNDED}; }}() : 0.0f"
-                        ),
-                        format!(
-                            "index < {cells_v}.len ? [&]{{ auto li = {cells_v}.ptr[index].constraint; return {BOUNDED}; }}() : 0.0f"
-                        ),
-                    )
-                }
-                None => {
-                    let mut pref_w = String::new();
-                    let mut pref_h = String::new();
-                    for item in default_cells {
-                        if let Either::Left((h_info, v_info)) = item {
-                            let h = compile_expression(h_info, ctx);
-                            let v = compile_expression(v_info, ctx);
-                            pref_w.push_str(&format!(
-                                "[&]{{ auto li = {h}; return {BOUNDED}; }}(),\n"
-                            ));
-                            pref_h.push_str(&format!(
-                                "[&]{{ auto li = {v}; return {BOUNDED}; }}(),\n"
-                            ));
-                        }
-                    }
-                    (
-                        format!(
-                            "const float pref_w[] = {{ {pref_w} }};\n\
-                             const float pref_h[] = {{ {pref_h} }};\n\
-                             const size_t cell_count = sizeof(pref_w) / sizeof(float);\n"
-                        ),
-                        "index < cell_count ? pref_w[index] : 0.0f".to_owned(),
-                        "index < cell_count ? pref_h[index] : 0.0f".to_owned(),
-                    )
-                }
-            };
+            let lambda = generate_flexbox_measure_lambda(measure_cells, ctx);
             format!(
-                "slint::private_api::solve_flexbox_layout_with_measure({data}, {repeater_indices}, \
-                 [&](uintptr_t index, std::optional<float> known_w, std::optional<float> known_h) \
-                 -> std::pair<float, float> {{\n\
-                    {defaults_decl}\
-                    float w = known_w.value_or({default_w});\n\
-                    float h = known_h.value_or({default_h});\n\
-                    if (known_w.has_value() && !known_h.has_value()) {{\n\
-                        [[maybe_unused]] float measure_known_w = w;\n\
-                        {v_body}\
-                        return {{ w, h }};\n\
-                    }}\n\
-                    if (known_h.has_value() && !known_w.has_value()) {{\n\
-                        [[maybe_unused]] float measure_known_h = h;\n\
-                        {h_body}\
-                        return {{ w, h }};\n\
-                    }}\n\
-                    return {{ w, h }};\n\
-                 }})"
+                "slint::private_api::solve_flexbox_layout_with_measure({data}, {repeater_indices}, {lambda})"
             )
         }
         Expression::WithGridInputData {
@@ -5764,6 +5627,120 @@ fn generate_with_layout_item_info(
         "[&]{{ {ri} {rs} {push_code} slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{} = slint::private_api::make_slice(std::span(cells_vector)); return {}; }}()",
         ident(cells_variable),
         compile_expression(sub_expression, ctx)
+    )
+}
+
+/// Emit the measure-callback lambda for a
+/// `solve_flexbox_layout_with_measure` call. For each static cell,
+/// `measure_cells[i]` carries `(h_info_given_known_h, v_info_given_known_w)` —
+/// `LayoutInfo` expressions that read the `measure_known_w` /
+/// `measure_known_h` locals. taffy calls the callback with exactly one of
+/// width/height known (the cross axis), so we recompute that cell's
+/// perpendicular info at the assigned dimension.
+fn generate_flexbox_measure_lambda(
+    measure_cells: &[llr::FlexboxMeasureCell],
+    ctx: &EvaluationContext,
+) -> String {
+    // cbindgen does not expose `LayoutInfo::preferred_bounded()`, so
+    // inline it: preferred_bounded = max(min(preferred, max), min).
+    const BOUNDED: &str = "std::max(std::min(li.preferred, li.max), li.min)";
+    let has_repeater = measure_cells
+        .iter()
+        .any(|item| matches!(item.kind, llr::FlexboxMeasureCellKind::Repeated(_)));
+    // Without a repeater the cell index is known at compile time, so switch
+    // on it (O(1) dispatch). With a repeater the count is only known at
+    // runtime: walk the elements, advancing `cursor` by 1 per static cell
+    // and by the repeater's instance count per repeater, until `index`'s
+    // range is found.
+    let (v_body, h_body) = if !has_repeater {
+        let mut v_cases = String::new();
+        let mut h_cases = String::new();
+        for (i, item) in measure_cells.iter().enumerate() {
+            if let llr::FlexboxMeasureCellKind::Static { h_info, v_info } = &item.kind {
+                let v = compile_expression(v_info, ctx);
+                let h = compile_expression(h_info, ctx);
+                v_cases.push_str(&format!(
+                    "case {i}: {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n"
+                ));
+                h_cases.push_str(&format!(
+                    "case {i}: {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n"
+                ));
+            }
+        }
+        (
+            format!("switch (index) {{\n{v_cases}default: break;\n}}\n"),
+            format!("switch (index) {{\n{h_cases}default: break;\n}}\n"),
+        )
+    } else {
+        let mut v_steps = String::new();
+        let mut h_steps = String::new();
+        for item in measure_cells {
+            match &item.kind {
+                llr::FlexboxMeasureCellKind::Static { h_info, v_info } => {
+                    let v = compile_expression(v_info, ctx);
+                    let h = compile_expression(h_info, ctx);
+                    let v_step = format!(
+                        "if (index == cursor) {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n\
+                         cursor += 1;\n"
+                    );
+                    let h_step = format!(
+                        "if (index == cursor) {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n\
+                         cursor += 1;\n"
+                    );
+                    v_steps.push_str(&v_step);
+                    h_steps.push_str(&h_step);
+                }
+                llr::FlexboxMeasureCellKind::Repeated(repeater) => {
+                    let i = usize::from(repeater.repeater_index);
+                    let v_step = format!(
+                        "{{ auto len = self->repeater_{i}.len(); \
+                         if (index >= cursor && index < cursor + len) {{ \
+                             if (auto *sub_comp = self->repeater_{i}.typed_instance_at(index - cursor)) {{ \
+                                 auto li = sub_comp->flexbox_layout_item_info_at_cross_width(w).constraint; \
+                                 return {{ w, {BOUNDED} }}; }} \
+                             return {{ w, h }}; }} \
+                         cursor += len; }}\n"
+                    );
+                    let h_step = format!(
+                        "{{ auto len = self->repeater_{i}.len(); \
+                         if (index >= cursor && index < cursor + len) {{ \
+                             if (auto *sub_comp = self->repeater_{i}.typed_instance_at(index - cursor)) {{ \
+                                 auto li = sub_comp->flexbox_layout_item_info_at_cross_height(h).constraint; \
+                                 return {{ {BOUNDED}, h }}; }} \
+                             return {{ w, h }}; }} \
+                         cursor += len; }}\n"
+                    );
+                    v_steps.push_str(&v_step);
+                    h_steps.push_str(&h_step);
+                }
+            }
+        }
+        (
+            format!("[[maybe_unused]] uintptr_t cursor = 0;\n{v_steps}"),
+            format!("[[maybe_unused]] uintptr_t cursor = 0;\n{h_steps}"),
+        )
+    };
+    // A dimension taffy didn't assign (`known_* == false`) arrives pre-resolved
+    // to the cell's preferred size by resolve_measure_defaults in i-slint-core.
+    format!(
+        "[&](uintptr_t index, float w, float h, bool known_w, bool known_h) \
+         -> std::pair<float, float> {{\n\
+            if (known_w && known_h)\n\
+                return {{ w, h }};\n\
+            if (known_w) {{ // measure the height at the width w\n\
+                [[maybe_unused]] float measure_known_w = w;\n\
+                {v_body}\
+                return {{ w, h }};\n\
+            }}\n\
+            if (known_h) {{ // measure the width at the height h\n\
+                [[maybe_unused]] float measure_known_h = h;\n\
+                {h_body}\
+                return {{ w, h }};\n\
+            }}\n\
+            // Neither dimension known (degenerate cell probe): the\n\
+            // pre-resolved defaults.\n\
+            return {{ w, h }};\n\
+         }}"
     )
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3600,20 +3600,15 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             ctx,
         ),
 
-        Expression::SolveFlexboxLayoutWithMeasure {
-            data,
-            repeater_indices,
-            measure_cells,
-            default_cells,
-            cells_variables,
-        } => generate_solve_flexbox_layout_with_measure(
-            data,
-            repeater_indices,
-            measure_cells,
-            default_cells,
-            cells_variables.as_ref(),
-            ctx,
-        ),
+        Expression::SolveFlexboxLayoutWithMeasure { data, repeater_indices, measure_cells } => {
+            let data = compile_expression(data, ctx);
+            let repeater_indices = compile_expression(repeater_indices, ctx);
+            let closure = generate_flexbox_measure_closure(measure_cells, ctx);
+            quote! { {
+                #closure
+                sp::solve_flexbox_layout_with_measure(&#data, #repeater_indices, Some(&mut measure))
+            } }
+        }
 
         Expression::WithGridInputData {
             cells_variable,
@@ -5637,24 +5632,21 @@ fn generate_with_flexbox_layout_item_info(
     } }
 }
 
-/// Emit a `solve_flexbox_layout_with_measure` call with a generated measure
-/// callback. For each static cell, `measure_cells[i]` is
+/// Emit the measure callback for a `solve_flexbox_layout_with_measure` call,
+/// bound to a `measure` local. For each static cell, `measure_cells[i]` carries
 /// `(h_info_given_known_h, v_info_given_known_w)` — `LayoutInfo` expressions
-/// that read the `__measure_known_w` / `__measure_known_h` locals. taffy calls
+/// that read the `measure_known_w` / `measure_known_h` locals. taffy calls
 /// the callback with exactly one of width/height known (the cross axis), so we
 /// recompute that cell's perpendicular info at the assigned dimension.
-fn generate_solve_flexbox_layout_with_measure(
-    data: &Expression,
-    repeater_indices: &Expression,
+fn generate_flexbox_measure_closure(
     measure_cells: &[llr::FlexboxMeasureCell],
-    default_cells: &[Either<(Expression, Expression), llr::LayoutRepeatedElement>],
-    cells_variables: Option<&(SmolStr, SmolStr)>,
     ctx: &EvaluationContext,
 ) -> TokenStream {
-    let data = compile_expression(data, ctx);
-    let repeater_indices = compile_expression(repeater_indices, ctx);
     let known_w_ident = ident("measure_known_w");
     let known_h_ident = ident("measure_known_h");
+    let has_repeater = measure_cells
+        .iter()
+        .any(|item| matches!(item.kind, llr::FlexboxMeasureCellKind::Repeated(_)));
 
     // Height-for-width / width-for-height: recompute the perpendicular info at
     // the dimension taffy assigned. Without a repeater the cell index is known at
@@ -5662,7 +5654,7 @@ fn generate_solve_flexbox_layout_with_measure(
     // only known at runtime: walk the elements, advancing `cursor` by 1 per static
     // cell and by the repeater's instance count per repeater, until `index`'s range
     // is found.
-    let (v_body, h_body) = if cells_variables.is_none() {
+    let (v_body, h_body) = if !has_repeater {
         let mut v_arms = Vec::new();
         let mut h_arms = Vec::new();
         for (i, item) in measure_cells.iter().enumerate() {
@@ -5683,19 +5675,21 @@ fn generate_solve_flexbox_layout_with_measure(
                 llr::FlexboxMeasureCellKind::Static { h_info, v_info } => {
                     let v = compile_expression(v_info, ctx);
                     let h = compile_expression(h_info, ctx);
-                    v_steps.push(quote!(
+                    let v_step = quote!(
                         if index == cursor { return (w, ({ #v }).preferred_bounded()); }
                         cursor += 1;
-                    ));
-                    h_steps.push(quote!(
+                    );
+                    let h_step = quote!(
                         if index == cursor { return (({ #h }).preferred_bounded(), h); }
                         cursor += 1;
-                    ));
+                    );
+                    v_steps.push(v_step);
+                    h_steps.push(h_step);
                 }
                 llr::FlexboxMeasureCellKind::Repeated(repeater) => {
                     let repeater_id =
                         format_ident!("repeater{}", usize::from(repeater.repeater_index));
-                    v_steps.push(quote!(
+                    let v_step = quote!(
                         {
                             let len = _self.#repeater_id.len();
                             if index >= cursor && index < cursor + len {
@@ -5710,8 +5704,8 @@ fn generate_solve_flexbox_layout_with_measure(
                             }
                             cursor += len;
                         }
-                    ));
-                    h_steps.push(quote!(
+                    );
+                    let h_step = quote!(
                         {
                             let len = _self.#repeater_id.len();
                             if index >= cursor && index < cursor + len {
@@ -5726,7 +5720,9 @@ fn generate_solve_flexbox_layout_with_measure(
                             }
                             cursor += len;
                         }
-                    ));
+                    );
+                    v_steps.push(v_step);
+                    h_steps.push(h_step);
                 }
             }
         }
@@ -5738,65 +5734,30 @@ fn generate_solve_flexbox_layout_with_measure(
         )
     };
 
-    // Preferred size per cell, returned when taffy asks for a dimension without
-    // a known cross-axis size (mirrors the plain `solve_flexbox_layout` measure).
-    // With a repeater, read the flat cell arrays; otherwise inline the constants.
-    let (defaults_decl, default_w, default_h) = match cells_variables {
-        Some((cells_h, cells_v)) => {
-            let cells_h = ident(cells_h);
-            let cells_v = ident(cells_v);
-            (
-                quote!(
-                    let pref_h_cells = #cells_h.as_slice();
-                    let pref_v_cells = #cells_v.as_slice();
-                ),
-                quote!(pref_h_cells.get(index).map_or(0f32, |c| c.constraint.preferred_bounded())),
-                quote!(pref_v_cells.get(index).map_or(0f32, |c| c.constraint.preferred_bounded())),
-            )
-        }
-        None => {
-            let mut def_w = Vec::new();
-            let mut def_h = Vec::new();
-            for item in default_cells {
-                if let Either::Left((h_info, v_info)) = item {
-                    let h = compile_expression(h_info, ctx);
-                    let v = compile_expression(v_info, ctx);
-                    def_w.push(quote!(({ #h }).preferred_bounded(),));
-                    def_h.push(quote!(({ #v }).preferred_bounded(),));
+    // A dimension taffy didn't assign (`known_* == false`) arrives pre-resolved
+    // to the cell's preferred size by resolve_measure_defaults in i-slint-core.
+    quote! {
+        let mut measure = |index: usize, w: f32, h: f32, known_w: bool, known_h: bool| -> (f32, f32) {
+            match (known_w, known_h) {
+                (true, true) => (w, h),
+                (true, false) => {
+                    let #known_w_ident = w;
+                    let _ = #known_w_ident;
+                    #v_body
+                    (w, h)
                 }
+                (false, true) => {
+                    let #known_h_ident = h;
+                    let _ = #known_h_ident;
+                    #h_body
+                    (w, h)
+                }
+                // Neither dimension known (degenerate cell probe): the
+                // pre-resolved defaults.
+                (false, false) => (w, h),
             }
-            (
-                quote!(
-                    let pref_w: &[f32] = &[#(#def_w)*];
-                    let pref_h: &[f32] = &[#(#def_h)*];
-                ),
-                quote!(pref_w.get(index).copied().unwrap_or(0f32)),
-                quote!(pref_h.get(index).copied().unwrap_or(0f32)),
-            )
-        }
-    };
-
-    quote! { {
-        #defaults_decl
-        let mut measure = |index: usize, known_w: Option<f32>, known_h: Option<f32>| -> (f32, f32) {
-            let w = known_w.unwrap_or_else(|| #default_w);
-            let h = known_h.unwrap_or_else(|| #default_h);
-            if known_w.is_some() && known_h.is_none() {
-                let #known_w_ident = w;
-                let _ = #known_w_ident;
-                #v_body
-                return (w, h);
-            }
-            if known_h.is_some() && known_w.is_none() {
-                let #known_h_ident = h;
-                let _ = #known_h_ident;
-                #h_body
-                return (w, h);
-            }
-            (w, h)
         };
-        sp::solve_flexbox_layout_with_measure(&#data, #repeater_indices, Some(&mut measure))
-    } }
+    }
 }
 
 /// Access a field offset via `FIELD_OFFSETS.field()`. The `FIELD_OFFSETS`

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -279,28 +279,18 @@ pub enum Expression {
     /// `measure_cells[i]` carries `(h_info_given_known_h, v_info_given_known_w)`,
     /// each a `LayoutInfo`-typed expression that reads
     /// `ReadLocalVariable("measure_known_w" / "measure_known_h")` (a `Float32`)
-    /// as its cross-axis constraint. `default_cells[i]` is the cell's
-    /// `(h_info, v_info)` at the default constraint (matching `data`'s cells);
-    /// it provides the preferred size returned when taffy asks for a dimension
-    /// without a known cross-axis size (mirroring the plain `solve_flexbox_layout`
-    /// measure). A repeater cell is measured by calling the matching cross-axis
-    /// accessor (`flexbox_layout_item_info_at_cross_width` or `_at_cross_height`)
-    /// on the instance taffy asks for.
+    /// as its cross-axis constraint. A repeater cell is measured by calling
+    /// the matching cross-axis accessor
+    /// (`flexbox_layout_item_info_at_cross_width` or `_at_cross_height`) on the
+    /// instance taffy asks for; the callback maps taffy's flat cell index to it
+    /// with a runtime cursor, since a repeater expands to a runtime number of
+    /// cells.
     SolveFlexboxLayoutWithMeasure {
         /// The `FlexboxLayoutData` (built inline with the cell arrays, so its
         /// temporaries live for the duration of the solve call).
         data: Box<Expression>,
         repeater_indices: Box<Expression>,
         measure_cells: Vec<FlexboxMeasureCell>,
-        /// Only used when `cells_variables` is `None`; empty otherwise.
-        default_cells: Vec<Either<(Expression, Expression), LayoutRepeatedElement>>,
-        /// Names of the flat `(cells_h, cells_v)` locals set up by the enclosing
-        /// `WithFlexboxLayoutItemInfo`. `Some` exactly when the layout has a
-        /// repeater: a repeater expands to a runtime number of cells, so the
-        /// callback maps taffy's flat cell index to an element with a runtime
-        /// cursor, and takes per-cell defaults from these arrays instead of the
-        /// per-element `default_cells`.
-        cells_variables: Option<(SmolStr, SmolStr)>,
     },
     /// Will call the sub_expression, with the cells variable set to the
     /// array of GridLayoutInputData from the elements
@@ -631,13 +621,7 @@ macro_rules! visit_impl {
                     $visitor(f);
                 });
             }
-            Expression::SolveFlexboxLayoutWithMeasure {
-                data,
-                repeater_indices,
-                measure_cells,
-                default_cells,
-                cells_variables: _,
-            } => {
+            Expression::SolveFlexboxLayoutWithMeasure { data, repeater_indices, measure_cells } => {
                 $visitor(data);
                 $visitor(repeater_indices);
                 measure_cells.$iter().for_each(|x| {
@@ -649,10 +633,6 @@ macro_rules! visit_impl {
                         $visitor(h_info);
                         $visitor(v_info);
                     }
-                });
-                default_cells.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v)| {
-                    $visitor(h);
-                    $visitor(v);
                 });
             }
             Expression::WithGridInputData { elements, sub_expression, .. } => {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -427,16 +427,11 @@ pub(super) fn solve_flexbox_layout(
                 name: "repeated_indices".into(),
                 ty: Type::Array(Type::Int32.into()),
             };
-            // With a repeater, the cell defaults come from the flat cell arrays
-            // the enclosing `WithFlexboxLayoutItemInfo` just built, so no
-            // `default_cells`.
             let sub_expression = if needs_measure {
                 llr_Expression::SolveFlexboxLayoutWithMeasure {
                     data: Box::new(data),
                     repeater_indices: Box::new(repeated_indices()),
                     measure_cells: measure_cells_for(layout, ctx),
-                    default_cells: vec![],
-                    cells_variables: Some((cells_h_var.clone().into(), cells_v_var.clone().into())),
                 }
             } else {
                 llr_Expression::ExtraBuiltinFunctionCall {
@@ -463,52 +458,10 @@ pub(super) fn solve_flexbox_layout(
                     return_ty: Type::LayoutCache,
                 };
             }
-            // Preferred (default-constraint) info per cell, matching the cells
-            // carried by `data`. Returned by the measure callback when taffy
-            // asks for a dimension without a known cross-axis size, so the
-            // both-unknown case mirrors the plain `solve_flexbox_layout`.
-            let default_cells = layout
-                .elems
-                .iter()
-                .map(|li| {
-                    let elem = &li.item.element;
-                    let v_constraint = if is_height_for_width_cell(elem) {
-                        default_cross_axis_constraint(elem)
-                    } else {
-                        None
-                    };
-                    let v_info = get_flex_cell_layout_info(
-                        elem,
-                        ctx,
-                        &li.item.constraints,
-                        Orientation::Vertical,
-                        v_constraint,
-                    );
-                    let h_constraint =
-                        elem.borrow().inherited_layout_info_h_with_constraint().is_some().then(
-                            || {
-                                crate::expression_tree::Expression::NumberLiteral(
-                                    f32::MAX as f64,
-                                    crate::expression_tree::Unit::Px,
-                                )
-                            },
-                        );
-                    let h_info = get_flex_cell_layout_info(
-                        elem,
-                        ctx,
-                        &li.item.constraints,
-                        Orientation::Horizontal,
-                        h_constraint,
-                    );
-                    Either::Left((h_info, v_info))
-                })
-                .collect();
             llr_Expression::SolveFlexboxLayoutWithMeasure {
                 data: Box::new(data),
                 repeater_indices: Box::new(empty_int32_slice()),
                 measure_cells: measure_cells_for(layout, ctx),
-                default_cells,
-                cells_variables: None,
             }
         }
     }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1894,33 +1894,42 @@ impl<'a> FlexboxLayoutCacheGenerator<'a> {
 /// Measure callback for height-for-width items in a FlexboxLayout.
 ///
 /// Called by taffy during the flex solve for items that need dynamic sizing.
-/// Receives `(child_index, known_width, known_height)` where `known_width`/`known_height`
-/// are `Some` if taffy has already determined that dimension.
-/// Returns `(width, height)`.
+/// Receives `(child_index, width, height, known_width, known_height)` where
+/// `known_width`/`known_height` say whether taffy has already determined that
+/// dimension; a dimension it has not is pre-resolved to the cell's preferred
+/// size. Returns `(width, height)`.
 pub type FlexboxMeasureFn<'a> =
-    Option<&'a mut dyn FnMut(usize, Option<Coord>, Option<Coord>) -> (Coord, Coord)>;
+    Option<&'a mut dyn FnMut(usize, Coord, Coord, bool, bool) -> (Coord, Coord)>;
+
+/// Adapt a [`FlexboxMeasureFn`] to the taffy-facing closure: resolve the
+/// dimensions taffy did not supply to the cell's preferred size, so the
+/// callback always receives concrete sizes plus which ones were known.
+fn resolve_measure_defaults<'a>(
+    cells_h: &'a [LayoutItemInfo],
+    cells_v: &'a [LayoutItemInfo],
+    measure: &'a mut dyn FnMut(usize, Coord, Coord, bool, bool) -> (Coord, Coord),
+) -> impl FnMut(usize, Option<Coord>, Option<Coord>) -> (Coord, Coord) + 'a {
+    move |index, known_w, known_h| {
+        let w = known_w.unwrap_or_else(|| {
+            cells_h.get(index).map_or(0 as Coord, |c| c.constraint.preferred_bounded())
+        });
+        let h = known_h.unwrap_or_else(|| {
+            cells_v.get(index).map_or(0 as Coord, |c| c.constraint.preferred_bounded())
+        });
+        measure(index, w, h, known_w.is_some(), known_h.is_some())
+    }
+}
 
 pub fn solve_flexbox_layout(
     data: &FlexboxLayoutData,
     repeater_indices: Slice<u32>,
 ) -> SharedVector<Coord> {
-    // Build a simple measure callback from the pre-computed cells data.
-    // This enables height-for-width: taffy calls back with the actual
-    // assigned width, and we return the pre-computed height from cells_v.
-    // The cells_v heights were computed with the horizontal preferred size
-    // as constraint, which is a good approximation.
-    let mut measure = |child_index: usize,
-                       known_w: Option<Coord>,
-                       known_h: Option<Coord>|
-     -> (Coord, Coord) {
-        let w = known_w.unwrap_or_else(|| {
-            data.cells_h.get(child_index).map_or(0 as Coord, |c| c.constraint.preferred_bounded())
-        });
-        let h = known_h.unwrap_or_else(|| {
-            data.cells_v.get(child_index).map_or(0 as Coord, |c| c.constraint.preferred_bounded())
-        });
-        (w, h)
-    };
+    // The identity measure callback returns the sizes pre-resolved from the
+    // cells data. The compiler emits this plain entry point only for layouts
+    // without height-for-width cells, so the pre-computed height is correct
+    // for whatever width taffy assigns; layouts with h4w cells go through
+    // a real measure callback instead.
+    let mut measure = |_: usize, w: Coord, h: Coord, _: bool, _: bool| -> (Coord, Coord) { (w, h) };
     solve_flexbox_layout_with_measure(data, repeater_indices, Some(&mut measure))
 }
 
@@ -1979,7 +1988,8 @@ pub fn solve_flexbox_layout_with_measure(
         }
     };
 
-    builder.compute_layout(available_width, available_height, measure);
+    let mut measure = measure.map(|m| resolve_measure_defaults(&data.cells_h, &data.cells_v, m));
+    builder.compute_layout(available_width, available_height, measure.as_mut().map(|m| m as _));
 
     // Extract results using the cache generator to handle repeaters.
     // If `order` sorting was applied, we need to collect results by original index first,
@@ -2365,19 +2375,65 @@ pub(crate) mod ffi {
     }
 
     /// The measure callback for C FFI. Returns (width, height) via out pointers.
-    /// `known_width`/`known_height` are negative if not determined yet.
+    /// A dimension taffy has not determined (`known_* == false`) is pre-resolved
+    /// to the cell's preferred size.
     /// A null function pointer means no measure callback.
     pub type FlexboxMeasureFnC = unsafe extern "C" fn(
         user_data: *mut core::ffi::c_void,
         child_index: usize,
-        known_width: Coord,
-        known_height: Coord,
+        width: Coord,
+        height: Coord,
+        known_width: bool,
+        known_height: bool,
         out_width: *mut Coord,
         out_height: *mut Coord,
     );
 
+    /// Turn a C measure callback (nullable fn pointer + user data) into the
+    /// closure form used internally.
+    ///
+    /// # Safety
+    /// `measure_fn`, when non-null, must be a valid `FlexboxMeasureFnC`
+    /// function pointer, passed as `*const c_void` because cbindgen can't
+    /// represent `Option<fn pointer>` in C++.
+    unsafe fn measure_closure_from_c(
+        measure_fn: *const core::ffi::c_void,
+        measure_user_data: *mut core::ffi::c_void,
+    ) -> Option<impl FnMut(usize, Coord, Coord, bool, bool) -> (Coord, Coord)> {
+        const {
+            assert!(
+                core::mem::size_of::<*const core::ffi::c_void>()
+                    == core::mem::size_of::<FlexboxMeasureFnC>()
+            );
+        }
+        if measure_fn.is_null() {
+            return None;
+        }
+        let c_measure = unsafe {
+            core::mem::transmute::<*const core::ffi::c_void, FlexboxMeasureFnC>(measure_fn)
+        };
+        Some(move |child_index: usize, w: Coord, h: Coord, known_w: bool, known_h: bool| {
+            let mut out_w: Coord = 0 as _;
+            let mut out_h: Coord = 0 as _;
+            // Safety: c_measure is a valid function pointer provided by the caller,
+            // and out_w/out_h are valid mutable pointers.
+            unsafe {
+                c_measure(
+                    measure_user_data,
+                    child_index,
+                    w,
+                    h,
+                    known_w,
+                    known_h,
+                    &mut out_w,
+                    &mut out_h,
+                );
+            }
+            (out_w, out_h)
+        })
+    }
+
     #[unsafe(no_mangle)]
-    #[allow(unsafe_code)]
     pub extern "C" fn slint_solve_flexbox_layout(
         data: &FlexboxLayoutData,
         repeater_indices: Slice<u32>,
@@ -2385,42 +2441,10 @@ pub(crate) mod ffi {
         measure_fn: *const core::ffi::c_void,
         measure_user_data: *mut core::ffi::c_void,
     ) {
-        // Safety: measure_fn, when non-null, is a valid FlexboxMeasureFnC function pointer
-        // passed as *const c_void because cbindgen can't represent Option<fn pointer> in C++.
-        const {
-            assert!(
-                core::mem::size_of::<*const core::ffi::c_void>()
-                    == core::mem::size_of::<FlexboxMeasureFnC>()
-            );
-        }
-        let measure_fn: Option<FlexboxMeasureFnC> = if measure_fn.is_null() {
-            None
-        } else {
-            Some(unsafe {
-                core::mem::transmute::<*const core::ffi::c_void, FlexboxMeasureFnC>(measure_fn)
-            })
-        };
-        if let Some(c_measure) = measure_fn {
-            let mut measure = |child_index: usize,
-                               known_w: Option<Coord>,
-                               known_h: Option<Coord>|
-             -> (Coord, Coord) {
-                let mut out_w: Coord = 0 as _;
-                let mut out_h: Coord = 0 as _;
-                // Safety: c_measure is a valid function pointer provided by the caller,
-                // and out_w/out_h are valid mutable pointers.
-                unsafe {
-                    c_measure(
-                        measure_user_data,
-                        child_index,
-                        known_w.unwrap_or(-1 as _),
-                        known_h.unwrap_or(-1 as _),
-                        &mut out_w,
-                        &mut out_h,
-                    );
-                }
-                (out_w, out_h)
-            };
+        // Safety: the caller guarantees `measure_fn` is a valid `FlexboxMeasureFnC`
+        // when non-null (see `measure_closure_from_c`).
+        let measure = unsafe { measure_closure_from_c(measure_fn, measure_user_data) };
+        if let Some(mut measure) = measure {
             *result = super::solve_flexbox_layout_with_measure(
                 data,
                 repeater_indices,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1363,7 +1363,7 @@ fn with_grid_input_data(
     result
 }
 
-fn restore_local(ctx: &mut EvalContext, name: &str, prev: Option<Value>) {
+pub(crate) fn restore_local(ctx: &mut EvalContext, name: &str, prev: Option<Value>) {
     if let Some(prev) = prev {
         ctx.locals.insert(SmolStr::from(name), prev);
     } else {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -6,7 +6,7 @@
 
 use crate::Value;
 use crate::eval::{EvalContext, eval_expression};
-use i_slint_compiler::llr::{Expression, FlexboxMeasureCellKind};
+use i_slint_compiler::llr::{Expression, FlexboxMeasureCell, FlexboxMeasureCellKind};
 use i_slint_core::SharedVector;
 use i_slint_core::layout::{
     BoxLayoutData, FlexboxLayoutData, FlexboxLayoutItemInfo, GridLayoutData, GridLayoutInputData,
@@ -350,21 +350,112 @@ pub(crate) fn call_extra_builtin(
     }
 }
 
+fn eval_info(ctx: &mut EvalContext, e: &Expression) -> LayoutInfo {
+    eval_expression(ctx, e).try_into().unwrap_or_default()
+}
+
+/// One flexbox cell as seen by the measure callback, after expanding
+/// repeaters (a repeater contributes one entry per instance).
+struct FlatCell<'a> {
+    kind: FlatCellKind<'a>,
+}
+
+enum FlatCellKind<'a> {
+    Static { h_info: &'a Expression, v_info: &'a Expression },
+    Repeated(vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, crate::instance::Instance>),
+}
+
+/// Flatten `measure_cells` into one entry per taffy cell. Static cells carry
+/// their `(h_info, v_info)` expressions; a repeater expands to one instance
+/// per row (re-measured through its own item tree at the assigned cross size).
+fn flatten_measure_cells<'a>(
+    ctx: &mut EvalContext,
+    measure_cells: &'a [FlexboxMeasureCell],
+) -> Vec<FlatCell<'a>> {
+    let mut flat: Vec<FlatCell> = Vec::with_capacity(measure_cells.len());
+    for item in measure_cells {
+        match &item.kind {
+            FlexboxMeasureCellKind::Static { h_info, v_info } => {
+                flat.push(FlatCell { kind: FlatCellKind::Static { h_info, v_info } })
+            }
+            FlexboxMeasureCellKind::Repeated(repeater) => {
+                if let Some(current) = ctx.current.as_ref() {
+                    let rep = &current.repeaters[repeater.repeater_index];
+                    rep.track_instance_changes();
+                    flat.extend(
+                        rep.instances_vec()
+                            .into_iter()
+                            .map(|instance| FlatCell { kind: FlatCellKind::Repeated(instance) }),
+                    );
+                }
+            }
+        }
+    }
+    flat
+}
+
+/// Measure callback body shared by the solve and cross-axis-info paths:
+/// re-evaluate the cell's perpendicular layout info with the
+/// `measure_known_w` / `measure_known_h` local set to the dimension taffy
+/// assigned (a dimension it did not assign, `known_* == false`, arrives
+/// pre-resolved to the cell's preferred size).
+fn measure_flexbox_cell(
+    ctx: &mut EvalContext,
+    flat: &[FlatCell],
+    index: usize,
+    w: f32,
+    h: f32,
+    known_w: bool,
+    known_h: bool,
+) -> (f32, f32) {
+    let Some(cell) = flat.get(index) else { return (w, h) };
+    // measure the height at the width `w`
+    let measure_height = |ctx: &mut EvalContext| match &cell.kind {
+        FlatCellKind::Static { v_info, .. } => {
+            let prev = ctx.locals.insert("measure_known_w".into(), Value::Number(w as f64));
+            let info = eval_info(ctx, v_info);
+            crate::eval::restore_local(ctx, "measure_known_w", prev);
+            (w, info.preferred_bounded())
+        }
+        FlatCellKind::Repeated(instance) => (
+            w,
+            instance
+                .as_pin_ref()
+                .flexbox_layout_item_info_at_cross_width(w)
+                .constraint
+                .preferred_bounded(),
+        ),
+    };
+    // measure the width at the height `h`
+    let measure_width = |ctx: &mut EvalContext| match &cell.kind {
+        FlatCellKind::Static { h_info, .. } => {
+            let prev = ctx.locals.insert("measure_known_h".into(), Value::Number(h as f64));
+            let info = eval_info(ctx, h_info);
+            crate::eval::restore_local(ctx, "measure_known_h", prev);
+            (info.preferred_bounded(), h)
+        }
+        FlatCellKind::Repeated(instance) => (
+            instance
+                .as_pin_ref()
+                .flexbox_layout_item_info_at_cross_height(h)
+                .constraint
+                .preferred_bounded(),
+            h,
+        ),
+    };
+    match (known_w, known_h) {
+        (true, true) => (w, h),
+        (true, false) => measure_height(ctx),
+        (false, true) => measure_width(ctx),
+        // Neither dimension known (degenerate cell probe): the
+        // pre-resolved defaults.
+        (false, false) => (w, h),
+    }
+}
+
 /// Interpret [`Expression::SolveFlexboxLayoutWithMeasure`].
-///
-/// Taffy calls the measure callback with exactly one of width/height known
-/// (the cross axis); we then re-evaluate that cell's perpendicular layout
-/// info with the `measure_known_w` / `measure_known_h` local set to the
-/// assigned dimension. Cells without a known cross-axis size fall back to
-/// the `default_cells` preferred size.
 pub(crate) fn solve_flexbox_layout_with_measure(ctx: &mut EvalContext, expr: &Expression) -> Value {
-    let Expression::SolveFlexboxLayoutWithMeasure {
-        data,
-        repeater_indices,
-        measure_cells,
-        default_cells,
-        cells_variables,
-    } = expr
+    let Expression::SolveFlexboxLayoutWithMeasure { data, repeater_indices, measure_cells } = expr
     else {
         return Value::Void;
     };
@@ -377,90 +468,9 @@ pub(crate) fn solve_flexbox_layout_with_measure(ctx: &mut EvalContext, expr: &Ex
     );
     let fp = s.get_field("flex_props").map(to_flex_props).unwrap_or_default();
 
-    let eval_info = |ctx: &mut EvalContext, e: &Expression| -> LayoutInfo {
-        eval_expression(ctx, e).try_into().unwrap_or_default()
-    };
-
-    // Flatten `measure_cells` into one entry per taffy cell. Static cells carry
-    // their `(h_info, v_info)` expressions; a repeater expands to one instance
-    // per row (re-measured through its own item tree at the assigned cross size).
-    // When there is no repeater (`cells_variables` is `None`) this is exactly
-    // `measure_cells`, and the per-cell defaults come from `default_cells`;
-    // otherwise the defaults come from the flat `cells_h`/`cells_v` arrays.
-    enum FlatCell<'a> {
-        Static(&'a Expression, &'a Expression),
-        Repeated(vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, crate::instance::Instance>),
-    }
-    let mut flat: Vec<FlatCell> = Vec::with_capacity(measure_cells.len());
-    for item in measure_cells {
-        match &item.kind {
-            FlexboxMeasureCellKind::Static { h_info, v_info } => {
-                flat.push(FlatCell::Static(h_info, v_info))
-            }
-            FlexboxMeasureCellKind::Repeated(repeater) => {
-                if let Some(current) = ctx.current.as_ref() {
-                    let rep = &current.repeaters[repeater.repeater_index];
-                    rep.track_instance_changes();
-                    flat.extend(rep.instances_vec().into_iter().map(FlatCell::Repeated));
-                }
-            }
-        }
-    }
-
-    // Preferred (default-constraint) size per cell, used when taffy asks for a
-    // dimension without a known cross-axis size. With a repeater, read the flat
-    // cell arrays (which include the expanded instances); otherwise evaluate the
-    // per-element `default_cells`.
-    let (mut pref_w, mut pref_h) = (Vec::new(), Vec::new());
-    if cells_variables.is_some() {
-        pref_w.extend(ch.iter().map(|c| c.constraint.preferred_bounded()));
-        pref_h.extend(cv.iter().map(|c| c.constraint.preferred_bounded()));
-    } else {
-        for item in default_cells {
-            if let itertools::Either::Left((h_info, v_info)) = item {
-                pref_w.push(eval_info(ctx, h_info).preferred_bounded());
-                pref_h.push(eval_info(ctx, v_info).preferred_bounded());
-            }
-        }
-    }
-
-    let mut measure = |index: usize, known_w: Option<f32>, known_h: Option<f32>| -> (f32, f32) {
-        let w = known_w.unwrap_or_else(|| pref_w.get(index).copied().unwrap_or(0f32));
-        let h = known_h.unwrap_or_else(|| pref_h.get(index).copied().unwrap_or(0f32));
-        match (known_w.is_some() && known_h.is_none(), flat.get(index)) {
-            (true, Some(FlatCell::Static(_, v_info))) => {
-                ctx.locals.insert("measure_known_w".into(), Value::Number(w as f64));
-                return (w, eval_info(ctx, v_info).preferred_bounded());
-            }
-            (true, Some(FlatCell::Repeated(instance))) => {
-                let nh = instance
-                    .as_pin_ref()
-                    .flexbox_layout_item_info_at_cross_width(w)
-                    .constraint
-                    .preferred_bounded();
-                return (w, nh);
-            }
-            _ => {}
-        }
-        if known_h.is_some() && known_w.is_none() {
-            match flat.get(index) {
-                Some(FlatCell::Static(h_info, _)) => {
-                    ctx.locals.insert("measure_known_h".into(), Value::Number(h as f64));
-                    let nw = eval_info(ctx, h_info).preferred_bounded();
-                    return (nw, h);
-                }
-                Some(FlatCell::Repeated(instance)) => {
-                    let nw = instance
-                        .as_pin_ref()
-                        .flexbox_layout_item_info_at_cross_height(h)
-                        .constraint
-                        .preferred_bounded();
-                    return (nw, h);
-                }
-                _ => {}
-            }
-        }
-        (w, h)
+    let flat = flatten_measure_cells(ctx, measure_cells);
+    let mut measure = |index: usize, w: f32, h: f32, known_w: bool, known_h: bool| {
+        measure_flexbox_cell(ctx, &flat, index, w, h, known_w, known_h)
     };
 
     Value::LayoutCache(i_slint_core::layout::solve_flexbox_layout_with_measure(


### PR DESCRIPTION
This is step 2/3 for fixing ionuc's "too short autosized window due to nested flexboxlayouts" testcase.

taffy's measure callback must return a full (width, height), but taffy only passes the dimensions its current phase has determined: one (the usual height-for-width query), both, or none (content-size probe). For the missing dimensions the generated callbacks fell back to per-cell preferred sizes, obtained by evaluating dedicated default-size expressions (the LLR's default_cells) on every invocation — duplicating values the FlexboxLayoutData cells already carry.

solve_flexbox_layout_with_measure now fills in the missing dimensions itself from its cell slices (resolve_measure_defaults), and the callback receives concrete sizes plus known_w/known_h flags saying which ones taffy assigned. These are the values the repeater path always read; for static height-for-width cells the default v-constraint becomes the container-width override the cell arrays carry, observable only when taffy probes a degenerate zero-preferred height-for-width (or width-for-height) cell. Plain solve_flexbox_layout's hand-built default closure becomes the identity.

This deletes default_cells and cells_variables from the LLR (the generators derive repeater-ness from measure_cells; the flat cell locals still exist on WithFlexboxLayoutItemInfo — only the measure callback's copy of their names is gone), the generated default arrays, and the C FFI's negative-means-unknown encoding. The generated callback moves to generate_flexbox_measure_closure / _lambda helpers, and the interpreter's flattening and measure dispatch into module-level functions, so an upcoming change can reuse them for the layout-info path. The interpreter now restores the measure_known_w/h locals it sets, instead of leaking them into the context.
