### PR TITLE
skia: Fix image layout and present ordering in the Skia/wgpu Vulkan interop

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -23,7 +23,9 @@ path = "lib.rs"
 wayland = ["glutin/wayland", "softbuffer/wayland", "softbuffer/wayland-dlopen"]
 x11 = ["glutin/x11", "glutin/glx", "softbuffer/x11", "softbuffer/x11-dlopen"]
 opengl = []
-vulkan = ["skia-safe/vulkan", "dep:ash", "vulkano"]
+# `vulkan-portability` is how wgpu compiles its Vulkan backend on Apple platforms (MoltenVK).
+# It feeds an apple-target-gated dependency of wgpu-core, so it's inert elsewhere.
+vulkan = ["skia-safe/vulkan", "dep:ash", "vulkano", "wgpu-29?/vulkan-portability", "wgpu-30?/vulkan-portability"]
 kms = ["softbuffer/kms"]
 # wgpu-{29,30} enables the wgpu surface module for internal use (e.g. linuxkms DRM rendering).
 # unstable-wgpu-{29,30} additionally exposes public API integration (GraphicsAPI, texture import).

--- a/internal/renderers/skia/build.rs
+++ b/internal/renderers/skia/build.rs
@@ -12,6 +12,9 @@ fn main() {
        skia_backend_software: { not(target_os = "android") },
        skia_backend_softbuffer: { all(skia_backend_software, feature = "softbuffer") },
        skia_windowed: { any(skia_backend_vulkan, skia_backend_opengl, skia_backend_metal, skia_backend_softbuffer) },
+       // Targets where wgpu and Skia both have their Vulkan backend compiled in.
+       // On Apple that's what the `vulkan` feature adds; Windows enables `wgpu/dx12` instead.
+       skia_wgpu_vulkan: { any(all(target_family = "unix", not(target_vendor = "apple")), all(target_vendor = "apple", feature = "vulkan")) },
     }
 
     println!("cargo:rustc-check-cfg=cfg(slint_nightly_test)");

--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -446,9 +446,13 @@ impl Backend {
     /// Like [`Self::make_surface`], but for the swapchain image handed out by
     /// [`wgpu::Surface::get_current_texture`].
     ///
-    /// wgpu returns surface textures to their `PRESENT` state at the end of every submission,
-    /// so that is the layout Skia finds the image in, not the color-attachment one a plain
-    /// render target is left in. Pair every call with [`Self::release_swapchain_surface`].
+    /// Nothing on this path writes the image before Skia does, so a freshly created swapchain
+    /// hands out images that are still in `UNDEFINED`, and naming the `PRESENT` layout wgpu
+    /// leaves them in from the second frame on would make Skia's barrier claim a layout the
+    /// image isn't in yet. `UNDEFINED` is accurate for the first use and legal for every later
+    /// one, at the price of discarding the previous contents, which this path never reads:
+    /// `render()` passes a buffer age of 0, so the scene is repainted in full every frame.
+    /// Pair every call with [`Self::release_swapchain_surface`].
     pub(crate) fn make_swapchain_surface(
         &self,
         gr_context: &mut skia_safe::gpu::DirectContext,
@@ -464,7 +468,7 @@ impl Backend {
                 vulkan::make_vulkan_surface(
                     gr_context,
                     texture,
-                    skia_safe::gpu::vk::ImageLayout::PRESENT_SRC_KHR,
+                    skia_safe::gpu::vk::ImageLayout::UNDEFINED,
                 )
             },
         }

--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -20,7 +20,7 @@ use crate::SkiaSharedContext;
 mod dx12;
 #[cfg(target_vendor = "apple")]
 mod metal;
-#[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+#[cfg(skia_wgpu_vulkan)]
 mod vulkan;
 
 /// See [`crate::attachment_color_space`].
@@ -365,7 +365,7 @@ pub(crate) enum Backend {
     Metal,
     #[cfg(target_family = "windows")]
     Dx12,
-    #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+    #[cfg(skia_wgpu_vulkan)]
     Vulkan,
 }
 
@@ -377,7 +377,7 @@ impl TryFrom<wgpu::Backend> for Backend {
             wgpu_29::Backend::Noop => {
                 Err(PlatformError::from("Cannot use WGPU Noop backend with Skia"))
             }
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             wgpu_29::Backend::Vulkan => Ok(Self::Vulkan),
             #[cfg(target_vendor = "apple")]
             wgpu_29::Backend::Metal => Ok(Self::Metal),
@@ -403,7 +403,7 @@ impl Backend {
             Self::Metal => metal::make_metal_context(device, queue),
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_context(&_adapter, &device, &queue) },
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             Self::Vulkan => unsafe { vulkan::make_vulkan_context(device, queue) },
         }
     }
