### PR TITLE
nodejs: accept both name spellings in the component constructor

### DIFF
--- a/api/node/README.md
+++ b/api/node/README.md
@@ -92,7 +92,9 @@ export component MainWindow inherits Window {
 ```
 
 Each exported Window component is exposed as a type constructor. The type constructor takes as parameter
-an object which allow to initialize the value of public properties or callbacks.
+an object which allow to initialize the value of public properties or callbacks. A name declared with a
+dash in `.slint` can be given either as declared (`"my-property"`) or with underscores (`my_property`),
+which is how it is exposed on the instance.
 
 **`main.js`**
 

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -86,17 +86,26 @@ test("loadFile constructor parameters", () => {
         path.join(dirname, "resources/test-constructor.slint"),
     ) as any;
     let hello = "";
+    let goodbye = "";
     const test = new demo.Test({
         say_hello: function () {
             hello = "hello";
         },
+        // A name declared with a dash is settable under either spelling.
+        say_goodbye: function () {
+            goodbye = "goodbye";
+        },
         check: "test",
+        "check-again": "test again",
     });
 
     test.say_hello();
+    test.say_goodbye();
 
     expect(test.check).toBe("test");
+    expect(test.check_again).toBe("test again");
     expect(hello).toBe("hello");
+    expect(goodbye).toBe("goodbye");
 });
 
 test("loadFile component instances and modules are sealed", () => {
@@ -208,22 +217,33 @@ test("accessing `window` on non-windowed components throws", () => {
 test("loadSource constructor parameters", () => {
     const source = `export component Test {
         callback say_hello();
+        callback say-goodbye();
         in-out property <string> check;
+        in-out property <string> check-again;
     }`;
     const path = "api.spec.ts";
     const demo = loadSource(source, path) as any;
     let hello = "";
+    let goodbye = "";
     const test = new demo.Test({
         say_hello: function () {
             hello = "hello";
         },
+        // A name declared with a dash is settable under either spelling.
+        "say-goodbye": function () {
+            goodbye = "goodbye";
+        },
         check: "test",
+        check_again: "test again",
     });
 
     test.say_hello();
+    test.say_goodbye();
 
     expect(test.check).toBe("test");
+    expect(test.check_again).toBe("test again");
     expect(hello).toBe("hello");
+    expect(goodbye).toBe("goodbye");
 });
 
 test("loadSource component instances and modules are sealed", () => {

--- a/api/node/__test__/resources/test-constructor.slint
+++ b/api/node/__test__/resources/test-constructor.slint
@@ -3,5 +3,7 @@
 
 export component Test {
     callback say_hello();
+    callback say-goodbye();
     in-out property <string> check;
+    in-out property <string> check-again;
 }

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -395,13 +395,31 @@ function loadSlint(loadData: LoadData): Object {
                     );
                 }
 
+                // A `.slint` name may contain dashes, which JavaScript won't
+                // take as a plain identifier, so the properties and callbacks
+                // of a component are exposed under their translated name.
+                // Accept both spellings here, so that the object passed to the
+                // constructor reads like the component it initializes.
+                const componentDefinition = instance.definition();
+                const declaredName = new Map<string, string>();
+                for (const name of [
+                    ...componentDefinition.properties.map((prop) => prop.name),
+                    ...componentDefinition.callbacks,
+                ]) {
+                    declaredName.set(name, name);
+                    declaredName.set(translateName(name), name);
+                }
+
                 for (var key in properties) {
                     const value = properties[key];
+                    // Unknown names are passed through, to be reported by the
+                    // setter below.
+                    const name = declaredName.get(key) ?? key;
 
                     if (value instanceof Function) {
-                        instance.setCallback(key, value);
+                        instance.setCallback(name, value);
                     } else {
-                        instance.setProperty(key, properties[key]);
+                        instance.setProperty(name, properties[key]);
                     }
                 }
 


### PR DESCRIPTION
Properties and callbacks are exposed on the instance with their dashes turned into underscores, but the object passed to the constructor had its keys forwarded to the native setters untouched, which look the name up exactly as declared. So `new ui.MainWindow({ my_callback: ... })` failed for a callback declared `my-callback`, while assigning to `instance.my_callback` worked.

Resolve each key against the component's declared names first, accepting either spelling. Unknown names still reach the setter, which reports them.
