### PR TITLE
Don't panic when reaching an item through a dead parent chain

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -64,6 +64,11 @@ pub fn concatenate_ident(ident: &str) -> SmolStr {
 
 /// Given a property reference to a native item (eg, the property name is empty)
 /// return tokens to the `ItemRc`
+///
+/// This walks the parent chain with `value()`, so it must only be spliced inside a guard on the
+/// same reference — a `then`/`map_or_default` of [`access_member`] — because the chain can die
+/// while a callback of a repeated element is still running (the enclosing popup closes itself,
+/// or the model drops the row the element belongs to).
 fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> String {
     let mut component_access = "self->".into();
 
@@ -3931,11 +3936,14 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                format!("slint::private_api::optional_then({t}, [&](auto&&x) {{ {}; }})", f("x"))
+                format!(
+                    "slint::private_api::optional_then({t}, [&]([[maybe_unused]] auto&&x) {{ {}; }})",
+                    f("x")
+                )
             }
             MemberAccess::OptionWithMember(t, m) => {
                 format!(
-                    "slint::private_api::optional_then({t}, [&](auto&&x) {{ {}; }})",
+                    "slint::private_api::optional_then({t}, [&]([[maybe_unused]] auto&&x) {{ {}; }})",
                     f(&format!("x{}", m))
                 )
             }
@@ -3947,13 +3955,13 @@ impl MemberAccess {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
                 format!(
-                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&](auto&&x) {{ return {}; }}))",
+                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }}))",
                     f("x")
                 )
             }
             MemberAccess::OptionWithMember(t, m) => {
                 format!(
-                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&](auto&&x) {{ return {}; }}))",
+                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }}))",
                     f(&format!("x{}", m))
                 )
             }
@@ -3964,11 +3972,11 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => MemberAccess::Option(f(t)),
             MemberAccess::Option(t) => MemberAccess::Option(format!(
-                "slint::private_api::optional_and_then({t}, [&](auto&&x) {{ return {}; }})",
+                "slint::private_api::optional_and_then({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }})",
                 f("x")
             )),
             MemberAccess::OptionWithMember(t, m) => MemberAccess::Option(format!(
-                "slint::private_api::optional_and_then({t}, [&](auto&&x) {{ return {}; }})",
+                "slint::private_api::optional_and_then({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }})",
                 f(&format!("x{}", m))
             )),
         }
@@ -4860,7 +4868,7 @@ fn compile_builtin_function_call(
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let window = access_window_field(ctx);
                 let focus_item = access_item_rc(pr, ctx);
-                format!("{window}.set_focus_item({focus_item}, true, slint::cbindgen_private::FocusReason::Programmatic);")
+                access_member(pr, ctx).then(|_| format!("{window}.set_focus_item({focus_item}, true, slint::cbindgen_private::FocusReason::Programmatic)"))
             } else {
                 panic!("internal error: invalid args to SetFocusItem {arguments:?}")
             }
@@ -4869,7 +4877,7 @@ fn compile_builtin_function_call(
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let window = access_window_field(ctx);
                 let focus_item = access_item_rc(pr, ctx);
-                format!("{window}.set_focus_item({focus_item}, false, slint::cbindgen_private::FocusReason::Programmatic);")
+                access_member(pr, ctx).then(|_| format!("{window}.set_focus_item({focus_item}, false, slint::cbindgen_private::FocusReason::Programmatic)"))
             } else {
                 panic!("internal error: invalid args to ClearFocusItem {arguments:?}")
             }
@@ -5147,6 +5155,9 @@ fn compile_builtin_function_call(
                     &local_reference.sub_component_path,
                 );
                 let parent_component = access_item_rc(anchor_ref, ctx);