@@ -418,7 +418,7 @@ impl Backend {
             Self::Metal => unsafe { metal::make_metal_surface(gr_context, texture) },
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_surface(gr_context, texture) },
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             Self::Vulkan => unsafe { vulkan::make_vulkan_surface(gr_context, texture) },
         }
     }
@@ -433,7 +433,7 @@ impl Backend {
             Self::Metal => unsafe { metal::import_metal_texture(canvas, texture) },
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::import_dx12_texture(canvas, texture) },
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             Self::Vulkan => unsafe { vulkan::import_vulkan_texture(canvas, texture) },
         }
     }

--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -84,7 +84,7 @@ impl WGPUSurface {
         surface_config.format = swapchain_format;
         surface.configure(&device, &surface_config);
 
-        let backend: Backend = adapter.get_info().backend.try_into()?;
+        let backend = Backend::new(&adapter, &device)?;
 
         let gr_context = backend.make_context(&adapter, &device, &queue);
 
@@ -240,12 +240,14 @@ impl crate::Surface for WGPUSurface {
             }
         };
 
-        let skia_surface = self.backend.make_surface(gr_context, &frame.texture);
+        let skia_surface = self.backend.make_swapchain_surface(gr_context, &frame.texture);
 
         let mut skia_surface = skia_surface
             .ok_or_else(|| PlatformError::from("Failed to create Skia surface from WGPU"))?;
 
         callback(skia_surface.canvas(), Some(gr_context), 0);
+
+        self.backend.release_swapchain_surface(gr_context, &mut skia_surface);
 
         self.flush_and_submit(gr_context);
 
@@ -366,19 +368,33 @@ pub(crate) enum Backend {
     #[cfg(target_family = "windows")]
     Dx12,
     #[cfg(skia_wgpu_vulkan)]
-    Vulkan,
+    Vulkan {
+        /// The family Skia has to hand the swapchain image back to, see
+        /// [`Backend::release_swapchain_surface`].
+        queue_family_index: u32,
+    },
 }
 
