### PR TITLE
Build the visual editor packages from the slint-editor example

### DIFF
--- a/.github/workflows/visual_editor_windows_msix.yaml
+++ b/.github/workflows/visual_editor_windows_msix.yaml
@@ -75,7 +75,7 @@ jobs:
           cargo +stable build `
             --manifest-path tools/lsp/Cargo.toml `
             --target ${{ matrix.target }} `
-            --bin slint-visual-editor `
+            --example slint-editor `
             --profile package-release `
             --no-default-features `
             --features backend-winit,renderer-skia
@@ -86,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: slint-visual-editor-${{ matrix.arch }}
-          path: target/${{ matrix.target }}/package-release/slint-visual-editor.exe
+          path: target/${{ matrix.target }}/package-release/examples/slint-editor.exe
           if-no-files-found: error
 
   package:
@@ -242,7 +242,7 @@ jobs:
             # Everything the manifest refers to has to be inside the layout:
             # `makeappx` resolves those paths within the package, not on disk.
             Copy-Item "$tiles/*.png" "$dist/Assets/"
-            Copy-Item "exe/slint-visual-editor-$arch/slint-visual-editor.exe" "$dist/slint-visual-editor.exe"
+            Copy-Item "exe/slint-visual-editor-$arch/slint-editor.exe" "$dist/slint-visual-editor.exe"
 
             # Each slice carries its own manifest, naming the version and the
             # architecture it was built for. Everything else about the slices

--- a/scripts/build_macos_app_with_cargo.bash
+++ b/scripts/build_macos_app_with_cargo.bash
@@ -11,7 +11,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 . "$SCRIPT_DIR/helpers.sh"
 
 usage() {
-    echo "Usage: $0 --bin <binary name> [--profile <profile>] [--] [cargo build args...]" >&2
+    echo "Usage: $0 --bin <binary name> | --example <example name> [--profile <profile>] [--] [cargo build args...]" >&2
 }
 
 if [ "$#" -lt 2 ]; then
@@ -20,11 +20,13 @@ if [ "$#" -lt 2 ]; then
 fi
 
 CARGO_TARGET_NAME=""
+CARGO_TARGET_KIND=--bin
 CARGO_PROFILE=dev
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --bin)
+        --bin|--example)
+            CARGO_TARGET_KIND="$1"
             CARGO_TARGET_NAME="$2"
             shift
             shift
@@ -83,10 +85,16 @@ env RUSTFLAGS='-Clink-args=-Wl,-rpath,@loader_path/../Frameworks' \
     cargo build \
         ${CARGO_TIMINGS_ARGS[@]+"${CARGO_TIMINGS_ARGS[@]}"} \
         --target "$RUST_TARGET" \
-        --bin "$CARGO_TARGET_NAME" \
+        "$CARGO_TARGET_KIND" "$CARGO_TARGET_NAME" \
         --profile "$CARGO_PROFILE" \
         "$@"
-EXECUTABLE="$CARGO_TARGET_DIR/$RUST_TARGET/$CARGO_PROFILE_DIR/$CARGO_TARGET_NAME"
+
+# Cargo puts examples in an examples/ sub-directory, binaries in the profile root.
+if [ "$CARGO_TARGET_KIND" = "--example" ]; then
+    EXECUTABLE="$CARGO_TARGET_DIR/$RUST_TARGET/$CARGO_PROFILE_DIR/examples/$CARGO_TARGET_NAME"
+else
+    EXECUTABLE="$CARGO_TARGET_DIR/$RUST_TARGET/$CARGO_PROFILE_DIR/$CARGO_TARGET_NAME"
+fi
 
 mkdir -p "$(dirname "$TARGET_BUILD_DIR/$EXECUTABLE_PATH")"
 rm -f "$TARGET_BUILD_DIR/$EXECUTABLE_PATH"

--- a/scripts/local_sparkle_update_test.sh
+++ b/scripts/local_sparkle_update_test.sh
@@ -159,7 +159,7 @@ build_editor_app() {
 
     local build_dir="$WORK_DIR/build"
     local app="$build_dir/$APP_NAME.app"
-    local executable="$ROOT_DIR/target/$RUST_TARGET/release/slint-visual-editor"
+    local executable="$ROOT_DIR/target/$RUST_TARGET/release/examples/slint-editor"
     local plist="$app/Contents/Info.plist"
 
     log "Building local Visual Editor binary for $RUST_TARGET"
@@ -169,7 +169,7 @@ build_editor_app() {
         cargo build \
             --release \
             --target "$RUST_TARGET" \
-            --bin slint-visual-editor \
+            --example slint-editor \
             --no-default-features \
             --features "$CARGO_FEATURES"
 

--- a/tools/lsp/dev.slint.VisualEditor.yml
+++ b/tools/lsp/dev.slint.VisualEditor.yml
@@ -73,10 +73,10 @@ modules:
         SKIA_GN_COMMAND: /app/bin/gn
     build-commands:
       - cargo --offline fetch --manifest-path Cargo.toml
-      - cargo build --manifest-path tools/lsp/Cargo.toml --bin slint-visual-editor
+      - cargo build --manifest-path tools/lsp/Cargo.toml --example slint-editor
         --profile package-release --offline --no-default-features
         --features backend-winit,renderer-skia
-      - install -Dm0755 target/package-release/slint-visual-editor ${FLATPAK_DEST}/bin/slint-visual-editor
+      - install -Dm0755 target/package-release/examples/slint-editor ${FLATPAK_DEST}/bin/slint-visual-editor
       - install -Dm0644 tools/lsp/packaging/linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       # The icon references the shared logo and tile backdrop, and librsvg only
       # resolves references within the document's own directory

--- a/tools/lsp/macos-project.yml
+++ b/tools/lsp/macos-project.yml
@@ -61,7 +61,7 @@ targets:
           MACOS_CARGO_TARGET_DIR_NAME=slint-visual-editor \
               ../../scripts/build_macos_app_with_cargo.bash \
               --profile package-release \
-              --bin slint-visual-editor \
+              --example slint-editor \
               --no-default-features \
               --features backend-winit,renderer-skia
         outputFiles:


### PR DESCRIPTION
7bd1cec08 removed the `slint-visual-editor` bin, but the packaging
configurations still ask cargo for it, so every packaging job fails with
`no bin target named slint-visual-editor`. These workflows only run on pull
requests, so it surfaced in #12872 rather than on the branch.

Builds the `slint-editor` example instead, in `macos-project.yml`, the
Windows MSIX workflow, the flatpak manifest and
`local_sparkle_update_test.sh`, reading the executable from cargo's
`examples/` sub-directory. `build_macos_app_with_cargo.bash` grows an
`--example` flag alongside `--bin`.

Shipped names are unchanged. The alternative is restoring the `[[bin]]`.