+                // `access_item_rc` unwraps the anchor's parent chain, so only emit the show when
+                // the very same reference is reachable
+                let anchor_reachable = access_member(anchor_ref, ctx);
                 ctx.with_reference_scope(*parent_level, &local_reference.sub_component_path, |parent_ctx| {
                 let popup = &ctx.compilation_unit.sub_components[parent_ctx.sub_component]
                     .popup_windows[*popup_index as usize];
@@ -5185,7 +5196,7 @@ fn compile_builtin_function_call(
                     }
                     _ => "[](bool) {}".to_string(),
                 };
-                component_access.then(|component_access| {
+                let show = component_access.then(|component_access| {
                     let compo_ptr = if compo_path.is_empty() {
                         format!("&*({component_access})")
                     } else {
@@ -5202,7 +5213,8 @@ fn compile_builtin_function_call(
                                                                             {window_kind},  \
                                                                             {is_open_setter})"
                     )
-                })
+                });
+                anchor_reachable.then(|_| show)
                 })
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")
@@ -5261,7 +5273,7 @@ fn compile_builtin_function_call(
             let set_id = context_menu
                 .then(|context_menu| format!("{context_menu}.popup_id = id"));
 
-            if let llr::Expression::NumberLiteral(tree_index) = entries {
+            let show = if let llr::Expression::NumberLiteral(tree_index) = entries {
                 // We have an MenuItem tree
                 let current_sub_component = ctx.current_sub_component().unwrap();
                 let item_tree_id = ident(&ctx.compilation_unit.sub_components[current_sub_component.menu_item_trees[*tree_index as usize].root].name);
@@ -5309,7 +5321,8 @@ fn compile_builtin_function_call(
                     }});
                     {set_id};
                 ", globals = ctx.generator_state.global_access)
-            }
+            };
+            context_menu.then(|_| show)
         }
         BuiltinFunction::SetSelectionOffsets => {
             if let [llr::Expression::PropertyReference(pr), from, to] = arguments {
@@ -5329,9 +5342,9 @@ fn compile_builtin_function_call(
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let window = access_window_field(ctx);
-                format!(
+                access_member(pr, ctx).map_or_default(|_| format!(
                     "[&]{{ slint::cbindgen_private::FontMetrics fm; slint_cpp_text_item_fontmetrics(&{window}.handle(), &{item_rc}, &fm); return fm; }}()"
-                )
+                ))
             } else {
                 panic!("internal error: invalid args to ItemFontMetrics {arguments:?}")
             }
@@ -5339,7 +5352,7 @@ fn compile_builtin_function_call(
         BuiltinFunction::ItemAbsolutePosition => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
-                format!("slint::LogicalPosition(slint::cbindgen_private::slint_item_absolute_position(&{item_rc}))")
+                access_member(pr, ctx).map_or_default(|_| format!("slint::LogicalPosition(slint::cbindgen_private::slint_item_absolute_position(&{item_rc}))"))
             } else {
                 panic!("internal error: invalid args to ItemAbsolutePosition {arguments:?}")
             }
@@ -5436,9 +5449,9 @@ fn compile_builtin_function_call(
             if let [llr::Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                format!(
+                access_member(pr, ctx).map_or_default(|_| format!(
                     "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at(&{item_rc}, static_cast<float>({t})))"
-                )
+                ))
             } else {
                 panic!("internal error: invalid args to PathPointAt {arguments:?}")
             }
@@ -5447,9 +5460,9 @@ fn compile_builtin_function_call(
             if let [llr::Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                format!(
+                access_member(pr, ctx).map_or_default(|_| format!(
                     "slint::cbindgen_private::slint_path_angle_at(&{item_rc}, static_cast<float>({t}))"
-                )
+                ))
             } else {
                 panic!("internal error: invalid args to PathAngleAt {arguments:?}")
             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3240,8 +3240,9 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                let r = f(quote!(x));
-                quote!({ let _ = #t.map(|x| #r); })
+                // `_x` so that `f` may ignore the member and only use this as a reachability guard
+                let r = f(quote!(_x));
+                quote!({ let _ = #t.map(|_x| #r); })
             }
             MemberAccess::OptionFn(opt, inner) => {
                 let r = f(inner);
@@ -3254,8 +3255,8 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                let r = f(quote!(x));
-                quote!(#t.map(|x| #r).unwrap_or_default())
+                let r = f(quote!(_x));
+                quote!(#t.map(|_x| #r).unwrap_or_default())
             }
             MemberAccess::OptionFn(opt, inner) => {
                 let r = f(inner);
@@ -3268,7 +3269,7 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => quote!(#t.get()),
             MemberAccess::Option(t) => {
-                quote!(#t.map(|x| x.get()).unwrap_or_default())
+                quote!(#t.map(|_x| _x.get()).unwrap_or_default())
             }
             MemberAccess::OptionFn(..) => panic!("function is not a property"),
         }
@@ -3325,6 +3326,11 @@ fn access_window_adapter_field(ctx: &EvaluationContext) -> TokenStream {
 
 /// Given a property reference to a native item (eg, the property name is empty)
 /// return tokens to the `ItemRc`
+///
+/// This walks the parent chain with `unwrap`, so it must only be spliced inside a guard on the
+/// same reference — a `then`/`map_or_default` of [`access_member`] — because the chain can die
+/// while a callback of a repeated element is still running (the enclosing popup closes itself,
+/// or the model drops the row the element belongs to).
 fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> TokenStream {
     let mut component_access_tokens = quote!(_self);
 
@@ -4309,9 +4315,9 @@ fn compile_builtin_function_call(
             if let [Expression::PropertyReference(pr)] = arguments {
                 let window_tokens = access_window_adapter_field(ctx);
                 let focus_item = access_item_rc(pr, ctx);
-                quote!(
+                access_member(pr, ctx).then(|_| quote!(
                     sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(#focus_item, true, sp::FocusReason::Programmatic)
-                )
+                ))
             } else {
                 panic!("internal error: invalid args to SetFocusItem {arguments:?}")
             }
@@ -4320,9 +4326,9 @@ fn compile_builtin_function_call(
             if let [Expression::PropertyReference(pr)] = arguments {
                 let window_tokens = access_window_adapter_field(ctx);
                 let focus_item = access_item_rc(pr, ctx);
-                quote!(
+                access_member(pr, ctx).then(|_| quote!(
                     sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(#focus_item, false, sp::FocusReason::Programmatic)
-                )
+                ))
             } else {
                 panic!("internal error: invalid args to ClearFocusItem {arguments:?}")
             }
@@ -4360,6 +4366,9 @@ fn compile_builtin_function_call(
                     &local_reference.sub_component_path,
                 );
                 let parent_item = access_item_rc(anchor_ref, ctx);
+                // `access_item_rc` unwraps the anchor's parent chain, so only emit the show when
+                // the very same reference is reachable
+                let anchor_reachable = access_member(anchor_ref, ctx);
 
                 ctx.with_reference_scope(
                     *parent_level,
@@ -4401,7 +4410,7 @@ fn compile_builtin_function_call(
                     };
                     access_member(is_open_ref, ctx).then(|p| quote!(#p.set(value)))
                 });
-                component_access_tokens.then(|component_access_tokens| {
+                let show = component_access_tokens.then(|component_access_tokens| {
                     let compo = quote!(#component_access_tokens #suffix);
                     // Keep the parent's `is-open` in sync: `show_popup` invokes this setter with `true`
                     // immediately and with `false` from every close path (see window.rs). Passing it
@@ -4452,7 +4461,8 @@ fn compile_builtin_function_call(
                         #compo.#popup_id_name.set(Some(popup_id));
                         #popup_window_id::user_init(popup_instance_vrc.clone());
                     })
-                })
+                });
+                anchor_reachable.then(|_| show)
                     },
                 )
             } else {
@@ -4567,7 +4577,7 @@ fn compile_builtin_function_call(
                 let window_adapter = #window_adapter_tokens;
             };
 
-            if let Expression::NumberLiteral(tree_index) = entries {
+            let show = if let Expression::NumberLiteral(tree_index) = entries {
                 // We have an MenuItem tree
                 let current_sub_component = ctx.current_sub_component().unwrap();
                 let item_tree_id = inner_component_id(
@@ -4645,7 +4655,8 @@ fn compile_builtin_function_call(
                     }
                     #slint_show
                 }}
-            }
+            };
+            context_menu.then(|_| show)
         }
         BuiltinFunction::SetSelectionOffsets => {
             if let [llr::Expression::PropertyReference(pr), from, to] = arguments {
@@ -4667,7 +4678,7 @@ fn compile_builtin_function_call(
                 let item = access_member(pr, ctx);
                 let item_rc = access_item_rc(pr, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
-                item.then(|item| {
+                item.map_or_default(|item| {
                     quote!(
                         #item.font_metrics(#window_adapter_tokens, #item_rc)
                     )
@@ -5091,9 +5102,9 @@ fn compile_builtin_function_call(
         BuiltinFunction::ItemAbsolutePosition => {
             if let [Expression::PropertyReference(pr)] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
-                quote!(
+                access_member(pr, ctx).map_or_default(|_| quote!(
                     sp::logical_position_to_api((*#item_rc).map_to_window((*#item_rc).geometry().origin))
-                )
+                ))
             } else {
                 panic!("internal error: invalid args to MapPointToWindow {arguments:?}")
             }
@@ -5139,15 +5150,17 @@ fn compile_builtin_function_call(
             if let [Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                quote!({
-                    let item_rc = #item_rc;
-                    sp::logical_position_to_api(
-                        item_rc
-                            .downcast::<sp::Path>()
-                            .unwrap()
-                            .as_pin_ref()
-                            .point_at(&item_rc, #t as f32),
-                    )
+                access_member(pr, ctx).map_or_default(|_| {
+                    quote!({
+                        let item_rc = #item_rc;
+                        sp::logical_position_to_api(
+                            item_rc
+                                .downcast::<sp::Path>()
+                                .unwrap()
+                                .as_pin_ref()
+                                .point_at(&item_rc, #t as f32),
+                        )
+                    })
                 })
             } else {
                 panic!("internal error: invalid args to PathPointAt {arguments:?}")
@@ -5157,13 +5170,15 @@ fn compile_builtin_function_call(
             if let [Expression::PropertyReference(pr), t] = arguments {
                 let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                quote!({
-                    let item_rc = #item_rc;
-                    item_rc
-                        .downcast::<sp::Path>()
-                        .unwrap()
-                        .as_pin_ref()
-                        .angle_at(&item_rc, #t as f32)
+                access_member(pr, ctx).map_or_default(|_| {
+                    quote!({
+                        let item_rc = #item_rc;
+                        item_rc
+                            .downcast::<sp::Path>()
+                            .unwrap()
+                            .as_pin_ref()
+                            .angle_at(&item_rc, #t as f32)
+                    })
                 })
             } else {
                 panic!("internal error: invalid args to PathAngleAt {arguments:?}")

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -96,17 +96,28 @@ fn root_instance(
     }
 }
 
+/// Walk `parent_level` steps up the parent chain, or `None` if an ancestor is already gone.
+///
+/// The parent chain of a repeated element can die while one of its callbacks is still running —
+/// the enclosing popup closes itself, or the model drops the row the element belongs to — and the
+/// element's own instance outlives it because the event dispatch holds it.
+pub(crate) fn try_walk_parent(
+    start: &Pin<Rc<SubComponentInstance>>,
+    level: usize,
+) -> Option<Pin<Rc<SubComponentInstance>>> {
+    let mut current = start.clone();
+    for _ in 0..level {
+        current = Pin::new(current.parent.upgrade()?);
+    }
+    Some(current)
+}
+
 /// Walk `parent_level` steps up the parent chain.
 pub(crate) fn walk_parent(
     start: &Pin<Rc<SubComponentInstance>>,
     level: usize,
 ) -> Pin<Rc<SubComponentInstance>> {
-    let mut current = start.clone();
-    for _ in 0..level {
-        let parent = current.parent.upgrade().expect("parent vanished during evaluation");
-        current = Pin::new(parent);
-    }
-    current
+    try_walk_parent(start, level).expect("parent vanished during evaluation")
 }
 
 impl i_slint_compiler::llr::TypeResolutionContext for EvalContext {
@@ -172,6 +183,17 @@ pub(crate) fn walk_sub_path(
         current = next;
     }
     current
+}
+
+/// Walk to the sub-component that owns `local`, or `None` if it is not reachable.
+///
+/// See [`try_walk_parent`] for when that happens.
+pub(crate) fn try_walk_to(
+    ctx: &EvalContext,
+    parent_level: usize,
+    path: &[llr::SubComponentInstanceIdx],
+) -> Option<Pin<Rc<SubComponentInstance>>> {
+    Some(walk_sub_path(try_walk_parent(ctx.current.as_ref()?, parent_level)?, path))
 }
 
 /// Walk to the sub-component that owns `local`.
@@ -2520,7 +2542,7 @@ pub(crate) fn resolve_item_rc_from_ref(
     let LocalMemberIndex::Native { item_index, .. } = &local_reference.reference else {
         return None;
     };
-    let owner = walk_to(ctx, *parent_level, &local_reference.sub_component_path);
+    let owner = try_walk_to(ctx, *parent_level, &local_reference.sub_component_path)?;
     let parent_inst = owner.root.get().and_then(|w| w.upgrade())?;
     let full_path = crate::item_tree_vtable::sub_component_path_of(&owner, &parent_inst);
     let flat_idx = find_flat_item_index(&parent_inst.item_table, &full_path, *item_index)?;

--- a/tests/cases/elements/popupwindow_close_in_repeater.slint
+++ b/tests/cases/elements/popupwindow_close_in_repeater.slint
@@ -1,0 +1,115 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// close() drops the popup component, while the handler that called it keeps running. In a repeated
+// element that handler lives in its own item tree, kept alive by the event dispatch, so its parent
+// chain now dangles. Reaching an item outside the popup afterwards — here fs.focus() — must not
+// panic; it simply does nothing.
+//
+// Both halves cover the same generated code but a different dispatch path holding the repeated
+// tree alive: the mouse grab for the click, the focus item for the key press.
+
+export component TestCase {
+    width: 300px;
+    height: 300px;
+
+    out property <bool> popup-clicked;
+    out property <bool> popup-key-pressed;
+    out property <bool> fs-has-focus: fs.has-focus;
+
+    callback show-click-popup;
+    show-click-popup => {
+        click-popup.show();
+    }
+
+    callback show-key-popup;
+    show-key-popup => {
+        key-popup.show();
+    }
+
+    fs := FocusScope { }
+
+    click-popup := PopupWindow {
+        close-policy: no-auto-close;
+        x: 0px;
+        y: 0px;
+        width: 100px;
+        height: 100px;
+
+        for _idx in 1: TouchArea {
+            clicked => {
+                root.popup-clicked = true;
+                click-popup.close();
+                fs.focus();
+            }
+        }
+    }
+
+    key-popup := PopupWindow {
+        close-policy: no-auto-close;
+        x: 0px;
+        y: 0px;
+        width: 100px;
+        height: 100px;
+
+        for _idx in 1: FocusScope {
+            key-pressed(event) => {
+                root.popup-key-pressed = true;
+                key-popup.close();
+                fs.focus();
+                accept
+            }
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+
+instance.invoke_show_click_popup();
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert!(instance.get_popup_clicked());
+// fs is outside the closed popup, so the focus call was a no-op
+assert!(!instance.get_fs_has_focus());
+
+instance.invoke_show_key_popup();
+// Tab focuses the repeated FocusScope in the popup, "a" then runs its key handler.
+slint_testing::send_keyboard_string_sequence(&instance, "\ta");
+assert!(instance.get_popup_key_pressed());
+assert!(!instance.get_fs_has_focus());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+
+instance.invoke_show_click_popup();
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert(instance.get_popup_clicked());
+// fs is outside the closed popup, so the focus call was a no-op
+assert(!instance.get_fs_has_focus());
+
+instance.invoke_show_key_popup();
+// Tab focuses the repeated FocusScope in the popup, "a" then runs its key handler.
+slint_testing::send_keyboard_string_sequence(&instance, "\ta");
+assert(instance.get_popup_key_pressed());
+assert(!instance.get_fs_has_focus());
+```
+
+```js
+var instance = new slint.TestCase({});
+
+instance.show_click_popup();
+slintlib.private_api.send_mouse_click(instance, 50., 50.);
+assert(instance.popup_clicked);
+// fs is outside the closed popup, so the focus call was a no-op
+assert(!instance.fs_has_focus);
+
+instance.show_key_popup();
+// Tab focuses the repeated FocusScope in the popup, "a" then runs its key handler.
+slintlib.private_api.send_keyboard_string_sequence(instance, "\ta");
+assert(instance.popup_key_pressed);
+assert(!instance.fs_has_focus);
+```
+*/

--- a/tests/cases/models/repeated_access_to_parent_items.slint
+++ b/tests/cases/models/repeated_access_to_parent_items.slint
@@ -1,0 +1,78 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Reaching an item of an enclosing component from a repeated element is fallible, because that
+// component may be gone while the repeated element runs (see
+// repeater_removed_while_handling_event.slint). Exercise the builtins that need an ItemRc from
+// inside a repeater, where the parent is alive: focus is covered by the other two test cases.
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    out property <bool> all-ok: ta-clicked && asc == txt.font-metrics.ascent
+        && abs.x == 5px && abs.y == 7px
+        && pt == pa.point-at(0.5) && ang == pa.angle-at(0.5);
+    out property <bool> ta-clicked;
+
+    ti := TextInput { x: 5px; y: 7px; width: 50px; height: 20px; }
+    txt := Text { x: 0px; y: 30px; text: "hello"; }
+    cm := ContextMenuArea {
+        x: 0px;
+        y: 60px;
+        width: 50px;
+        height: 20px;
+        Menu {
+            MenuItem { title: "a"; }
+        }
+    }
+    pop := PopupWindow { width: 20px; height: 20px; Text { text: "p"; } }
+    pa := Path {
+        MoveTo { x: 0; y: 0; }
+        LineTo { x: 10; y: 10; }
+    }
+
+    for _idx in 1: TouchArea {
+        x: 200px;
+        y: 200px;
+        width: 10px;
+        height: 10px;
+        clicked => {
+            root.asc = txt.font-metrics.ascent;
+            ti.select-all();
+            ti.set-selection-offsets(0, 1);
+            root.abs = ti.absolute-position;
+            root.pt = pa.point-at(0.5);
+            root.ang = pa.angle-at(0.5);
+            cm.show({ x: 0, y: 0 });
+            pop.show();
+            root.ta-clicked = true;
+        }
+    }
+
+    out property <length> asc;
+    out property <Point> abs;
+    out property <Point> pt;
+    out property <angle> ang;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 205., 205.);
+assert!(instance.get_all_ok());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 205., 205.);
+assert(instance.get_all_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+slintlib.private_api.send_mouse_click(instance, 205., 205.);
+assert(instance.all_ok);
+```
+*/

--- a/tests/cases/models/repeater_removed_while_handling_event.slint
+++ b/tests/cases/models/repeater_removed_while_handling_event.slint
@@ -76,9 +76,9 @@ assert_eq(instance.get_clicked(), 1);
 
 ```js
 let model = new slintlib.ArrayModel([1]);
-var instance = new slint.TestCase({
-    remove_row: function() { model.pop(); }
-});
+var instance = new slint.TestCase({});
+// The instance accessor takes the translated name; the constructor's object would need "remove-row".
+instance.remove_row = function() { model.pop(); };
 instance.model = model;
 
 slintlib.private_api.send_mouse_click(instance, 50., 50.);

--- a/tests/cases/models/repeater_removed_while_handling_event.slint
+++ b/tests/cases/models/repeater_removed_while_handling_event.slint
@@ -1,0 +1,93 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Removing a row destroys the repeated item tree of that row right away, while the handler that
+// triggered the removal keeps running: the event dispatch holds the inner element's own item tree
+// alive, but its parent chain is gone. Reaching an item through that dead chain — here row-fs in
+// the removed row and fs in the root — must not panic; it simply does nothing.
+
+export component TestCase {
+    width: 300px;
+    height: 300px;
+
+    in-out property <[int]> model;
+    callback remove-row();
+
+    out property <int> clicked;
+    out property <bool> fs-has-focus: fs.has-focus;
+
+    fs := FocusScope { }
+
+    for row in model: Rectangle {
+        x: 0px;
+        y: 0px;
+        width: 100px;
+        height: 100px;
+
+        row-fs := FocusScope { }
+
+        for _idx in 1: TouchArea {
+            clicked => {
+                root.clicked += 1;
+                root.remove-row();
+                // This row is gone, so neither target is reachable anymore.
+                row-fs.focus();
+                fs.focus();
+            }
+        }
+    }
+}
+
+/*
+```rust
+use slint::Model;
+let instance = TestCase::new().unwrap();
+let model = std::rc::Rc::new(slint::VecModel::from(vec![1i32]));
+instance.set_model(model.clone().into());
+let m = model.clone();
+instance.on_remove_row(move || { m.remove(0); });
+
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq!(instance.get_clicked(), 1);
+assert_eq!(model.row_count(), 0);
+assert!(!instance.get_fs_has_focus());
+
+// the row is gone, so a second click hits nothing
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq!(instance.get_clicked(), 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+auto model = std::make_shared<slint::VectorModel<int>>(std::vector<int>{1});
+instance.set_model(model);
+instance.on_remove_row([model] { model->erase(0); });
+
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq(instance.get_clicked(), 1);
+assert_eq(model->row_count(), 0);
+assert(!instance.get_fs_has_focus());
+
+// the row is gone, so a second click hits nothing
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq(instance.get_clicked(), 1);
+```
+
+```js
+let model = new slintlib.ArrayModel([1]);
+var instance = new slint.TestCase({
+    remove_row: function() { model.pop(); }
+});
+instance.model = model;
+
+slintlib.private_api.send_mouse_click(instance, 50., 50.);
+assert.equal(instance.clicked, 1);
+assert.equal(instance.model.length, 0);
+assert(!instance.fs_has_focus);
+
+// the row is gone, so a second click hits nothing
+slintlib.private_api.send_mouse_click(instance, 50., 50.);
+assert.equal(instance.clicked, 1);
+```
+*/


### PR DESCRIPTION
The parent chain of a repeated element can die while one of its callbacks is still running: the enclosing PopupWindow closes itself, or the model drops the row the element belongs to. The element's own item tree outlives that, because the event dispatch holds it, so its parent weak dangles.

Property accesses already cope with this (see the MemberAccess doc comment and issue #3464), but `access_item_rc` walks the same chain with `unwrap`, so anything needing an ItemRc panicked instead — `fs.focus()` in the test cases below.

Ask `access_member` for the same reference first, and only emit the code when it says the member is reachable: within that guard, walking up to the item cannot fail. Several call sites did that already; the rest now do it through `MemberAccess::if_reachable`.

`ItemFontMetrics` used `then`, which evaluates to `()`, so reading `font-metrics` from a repeated element did not even compile.

Fixes #12847
