### PR TITLE
Forward private base references used as property defaults

### DIFF
--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -133,6 +133,7 @@ pub async fn run_passes(
     lower_component_container::lower_component_container(doc, type_loader, diag);
     collect_subcomponents::collect_subcomponents(doc);
 
+    let mut lower_states_forwarded_cache = Default::default();
     doc.visit_all_used_components(|component| {
         apply_default_properties_from_style::apply_default_properties_from_style(
             component,
@@ -140,7 +141,12 @@ pub async fn run_passes(
             &palette,
             diag,
         );
-        lower_states::lower_states(component, diag);
+        lower_states::lower_states(
+            component,
+            &symbol_counters,
+            &mut lower_states_forwarded_cache,
+            diag,
+        );
         lower_text_input_interface::lower_text_input_interface(component);
         compile_paths::compile_paths(component, &doc.local_registry, diag);
         repeater_component::process_repeater_components(component);

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -10,20 +10,32 @@ use crate::expression_tree::*;
 use crate::langtype::ElementType;
 use crate::langtype::Type;
 use crate::object_tree::*;
+use crate::symbol_counters::SymbolCounters;
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
 use std::rc::{Rc, Weak};
 
-pub fn lower_states(component: &Rc<Component>, diag: &mut BuildDiagnostics) {
+/// Maps a private reference to the forwarding property/callback synthesized for it by
+/// `forwarded_reference`, so it's only synthesized once per reference.
+type ForwardedReferenceCache = HashMap<NamedReference, NamedReference>;
+
+pub fn lower_states(
+    component: &Rc<Component>,
+    symbol_counters: &SymbolCounters,
+    forwarded_cache: &mut ForwardedReferenceCache,
+    diag: &mut BuildDiagnostics,
+) {
     let state_info_type = crate::typeregister::BUILTIN.state_info_type.clone().into();
     recurse_elem(&component.root_element, &(), &mut |elem, _| {
-        lower_state_in_element(elem, &state_info_type, diag)
+        lower_state_in_element(elem, &state_info_type, symbol_counters, forwarded_cache, diag)
     });
 }
 
 fn lower_state_in_element(
     root_element: &ElementRc,
     state_info_type: &Type,
+    symbol_counters: &SymbolCounters,
+    forwarded_cache: &mut ForwardedReferenceCache,
     diag: &mut BuildDiagnostics,
 ) {
     if root_element.borrow().states.is_empty() {
@@ -59,7 +71,12 @@ fn lower_state_in_element(
         for (property_reference, expr, node) in state.property_changes {
             affected_properties.insert(property_reference.clone());
             let element = property_reference.element();
-            let property_expr = match expression_for_property(&element, property_reference.name()) {
+            let property_expr = match expression_for_property(
+                &element,
+                property_reference.name(),
+                symbol_counters,
+                forwarded_cache,
+            ) {
                 ExpressionForProperty::TwoWayBinding => {
                     diag.push_error(
                     format!("Cannot change the property '{}' in a state because it is initialized with a two-way binding", property_reference.name()),
@@ -68,13 +85,6 @@ fn lower_state_in_element(
                     continue;
                 }
                 ExpressionForProperty::Expression(e) => e,
-                ExpressionForProperty::InvalidBecauseOfIssue1461 => {
-                    diag.push_error(
-                        format!("Internal error: The expression for the default state currently cannot be represented: https://github.com/slint-ui/slint/issues/1461\nAs a workaround, add a binding for property {}", property_reference.name()),
-                        &node
-                    );
-                    continue;
-                }
             };
             let new_expr = Expression::Condition {
                 condition: Box::new(Expression::BinaryExpression {
@@ -191,24 +201,30 @@ fn compute_state_property_name(root_element: &ElementRc) -> SmolStr {
 enum ExpressionForProperty {
     TwoWayBinding,
     Expression(Expression),
-    /// Workaround: the expression can't be represented with the current data structure, so make it an error for now.
-    InvalidBecauseOfIssue1461,
 }
 
 /// Return the expression binding currently associated to the given property
-fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProperty {
+fn expression_for_property(
+    element: &ElementRc,
+    name: &str,
+    symbol_counters: &SymbolCounters,
+    forwarded_cache: &mut ForwardedReferenceCache,
+) -> ExpressionForProperty {
     let mut element_it = Some(element.clone());
     let mut in_base = false;
     while let Some(elem) = element_it {
-        if let Some(e) = elem.borrow().binding(name) {
-            if !e.two_way_bindings.is_empty() {
+        // Clone out of `elem` and drop the borrow: forwarding below needs to borrow `elem` mutably.
+        let existing_binding = elem
+            .borrow()
+            .binding(name)
+            .map(|e| (!e.two_way_bindings.is_empty(), e.expression.clone()));
+        if let Some((is_two_way_binding, mut expr)) = existing_binding {
+            if is_two_way_binding {
                 return ExpressionForProperty::TwoWayBinding;
             }
-            let mut expr = e.expression.clone();
             if !matches!(expr, Expression::Invalid) {
                 if in_base {
-                    // Check that the expression is valid in the new scope
-                    let mut has_invalid = false;
+                    // Rewrite references from `elem`'s point of view to `element`'s.
                     expr.visit_recursive_mut(&mut |ex| match ex {
                         Expression::PropertyReference(nr)
                         | Expression::FunctionCall {
@@ -222,14 +238,19 @@ fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProp
                                 &e.borrow().enclosing_component,
                                 &elem.borrow().enclosing_component,
                             ) {
-                                has_invalid = true;
+                                // A private sibling of `elem`: not reachable from outside its
+                                // component, so forward it through a synthesized member on `elem`.
+                                let forwarded = forwarded_reference(
+                                    nr,
+                                    &elem,
+                                    symbol_counters,
+                                    forwarded_cache,
+                                );
+                                *nr = NamedReference::new(element, forwarded.name().clone());
                             }
                         }
                         _ => (),
                     });
-                    if has_invalid {
-                        return ExpressionForProperty::InvalidBecauseOfIssue1461;
-                    }
                 }
 
                 return ExpressionForProperty::Expression(expr);
@@ -247,4 +268,50 @@ fn expression_for_property(element: &ElementRc, name: &str) -> ExpressionForProp
     });
 
     ExpressionForProperty::Expression(expr)
+}
+
+fn forwarded_reference(
+    original: &NamedReference,
+    base_root: &ElementRc,
+    symbol_counters: &SymbolCounters,
+    forwarded_cache: &mut ForwardedReferenceCache,
+) -> NamedReference {
+    // reuse the forward if one exists
+    if let Some(existing) = forwarded_cache.get(original) {
+        return existing.clone();
+    }
+
+    // Create a property/callback on `base_root` that forwards to `original`
+    let ty = original.ty();
+    let new_name = symbol_counters.generate_name("forward_reference_");
+    let binding = match &ty {
+        Type::Callback(f) | Type::Function(f) => {
+            let arguments = f
+                .args
+                .iter()
+                .enumerate()
+                .map(|(index, arg_ty)| Expression::FunctionParameterReference {
+                    index,
+                    ty: arg_ty.clone(),
+                })
+                .collect();
+            let function = if matches!(ty, Type::Callback(_)) {
+                Callable::Callback(original.clone())
+            } else {
+                Callable::Function(original.clone())
+            };
+            Expression::FunctionCall { function, arguments, source_location: None }
+        }
+        _ => Expression::PropertyReference(original.clone()),
+    };
+
+    base_root.borrow_mut().property_declarations.insert(
+        new_name.clone(),
+        PropertyDeclaration { property_type: ty, ..PropertyDeclaration::default() },
+    );
+    base_root.borrow_mut().set_binding(new_name.clone(), BindingExpression::from(binding));
+
+    let forwarded = NamedReference::new(base_root, new_name);
+    forwarded_cache.insert(original.clone(), forwarded.clone());
+    forwarded
 }

--- a/internal/compiler/tests/syntax/lookup/issue_1461.slint
+++ b/internal/compiler/tests/syntax/lookup/issue_1461.slint
@@ -23,9 +23,7 @@ component Button inherits Rectangle {
              states [
                  highlight when counter > 45 : {
                      background: red;
-//                   >error{Internal error: The expression for the default state currently cannot be represented: https://github.com/slint-ui/slint/issues/1461↵As a workaround, add a binding for property background}
                  }
-//              <error{Internal error: The expression for the default state currently cannot be represented: https://github.com/slint-ui/slint/issues/1461↵As a workaround, add a binding for property background}
              ]
          }
       }

--- a/tests/cases/properties/issue1461_state_default_via_base_private_reference.slint
+++ b/tests/cases/properties/issue1461_state_default_via_base_private_reference.slint
@@ -1,0 +1,115 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Base {
+    in-out property <int> p2: inner.width / 1px;
+    in-out property <int> p3: inner.compute-value(3);
+    in-out property <int> p4: inner.compute-cb(5);
+    inner := Rectangle {
+        width: 10px;
+        pure function compute-value(x: int) -> int {
+            return x + 10;
+        }
+        pure callback compute-cb(int) -> int;
+        compute-cb(x) => x * 2;
+    }
+}
+
+export component TestCase {
+    b1 := Base {}
+    b2 := Base {}
+    in-out property <bool> cond;
+
+    out property <int> v1: b1.p2;
+    out property <int> v2: b1.p3;
+    out property <int> v3: b1.p4;
+    out property <int> v4: b2.p2;
+    out property <int> v5: b2.p3;
+    out property <int> v6: b2.p4;
+
+    states [
+        s when cond: {
+            b1.p2: 42;
+            b1.p3: 43;
+            b1.p4: 44;
+            b2.p2: 142;
+            b2.p3: 143;
+            b2.p4: 144;
+        }
+    ]
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_v1(), 10);
+assert_eq!(instance.get_v2(), 13);
+assert_eq!(instance.get_v3(), 10);
+assert_eq!(instance.get_v4(), 10);
+assert_eq!(instance.get_v5(), 13);
+assert_eq!(instance.get_v6(), 10);
+instance.set_cond(true);
+assert_eq!(instance.get_v1(), 42);
+assert_eq!(instance.get_v2(), 43);
+assert_eq!(instance.get_v3(), 44);
+assert_eq!(instance.get_v4(), 142);
+assert_eq!(instance.get_v5(), 143);
+assert_eq!(instance.get_v6(), 144);
+instance.set_cond(false);
+assert_eq!(instance.get_v1(), 10);
+assert_eq!(instance.get_v2(), 13);
+assert_eq!(instance.get_v3(), 10);
+assert_eq!(instance.get_v4(), 10);
+assert_eq!(instance.get_v5(), 13);
+assert_eq!(instance.get_v6(), 10);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_v1(), 10);
+assert_eq(instance.get_v2(), 13);
+assert_eq(instance.get_v3(), 10);
+assert_eq(instance.get_v4(), 10);
+assert_eq(instance.get_v5(), 13);
+assert_eq(instance.get_v6(), 10);
+instance.set_cond(true);
+assert_eq(instance.get_v1(), 42);
+assert_eq(instance.get_v2(), 43);
+assert_eq(instance.get_v3(), 44);
+assert_eq(instance.get_v4(), 142);
+assert_eq(instance.get_v5(), 143);
+assert_eq(instance.get_v6(), 144);
+instance.set_cond(false);
+assert_eq(instance.get_v1(), 10);
+assert_eq(instance.get_v2(), 13);
+assert_eq(instance.get_v3(), 10);
+assert_eq(instance.get_v4(), 10);
+assert_eq(instance.get_v5(), 13);
+assert_eq(instance.get_v6(), 10);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.v1, 10);
+assert.equal(instance.v2, 13);
+assert.equal(instance.v3, 10);
+assert.equal(instance.v4, 10);
+assert.equal(instance.v5, 13);
+assert.equal(instance.v6, 10);
+instance.cond = true;
+assert.equal(instance.v1, 42);
+assert.equal(instance.v2, 43);
+assert.equal(instance.v3, 44);
+assert.equal(instance.v4, 142);
+assert.equal(instance.v5, 143);
+assert.equal(instance.v6, 144);
+instance.cond = false;
+assert.equal(instance.v1, 10);
+assert.equal(instance.v2, 13);
+assert.equal(instance.v3, 10);
+assert.equal(instance.v4, 10);
+assert.equal(instance.v5, 13);
+assert.equal(instance.v6, 10);
+```
+*/

--- a/tests/cases/properties/issue1461_state_default_via_base_private_reference.slint
+++ b/tests/cases/properties/issue1461_state_default_via_base_private_reference.slint
@@ -5,14 +5,22 @@ component Base {
     in-out property <int> p2: inner.width / 1px;
     in-out property <int> p3: inner.compute-value(3);
     in-out property <int> p4: inner.compute-cb(5);
+    in-out property <string> p5: inner.text;
     inner := Rectangle {
+        in-out property <string> text <=> input.text;
         width: 10px;
         pure function compute-value(x: int) -> int {
             return x + 10;
         }
         pure callback compute-cb(int) -> int;
         compute-cb(x) => x * 2;
+
+        input := TextInput {
+            text: "hello";
+        }
     }
+    callback change-text(string);
+    change-text(t) => { inner.text = t; }
 }
 
 export component TestCase {
@@ -23,18 +31,25 @@ export component TestCase {
     out property <int> v1: b1.p2;
     out property <int> v2: b1.p3;
     out property <int> v3: b1.p4;
+    out property <string> v7: b1.p5;
     out property <int> v4: b2.p2;
     out property <int> v5: b2.p3;
     out property <int> v6: b2.p4;
+    out property <string> v8: b2.p5;
+
+    callback change-b1-text(string);
+    change-b1-text(t) => { b1.change-text(t); }
 
     states [
         s when cond: {
             b1.p2: 42;
             b1.p3: 43;
             b1.p4: 44;
+            b1.p5: "s1";
             b2.p2: 142;
             b2.p3: 143;
             b2.p4: 144;
+            b2.p5: "s2";
         }
     ]
 }
@@ -48,6 +63,8 @@ assert_eq!(instance.get_v3(), 10);
 assert_eq!(instance.get_v4(), 10);
 assert_eq!(instance.get_v5(), 13);
 assert_eq!(instance.get_v6(), 10);
+assert_eq!(instance.get_v7(), "hello");
+assert_eq!(instance.get_v8(), "hello");
 instance.set_cond(true);
 assert_eq!(instance.get_v1(), 42);
 assert_eq!(instance.get_v2(), 43);
@@ -55,6 +72,8 @@ assert_eq!(instance.get_v3(), 44);
 assert_eq!(instance.get_v4(), 142);
 assert_eq!(instance.get_v5(), 143);
 assert_eq!(instance.get_v6(), 144);
+assert_eq!(instance.get_v7(), "s1");
+assert_eq!(instance.get_v8(), "s2");
 instance.set_cond(false);
 assert_eq!(instance.get_v1(), 10);
 assert_eq!(instance.get_v2(), 13);
@@ -62,6 +81,19 @@ assert_eq!(instance.get_v3(), 10);
 assert_eq!(instance.get_v4(), 10);
 assert_eq!(instance.get_v5(), 13);
 assert_eq!(instance.get_v6(), 10);
+assert_eq!(instance.get_v7(), "hello");
+assert_eq!(instance.get_v8(), "hello");
+// The default-value branch forwards a *live* reference to the private TextInput's
+// text property, not a snapshot taken when the forwarding property was synthesized.
+instance.invoke_change_b1_text("edited".into());
+assert_eq!(instance.get_v7(), "edited");
+assert_eq!(instance.get_v8(), "hello");
+instance.set_cond(true);
+assert_eq!(instance.get_v7(), "s1");
+assert_eq!(instance.get_v8(), "s2");
+instance.set_cond(false);
+assert_eq!(instance.get_v7(), "edited");
+assert_eq!(instance.get_v8(), "hello");
 ```
 
 ```cpp
@@ -73,6 +105,8 @@ assert_eq(instance.get_v3(), 10);
 assert_eq(instance.get_v4(), 10);
 assert_eq(instance.get_v5(), 13);
 assert_eq(instance.get_v6(), 10);
+assert_eq(instance.get_v7(), "hello");
+assert_eq(instance.get_v8(), "hello");
 instance.set_cond(true);
 assert_eq(instance.get_v1(), 42);
 assert_eq(instance.get_v2(), 43);
@@ -80,6 +114,8 @@ assert_eq(instance.get_v3(), 44);
 assert_eq(instance.get_v4(), 142);
 assert_eq(instance.get_v5(), 143);
 assert_eq(instance.get_v6(), 144);
+assert_eq(instance.get_v7(), "s1");
+assert_eq(instance.get_v8(), "s2");
 instance.set_cond(false);
 assert_eq(instance.get_v1(), 10);
 assert_eq(instance.get_v2(), 13);
@@ -87,6 +123,19 @@ assert_eq(instance.get_v3(), 10);
 assert_eq(instance.get_v4(), 10);
 assert_eq(instance.get_v5(), 13);
 assert_eq(instance.get_v6(), 10);
+assert_eq(instance.get_v7(), "hello");
+assert_eq(instance.get_v8(), "hello");
+// The default-value branch forwards a *live* reference to the private TextInput's
+// text property, not a snapshot taken when the forwarding property was synthesized.
+instance.invoke_change_b1_text("edited");
+assert_eq(instance.get_v7(), "edited");
+assert_eq(instance.get_v8(), "hello");
+instance.set_cond(true);
+assert_eq(instance.get_v7(), "s1");
+assert_eq(instance.get_v8(), "s2");
+instance.set_cond(false);
+assert_eq(instance.get_v7(), "edited");
+assert_eq(instance.get_v8(), "hello");
 ```
 
 ```js
@@ -97,6 +146,8 @@ assert.equal(instance.v3, 10);
 assert.equal(instance.v4, 10);
 assert.equal(instance.v5, 13);
 assert.equal(instance.v6, 10);
+assert.equal(instance.v7, "hello");
+assert.equal(instance.v8, "hello");
 instance.cond = true;
 assert.equal(instance.v1, 42);
 assert.equal(instance.v2, 43);
@@ -104,6 +155,8 @@ assert.equal(instance.v3, 44);
 assert.equal(instance.v4, 142);
 assert.equal(instance.v5, 143);
 assert.equal(instance.v6, 144);
+assert.equal(instance.v7, "s1");
+assert.equal(instance.v8, "s2");
 instance.cond = false;
 assert.equal(instance.v1, 10);
 assert.equal(instance.v2, 13);
@@ -111,5 +164,18 @@ assert.equal(instance.v3, 10);
 assert.equal(instance.v4, 10);
 assert.equal(instance.v5, 13);
 assert.equal(instance.v6, 10);
+assert.equal(instance.v7, "hello");
+assert.equal(instance.v8, "hello");
+// The default-value branch forwards a *live* reference to the private TextInput's
+// text property, not a snapshot taken when the forwarding property was synthesized.
+instance.change_b1_text("edited");
+assert.equal(instance.v7, "edited");
+assert.equal(instance.v8, "hello");
+instance.cond = true;
+assert.equal(instance.v7, "s1");
+assert.equal(instance.v8, "s2");
+instance.cond = false;
+assert.equal(instance.v7, "edited");
+assert.equal(instance.v8, "hello");
 ```
 */


### PR DESCRIPTION
Closes #1461 

This fix creates a new property on the base element during lowering so it can be accessed by other elements