-impl TryFrom<wgpu::Backend> for Backend {
-    type Error = PlatformError;
-
-    fn try_from(wgpu_backend: wgpu::Backend) -> Result<Self, Self::Error> {
-        match wgpu_backend {
+impl Backend {
+    pub(crate) fn new(
+        adapter: &wgpu::Adapter,
+        _device: &wgpu::Device,
+    ) -> Result<Self, PlatformError> {
+        match adapter.get_info().backend {
             wgpu_29::Backend::Noop => {
                 Err(PlatformError::from("Cannot use WGPU Noop backend with Skia"))
             }
             #[cfg(skia_wgpu_vulkan)]
-            wgpu_29::Backend::Vulkan => Ok(Self::Vulkan),
+            wgpu_29::Backend::Vulkan => Ok(Self::Vulkan {
+                // SAFETY: `_device` is a Vulkan device, as the adapter's backend just said.
+                queue_family_index: unsafe { vulkan::queue_family_index(_device) }.ok_or_else(
+                    || {
+                        PlatformError::from(
+                            "Cannot query the queue family of the WGPU Vulkan device",
+                        )
+                    },
+                )?,
+            }),
             #[cfg(target_vendor = "apple")]
             wgpu_29::Backend::Metal => Ok(Self::Metal),
             #[cfg(target_family = "windows")]
@@ -389,9 +405,7 @@ impl TryFrom<wgpu::Backend> for Backend {
             ))),
         }
     }
-}
 
-impl Backend {
     pub(crate) fn make_context(
         &self,
         _adapter: &wgpu::Adapter,
@@ -404,7 +418,7 @@ impl Backend {
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_context(&_adapter, &device, &queue) },
             #[cfg(skia_wgpu_vulkan)]
-            Self::Vulkan => unsafe { vulkan::make_vulkan_context(device, queue) },
+            Self::Vulkan { .. } => unsafe { vulkan::make_vulkan_context(device, queue) },
         }
     }
 
@@ -419,7 +433,62 @@ impl Backend {
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_surface(gr_context, texture) },
             #[cfg(skia_wgpu_vulkan)]
-            Self::Vulkan => unsafe { vulkan::make_vulkan_surface(gr_context, texture) },
+            Self::Vulkan { .. } => unsafe {
+                vulkan::make_vulkan_surface(
+                    gr_context,
+                    texture,
+                    skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+                )
+            },
+        }
+    }
+
+    /// Like [`Self::make_surface`], but for the swapchain image handed out by
+    /// [`wgpu::Surface::get_current_texture`].
+    ///
+    /// wgpu returns surface textures to their `PRESENT` state at the end of every submission,
+    /// so that is the layout Skia finds the image in, not the color-attachment one a plain
+    /// render target is left in. Pair every call with [`Self::release_swapchain_surface`].
+    pub(crate) fn make_swapchain_surface(
+        &self,
+        gr_context: &mut skia_safe::gpu::DirectContext,
+        texture: &wgpu::Texture,
+    ) -> Option<skia_safe::Surface> {
+        match self {
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => unsafe { metal::make_metal_surface(gr_context, texture) },
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => unsafe { dx12::make_dx12_surface(gr_context, texture) },
+            #[cfg(skia_wgpu_vulkan)]
+            Self::Vulkan { .. } => unsafe {
+                vulkan::make_vulkan_surface(
+                    gr_context,
+                    texture,
+                    skia_safe::gpu::vk::ImageLayout::PRESENT_SRC_KHR,
+                )
+            },
+        }
+    }
+
+    /// Hands a surface made by [`Self::make_swapchain_surface`] back in the state
+    /// [`wgpu::SurfaceTexture::present`] expects to find it in.
+    pub(crate) fn release_swapchain_surface(
+        &self,
+        _gr_context: &mut skia_safe::gpu::DirectContext,
+        _skia_surface: &mut skia_safe::Surface,
+    ) {
+        match self {
+            // Metal and D3D12 have no image layout for Skia to hand back.
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => {}
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => {}
+            #[cfg(skia_wgpu_vulkan)]
+            Self::Vulkan { queue_family_index } => vulkan::release_vulkan_swapchain_surface(
+                _gr_context,
+                _skia_surface,
+                *queue_family_index,
+            ),
         }
     }
 
@@ -434,7 +503,7 @@ impl Backend {
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::import_dx12_texture(canvas, texture) },
             #[cfg(skia_wgpu_vulkan)]
-            Self::Vulkan => unsafe { vulkan::import_vulkan_texture(canvas, texture) },
+            Self::Vulkan { .. } => unsafe { vulkan::import_vulkan_texture(canvas, texture) },
         }
     }
 }

