### PR TITLE
remote preview: don't trust everything a viewer sends

### DIFF
--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -7,6 +7,11 @@ pub mod completion;
 mod formatting;
 mod goto;
 mod hover;
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"),
+))]
+mod preview_files;
 mod semantic_tokens;
 mod signature_help;
 #[cfg(test)]
@@ -134,6 +139,9 @@ pub fn send_state_to_preview(ctx: &Context) {
 pub fn send_files_to_preview(ctx: &Context, files: &[lsp_types::Url]) {
     #[cfg(feature = "preview-remote")]
     let mut fonts_sent = HashSet::<PathBuf>::new();
+    // Only the files that aren't loaded yet are read off disk, so build the
+    // access rules on the first one that is — most requests never need them.
+    let file_access = std::cell::OnceCell::new();
     for url in files {
         if let Some(node) = ctx.document_cache.get_document(url).and_then(|doc| doc.node.as_ref()) {
             let version = ctx.document_cache.document_version_by_path(node.source_file.path());
@@ -151,6 +159,21 @@ pub fn send_files_to_preview(ctx: &Context, files: &[lsp_types::Url]) {
             tracing::warn!("Cannot convert URL to file path: {url}");
             continue;
         };
+        let file_access = file_access.get_or_init(|| {
+            preview_files::PreviewFileAccess::new(
+                &ctx.init_param,
+                &ctx.preview_config,
+                &ctx.document_cache,
+            )
+        });
+        if !file_access.allows(&path) {
+            tracing::warn!(
+                "Refusing to send {} to the preview: not a file of the project being previewed",
+                path.display()
+            );
+            ctx.to_preview.send(&LspToPreviewMessage::ForgetFile { url: url.clone() });
+            continue;
+        }
         match std::fs::read(&path) {
             Ok(contents) => {
                 tracing::debug!("Sending file {} ({} bytes) to preview", url, contents.len());

--- a/tools/lsp/language/preview_files.rs
+++ b/tools/lsp/language/preview_files.rs
@@ -1,0 +1,242 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore avif svgz ttc
+
+//! Which files on the developer's machine a preview may ask for.
+//!
+//! The remote preview runs on another device and asks the LSP for the files it
+//! needs by URL, so this is the boundary between the project being previewed
+//! and the rest of the disk. Files the LSP pushes on its own — the loaded
+//! sources, the fonts they import — don't go through here.
+
+use crate::common::{DocumentCache, uri_to_file};
+use i_slint_compiler::pathutils::{clean_path, is_url};
+use i_slint_live_preview::protocol::PreviewConfig;
+use lsp_types::InitializeParams;
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// The images and fonts a `.slint` can reference. Assets aren't compiled, so
+/// the compiler doesn't know about them until the full pass pipeline has run
+/// (which the LSP doesn't do) and they have to be recognized by their name.
+const ASSET_EXTENSIONS: &[&str] = &[
+    // images, mirroring `i_slint_core::graphics::image_mime_type_from_extension`
+    "png", "jpg", "jpeg", "svg", "svgz", "gif", "webp", "bmp", "ico", "avif", //
+    // fonts, mirroring `i_slint_compiler::pathutils::is_font_file`
+    "ttf", "ttc", "otf",
+];
+
+/// The files a preview may be sent, read from disk.
+pub struct PreviewFileAccess {
+    /// Directories files may come from: the workspace the editor opened, the
+    /// configured include and library paths, and the directories of the
+    /// documents already loaded (which covers editing a file outside any
+    /// workspace).
+    roots: HashSet<PathBuf>,
+    /// Every file the compiler loaded for this project. Sources aren't required
+    /// to be named `.slint`, so this is what says a file belongs to the project
+    /// rather than its name does.
+    project_files: HashSet<PathBuf>,
+}
+
+impl PreviewFileAccess {
+    pub fn new(
+        init_param: &InitializeParams,
+        preview_config: &PreviewConfig,
+        document_cache: &DocumentCache,
+    ) -> Self {
+        let project_files = document_cache.all_paths_to_watch();
+
+        // Deduplicated before canonicalizing: a project has many more files
+        // than directories, and each candidate costs a system call. `builtin:/…`
+        // paths aren't on disk at all.
+        let mut candidates: HashSet<PathBuf> =
+            crate::common::host_language_search::resolve_workspace_folders(init_param)
+                .iter()
+                .filter_map(|folder| uri_to_file(&folder.uri))
+                .chain(preview_config.include_paths.iter().cloned())
+                .chain(preview_config.library_paths.values().cloned())
+                .collect();
+        candidates.extend(
+            project_files
+                .iter()
+                .filter(|path| !is_url(path))
+                .filter_map(|path| path.parent())
+                .map(Path::to_path_buf),
+        );
+
+        let roots = candidates
+            .iter()
+            .filter_map(|path| {
+                // Canonical, so that comparing against a requested path can't
+                // be sidestepped with `..` or a symlink.
+                let path = path.canonicalize().ok()?;
+                // A candidate given as a file — a library mapped to a single
+                // `.slint` — stands for the directory it sits in, which is the
+                // unit the rest of that library lives in.
+                if path.is_dir() { Some(path) } else { Some(path.parent()?.to_path_buf()) }
+            })
+            .collect();
+
+        Self { roots, project_files }
+    }
+
+    /// Whether a preview may be sent the contents of `path`, read from disk.
+    ///
+    /// A file has to sit in one of the roots — that is what keeps a viewer to
+    /// the project being previewed — and be part of that project: either the
+    /// compiler already loaded it, or it is named like an asset a `.slint` can
+    /// reference. Without the second half, a viewer could ask for the `.env` or
+    /// the `.git/config` that happen to sit next to the sources.
+    pub fn allows(&self, path: &Path) -> bool {
+        // The two halves normalize differently on purpose: the root test has to
+        // resolve `..` and symlinks to mean anything, while the compiler's paths
+        // are cleaned but not canonical, so that is what they compare against.
+        let Ok(canonical) = path.canonicalize() else {
+            return false;
+        };
+        if !self.roots.iter().any(|root| canonical.starts_with(root)) {
+            return false;
+        }
+        self.project_files.contains(&clean_path(path)) || is_asset(path)
+    }
+}
+
+fn is_asset(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| {
+        ASSET_EXTENSIONS.iter().any(|asset| extension.eq_ignore_ascii_case(asset))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::test::empty_document_cache;
+
+    fn access(preview_config: PreviewConfig, document_cache: &DocumentCache) -> PreviewFileAccess {
+        PreviewFileAccess::new(&InitializeParams::default(), &preview_config, document_cache)
+    }
+
+    #[test]
+    fn reads_only_project_files_within_the_roots() {
+        let root = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let preview_config =
+            PreviewConfig { include_paths: vec![root.path().to_path_buf()], ..Default::default() };
+        let access = access(preview_config, &empty_document_cache());
+
+        // Assets the sources reference, whatever the extension's case.
+        let asset = root.path().join("logo.PNG");
+        std::fs::write(&asset, []).unwrap();
+        assert!(access.allows(&asset));
+
+        // Not something a preview shows, even inside the project.
+        let secret = root.path().join(".env");
+        std::fs::write(&secret, "TOKEN=42").unwrap();
+        assert!(!access.allows(&secret));
+
+        // Outside the roots, whether asked for directly or through `..`.
+        let outside = elsewhere.path().join("logo.png");
+        std::fs::write(&outside, []).unwrap();
+        assert!(!access.allows(&outside));
+        let traversal =
+            root.path().join("..").join(elsewhere.path().file_name().unwrap()).join("logo.png");
+        assert!(!access.allows(&traversal));
+
+        assert!(!access.allows(&root.path().join("missing.png")));
+    }
+
+    #[test]
+    fn reads_a_source_the_compiler_loaded_whatever_its_name() {
+        // Nothing requires a source to be named `.slint`.
+        let project = tempfile::tempdir().unwrap();
+        let source = project.path().join("sources.not-slint");
+        let contents = "export component Main {}";
+        std::fs::write(&source, contents).unwrap();
+
+        let mut ctx = crate::language::test::mock_context();
+        crate::language::test::load(&mut ctx, &source, contents);
+        let access = access(PreviewConfig::default(), &ctx.document_cache);
+
+        assert!(access.allows(&source));
+        // ... but a file beside it that the compiler never loaded is refused.
+        let secret = project.path().join(".env");
+        std::fs::write(&secret, "TOKEN=42").unwrap();
+        assert!(!access.allows(&secret));
+    }
+
+    #[test]
+    fn a_library_mapped_to_a_file_makes_its_directory_readable() {
+        let library = tempfile::tempdir().unwrap();
+        let entry_point = library.path().join("lib.slint");
+        std::fs::write(&entry_point, "export component Lib {}").unwrap();
+        let logo = library.path().join("logo.png");
+        std::fs::write(&logo, []).unwrap();
+
+        let preview_config = PreviewConfig {
+            library_paths: [("widgets".to_string(), entry_point)].into_iter().collect(),
+            ..Default::default()
+        };
+        let access = access(preview_config, &empty_document_cache());
+
+        // `@widgets` imports lib.slint, which references the files beside it.
+        assert!(access.allows(&logo));
+    }
+
+    /// End to end through [`crate::language::send_files_to_preview`]: a viewer
+    /// asks for the files its compiler resolves — the `.slint` its sources
+    /// import, and the assets they reference — and both have to make it
+    /// through, or the preview shows a broken component.
+    #[test]
+    fn serves_the_files_a_viewer_asks_for() {
+        use i_slint_live_preview::protocol::{LspToPreviewMessage, PreviewTarget};
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        struct Recorder(Rc<RefCell<Vec<LspToPreviewMessage>>>);
+        impl crate::common::LspToPreview for Recorder {
+            fn send(&self, message: &LspToPreviewMessage) {
+                self.0.borrow_mut().push(message.clone());
+            }
+            fn preview_target(&self) -> PreviewTarget {
+                PreviewTarget::Dummy
+            }
+        }
+
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join("other.slint"), "export component Other { }").unwrap();
+        std::fs::write(project.path().join("logo.png"), []).unwrap();
+        let main = project.path().join("main.slint");
+        let main_source = r#"
+            import { Other } from "other.slint";
+            export component Main {
+                Image { source: @image-url("logo.png"); }
+                Other { }
+            }
+        "#;
+        std::fs::write(&main, main_source).unwrap();
+
+        let recorded = Rc::new(RefCell::new(Vec::new()));
+        let mut ctx = crate::language::Context {
+            to_preview: crate::common::LspToPreviews::with_one(Recorder(recorded.clone())),
+            ..crate::language::test::mock_context()
+        };
+        crate::language::test::load(&mut ctx, &main, main_source);
+        recorded.borrow_mut().clear();
+
+        // `other.slint` is a document the compiler loaded; `logo.png` is not,
+        // because the LSP only runs the import passes.
+        let requested = ["other.slint", "logo.png"]
+            .map(|file| lsp_types::Url::from_file_path(project.path().join(file)).unwrap());
+        crate::language::send_files_to_preview(&ctx, &requested);
+
+        let recorded = recorded.borrow();
+        let served = recorded
+            .iter()
+            .filter(|message| matches!(message, LspToPreviewMessage::SetContents { .. }))
+            .count();
+        assert_eq!(served, 2, "both requested files should have been served: {recorded:?}");
+    }
+}

--- a/tools/lsp/preview/connector/remote.rs
+++ b/tools/lsp/preview/connector/remote.rs
@@ -54,7 +54,7 @@ struct RemoteLspConnection {
 #[derive(Clone)]
 struct SharedState {
     connection: Arc<Mutex<Option<RemoteLspConnection>>>,
-    preview_to_lsp_sender: mpsc::UnboundedSender<PreviewToLspMessage>,
+    preview_to_lsp_sender: RemotePreviewSender,
     /// Back-reference to the owning [`LspToPreviews`]. Used to forward
     /// `RemoteConnectionState` updates to the dialog. `Weak` so it can
     /// be stored inside the owner without forming an `Rc` cycle.
@@ -89,7 +89,7 @@ impl RemoteLspToPreview {
         Self {
             shared: SharedState {
                 connection: Arc::default(),
-                preview_to_lsp_sender,
+                preview_to_lsp_sender: RemotePreviewSender(preview_to_lsp_sender),
                 to_previews,
                 generation: Rc::default(),
             },
@@ -257,9 +257,7 @@ impl RemoteLspToPreview {
 
         // Have the LSP push configuration, file contents, and the previewed
         // component, so the viewer leaves its idle screen on its own.
-        let _ = shared
-            .preview_to_lsp_sender
-            .send(PreviewToLspMessage::RequestState { files: Vec::new() });
+        shared.preview_to_lsp_sender.send(PreviewToLspMessage::RequestState { files: Vec::new() });
 
         Ok(())
     }
@@ -385,11 +383,7 @@ impl RemoteLspToPreview {
                                     last_pong.set(Instant::now());
                                 }
                                 Ok(msg) => {
-                                    shared.preview_to_lsp_sender.send(msg).unwrap_or_else(|err| {
-                                        tracing::error!(
-                                            "Failed sending message from remote preview server to LSP server: {err}"
-                                        );
-                                    });
+                                    shared.preview_to_lsp_sender.send(msg);
                                 }
                                 Err(e) => {
                                     tracing::error!(
@@ -440,6 +434,44 @@ impl RemoteLspToPreview {
                 connection.task.abort();
             }
         }
+    }
+}
+
+/// The LSP's message channel, which the trusted local preview process also
+/// feeds, seen from the remote connection. Everything a remote viewer sends
+/// goes through here, so the check can't be forgotten at a call site.
+#[derive(Clone)]
+struct RemotePreviewSender(mpsc::UnboundedSender<PreviewToLspMessage>);
+
+impl RemotePreviewSender {
+    /// A remote viewer runs on someone else's machine: it may report what it
+    /// compiled and ask for the files it needs, and nothing else. That, not
+    /// "does it reach the editor", is where the line is — a viewer's whole job
+    /// is to send back diagnostics.
+    ///
+    /// Listed positively on purpose: a new variant stays refused until it is
+    /// deliberately allowed.
+    ///
+    /// Refused messages are dropped rather than taken as grounds to hang up:
+    /// the reconnect loop would only dial it again, and by then
+    /// the peer already has everything the connection was going to give it.
+    fn send(&self, message: PreviewToLspMessage) {
+        if !matches!(
+            message,
+            PreviewToLspMessage::Diagnostics { .. }
+                | PreviewToLspMessage::DebugMessage { .. }
+                | PreviewToLspMessage::RequestState { .. }
+        ) {
+            tracing::warn!(
+                "Ignoring message that a remote preview server may not send: {message:?}"
+            );
+            return;
+        }
+        self.0.send(message).unwrap_or_else(|err| {
+            tracing::error!(
+                "Failed sending message from remote preview server to LSP server: {err}"
+            );
+        });
     }
 }
 
@@ -567,30 +599,41 @@ mod tests {
         .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
     }
 
+    /// A viewer on an arbitrary port with a connector attached to it, past the
+    /// handshake and the initial state push both sides start a session with.
+    async fn connected_viewer() -> (
+        Connection,
+        mpsc::UnboundedReceiver<ConnectionMessage>,
+        RemoteLspToPreview,
+        mpsc::UnboundedReceiver<PreviewToLspMessage>,
+    ) {
+        let (viewer, mut viewer_rx) = listen(0).await;
+
+        let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
+        let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+        connector.connect(["127.0.0.1"], viewer.local_port()).await.unwrap();
+        expect_message(
+            &mut viewer_rx,
+            |m| matches!(m, ConnectionMessage::Connected { .. }),
+            "viewer connection",
+        )
+        .await;
+        expect_message(
+            &mut to_lsp_rx,
+            |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
+            "RequestState after connecting",
+        )
+        .await;
+
+        (viewer, viewer_rx, connector, to_lsp_rx)
+    }
+
     #[tokio::test]
     async fn reconnects_after_connection_loss() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                let (viewer, mut viewer_rx) = listen(0).await;
+                let (viewer, viewer_rx, connector, mut to_lsp_rx) = connected_viewer().await;
                 let port = viewer.local_port();
-
-                let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
-                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
-                connector.connect(["127.0.0.1"], port).await.unwrap();
-                expect_message(
-                    &mut viewer_rx,
-                    |m| matches!(m, ConnectionMessage::Connected { .. }),
-                    "viewer connection",
-                )
-                .await;
-                // Consume the initial state push, so the wait below can only
-                // match the reconnect's.
-                expect_message(
-                    &mut to_lsp_rx,
-                    |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
-                    "RequestState after connecting",
-                )
-                .await;
 
                 // Replace the viewer on the same port, like an app whose
                 // connection the OS cut while backgrounded.
@@ -612,6 +655,46 @@ mod tests {
                     "RequestState after reconnecting",
                 )
                 .await;
+
+                connector.disconnect().await;
+            })
+            .await;
+    }
+
+    /// A viewer is on the far end of the network: it may not drive the editor.
+    #[tokio::test]
+    async fn drops_messages_a_viewer_may_not_send() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, _viewer_rx, connector, mut to_lsp_rx) = connected_viewer().await;
+
+                // A message that drives the editor, followed by one a viewer is
+                // allowed to send.
+                viewer
+                    .send(PreviewToLspMessage::ShowDocument {
+                        file: lsp_types::Url::parse("file:///test.slint").unwrap(),
+                        selection: lsp_types::Range::default(),
+                        take_focus: true,
+                    })
+                    .unwrap();
+                viewer
+                    .send(PreviewToLspMessage::Diagnostics {
+                        uri: lsp_types::Url::parse("file:///test.slint").unwrap(),
+                        version: None,
+                        diagnostics: Vec::new(),
+                    })
+                    .unwrap();
+
+                // The channel keeps the order the viewer sent in, so the
+                // diagnostics arriving first means the other one was dropped.
+                let message = tokio::time::timeout(Duration::from_secs(15), to_lsp_rx.recv())
+                    .await
+                    .expect("timed out waiting for the diagnostics")
+                    .expect("message channel closed");
+                assert!(
+                    matches!(message, PreviewToLspMessage::Diagnostics { .. }),
+                    "a message the viewer may not send reached the LSP: {message:?}"
+                );
 
                 connector.disconnect().await;
             })

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -296,7 +296,7 @@ export component RemotePreviewView inherits Rectangle {
                     }
 
                     Text {
-                        text: @tr("Connecting sends this project's .slint files, images and fonts to the device over the local network, without encryption. Only connect to a device you trust.");
+                        text: @tr("Connecting sends this project's .slint files, images and fonts to the device over the local network, without encryption. Only connect to a trusted device.");
                         color: Palette.foreground;
                         opacity: 0.7;
                         font-size: 11px;

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -295,6 +295,14 @@ export component RemotePreviewView inherits Rectangle {
                         }
                     }
 
+                    Text {
+                        text: @tr("Connecting sends this project's .slint files, images and fonts to the device over the local network, without encryption. Only connect to a device you trust.");
+                        color: Palette.foreground;
+                        opacity: 0.7;
+                        font-size: 11px;
+                        wrap: word-wrap;
+                    }
+
                     if root.connecting: Text {
                         text: @tr("Connecting to {}…", Api.remote-connection-target);
                         color: Palette.foreground;


### PR DESCRIPTION
The connector forwarded every decoded message into the channel the trusted local preview process uses, so a viewer could drive the editor with SendWorkspaceEdit or ShowDocument, and have any file on the machine read and sent back to it through RequestState.

Only forward what a viewer legitimately sends: diagnostics, debug messages and file requests. Serve those requests from the project being previewed alone: a file has to sit in the workspace, an include path, a library path or next to a loaded document, and be either a file the compiler loaded or an image or font the sources can reference.

The connect dialog now says what connecting shares with the device.

