### PR TITLE
FlexboxLayout: measure callback for the info path

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -294,6 +294,26 @@ flexbox_layout_info_cross_axis(cbindgen_private::Slice<cbindgen_private::LayoutI
             flex_wrap, constraint_size);
 }
 
+// Like `flexbox_layout_info_cross_axis`, but with a measure callback (see
+// `flexbox_measure_thunk`) so height-for-width cells are re-measured at the
+// size taffy assigns them.
+template<typename MeasureFn>
+inline cbindgen_private::LayoutInfo flexbox_layout_info_cross_axis_with_measure(
+        cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> cells_h,
+        cbindgen_private::Slice<cbindgen_private::LayoutItemInfo> cells_v,
+        cbindgen_private::Slice<cbindgen_private::FlexItemProps> flex_props, float spacing_h,
+        float spacing_v, const cbindgen_private::Padding &padding_h,
+        const cbindgen_private::Padding &padding_v,
+        cbindgen_private::FlexboxLayoutDirection direction,
+        cbindgen_private::FlexboxLayoutWrap flex_wrap, float constraint_size, MeasureFn measure)
+{
+    return cbindgen_private::slint_flexbox_layout_info_cross_axis_with_measure(
+            cells_h, cells_v, flex_props, spacing_h, spacing_v, &padding_h, &padding_v, direction,
+            flex_wrap, constraint_size,
+            reinterpret_cast<const void *>(&flexbox_measure_thunk<MeasureFn>),
+            reinterpret_cast<void *>(&measure));
+}
+
 /// Access the layout cache of an item within a repeater (standard cache)
 template<typename T>
 inline T layout_cache_access(const SharedVector<T> &cache, int offset, int repeater_index,

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4675,6 +4675,14 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 "slint::private_api::solve_flexbox_layout_with_measure({data}, {repeater_indices}, {lambda})"
             )
         }
+        Expression::FlexboxLayoutInfoCrossAxisWithMeasure { arguments, measure_cells } => {
+            let mut a = arguments.iter().map(|a| compile_expression(a, ctx));
+            let lambda = generate_flexbox_measure_lambda(measure_cells, ctx);
+            format!(
+                "slint::private_api::flexbox_layout_info_cross_axis_with_measure({}, {lambda})",
+                a.join(",")
+            )
+        }
         Expression::WithGridInputData {
             cells_variable,
             repeater_indices_var_name,
@@ -5630,13 +5638,17 @@ fn generate_with_layout_item_info(
     )
 }
 
-/// Emit the measure-callback lambda for a
-/// `solve_flexbox_layout_with_measure` call. For each static cell,
+/// Emit the measure-callback lambda shared by
+/// `solve_flexbox_layout_with_measure` and
+/// `flexbox_layout_info_cross_axis_with_measure` calls. For each static cell,
 /// `measure_cells[i]` carries `(h_info_given_known_h, v_info_given_known_w)` —
 /// `LayoutInfo` expressions that read the `measure_known_w` /
-/// `measure_known_h` locals. taffy calls the callback with exactly one of
+/// `measure_known_h` locals. taffy calls the callback with at most one of
 /// width/height known (the cross axis), so we recompute that cell's
-/// perpendicular info at the assigned dimension.
+/// perpendicular info at the assigned dimension. A call with neither dimension
+/// known is a content-size probe (see `FlexboxMeasureFn` in i-slint-core): it
+/// measures the free axis at the default size — the horizontal axis for a
+/// width-for-height-only cell, the vertical one otherwise.
 fn generate_flexbox_measure_lambda(
     measure_cells: &[llr::FlexboxMeasureCell],
     ctx: &EvaluationContext,
@@ -5652,28 +5664,30 @@ fn generate_flexbox_measure_lambda(
     // runtime: walk the elements, advancing `cursor` by 1 per static cell
     // and by the repeater's instance count per repeater, until `index`'s
     // range is found.
-    let (v_body, h_body) = if !has_repeater {
+    let (v_body, h_body, probe_body) = if !has_repeater {
         let mut v_cases = String::new();
         let mut h_cases = String::new();
+        let mut probe_cases = String::new();
         for (i, item) in measure_cells.iter().enumerate() {
             if let llr::FlexboxMeasureCellKind::Static { h_info, v_info } = &item.kind {
                 let v = compile_expression(v_info, ctx);
                 let h = compile_expression(h_info, ctx);
-                v_cases.push_str(&format!(
-                    "case {i}: {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n"
-                ));
-                h_cases.push_str(&format!(
-                    "case {i}: {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n"
-                ));
+                let v_case = format!("case {i}: {{ auto li = {v}; return {{ w, {BOUNDED} }}; }}\n");
+                let h_case = format!("case {i}: {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n");
+                probe_cases.push_str(if item.w4h_only { &h_case } else { &v_case });
+                v_cases.push_str(&v_case);
+                h_cases.push_str(&h_case);
             }
         }
         (
             format!("switch (index) {{\n{v_cases}default: break;\n}}\n"),
             format!("switch (index) {{\n{h_cases}default: break;\n}}\n"),
+            format!("switch (index) {{\n{probe_cases}default: break;\n}}\n"),
         )
     } else {
         let mut v_steps = String::new();
         let mut h_steps = String::new();
+        let mut probe_steps = String::new();
         for item in measure_cells {
             match &item.kind {
                 llr::FlexboxMeasureCellKind::Static { h_info, v_info } => {
@@ -5687,6 +5701,7 @@ fn generate_flexbox_measure_lambda(
                         "if (index == cursor) {{ auto li = {h}; return {{ {BOUNDED}, h }}; }}\n\
                          cursor += 1;\n"
                     );
+                    probe_steps.push_str(if item.w4h_only { &h_step } else { &v_step });
                     v_steps.push_str(&v_step);
                     h_steps.push_str(&h_step);
                 }
@@ -5710,6 +5725,7 @@ fn generate_flexbox_measure_lambda(
                              return {{ w, h }}; }} \
                          cursor += len; }}\n"
                     );
+                    probe_steps.push_str(if item.w4h_only { &h_step } else { &v_step });
                     v_steps.push_str(&v_step);
                     h_steps.push_str(&h_step);
                 }
@@ -5718,6 +5734,7 @@ fn generate_flexbox_measure_lambda(
         (
             format!("[[maybe_unused]] uintptr_t cursor = 0;\n{v_steps}"),
             format!("[[maybe_unused]] uintptr_t cursor = 0;\n{h_steps}"),
+            format!("[[maybe_unused]] uintptr_t cursor = 0;\n{probe_steps}"),
         )
     };
     // A dimension taffy didn't assign (`known_* == false`) arrives pre-resolved
@@ -5737,8 +5754,11 @@ fn generate_flexbox_measure_lambda(
                 {h_body}\
                 return {{ w, h }};\n\
             }}\n\
