### PR TITLE
FlexboxLayout: take the measure path when all h4w cells are repeated

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -468,6 +468,15 @@ pub(super) fn solve_flexbox_layout(
 fn flexbox_needs_measure(layout: &crate::layout::FlexboxLayout) -> bool {
     layout.elems.iter().any(|li| {
         let elem = &li.item.element;
+        // For a repeater, check the repeated component's root — the element
+        // the measure callback queries. The repeated element itself has a
+        // materialized layoutinfo property, which makes
+        // is_height_for_width_cell return false.
+        if elem.borrow().repeated.is_some() {
+            let root = elem.borrow().base_type.as_component().root_element.clone();
+            return root.borrow().inherited_layout_info_v_with_constraint().is_some()
+                || root.borrow().inherited_layout_info_h_with_constraint().is_some();
+        }
         is_height_for_width_cell(elem)
             || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
     })

--- a/tests/cases/layout/flexbox_hforw_at_assigned_width.slint
+++ b/tests/cases/layout/flexbox_hforw_at_assigned_width.slint
@@ -63,6 +63,17 @@ component RepeatedCard inherits Rectangle {
     }
 }
 
+// All cells repeated, no static sibling: the flexbox must still count the
+// repeated component's root as height-for-width capable and take the measure
+// path (a static capable sibling used to mask a repeater-blind capability
+// check).
+component RepeaterOnlyCard inherits Rectangle {
+    FlexboxLayout {
+        padding: 10px;
+        for i in 1: InnerFlex { }
+    }
+}
+
 // Column mirror, for the width-for-height case.
 component InnerFlexColumn inherits Rectangle {
     FlexboxLayout {
@@ -85,7 +96,7 @@ component RepeatedCardColumn inherits Rectangle {
 
 export component TestCase inherits Window {
     width: 800px;
-    height: 750px;
+    height: 1000px;
 
     // Single-line reference, so the assertions stay font-independent
     // (the nodejs backend has no test fonts).
@@ -198,12 +209,30 @@ export component TestCase inherits Window {
         repColAnchor := Rectangle { width: 5px; height: column-height; }
     }
 
+    // Repeater-only card: the card's flexbox has no static cell at all. The
+    // narrow basis shrinks the inner flexbox below its preferred width (one
+    // text per line, three lines) — at its preferred width the default
+    // pre-measure is accidentally correct and would hide a missing measure
+    // callback.
+    property <length> narrow-w: t + 50px;
+    FlexboxLayout {
+        x: 0; y: 740px; width: w; height: 250px;
+        flex-direction: row;
+        flex-wrap: wrap;
+        padding: 0px; spacing: 0px;
+        cross-axis-line-alignment: start;
+        cross-axis-alignment: start;
+        RepeaterOnlyCard { flex-shrink: 0; flex-basis: narrow-w; }
+        repOnlyAnchor := Rectangle { width: w; height: 5px; }
+    }
+
     out property <length> wrapped-h: wrappedCell.height;
     out property <length> nowrap-h: nowrapCell.height;
     out property <length> constrained-h: anchor.y;
     out property <length> constrained-w: colAnchor.x;
     out property <length> constrained-rep-h: repAnchor.y;
     out property <length> constrained-rep-w: repColAnchor.x;
+    out property <length> constrained-rep-only-h: repOnlyAnchor.y;
 
     // Inner wraps to two lines (spacing 10) + outer padding 20.
     out property <bool> wrapped-ok: abs(wrapped-h - (2 * line-height + 10px + 20px)) < 1px;
@@ -214,9 +243,11 @@ export component TestCase inherits Window {
     out property <bool> constrained-w-ok: abs(constrained-w - (2 * t + 10px + 20px)) < 1px;
     out property <bool> constrained-rep-ok: abs(constrained-rep-h - (2 * line-height + 10px + 20px)) < 1px;
     out property <bool> constrained-rep-w-ok: abs(constrained-rep-w - (2 * t + 10px + 20px)) < 1px;
+    // One text per line: three lines (2 * spacing 10) + outer padding 20.
+    out property <bool> constrained-rep-only-ok: abs(constrained-rep-only-h - (3 * line-height + 20px + 20px)) < 1px;
 
     out property <bool> test: wrapped-ok && nowrap-ok && constrained-ok && constrained-w-ok
-        && constrained-rep-ok && constrained-rep-w-ok;
+        && constrained-rep-ok && constrained-rep-w-ok && constrained-rep-only-ok;
 }
 
 /*
@@ -234,6 +265,8 @@ assert!(instance.get_constrained_rep_ok(), "repeated cell height wrong: {} for l
     instance.get_constrained_rep_h(), instance.get_line_height());
 assert!(instance.get_constrained_rep_w_ok(), "repeated cell width wrong: {}",
     instance.get_constrained_rep_w());
+assert!(instance.get_constrained_rep_only_ok(), "repeater-only cell height wrong: {} for line height {}",
+    instance.get_constrained_rep_only_h(), instance.get_line_height());
 ```
 
 ```cpp
@@ -245,6 +278,7 @@ assert(instance.get_constrained_ok());
 assert(instance.get_constrained_w_ok());
 assert(instance.get_constrained_rep_ok());
 assert(instance.get_constrained_rep_w_ok());
+assert(instance.get_constrained_rep_only_ok());
 ```
 
 ```js
@@ -255,5 +289,6 @@ assert(instance.constrained_ok);
 assert(instance.constrained_w_ok);
 assert(instance.constrained_rep_ok);
 assert(instance.constrained_rep_w_ok);
+assert(instance.constrained_rep_only_ok);
 ```
 */


### PR DESCRIPTION
flexbox_needs_measure never counted a repeated element: the
materialized layoutinfo property on the repeated element makes
is_height_for_width_cell return false, and a height-for-width static
sibling usually masked that. A flexbox whose cells are all repeated
took the callback-free path, so its height-for-width cells stayed at
the size they were pre-measured at instead of the size taffy assigns.

Check the repeated component's root instead — the element the measure
callback queries. The new repeater-only sub-case shrinks the card below
its preferred width, where the missing callback is observable (at the
preferred width the default pre-measure is accidentally correct).