### PR TITLE
fix: popup width/height offset calculation on update

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1648,7 +1648,10 @@ impl WindowInner {
                             let layout_info_h = component
                                 .as_ref()
                                 .layout_info(crate::layout::Orientation::Horizontal);
-                            let w = layout_info_h.min.min(layout_info_h.max);
+                            let w = layout_info_h
+                                .preferred
+                                .max(layout_info_h.min)
+                                .min(layout_info_h.max);
                             window_item.width.set(LogicalLength::new(w));
                             w
                         };
@@ -1657,7 +1660,10 @@ impl WindowInner {
                             let layout_info_v = component
                                 .as_ref()
                                 .layout_info(crate::layout::Orientation::Vertical);
-                            let h = layout_info_v.min.min(layout_info_v.max);
+                            let h = layout_info_v
+                                .preferred
+                                .max(layout_info_v.min)
+                                .min(layout_info_v.max);
                             window_item.height.set(LogicalLength::new(h));
                             h
                         };

--- a/tests/cases/elements/popupwindow_size_preferred.slint
+++ b/tests/cases/elements/popupwindow_size_preferred.slint
@@ -1,0 +1,99 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Check that a popup whose content can shrink below its preferred size (for example wrapped text)
+// is sized to its preferred size clamped to [min, max], and not just to its minimum size.
+// This must hold both for a simulated (ChildWindow) popup and for a native (TopLevel) popup.
+
+export global Properties {
+    in-out property <length> popup-width: -1px;
+    in-out property <length> popup-height: -1px;
+}
+
+export component TestCase {
+    callback show_popup();
+    show_popup => {
+        popup.show();
+    }
+
+    width: 600px;
+    height: 400px;
+
+    popup := PopupWindow {
+        close-policy: PopupClosePolicy.no-auto-close;
+
+        changed width => {
+            Properties.popup-width = self.width;
+        }
+        changed height => {
+            Properties.popup-height = self.height;
+        }
+        init => {
+            Properties.popup-width = self.width;
+            Properties.popup-height = self.height;
+        }
+
+        // Shrinkable content: min < preferred < max, mimicking a wrapped Text whose
+        // preferred (single-line) width is larger than its min (narrowest breakable) width.
+        Rectangle {
+            min-width: 50px;
+            preferred-width: 150px;
+            max-width: 300px;
+            min-height: 40px;
+            preferred-height: 80px;
+            max-height: 300px;
+        }
+    }
+}
+
+/*
+
+```rust
+// Simulated popup (PopupWindowLocation::ChildWindow)
+use slint::*;
+
+let instance = TestCase::new().unwrap();
+let inner = slint_testing::WindowInner::from_pub(&instance.window());
+
+instance.invoke_show_popup();
+
+assert_eq!(inner.active_popups.borrow().len(), 1);
+assert!(
+    matches!(
+        inner.active_popups.borrow().first().unwrap().location,
+        slint_testing::PopupWindowLocation::ChildWindow(..)
+    ),
+    "The popup is expected to be a ChildWindow"
+);
+
+// The popup must be sized to its preferred size (150x80), not its minimum size (50x40).
+assert_eq!(instance.global::<Properties<'_>>().get_popup_width(), 150.);
+assert_eq!(instance.global::<Properties<'_>>().get_popup_height(), 80.);
+```
+
+```rust
+// Native popup (PopupWindowLocation::TopLevel)
+use slint::*;
+
+let instance = TestCase::new().unwrap();
+let inner = slint_testing::WindowInner::from_pub(&instance.window());
+slint_testing::access_testing_window(instance.window(), |w| w.use_native_popup(true));
+
+instance.invoke_show_popup();
+
+assert_eq!(inner.active_popups.borrow().len(), 1);
+assert!(
+    matches!(
+        inner.active_popups.borrow().first().unwrap().location,
+        slint_testing::PopupWindowLocation::TopLevel(..)
+    ),
+    "The popup is expected to be a TopLevel window"
+);
+
+// A native popup must be sized identically to a simulated one: preferred size (150x80),
+// not its minimum size (50x40).
+assert_eq!(instance.global::<Properties<'_>>().get_popup_width(), 150.);
+assert_eq!(instance.global::<Properties<'_>>().get_popup_height(), 80.);
+```
+
+*/


### PR DESCRIPTION
Closes #12859

`PopupWindow` positioning that depends on `self.width`/`self.height` could render off-center whenever the popup's content could shrink below its `preferred` size.

The cause was two different, inconsistent size formulas were used for the same popup:

- `show_popup()` computes the popup's size correctly: `preferred`, clamped to [min, max]. It also evaluates the x/y binding for positioning using this size.
- Immediately after, `show_popup()` calls `update_popup_properties()`, which re-evaluates the position but then recomputes the size a second time using:
`let w = layout_info_h.min.min(layout_info_h.max);`
- Since `min <= max` always holds, this just evaluates to `layout_info_h.min`, ignoring preferred entirely.

For non-wrapping content, `min == preferred == max`, so the bug is invisible. For wrap-enabled text, min (roughly the widest unbreakable word) is much smaller than preferred (the natural single-line width). This results in the popup positioned as if it was the preferred size but rendered at the minimum size.