### PR TITLE
FlexboxLayout: no measure arm for cells that cannot use the constraint

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5736,6 +5736,11 @@ fn generate_flexbox_measure_lambda(
                     v_steps.push_str(&v_step);
                     h_steps.push_str(&h_step);
                 }
+                llr::FlexboxMeasureCellKind::Fixed => {
+                    probe_steps.push_str("cursor += 1;\n");
+                    v_steps.push_str("cursor += 1;\n");
+                    h_steps.push_str("cursor += 1;\n");
+                }
             }
         }
         (

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5830,6 +5830,12 @@ fn generate_flexbox_measure_closure(
                     v_steps.push(v_step);
                     h_steps.push(h_step);
                 }
+                llr::FlexboxMeasureCellKind::Fixed => {
+                    let step = quote!(cursor += 1;);
+                    probe_steps.push(step.clone());
+                    v_steps.push(step.clone());
+                    h_steps.push(step);
+                }
             }
         }
         // The final `cursor += …` is a dead write; `let _ = cursor;` consumes it

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -863,6 +863,31 @@ impl FlexboxLayout {
     }
 }
 
+/// Whether the builtin — or the native class it resolves to after the
+/// `resolve_native_classes` pass — has no intrinsic size (Rectangle, Empty,
+/// TouchArea, etc.): its layout info is the static default, never
+/// height-for-width.
+fn has_no_intrinsic_size(base: &ElementType) -> bool {
+    let name = match base {
+        ElementType::Builtin(b) => b.name.as_str(),
+        ElementType::Native(n) => n.class_name.as_str(),
+        _ => return false,
+    };
+    matches!(
+        name,
+        "Rectangle"
+            | "BasicBorderRectangle"
+            | "BorderRectangle"
+            | "Empty"
+            | "TouchArea"
+            | "FocusScope"
+            | "Opacity"
+            | "Layer"
+            | "BoxShadow"
+            | "Clip"
+    )
+}
+
 /// Controls whether `implicit_layout_info_call` returns layout info for builtins
 /// that don't have an intrinsic size (Rectangle, Empty, TouchArea, etc.).
 #[derive(Clone, Copy, PartialEq)]
@@ -926,18 +951,8 @@ pub fn implicit_layout_info_call(
                     }
                 }
             }
