### PR TITLE
compiler: warn instead of erroring on a callback aliased twice

### DIFF
--- a/internal/compiler/passes/remove_aliases.rs
+++ b/internal/compiler/passes/remove_aliases.rs
@@ -161,7 +161,8 @@ pub fn remove_aliases(doc: &Document, diag: &mut BuildDiagnostics) {
             let elem = nr.element();
             let elem = elem.borrow();
             if let Some(b) = elem.binding(nr.name()) {
-                diag.push_error(
+                // Only a warning: this compiled fine up to 1.17 and code relies on it.
+                diag.push_warning(
                     format!(
                         "Callback '{}' shares a handler slot with {other_names}, so only one of them can have an implementation",
                         nr.name()

--- a/internal/compiler/tests/syntax/lookup/callback_alias_multiple_names.slint
+++ b/internal/compiler/tests/syntax/lookup/callback_alias_multiple_names.slint
@@ -3,9 +3,9 @@
 
 export component Xxx inherits Window {
     callback clicked-b <=> button.clicked;
-//                     >                <error{Callback 'clicked-b' shares a handler slot with 'clicked-a', so only one of them can have an implementation}
+//                     >                <warning{Callback 'clicked-b' shares a handler slot with 'clicked-a', so only one of them can have an implementation}
     callback clicked-a <=> button.clicked;
-//                     >                <error{Callback 'clicked-a' shares a handler slot with 'clicked-b', so only one of them can have an implementation}
+//                     >                <warning{Callback 'clicked-a' shares a handler slot with 'clicked-b', so only one of them can have an implementation}
 
     button := TouchArea {}
 }


### PR DESCRIPTION
#12852 made two aliases of the same callback an error. The crater run turned up existing code that this rejects, so report it as a warning instead: the runtime behaviour is the same either way, only one of the aliases ends up carrying the implementation.