--- a/internal/renderers/skia/wgpu_29_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_29_surface/vulkan.rs
@@ -32,6 +32,7 @@ unsafe fn wrap_vulkan_texture(
     vk_image_raw: u64,
     vk_format: skia_safe::gpu::vk::Format,
     color_type: skia_safe::ColorType,
+    layout: skia_safe::gpu::vk::ImageLayout,
     color_space: skia_safe::ColorSpace,
 ) -> Option<skia_safe::Surface> {
     unsafe {
@@ -39,7 +40,7 @@ unsafe fn wrap_vulkan_texture(
             vk_image_raw as _,
             skia_safe::gpu::vk::Alloc::default(),
             skia_safe::gpu::vk::ImageTiling::OPTIMAL,
-            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            layout,
             vk_format,
             1,
             None,
@@ -63,9 +64,14 @@ unsafe fn wrap_vulkan_texture(
 /// # Safety
 /// The caller must ensure `texture` was created by a Vulkan-backed wgpu device and remains
 /// valid for the lifetime of the returned `skia_safe::Surface`.
+///
+/// `layout` is the layout wgpu leaves the image in, which Skia transitions away from before
+/// its first draw. Getting it wrong doesn't just trip the validation layers, it makes the
+/// barrier Skia emits name the wrong source layout.
 pub unsafe fn make_vulkan_surface(
     gr_context: &mut skia_safe::gpu::DirectContext,
     texture: &wgpu::Texture,
+    layout: skia_safe::gpu::vk::ImageLayout,
 ) -> Option<skia_safe::Surface> {
     // SAFETY: texture is borrowed for the duration of this call; the Vulkan handle is copied
     // into Skia's internal BackendRenderTarget via wrap_vulkan_texture.
@@ -81,9 +87,46 @@ pub unsafe fn make_vulkan_surface(
             vk_image_raw,
             vk_format,
             color_type,
+            layout,
             super::attachment_color_space(texture),
         )
     }
+}
+
+/// Records the transition back to `PRESENT_SRC_KHR` and flushes it.
+///
+/// wgpu's tracker still believes the swapchain image is in its `PRESENT` state, because that is
+/// where wgpu itself left it before Skia took over. Leaving it in Skia's color-attachment layout
+/// would make the barrier `wgpu::Queue::present` emits name a source layout the image isn't in.
+pub fn release_vulkan_swapchain_surface(
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    skia_surface: &mut skia_safe::Surface,
+    queue_family_index: u32,
+) {
+    let present_state = skia_safe::gpu::vk::mutable_texture_states::new_vulkan(
+        skia_safe::gpu::vk::ImageLayout::PRESENT_SRC_KHR,
+        queue_family_index,
+    );
+    gr_context.flush_surface_with_texture_state(
+        skia_surface,
+        &skia_safe::gpu::FlushInfo::default(),
+        Some(&present_state),
+    );
+}
+
+/// Extension names as `String`, for [`vk::BackendContextBuilder::with_extensions`]. Vulkan
+/// extension names are ASCII, so the lossy conversion can't lose anything.
+fn cstr_names(names: &[&'static std::ffi::CStr]) -> Vec<String> {
+    names.iter().map(|name| name.to_string_lossy().into_owned()).collect()
+}
+
+/// The queue family the wgpu device submits on, which is also the one Skia has to hand the
+/// swapchain image back to.
+///
+/// # Safety
+/// `device` must be backed by the Vulkan wgpu backend.
+pub unsafe fn queue_family_index(device: &wgpu::Device) -> Option<u32> {
+    unsafe { Some(device.as_hal::<wgpu::wgc::api::Vulkan>()?.queue_family_index()) }
 }
 
 pub unsafe fn import_vulkan_texture(
@@ -174,6 +217,13 @@ pub unsafe fn make_vulkan_context(
             }
         };
 
+        // Skia gates features on the extensions it's told about, and rejects anything it
+        // considers unsupported: without `VK_KHR_swapchain` in this list it refuses to wrap an
+        // image that's in `PRESENT_SRC_KHR` layout, which is how wgpu hands out swapchain
+        // images. Hand it what wgpu actually enabled, no more.
+        let instance_extensions = cstr_names(vulkan_device.shared_instance().extensions());
+        let device_extensions = cstr_names(vulkan_device.enabled_device_extensions());
+
         // WGPU 29 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the
         // physical device is chosen, causing it to ask for unsupported features/functions.
         let backend = vk::BackendContext::new_builder(
@@ -183,6 +233,10 @@ pub unsafe fn make_vulkan_context(
             (vulkan_queue_raw.as_raw() as _, vulkan_device.queue_family_index() as _),
             &get_proc,
             Some(vk::Version::new(1, 3, 0)),
+        )
+        .with_extensions(
+            &instance_extensions.iter().map(String::as_str).collect::<Vec<_>>(),
+            &device_extensions.iter().map(String::as_str).collect::<Vec<_>>(),
         )
         .build();
 

--- a/internal/renderers/skia/wgpu_30_surface.rs
+++ b/internal/renderers/skia/wgpu_30_surface.rs
@@ -20,7 +20,7 @@ use crate::SkiaSharedContext;
 mod dx12;
 #[cfg(target_vendor = "apple")]
 mod metal;
-#[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+#[cfg(skia_wgpu_vulkan)]
 mod vulkan;
 
 /// See [`crate::attachment_color_space`].
@@ -377,7 +377,7 @@ pub(crate) enum Backend {
     Metal,
     #[cfg(target_family = "windows")]
     Dx12,
-    #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+    #[cfg(skia_wgpu_vulkan)]
     Vulkan,
 }
 
@@ -389,7 +389,7 @@ impl TryFrom<wgpu::Backend> for Backend {
             wgpu_30::Backend::Noop => {
                 Err(PlatformError::from("Cannot use WGPU Noop backend with Skia"))
             }
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             wgpu_30::Backend::Vulkan => Ok(Self::Vulkan),
             #[cfg(target_vendor = "apple")]
             wgpu_30::Backend::Metal => Ok(Self::Metal),
@@ -415,7 +415,7 @@ impl Backend {
             Self::Metal => metal::make_metal_context(device, queue),
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_context(&_adapter, &device, &queue) },
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             Self::Vulkan => unsafe { vulkan::make_vulkan_context(device, queue) },
         }
     }
@@ -430,7 +430,7 @@ impl Backend {
             Self::Metal => unsafe { metal::make_metal_surface(gr_context, texture) },
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_surface(gr_context, texture) },
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             Self::Vulkan => unsafe { vulkan::make_vulkan_surface(gr_context, texture) },
         }
     }
@@ -445,7 +445,7 @@ impl Backend {
             Self::Metal => unsafe { metal::import_metal_texture(canvas, texture) },
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::import_dx12_texture(canvas, texture) },
-            #[cfg(all(target_family = "unix", not(target_vendor = "apple")))]
+            #[cfg(skia_wgpu_vulkan)]
             Self::Vulkan => unsafe { vulkan::import_vulkan_texture(canvas, texture) },
         }
     }