-            // Neither dimension known (degenerate cell probe): the\n\
-            // pre-resolved defaults.\n\
+            // Content-size probe: measure the free axis at the default size, so\n\
+            // the returned pair is self-consistent.\n\
+            [[maybe_unused]] float measure_known_w = w;\n\
+            [[maybe_unused]] float measure_known_h = h;\n\
+            {probe_body}\
             return {{ w, h }};\n\
          }}"
     )

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3610,6 +3610,15 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             } }
         }
 
+        Expression::FlexboxLayoutInfoCrossAxisWithMeasure { arguments, measure_cells } => {
+            let a = compile_builtin_arguments(arguments, ctx);
+            let closure = generate_flexbox_measure_closure(measure_cells, ctx);
+            quote! { {
+                #closure
+                sp::flexbox_layout_info_cross_axis_with_measure(#(#a as _,)* Some(&mut measure))
+            } }
+        }
+
         Expression::WithGridInputData {
             cells_variable,
             repeater_indices_var_name,
@@ -3810,16 +3819,27 @@ fn compile_item_member_function_call(expr: &Expression, ctx: &EvaluationContext)
     fun.map_or_default(|fun| quote!(#fun(#window_adapter_tokens, #item_rc)))
 }
 
+/// Compile builtin-call arguments: structs are passed by reference.
+fn compile_builtin_arguments(
+    arguments: &[Expression],
+    ctx: &EvaluationContext,
+) -> Vec<TokenStream> {
+    arguments
+        .iter()
+        .map(|a| {
+            let arg = compile_expression(a, ctx);
+            if matches!(a.ty(ctx), Type::Struct { .. }) { quote!(&#arg) } else { arg }
+        })
+        .collect()
+}
+
 #[inline(never)]
 fn compile_extra_builtin_function_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
     let Expression::ExtraBuiltinFunctionCall { function, arguments, return_ty: _ } = expr else {
         unreachable!()
     };
     let f = ident(function);
-    let a = arguments.iter().map(|a| {
-        let arg = compile_expression(a, ctx);
-        if matches!(a.ty(ctx), Type::Struct { .. }) { quote!(&#arg) } else { arg }
-    });
+    let a = compile_builtin_arguments(arguments, ctx);
     quote! { sp::#f(#(#a as _),*) }
 }
 
@@ -5632,12 +5652,17 @@ fn generate_with_flexbox_layout_item_info(
     } }
 }
 
-/// Emit the measure callback for a `solve_flexbox_layout_with_measure` call,
-/// bound to a `measure` local. For each static cell, `measure_cells[i]` carries
+/// Emit the measure callback shared by `solve_flexbox_layout_with_measure` and
+/// `flexbox_layout_info_cross_axis_with_measure` calls, bound to a `measure`
+/// local. For each static cell, `measure_cells[i]` carries
 /// `(h_info_given_known_h, v_info_given_known_w)` — `LayoutInfo` expressions
 /// that read the `measure_known_w` / `measure_known_h` locals. taffy calls
-/// the callback with exactly one of width/height known (the cross axis), so we
-/// recompute that cell's perpendicular info at the assigned dimension.
+/// the callback with at most one of width/height known (the cross axis), so we
+/// recompute that cell's perpendicular info at the assigned dimension. A call
+/// with neither dimension known is a content-size probe (see `FlexboxMeasureFn`
+/// in i-slint-core): it measures the free axis at the default size — the
+/// horizontal axis for a width-for-height-only cell, the vertical one
+/// otherwise.
 fn generate_flexbox_measure_closure(
     measure_cells: &[llr::FlexboxMeasureCell],
     ctx: &EvaluationContext,
@@ -5654,22 +5679,31 @@ fn generate_flexbox_measure_closure(
     // only known at runtime: walk the elements, advancing `cursor` by 1 per static
     // cell and by the repeater's instance count per repeater, until `index`'s range
     // is found.
-    let (v_body, h_body) = if !has_repeater {
+    let (v_body, h_body, probe_body) = if !has_repeater {
         let mut v_arms = Vec::new();
         let mut h_arms = Vec::new();
+        let mut probe_arms = Vec::new();
         for (i, item) in measure_cells.iter().enumerate() {
             if let llr::FlexboxMeasureCellKind::Static { h_info, v_info } = &item.kind {
                 let idx = proc_macro2::Literal::usize_unsuffixed(i);
                 let v = compile_expression(v_info, ctx);
                 let h = compile_expression(h_info, ctx);
-                v_arms.push(quote!(#idx => return (w, ({ #v }).preferred_bounded()),));
-                h_arms.push(quote!(#idx => return (({ #h }).preferred_bounded(), h),));
+                let v_arm = quote!(#idx => return (w, ({ #v }).preferred_bounded()),);
+                let h_arm = quote!(#idx => return (({ #h }).preferred_bounded(), h),);
+                probe_arms.push(if item.w4h_only { h_arm.clone() } else { v_arm.clone() });
+                v_arms.push(v_arm);
+                h_arms.push(h_arm);
             }
         }
-        (quote!(match index { #(#v_arms)* _ => {} }), quote!(match index { #(#h_arms)* _ => {} }))
+        (
+            quote!(match index { #(#v_arms)* _ => {} }),
+            quote!(match index { #(#h_arms)* _ => {} }),
+            quote!(match index { #(#probe_arms)* _ => {} }),
+        )
     } else {
         let mut v_steps = Vec::new();
         let mut h_steps = Vec::new();
+        let mut probe_steps = Vec::new();
         for item in measure_cells {
             match &item.kind {
                 llr::FlexboxMeasureCellKind::Static { h_info, v_info } => {
@@ -5683,6 +5717,7 @@ fn generate_flexbox_measure_closure(
                         if index == cursor { return (({ #h }).preferred_bounded(), h); }
                         cursor += 1;
                     );
+                    probe_steps.push(if item.w4h_only { h_step.clone() } else { v_step.clone() });
                     v_steps.push(v_step);
                     h_steps.push(h_step);
                 }
@@ -5721,6 +5756,7 @@ fn generate_flexbox_measure_closure(
                             cursor += len;
                         }
                     );
+                    probe_steps.push(if item.w4h_only { h_step.clone() } else { v_step.clone() });
                     v_steps.push(v_step);
                     h_steps.push(h_step);
                 }
@@ -5731,6 +5767,7 @@ fn generate_flexbox_measure_closure(
         (
             quote!(let mut cursor = 0usize; #(#v_steps)* let _ = cursor;),
             quote!(let mut cursor = 0usize; #(#h_steps)* let _ = cursor;),
+            quote!(let mut cursor = 0usize; #(#probe_steps)* let _ = cursor;),
         )
     };
 
@@ -5752,9 +5789,14 @@ fn generate_flexbox_measure_closure(
                     #h_body
                     (w, h)
                 }
-                // Neither dimension known (degenerate cell probe): the
-                // pre-resolved defaults.
-                (false, false) => (w, h),
+                (false, false) => {
+                    let #known_w_ident = w;
+                    let _ = #known_w_ident;
+                    let #known_h_ident = h;
+                    let _ = #known_h_ident;
+                    #probe_body
+                    (w, h)
+                }
             }
         };
     }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -28,6 +28,11 @@ pub use crate::expression_tree::MouseCursorInner;
 #[derive(Debug, Clone)]
 pub struct FlexboxMeasureCell {
     pub kind: FlexboxMeasureCellKind,
+    /// The cell is width-for-height only: a probe with neither dimension known
+    /// measures its horizontal axis at the default height (any other cell
+    /// measures its vertical axis at the default width), keeping the probe
+    /// result self-consistent (see `FlexboxMeasureFn` in i-slint-core).
+    pub w4h_only: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -292,6 +297,17 @@ pub enum Expression {
         repeater_indices: Box<Expression>,
         measure_cells: Vec<FlexboxMeasureCell>,
     },
+    /// Calls `flexbox_layout_info_cross_axis_with_measure` with the same
+    /// generated measure callback as [`Self::SolveFlexboxLayoutWithMeasure`],
+    /// so height-for-width cells are measured at the main-axis size taffy
+    /// assigns them rather than at the container size the cells in `arguments`
+    /// were pre-measured at.
+    FlexboxLayoutInfoCrossAxisWithMeasure {
+        /// The arguments of `flexbox_layout_info_cross_axis` (without the
+        /// trailing measure callback).
+        arguments: Vec<Expression>,
+        measure_cells: Vec<FlexboxMeasureCell>,
+    },
     /// Will call the sub_expression, with the cells variable set to the
     /// array of GridLayoutInputData from the elements
     WithGridInputData {
@@ -480,6 +496,9 @@ impl Expression {
             Self::WithLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
             Self::WithFlexboxLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
             Self::SolveFlexboxLayoutWithMeasure { .. } => Type::LayoutCache,
+            Self::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => {
+                crate::typeregister::layout_info_type().into()
+            }
             Self::WithGridInputData { sub_expression, .. } => sub_expression.ty(ctx),
             Self::MinMax { ty, .. } => ty.clone(),
             Self::EmptyComponentFactory => Type::ComponentFactory,
@@ -624,6 +643,19 @@ macro_rules! visit_impl {
             Expression::SolveFlexboxLayoutWithMeasure { data, repeater_indices, measure_cells } => {
                 $visitor(data);
                 $visitor(repeater_indices);
+                measure_cells.$iter().for_each(|x| {
+                    if let FlexboxMeasureCell {
+                        kind: FlexboxMeasureCellKind::Static { h_info, v_info },
+                        ..
+                    } = x
+                    {
+                        $visitor(h_info);
+                        $visitor(v_info);
+                    }
+                });
+            }
+            Expression::FlexboxLayoutInfoCrossAxisWithMeasure { arguments, measure_cells } => {
+                arguments.$iter().for_each(&mut $visitor);
                 measure_cells.$iter().for_each(|x| {
                     if let FlexboxMeasureCell {
                         kind: FlexboxMeasureCellKind::Static { h_info, v_info },

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -416,11 +416,7 @@ pub(super) fn solve_flexbox_layout(
         .map(|e| Box::new(super::lower_expression::lower_expression(e, ctx)));
     // Only height-for-width-capable cells benefit from re-measuring;
     // a flexbox without any keeps the cheaper plain solve.
-    let needs_measure = layout.elems.iter().any(|li| {
-        let elem = &li.item.element;
-        is_height_for_width_cell(elem)
-            || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
-    });
+    let needs_measure = flexbox_needs_measure(layout);
     match fld.compute_cells {
         Some((cells_h_var, cells_v_var, flex_var, elements)) => {
             let repeated_indices = || llr_Expression::ReadLocalVariable {
@@ -467,9 +463,20 @@ pub(super) fn solve_flexbox_layout(
     }
 }
 
-/// Per-element measure inputs for `SolveFlexboxLayoutWithMeasure`: the cell's
-/// `(h_info, v_info)` measured at the dimension taffy assigns, read from the
-/// `measure_known_w` / `measure_known_h` locals. A repeated element becomes a
+/// Whether any cell of the flexbox is height-for-width (or width-for-height)
+/// capable, so a solve or cross-axis info computation needs a measure callback.
+fn flexbox_needs_measure(layout: &crate::layout::FlexboxLayout) -> bool {
+    layout.elems.iter().any(|li| {
+        let elem = &li.item.element;
+        is_height_for_width_cell(elem)
+            || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
+    })
+}
+
+/// Per-element measure inputs for `SolveFlexboxLayoutWithMeasure` and
+/// `FlexboxLayoutInfoCrossAxisWithMeasure`: the cell's `(h_info, v_info)`
+/// measured at the dimension taffy assigns, read from the `measure_known_w` /
+/// `measure_known_h` locals. A repeated element becomes a
 /// `FlexboxMeasureCellKind::Repeated`: its instances are only known at solve
 /// time, so the generated callback queries the instance directly.
 fn measure_cells_for(
@@ -481,6 +488,16 @@ fn measure_cells_for(
         .iter()
         .map(|li| {
             let elem = &li.item.element;
+            // A width-for-height-only cell probes its horizontal axis; mirror
+            // the element the measure will actually query (the repeated
+            // component's root for a repeater).
+            let query_elem = if elem.borrow().repeated.is_some() {
+                elem.borrow().base_type.as_component().root_element.clone()
+            } else {
+                elem.clone()
+            };
+            let w4h_only = query_elem.borrow().inherited_layout_info_h_with_constraint().is_some()
+                && query_elem.borrow().inherited_layout_info_v_with_constraint().is_none();
             if elem.borrow().repeated.is_some() {
                 let repeater_index =
                     match ctx.mapping.element_mapping.get(&elem.clone().into()).unwrap() {
@@ -492,6 +509,7 @@ fn measure_cells_for(
                         repeater_index,
                         row_child_templates: None,
                     }),
+                    w4h_only,
                 };
             }
             let v_constraint = is_height_for_width_cell(elem).then(|| {
@@ -521,7 +539,7 @@ fn measure_cells_for(
                 Orientation::Horizontal,
                 h_constraint,
             );
-            FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Static { h_info, v_info } }
+            FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Static { h_info, v_info }, w4h_only }
         })
         .collect()
 }
@@ -659,6 +677,23 @@ fn compute_flexbox_layout_info_for_direction(
             constraint_size,
         ];
 
+        // Re-measure height-for-width cells at the main-axis size taffy
+        // assigns them, not at the container size the cells in `arguments`
+        // were pre-measured at: e.g. a nested wrapping flexbox laid out at
+        // its preferred width can be taller than when given the full
+        // container width.
+        let sub_expression = if flexbox_needs_measure(layout) {
+            llr_Expression::FlexboxLayoutInfoCrossAxisWithMeasure {
+                arguments,
+                measure_cells: measure_cells_for(layout, ctx),
+            }
+        } else {
+            llr_Expression::ExtraBuiltinFunctionCall {
+                function: "flexbox_layout_info_cross_axis".into(),
+                arguments,
+                return_ty: crate::typeregister::layout_info_type().into(),
+            }
+        };
         match fld.compute_cells {
             Some((cells_h_var, cells_v_var, flex_var, elements)) => {
                 llr_Expression::WithFlexboxLayoutItemInfo {
@@ -669,18 +704,10 @@ fn compute_flexbox_layout_info_for_direction(
                     elements,
                     // Info computation, not a solve: no container width to forward.
                     repeated_cross_width: None,
-                    sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
-                        function: "flexbox_layout_info_cross_axis".into(),
-                        arguments,
-                        return_ty: crate::typeregister::layout_info_type().into(),
-                    }),
+                    sub_expression: Box::new(sub_expression),
                 }
             }
-            None => llr_Expression::ExtraBuiltinFunctionCall {
-                function: "flexbox_layout_info_cross_axis".into(),
-                arguments,
-                return_ty: crate::typeregister::layout_info_type().into(),
-            },
+            None => sub_expression,
         }
     } else {
         // Main axis: only needs same-axis cells, avoiding cross-axis binding loop.

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -74,6 +74,7 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::WithLayoutItemInfo { .. } => return isize::MAX,
         Expression::WithFlexboxLayoutItemInfo { .. } => return isize::MAX,
         Expression::SolveFlexboxLayoutWithMeasure { .. } => return isize::MAX,
+        Expression::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => return isize::MAX,
         Expression::WithGridInputData { .. } => return isize::MAX,
         Expression::MinMax { .. } => 10,
         Expression::EmptyComponentFactory => 10,

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -675,6 +675,9 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
             Expression::WithFlexboxLayoutItemInfo { .. } => {
                 write!(f, "WithFlexboxLayoutItemInfo(TODO)",)
             }
+            Expression::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => {
+                write!(f, "FlexboxLayoutInfoCrossAxisWithMeasure(TODO)",)
+            }
             Expression::SolveFlexboxLayoutWithMeasure { .. } => {
                 write!(f, "SolveFlexboxLayoutWithMeasure(TODO)",)
             }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1898,6 +1898,11 @@ impl<'a> FlexboxLayoutCacheGenerator<'a> {
 /// `known_width`/`known_height` say whether taffy has already determined that
 /// dimension; a dimension it has not is pre-resolved to the cell's preferred
 /// size. Returns `(width, height)`.
+///
+/// A call with neither dimension known is a content-size probe. Its result
+/// must be a self-consistent pair (each dimension measured at the other):
+/// taffy caches it and reuses one dimension for a later query with the other
+/// one known.
 pub type FlexboxMeasureFn<'a> =
     Option<&'a mut dyn FnMut(usize, Coord, Coord, bool, bool) -> (Coord, Coord)>;
 
@@ -2143,6 +2148,39 @@ pub fn flexbox_layout_info_cross_axis(
     flex_wrap: FlexboxLayoutWrap,
     constraint_size: Coord,
 ) -> LayoutInfo {
+    flexbox_layout_info_cross_axis_with_measure(
+        cells_h,
+        cells_v,
+        flex_props,
+        spacing_h,
+        spacing_v,
+        padding_h,
+        padding_v,
+        direction,
+        flex_wrap,
+        constraint_size,
+        None,
+    )
+}
+
+/// Same as [`flexbox_layout_info_cross_axis`], with a measure callback so
+/// height-for-width cells (e.g. a nested wrapping flexbox) are measured at the
+/// main-axis size taffy actually assigns them, not at the pre-computed cell
+/// size (which was measured at the container width).
+#[allow(clippy::too_many_arguments)]
+pub fn flexbox_layout_info_cross_axis_with_measure(
+    cells_h: Slice<LayoutItemInfo>,
+    cells_v: Slice<LayoutItemInfo>,
+    flex_props: Slice<FlexItemProps>,
+    spacing_h: Coord,
+    spacing_v: Coord,
+    padding_h: &Padding,
+    padding_v: &Padding,
+    direction: FlexboxLayoutDirection,
+    flex_wrap: FlexboxLayoutWrap,
+    constraint_size: Coord,
+    measure: FlexboxMeasureFn<'_>,
+) -> LayoutInfo {
     debug_assert_eq!(cells_h.len(), cells_v.len());
     debug_assert_eq!(cells_h.len(), flex_props.len());
     if cells_h.is_empty() {
@@ -2242,7 +2280,7 @@ pub fn flexbox_layout_info_cross_axis(
         flex_direction: taffy_direction,
         container_width,
         container_height,
-        use_measure_for_cross_axis: false,
+        use_measure_for_cross_axis: measure.is_some(),
     });
 
     let (available_width, available_height) = match direction {
@@ -2254,7 +2292,8 @@ pub fn flexbox_layout_info_cross_axis(
         }
     };
 
-    builder.compute_layout(available_width, available_height, None);
+    let mut measure = measure.map(|m| resolve_measure_defaults(&cells_h, &cells_v, m));
+    builder.compute_layout(available_width, available_height, measure.as_mut().map(|m| m as _));
 
     let (total_width, total_height) = builder.container_size();
     let cross_size = match direction {
@@ -2503,6 +2542,41 @@ pub(crate) mod ffi {
             direction,
             flex_wrap,
             constraint_size,
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    /// Like `slint_flexbox_layout_info_cross_axis`, with a measure callback so
+    /// height-for-width cells are re-measured at the size taffy assigns them.
+    pub extern "C" fn slint_flexbox_layout_info_cross_axis_with_measure(
+        cells_h: Slice<LayoutItemInfo>,
+        cells_v: Slice<LayoutItemInfo>,
+        flex_props: Slice<FlexItemProps>,
+        spacing_h: Coord,
+        spacing_v: Coord,
+        padding_h: &Padding,
+        padding_v: &Padding,
+        direction: FlexboxLayoutDirection,
+        flex_wrap: FlexboxLayoutWrap,
+        constraint_size: Coord,
+        measure_fn: *const core::ffi::c_void,
+        measure_user_data: *mut core::ffi::c_void,
+    ) -> LayoutInfo {
+        // Safety: the caller guarantees `measure_fn` is a valid `FlexboxMeasureFnC`
+        // when non-null (see `measure_closure_from_c`).
+        let mut measure = unsafe { measure_closure_from_c(measure_fn, measure_user_data) };
+        super::flexbox_layout_info_cross_axis_with_measure(
+            cells_h,
+            cells_v,
+            flex_props,
+            spacing_h,
+            spacing_v,
+            padding_h,
+            padding_v,
+            direction,
+            flex_wrap,
+            constraint_size,
+            measure.as_mut().map(|m| m as _),
         )
     }
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1006,6 +1006,9 @@ pub fn eval_expression(ctx: &mut EvalContext, expression: &Expression) -> Value 
         Expression::SolveFlexboxLayoutWithMeasure { .. } => {
             crate::eval_layout::solve_flexbox_layout_with_measure(ctx, expression)
         }
+        Expression::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => {
+            crate::eval_layout::flexbox_layout_info_cross_axis_with_measure(ctx, expression)
+        }
         Expression::TranslationReference { .. } => {
             // TranslationReference is only emitted when `bundle-translations`
             // is active, which the interpreter does not use. Runtime @tr()

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -358,6 +358,7 @@ fn eval_info(ctx: &mut EvalContext, e: &Expression) -> LayoutInfo {
 /// repeaters (a repeater contributes one entry per instance).
 struct FlatCell<'a> {
     kind: FlatCellKind<'a>,
+    w4h_only: bool,
 }
 
 enum FlatCellKind<'a> {
@@ -375,18 +376,18 @@ fn flatten_measure_cells<'a>(
     let mut flat: Vec<FlatCell> = Vec::with_capacity(measure_cells.len());
     for item in measure_cells {
         match &item.kind {
-            FlexboxMeasureCellKind::Static { h_info, v_info } => {
-                flat.push(FlatCell { kind: FlatCellKind::Static { h_info, v_info } })
-            }
+            FlexboxMeasureCellKind::Static { h_info, v_info } => flat.push(FlatCell {
+                kind: FlatCellKind::Static { h_info, v_info },
+                w4h_only: item.w4h_only,
+            }),
             FlexboxMeasureCellKind::Repeated(repeater) => {
                 if let Some(current) = ctx.current.as_ref() {
                     let rep = &current.repeaters[repeater.repeater_index];
                     rep.track_instance_changes();
-                    flat.extend(
-                        rep.instances_vec()
-                            .into_iter()
-                            .map(|instance| FlatCell { kind: FlatCellKind::Repeated(instance) }),
-                    );
+                    flat.extend(rep.instances_vec().into_iter().map(|instance| FlatCell {
+                        kind: FlatCellKind::Repeated(instance),
+                        w4h_only: item.w4h_only,
+                    }));
                 }
             }
         }
@@ -398,7 +399,9 @@ fn flatten_measure_cells<'a>(
 /// re-evaluate the cell's perpendicular layout info with the
 /// `measure_known_w` / `measure_known_h` local set to the dimension taffy
 /// assigned (a dimension it did not assign, `known_* == false`, arrives
-/// pre-resolved to the cell's preferred size).
+/// pre-resolved to the cell's preferred size). A probe with neither dimension
+/// known measures the cell's free axis at the default size (see
+/// `FlexboxMeasureFn` in i-slint-core).
 fn measure_flexbox_cell(
     ctx: &mut EvalContext,
     flat: &[FlatCell],
@@ -447,9 +450,13 @@ fn measure_flexbox_cell(
         (true, true) => (w, h),
         (true, false) => measure_height(ctx),
         (false, true) => measure_width(ctx),
-        // Neither dimension known (degenerate cell probe): the
-        // pre-resolved defaults.
-        (false, false) => (w, h),
+        (false, false) => {
+            if cell.w4h_only {
+                measure_width(ctx)
+            } else {
+                measure_height(ctx)
+            }
+        }
     }
 }
 
@@ -499,4 +506,39 @@ pub(crate) fn solve_flexbox_layout_with_measure(ctx: &mut EvalContext, expr: &Ex
         Slice::from_slice(&ri),
         Some(&mut measure),
     ))
+}
+
+/// Interpret [`Expression::FlexboxLayoutInfoCrossAxisWithMeasure`]: the
+/// `flexbox_layout_info_cross_axis` builtin plus the measure callback, so
+/// height-for-width cells are measured at the main-axis size taffy assigns
+/// them rather than at the container size the cells were pre-measured at.
+pub(crate) fn flexbox_layout_info_cross_axis_with_measure(
+    ctx: &mut EvalContext,
+    expr: &Expression,
+) -> Value {
+    let Expression::FlexboxLayoutInfoCrossAxisWithMeasure { arguments, measure_cells } = expr
+    else {
+        return Value::Void;
+    };
+    let a: Vec<Value> = arguments.iter().map(|e| eval_expression(ctx, e)).collect();
+    let (ch, cv) = (to_cells(&a[0]), to_cells(&a[1]));
+    let fp = to_flex_props(&a[2]);
+    let flat = flatten_measure_cells(ctx, measure_cells);
+    let mut measure = |index: usize, w: f32, h: f32, known_w: bool, known_h: bool| {
+        measure_flexbox_cell(ctx, &flat, index, w, h, known_w, known_h)
+    };
+    i_slint_core::layout::flexbox_layout_info_cross_axis_with_measure(
+        Slice::from_slice(&ch),
+        Slice::from_slice(&cv),
+        Slice::from_slice(&fp),
+        to_f32(&a[3]),
+        to_f32(&a[4]),
+        &to_padding(&a[5]),
+        &to_padding(&a[6]),
+        to_enum(&a[7]),
+        to_enum(&a[8]),
+        to_f32(&a[9]),
+        Some(&mut measure),
+    )
+    .into()
 }

--- a/tests/cases/layout/flexbox_hforw_at_assigned_width.slint
+++ b/tests/cases/layout/flexbox_hforw_at_assigned_width.slint
@@ -1,0 +1,259 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A height-for-width cell of a row flexbox must be measured at the width taffy
+// assigns it (its preferred width when it doesn't grow), not at the container
+// width. Here the inner flexbox's preferred width is the wrapping "square"
+// estimate (two texts per line), so it wraps to two lines even though it would
+// fit on one line at the full container width. The outer flexbox's reported
+// height must include that second line — this is what sizes an auto-sized
+// window.
+
+component ReportedCard inherits Rectangle {
+    FlexboxLayout {
+        padding: 10px;
+        spacing: 30px;
+        Text { text: "Button1"; }
+        FlexboxLayout {
+            spacing: 10px;
+            Text { text: "Button2"; }
+            Text { text: "Button3"; }
+            Text { text: "Button4"; }
+        }
+    }
+}
+
+// Mirror of ReportedCard with column direction, for the width-for-height case.
+// All labels use the same string: the width assertion compares against the
+// reference text's width, so the cells must not depend on every "ButtonN"
+// happening to render equally wide.
+component ReportedCardColumn inherits Rectangle {
+    FlexboxLayout {
+        flex-direction: column;
+        padding: 10px;
+        spacing: 30px;
+        Text { text: "Button1"; }
+        FlexboxLayout {
+            flex-direction: column;
+            spacing: 10px;
+            Text { text: "Button1"; }
+            Text { text: "Button1"; }
+            Text { text: "Button1"; }
+        }
+    }
+}
+
+// Repeater flavor of ReportedCard: the h4w inner flexbox is a repeated cell,
+// so the measure callback maps taffy's flat cell index to a runtime instance
+// (the runtime-cell-count path) instead of a static cell.
+component InnerFlex inherits Rectangle {
+    FlexboxLayout {
+        spacing: 10px;
+        Text { text: "Button2"; }
+        Text { text: "Button3"; }
+        Text { text: "Button4"; }
+    }
+}
+component RepeatedCard inherits Rectangle {
+    FlexboxLayout {
+        padding: 10px;
+        spacing: 30px;
+        Text { text: "Button1"; }
+        for i in 1: InnerFlex { }
+    }
+}
+
+// Column mirror, for the width-for-height case.
+component InnerFlexColumn inherits Rectangle {
+    FlexboxLayout {
+        flex-direction: column;
+        spacing: 10px;
+        Text { text: "Button1"; }
+        Text { text: "Button1"; }
+        Text { text: "Button1"; }
+    }
+}
+component RepeatedCardColumn inherits Rectangle {
+    FlexboxLayout {
+        flex-direction: column;
+        padding: 10px;
+        spacing: 30px;
+        Text { text: "Button1"; }
+        for i in 1: InnerFlexColumn { }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 800px;
+    height: 750px;
+
+    // Single-line reference, so the assertions stay font-independent
+    // (the nodejs backend has no test fonts).
+    refLine := Text { x: -3000px; text: "Button1"; wrap: no-wrap; }
+    out property <length> line-height: refLine.height;
+    property <length> t: refLine.width;
+
+    // Wide enough for one outer line: Button1 + spacing 30 + inner at its
+    // preferred width (2 texts + spacing 10), plus padding 20 and slack.
+    property <length> w: 3 * t + 80px;
+
+    // Inner flexbox wraps at its preferred width: two lines.
+    wrapped := VerticalLayout {
+        x: 0; y: 0; width: w; height: 450px;
+        alignment: start;
+        wrappedCell := Rectangle {
+            FlexboxLayout {
+                padding: 10px;
+                spacing: 30px;
+                Text { text: "Button1"; }
+                FlexboxLayout {
+                    spacing: 10px;
+                    Text { text: "Button2"; }
+                    Text { text: "Button3"; }
+                    Text { text: "Button4"; }
+                }
+            }
+        }
+    }
+
+    // no-wrap reference: the inner flexbox's preferred width is its full
+    // single-line width, so everything stays on one line.
+    nowrap := VerticalLayout {
+        x: 400px; y: 0; width: 4 * t + 100px; height: 450px;
+        alignment: start;
+        nowrapCell := Rectangle {
+            FlexboxLayout {
+                padding: 10px;
+                spacing: 30px;
+                Text { text: "Button1"; }
+                FlexboxLayout {
+                    spacing: 10px;
+                    flex-wrap: no-wrap;
+                    Text { text: "Button2"; }
+                    Text { text: "Button3"; }
+                    Text { text: "Button4"; }
+                }
+            }
+        }
+    }
+
+    // Same content as `wrapped`, but measured through the *constrained*
+    // layout-info function (`layoutinfo-v-with-constraint`): a
+    // height-for-width cell of a wrapping flexbox is measured that way at its
+    // assigned width — like an auto-sized window is. On that path the cells
+    // are pre-measured at the container width, so the taffy measure callback
+    // must return self-consistent (width, height-at-that-width) pairs, or
+    // taffy's measure cache serves the pre-measured height for the inner
+    // flexbox and drops its second line.
+    FlexboxLayout {
+        x: 0; y: 200px; width: w; height: 250px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        cross-axis-line-alignment: start;
+        cross-axis-alignment: start;
+        ReportedCard { flex-shrink: 0; flex-basis: w; }
+        anchor := Rectangle { width: w; height: 5px; }
+    }
+
+    // Width-for-height mirror of the case above: a column-direction card as the
+    // cell of a wrapping column flexbox, measured at its assigned height. The
+    // inner column flexbox's preferred height is the wrapping estimate (two
+    // texts per column), so it wraps into a second column that the reported
+    // width must include.
+    property <length> column-height: 3 * line-height + 80px;
+    FlexboxLayout {
+        x: 400px; y: 200px; width: 380px; height: column-height;
+        flex-direction: column;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        cross-axis-line-alignment: start;
+        cross-axis-alignment: start;
+        ReportedCardColumn { flex-shrink: 0; flex-basis: column-height; }
+        colAnchor := Rectangle { width: 5px; height: column-height; }
+    }
+
+    // Same as the two constrained cases, with the repeated cards: exercises
+    // the runtime-cell-count (repeater) measure callback through the info
+    // path.
+    FlexboxLayout {
+        x: 0; y: 480px; width: w; height: 250px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        cross-axis-line-alignment: start;
+        cross-axis-alignment: start;
+        RepeatedCard { flex-shrink: 0; flex-basis: w; }
+        repAnchor := Rectangle { width: w; height: 5px; }
+    }
+
+    FlexboxLayout {
+        x: 400px; y: 480px; width: 380px; height: column-height;
+        flex-direction: column;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        cross-axis-line-alignment: start;
+        cross-axis-alignment: start;
+        RepeatedCardColumn { flex-shrink: 0; flex-basis: column-height; }
+        repColAnchor := Rectangle { width: 5px; height: column-height; }
+    }
+
+    out property <length> wrapped-h: wrappedCell.height;
+    out property <length> nowrap-h: nowrapCell.height;
+    out property <length> constrained-h: anchor.y;
+    out property <length> constrained-w: colAnchor.x;
+    out property <length> constrained-rep-h: repAnchor.y;
+    out property <length> constrained-rep-w: repColAnchor.x;
+
+    // Inner wraps to two lines (spacing 10) + outer padding 20.
+    out property <bool> wrapped-ok: abs(wrapped-h - (2 * line-height + 10px + 20px)) < 1px;
+    // Single line + outer padding 20.
+    out property <bool> nowrap-ok: abs(nowrap-h - (line-height + 20px)) < 1px;
+    out property <bool> constrained-ok: abs(constrained-h - (2 * line-height + 10px + 20px)) < 1px;
+    // Inner wraps into two columns (spacing 10) + outer padding 20.
+    out property <bool> constrained-w-ok: abs(constrained-w - (2 * t + 10px + 20px)) < 1px;
+    out property <bool> constrained-rep-ok: abs(constrained-rep-h - (2 * line-height + 10px + 20px)) < 1px;
+    out property <bool> constrained-rep-w-ok: abs(constrained-rep-w - (2 * t + 10px + 20px)) < 1px;
+
+    out property <bool> test: wrapped-ok && nowrap-ok && constrained-ok && constrained-w-ok
+        && constrained-rep-ok && constrained-rep-w-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_nowrap_ok(), "no-wrap cell height wrong: {} for line height {}",
+    instance.get_nowrap_h(), instance.get_line_height());
+assert!(instance.get_wrapped_ok(), "wrapped cell height wrong: {} for line height {}",
+    instance.get_wrapped_h(), instance.get_line_height());
+assert!(instance.get_constrained_ok(), "constrained-path cell height wrong: {} for line height {}",
+    instance.get_constrained_h(), instance.get_line_height());
+assert!(instance.get_constrained_w_ok(), "constrained-path cell width wrong: {}",
+    instance.get_constrained_w());
+assert!(instance.get_constrained_rep_ok(), "repeated cell height wrong: {} for line height {}",
+    instance.get_constrained_rep_h(), instance.get_line_height());
+assert!(instance.get_constrained_rep_w_ok(), "repeated cell width wrong: {}",
+    instance.get_constrained_rep_w());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_nowrap_ok());
+assert(instance.get_wrapped_ok());
+assert(instance.get_constrained_ok());
+assert(instance.get_constrained_w_ok());
+assert(instance.get_constrained_rep_ok());
+assert(instance.get_constrained_rep_w_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.nowrap_ok);
+assert(instance.wrapped_ok);
+assert(instance.constrained_ok);
+assert(instance.constrained_w_ok);
+assert(instance.constrained_rep_ok);
+assert(instance.constrained_rep_w_ok);
+```
+*/


### PR DESCRIPTION
This is the fix for ionuc's testcase of nested flexboxlayouts leading to a wrong window size.

The cross-axis layout info ran taffy without a measure callback, so a
nested wrapping flexbox cell kept the height pre-measured at the
container width instead of the width taffy assigns it (its own
preferred width, where it wraps to more lines). The window height comes
from the root's vertical layout info at the preferred width, so an
auto-sized window ended up too short for its contents.

- new core function flexbox_layout_info_cross_axis_with_measure, taking
  the same measure callback the solve path uses, with a C FFI and C++
  wrapper like the solve's
- new LLR expression FlexboxLayoutInfoCrossAxisWithMeasure, built in the
  cross-axis info lowering when a cell is height-for-width capable; the
  generators emit the same measure callback as the solve, extended with
  the content-size probe: a call with neither dimension known returns a
  self-consistent pair (taffy caches it and reuses one dimension for a
  later query with the other one known), measuring the vertical axis at
  the default width — or the horizontal axis at the default height for
  a width-for-height-only cell (the new per-cell w4h_only flag)
- the interpreter (which interprets the LLR) reuses the solve's measure
  dispatch