### PR TITLE
FlexboxLayout: don't build the flex-props array for unwrapped-main

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -4660,7 +4660,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
         } => generate_with_flexbox_layout_item_info(
             cells_h_variable,
             cells_v_variable,
-            flex_props_variable,
+            flex_props_variable.as_deref(),
             repeater_indices_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
             repeated_cross_width.as_deref(),
@@ -5774,7 +5774,7 @@ fn generate_flexbox_measure_lambda(
 fn generate_with_flexbox_layout_item_info(
     cells_h_variable: &str,
     cells_v_variable: &str,
-    flex_props_variable: &str,
+    flex_props_variable: Option<&str>,
     repeated_indices_var_name: Option<&str>,
     elements: &[Either<
         (llr::Expression, llr::Expression, llr::Expression),
@@ -5785,11 +5785,20 @@ fn generate_with_flexbox_layout_item_info(
     ctx: &llr_EvaluationContext<CppGeneratorContext>,
 ) -> String {
     let repeated_indices_var_name = repeated_indices_var_name.map(ident);
+    // With no flex-props variable the sub-expression only reads the cells, so
+    // don't evaluate (and thus depend on) a static cell's flex properties. A
+    // repeated cell still computes its props inside the bundled item-info call,
+    // whose constraint half is needed either way.
+    let wants_flex_props = flex_props_variable.is_some();
     // Container width forwarded to repeated cells' vertical query (column flex),
     // so a height-for-width instance wraps to the real width like a static cell.
     let cross_width = repeated_cross_width.map(|w| compile_expression(w, ctx));
     let mut push_code =
-        "std::vector<slint::cbindgen_private::LayoutItemInfo> cells_vector_h; std::vector<slint::cbindgen_private::LayoutItemInfo> cells_vector_v; std::vector<slint::cbindgen_private::FlexItemProps> flex_props_vector;".to_owned();
+        "std::vector<slint::cbindgen_private::LayoutItemInfo> cells_vector_h; std::vector<slint::cbindgen_private::LayoutItemInfo> cells_vector_v;".to_owned();
+    if wants_flex_props {
+        push_code
+            .push_str(" std::vector<slint::cbindgen_private::FlexItemProps> flex_props_vector;");
+    }
     let mut repeater_idx = 0usize;
 
     for item in elements {
@@ -5797,12 +5806,19 @@ fn generate_with_flexbox_layout_item_info(
             Either::Left((value_h, value_v, value_flex)) => {
                 write!(
                     push_code,
-                    "cells_vector_h.push_back({{ {} }}); cells_vector_v.push_back({{ {} }}); flex_props_vector.push_back({{ {} }});",
+                    "cells_vector_h.push_back({{ {} }}); cells_vector_v.push_back({{ {} }});",
                     compile_expression(value_h, ctx),
                     compile_expression(value_v, ctx),
-                    compile_expression(value_flex, ctx)
                 )
                 .unwrap();
+                if wants_flex_props {
+                    write!(
+                        push_code,
+                        "flex_props_vector.push_back({{ {} }});",
+                        compile_expression(value_flex, ctx)
+                    )
+                    .unwrap();
+                }
             }
             Either::Right(repeater) => {
                 let repeater_index = usize::from(repeater.repeater_index);
@@ -5837,6 +5853,16 @@ fn generate_with_flexbox_layout_item_info(
                 };
                 // The instance vtable returns the bundled FlexboxLayoutItemInfo; split
                 // it into the constraint cell and the (axis-independent) flex props.
+                let flex_push = if wants_flex_props {
+                    "flex_props_vector.push_back(info_h.props); "
+                } else {
+                    ""
+                };
+                let flex_resize = if wants_flex_props {
+                    "flex_props_vector.resize(start_offset + repeater_len); "
+                } else {
+                    ""
+                };
                 write!(
                     push_code,
                     "{{ \
@@ -5844,13 +5870,13 @@ fn generate_with_flexbox_layout_item_info(
                      self->repeater_{repeater_index}.for_each([&](const auto &sub_comp){{ \
                      auto info_h = sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Horizontal, std::nullopt); \
                      auto info_v = {v_query}; \
-                     flex_props_vector.push_back(info_h.props); \
+                     {flex_push}\
                      cells_vector_h.push_back({{ info_h.constraint, {{}} }}); \
                      cells_vector_v.push_back({{ info_v.constraint, {{}} }}); }}); \
                      auto repeater_len = self->repeater_{repeater_index}.len(); \
                      cells_vector_h.resize(start_offset + repeater_len); \
                      cells_vector_v.resize(start_offset + repeater_len); \
-                     flex_props_vector.resize(start_offset + repeater_len); }}"
+                     {flex_resize}}}"
                 )
                 .unwrap();
             }
@@ -5865,12 +5891,17 @@ fn generate_with_flexbox_layout_item_info(
         .unwrap();
         format!("std::array<int, {}> {ri}_array;", 2 * repeater_idx)
     });
+    let flex_slice = flex_props_variable.map_or(String::new(), |v| {
+        format!(
+            "[[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexItemProps>{} = slint::private_api::make_slice(std::span(flex_props_vector)); ",
+            ident(v)
+        )
+    });
     format!(
-        "[&]{{ {ri} {push_code} [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{cells_h} = slint::private_api::make_slice(std::span(cells_vector_h)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{cells_v} = slint::private_api::make_slice(std::span(cells_vector_v)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::FlexItemProps>{flex_props} = slint::private_api::make_slice(std::span(flex_props_vector)); return {}; }}()",
+        "[&]{{ {ri} {push_code} [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{cells_h} = slint::private_api::make_slice(std::span(cells_vector_h)); [[maybe_unused]] slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{cells_v} = slint::private_api::make_slice(std::span(cells_vector_v)); {flex_slice}return {}; }}()",
         compile_expression(sub_expression, ctx),
         cells_h = ident(cells_h_variable),
         cells_v = ident(cells_v_variable),
-        flex_props = ident(flex_props_variable),
     )
 }
 

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3592,7 +3592,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
         } => generate_with_flexbox_layout_item_info(
             cells_h_variable,
             cells_v_variable,
-            flex_props_variable,
+            flex_props_variable.as_deref(),
             repeater_indices_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
             repeated_cross_width.as_deref(),
@@ -5599,13 +5599,18 @@ fn generate_with_layout_item_info(
 fn generate_with_flexbox_layout_item_info(
     cells_h_variable: &str,
     cells_v_variable: &str,
-    flex_props_variable: &str,
+    flex_props_variable: Option<&str>,
     repeated_indices_var_name: Option<&str>,
     elements: &[Either<(Expression, Expression, Expression), llr::LayoutRepeatedElement>],
     repeated_cross_width: Option<&Expression>,
     sub_expression: &Expression,
     ctx: &EvaluationContext,
 ) -> TokenStream {
+    // With no flex-props variable the sub-expression only reads the cells, so
+    // don't evaluate (and thus depend on) a static cell's flex properties. A
+    // repeated cell still computes its props inside the bundled item-info call,
+    // whose constraint half is needed either way.
+    let wants_flex_props = flex_props_variable.is_some();
     let repeated_indices_var_name = repeated_indices_var_name.map(ident);
     // Container width forwarded to repeated cells' vertical query (column flex),
     // so a height-for-width instance wraps to the real width like a static cell.
@@ -5620,12 +5625,15 @@ fn generate_with_flexbox_layout_item_info(
             Either::Left((value_h, value_v, value_flex)) => {
                 let value_h = compile_expression(value_h, ctx);
                 let value_v = compile_expression(value_v, ctx);
-                let value_flex = compile_expression(value_flex, ctx);
+                let flex_push = wants_flex_props.then(|| {
+                    let value_flex = compile_expression(value_flex, ctx);
+                    quote!(items_vec_flex.push(#value_flex);)
+                });
                 fixed_count += 1;
                 push_code.push(quote!(
                     items_vec_h.push(#value_h);
                     items_vec_v.push(#value_v);
-                    items_vec_flex.push(#value_flex);
+                    #flex_push
                 ))
             }
             Either::Right(repeater) => {
@@ -5652,11 +5660,15 @@ fn generate_with_flexbox_layout_item_info(
                 };
                 // The instance vtable returns the bundled `FlexboxLayoutItemInfo`;
                 // split it into the constraint cell and the flex props.
+                let flex_push =
+                    wants_flex_props.then(|| quote!(items_vec_flex.push(info_h.props);));
+                let flex_placeholder = wants_flex_props
+                    .then(|| quote!(items_vec_flex.push(::core::default::Default::default());));
                 let loop_code = quote!(for i in 0.._self.#repeater_id.len() {
                     if let Some(sub_comp) = _self.#repeater_id.instance_at(i) {
                         let info_h = sub_comp.as_pin_ref().flexbox_layout_item_info(sp::Orientation::Horizontal, None);
                         let info_v = #v_query;
-                        items_vec_flex.push(info_h.props);
+                        #flex_push
                         items_vec_h.push(sp::LayoutItemInfo { constraint: info_h.constraint, ..::core::default::Default::default() });
                         items_vec_v.push(sp::LayoutItemInfo { constraint: info_v.constraint, ..::core::default::Default::default() });
                     } else {
@@ -5664,7 +5676,7 @@ fn generate_with_flexbox_layout_item_info(
                         // count stays in sync with the repeater length written above.
                         items_vec_h.push(::core::default::Default::default());
                         items_vec_v.push(::core::default::Default::default());
-                        items_vec_flex.push(::core::default::Default::default());
+                        #flex_placeholder
                     }
                 });
                 push_code.push(quote!(
@@ -5685,18 +5697,26 @@ fn generate_with_flexbox_layout_item_info(
         repeated_indices_var_name.map(|ri| quote!(let #ri = sp::Slice::from_slice(&#ri);));
     let cells_h_variable = ident(cells_h_variable);
     let cells_v_variable = ident(cells_v_variable);
-    let flex_props_variable = ident(flex_props_variable);
+    let (flex_decl, flex_slice) = flex_props_variable
+        .map(|v| {
+            let v = ident(v);
+            (
+                quote!(let mut items_vec_flex = sp::Vec::with_capacity(#fixed_count #repeated_count_code);),
+                quote!(let #v = sp::Slice::from_slice(&items_vec_flex);),
+            )
+        })
+        .unzip();
     let sub_expression = compile_expression(sub_expression, ctx);
 
     quote! { {
         #ri_init_code
         let mut items_vec_h = sp::Vec::with_capacity(#fixed_count #repeated_count_code);
         let mut items_vec_v = sp::Vec::with_capacity(#fixed_count #repeated_count_code);
-        let mut items_vec_flex = sp::Vec::with_capacity(#fixed_count #repeated_count_code);
+        #flex_decl
         #(#push_code)*
         let #cells_h_variable = sp::Slice::from_slice(&items_vec_h);
         let #cells_v_variable = sp::Slice::from_slice(&items_vec_v);
-        let #flex_props_variable = sp::Slice::from_slice(&items_vec_flex);
+        #flex_slice
         #ri_from_slice
         #sub_expression
     } }

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -263,8 +263,13 @@ pub enum Expression {
         cells_h_variable: String,
         /// The local variable for vertical cells
         cells_v_variable: String,
-        /// The local variable for the per-item flex properties
-        flex_props_variable: String,
+        /// The local variable for the per-item flex properties. `None` when the
+        /// sub-expression does not read them (e.g. `flexbox_layout_unwrapped_main`):
+        /// the flex-props expressions are then not evaluated, so the binding does
+        /// not depend on a static cell's flex properties. (A repeated cell still
+        /// computes its props inside the bundled item-info call, whose constraint
+        /// half is needed either way.)
+        flex_props_variable: Option<String>,
         /// The name for the local variable that contains the repeater indices
         repeater_indices_var_name: Option<SmolStr>,
         /// Either an expression triple of type (LayoutItemInfo, LayoutItemInfo,
@@ -637,6 +642,9 @@ macro_rules! visit_impl {
                 elements.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v, f)| {
                     $visitor(h);
                     $visitor(v);
+                    // Visited even when `flex_props_variable` is `None` and the
+                    // generators skip `f`: this only over-counts property use,
+                    // and the layout's solve binding reads the same properties.
                     $visitor(f);
                 });
             }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -439,7 +439,7 @@ pub(super) fn solve_flexbox_layout(
             llr_Expression::WithFlexboxLayoutItemInfo {
                 cells_h_variable: cells_h_var,
                 cells_v_variable: cells_v_var,
-                flex_props_variable: flex_var,
+                flex_props_variable: Some(flex_var),
                 repeater_indices_var_name: Some("repeated_indices".into()),
                 elements,
                 repeated_cross_width,
@@ -708,7 +708,7 @@ fn compute_flexbox_layout_info_for_direction(
                 llr_Expression::WithFlexboxLayoutItemInfo {
                     cells_h_variable: cells_h_var,
                     cells_v_variable: cells_v_var,
-                    flex_props_variable: flex_var,
+                    flex_props_variable: Some(flex_var),
                     repeater_indices_var_name: None,
                     elements,
                     // Info computation, not a solve: no container width to forward.
@@ -734,7 +734,7 @@ fn compute_flexbox_layout_info_for_direction(
                 llr_Expression::WithFlexboxLayoutItemInfo {
                     cells_h_variable: cells_h_var,
                     cells_v_variable: cells_v_var,
-                    flex_props_variable: flex_var.clone(),
+                    flex_props_variable: Some(flex_var.clone()),
                     repeater_indices_var_name: None,
                     elements,
                     // Info computation, not a solve: no container width to forward.
@@ -1294,11 +1294,13 @@ fn flexbox_unwrapped_main_expr(
         return_ty: Type::Float32,
     };
     match fld.compute_cells {
-        Some((cells_h_variable, cells_v_variable, flex_props_variable, elements)) => {
+        Some((cells_h_variable, cells_v_variable, _, elements)) => {
             llr_Expression::WithFlexboxLayoutItemInfo {
                 cells_h_variable,
                 cells_v_variable,
-                flex_props_variable,
+                // The call only reads the cells, so don't evaluate the
+                // per-item flex properties (that would depend on them).
+                flex_props_variable: None,
                 repeater_indices_var_name: None,
                 elements,
                 // Info computation, not a solve: no container width to forward.

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1009,7 +1009,7 @@ pub fn eval_expression(ctx: &mut EvalContext, expression: &Expression) -> Value 
             ctx,
             cells_h_variable,
             cells_v_variable,
-            flex_props_variable,
+            flex_props_variable.as_deref(),
             elements,
             repeated_cross_width.as_deref(),
             sub_expression,
@@ -1201,7 +1201,7 @@ fn with_flexbox_layout_item_info(
     ctx: &mut EvalContext,
     cells_h_variable: &str,
     cells_v_variable: &str,
-    flex_props_variable: &str,
+    flex_props_variable: Option<&str>,
     elements: &[itertools::Either<
         (Expression, Expression, Expression),
         i_slint_compiler::llr::LayoutRepeatedElement,
@@ -1222,7 +1222,12 @@ fn with_flexbox_layout_item_info(
             itertools::Either::Left((h, v, props)) => {
                 cells_h.push(eval_expression(ctx, h));
                 cells_v.push(eval_expression(ctx, v));
-                flex_props.push(eval_expression(ctx, props));
+                // With no flex-props variable the sub-expression only reads the
+                // cells; don't evaluate (and thus depend on) the static cell's
+                // flex properties.
+                if flex_props_variable.is_some() {
+                    flex_props.push(eval_expression(ctx, props));
+                }
             }
             itertools::Either::Right(repeater) => {
                 let offset = cells_h.len() as u32;
@@ -1232,7 +1237,7 @@ fn with_flexbox_layout_item_info(
                     cross_width,
                     &mut cells_h,
                     &mut cells_v,
-                    &mut flex_props,
+                    flex_props_variable.is_some().then_some(&mut flex_props),
                 );
                 repeated_indices.push(offset);
                 repeated_indices.push(instances);
@@ -1243,9 +1248,9 @@ fn with_flexbox_layout_item_info(
         ctx.locals.insert(SmolStr::from(cells_h_variable), Value::Model(model_from_vec(cells_h)));
     let prev_v =
         ctx.locals.insert(SmolStr::from(cells_v_variable), Value::Model(model_from_vec(cells_v)));
-    let prev_fp = ctx
-        .locals
-        .insert(SmolStr::from(flex_props_variable), Value::Model(model_from_vec(flex_props)));
+    let prev_fp = flex_props_variable.map(|name| {
+        ctx.locals.insert(SmolStr::from(name), Value::Model(model_from_vec(flex_props)))
+    });
     let prev_ri = ctx.locals.insert(
         SmolStr::new_static("repeated_indices"),
         Value::Model(model_from_vec(
@@ -1255,7 +1260,9 @@ fn with_flexbox_layout_item_info(
     let result = eval_expression(ctx, sub_expression);
     restore_local(ctx, cells_h_variable, prev_h);
     restore_local(ctx, cells_v_variable, prev_v);
-    restore_local(ctx, flex_props_variable, prev_fp);
+    if let Some(name) = flex_props_variable {
+        restore_local(ctx, name, prev_fp.flatten());
+    }
     restore_local(ctx, "repeated_indices", prev_ri);
     result
 }
@@ -1266,7 +1273,7 @@ fn push_repeater_flexbox_items(
     cross_width: Option<f32>,
     cells_h: &mut Vec<Value>,
     cells_v: &mut Vec<Value>,
-    flex_props: &mut Vec<Value>,
+    mut flex_props: Option<&mut Vec<Value>>,
 ) -> u32 {
     use i_slint_core::items::Orientation;
     use i_slint_core::model::RepeatedItemTree;
@@ -1296,7 +1303,9 @@ fn push_repeater_flexbox_items(
         };
         // The flex props are axis-independent: both bundled infos carry the
         // same ones, take them from the horizontal query.
-        flex_props.push(flex_props_to_value(info_h.props));
+        if let Some(fp) = flex_props.as_mut() {
+            fp.push(flex_props_to_value(info_h.props));
+        }
         cells_h.push(layout_item_info_to_value(info_h.constraint));
         cells_v.push(layout_item_info_to_value(info_v.constraint));
     }

--- a/tests/cases/layout/flexbox_column_wrap_when_needed.slint
+++ b/tests/cases/layout/flexbox_column_wrap_when_needed.slint
@@ -20,9 +20,14 @@
 // translucent orange. Before the fix the flex reserved less than it drew, so
 // items spilled past the outline into the sibling; now the outline hugs the
 // items and stops before the sibling.
+//
+// The third column repeats the no-wrap cases with a repeater among the cells:
+// the natural single-line size is then computed from runtime cell arrays
+// instead of static cells. Repeated items can't be referenced by id, so these
+// assert on the flex's reported box (main extent 130px = single line).
 
 export component TestCase inherits Window {
-    width: 800px;
+    width: 1200px;
     height: 490px;
 
     // Column of "flex-direction: column" cases on the left, "flex-direction:
@@ -40,6 +45,13 @@ export component TestCase inherits Window {
         vertical-alignment: center;
         font-size: 15px;
         text: "flex-direction: row (in a VerticalLayout)";
+    }
+    Text {
+        x: 800px; y: 0; width: 400px; height: 35px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        font-size: 15px;
+        text: "repeated cells";
     }
 
     // --- Tall: 300px is more than the 130px the column needs -> no wrap ---
@@ -142,6 +154,54 @@ export component TestCase inherits Window {
         }
     }
 
+    // --- Tall with a repeater: a static cell followed by two repeated ones,
+    // same geometry as the tall case -> no wrap ---
+    repTallFlexBg := Rectangle {
+        x: 800px; y: 40px; width: 400px; height: 300px;
+        border-color: gray;
+        border-width: 1px;
+        HorizontalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            repTallFlex := FlexboxLayout {
+                flex-direction: column;
+                spacing: 5px;
+                Rectangle { width: 50px; height: 40px; background: #c33; }
+                for c in [#3c3, #36c]: Rectangle { width: 50px; height: 40px; background: c; }
+            }
+            repTallSibling := Rectangle { min-width: 100px; height: 130px; background: #ffa50080; }
+        }
+        Rectangle {
+            x: repTallFlex.x; y: repTallFlex.y; width: repTallFlex.width; height: repTallFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
+    // --- Wide with a repeater: two repeated cells before a static one,
+    // same geometry as the wide case -> no wrap ---
+    repWideFlexBg := Rectangle {
+        x: 800px; y: 350px; width: 300px; height: 130px;
+        border-color: gray;
+        border-width: 1px;
+        VerticalLayout {
+            alignment: start;
+            cross-axis-alignment: start;
+            spacing: 10px;
+            repWideFlex := FlexboxLayout {
+                flex-direction: row;
+                spacing: 5px;
+                for c in [#c33, #3c3]: Rectangle { width: 40px; height: 50px; background: c; }
+                Rectangle { width: 40px; height: 50px; background: #36c; }
+            }
+            repWideSibling := Rectangle { min-height: 60px; width: 130px; background: #ffa50080; }
+        }
+        Rectangle {
+            x: repWideFlex.x; y: repWideFlex.y; width: repWideFlex.width; height: repWideFlex.height;
+            background: transparent; border-color: #f0f; border-width: 2px;
+        }
+    }
+
     // Tall: the three items form a single column (same x, increasing y) and the
     // flex stays one column wide.
     out property <bool> tall_single_column: t1.x == t2.x && t2.x == t3.x
@@ -168,8 +228,18 @@ export component TestCase inherits Window {
     out property <bool> narrow_wraps: n3.y > n1.y && narrowFlex.height > 50px;
     out property <bool> narrow_no_overlap: narrowSibling.y >= narrowFlex.y + narrowFlex.height;
 
+    // Repeated: one column wide, and the reported height is the natural
+    // single-column height (three items + two spacings), so it did not wrap.
+    out property <bool> rep_tall_natural: repTallFlex.width == 50px && repTallFlex.height == 130px;
+    out property <bool> rep_tall_no_overlap: repTallSibling.x >= repTallFlex.x + repTallFlex.width;
+
+    // Repeated rotated: one row tall, natural single-row width.
+    out property <bool> rep_wide_natural: repWideFlex.height == 50px && repWideFlex.width == 130px;
+    out property <bool> rep_wide_no_overlap: repWideSibling.y >= repWideFlex.y + repWideFlex.height;
+
     out property <bool> test: tall_single_column && tall_no_overlap && short_wraps && short_no_overlap
-        && wide_single_row && wide_no_overlap && narrow_wraps && narrow_no_overlap;
+        && wide_single_row && wide_no_overlap && narrow_wraps && narrow_no_overlap
+        && rep_tall_natural && rep_tall_no_overlap && rep_wide_natural && rep_wide_no_overlap;
 }
 
 /*
@@ -183,6 +253,10 @@ assert(handle->get_wide_single_row());
 assert(handle->get_wide_no_overlap());
 assert(handle->get_narrow_wraps());
 assert(handle->get_narrow_no_overlap());
+assert(handle->get_rep_tall_natural());
+assert(handle->get_rep_tall_no_overlap());
+assert(handle->get_rep_wide_natural());
+assert(handle->get_rep_wide_no_overlap());
 assert(handle->get_test());
 ```
 
@@ -196,6 +270,10 @@ assert!(instance.get_wide_single_row(), "wide row flex must not wrap");
 assert!(instance.get_wide_no_overlap(), "wide flex overlaps its sibling");
 assert!(instance.get_narrow_wraps(), "narrow row flex must wrap into a 2nd row");
 assert!(instance.get_narrow_no_overlap(), "narrow flex overlaps its sibling");
+assert!(instance.get_rep_tall_natural(), "repeated column flex must keep its natural size");
+assert!(instance.get_rep_tall_no_overlap(), "repeated column flex overlaps its sibling");
+assert!(instance.get_rep_wide_natural(), "repeated row flex must keep its natural size");
+assert!(instance.get_rep_wide_no_overlap(), "repeated row flex overlaps its sibling");
 assert!(instance.get_test());
 ```
 
@@ -209,6 +287,10 @@ assert(instance.wide_single_row);
 assert(instance.wide_no_overlap);
 assert(instance.narrow_wraps);
 assert(instance.narrow_no_overlap);
+assert(instance.rep_tall_natural);
+assert(instance.rep_tall_no_overlap);
+assert(instance.rep_wide_natural);
+assert(instance.rep_wide_no_overlap);
 assert(instance.test);
 ```
 */


### PR DESCRIPTION
Optimization after the removal of `flex-basis`:

Since `flexbox_layout_unwrapped_main()` only reads the cells,
the `WithFlexboxLayoutItemInfo` wrapper on that path kept evaluating the
per-item flex properties into an array nobody read — so the binding
re-evaluated when e.g. a static cell's `flex-order` changed. Make the
`flex-props` variable optional and skip the array when it is None. A
repeated cell still computes its props inside the bundled item-info
call, whose constraint half is needed either way.