--- a/internal/renderers/skia/wgpu_30_surface.rs
+++ b/internal/renderers/skia/wgpu_30_surface.rs
@@ -277,6 +277,24 @@ impl crate::Surface for WGPUSurface {
 
         self.flush_and_submit(gr_context);
 
+        // Skia drew via the raw queue behind wgpu's back, and `Queue::present` skips its own
+        // transition when the tracker already says PRESENT, so nothing would order the
+        // presentation after Skia's work: the clear submission above signals its semaphore
+        // before Skia even starts. Referencing the frame texture in a submission of our own
+        // makes present wait for it.
+        let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Skia present ordering encoder"),
+        });
+        encoder.transition_resources(
+            std::iter::empty(),
+            std::iter::once(wgpu::TextureTransition {
+                texture: &frame.texture,
+                selector: None,
+                state: wgpu::TextureUses::PRESENT,
+            }),
+        );
+        self.queue.submit(Some(encoder.finish()));
+
         if let Some(pre_present_callback) = pre_present_callback.borrow_mut().as_mut() {
             pre_present_callback();
         }

--- a/internal/renderers/skia/wgpu_30_surface.rs
+++ b/internal/renderers/skia/wgpu_30_surface.rs
@@ -84,7 +84,7 @@ impl WGPUSurface {
         surface_config.format = swapchain_format;
         surface.configure(&device, &surface_config);
 
-        let backend: Backend = adapter.get_info().backend.try_into()?;
+        let backend = Backend::new(&adapter, &device)?;
 
         let gr_context = backend.make_context(&adapter, &device, &queue);
 
@@ -266,12 +266,14 @@ impl crate::Surface for WGPUSurface {
         });
         self.queue.submit(Some(encoder.finish()));
 
-        let skia_surface = self.backend.make_surface(gr_context, &frame.texture);
+        let skia_surface = self.backend.make_swapchain_surface(gr_context, &frame.texture);
 
         let mut skia_surface = skia_surface
             .ok_or_else(|| PlatformError::from("Failed to create Skia surface from WGPU"))?;
 
         callback(skia_surface.canvas(), Some(gr_context), 0);
+
+        self.backend.release_swapchain_surface(gr_context, &mut skia_surface);
 
         self.flush_and_submit(gr_context);
 
@@ -378,19 +380,33 @@ pub(crate) enum Backend {
     #[cfg(target_family = "windows")]
     Dx12,
     #[cfg(skia_wgpu_vulkan)]
-    Vulkan,
+    Vulkan {
+        /// The family Skia has to hand the swapchain image back to, see
+        /// [`Backend::release_swapchain_surface`].
+        queue_family_index: u32,
+    },
 }
 