-            ElementType::Builtin(base_type)
-                if matches!(
-                    base_type.name.as_str(),
-                    "Rectangle"
-                        | "Empty"
-                        | "TouchArea"
-                        | "FocusScope"
-                        | "Opacity"
-                        | "Layer"
-                        | "BoxShadow"
-                        | "Clip"
-                ) =>
+            base @ (ElementType::Builtin(_) | ElementType::Native(_))
+                if has_no_intrinsic_size(base) =>
             {
                 if filter == BuiltinFilter::SkipNonImplicit {
                     return None;

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -45,6 +45,10 @@ pub enum FlexboxMeasureCellKind {
     /// A repeater: its instances are only known at run time, so the generated
     /// callback queries the instance directly.
     Repeated(LayoutRepeatedElement),
+    /// A cell whose layout info does not depend on the perpendicular axis (no
+    /// constrained layout-info function): the sizes pre-resolved from the cell
+    /// arrays are already correct, so no measure arm is generated.
+    Fixed,
 }
 
 #[derive(Debug, Clone)]

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -463,22 +463,29 @@ pub(super) fn solve_flexbox_layout(
     }
 }
 
+/// Whether the cell's vertical info depends on the width (height-for-width)
+/// and its horizontal info on the height (width-for-height). For a repeater,
+/// check the repeated component's root: that is the element the measure
+/// callback queries.
+fn cell_measure_capability(elem: &ElementRc) -> (bool, bool) {
+    if elem.borrow().repeated.is_some() {
+        let root = elem.borrow().base_type.as_component().root_element.clone();
+        let h4w = root.borrow().inherited_layout_info_v_with_constraint().is_some();
+        let w4h = root.borrow().inherited_layout_info_h_with_constraint().is_some();
+        return (h4w, w4h);
+    }
+    (
+        is_height_for_width_cell(elem),
+        elem.borrow().inherited_layout_info_h_with_constraint().is_some(),
+    )
+}
+
 /// Whether any cell of the flexbox is height-for-width (or width-for-height)
 /// capable, so a solve or cross-axis info computation needs a measure callback.
 fn flexbox_needs_measure(layout: &crate::layout::FlexboxLayout) -> bool {
     layout.elems.iter().any(|li| {
-        let elem = &li.item.element;
-        // For a repeater, check the repeated component's root — the element
-        // the measure callback queries. The repeated element itself has a
-        // materialized layoutinfo property, which makes
-        // is_height_for_width_cell return false.
-        if elem.borrow().repeated.is_some() {
-            let root = elem.borrow().base_type.as_component().root_element.clone();
-            return root.borrow().inherited_layout_info_v_with_constraint().is_some()
-                || root.borrow().inherited_layout_info_h_with_constraint().is_some();
-        }
-        is_height_for_width_cell(elem)
-            || elem.borrow().inherited_layout_info_h_with_constraint().is_some()
+        let (h4w, w4h) = cell_measure_capability(&li.item.element);
+        h4w || w4h
     })
 }
 
@@ -487,7 +494,9 @@ fn flexbox_needs_measure(layout: &crate::layout::FlexboxLayout) -> bool {
 /// measured at the dimension taffy assigns, read from the `measure_known_w` /
 /// `measure_known_h` locals. A repeated element becomes a
 /// `FlexboxMeasureCellKind::Repeated`: its instances are only known at solve
-/// time, so the generated callback queries the instance directly.
+/// time, so the generated callback queries the instance directly. A static
+/// element with no constrained layout info becomes a
+/// `FlexboxMeasureCellKind::Fixed` and gets no measure arm.
 fn measure_cells_for(
     layout: &crate::layout::FlexboxLayout,
     ctx: &mut ExpressionLoweringCtx,
@@ -497,17 +506,9 @@ fn measure_cells_for(
         .iter()
         .map(|li| {
             let elem = &li.item.element;
-            // A width-for-height-only cell probes its horizontal axis; mirror
-            // the element the measure will actually query (the repeated
-            // component's root for a repeater).
-            let query_elem = if elem.borrow().repeated.is_some() {
-                elem.borrow().base_type.as_component().root_element.clone()
-            } else {
-                elem.clone()
-            };
-            let w4h_only = query_elem.borrow().inherited_layout_info_h_with_constraint().is_some()
-                && query_elem.borrow().inherited_layout_info_v_with_constraint().is_none();
             if elem.borrow().repeated.is_some() {
+                let (h4w, w4h) = cell_measure_capability(elem);
+                let w4h_only = w4h && !h4w;
                 let repeater_index =
                     match ctx.mapping.element_mapping.get(&elem.clone().into()).unwrap() {
                         LoweredElement::Repeated { repeated_index } => *repeated_index,
@@ -521,11 +522,13 @@ fn measure_cells_for(
                     w4h_only,
                 };
             }
-            let v_constraint = is_height_for_width_cell(elem).then(|| {
-                crate::expression_tree::Expression::ReadLocalVariable {
-                    name: "measure_known_w".into(),
-                    ty: Type::LogicalLength,
-                }
+            let (h4w, w4h) = cell_measure_capability(elem);
+            if !h4w && !w4h {
+                return FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Fixed, w4h_only: false };
+            }
+            let v_constraint = h4w.then(|| crate::expression_tree::Expression::ReadLocalVariable {
+                name: "measure_known_w".into(),
+                ty: Type::LogicalLength,
             });
             let v_info = get_flex_cell_layout_info(
                 elem,
@@ -534,13 +537,10 @@ fn measure_cells_for(
                 Orientation::Vertical,
                 v_constraint,
             );
-            let h_constraint =
-                elem.borrow().inherited_layout_info_h_with_constraint().is_some().then(|| {
-                    crate::expression_tree::Expression::ReadLocalVariable {
-                        name: "measure_known_h".into(),
-                        ty: Type::LogicalLength,
-                    }
-                });
+            let h_constraint = w4h.then(|| crate::expression_tree::Expression::ReadLocalVariable {
+                name: "measure_known_h".into(),
+                ty: Type::LogicalLength,
+            });
             let h_info = get_flex_cell_layout_info(
                 elem,
                 ctx,
@@ -548,7 +548,10 @@ fn measure_cells_for(
                 Orientation::Horizontal,
                 h_constraint,
             );
-            FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Static { h_info, v_info }, w4h_only }
+            FlexboxMeasureCell {
+                kind: FlexboxMeasureCellKind::Static { h_info, v_info },
+                w4h_only: w4h && !h4w,
+            }
         })
         .collect()
 }

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -353,8 +353,13 @@ struct FlatCell<'a> {
 }
 
 enum FlatCellKind<'a> {
-    Static { h_info: &'a Expression, v_info: &'a Expression },
+    Static {
+        h_info: &'a Expression,
+        v_info: &'a Expression,
+    },
     Repeated(vtable::VRc<i_slint_core::item_tree::ItemTreeVTable, crate::instance::Instance>),
+    /// No constrained layout info: the pre-resolved sizes are already correct.
+    Fixed,
 }
 
 /// Flatten `measure_cells` into one entry per taffy cell. Static cells carry
@@ -380,6 +385,9 @@ fn flatten_measure_cells<'a>(
                         w4h_only: item.w4h_only,
                     }));
                 }
+            }
+            FlexboxMeasureCellKind::Fixed => {
+                flat.push(FlatCell { kind: FlatCellKind::Fixed, w4h_only: item.w4h_only })
             }
         }
     }
@@ -419,6 +427,7 @@ fn measure_flexbox_cell(
                 .constraint
                 .preferred_bounded(),
         ),
+        FlatCellKind::Fixed => (w, h),
     };
     // measure the width at the height `h`
     let measure_width = |ctx: &mut EvalContext| match &cell.kind {
@@ -436,6 +445,7 @@ fn measure_flexbox_cell(
                 .preferred_bounded(),
             h,
         ),
+        FlatCellKind::Fixed => (w, h),
     };
     match (known_w, known_h) {
         (true, true) => (w, h),


### PR DESCRIPTION
Another optimization, this one around the measure callback.

A cell without a constrained layout-info function got a measure arm that
re-evaluated its plain layout info, returning the value the callback was
already handed. Such cells now lower to FlexboxMeasureCellKind::Fixed:
no arm is generated (a repeater walk just advances its cursor), and a
flexbox with no height-for-width (or width-for-height) cell at all
keeps the plain, callback-free path.

Cell capability is decided in one place, cell_measure_capability. That
required teaching implicit_layout_info_call that by LLR-lowering time
builtins are resolved to native classes: it fell through to the
ImplicitLayoutInfo call for Rectangle & friends, so every such cell
counted as height-for-width and needs_measure was almost always true.
It now recognizes no-intrinsic-size native classes; their cells also
get the static layout-info struct the early passes already use, instead
of a vtable call.

Note on the implicit_layout_info_call change: it affects all layout kinds, but only in the LLR lowering — callers running before resolve_native_classes still match the Builtin arm and are unchanged. 
The substitution is value-exact: every class in the list implements layout_info as literally `LayoutInfo { stretch: 1., ..LayoutInfo::default() }`, which is the hard-coded struct field for field, and none of them reads any property, so no dependency tracking is lost.