-impl TryFrom<wgpu::Backend> for Backend {
-    type Error = PlatformError;
-
-    fn try_from(wgpu_backend: wgpu::Backend) -> Result<Self, Self::Error> {
-        match wgpu_backend {
+impl Backend {
+    pub(crate) fn new(
+        adapter: &wgpu::Adapter,
+        _device: &wgpu::Device,
+    ) -> Result<Self, PlatformError> {
+        match adapter.get_info().backend {
             wgpu_30::Backend::Noop => {
                 Err(PlatformError::from("Cannot use WGPU Noop backend with Skia"))
             }
             #[cfg(skia_wgpu_vulkan)]
-            wgpu_30::Backend::Vulkan => Ok(Self::Vulkan),
+            wgpu_30::Backend::Vulkan => Ok(Self::Vulkan {
+                // SAFETY: `_device` is a Vulkan device, as the adapter's backend just said.
+                queue_family_index: unsafe { vulkan::queue_family_index(_device) }.ok_or_else(
+                    || {
+                        PlatformError::from(
+                            "Cannot query the queue family of the WGPU Vulkan device",
+                        )
+                    },
+                )?,
+            }),
             #[cfg(target_vendor = "apple")]
             wgpu_30::Backend::Metal => Ok(Self::Metal),
             #[cfg(target_family = "windows")]
@@ -401,9 +417,7 @@ impl TryFrom<wgpu::Backend> for Backend {
             ))),
         }
     }
-}
 
-impl Backend {
     pub(crate) fn make_context(
         &self,
         _adapter: &wgpu::Adapter,
@@ -416,7 +430,7 @@ impl Backend {
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_context(&_adapter, &device, &queue) },
             #[cfg(skia_wgpu_vulkan)]
-            Self::Vulkan => unsafe { vulkan::make_vulkan_context(device, queue) },
+            Self::Vulkan { .. } => unsafe { vulkan::make_vulkan_context(device, queue) },
         }
     }
 
@@ -431,7 +445,62 @@ impl Backend {
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::make_dx12_surface(gr_context, texture) },
             #[cfg(skia_wgpu_vulkan)]
-            Self::Vulkan => unsafe { vulkan::make_vulkan_surface(gr_context, texture) },
+            Self::Vulkan { .. } => unsafe {
+                vulkan::make_vulkan_surface(
+                    gr_context,
+                    texture,
+                    skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+                )
+            },
+        }
+    }
+
+    /// Like [`Self::make_surface`], but for the swapchain image handed out by
+    /// [`wgpu::Surface::get_current_texture`].
+    ///
+    /// wgpu returns surface textures to their `PRESENT` state at the end of every submission,
+    /// so that is the layout Skia finds the image in, not the color-attachment one a plain
+    /// render target is left in. Pair every call with [`Self::release_swapchain_surface`].
+    pub(crate) fn make_swapchain_surface(
+        &self,
+        gr_context: &mut skia_safe::gpu::DirectContext,
+        texture: &wgpu::Texture,
+    ) -> Option<skia_safe::Surface> {
+        match self {
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => unsafe { metal::make_metal_surface(gr_context, texture) },
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => unsafe { dx12::make_dx12_surface(gr_context, texture) },
+            #[cfg(skia_wgpu_vulkan)]
+            Self::Vulkan { .. } => unsafe {
+                vulkan::make_vulkan_surface(
+                    gr_context,
+                    texture,
+                    skia_safe::gpu::vk::ImageLayout::PRESENT_SRC_KHR,
+                )
+            },
+        }
+    }
+
+    /// Hands a surface made by [`Self::make_swapchain_surface`] back in the state
+    /// [`wgpu::Queue::present`] expects to find it in.
+    pub(crate) fn release_swapchain_surface(
+        &self,
+        _gr_context: &mut skia_safe::gpu::DirectContext,
+        _skia_surface: &mut skia_safe::Surface,
+    ) {
+        match self {
+            // Metal and D3D12 have no image layout for Skia to hand back.
+            #[cfg(target_vendor = "apple")]
+            Self::Metal => {}
+            #[cfg(target_family = "windows")]
+            Self::Dx12 => {}
+            #[cfg(skia_wgpu_vulkan)]
+            Self::Vulkan { queue_family_index } => vulkan::release_vulkan_swapchain_surface(
+                _gr_context,
+                _skia_surface,
+                *queue_family_index,
+            ),
         }
     }
 
@@ -446,7 +515,7 @@ impl Backend {
             #[cfg(target_family = "windows")]
             Self::Dx12 => unsafe { dx12::import_dx12_texture(canvas, texture) },
             #[cfg(skia_wgpu_vulkan)]
-            Self::Vulkan => unsafe { vulkan::import_vulkan_texture(canvas, texture) },
+            Self::Vulkan { .. } => unsafe { vulkan::import_vulkan_texture(canvas, texture) },
         }
     }
 }

--- a/internal/renderers/skia/wgpu_30_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_30_surface/vulkan.rs
@@ -86,6 +86,12 @@ pub unsafe fn make_vulkan_surface(
     }
 }
 
+/// Extension names as `String`, for [`vk::BackendContextBuilder::with_extensions`]. Vulkan
+/// extension names are ASCII, so the lossy conversion can't lose anything.
+fn cstr_names(names: &[&'static std::ffi::CStr]) -> Vec<String> {
+    names.iter().map(|name| name.to_string_lossy().into_owned()).collect()
+}
+
 pub unsafe fn import_vulkan_texture(
     canvas: &skia_safe::Canvas,
     texture: wgpu::Texture,
@@ -174,6 +180,13 @@ pub unsafe fn make_vulkan_context(
             }
         };
 
+        // Skia gates features on the extensions it's told about, and rejects anything it
+        // considers unsupported: without `VK_KHR_swapchain` in this list it refuses to wrap an
+        // image that's in `PRESENT_SRC_KHR` layout, which is how wgpu hands out swapchain
+        // images. Hand it what wgpu actually enabled, no more.
+        let instance_extensions = cstr_names(vulkan_device.shared_instance().extensions());
+        let device_extensions = cstr_names(vulkan_device.enabled_device_extensions());
+
         // WGPU 29 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the
         // physical device is chosen, causing it to ask for unsupported features/functions.
         let backend = vk::BackendContext::new_builder(
@@ -183,6 +196,10 @@ pub unsafe fn make_vulkan_context(
             (vulkan_queue_raw.as_raw() as _, vulkan_device.queue_family_index() as _),
             &get_proc,
             Some(vk::Version::new(1, 3, 0)),
+        )
+        .with_extensions(
+            &instance_extensions.iter().map(String::as_str).collect::<Vec<_>>(),
+            &device_extensions.iter().map(String::as_str).collect::<Vec<_>>(),
         )
         .build();
 

--- a/internal/renderers/skia/wgpu_30_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_30_surface/vulkan.rs
@@ -32,6 +32,7 @@ unsafe fn wrap_vulkan_texture(
     vk_image_raw: u64,
     vk_format: skia_safe::gpu::vk::Format,
     color_type: skia_safe::ColorType,
+    layout: skia_safe::gpu::vk::ImageLayout,
     color_space: skia_safe::ColorSpace,
 ) -> Option<skia_safe::Surface> {
     unsafe {
@@ -39,7 +40,7 @@ unsafe fn wrap_vulkan_texture(
             vk_image_raw as _,
             skia_safe::gpu::vk::Alloc::default(),
             skia_safe::gpu::vk::ImageTiling::OPTIMAL,
-            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            layout,
             vk_format,
             1,
             None,
@@ -63,9 +64,14 @@ unsafe fn wrap_vulkan_texture(
 /// # Safety
 /// The caller must ensure `texture` was created by a Vulkan-backed wgpu device and remains
 /// valid for the lifetime of the returned `skia_safe::Surface`.
+///
+/// `layout` is the layout wgpu leaves the image in, which Skia transitions away from before
+/// its first draw. Getting it wrong doesn't just trip the validation layers, it makes the
+/// barrier Skia emits name the wrong source layout.
 pub unsafe fn make_vulkan_surface(
     gr_context: &mut skia_safe::gpu::DirectContext,
     texture: &wgpu::Texture,
+    layout: skia_safe::gpu::vk::ImageLayout,
 ) -> Option<skia_safe::Surface> {
     // SAFETY: texture is borrowed for the duration of this call; the Vulkan handle is copied
     // into Skia's internal BackendRenderTarget via wrap_vulkan_texture.
@@ -81,15 +87,46 @@ pub unsafe fn make_vulkan_surface(
             vk_image_raw,
             vk_format,
             color_type,
+            layout,
             super::attachment_color_space(texture),
         )
     }
+}
+
+/// Records the transition back to `PRESENT_SRC_KHR` and flushes it.
+///
+/// wgpu's tracker still believes the swapchain image is in its `PRESENT` state, because that is
+/// where wgpu itself left it before Skia took over. Leaving it in Skia's color-attachment layout
+/// would make the barrier `wgpu::Queue::present` emits name a source layout the image isn't in.
+pub fn release_vulkan_swapchain_surface(
+    gr_context: &mut skia_safe::gpu::DirectContext,
+    skia_surface: &mut skia_safe::Surface,
+    queue_family_index: u32,
+) {
+    let present_state = skia_safe::gpu::vk::mutable_texture_states::new_vulkan(
+        skia_safe::gpu::vk::ImageLayout::PRESENT_SRC_KHR,
+        queue_family_index,
+    );
+    gr_context.flush_surface_with_texture_state(
+        skia_surface,
+        &skia_safe::gpu::FlushInfo::default(),
+        Some(&present_state),
+    );
 }
 
 /// Extension names as `String`, for [`vk::BackendContextBuilder::with_extensions`]. Vulkan
 /// extension names are ASCII, so the lossy conversion can't lose anything.
 fn cstr_names(names: &[&'static std::ffi::CStr]) -> Vec<String> {
     names.iter().map(|name| name.to_string_lossy().into_owned()).collect()
+}
+
+/// The queue family the wgpu device submits on, which is also the one Skia has to hand the
+/// swapchain image back to.
+///
+/// # Safety
+/// `device` must be backed by the Vulkan wgpu backend.
+pub unsafe fn queue_family_index(device: &wgpu::Device) -> Option<u32> {
+    unsafe { Some(device.as_hal::<wgpu::wgc::api::Vulkan>()?.queue_family_index()) }
 }
 
 pub unsafe fn import_vulkan_texture(

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -89,7 +89,7 @@ impl SkiaWGPU29Renderer {
     ) -> Result<Self, PlatformError> {
         use crate::wgpu_29_surface::{Backend, WGPUSurface};
 
-        let backend: Backend = adapter.get_info().backend.try_into()?;
+        let backend = Backend::new(&adapter, &device)?;
 
         let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
             PlatformError::from("Failed to create Skia graphics context from WGPU")

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -152,7 +152,7 @@ impl SkiaWGPU30Renderer {
     ) -> Result<Self, PlatformError> {
         use crate::wgpu_30_surface::{Backend, WGPUSurface};
 
-        let backend: Backend = adapter.get_info().backend.try_into()?;
+        let backend = Backend::new(&adapter, &device)?;
 
         let gr_context = backend.make_context(&adapter, &device, &queue).ok_or_else(|| {
             PlatformError::from("Failed to create Skia graphics context from WGPU")


### PR DESCRIPTION
Skia draws into wgpu's swapchain image through the raw Vulkan queue. That
handoff was wrong in three ways, on every Vulkan platform:

- **Image layout.** Skia was told the image is in `COLOR_ATTACHMENT_OPTIMAL`,
  but wgpu returns surface textures to `PRESENT` at the end of every
  submission, and nothing handed the image back afterwards. So Skia's barrier
  named the wrong source layout going in, and wgpu's present barrier named the
  wrong one coming out. Wrap the image in the layout wgpu actually leaves it
  in, and flush Skia back to `PRESENT_SRC_KHR` before presenting (wgpu 29 and 30).
- **Extensions.** Skia gates its capabilities on the extension list it is
  given; with an empty one it doesn't know `VK_KHR_swapchain` and refuses to
  wrap a `PRESENT_SRC_KHR` image at all, which is what the wgpu 30 path hands
  it. Pass through what wgpu enabled, no more.
- **Present ordering (wgpu 30).** Skia's submission is invisible to wgpu, so
  the semaphore present waits on doesn't cover the drawing. Submit a near-empty
  command buffer referencing the frame texture after Skia's work. Same fix, and
  the same intermittent partially blank frames, as #12861, which did wgpu 29.
