### PR TITLE
remote preview: Pair with an on-screen code and encrypt the session

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -70,6 +70,7 @@ casesensitive
 CDPATH
 cfgs
 CFLAGS
+chacha
 charmap
 checkboxtile
 checkmark
@@ -77,6 +78,7 @@ checkstate
 chipset
 chrono
 Cinstrument
+ciphertext
 circledraw
 circularprogressindicator
 CLIB
@@ -116,6 +118,7 @@ cpos
 cppbuild
 cppdocs
 cppreference
+CSPRNG
 cstyle
 Csvg
 ctest
@@ -267,6 +270,7 @@ hidpi
 highp
 HINSTANCE
 Hira
+hkdf
 hmac
 hlayout
 hmenu
@@ -461,6 +465,7 @@ optipng
 ospi
 othercomp
 ovmf
+PAKE
 Pantone
 partytown
 PATCHLEVEL
@@ -474,6 +479,7 @@ picotool
 pixabay
 pixelcolor
 pkgs
+poly
 popupwindow
 prec
 prediv
@@ -581,6 +587,7 @@ Snackbars
 Softbuffer
 Sorkin
 sourcestruct
+spake
 spinboxes
 SPIRAM
 SPRINTF

--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -267,6 +267,7 @@ hidpi
 highp
 HINSTANCE
 Hira
+hmac
 hlayout
 hmenu
 horizontalbox

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3641,7 +3641,6 @@ dependencies = [
  "getifs",
  "getrandom 0.2.17",
  "hkdf",
- "hmac",
  "hostname",
  "i-slint-compiler",
  "i-slint-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1155,17 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -1152,6 +1173,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1192,6 +1226,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1637,6 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1678,6 +1724,32 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "darling"
@@ -2268,6 +2340,12 @@ dependencies = [
  "web-sys",
  "wgpu 30.0.0",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -3089,6 +3167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,10 +3634,13 @@ version = "1.18.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
+ "chacha20poly1305",
  "dashmap",
  "derive_more",
  "futures-util",
  "getifs",
+ "getrandom 0.2.17",
+ "hkdf",
  "hmac",
  "hostname",
  "i-slint-compiler",
@@ -3564,6 +3654,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "slint-interpreter",
+ "spake2",
  "subtle",
  "tokio",
  "tokio-tungstenite 0.30.0",
@@ -3978,6 +4069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -5577,6 +5677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5954,6 +6060,17 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "polycool"
@@ -6414,7 +6531,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -6427,6 +6544,15 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -7922,6 +8048,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
 
 [[package]]
+name = "spake2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5482afe85a0b6ce956c945401598dbc527593c77ba51d0a87a586938b1b893a"
+dependencies = [
+ "curve25519-dalek",
+ "hkdf",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
 name = "spdx"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8874,6 +9012,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7722,6 +7722,7 @@ dependencies = [
  "tempfile",
  "tikv-jemallocator",
  "tokio",
+ "tokio-tungstenite 0.30.0",
  "tokio-tungstenite-wasm",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -3088,6 +3089,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3541,6 +3551,7 @@ dependencies = [
  "derive_more",
  "futures-util",
  "getifs",
+ "hmac",
  "hostname",
  "i-slint-compiler",
  "i-slint-core",
@@ -3548,9 +3559,12 @@ dependencies = [
  "mdns-sd",
  "notify",
  "postcard",
+ "rand 0.9.5",
  "serde",
  "serde_json",
+ "sha2",
  "slint-interpreter",
+ "subtle",
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
@@ -7219,6 +7233,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
@@ -150,7 +150,7 @@ Run `slint-viewer --help` for the authoritative, always-current list. The common
 | `--remote` | Start in remote mode and wait for the editor to connect. See [Remote Viewer](#remote-viewer). |
 | `--remote-address <address>` | Address and port to listen on in remote mode. Defaults to an auto-assigned port on all interfaces. |
 | `--pairing-code <code>` | Always require this four-digit pairing code instead of showing a generated one, for devices with no usable display. |
-| `--no-pairing` | Accept any connection without pairing. Only for networks you control. |
+| `--no-pairing` | Accept any connection without pairing or encryption. Only for networks you control; the editor warns once before connecting to such a viewer. |
 | `--component <name>` | Load the component with this name. Defaults to the last exported component. |
 | `--style <style>` | Set the widget style. Defaults to `fluent`. |
 | `--backend <backend>` | Override the Slint rendering <Link type="backends_and_renderers" label="backend"/>. |

--- a/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
@@ -129,6 +129,8 @@ By default it listens on an automatically assigned port on all network interface
 Pass `--remote-address <address>` to choose a specific address and port.
 
 To connect, open the live preview of a `.slint` file in your editor, then pick **Remote** from the combobox in the top-right corner of the preview and enter the address the viewer shows.
+The viewer then displays a four-digit code; type it into the editor to confirm the connection.
+It only asks once per viewer run, so reconnecting later doesn't interrupt you.
 The editor compiles the `.slint` file and sends the result to the remote viewer, reloading it as you edit, while debug output from the previewed UI is sent back to the editor.
 
 `--remote` doesn't take a file path, and can't be combined with `--screenshot` or `--check`.
@@ -147,6 +149,8 @@ Run `slint-viewer --help` for the authoritative, always-current list. The common
 | `--check` | Compile the file, print diagnostics, and exit without opening a window. Incompatible with the options above. |
 | `--remote` | Start in remote mode and wait for the editor to connect. See [Remote Viewer](#remote-viewer). |
 | `--remote-address <address>` | Address and port to listen on in remote mode. Defaults to an auto-assigned port on all interfaces. |
+| `--pairing-code <code>` | Always require this four-digit pairing code instead of showing a generated one, for devices with no usable display. |
+| `--no-pairing` | Accept any connection without pairing. Only for networks you control. |
 | `--component <name>` | Load the component with this name. Defaults to the last exported component. |
 | `--style <style>` | Set the widget style. Defaults to `fluent`. |
 | `--backend <backend>` | Override the Slint rendering <Link type="backends_and_renderers" label="backend"/>. |

--- a/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/slint-viewer.mdx
@@ -150,7 +150,7 @@ Run `slint-viewer --help` for the authoritative, always-current list. The common
 | `--remote` | Start in remote mode and wait for the editor to connect. See [Remote Viewer](#remote-viewer). |
 | `--remote-address <address>` | Address and port to listen on in remote mode. Defaults to an auto-assigned port on all interfaces. |
 | `--pairing-code <code>` | Always require this four-digit pairing code instead of showing a generated one, for devices with no usable display. |
-| `--no-pairing` | Accept any connection without pairing or encryption. Only for networks you control; the editor warns once before connecting to such a viewer. |
+| `--no-pairing` | Accept any connection without pairing or encryption. Only for networks you control; the editor warns before each connection to such a viewer. |
 | `--component <name>` | Load the component with this name. Defaults to the last exported component. |
 | `--style <style>` | Set the widget style. Defaults to `fluent`. |
 | `--backend <backend>` | Override the Slint rendering <Link type="backends_and_renderers" label="backend"/>. |

--- a/internal/editor-preview/lsp_to_previews.rs
+++ b/internal/editor-preview/lsp_to_previews.rs
@@ -34,6 +34,8 @@ pub trait RemoteTransport {
     fn submit_pairing_code(&self, code: String);
     /// Abandon the pairing attempt the user was prompted for.
     fn cancel_pairing(&self);
+    /// Connect to the pairing-disabled viewer the user was warned about.
+    fn accept_unpaired_connection(&self);
 }
 
 /// Fans LSP messages out to the active local preview and, if connected, to a

--- a/internal/editor-preview/lsp_to_previews.rs
+++ b/internal/editor-preview/lsp_to_previews.rs
@@ -30,6 +30,10 @@ pub trait RemoteTransport {
         port: u16,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>>>>;
     fn disconnect(&self) -> std::pin::Pin<Box<dyn Future<Output = ()>>>;
+    /// The code the user read off the viewer's screen.
+    fn submit_pairing_code(&self, code: String);
+    /// Abandon the pairing attempt the user was prompted for.
+    fn cancel_pairing(&self);
 }
 
 /// Fans LSP messages out to the active local preview and, if connected, to a

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["debug"], optional = true }
 tracing = { workspace = true, optional = true }
 # protocol: the pairing handshake, needed by both ends of the connection
-hmac = { version = "0.12.1", optional = true }
 spake2 = { version = "0.4.0", optional = true }
 hkdf = { version = "0.12.4", optional = true }
 chacha20poly1305 = { version = "0.10.1", optional = true }
@@ -74,7 +73,6 @@ protocol = [
   "dep:serde_json",
   "dep:derive_more",
   "dep:tracing",
-  "dep:hmac",
   "dep:sha2",
   "dep:subtle",
   "dep:spake2",

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -21,6 +21,10 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["debug"], optional = true }
 tracing = { workspace = true, optional = true }
+# protocol: the pairing handshake, needed by both ends of the connection
+hmac = { version = "0.12.1", optional = true }
+sha2 = { version = "0.10.9", default-features = false, optional = true }
+subtle = { version = "2.6.1", default-features = false, optional = true }
 # file-watcher
 notify = { version = "8.0.0", default-features = false, features = ["macos_kqueue"], optional = true }
 i-slint-compiler = { workspace = true, optional = true }
@@ -36,6 +40,9 @@ postcard = { version = "1.1.3", default-features = false, features = ["alloc"], 
 base64 = { version = "0.23", optional = true }
 hostname = { version = "0.4.1", optional = true }
 anyhow = { version = "1.0.100", optional = true }
+# remote: only the viewer generates pairing secrets, so the random source
+# stays out of the LSP's browser builds.
+rand = { version = "0.9.5", optional = true }
 
 [target.'cfg(not(any(target_vendor = "apple", target_arch = "wasm32")))'.dependencies]
 mdns-sd = { version = "0.20.0", default-features = false, optional = true }
@@ -43,11 +50,16 @@ mdns-sd = { version = "0.20.0", default-features = false, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 getifs = { version = "0.6.1", optional = true }
 
+# The cool-down tests move the clock rather than sleeping through a
+# 60-second pairing deadline.
+[dev-dependencies]
+tokio = { version = "1.48.0", features = ["test-util"] }
+
 [lib]
 path = "lib.rs"
 
 [features]
-protocol = ["dep:lsp-types", "dep:serde", "dep:serde_json", "dep:derive_more", "dep:tracing"]
+protocol = ["dep:lsp-types", "dep:serde", "dep:serde_json", "dep:derive_more", "dep:tracing", "dep:hmac", "dep:sha2", "dep:subtle"]
 file-watcher = ["dep:notify", "dep:i-slint-compiler"]
 live-component = ["file-watcher", "dep:slint-interpreter", "dep:i-slint-core"]
 ffi = ["live-component", "slint-interpreter/ffi"]
@@ -64,6 +76,7 @@ remote = [
   "dep:postcard",
   "dep:base64",
   "dep:hostname",
+  "dep:rand",
   "dep:mdns-sd",
   "dep:getifs",
   "slint-interpreter/accessibility",

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -23,6 +23,9 @@ derive_more = { workspace = true, features = ["debug"], optional = true }
 tracing = { workspace = true, optional = true }
 # protocol: the pairing handshake, needed by both ends of the connection
 hmac = { version = "0.12.1", optional = true }
+spake2 = { version = "0.4.0", optional = true }
+hkdf = { version = "0.12.4", optional = true }
+chacha20poly1305 = { version = "0.10.1", optional = true }
 sha2 = { version = "0.10.9", default-features = false, optional = true }
 subtle = { version = "2.6.1", default-features = false, optional = true }
 # file-watcher
@@ -50,6 +53,12 @@ mdns-sd = { version = "0.20.0", default-features = false, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 getifs = { version = "0.6.1", optional = true }
 
+# A PAKE needs randomness on *both* sides, unlike the HMAC exchange it
+# replaces, so the browser build of the LSP now needs a CSPRNG too. spake2
+# pulls getrandom 0.2, which has to be told to use the JS backend.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"], optional = true }
+
 # The cool-down tests move the clock rather than sleeping through a
 # 60-second pairing deadline.
 [dev-dependencies]
@@ -59,7 +68,20 @@ tokio = { version = "1.48.0", features = ["test-util"] }
 path = "lib.rs"
 
 [features]
-protocol = ["dep:lsp-types", "dep:serde", "dep:serde_json", "dep:derive_more", "dep:tracing", "dep:hmac", "dep:sha2", "dep:subtle"]
+protocol = [
+  "dep:lsp-types",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:derive_more",
+  "dep:tracing",
+  "dep:hmac",
+  "dep:sha2",
+  "dep:subtle",
+  "dep:spake2",
+  "dep:hkdf",
+  "dep:chacha20poly1305",
+  "dep:getrandom",
+]
 file-watcher = ["dep:notify", "dep:i-slint-compiler"]
 live-component = ["file-watcher", "dep:slint-interpreter", "dep:i-slint-core"]
 ffi = ["live-component", "slint-interpreter/ffi"]

--- a/internal/live-preview/protocol.rs
+++ b/internal/live-preview/protocol.rs
@@ -4,6 +4,7 @@
 mod lsp_to_preview;
 pub mod pairing;
 mod preview_to_lsp;
+pub mod session;
 mod versioned_url;
 
 pub use lsp_to_preview::{

--- a/internal/live-preview/protocol.rs
+++ b/internal/live-preview/protocol.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 mod lsp_to_preview;
+pub mod pairing;
 mod preview_to_lsp;
 mod versioned_url;
 
 pub use lsp_to_preview::{
     LspToPreview, LspToPreviewMessage, PreviewComponent, PreviewConfig, RemoteConnectionState,
 };
+pub use pairing::PairingRejection;
 pub use preview_to_lsp::{PreviewTarget, PreviewToLsp, PreviewToLspMessage};
 pub use versioned_url::VersionedUrl;
 

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -99,6 +99,10 @@ pub enum RemoteConnectionState {
     /// The viewer is showing a pairing code and is waiting for the user to
     /// type it into the editor.
     PairingRequired,
+    /// The viewer has pairing disabled, so the session would be neither
+    /// authenticated nor encrypted. Waiting for the user to accept that or
+    /// cancel.
+    UnpairedWarning,
     Connected,
     Failed,
 }

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -75,14 +75,16 @@ pub enum LspToPreviewMessage {
     OpenProject {
         root: Url,
     },
-    /// Answer to [`super::PreviewToLspMessage::PairingChallenge`], and the first
-    /// thing a remote connection sends. `token_proof` is present only if this
-    /// editor already paired with the viewer during its current run.
+    /// Answer to [`super::PreviewToLspMessage::PairingReady`], and the first
+    /// thing a remote connection sends. `token` names the reconnect token
+    /// this editor holds from pairing with the viewer earlier in its run;
+    /// holding it is proven in the exchange that follows, never by sending it.
     PairingHello {
-        token_proof: Option<super::pairing::Proof>,
+        token: Option<super::pairing::TokenId>,
     },
     /// The client's half of the SPAKE2 exchange, plus proof that it derived
-    /// the same key. Answers [`super::PreviewToLspMessage::PairingRequired`].
+    /// the same key. Answers [`super::PreviewToLspMessage::PairingRequired`]
+    /// and [`super::PreviewToLspMessage::PairingTokenChallenge`].
     PairingResponse {
         element: super::pairing::Element,
         confirmation: super::pairing::Confirmation,

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -81,10 +81,11 @@ pub enum LspToPreviewMessage {
     PairingHello {
         token_proof: Option<super::pairing::Proof>,
     },
-    /// The code the user read off the viewer's screen, proven against the
-    /// challenge nonce. Answers [`super::PreviewToLspMessage::PairingRequired`].
-    PairingCodeProof {
-        proof: super::pairing::Proof,
+    /// The client's half of the SPAKE2 exchange, plus proof that it derived
+    /// the same key. Answers [`super::PreviewToLspMessage::PairingRequired`].
+    PairingResponse {
+        element: super::pairing::Element,
+        confirmation: super::pairing::Confirmation,
     },
 }
 

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -75,6 +75,17 @@ pub enum LspToPreviewMessage {
     OpenProject {
         root: Url,
     },
+    /// Answer to [`super::PreviewToLspMessage::PairingChallenge`], and the first
+    /// thing a remote connection sends. `token_proof` is present only if this
+    /// editor already paired with the viewer during its current run.
+    PairingHello {
+        token_proof: Option<super::pairing::Proof>,
+    },
+    /// The code the user read off the viewer's screen, proven against the
+    /// challenge nonce. Answers [`super::PreviewToLspMessage::PairingRequired`].
+    PairingCodeProof {
+        proof: super::pairing::Proof,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -82,6 +93,9 @@ pub enum LspToPreviewMessage {
 pub enum RemoteConnectionState {
     Disconnected,
     Connecting,
+    /// The viewer is showing a pairing code and is waiting for the user to
+    /// type it into the editor.
+    PairingRequired,
     Connected,
     Failed,
 }

--- a/internal/live-preview/protocol/pairing.rs
+++ b/internal/live-preview/protocol/pairing.rs
@@ -45,13 +45,6 @@ pub struct Token([u8; TOKEN_LEN]);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct TokenId([u8; TOKEN_ID_LEN]);
 
-/// Compare without leaking where the two first differ.
-fn constant_time_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
-    use subtle::ConstantTimeEq as _;
-
-    a.ct_eq(b).into()
-}
-
 #[cfg(test)]
 impl Token {
     /// A token no viewer ever issued, for tests that need one to be refused.
@@ -100,15 +93,18 @@ impl Element {
     }
 }
 
-/// Proof of having derived the same key. Not [`PartialEq`], for the same
-/// reason [`Proof`] isn't.
+/// Proof of having derived the same key. Deliberately not [`PartialEq`]:
+/// comparing with `==` gives away where two proofs first differ, so
+/// [`Confirmation::matches`] is the only way to compare.
 #[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Confirmation([u8; 32]);
 
 impl Confirmation {
     /// Compare without leaking where the two first differ.
     pub fn matches(&self, other: &Confirmation) -> bool {
-        constant_time_eq(&self.0, &other.0)
+        use subtle::ConstantTimeEq as _;
+
+        self.0.ct_eq(&other.0).into()
     }
 }
 
@@ -120,10 +116,13 @@ pub struct HandshakeFailed;
 
 /// Everything derived once both sides finish.
 pub struct Secrets {
-    /// The viewer proves knowledge with this; the editor checks it.
-    pub viewer_confirmation: Confirmation,
+    /// The viewer proves knowledge with this; the editor checks it. Not
+    /// public: which one to send and which to check is decided by
+    /// [`Self::confirmation`] and [`Self::peer_confirms`], never at a call
+    /// site.
+    viewer_confirmation: Confirmation,
     /// The editor proves knowledge with this; the viewer checks it.
-    pub editor_confirmation: Confirmation,
+    editor_confirmation: Confirmation,
     /// Reconnect token, bound to this exchange rather than to the code.
     pub token: Token,
     /// Public name of `token`, for announcing it on reconnect.
@@ -133,14 +132,46 @@ pub struct Secrets {
     viewer_to_editor: [u8; session::DIRECTION_KEY_LEN],
     /// Session key for editor-to-viewer frames.
     editor_to_viewer: [u8; session::DIRECTION_KEY_LEN],
-    /// Which side derived this, so [`Self::session`] knows the directions.
+    /// Which side derived this, so the role-dependent accessors know their
+    /// directions.
     role: Role,
 }
 
 impl Secrets {
     /// The sealed session for the side that ran the handshake.
+    ///
+    /// The one place that decides who seals with which key. Getting this
+    /// wrong compiles fine and only surfaces as every frame failing to
+    /// open, which is why it isn't decided at the call sites.
     pub fn session(&self) -> (session::Sealing, session::Opening) {
-        session_pair(self.role, self.viewer_to_editor, self.editor_to_viewer)
+        let (seal, open) = match self.role {
+            Role::Viewer => (self.viewer_to_editor, self.editor_to_viewer),
+            Role::Editor => (self.editor_to_viewer, self.viewer_to_editor),
+        };
+        (
+            session::Sealing::Sealed(session::Sealer::new(seal)),
+            session::Opening::Sealed(session::Opener::new(open)),
+        )
+    }
+
+    /// The proof this side sends to the peer.
+    pub fn confirmation(&self) -> Confirmation {
+        match self.role {
+            Role::Viewer => self.viewer_confirmation,
+            Role::Editor => self.editor_confirmation,
+        }
+    }
+
+    /// Whether `theirs` proves the peer derived the same key. Like the
+    /// session keys, which confirmation is the peer's is decided here and
+    /// not at the call sites: picking the wrong one would accept our own
+    /// proof as the peer's.
+    pub fn peer_confirms(&self, theirs: &Confirmation) -> bool {
+        let peers = match self.role {
+            Role::Viewer => &self.editor_confirmation,
+            Role::Editor => &self.viewer_confirmation,
+        };
+        theirs.matches(peers)
     }
 }
 
@@ -150,24 +181,6 @@ impl Secrets {
     pub fn key_material(&self) -> [&[u8]; 2] {
         [&self.viewer_to_editor, &self.editor_to_viewer]
     }
-}
-
-/// The one place that decides who seals with which key. Getting this wrong
-/// compiles fine and only surfaces as every frame failing to open, which is
-/// why it isn't decided at the call sites.
-fn session_pair(
-    role: Role,
-    viewer_to_editor: [u8; session::DIRECTION_KEY_LEN],
-    editor_to_viewer: [u8; session::DIRECTION_KEY_LEN],
-) -> (session::Sealing, session::Opening) {
-    let (seal, open) = match role {
-        Role::Viewer => (viewer_to_editor, editor_to_viewer),
-        Role::Editor => (editor_to_viewer, viewer_to_editor),
-    };
-    (
-        session::Sealing::Sealed(session::Sealer::new(seal)),
-        session::Opening::Sealed(session::Opener::new(open)),
-    )
 }
 
 /// One side of the SPAKE2 exchange, mid-flight.
@@ -251,6 +264,18 @@ impl Handshake {
             editor_to_viewer: expand(&hkdf, b"seal-editor-to-viewer"),
             role: self.role,
         })
+    }
+
+    /// Finish against the peer's element and require their proof, for the
+    /// side that receives both together. One call, so no call site can
+    /// finish and forget to check.
+    pub fn finish_confirmed(
+        self,
+        peer: &Element,
+        theirs: &Confirmation,
+    ) -> Result<Secrets, HandshakeFailed> {
+        let secrets = self.finish(peer)?;
+        if secrets.peer_confirms(theirs) { Ok(secrets) } else { Err(HandshakeFailed) }
     }
 }
 

--- a/internal/live-preview/protocol/pairing.rs
+++ b/internal/live-preview/protocol/pairing.rs
@@ -1,0 +1,322 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! The pairing handshake that guards the remote preview connection.
+//!
+//! The viewer listens on the wildcard address and advertises itself over
+//! mDNS, so reaching the port proves nothing. A client is admitted only
+//! once it proves it can see the viewer's screen, by echoing back the code
+//! displayed there.
+//!
+//! Nothing secret crosses the wire: both proofs are HMAC-SHA256 over a
+//! per-connection nonce, and the reconnect token is derived rather than
+//! sent.
+
+use std::time::Duration;
+
+/// Byte length of the viewer's per-connection nonce.
+const NONCE_LEN: usize = 32;
+
+/// Byte length of a proof.
+const MAC_LEN: usize = 32;
+
+/// Byte length of a reconnect token.
+const TOKEN_LEN: usize = 32;
+
+/// The viewer's per-connection challenge.
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
+pub struct Nonce([u8; NONCE_LEN]);
+
+/// Proof of holding a credential, without revealing it.
+///
+/// Deliberately not [`PartialEq`]: comparing proofs with `==` gives away
+/// where they first differ, so [`Proof::matches`] is the only way to
+/// compare two.
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
+pub struct Proof([u8; MAC_LEN]);
+
+/// A reconnect token, derived from a completed code exchange.
+///
+/// Has no `Serialize`, which is the point: both ends compute it, and it
+/// must never end up in a message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Token([u8; TOKEN_LEN]);
+
+impl Proof {
+    /// Compare without leaking where the two first differ.
+    pub fn matches(&self, other: &Proof) -> bool {
+        use subtle::ConstantTimeEq as _;
+
+        self.0.ct_eq(&other.0).into()
+    }
+}
+
+#[cfg(test)]
+impl Nonce {
+    /// A predictable nonce, so tests can assert on what a proof depends on.
+    pub fn for_test(byte: u8) -> Self {
+        Self([byte; NONCE_LEN])
+    }
+}
+
+impl Token {
+    /// Only for checking that a token never reaches the wire.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Digits in a generated pairing code, short enough to read off a phone
+/// across a desk.
+///
+/// 10000 combinations isn't much, so what makes guessing impractical is the
+/// limits around it: [`MAX_ATTEMPTS`] per prompt, a cool-down that doubles
+/// with each failure, and a prompt the device's owner can see. A generated
+/// code is fresh each time; one pinned with `--pairing-code` isn't, which
+/// is what the escalation is for.
+pub const CODE_DIGITS: u32 = 4;
+
+/// Whether `code` has the shape of a pairing code. Pinned codes are held to
+/// it too, so they stay typeable in the editor's digits-only field.
+pub fn is_valid_code(code: &str) -> bool {
+    code.len() == CODE_DIGITS as usize && code.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// How long a displayed code stays valid before the viewer drops the connection.
+pub const CODE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How many wrong codes a single connection may offer before it's closed.
+pub const MAX_ATTEMPTS: u8 = 3;
+
+/// Shortest gap between prompts, so an unauthenticated peer can't keep one
+/// on the device's screen. Grows with repeated failures.
+pub const PROMPT_RATE_LIMIT: Duration = Duration::from_secs(30);
+
+/// Which secret a proof was computed from. Domain separated, so a proof
+/// from one exchange can't be presented as the other.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Credential {
+    /// The code the viewer displays on screen.
+    Code,
+    /// The token the viewer issued after a previous successful pairing.
+    Token,
+}
+
+impl Credential {
+    fn domain(self) -> &'static [u8] {
+        match self {
+            Credential::Code => b"slint-preview-pairing-code-v1",
+            Credential::Token => b"slint-preview-pairing-token-v1",
+        }
+    }
+}
+
+/// Compute the proof for `secret` against the viewer's `nonce`: the ASCII
+/// digits for [`Credential::Code`], the raw bytes for [`Credential::Token`].
+pub fn proof(credential: Credential, secret: &[u8], nonce: &Nonce) -> Proof {
+    use hmac::Mac as _;
+
+    // A key of any length is fine for HMAC, so this can't fail.
+    let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(secret)
+        .expect("HMAC accepts keys of any length");
+    mac.update(credential.domain());
+    mac.update(&nonce.0);
+    Proof(mac.finalize().into_bytes().into())
+}
+
+/// Derive the reconnect token from a code exchange that just succeeded.
+///
+/// Both ends compute it, so it never has to be sent. Sending it would put
+/// the credential itself on a plaintext socket for anyone to lift.
+pub fn derive_token(code: &str, nonce: &Nonce) -> Token {
+    use hmac::Mac as _;
+
+    let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(code.as_bytes())
+        .expect("HMAC accepts keys of any length");
+    mac.update(b"slint-preview-pairing-derive-v1");
+    mac.update(&nonce.0);
+    Token(mac.finalize().into_bytes().into())
+}
+
+/// Random material, which only the viewer needs. Keeping it here keeps the
+/// random source out of the LSP's browser builds.
+#[cfg(feature = "remote")]
+pub mod generate {
+    use super::{CODE_DIGITS, Nonce};
+    use rand::Rng as _;
+
+    /// A fresh nonce for one connection's challenge.
+    pub fn nonce() -> Nonce {
+        Nonce(rand::rng().random())
+    }
+
+    /// A fresh pairing code, zero-padded to [`CODE_DIGITS`] digits.
+    pub fn code() -> String {
+        let modulus = 10u32.pow(CODE_DIGITS);
+        format!("{:0width$}", rand::rng().random_range(0..modulus), width = CODE_DIGITS as usize)
+    }
+}
+
+/// Why the viewer turned a client away.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PairingRejection {
+    /// The code didn't match. Retry until the attempts run out.
+    BadCode,
+    /// Not a token this viewer issued, usually because it restarted. The
+    /// client should forget it and pair again.
+    BadToken,
+    /// The code wasn't entered within [`CODE_TIMEOUT`].
+    Expired,
+    /// [`MAX_ATTEMPTS`] wrong codes in a row.
+    TooManyAttempts,
+    /// Someone else is part-way through pairing with this viewer.
+    Busy,
+    /// A prompt ended too recently. Retrying works, just not yet; carries
+    /// how long is left so the editor can say when.
+    TooSoon { retry_after_seconds: u16 },
+}
+
+impl PairingRejection {
+    /// Whether retrying is pointless. The reconnect loop retries forever by
+    /// design, so a rejection that will keep happening has to stop it.
+    /// [`Self::BadToken`] isn't terminal: the client forgets the token and
+    /// falls through to the code.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Expired | Self::TooManyAttempts)
+    }
+}
+
+/// Text shown in the editor when a connection attempt ends this way.
+impl std::fmt::Display for PairingRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadCode => f.write_str("Incorrect pairing code"),
+            Self::BadToken => f.write_str("The viewer no longer recognizes this editor"),
+            Self::Expired => f.write_str("The pairing code expired before it was entered"),
+            Self::TooManyAttempts => f.write_str("Too many incorrect pairing codes"),
+            Self::Busy => f.write_str("Another computer is pairing with the viewer"),
+            Self::TooSoon { retry_after_seconds: 1 } => f.write_str("Try again in a second"),
+            Self::TooSoon { retry_after_seconds } => {
+                write!(f, "Try again in {retry_after_seconds} seconds")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_is_stable_and_key_dependent() {
+        let nonce = Nonce::for_test(7);
+        assert!(proof(Credential::Code, b"123456", &nonce).matches(&proof(
+            Credential::Code,
+            b"123456",
+            &nonce
+        )));
+        assert!(!proof(Credential::Code, b"123456", &nonce).matches(&proof(
+            Credential::Code,
+            b"123457",
+            &nonce
+        )));
+    }
+
+    #[test]
+    fn proof_is_nonce_dependent() {
+        assert!(!proof(Credential::Code, b"123456", &Nonce::for_test(1)).matches(&proof(
+            Credential::Code,
+            b"123456",
+            &Nonce::for_test(2)
+        )));
+    }
+
+    #[test]
+    fn a_derived_token_is_not_a_proof_of_the_same_inputs() {
+        let nonce = Nonce::for_test(7);
+        // Sharing an HMAC key across purposes is how one exchange's output
+        // becomes another's credential.
+        for credential in [Credential::Code, Credential::Token] {
+            assert_ne!(
+                derive_token("4321", &nonce).as_bytes(),
+                proof(credential, b"4321", &nonce).0.as_slice()
+            );
+        }
+    }
+
+    #[test]
+    fn a_derived_token_needs_both_the_code_and_the_nonce() {
+        let nonce = Nonce::for_test(7);
+        assert_eq!(derive_token("4321", &nonce), derive_token("4321", &nonce));
+        assert_ne!(derive_token("4321", &nonce), derive_token("1234", &nonce));
+        assert_ne!(derive_token("4321", &nonce), derive_token("4321", &Nonce::for_test(8)));
+    }
+
+    #[test]
+    fn credentials_are_domain_separated() {
+        let nonce = Nonce::for_test(7);
+        assert!(!proof(Credential::Code, b"secret", &nonce).matches(&proof(
+            Credential::Token,
+            b"secret",
+            &nonce
+        )));
+    }
+
+    #[test]
+    fn matches_agrees_with_the_inputs() {
+        let nonce = Nonce::for_test(7);
+        let a = proof(Credential::Code, b"123456", &nonce);
+        let b = proof(Credential::Code, b"123456", &nonce);
+        let c = proof(Credential::Code, b"654321", &nonce);
+        assert!(a.matches(&b));
+        assert!(!a.matches(&c));
+    }
+
+    #[test]
+    fn code_validation_matches_what_is_generated() {
+        assert!(is_valid_code("0000"));
+        assert!(is_valid_code("4321"));
+        assert!(!is_valid_code(""));
+        assert!(!is_valid_code("123"));
+        assert!(!is_valid_code("12345"));
+        assert!(!is_valid_code("12a4"));
+        // Digits, not just anything that parses as a number.
+        assert!(!is_valid_code("+123"));
+        assert!(!is_valid_code("１２３４"));
+    }
+
+    #[cfg(feature = "remote")]
+    #[test]
+    fn generated_codes_are_valid() {
+        for _ in 0..1000 {
+            let code = generate::code();
+            assert!(is_valid_code(&code), "generated {code} is not a valid code");
+        }
+    }
+
+    #[test]
+    fn only_hopeless_rejections_are_terminal() {
+        assert!(PairingRejection::Expired.is_terminal());
+        assert!(PairingRejection::TooManyAttempts.is_terminal());
+        // The client retries these: a bad code gets another attempt, a stale
+        // token falls back to the code flow, and Busy clears on its own.
+        assert!(!PairingRejection::BadCode.is_terminal());
+        assert!(!PairingRejection::BadToken.is_terminal());
+        assert!(!PairingRejection::Busy.is_terminal());
+        assert!(!PairingRejection::TooSoon { retry_after_seconds: 30 }.is_terminal());
+    }
+
+    #[test]
+    fn the_cool_down_says_how_long_is_left() {
+        assert_eq!(
+            PairingRejection::TooSoon { retry_after_seconds: 18 }.to_string(),
+            "Try again in 18 seconds"
+        );
+        // One second reads badly in the plural form.
+        assert_eq!(
+            PairingRejection::TooSoon { retry_after_seconds: 1 }.to_string(),
+            "Try again in a second"
+        );
+    }
+}

--- a/internal/live-preview/protocol/pairing.rs
+++ b/internal/live-preview/protocol/pairing.rs
@@ -8,10 +8,17 @@
 //! once it proves it can see the viewer's screen, by echoing back the code
 //! displayed there.
 //!
-//! Nothing secret crosses the wire: both proofs are HMAC-SHA256 over a
-//! per-connection nonce, and the reconnect token is derived rather than
-//! sent.
+//! The code is established with SPAKE2, a password-authenticated key
+//! exchange: a passive observer learns nothing about it, and an active one
+//! gets a single guess per attempt with no offline search to fall back on.
+//! That is what makes four digits defensible -- the limits elsewhere in
+//! this module bound the online guessing, and there is no other avenue.
+//!
+//! The exchange also yields a session key, so everything after pairing is
+//! sealed, and the reconnect token is derived from that key rather than
+//! from the code.
 
+use crate::protocol::session;
 use std::time::Duration;
 
 /// Byte length of the viewer's per-connection nonce.
@@ -42,12 +49,17 @@ pub struct Proof([u8; MAC_LEN]);
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Token([u8; TOKEN_LEN]);
 
+/// Compare without leaking where the two first differ.
+fn constant_time_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    use subtle::ConstantTimeEq as _;
+
+    a.ct_eq(b).into()
+}
+
 impl Proof {
     /// Compare without leaking where the two first differ.
     pub fn matches(&self, other: &Proof) -> bool {
-        use subtle::ConstantTimeEq as _;
-
-        self.0.ct_eq(&other.0).into()
+        constant_time_eq(&self.0, &other.0)
     }
 }
 
@@ -59,6 +71,14 @@ impl Nonce {
     }
 }
 
+#[cfg(test)]
+impl Token {
+    /// A token no viewer ever issued, for tests that need one to be refused.
+    pub fn for_test(byte: u8) -> Self {
+        Self([byte; TOKEN_LEN])
+    }
+}
+
 impl Token {
     /// Only for checking that a token never reaches the wire.
     pub fn as_bytes(&self) -> &[u8] {
@@ -66,14 +86,206 @@ impl Token {
     }
 }
 
+/// Label mixed into every derivation, so keys from this protocol can never
+/// collide with keys from another that happens to share inputs.
+const TRANSCRIPT_LABEL: &[u8] = b"slint-preview-pairing-spake2-v1";
+
+/// Which end of the exchange a party is. SPAKE2 is asymmetric: the two
+/// sides use different generator points, and both must agree who is who or
+/// the shared secret silently fails to match.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Role {
+    Viewer,
+    Editor,
+}
+
+/// One side's public element, sent to the peer.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct Element(Vec<u8>);
+
+#[cfg(test)]
+impl Element {
+    /// Deliberately malformed input, for tests.
+    pub fn for_test(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Proof of having derived the same key. Not [`PartialEq`], for the same
+/// reason [`Proof`] isn't.
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
+pub struct Confirmation([u8; 32]);
+
+impl Confirmation {
+    /// Compare without leaking where the two first differ.
+    pub fn matches(&self, other: &Confirmation) -> bool {
+        constant_time_eq(&self.0, &other.0)
+    }
+}
+
+/// The exchange failed. Deliberately one variant: distinguishing "wrong
+/// code" from "tampered with" would tell an attacker which of the two they
+/// achieved.
+#[derive(Debug)]
+pub struct HandshakeFailed;
+
+/// Everything derived once both sides finish.
+pub struct Secrets {
+    /// The viewer proves knowledge with this; the editor checks it.
+    pub viewer_confirmation: Confirmation,
+    /// The editor proves knowledge with this; the viewer checks it.
+    pub editor_confirmation: Confirmation,
+    /// Reconnect token, bound to this exchange rather than to the code.
+    pub token: Token,
+    /// Session key for viewer-to-editor frames. Not public: key material
+    /// leaves this module only inside a [`session`] codec.
+    viewer_to_editor: [u8; session::DIRECTION_KEY_LEN],
+    /// Session key for editor-to-viewer frames.
+    editor_to_viewer: [u8; session::DIRECTION_KEY_LEN],
+    /// Which side derived this, so [`Self::session`] knows the directions.
+    role: Role,
+}
+
+impl Secrets {
+    /// The sealed session for the side that ran the handshake.
+    pub fn session(&self) -> (session::Sealing, session::Opening) {
+        session_pair(self.role, self.viewer_to_editor, self.editor_to_viewer)
+    }
+}
+
+#[cfg(test)]
+impl Secrets {
+    /// Raw key material, for asserting it never crosses the wire.
+    pub fn key_material(&self) -> [&[u8]; 2] {
+        [&self.viewer_to_editor, &self.editor_to_viewer]
+    }
+}
+
+/// The one place that decides who seals with which key. Getting this wrong
+/// compiles fine and only surfaces as every frame failing to open, which is
+/// why it isn't decided at the call sites.
+fn session_pair(
+    role: Role,
+    viewer_to_editor: [u8; session::DIRECTION_KEY_LEN],
+    editor_to_viewer: [u8; session::DIRECTION_KEY_LEN],
+) -> (session::Sealing, session::Opening) {
+    let (seal, open) = match role {
+        Role::Viewer => (viewer_to_editor, editor_to_viewer),
+        Role::Editor => (editor_to_viewer, viewer_to_editor),
+    };
+    (
+        session::Sealing::Sealed(session::Sealer::new(seal)),
+        session::Opening::Sealed(session::Opener::new(open)),
+    )
+}
+
+/// One side of the SPAKE2 exchange, mid-flight.
+pub struct Handshake {
+    state: spake2::Spake2<spake2::Ed25519Group>,
+    role: Role,
+    element: Element,
+}
+
+impl Handshake {
+    /// Begin, holding `code` as the shared low-entropy secret.
+    pub fn start(role: Role, code: &str) -> Self {
+        let password = spake2::Password::new(code.as_bytes());
+        let viewer = spake2::Identity::new(b"slint-preview-viewer");
+        let editor = spake2::Identity::new(b"slint-preview-editor");
+        let (state, element) = match role {
+            Role::Viewer => {
+                spake2::Spake2::<spake2::Ed25519Group>::start_a(&password, &viewer, &editor)
+            }
+            Role::Editor => {
+                spake2::Spake2::<spake2::Ed25519Group>::start_b(&password, &viewer, &editor)
+            }
+        };
+        Self { state, role, element: Element(element) }
+    }
+
+    /// The element to send to the peer.
+    pub fn element(&self) -> &Element {
+        &self.element
+    }
+
+    /// Finish against the peer's element.
+    ///
+    /// A wrong code doesn't fail here -- it produces a *different* key, and
+    /// the mismatch only surfaces when the confirmations are compared. That
+    /// is the property the whole design rests on: the wire carries nothing
+    /// an observer can test a guess against.
+    pub fn finish(self, peer: &Element) -> Result<Secrets, HandshakeFailed> {
+        let key = self.state.finish(&peer.0).map_err(|_| HandshakeFailed)?;
+
+        // Both elements in a fixed order, length-prefixed so no pair of
+        // different exchanges can produce the same transcript bytes.
+        let (a, b) = match self.role {
+            Role::Viewer => (&self.element, peer),
+            Role::Editor => (peer, &self.element),
+        };
+        let mut transcript =
+            Vec::with_capacity(TRANSCRIPT_LABEL.len() + a.0.len() + b.0.len() + 16);
+        transcript.extend_from_slice(TRANSCRIPT_LABEL);
+        for part in [&a.0, &b.0] {
+            transcript.extend_from_slice(&(part.len() as u64).to_be_bytes());
+            transcript.extend_from_slice(part);
+        }
+
+        let hkdf = hkdf::Hkdf::<sha2::Sha256>::new(Some(&transcript), &key);
+        Ok(Secrets {
+            viewer_confirmation: Confirmation(expand32(&hkdf, b"confirm-viewer")),
+            editor_confirmation: Confirmation(expand32(&hkdf, b"confirm-editor")),
+            token: Token(expand32(&hkdf, b"reconnect-token")),
+            viewer_to_editor: expand32(&hkdf, b"seal-viewer-to-editor"),
+            editor_to_viewer: expand32(&hkdf, b"seal-editor-to-viewer"),
+            role: self.role,
+        })
+    }
+}
+
+fn expand32(hkdf: &hkdf::Hkdf<sha2::Sha256>, label: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    // Only fails for absurd output lengths.
+    hkdf.expand(label, &mut out).expect("32 bytes is a valid HKDF output length");
+    out
+}
+
+/// Derive the same session keys from a token, for a reconnect that skips
+/// the code entirely.
+///
+/// Safe to key directly because a token is 32 random bytes rather than four
+/// digits, so there is nothing to search. It gives no forward secrecy,
+/// though: whoever learns the token can open recorded sessions from this
+/// viewer run. A DH exchange authenticated by the token would fix that, and
+/// would be the next thing to add.
+pub fn session_from_token(
+    role: Role,
+    token: &Token,
+    nonce: &Nonce,
+) -> (session::Sealing, session::Opening) {
+    let mut salt = Vec::with_capacity(TRANSCRIPT_LABEL.len() + NONCE_LEN);
+    salt.extend_from_slice(TRANSCRIPT_LABEL);
+    salt.extend_from_slice(&nonce.0);
+
+    let hkdf = hkdf::Hkdf::<sha2::Sha256>::new(Some(&salt), &token.0);
+    session_pair(
+        role,
+        expand32(&hkdf, b"seal-viewer-to-editor"),
+        expand32(&hkdf, b"seal-editor-to-viewer"),
+    )
+}
+
 /// Digits in a generated pairing code, short enough to read off a phone
 /// across a desk.
 ///
-/// 10000 combinations isn't much, so what makes guessing impractical is the
-/// limits around it: [`MAX_ATTEMPTS`] per prompt, a cool-down that doubles
-/// with each failure, and a prompt the device's owner can see. A generated
-/// code is fresh each time; one pinned with `--pairing-code` isn't, which
-/// is what the escalation is for.
+/// 10000 combinations isn't much, and that is only safe because the code is
+/// established through a PAKE: there is no offline search to fall back on,
+/// so every guess costs an online attempt. [`MAX_ATTEMPTS`] per prompt and a
+/// cool-down that doubles with each failure bound those, and each attempt
+/// puts a prompt in front of whoever holds the device.
+///
+/// A generated code is fresh each time; one pinned with `--pairing-code`
+/// isn't, which is what the escalation is for.
 pub const CODE_DIGITS: u32 = 4;
 
 /// Whether `code` has the shape of a pairing code. Pinned codes are held to
@@ -92,50 +304,17 @@ pub const MAX_ATTEMPTS: u8 = 3;
 /// on the device's screen. Grows with repeated failures.
 pub const PROMPT_RATE_LIMIT: Duration = Duration::from_secs(30);
 
-/// Which secret a proof was computed from. Domain separated, so a proof
-/// from one exchange can't be presented as the other.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Credential {
-    /// The code the viewer displays on screen.
-    Code,
-    /// The token the viewer issued after a previous successful pairing.
-    Token,
-}
-
-impl Credential {
-    fn domain(self) -> &'static [u8] {
-        match self {
-            Credential::Code => b"slint-preview-pairing-code-v1",
-            Credential::Token => b"slint-preview-pairing-token-v1",
-        }
-    }
-}
-
-/// Compute the proof for `secret` against the viewer's `nonce`: the ASCII
-/// digits for [`Credential::Code`], the raw bytes for [`Credential::Token`].
-pub fn proof(credential: Credential, secret: &[u8], nonce: &Nonce) -> Proof {
+/// Prove possession of a reconnect token against the viewer's `nonce`,
+/// without revealing the token itself.
+pub fn token_proof(token: &Token, nonce: &Nonce) -> Proof {
     use hmac::Mac as _;
 
     // A key of any length is fine for HMAC, so this can't fail.
-    let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(secret)
+    let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(&token.0)
         .expect("HMAC accepts keys of any length");
-    mac.update(credential.domain());
+    mac.update(b"slint-preview-pairing-token-v1");
     mac.update(&nonce.0);
     Proof(mac.finalize().into_bytes().into())
-}
-
-/// Derive the reconnect token from a code exchange that just succeeded.
-///
-/// Both ends compute it, so it never has to be sent. Sending it would put
-/// the credential itself on a plaintext socket for anyone to lift.
-pub fn derive_token(code: &str, nonce: &Nonce) -> Token {
-    use hmac::Mac as _;
-
-    let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(code.as_bytes())
-        .expect("HMAC accepts keys of any length");
-    mac.update(b"slint-preview-pairing-derive-v1");
-    mac.update(&nonce.0);
-    Token(mac.finalize().into_bytes().into())
 }
 
 /// Random material, which only the viewer needs. Keeping it here keeps the
@@ -209,68 +388,113 @@ mod tests {
     use super::*;
 
     #[test]
-    fn proof_is_stable_and_key_dependent() {
+    fn a_token_proof_needs_the_token_and_the_nonce() {
         let nonce = Nonce::for_test(7);
-        assert!(proof(Credential::Code, b"123456", &nonce).matches(&proof(
-            Credential::Code,
-            b"123456",
-            &nonce
-        )));
-        assert!(!proof(Credential::Code, b"123456", &nonce).matches(&proof(
-            Credential::Code,
-            b"123457",
-            &nonce
-        )));
+        let a = token_proof(&Token::for_test(1), &nonce);
+        assert!(a.matches(&token_proof(&Token::for_test(1), &nonce)));
+        assert!(!a.matches(&token_proof(&Token::for_test(2), &nonce)));
+        assert!(!a.matches(&token_proof(&Token::for_test(1), &Nonce::for_test(8))));
     }
 
+    /// The whole point: same code on both sides, same keys.
     #[test]
-    fn proof_is_nonce_dependent() {
-        assert!(!proof(Credential::Code, b"123456", &Nonce::for_test(1)).matches(&proof(
-            Credential::Code,
-            b"123456",
-            &Nonce::for_test(2)
-        )));
+    fn matching_codes_agree_on_everything() {
+        let viewer = Handshake::start(Role::Viewer, "4321");
+        let editor = Handshake::start(Role::Editor, "4321");
+        let (ve, ee) = (viewer.element().clone(), editor.element().clone());
+        let vs = viewer.finish(&ee).unwrap();
+        let es = editor.finish(&ve).unwrap();
+
+        assert!(vs.viewer_confirmation.matches(&es.viewer_confirmation));
+        assert!(vs.editor_confirmation.matches(&es.editor_confirmation));
+        assert_eq!(vs.viewer_to_editor, es.viewer_to_editor);
+        assert_eq!(vs.editor_to_viewer, es.editor_to_viewer);
+        assert_eq!(vs.token, es.token);
     }
 
+    /// A wrong code has to fail at confirmation, not earlier: nothing on
+    /// the wire may let an observer test a guess.
     #[test]
-    fn a_derived_token_is_not_a_proof_of_the_same_inputs() {
-        let nonce = Nonce::for_test(7);
-        // Sharing an HMAC key across purposes is how one exchange's output
-        // becomes another's credential.
-        for credential in [Credential::Code, Credential::Token] {
-            assert_ne!(
-                derive_token("4321", &nonce).as_bytes(),
-                proof(credential, b"4321", &nonce).0.as_slice()
-            );
-        }
+    fn a_wrong_code_only_shows_up_at_confirmation() {
+        let viewer = Handshake::start(Role::Viewer, "4321");
+        let editor = Handshake::start(Role::Editor, "1234");
+        let (ve, ee) = (viewer.element().clone(), editor.element().clone());
+
+        // Both sides complete the exchange without complaint ...
+        let vs = viewer.finish(&ee).unwrap();
+        let es = editor.finish(&ve).unwrap();
+
+        // ... and only the confirmations reveal the mismatch.
+        assert!(!vs.editor_confirmation.matches(&es.editor_confirmation));
+        assert!(!vs.viewer_confirmation.matches(&es.viewer_confirmation));
+        assert_ne!(vs.viewer_to_editor, es.viewer_to_editor);
+        assert_ne!(vs.token, es.token);
     }
 
+    /// Each run must produce fresh keys, or a recorded session could be
+    /// replayed against a later one.
     #[test]
-    fn a_derived_token_needs_both_the_code_and_the_nonce() {
-        let nonce = Nonce::for_test(7);
-        assert_eq!(derive_token("4321", &nonce), derive_token("4321", &nonce));
-        assert_ne!(derive_token("4321", &nonce), derive_token("1234", &nonce));
-        assert_ne!(derive_token("4321", &nonce), derive_token("4321", &Nonce::for_test(8)));
+    fn every_exchange_derives_different_keys() {
+        let run = || {
+            let viewer = Handshake::start(Role::Viewer, "4321");
+            let editor = Handshake::start(Role::Editor, "4321");
+            let (ve, ee) = (viewer.element().clone(), editor.element().clone());
+            let _ = editor.finish(&ve).unwrap();
+            viewer.finish(&ee).unwrap()
+        };
+        assert_ne!(run().viewer_to_editor, run().viewer_to_editor);
     }
 
+    /// Reflecting a party's own message back at it must not work. The
+    /// crate tags each element with its role and refuses the mismatch, so
+    /// this fails outright rather than quietly deriving a different key.
     #[test]
-    fn credentials_are_domain_separated() {
-        let nonce = Nonce::for_test(7);
-        assert!(!proof(Credential::Code, b"secret", &nonce).matches(&proof(
-            Credential::Token,
-            b"secret",
-            &nonce
-        )));
+    fn a_reflected_element_is_refused() {
+        let one = Handshake::start(Role::Viewer, "4321");
+        let two = Handshake::start(Role::Viewer, "4321");
+        let b = two.element().clone();
+        assert!(one.finish(&b).is_err(), "a same-role element was accepted");
     }
 
+    /// The confirmations are separate outputs: revealing one must not
+    /// hand over the other, nor the sealing keys.
     #[test]
-    fn matches_agrees_with_the_inputs() {
-        let nonce = Nonce::for_test(7);
-        let a = proof(Credential::Code, b"123456", &nonce);
-        let b = proof(Credential::Code, b"123456", &nonce);
-        let c = proof(Credential::Code, b"654321", &nonce);
-        assert!(a.matches(&b));
-        assert!(!a.matches(&c));
+    fn derived_values_are_all_distinct() {
+        let viewer = Handshake::start(Role::Viewer, "4321");
+        let editor = Handshake::start(Role::Editor, "4321");
+        let ee = editor.element().clone();
+        let s = viewer.finish(&ee).unwrap();
+        let mut seen = std::collections::HashSet::new();
+        assert!(seen.insert(s.viewer_confirmation.0));
+        assert!(seen.insert(s.editor_confirmation.0));
+        assert!(seen.insert(s.viewer_to_editor));
+        assert!(seen.insert(s.editor_to_viewer));
+        assert!(seen.insert(*s.token.as_bytes().first_chunk::<32>().unwrap()));
+    }
+
+    /// Both roles from the same token and nonce make one working session:
+    /// what the viewer seals, the editor opens, and vice versa.
+    #[test]
+    fn a_token_session_connects_the_two_roles() {
+        let token = Token::for_test(3);
+        let nonce = Nonce::for_test(1);
+        let (mut viewer_seal, mut viewer_open) = session_from_token(Role::Viewer, &token, &nonce);
+        let (mut editor_seal, mut editor_open) = session_from_token(Role::Editor, &token, &nonce);
+        let down = viewer_seal.seal(b"to the editor".to_vec()).unwrap();
+        assert_eq!(editor_open.open(&down).unwrap().as_ref(), b"to the editor");
+        let up = editor_seal.seal(b"to the viewer".to_vec()).unwrap();
+        assert_eq!(viewer_open.open(&up).unwrap().as_ref(), b"to the viewer");
+    }
+
+    /// The viewer picks a fresh nonce per connection, so a token gives
+    /// different session keys every time it is used.
+    #[test]
+    fn a_token_session_is_fresh_per_connection() {
+        let token = Token::for_test(3);
+        let (mut sealer, _) = session_from_token(Role::Viewer, &token, &Nonce::for_test(1));
+        let (_, mut opener) = session_from_token(Role::Editor, &token, &Nonce::for_test(9));
+        let sealed = sealer.seal(b"stale".to_vec()).unwrap();
+        assert!(opener.open(&sealed).is_err(), "keys survived a nonce change");
     }
 
     #[test]

--- a/internal/live-preview/protocol/pairing.rs
+++ b/internal/live-preview/protocol/pairing.rs
@@ -15,32 +15,19 @@
 //! this module bound the online guessing, and there is no other avenue.
 //!
 //! The exchange also yields a session key, so everything after pairing is
-//! sealed, and the reconnect token is derived from that key rather than
-//! from the code.
+//! sealed. The reconnect token is derived from that key rather than from
+//! the code, and using it means running the same exchange again with the
+//! token as the secret: every session gets fresh keys, so recorded traffic
+//! stays sealed even if the token leaks later.
 
 use crate::protocol::session;
 use std::time::Duration;
 
-/// Byte length of the viewer's per-connection nonce.
-const NONCE_LEN: usize = 32;
-
-/// Byte length of a proof.
-const MAC_LEN: usize = 32;
-
 /// Byte length of a reconnect token.
 const TOKEN_LEN: usize = 32;
 
-/// The viewer's per-connection challenge.
-#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
-pub struct Nonce([u8; NONCE_LEN]);
-
-/// Proof of holding a credential, without revealing it.
-///
-/// Deliberately not [`PartialEq`]: comparing proofs with `==` gives away
-/// where they first differ, so [`Proof::matches`] is the only way to
-/// compare two.
-#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
-pub struct Proof([u8; MAC_LEN]);
+/// Byte length of a token id.
+const TOKEN_ID_LEN: usize = 16;
 
 /// A reconnect token, derived from a completed code exchange.
 ///
@@ -49,6 +36,15 @@ pub struct Proof([u8; MAC_LEN]);
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Token([u8; TOKEN_LEN]);
 
+/// The public name of a [`Token`], derived alongside it.
+///
+/// The editor announces it on reconnect, so the viewer knows which token
+/// to run the exchange with. It proves nothing by itself: anyone on the
+/// network can read it off the wire and replay it, and gets no further
+/// than the exchange the token itself is required for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct TokenId([u8; TOKEN_ID_LEN]);
+
 /// Compare without leaking where the two first differ.
 fn constant_time_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
     use subtle::ConstantTimeEq as _;
@@ -56,26 +52,19 @@ fn constant_time_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
     a.ct_eq(b).into()
 }
 
-impl Proof {
-    /// Compare without leaking where the two first differ.
-    pub fn matches(&self, other: &Proof) -> bool {
-        constant_time_eq(&self.0, &other.0)
-    }
-}
-
-#[cfg(test)]
-impl Nonce {
-    /// A predictable nonce, so tests can assert on what a proof depends on.
-    pub fn for_test(byte: u8) -> Self {
-        Self([byte; NONCE_LEN])
-    }
-}
-
 #[cfg(test)]
 impl Token {
     /// A token no viewer ever issued, for tests that need one to be refused.
     pub fn for_test(byte: u8) -> Self {
         Self([byte; TOKEN_LEN])
+    }
+}
+
+#[cfg(test)]
+impl TokenId {
+    /// An id no viewer ever issued.
+    pub fn for_test(byte: u8) -> Self {
+        Self([byte; TOKEN_ID_LEN])
     }
 }
 
@@ -137,6 +126,8 @@ pub struct Secrets {
     pub editor_confirmation: Confirmation,
     /// Reconnect token, bound to this exchange rather than to the code.
     pub token: Token,
+    /// Public name of `token`, for announcing it on reconnect.
+    pub token_id: TokenId,
     /// Session key for viewer-to-editor frames. Not public: key material
     /// leaves this module only inside a [`session`] codec.
     viewer_to_editor: [u8; session::DIRECTION_KEY_LEN],
@@ -187,9 +178,28 @@ pub struct Handshake {
 }
 
 impl Handshake {
-    /// Begin, holding `code` as the shared low-entropy secret.
-    pub fn start(role: Role, code: &str) -> Self {
-        let password = spake2::Password::new(code.as_bytes());
+    /// Begin a first pairing, with the on-screen code as the secret.
+    pub fn with_code(role: Role, code: &str) -> Self {
+        Self::start(role, b"code:", code.as_bytes())
+    }
+
+    /// Begin a reconnect, with an issued token as the secret.
+    ///
+    /// The token has plenty of entropy, but running it through the same
+    /// exchange instead of keying a session from it directly buys forward
+    /// secrecy: the session keys come out of the fresh exchange, so someone
+    /// who records the traffic and later steals the token opens nothing.
+    pub fn with_token(role: Role, token: &Token) -> Self {
+        Self::start(role, b"token:", &token.0)
+    }
+
+    /// The prefix keeps the two secret spaces apart, so a code exchange
+    /// and a token exchange can never agree with each other.
+    fn start(role: Role, prefix: &[u8], secret: &[u8]) -> Self {
+        let mut keyed = Vec::with_capacity(prefix.len() + secret.len());
+        keyed.extend_from_slice(prefix);
+        keyed.extend_from_slice(secret);
+        let password = spake2::Password::new(&keyed);
         let viewer = spake2::Identity::new(b"slint-preview-viewer");
         let editor = spake2::Identity::new(b"slint-preview-editor");
         let (state, element) = match role {
@@ -233,46 +243,22 @@ impl Handshake {
 
         let hkdf = hkdf::Hkdf::<sha2::Sha256>::new(Some(&transcript), &key);
         Ok(Secrets {
-            viewer_confirmation: Confirmation(expand32(&hkdf, b"confirm-viewer")),
-            editor_confirmation: Confirmation(expand32(&hkdf, b"confirm-editor")),
-            token: Token(expand32(&hkdf, b"reconnect-token")),
-            viewer_to_editor: expand32(&hkdf, b"seal-viewer-to-editor"),
-            editor_to_viewer: expand32(&hkdf, b"seal-editor-to-viewer"),
+            viewer_confirmation: Confirmation(expand(&hkdf, b"confirm-viewer")),
+            editor_confirmation: Confirmation(expand(&hkdf, b"confirm-editor")),
+            token: Token(expand(&hkdf, b"reconnect-token")),
+            token_id: TokenId(expand(&hkdf, b"reconnect-token-id")),
+            viewer_to_editor: expand(&hkdf, b"seal-viewer-to-editor"),
+            editor_to_viewer: expand(&hkdf, b"seal-editor-to-viewer"),
             role: self.role,
         })
     }
 }
 
-fn expand32(hkdf: &hkdf::Hkdf<sha2::Sha256>, label: &[u8]) -> [u8; 32] {
-    let mut out = [0u8; 32];
+fn expand<const N: usize>(hkdf: &hkdf::Hkdf<sha2::Sha256>, label: &[u8]) -> [u8; N] {
+    let mut out = [0u8; N];
     // Only fails for absurd output lengths.
-    hkdf.expand(label, &mut out).expect("32 bytes is a valid HKDF output length");
+    hkdf.expand(label, &mut out).expect("a short HKDF output length is always valid");
     out
-}
-
-/// Derive the same session keys from a token, for a reconnect that skips
-/// the code entirely.
-///
-/// Safe to key directly because a token is 32 random bytes rather than four
-/// digits, so there is nothing to search. It gives no forward secrecy,
-/// though: whoever learns the token can open recorded sessions from this
-/// viewer run. A DH exchange authenticated by the token would fix that, and
-/// would be the next thing to add.
-pub fn session_from_token(
-    role: Role,
-    token: &Token,
-    nonce: &Nonce,
-) -> (session::Sealing, session::Opening) {
-    let mut salt = Vec::with_capacity(TRANSCRIPT_LABEL.len() + NONCE_LEN);
-    salt.extend_from_slice(TRANSCRIPT_LABEL);
-    salt.extend_from_slice(&nonce.0);
-
-    let hkdf = hkdf::Hkdf::<sha2::Sha256>::new(Some(&salt), &token.0);
-    session_pair(
-        role,
-        expand32(&hkdf, b"seal-viewer-to-editor"),
-        expand32(&hkdf, b"seal-editor-to-viewer"),
-    )
 }
 
 /// Digits in a generated pairing code, short enough to read off a phone
@@ -304,30 +290,12 @@ pub const MAX_ATTEMPTS: u8 = 3;
 /// on the device's screen. Grows with repeated failures.
 pub const PROMPT_RATE_LIMIT: Duration = Duration::from_secs(30);
 
-/// Prove possession of a reconnect token against the viewer's `nonce`,
-/// without revealing the token itself.
-pub fn token_proof(token: &Token, nonce: &Nonce) -> Proof {
-    use hmac::Mac as _;
-
-    // A key of any length is fine for HMAC, so this can't fail.
-    let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(&token.0)
-        .expect("HMAC accepts keys of any length");
-    mac.update(b"slint-preview-pairing-token-v1");
-    mac.update(&nonce.0);
-    Proof(mac.finalize().into_bytes().into())
-}
-
 /// Random material, which only the viewer needs. Keeping it here keeps the
 /// random source out of the LSP's browser builds.
 #[cfg(feature = "remote")]
 pub mod generate {
-    use super::{CODE_DIGITS, Nonce};
+    use super::CODE_DIGITS;
     use rand::Rng as _;
-
-    /// A fresh nonce for one connection's challenge.
-    pub fn nonce() -> Nonce {
-        Nonce(rand::rng().random())
-    }
 
     /// A fresh pairing code, zero-padded to [`CODE_DIGITS`] digits.
     pub fn code() -> String {
@@ -387,20 +355,11 @@ impl std::fmt::Display for PairingRejection {
 mod tests {
     use super::*;
 
-    #[test]
-    fn a_token_proof_needs_the_token_and_the_nonce() {
-        let nonce = Nonce::for_test(7);
-        let a = token_proof(&Token::for_test(1), &nonce);
-        assert!(a.matches(&token_proof(&Token::for_test(1), &nonce)));
-        assert!(!a.matches(&token_proof(&Token::for_test(2), &nonce)));
-        assert!(!a.matches(&token_proof(&Token::for_test(1), &Nonce::for_test(8))));
-    }
-
     /// The whole point: same code on both sides, same keys.
     #[test]
     fn matching_codes_agree_on_everything() {
-        let viewer = Handshake::start(Role::Viewer, "4321");
-        let editor = Handshake::start(Role::Editor, "4321");
+        let viewer = Handshake::with_code(Role::Viewer, "4321");
+        let editor = Handshake::with_code(Role::Editor, "4321");
         let (ve, ee) = (viewer.element().clone(), editor.element().clone());
         let vs = viewer.finish(&ee).unwrap();
         let es = editor.finish(&ve).unwrap();
@@ -410,14 +369,15 @@ mod tests {
         assert_eq!(vs.viewer_to_editor, es.viewer_to_editor);
         assert_eq!(vs.editor_to_viewer, es.editor_to_viewer);
         assert_eq!(vs.token, es.token);
+        assert_eq!(vs.token_id, es.token_id);
     }
 
     /// A wrong code has to fail at confirmation, not earlier: nothing on
     /// the wire may let an observer test a guess.
     #[test]
     fn a_wrong_code_only_shows_up_at_confirmation() {
-        let viewer = Handshake::start(Role::Viewer, "4321");
-        let editor = Handshake::start(Role::Editor, "1234");
+        let viewer = Handshake::with_code(Role::Viewer, "4321");
+        let editor = Handshake::with_code(Role::Editor, "1234");
         let (ve, ee) = (viewer.element().clone(), editor.element().clone());
 
         // Both sides complete the exchange without complaint ...
@@ -436,8 +396,8 @@ mod tests {
     #[test]
     fn every_exchange_derives_different_keys() {
         let run = || {
-            let viewer = Handshake::start(Role::Viewer, "4321");
-            let editor = Handshake::start(Role::Editor, "4321");
+            let viewer = Handshake::with_code(Role::Viewer, "4321");
+            let editor = Handshake::with_code(Role::Editor, "4321");
             let (ve, ee) = (viewer.element().clone(), editor.element().clone());
             let _ = editor.finish(&ve).unwrap();
             viewer.finish(&ee).unwrap()
@@ -450,8 +410,8 @@ mod tests {
     /// this fails outright rather than quietly deriving a different key.
     #[test]
     fn a_reflected_element_is_refused() {
-        let one = Handshake::start(Role::Viewer, "4321");
-        let two = Handshake::start(Role::Viewer, "4321");
+        let one = Handshake::with_code(Role::Viewer, "4321");
+        let two = Handshake::with_code(Role::Viewer, "4321");
         let b = two.element().clone();
         assert!(one.finish(&b).is_err(), "a same-role element was accepted");
     }
@@ -460,41 +420,64 @@ mod tests {
     /// hand over the other, nor the sealing keys.
     #[test]
     fn derived_values_are_all_distinct() {
-        let viewer = Handshake::start(Role::Viewer, "4321");
-        let editor = Handshake::start(Role::Editor, "4321");
+        let viewer = Handshake::with_code(Role::Viewer, "4321");
+        let editor = Handshake::with_code(Role::Editor, "4321");
         let ee = editor.element().clone();
         let s = viewer.finish(&ee).unwrap();
         let mut seen = std::collections::HashSet::new();
-        assert!(seen.insert(s.viewer_confirmation.0));
-        assert!(seen.insert(s.editor_confirmation.0));
-        assert!(seen.insert(s.viewer_to_editor));
-        assert!(seen.insert(s.editor_to_viewer));
-        assert!(seen.insert(*s.token.as_bytes().first_chunk::<32>().unwrap()));
+        assert!(seen.insert(s.viewer_confirmation.0.to_vec()));
+        assert!(seen.insert(s.editor_confirmation.0.to_vec()));
+        assert!(seen.insert(s.viewer_to_editor.to_vec()));
+        assert!(seen.insert(s.editor_to_viewer.to_vec()));
+        assert!(seen.insert(s.token.as_bytes().to_vec()));
+        assert!(seen.insert(s.token_id.0.to_vec()));
     }
 
-    /// Both roles from the same token and nonce make one working session:
-    /// what the viewer seals, the editor opens, and vice versa.
+    /// A token exchange works like a code exchange: same token, same keys,
+    /// and the sealed session connects the two roles.
     #[test]
-    fn a_token_session_connects_the_two_roles() {
+    fn a_token_exchange_connects_the_two_roles() {
         let token = Token::for_test(3);
-        let nonce = Nonce::for_test(1);
-        let (mut viewer_seal, mut viewer_open) = session_from_token(Role::Viewer, &token, &nonce);
-        let (mut editor_seal, mut editor_open) = session_from_token(Role::Editor, &token, &nonce);
+        let viewer = Handshake::with_token(Role::Viewer, &token);
+        let editor = Handshake::with_token(Role::Editor, &token);
+        let (ve, ee) = (viewer.element().clone(), editor.element().clone());
+        let vs = viewer.finish(&ee).unwrap();
+        let es = editor.finish(&ve).unwrap();
+
+        assert!(vs.editor_confirmation.matches(&es.editor_confirmation));
+        let (mut viewer_seal, _) = vs.session();
+        let (_, mut editor_open) = es.session();
         let down = viewer_seal.seal(b"to the editor".to_vec()).unwrap();
         assert_eq!(editor_open.open(&down).unwrap().as_ref(), b"to the editor");
-        let up = editor_seal.seal(b"to the viewer".to_vec()).unwrap();
-        assert_eq!(viewer_open.open(&up).unwrap().as_ref(), b"to the viewer");
     }
 
-    /// The viewer picks a fresh nonce per connection, so a token gives
-    /// different session keys every time it is used.
+    /// A wrong token fails like a wrong code: both sides finish without
+    /// complaint and only the confirmations disagree. This is what stops a
+    /// peer that sniffed a token *id* off the wire.
     #[test]
-    fn a_token_session_is_fresh_per_connection() {
+    fn a_wrong_token_only_shows_up_at_confirmation() {
+        let viewer = Handshake::with_token(Role::Viewer, &Token::for_test(3));
+        let editor = Handshake::with_token(Role::Editor, &Token::for_test(9));
+        let (ve, ee) = (viewer.element().clone(), editor.element().clone());
+        let vs = viewer.finish(&ee).unwrap();
+        let es = editor.finish(&ve).unwrap();
+        assert!(!vs.editor_confirmation.matches(&es.editor_confirmation));
+        assert!(!vs.viewer_confirmation.matches(&es.viewer_confirmation));
+    }
+
+    /// The forward-secrecy property this design buys: reusing a token still
+    /// produces fresh keys every session, so no recorded session can be
+    /// opened by learning the token later.
+    #[test]
+    fn a_token_exchange_gives_fresh_keys_every_time() {
         let token = Token::for_test(3);
-        let (mut sealer, _) = session_from_token(Role::Viewer, &token, &Nonce::for_test(1));
-        let (_, mut opener) = session_from_token(Role::Editor, &token, &Nonce::for_test(9));
-        let sealed = sealer.seal(b"stale".to_vec()).unwrap();
-        assert!(opener.open(&sealed).is_err(), "keys survived a nonce change");
+        let run = || {
+            let viewer = Handshake::with_token(Role::Viewer, &token);
+            let editor = Handshake::with_token(Role::Editor, &token);
+            let ee = editor.element().clone();
+            viewer.finish(&ee).unwrap()
+        };
+        assert_ne!(run().viewer_to_editor, run().viewer_to_editor);
     }
 
     #[test]

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -60,7 +60,7 @@ pub enum PreviewToLspMessage {
     /// The preview UI asked to disconnect the remote viewer.
     DisconnectRemote,
     /// The user typed a pairing code into the preview UI. Carries the code
-    /// itself; the LSP owns the nonce and turns it into a proof.
+    /// itself; the LSP runs the SPAKE2 exchange with it.
     SubmitPairingCode { code: String },
     /// The user dismissed the pairing prompt in the preview UI.
     CancelPairing,
@@ -70,15 +70,20 @@ pub enum PreviewToLspMessage {
     /// Ask the LSP to load a component and answer with
     /// [`super::LspToPreviewMessage::ShowPreview`].
     RequestPreview { component: PreviewComponent },
-    /// First message on a remote connection: the nonce both pairing proofs
-    /// are computed against. See [`super::pairing`].
+    /// First message on a remote connection: the nonce the token proof is
+    /// computed against, which also freshens the keys of a token session.
+    /// See [`super::pairing`].
     PairingChallenge { nonce: super::pairing::Nonce },
     /// The client offered no usable token, so the viewer is now showing a
-    /// pairing code and waiting for the user to type it.
-    PairingRequired { attempts_left: u8, expires_in_seconds: u16 },
-    /// The client is authenticated. Carries nothing: when this followed a
-    /// code exchange both ends derive the reconnect token from the code and
-    /// the nonce, so the token itself never crosses the wire.
+    /// pairing code and waiting for the user to type it. `element` starts
+    /// the SPAKE2 exchange the code is established through; a fresh one is
+    /// sent for every attempt.
+    PairingRequired { attempts_left: u8, expires_in_seconds: u16, element: super::pairing::Element },
+    /// The viewer derived the same key, and proves it. The session is
+    /// sealed from the next frame on.
+    PairingConfirm { confirmation: super::pairing::Confirmation },
+    /// A token was accepted, or pairing is disabled. A code exchange never
+    /// ends with this: its acceptance is [`Self::PairingConfirm`].
     PairingAccepted,
     /// The client is not authenticated. Whether retrying is worthwhile is
     /// [`PairingRejection::is_terminal`].

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -70,20 +70,25 @@ pub enum PreviewToLspMessage {
     /// Ask the LSP to load a component and answer with
     /// [`super::LspToPreviewMessage::ShowPreview`].
     RequestPreview { component: PreviewComponent },
-    /// First message on a remote connection: the nonce the token proof is
-    /// computed against, which also freshens the keys of a token session.
-    /// See [`super::pairing`].
-    PairingChallenge { nonce: super::pairing::Nonce },
+    /// First message on a remote connection: the viewer is ready for
+    /// [`super::LspToPreviewMessage::PairingHello`]. See [`super::pairing`].
+    PairingReady,
     /// The client offered no usable token, so the viewer is now showing a
     /// pairing code and waiting for the user to type it. `element` starts
     /// the SPAKE2 exchange the code is established through; a fresh one is
     /// sent for every attempt.
     PairingRequired { attempts_left: u8, expires_in_seconds: u16, element: super::pairing::Element },
+    /// The client announced a token this viewer issued, so the viewer opens
+    /// the reconnect exchange, with the token as the secret and nobody on
+    /// the screen. Answered like a code prompt, by
+    /// [`super::LspToPreviewMessage::PairingResponse`].
+    PairingTokenChallenge { element: super::pairing::Element },
     /// The viewer derived the same key, and proves it. The session is
     /// sealed from the next frame on.
     PairingConfirm { confirmation: super::pairing::Confirmation },
-    /// A token was accepted, or pairing is disabled. A code exchange never
-    /// ends with this: its acceptance is [`Self::PairingConfirm`].
+    /// Pairing is disabled on this viewer, so there is nothing to prove and
+    /// the session stays plaintext. Nothing else ends with this message: a
+    /// code or token exchange ends with [`Self::PairingConfirm`].
     PairingAccepted,
     /// The client is not authenticated. Whether retrying is worthwhile is
     /// [`PairingRejection::is_terminal`].

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use lsp_types::Url;
 
-use super::{PreviewComponent, Result, SourceFileVersion};
+use super::{PairingRejection, PreviewComponent, Result, SourceFileVersion};
 
 #[cfg(target_arch = "wasm32")]
 use super::wasm_prelude::*;
@@ -59,12 +59,30 @@ pub enum PreviewToLspMessage {
     ConnectRemote { addresses: Vec<String>, port: u16 },
     /// The preview UI asked to disconnect the remote viewer.
     DisconnectRemote,
+    /// The user typed a pairing code into the preview UI. Carries the code
+    /// itself; the LSP owns the nonce and turns it into a proof.
+    SubmitPairingCode { code: String },
+    /// The user dismissed the pairing prompt in the preview UI.
+    CancelPairing,
     /// Answer to [`super::LspToPreviewMessage::Ping`], consumed by the LSP's
     /// WebSocket connector.
     Pong,
     /// Ask the LSP to load a component and answer with
     /// [`super::LspToPreviewMessage::ShowPreview`].
     RequestPreview { component: PreviewComponent },
+    /// First message on a remote connection: the nonce both pairing proofs
+    /// are computed against. See [`super::pairing`].
+    PairingChallenge { nonce: super::pairing::Nonce },
+    /// The client offered no usable token, so the viewer is now showing a
+    /// pairing code and waiting for the user to type it.
+    PairingRequired { attempts_left: u8, expires_in_seconds: u16 },
+    /// The client is authenticated. Carries nothing: when this followed a
+    /// code exchange both ends derive the reconnect token from the code and
+    /// the nonce, so the token itself never crosses the wire.
+    PairingAccepted,
+    /// The client is not authenticated. Whether retrying is worthwhile is
+    /// [`PairingRejection::is_terminal`].
+    PairingRejected { reason: PairingRejection },
 }
 
 /// One transport from a preview back to the LSP.

--- a/internal/live-preview/protocol/preview_to_lsp.rs
+++ b/internal/live-preview/protocol/preview_to_lsp.rs
@@ -64,6 +64,9 @@ pub enum PreviewToLspMessage {
     SubmitPairingCode { code: String },
     /// The user dismissed the pairing prompt in the preview UI.
     CancelPairing,
+    /// The user agreed to connect to a viewer that has pairing disabled,
+    /// knowing the session will not be encrypted.
+    AcceptUnpairedConnection,
     /// Answer to [`super::LspToPreviewMessage::Ping`], consumed by the LSP's
     /// WebSocket connector.
     Pong,

--- a/internal/live-preview/protocol/session.rs
+++ b/internal/live-preview/protocol/session.rs
@@ -184,8 +184,8 @@ mod tests {
 
     #[test]
     fn the_sealed_codec_round_trips() {
-        let mut sealing = Sealing::Sealed(Sealer::new([7u8; 32]));
-        let mut opening = Opening::Sealed(Opener::new([7u8; 32]));
+        let (sealer, opener) = pair();
+        let (mut sealing, mut opening) = (Sealing::Sealed(sealer), Opening::Sealed(opener));
         let sent = sealing.seal(b"shut".to_vec()).unwrap();
         assert_ne!(sent, b"shut");
         assert_eq!(opening.open(&sent).unwrap().as_ref(), b"shut");

--- a/internal/live-preview/protocol/session.rs
+++ b/internal/live-preview/protocol/session.rs
@@ -1,0 +1,193 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Authenticated encryption for an established session.
+//!
+//! One key per direction, so the two halves can live in different tasks
+//! without sharing a counter. Nonces are the frame counter, which works
+//! because every key here is used by exactly one sender and TCP delivers
+//! in order: a repeated or reordered frame fails to open rather than
+//! being accepted twice.
+
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use std::borrow::Cow;
+
+/// Bytes of key material one direction needs.
+pub const DIRECTION_KEY_LEN: usize = 32;
+
+/// The frame counter ran out. Unreachable in practice at 2^64 frames, but
+/// wrapping it would reuse a nonce, which loses everything.
+#[derive(Debug)]
+pub struct CounterExhausted;
+
+/// The frame didn't decrypt: tampered with, reordered, or from a peer that
+/// derived a different key. All three are the same answer -- drop it.
+#[derive(Debug)]
+pub struct NotAuthentic;
+
+fn nonce_for(counter: u64) -> Nonce {
+    let mut bytes = [0u8; 12];
+    bytes[4..].copy_from_slice(&counter.to_be_bytes());
+    *Nonce::from_slice(&bytes)
+}
+
+/// The writing half of a session.
+pub struct Sealer {
+    cipher: ChaCha20Poly1305,
+    counter: u64,
+}
+
+impl Sealer {
+    pub fn new(key: [u8; DIRECTION_KEY_LEN]) -> Self {
+        Self { cipher: ChaCha20Poly1305::new(Key::from_slice(&key)), counter: 0 }
+    }
+
+    /// Takes the buffer and encrypts it in place: the plaintext is spent
+    /// either way, and this saves copying every outbound frame.
+    pub fn seal(&mut self, mut plaintext: Vec<u8>) -> Result<Vec<u8>, CounterExhausted> {
+        let nonce = nonce_for(self.counter);
+        self.counter = self.counter.checked_add(1).ok_or(CounterExhausted)?;
+        // Encryption itself only fails on absurd input lengths.
+        self.cipher.encrypt_in_place(&nonce, b"", &mut plaintext).map_err(|_| CounterExhausted)?;
+        Ok(plaintext)
+    }
+}
+
+/// The reading half of a session.
+pub struct Opener {
+    cipher: ChaCha20Poly1305,
+    counter: u64,
+}
+
+impl Opener {
+    pub fn new(key: [u8; DIRECTION_KEY_LEN]) -> Self {
+        Self { cipher: ChaCha20Poly1305::new(Key::from_slice(&key)), counter: 0 }
+    }
+
+    pub fn open(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>, NotAuthentic> {
+        let nonce = nonce_for(self.counter);
+        let plaintext = self.cipher.decrypt(&nonce, ciphertext).map_err(|_| NotAuthentic)?;
+        // Only advance once the frame proved authentic, so a rejected frame
+        // doesn't throw the counters out of step.
+        self.counter = self.counter.saturating_add(1);
+        Ok(plaintext)
+    }
+}
+
+/// The outbound half of a session's codec.
+///
+/// Owns the decision between sealing and passing frames through, so no send
+/// path carries its own "is this session encrypted?" branch. `Plaintext`
+/// exists for `--no-pairing`, which establishes no shared secret.
+pub enum Sealing {
+    Plaintext,
+    Sealed(Sealer),
+}
+
+impl Sealing {
+    pub fn seal(&mut self, plaintext: Vec<u8>) -> Result<Vec<u8>, CounterExhausted> {
+        match self {
+            Self::Plaintext => Ok(plaintext),
+            Self::Sealed(sealer) => sealer.seal(plaintext),
+        }
+    }
+}
+
+/// The inbound half of a session's codec, mirroring [`Sealing`].
+pub enum Opening {
+    Plaintext,
+    Sealed(Opener),
+}
+
+impl Opening {
+    /// Borrowed in the plaintext case, so `--no-pairing` doesn't pay for a
+    /// copy of every inbound frame.
+    pub fn open<'a>(&mut self, frame: &'a [u8]) -> Result<Cow<'a, [u8]>, NotAuthentic> {
+        match self {
+            Self::Plaintext => Ok(Cow::Borrowed(frame)),
+            Self::Sealed(opener) => opener.open(frame).map(Cow::Owned),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pair() -> (Sealer, Opener) {
+        (Sealer::new([7u8; 32]), Opener::new([7u8; 32]))
+    }
+
+    #[test]
+    fn a_sealed_frame_opens() {
+        let (mut sealer, mut opener) = pair();
+        let sealed = sealer.seal(b"hello".to_vec()).unwrap();
+        assert_ne!(sealed, b"hello", "the plaintext went out as-is");
+        assert_eq!(opener.open(&sealed).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn frames_must_arrive_in_order() {
+        let (mut sealer, mut opener) = pair();
+        let first = sealer.seal(b"one".to_vec()).unwrap();
+        let second = sealer.seal(b"two".to_vec()).unwrap();
+        // Skipping the first puts the counter out of step, so the second
+        // doesn't open either.
+        assert!(opener.open(&second).is_err());
+        assert_eq!(opener.open(&first).unwrap(), b"one");
+    }
+
+    #[test]
+    fn a_replayed_frame_is_refused() {
+        let (mut sealer, mut opener) = pair();
+        let sealed = sealer.seal(b"once".to_vec()).unwrap();
+        assert_eq!(opener.open(&sealed).unwrap(), b"once");
+        assert!(opener.open(&sealed).is_err(), "a repeat was accepted");
+    }
+
+    #[test]
+    fn tampering_is_caught() {
+        let (mut sealer, mut opener) = pair();
+        let mut sealed = sealer.seal(b"intact".to_vec()).unwrap();
+        let last = sealed.len() - 1;
+        sealed[last] ^= 0x01;
+        assert!(opener.open(&sealed).is_err());
+    }
+
+    #[test]
+    fn a_different_key_cannot_open() {
+        let mut sealer = Sealer::new([1u8; 32]);
+        let mut opener = Opener::new([2u8; 32]);
+        let sealed = sealer.seal(b"secret".to_vec()).unwrap();
+        assert!(opener.open(&sealed).is_err());
+    }
+
+    #[test]
+    fn a_rejected_frame_keeps_the_counter_in_step() {
+        let (mut sealer, mut opener) = pair();
+        let good = sealer.seal(b"good".to_vec()).unwrap();
+        let mut bad = good.clone();
+        bad[0] ^= 0xff;
+        assert!(opener.open(&bad).is_err());
+        // The counter didn't move, so the real frame still opens.
+        assert_eq!(opener.open(&good).unwrap(), b"good");
+    }
+
+    #[test]
+    fn the_plaintext_codec_passes_frames_through() {
+        let (mut sealing, mut opening) = (Sealing::Plaintext, Opening::Plaintext);
+        let sent = sealing.seal(b"open".to_vec()).unwrap();
+        assert_eq!(sent, b"open");
+        assert!(matches!(opening.open(&sent).unwrap(), Cow::Borrowed(b"open")));
+    }
+
+    #[test]
+    fn the_sealed_codec_round_trips() {
+        let mut sealing = Sealing::Sealed(Sealer::new([7u8; 32]));
+        let mut opening = Opening::Sealed(Opener::new([7u8; 32]));
+        let sent = sealing.seal(b"shut".to_vec()).unwrap();
+        assert_ne!(sent, b"shut");
+        assert_eq!(opening.open(&sent).unwrap().as_ref(), b"shut");
+    }
+}

--- a/internal/live-preview/remote.rs
+++ b/internal/live-preview/remote.rs
@@ -5,4 +5,4 @@ mod compilation;
 mod connection;
 
 pub use compilation::init_compiler;
-pub use connection::{CacheEntry, Connection, ConnectionMessage, FileCache};
+pub use connection::{CacheEntry, Connection, ConnectionMessage, FileCache, PairingPolicy};

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -12,9 +12,9 @@ use std::{
 
 use crate::REBUILD_DEBOUNCE;
 use crate::protocol::pairing::{
-    self, CODE_TIMEOUT, Credential, MAX_ATTEMPTS, Nonce, PROMPT_RATE_LIMIT, PairingRejection,
-    Proof, Token,
+    self, CODE_TIMEOUT, MAX_ATTEMPTS, Nonce, PROMPT_RATE_LIMIT, PairingRejection, Proof, Token,
 };
+use crate::protocol::session;
 use crate::protocol::{
     LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PreviewComponent, PreviewConfig,
     PreviewToLspMessage, SLINT_PROTOCOLS_HEADER, SLINT_VERSION, SLINT_VERSION_HEADER,
@@ -129,12 +129,14 @@ enum Screen {
 }
 
 impl PairingState {
-    /// Whether `offered` proves possession of a token we handed out.
-    fn accepts_token(&self, offered: &Proof, nonce: &Nonce) -> bool {
-        // Bitwise `|` rather than `||`: checking every token regardless keeps
-        // the answer from depending on which one matched.
-        self.tokens.iter().fold(false, |found, token| {
-            found | pairing::proof(Credential::Token, token.as_bytes(), nonce).matches(offered)
+    /// The token `offered` proves possession of, if we handed it out. The
+    /// value is needed and not just a yes/no, because it keys the session.
+    fn accepting_token(&self, offered: &Proof, nonce: &Nonce) -> Option<Token> {
+        // Fold rather than `find`: checking every token regardless keeps the
+        // work from depending on which one matched.
+        self.tokens.iter().fold(None, |found, token| {
+            let matched = pairing::token_proof(token, nonce).matches(offered);
+            if matched { Some(*token) } else { found }
         })
     }
 
@@ -357,7 +359,7 @@ pub enum ConnectionMessage {
 pub struct Connection {
     local_addr: SocketAddr,
     thread_handle: Option<(std::thread::JoinHandle<()>, sync::oneshot::Sender<()>)>,
-    message_sender: sync::mpsc::UnboundedSender<Message>,
+    message_sender: sync::mpsc::UnboundedSender<Outbound>,
     file_cache: FileCache,
     /// Files the currently shown component depends on. `SetContents` notifications for URLs
     /// outside this set are ignored, so unrelated edits in the user's editor don't trigger a
@@ -370,13 +372,22 @@ pub struct Connection {
     device_name: Mutex<String>,
 }
 
+/// Something queued for the write half.
+enum Outbound {
+    /// A protocol message, sealed if the session has keys.
+    Payload(Vec<u8>),
+    /// A WebSocket control frame. Never sealed: it belongs to the transport,
+    /// not to the protocol running on top of it.
+    Control(Message),
+}
+
 /// Serialize a message into the wire format and queue it on the write half.
 fn encode_and_send(
-    sender: &UnboundedSender<Message>,
+    sender: &UnboundedSender<Outbound>,
     message: &impl Serialize,
 ) -> anyhow::Result<()> {
     let data: Vec<u8> = postcard::to_allocvec(message)?;
-    sender.send(Message::Binary(data.into()))?;
+    sender.send(Outbound::Payload(data))?;
     Ok(())
 }
 
@@ -477,11 +488,11 @@ impl Connection {
                 // stalls mid-handshake or never enters a code can't hold the listener
                 // up, and the running session survives until someone replaces it.
                 let (admitted_sender, mut admitted_receiver) =
-                    sync::mpsc::unbounded_channel::<(Sink, Source, SocketAddr)>();
+                    sync::mpsc::unbounded_channel::<(Sink, Source, SocketAddr, session::Sealing, session::Opening)>();
                 // The sink is the write half; the JoinHandle is the read-half task. We keep
                 // both so an admitted connection can abort the in-flight task and reset shared
                 // state before its messages race with the new client's.
-                let mut current_session: Option<(Sink, tokio::task::JoinHandle<()>)> = None;
+                let mut current_session: Option<(Sink, tokio::task::JoinHandle<()>, session::Sealing)> = None;
                 loop {
                     tokio::select! {
                         accept = listener.accept() => {
@@ -516,8 +527,8 @@ impl Connection {
                         admitted = admitted_receiver.recv() => {
                             // `admitted_sender` is held by this loop, so the channel
                             // never closes while we're running.
-                            let Some((sink, receiver, addr)) = admitted else { continue };
-                            if let Some((_old_sink, old_handle)) = current_session.take() {
+                            let Some((sink, receiver, addr, sealing, opening)) = admitted else { continue };
+                            if let Some((_old_sink, old_handle, _)) = current_session.take() {
                                 // A finished handle is just a stale session left
                                 // behind by an earlier disconnect, not a takeover.
                                 if !old_handle.is_finished() {
@@ -539,17 +550,30 @@ impl Connection {
                                 inner_dependencies.clone(),
                                 inner_message_sender.clone(),
                                 addr,
+                                opening,
                             ));
-                            current_session = Some((sink, handle));
+                            current_session = Some((sink, handle, sealing));
                         }
                         _ = &mut quit_receiver => {
                             tracing::info!("Quit signal received, shutting down connection thread.");
                             break;
                         }
                         message = message_receiver.recv() => {
-                            if let (Some(message), Some((sink, _))) = (message, current_session.as_mut())
-                                && let Err(err) = sink.send(message).await {
-                                tracing::error!("Failed sending message to Websocket: {err}");
+                            if let (Some(outbound), Some((sink, _, sealing))) = (message, current_session.as_mut()) {
+                                let frame = match outbound {
+                                    Outbound::Control(frame) => Some(frame),
+                                    Outbound::Payload(bytes) => match sealing.seal(bytes) {
+                                        Ok(sealed) => Some(Message::Binary(sealed.into())),
+                                        Err(err) => {
+                                            tracing::error!("Cannot seal outbound frame: {err:?}");
+                                            None
+                                        }
+                                    },
+                                };
+                                if let Some(frame) = frame
+                                    && let Err(err) = sink.send(frame).await {
+                                    tracing::error!("Failed sending message to Websocket: {err}");
+                                }
                             }
                         }
                     }
@@ -615,7 +639,7 @@ impl Connection {
         policy: PairingPolicy,
         pairing_state: Arc<Mutex<PairingState>>,
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
-        admitted: UnboundedSender<(Sink, Source, SocketAddr)>,
+        admitted: UnboundedSender<(Sink, Source, SocketAddr, session::Sealing, session::Opening)>,
         // Held for as long as this connection is being admitted, so the
         // listener can bound how many are in flight.
         _permit: sync::OwnedSemaphorePermit,
@@ -645,9 +669,9 @@ impl Connection {
         )
         .await
         {
-            Ok(()) => {
+            Ok((sealing, opening)) => {
                 tracing::info!("Paired with {remote_addr:?}");
-                admitted.send((sink, receiver, remote_addr)).ok();
+                admitted.send((sink, receiver, remote_addr, sealing, opening)).ok();
             }
             Err(Denied::Gone) => {
                 tracing::info!("{remote_addr:?} gave up before pairing completed");
@@ -678,7 +702,7 @@ impl Connection {
         policy: &PairingPolicy,
         pairing_state: &Arc<Mutex<PairingState>>,
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
-    ) -> Result<(), Denied> {
+    ) -> Result<(session::Sealing, session::Opening), Denied> {
         let nonce = pairing::generate::nonce();
         send_on(sink, &PreviewToLspMessage::PairingChallenge { nonce }).await?;
 
@@ -693,20 +717,23 @@ impl Connection {
         };
 
         if *policy == PairingPolicy::Disabled {
-            // --no-pairing: everyone is admitted, so there is no token to
-            // derive and nothing for the client to remember.
+            // --no-pairing: everyone is admitted, so there is no shared
+            // secret, and nothing to key a sealed session with either.
             send_on(sink, &PreviewToLspMessage::PairingAccepted).await?;
-            return Ok(());
+            return Ok((session::Sealing::Plaintext, session::Opening::Plaintext));
         }
 
         if let Some(offered) = token_proof {
-            if pairing_state.lock().unwrap().accepts_token(&offered, &nonce) {
+            // Bound first: holding the guard across the await below would
+            // make this future non-Send.
+            let accepted = pairing_state.lock().unwrap().accepting_token(&offered, &nonce);
+            if let Some(token) = accepted {
                 // An editor we already paired with, reconnecting. Keep the
                 // screen alone: this is the common case after a network blip
                 // or the viewer coming back to the foreground.
                 tracing::info!("{remote_addr:?} presented a valid token; no code needed");
                 send_on(sink, &PreviewToLspMessage::PairingAccepted).await?;
-                return Ok(());
+                return Ok(pairing::session_from_token(pairing::Role::Viewer, &token, &nonce));
             }
             tracing::info!("{remote_addr:?} presented a token we did not issue");
             // Almost always a token from a previous run of this viewer. Say
@@ -724,18 +751,25 @@ impl Connection {
         let mut guard = PromptGuard::begin(pairing_state, message_handler, remote_addr, &code)
             .map_err(Denied::Pairing)?;
 
-        let expected = pairing::proof(Credential::Code, code.as_bytes(), &nonce);
         let deadline = tokio::time::Instant::now() + CODE_TIMEOUT;
         let remaining = || deadline.saturating_duration_since(tokio::time::Instant::now());
-        let prompt = |attempts_left| PreviewToLspMessage::PairingRequired {
-            attempts_left,
-            expires_in_seconds: remaining().as_secs() as u16,
-        };
         let mut attempts_left = MAX_ATTEMPTS;
 
-        send_on(sink, &prompt(attempts_left)).await?;
-
         loop {
+            // A fresh exchange per attempt: the state is consumed by
+            // finishing, and reusing an element across guesses would leak
+            // more than one guess's worth.
+            let handshake = pairing::Handshake::start(pairing::Role::Viewer, &code);
+            send_on(
+                sink,
+                &PreviewToLspMessage::PairingRequired {
+                    attempts_left,
+                    expires_in_seconds: remaining().as_secs() as u16,
+                    element: handshake.element().clone(),
+                },
+            )
+            .await?;
+
             let Some(message) = next_message(receiver, remaining()).await else {
                 // End of stream covers both a deadline that lapsed and a peer
                 // that vanished. The clock is what tells them apart, and
@@ -746,21 +780,33 @@ impl Connection {
                     Denied::Gone
                 });
             };
-            let LspToPreviewMessage::PairingCodeProof { proof } = message else {
+            let LspToPreviewMessage::PairingResponse { element, confirmation } = message else {
                 tracing::warn!("Ignoring {message:?} from {remote_addr:?} during pairing");
                 continue;
             };
 
-            if proof.matches(&expected) {
+            // A wrong code doesn't fail here: it produces different keys,
+            // and only the confirmation tells us so. That is the point --
+            // the wire carries nothing to test a guess against offline.
+            let accepted = handshake
+                .finish(&element)
+                .ok()
+                .filter(|secrets| confirmation.matches(&secrets.editor_confirmation));
+
+            if let Some(secrets) = accepted {
                 tracing::info!("{remote_addr:?} entered the pairing code correctly");
-                // Derived, not sent: the client computes the same value from
-                // the code it just proved and the nonce it was challenged with.
-                pairing_state.lock().unwrap().remember_token(pairing::derive_token(&code, &nonce));
-                send_on(sink, &PreviewToLspMessage::PairingAccepted).await?;
+                pairing_state.lock().unwrap().remember_token(secrets.token);
+                send_on(
+                    sink,
+                    &PreviewToLspMessage::PairingConfirm {
+                        confirmation: secrets.viewer_confirmation,
+                    },
+                )
+                .await?;
                 // Tells the guard the incoming session is about to drive the
                 // screen, so the viewer shouldn't restore what we displaced.
                 guard.accepted = true;
-                return Ok(());
+                return Ok(secrets.session());
             }
 
             attempts_left -= 1;
@@ -772,7 +818,6 @@ impl Connection {
                 &PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode },
             )
             .await?;
-            send_on(sink, &prompt(attempts_left)).await?;
         }
     }
 
@@ -781,8 +826,9 @@ impl Connection {
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
         file_cache: FileCache,
         dependencies: Arc<Mutex<HashSet<Url>>>,
-        message_sender: UnboundedSender<Message>,
+        message_sender: UnboundedSender<Outbound>,
         remote_addr: SocketAddr,
+        mut opening: session::Opening,
     ) {
         message_handler(ConnectionMessage::Connected { remote_addr });
         // `Some(deadline)` while a `SetContents`-driven rebuild is pending. The sleep_until
@@ -808,7 +854,13 @@ impl Connection {
                             tracing::warn!("Received text message: {text}");
                         }
                         Ok(Message::Binary(bin)) => {
-                            match postcard::from_bytes::<LspToPreviewMessage>(&bin) {
+                            let Ok(plain) = opening.open(&bin) else {
+                                // Tampered, reordered, or from a peer that
+                                // derived a different key.
+                                tracing::error!("Dropping a frame that failed to open");
+                                break;
+                            };
+                            match postcard::from_bytes::<LspToPreviewMessage>(&plain) {
                                 Ok(message) => {
                                     tracing::debug!("Received message {message:?}");
                                     match message {
@@ -936,7 +988,7 @@ impl Connection {
                                         // Pairing is settled before the session starts, so
                                         // these can only be a confused or malicious peer.
                                         LspToPreviewMessage::PairingHello { .. }
-                                        | LspToPreviewMessage::PairingCodeProof { .. } => {
+                                        | LspToPreviewMessage::PairingResponse { .. } => {
                                             tracing::warn!(
                                                 "Ignoring pairing message on an established session"
                                             );
@@ -949,7 +1001,7 @@ impl Connection {
                             }
                         }
                         Ok(Message::Ping(data)) => {
-                            message_sender.send(Message::Pong(data)).ok();
+                            message_sender.send(Outbound::Control(Message::Pong(data))).ok();
                         }
                         Ok(Message::Pong(_)) => {}
                         Ok(Message::Close(_)) => {
@@ -1323,7 +1375,8 @@ mod cool_down_tests {
 #[cfg(test)]
 mod session_tests {
     use super::{Connection, ConnectionMessage, MAX_PENDING_ADMISSIONS, PairingPolicy};
-    use crate::protocol::pairing::{self, Credential, MAX_ATTEMPTS, Nonce, Token};
+    use crate::protocol::pairing::{self, MAX_ATTEMPTS, Nonce, Token};
+    use crate::protocol::session;
     use crate::protocol::{
         LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PairingRejection, PreviewToLspMessage,
     };
@@ -1448,39 +1501,85 @@ mod session_tests {
         let Some(PreviewToLspMessage::PairingChallenge { nonce }) = recv(client).await else {
             panic!("expected a challenge");
         };
-        let token_proof =
-            token.map(|token| pairing::proof(Credential::Token, token.as_bytes(), &nonce));
+        let token_proof = token.map(|token| pairing::token_proof(token, &nonce));
         send(client, &LspToPreviewMessage::PairingHello { token_proof }).await;
         nonce
     }
 
-    async fn offer_code(client: &mut Client, code: &str, nonce: &Nonce) {
-        let proof = pairing::proof(Credential::Code, code.as_bytes(), nonce);
-        send(client, &LspToPreviewMessage::PairingCodeProof { proof }).await;
+    /// Complete the editor's half of the exchange for `code`.
+    ///
+    /// Returns the derived secrets, or the viewer's rejection. A wrong code
+    /// gets all the way to the confirmation exchange -- that is the property
+    /// under test.
+    async fn answer_code(
+        client: &mut Client,
+        code: &str,
+        element: &pairing::Element,
+    ) -> Result<pairing::Secrets, PairingRejection> {
+        let handshake = pairing::Handshake::start(pairing::Role::Editor, code);
+        let ours = handshake.element().clone();
+        let secrets = handshake.finish(element).expect("the viewer's element is well formed");
+        send(
+            client,
+            &LspToPreviewMessage::PairingResponse {
+                element: ours,
+                confirmation: secrets.editor_confirmation,
+            },
+        )
+        .await;
+        match recv(client).await {
+            Some(PreviewToLspMessage::PairingConfirm { confirmation }) => {
+                assert!(
+                    confirmation.matches(&secrets.viewer_confirmation),
+                    "the viewer confirmed with a key we did not derive"
+                );
+                Ok(secrets)
+            }
+            Some(PreviewToLspMessage::PairingRejected { reason }) => Err(reason),
+            other => panic!("unexpected answer to the pairing response: {other:?}"),
+        }
     }
 
     /// Dial as a stranger and wait for the viewer to put a code on screen.
-    async fn knock(viewer: &Viewer) -> (Client, Nonce) {
+    async fn knock(viewer: &Viewer) -> (Client, pairing::Element) {
         let mut client = viewer.dial().await;
-        let nonce = hello(&mut client, None).await;
-        assert!(
-            matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingRequired { .. })),
-            "expected a code prompt"
-        );
-        (client, nonce)
+        hello(&mut client, None).await;
+        let Some(PreviewToLspMessage::PairingRequired { element, .. }) = recv(&mut client).await
+        else {
+            panic!("expected a code prompt");
+        };
+        (client, element)
     }
 
-    /// Dial, pair with the code the viewer displays, and return the socket
-    /// plus the token it was issued.
-    async fn pair(viewer: &mut Viewer) -> (Client, Token) {
-        let (mut client, nonce) = knock(viewer).await;
+    /// A client past the handshake, sealing and opening like the real one.
+    struct Paired {
+        client: Client,
+        sealing: session::Sealing,
+        opening: session::Opening,
+    }
+
+    impl Paired {
+        async fn send(&mut self, message: &LspToPreviewMessage) {
+            let bytes = postcard::to_allocvec(message).unwrap();
+            let sealed = self.sealing.seal(bytes).unwrap();
+            self.client.send(Message::Binary(sealed.into())).await.unwrap();
+        }
+
+        async fn recv(&mut self) -> Option<PreviewToLspMessage> {
+            let raw = recv_raw(&mut self.client).await?;
+            let plain = self.opening.open(&raw).expect("the viewer sealed with another key");
+            Some(postcard::from_bytes(&plain).unwrap())
+        }
+    }
+
+    /// Dial, pair with the code the viewer displays, and return a sealed
+    /// session plus the token it derived.
+    async fn pair(viewer: &mut Viewer) -> (Paired, Token) {
+        let (mut client, element) = knock(viewer).await;
         let code = viewer.next_code().await;
-        offer_code(&mut client, &code, &nonce).await;
-        assert!(
-            matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingAccepted)),
-            "expected to be accepted"
-        );
-        (client, pairing::derive_token(&code, &nonce))
+        let secrets = answer_code(&mut client, &code, &element).await.expect("accepted");
+        let (sealing, opening) = secrets.session();
+        (Paired { client, sealing, opening }, secrets.token)
     }
 
     #[tokio::test]
@@ -1495,18 +1594,19 @@ mod session_tests {
         ));
         assert!(matches!(viewer.next_event().await, ConnectionMessage::Connected { .. }));
 
-        // The session is live: the keepalive round trip works.
-        send(&mut client, &LspToPreviewMessage::Ping).await;
-        assert!(matches!(recv(&mut client).await, Some(PreviewToLspMessage::Pong)));
+        // The session is live, and sealed: the keepalive round trip works
+        // only because both sides derived the same keys.
+        client.send(&LspToPreviewMessage::Ping).await;
+        assert!(matches!(client.recv().await, Some(PreviewToLspMessage::Pong)));
     }
 
     #[tokio::test]
     async fn wrong_code_burns_attempts_then_closes() {
         let mut viewer = Viewer::start(PairingPolicy::Generated).await;
         let mut client = viewer.dial().await;
-        let nonce = hello(&mut client, None).await;
+        hello(&mut client, None).await;
 
-        let Some(PreviewToLspMessage::PairingRequired { attempts_left, .. }) =
+        let Some(PreviewToLspMessage::PairingRequired { attempts_left, mut element, .. }) =
             recv(&mut client).await
         else {
             panic!("expected a code prompt");
@@ -1518,25 +1618,23 @@ mod session_tests {
         let wrong = if code == "0000" { "1111" } else { "0000" };
 
         for expected_left in (1..MAX_ATTEMPTS).rev() {
-            offer_code(&mut client, wrong, &nonce).await;
             assert!(matches!(
-                recv(&mut client).await,
-                Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode })
+                answer_code(&mut client, wrong, &element).await,
+                Err(PairingRejection::BadCode)
             ));
-            let Some(PreviewToLspMessage::PairingRequired { attempts_left, .. }) =
+            let Some(PreviewToLspMessage::PairingRequired { attempts_left, element: next, .. }) =
                 recv(&mut client).await
             else {
                 panic!("expected another code prompt");
             };
             assert_eq!(attempts_left, expected_left);
+            // A fresh exchange per attempt, so one guess never helps the next.
+            element = next;
         }
 
-        offer_code(&mut client, wrong, &nonce).await;
         assert!(matches!(
-            recv(&mut client).await,
-            Some(PreviewToLspMessage::PairingRejected {
-                reason: PairingRejection::TooManyAttempts
-            })
+            answer_code(&mut client, wrong, &element).await,
+            Err(PairingRejection::TooManyAttempts)
         ));
         assert!(recv(&mut client).await.is_none(), "viewer should close the socket");
     }
@@ -1564,9 +1662,8 @@ mod session_tests {
         drop(silent);
     }
 
-    /// The reconnect token must never be transmitted. Sending it would put
-    /// the credential itself on a plaintext socket, where anyone listening
-    /// could lift it and reconnect silently for the viewer's whole run.
+    /// Nothing an observer can use may reach the wire: not the code, not the
+    /// token, not the session keys.
     #[tokio::test]
     async fn nothing_secret_reaches_the_wire() {
         let mut viewer = Viewer::start(PairingPolicy::Generated).await;
@@ -1574,34 +1671,49 @@ mod session_tests {
 
         let mut frames: Vec<Vec<u8>> = Vec::new();
         frames.push(recv_raw(&mut client).await.expect("challenge"));
-        let nonce =
-            match postcard::from_bytes::<PreviewToLspMessage>(frames.last().unwrap()).unwrap() {
-                PreviewToLspMessage::PairingChallenge { nonce } => nonce,
-                other => panic!("expected a challenge, got {other:?}"),
-            };
         send(&mut client, &LspToPreviewMessage::PairingHello { token_proof: None }).await;
-        frames.push(recv_raw(&mut client).await.expect("prompt"));
+
+        let prompt = recv_raw(&mut client).await.expect("prompt");
+        frames.push(prompt.clone());
+        let PreviewToLspMessage::PairingRequired { element, .. } =
+            postcard::from_bytes(&prompt).unwrap()
+        else {
+            panic!("expected a code prompt");
+        };
 
         let code = viewer.next_code().await;
-        offer_code(&mut client, &code, &nonce).await;
-        frames.push(recv_raw(&mut client).await.expect("acceptance"));
+        let handshake = pairing::Handshake::start(pairing::Role::Editor, &code);
+        let ours = handshake.element().clone();
+        let secrets = handshake.finish(&element).unwrap();
+        send(
+            &mut client,
+            &LspToPreviewMessage::PairingResponse {
+                element: ours,
+                confirmation: secrets.editor_confirmation,
+            },
+        )
+        .await;
+        frames.push(recv_raw(&mut client).await.expect("confirmation"));
 
-        let token = pairing::derive_token(&code, &nonce);
+        let [key_down, key_up] = secrets.key_material();
         for frame in &frames {
-            assert!(
-                !frame.windows(token.as_bytes().len()).any(|w| w == token.as_bytes()),
-                "the viewer put the reconnect token on the wire"
-            );
-            assert!(
-                !frame.windows(code.len()).any(|w| w == code.as_bytes()),
-                "the viewer put the pairing code on the wire"
-            );
+            for (what, needle) in [
+                ("the pairing code", code.as_bytes()),
+                ("the reconnect token", secrets.token.as_bytes()),
+                ("a session key", key_down),
+                ("a session key", key_up),
+            ] {
+                assert!(
+                    !frame.windows(needle.len()).any(|w| w == needle),
+                    "{what} appeared on the wire"
+                );
+            }
         }
 
         // ... and the token both sides derived is the one that works.
         drop(client);
         let mut again = viewer.dial().await;
-        hello(&mut again, Some(&token)).await;
+        hello(&mut again, Some(&secrets.token)).await;
         assert!(matches!(recv(&mut again).await, Some(PreviewToLspMessage::PairingAccepted)));
     }
 
@@ -1628,7 +1740,7 @@ mod session_tests {
         let viewer = Viewer::start(PairingPolicy::Generated).await;
         let mut client = viewer.dial().await;
         // A token from some other viewer, or from a previous run of this one.
-        hello(&mut client, Some(&pairing::derive_token("9999", &Nonce::for_test(9)))).await;
+        hello(&mut client, Some(&Token::for_test(9))).await;
 
         assert!(matches!(
             recv(&mut client).await,
@@ -1661,8 +1773,8 @@ mod session_tests {
         viewer.expect_prompt_finished(false).await;
 
         // The original session is untouched.
-        send(&mut established, &LspToPreviewMessage::Ping).await;
-        assert!(matches!(recv(&mut established).await, Some(PreviewToLspMessage::Pong)));
+        established.send(&LspToPreviewMessage::Ping).await;
+        assert!(matches!(established.recv().await, Some(PreviewToLspMessage::Pong)));
     }
 
     #[tokio::test]
@@ -1719,23 +1831,21 @@ mod session_tests {
 
         // A brand new editor, with no token, pairing straight afterwards.
         let mut fresh = viewer.dial().await;
-        let nonce = hello(&mut fresh, None).await;
-        assert!(
-            matches!(recv(&mut fresh).await, Some(PreviewToLspMessage::PairingRequired { .. })),
-            "a successful pairing must not lock out the next one"
-        );
+        hello(&mut fresh, None).await;
+        let Some(PreviewToLspMessage::PairingRequired { element, .. }) = recv(&mut fresh).await
+        else {
+            panic!("a successful pairing must not lock out the next one");
+        };
         let code = viewer.next_code().await;
-        offer_code(&mut fresh, &code, &nonce).await;
-        assert!(matches!(recv(&mut fresh).await, Some(PreviewToLspMessage::PairingAccepted)));
+        answer_code(&mut fresh, &code, &element).await.expect("accepted");
     }
 
     #[tokio::test]
     async fn a_fixed_code_is_accepted_without_reading_the_screen() {
-        let viewer = Viewer::start(PairingPolicy::Fixed("135791".into())).await;
-        let (mut client, nonce) = knock(&viewer).await;
+        let viewer = Viewer::start(PairingPolicy::Fixed("1357".into())).await;
+        let (mut client, element) = knock(&viewer).await;
 
-        offer_code(&mut client, "135791", &nonce).await;
-        assert!(matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingAccepted)));
+        answer_code(&mut client, "1357", &element).await.expect("accepted");
     }
 
     #[tokio::test]
@@ -1748,32 +1858,44 @@ mod session_tests {
         assert!(matches!(viewer.next_event().await, ConnectionMessage::Connected { .. }));
     }
 
+    /// An element harvested from some other exchange must not be usable
+    /// here, even with the right code: the transcript binds both halves.
     #[tokio::test]
-    async fn a_proof_for_the_wrong_nonce_is_refused() {
+    async fn an_element_from_another_exchange_is_refused() {
         let mut viewer = Viewer::start(PairingPolicy::Generated).await;
-        let (mut client, _nonce) = knock(&viewer).await;
+        let (mut client, _element) = knock(&viewer).await;
         let code = viewer.next_code().await;
 
-        // Right code, replayed against a nonce from some other exchange.
-        offer_code(&mut client, &code, &Nonce::for_test(0)).await;
+        // A well-formed element, but from an exchange this viewer never ran.
+        let elsewhere = pairing::Handshake::start(pairing::Role::Viewer, &code);
         assert!(matches!(
-            recv(&mut client).await,
-            Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode })
+            answer_code(&mut client, &code, elsewhere.element()).await,
+            Err(PairingRejection::BadCode)
         ));
     }
 
     #[tokio::test]
-    async fn a_garbage_proof_is_refused() {
+    async fn a_garbage_element_is_refused() {
         let viewer = Viewer::start(PairingPolicy::Generated).await;
         let mut client = viewer.dial().await;
         hello(&mut client, None).await;
-        assert!(matches!(
-            recv(&mut client).await,
-            Some(PreviewToLspMessage::PairingRequired { .. })
-        ));
+        let Some(PreviewToLspMessage::PairingRequired { element, .. }) = recv(&mut client).await
+        else {
+            panic!("expected a code prompt");
+        };
 
-        let bogus = pairing::proof(Credential::Code, b"nonsense", &Nonce::for_test(0));
-        send(&mut client, &LspToPreviewMessage::PairingCodeProof { proof: bogus }).await;
+        // Nonsense in place of a group element, with a confirmation that
+        // cannot possibly match.
+        let handshake = pairing::Handshake::start(pairing::Role::Editor, "0000");
+        let secrets = handshake.finish(&element).unwrap();
+        send(
+            &mut client,
+            &LspToPreviewMessage::PairingResponse {
+                element: pairing::Element::for_test(vec![0u8; 33]),
+                confirmation: secrets.editor_confirmation,
+            },
+        )
+        .await;
         assert!(matches!(
             recv(&mut client).await,
             Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode })

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::REBUILD_DEBOUNCE;
 use crate::protocol::pairing::{
-    self, CODE_TIMEOUT, MAX_ATTEMPTS, Nonce, PROMPT_RATE_LIMIT, PairingRejection, Proof, Token,
+    self, CODE_TIMEOUT, MAX_ATTEMPTS, PROMPT_RATE_LIMIT, PairingRejection, Token, TokenId,
 };
 use crate::protocol::session;
 use crate::protocol::{
@@ -109,7 +109,7 @@ struct PairingState {
     consecutive_failures: u32,
     /// Tokens issued during this viewer run. Deliberately not persisted:
     /// restarting the viewer makes every editor pair again.
-    tokens: VecDeque<Token>,
+    tokens: VecDeque<(TokenId, Token)>,
 }
 
 /// What the screen is doing about pairing.
@@ -129,20 +129,16 @@ enum Screen {
 }
 
 impl PairingState {
-    /// The token `offered` proves possession of, if we handed it out. The
-    /// value is needed and not just a yes/no, because it keys the session.
-    fn accepting_token(&self, offered: &Proof, nonce: &Nonce) -> Option<Token> {
-        // Fold rather than `find`: checking every token regardless keeps the
-        // work from depending on which one matched.
-        self.tokens.iter().fold(None, |found, token| {
-            let matched = pairing::token_proof(token, nonce).matches(offered);
-            if matched { Some(*token) } else { found }
-        })
+    /// The token the client announced, if it is one we issued. A plain
+    /// lookup, because the id is public; possession of the token itself is
+    /// proven by the exchange that follows.
+    fn issued_token(&self, id: &TokenId) -> Option<Token> {
+        self.tokens.iter().find(|(known, _)| known == id).map(|(_, token)| *token)
     }
 
     /// Accept `token` on future connections from whoever just paired.
-    fn remember_token(&mut self, token: Token) {
-        self.tokens.push_back(token);
+    fn remember_token(&mut self, id: TokenId, token: Token) {
+        self.tokens.push_back((id, token));
         while self.tokens.len() > MAX_REMEMBERED_TOKENS {
             self.tokens.pop_front();
         }
@@ -703,12 +699,11 @@ impl Connection {
         pairing_state: &Arc<Mutex<PairingState>>,
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
     ) -> Result<(session::Sealing, session::Opening), Denied> {
-        let nonce = pairing::generate::nonce();
-        send_on(sink, &PreviewToLspMessage::PairingChallenge { nonce }).await?;
+        send_on(sink, &PreviewToLspMessage::PairingReady).await?;
 
         // The client answers this much on its own; no human is involved yet.
-        let token_proof = match next_message(receiver, HELLO_TIMEOUT).await {
-            Some(LspToPreviewMessage::PairingHello { token_proof }) => token_proof,
+        let announced = match next_message(receiver, HELLO_TIMEOUT).await {
+            Some(LspToPreviewMessage::PairingHello { token }) => token,
             Some(other) => {
                 tracing::warn!("Expected PairingHello from {remote_addr:?}, got {other:?}");
                 return Err(Denied::Gone);
@@ -723,19 +718,21 @@ impl Connection {
             return Ok((session::Sealing::Plaintext, session::Opening::Plaintext));
         }
 
-        if let Some(offered) = token_proof {
-            // Bound first: holding the guard across the await below would
+        if let Some(id) = announced {
+            // Bound first: holding the guard across the awaits below would
             // make this future non-Send.
-            let accepted = pairing_state.lock().unwrap().accepting_token(&offered, &nonce);
-            if let Some(token) = accepted {
-                // An editor we already paired with, reconnecting. Keep the
-                // screen alone: this is the common case after a network blip
-                // or the viewer coming back to the foreground.
-                tracing::info!("{remote_addr:?} presented a valid token; no code needed");
-                send_on(sink, &PreviewToLspMessage::PairingAccepted).await?;
-                return Ok(pairing::session_from_token(pairing::Role::Viewer, &token, &nonce));
+            let issued = pairing_state.lock().unwrap().issued_token(&id);
+            if let Some(token) = issued {
+                if let Some(session) =
+                    Self::token_exchange(sink, receiver, remote_addr, &token).await?
+                {
+                    return Ok(session);
+                }
+                // Announced one of our ids but couldn't prove the token:
+                // treated exactly like a token we never issued.
+            } else {
+                tracing::info!("{remote_addr:?} announced a token we did not issue");
             }
-            tracing::info!("{remote_addr:?} presented a token we did not issue");
             // Almost always a token from a previous run of this viewer. Say
             // so, so the client forgets it, then fall through to the code.
             let reason = PairingRejection::BadToken;
@@ -759,7 +756,7 @@ impl Connection {
             // A fresh exchange per attempt: the state is consumed by
             // finishing, and reusing an element across guesses would leak
             // more than one guess's worth.
-            let handshake = pairing::Handshake::start(pairing::Role::Viewer, &code);
+            let handshake = pairing::Handshake::with_code(pairing::Role::Viewer, &code);
             send_on(
                 sink,
                 &PreviewToLspMessage::PairingRequired {
@@ -795,7 +792,7 @@ impl Connection {
 
             if let Some(secrets) = accepted {
                 tracing::info!("{remote_addr:?} entered the pairing code correctly");
-                pairing_state.lock().unwrap().remember_token(secrets.token);
+                pairing_state.lock().unwrap().remember_token(secrets.token_id, secrets.token);
                 send_on(
                     sink,
                     &PreviewToLspMessage::PairingConfirm {
@@ -819,6 +816,56 @@ impl Connection {
             )
             .await?;
         }
+    }
+
+    /// Run the reconnect exchange, with `token` as the secret.
+    ///
+    /// The same exchange as for a code, minus the human: the token never
+    /// crosses the wire, and the session keys are fresh, so recording this
+    /// connection is worthless even to someone who steals the token later.
+    ///
+    /// `Ok(None)` means the peer announced the token but could not prove
+    /// holding it; the caller treats that like a token we never issued.
+    async fn token_exchange(
+        sink: &mut Sink,
+        receiver: &mut Source,
+        remote_addr: SocketAddr,
+        token: &Token,
+    ) -> Result<Option<(session::Sealing, session::Opening)>, Denied> {
+        let handshake = pairing::Handshake::with_token(pairing::Role::Viewer, token);
+        send_on(
+            sink,
+            &PreviewToLspMessage::PairingTokenChallenge { element: handshake.element().clone() },
+        )
+        .await?;
+
+        let Some(message) = next_message(receiver, HELLO_TIMEOUT).await else {
+            return Err(Denied::Gone);
+        };
+        let LspToPreviewMessage::PairingResponse { element, confirmation } = message else {
+            tracing::warn!("Expected the reconnect response from {remote_addr:?}, got {message:?}");
+            return Err(Denied::Gone);
+        };
+
+        let accepted = handshake
+            .finish(&element)
+            .ok()
+            .filter(|secrets| confirmation.matches(&secrets.editor_confirmation));
+        let Some(secrets) = accepted else {
+            tracing::info!("{remote_addr:?} announced a token it could not prove");
+            return Ok(None);
+        };
+
+        // An editor we already paired with, reconnecting. Keep the screen
+        // alone: this is the common case after a network blip or the viewer
+        // coming back to the foreground.
+        tracing::info!("{remote_addr:?} proved its token; no code needed");
+        send_on(
+            sink,
+            &PreviewToLspMessage::PairingConfirm { confirmation: secrets.viewer_confirmation },
+        )
+        .await?;
+        Ok(Some(secrets.session()))
     }
 
     async fn handle_connection(
@@ -1375,7 +1422,7 @@ mod cool_down_tests {
 #[cfg(test)]
 mod session_tests {
     use super::{Connection, ConnectionMessage, MAX_PENDING_ADMISSIONS, PairingPolicy};
-    use crate::protocol::pairing::{self, MAX_ATTEMPTS, Nonce, Token};
+    use crate::protocol::pairing::{self, MAX_ATTEMPTS, Token, TokenId};
     use crate::protocol::session;
     use crate::protocol::{
         LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PairingRejection, PreviewToLspMessage,
@@ -1496,14 +1543,13 @@ mod session_tests {
         .expect("viewer sent no reply")
     }
 
-    /// Read the challenge and answer it with `token_proof`.
-    async fn hello(client: &mut Client, token: Option<&Token>) -> Nonce {
-        let Some(PreviewToLspMessage::PairingChallenge { nonce }) = recv(client).await else {
-            panic!("expected a challenge");
-        };
-        let token_proof = token.map(|token| pairing::token_proof(token, &nonce));
-        send(client, &LspToPreviewMessage::PairingHello { token_proof }).await;
-        nonce
+    /// Read the viewer's opener and answer it, announcing `token`.
+    async fn hello(client: &mut Client, token: Option<TokenId>) {
+        assert!(
+            matches!(recv(client).await, Some(PreviewToLspMessage::PairingReady)),
+            "expected the viewer to open pairing"
+        );
+        send(client, &LspToPreviewMessage::PairingHello { token }).await;
     }
 
     /// Complete the editor's half of the exchange for `code`.
@@ -1516,7 +1562,16 @@ mod session_tests {
         code: &str,
         element: &pairing::Element,
     ) -> Result<pairing::Secrets, PairingRejection> {
-        let handshake = pairing::Handshake::start(pairing::Role::Editor, code);
+        let handshake = pairing::Handshake::with_code(pairing::Role::Editor, code);
+        answer_with(client, handshake, element).await
+    }
+
+    /// Send the response for a started exchange and read the verdict.
+    async fn answer_with(
+        client: &mut Client,
+        handshake: pairing::Handshake,
+        element: &pairing::Element,
+    ) -> Result<pairing::Secrets, PairingRejection> {
         let ours = handshake.element().clone();
         let secrets = handshake.finish(element).expect("the viewer's element is well formed");
         send(
@@ -1573,19 +1628,33 @@ mod session_tests {
     }
 
     /// Dial, pair with the code the viewer displays, and return a sealed
-    /// session plus the token it derived.
-    async fn pair(viewer: &mut Viewer) -> (Paired, Token) {
+    /// session plus everything the exchange derived.
+    async fn pair(viewer: &mut Viewer) -> (Paired, pairing::Secrets) {
         let (mut client, element) = knock(viewer).await;
         let code = viewer.next_code().await;
         let secrets = answer_code(&mut client, &code, &element).await.expect("accepted");
         let (sealing, opening) = secrets.session();
-        (Paired { client, sealing, opening }, secrets.token)
+        (Paired { client, sealing, opening }, secrets)
+    }
+
+    /// Dial again and run the token exchange, as a reconnecting editor would.
+    async fn reconnect(viewer: &Viewer, secrets: &pairing::Secrets) -> Paired {
+        let mut client = viewer.dial().await;
+        hello(&mut client, Some(secrets.token_id)).await;
+        let Some(PreviewToLspMessage::PairingTokenChallenge { element }) = recv(&mut client).await
+        else {
+            panic!("expected the reconnect exchange to open");
+        };
+        let handshake = pairing::Handshake::with_token(pairing::Role::Editor, &secrets.token);
+        let fresh = answer_with(&mut client, handshake, &element).await.expect("accepted");
+        let (sealing, opening) = fresh.session();
+        Paired { client, sealing, opening }
     }
 
     #[tokio::test]
     async fn correct_code_is_accepted_and_session_works() {
         let mut viewer = Viewer::start(PairingPolicy::Generated).await;
-        let (mut client, _token) = pair(&mut viewer).await;
+        let (mut client, _secrets) = pair(&mut viewer).await;
 
         // The prompt comes down, and the viewer is told the newcomer took over.
         assert!(matches!(
@@ -1670,8 +1739,8 @@ mod session_tests {
         let mut client = viewer.dial().await;
 
         let mut frames: Vec<Vec<u8>> = Vec::new();
-        frames.push(recv_raw(&mut client).await.expect("challenge"));
-        send(&mut client, &LspToPreviewMessage::PairingHello { token_proof: None }).await;
+        frames.push(recv_raw(&mut client).await.expect("opener"));
+        send(&mut client, &LspToPreviewMessage::PairingHello { token: None }).await;
 
         let prompt = recv_raw(&mut client).await.expect("prompt");
         frames.push(prompt.clone());
@@ -1682,7 +1751,7 @@ mod session_tests {
         };
 
         let code = viewer.next_code().await;
-        let handshake = pairing::Handshake::start(pairing::Role::Editor, &code);
+        let handshake = pairing::Handshake::with_code(pairing::Role::Editor, &code);
         let ours = handshake.element().clone();
         let secrets = handshake.finish(&element).unwrap();
         send(
@@ -1710,22 +1779,23 @@ mod session_tests {
             }
         }
 
-        // ... and the token both sides derived is the one that works.
+        // ... and the token both sides derived is the one that reconnects.
         drop(client);
-        let mut again = viewer.dial().await;
-        hello(&mut again, Some(&secrets.token)).await;
-        assert!(matches!(recv(&mut again).await, Some(PreviewToLspMessage::PairingAccepted)));
+        let mut again = reconnect(&viewer, &secrets).await;
+        again.send(&LspToPreviewMessage::Ping).await;
+        assert!(matches!(again.recv().await, Some(PreviewToLspMessage::Pong)));
     }
 
     #[tokio::test]
     async fn a_token_reconnects_without_a_prompt() {
         let mut viewer = Viewer::start(PairingPolicy::Generated).await;
-        let (first, token) = pair(&mut viewer).await;
+        let (first, secrets) = pair(&mut viewer).await;
         drop(first);
 
-        let mut client = viewer.dial().await;
-        hello(&mut client, Some(&token)).await;
-        assert!(matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingAccepted)));
+        let mut client = reconnect(&viewer, &secrets).await;
+        // The session is sealed with keys from the fresh exchange.
+        client.send(&LspToPreviewMessage::Ping).await;
+        assert!(matches!(client.recv().await, Some(PreviewToLspMessage::Pong)));
         // No code was ever generated for the second connection.
         assert!(
             !viewer
@@ -1735,12 +1805,27 @@ mod session_tests {
         );
     }
 
+    /// Two reconnects with one token must not share keys: recording a
+    /// session and later stealing the token opens nothing.
+    #[tokio::test]
+    async fn every_reconnect_has_fresh_keys() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let (first, secrets) = pair(&mut viewer).await;
+        drop(first);
+
+        let mut one = reconnect(&viewer, &secrets).await;
+        let mut two = reconnect(&viewer, &secrets).await;
+        let a = one.sealing.seal(postcard::to_allocvec(&LspToPreviewMessage::Ping).unwrap());
+        let b = two.sealing.seal(postcard::to_allocvec(&LspToPreviewMessage::Ping).unwrap());
+        assert_ne!(a.unwrap(), b.unwrap(), "two sessions sealed alike");
+    }
+
     #[tokio::test]
     async fn an_unknown_token_falls_back_to_the_code() {
         let viewer = Viewer::start(PairingPolicy::Generated).await;
         let mut client = viewer.dial().await;
         // A token from some other viewer, or from a previous run of this one.
-        hello(&mut client, Some(&Token::for_test(9))).await;
+        hello(&mut client, Some(TokenId::for_test(9))).await;
 
         assert!(matches!(
             recv(&mut client).await,
@@ -1752,10 +1837,37 @@ mod session_tests {
         ));
     }
 
+    /// A token id crosses the wire in the clear, so anyone can announce it.
+    /// Without the token behind it, the exchange must fail and leave the
+    /// announcer no better off than any stranger.
+    #[tokio::test]
+    async fn an_id_without_the_token_is_refused() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let (first, secrets) = pair(&mut viewer).await;
+        drop(first);
+
+        let mut sniffer = viewer.dial().await;
+        hello(&mut sniffer, Some(secrets.token_id)).await;
+        let Some(PreviewToLspMessage::PairingTokenChallenge { element }) = recv(&mut sniffer).await
+        else {
+            panic!("expected the reconnect exchange to open");
+        };
+        let handshake = pairing::Handshake::with_token(pairing::Role::Editor, &Token::for_test(9));
+        assert!(matches!(
+            answer_with(&mut sniffer, handshake, &element).await,
+            Err(PairingRejection::BadToken)
+        ));
+        // ... and ends up at the code prompt, like any stranger.
+        assert!(matches!(
+            recv(&mut sniffer).await,
+            Some(PreviewToLspMessage::PairingRequired { .. })
+        ));
+    }
+
     #[tokio::test]
     async fn a_knocker_cannot_displace_a_live_session() {
         let mut viewer = Viewer::start(PairingPolicy::Generated).await;
-        let (mut established, _token) = pair(&mut viewer).await;
+        let (mut established, _secrets) = pair(&mut viewer).await;
         // Clear the setup pairing's own prompt, so the wait below can only
         // match the intruder's.
         viewer.expect_prompt_finished(true).await;
@@ -1826,7 +1938,7 @@ mod session_tests {
     #[tokio::test]
     async fn a_successful_pairing_does_not_hold_off_the_next_one() {
         let mut viewer = Viewer::start(PairingPolicy::Generated).await;
-        let (client, _token) = pair(&mut viewer).await;
+        let (client, _secrets) = pair(&mut viewer).await;
         drop(client);
 
         // A brand new editor, with no token, pairing straight afterwards.
@@ -1867,7 +1979,7 @@ mod session_tests {
         let code = viewer.next_code().await;
 
         // A well-formed element, but from an exchange this viewer never ran.
-        let elsewhere = pairing::Handshake::start(pairing::Role::Viewer, &code);
+        let elsewhere = pairing::Handshake::with_code(pairing::Role::Viewer, &code);
         assert!(matches!(
             answer_code(&mut client, &code, elsewhere.element()).await,
             Err(PairingRejection::BadCode)
@@ -1886,7 +1998,7 @@ mod session_tests {
 
         // Nonsense in place of a group element, with a confirmation that
         // cannot possibly match.
-        let handshake = pairing::Handshake::start(pairing::Role::Editor, "0000");
+        let handshake = pairing::Handshake::with_code(pairing::Role::Editor, "0000");
         let secrets = handshake.finish(&element).unwrap();
         send(
             &mut client,

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -50,6 +50,16 @@ type Sink = SplitSink<WebSocketStream<TcpStream>, Message>;
 /// Read half of an accepted connection.
 type Source = SplitStream<WebSocketStream<TcpStream>>;
 
+/// A connection that made it through pairing, on its way from the admitting
+/// task to the accept loop.
+struct Admitted {
+    sink: Sink,
+    source: Source,
+    remote_addr: SocketAddr,
+    sealing: session::Sealing,
+    opening: session::Opening,
+}
+
 /// How long a peer has to complete the WebSocket upgrade. A peer that opens
 /// a socket and then says nothing would otherwise hold a task and a file
 /// descriptor for as long as the viewer runs.
@@ -484,7 +494,7 @@ impl Connection {
                 // stalls mid-handshake or never enters a code can't hold the listener
                 // up, and the running session survives until someone replaces it.
                 let (admitted_sender, mut admitted_receiver) =
-                    sync::mpsc::unbounded_channel::<(Sink, Source, SocketAddr, session::Sealing, session::Opening)>();
+                    sync::mpsc::unbounded_channel::<Admitted>();
                 // The sink is the write half; the JoinHandle is the read-half task. We keep
                 // both so an admitted connection can abort the in-flight task and reset shared
                 // state before its messages race with the new client's.
@@ -523,7 +533,7 @@ impl Connection {
                         admitted = admitted_receiver.recv() => {
                             // `admitted_sender` is held by this loop, so the channel
                             // never closes while we're running.
-                            let Some((sink, receiver, addr, sealing, opening)) = admitted else { continue };
+                            let Some(Admitted { sink, source, remote_addr, sealing, opening }) = admitted else { continue };
                             if let Some((_old_sink, old_handle, _)) = current_session.take() {
                                 // A finished handle is just a stale session left
                                 // behind by an earlier disconnect, not a takeover.
@@ -540,12 +550,12 @@ impl Connection {
                                 inner_dependencies.lock().unwrap().clear();
                             }
                             let handle = tokio::spawn(Self::handle_connection(
-                                receiver,
+                                source,
                                 message_handler.clone(),
                                 inner_file_cache.clone(),
                                 inner_dependencies.clone(),
                                 inner_message_sender.clone(),
-                                addr,
+                                remote_addr,
                                 opening,
                             ));
                             current_session = Some((sink, handle, sealing));
@@ -635,7 +645,7 @@ impl Connection {
         policy: PairingPolicy,
         pairing_state: Arc<Mutex<PairingState>>,
         message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
-        admitted: UnboundedSender<(Sink, Source, SocketAddr, session::Sealing, session::Opening)>,
+        admitted: UnboundedSender<Admitted>,
         // Held for as long as this connection is being admitted, so the
         // listener can bound how many are in flight.
         _permit: sync::OwnedSemaphorePermit,
@@ -667,7 +677,9 @@ impl Connection {
         {
             Ok((sealing, opening)) => {
                 tracing::info!("Paired with {remote_addr:?}");
-                admitted.send((sink, receiver, remote_addr, sealing, opening)).ok();
+                admitted
+                    .send(Admitted { sink, source: receiver, remote_addr, sealing, opening })
+                    .ok();
             }
             Err(Denied::Gone) => {
                 tracing::info!("{remote_addr:?} gave up before pairing completed");
@@ -785,19 +797,12 @@ impl Connection {
             // A wrong code doesn't fail here: it produces different keys,
             // and only the confirmation tells us so. That is the point --
             // the wire carries nothing to test a guess against offline.
-            let accepted = handshake
-                .finish(&element)
-                .ok()
-                .filter(|secrets| confirmation.matches(&secrets.editor_confirmation));
-
-            if let Some(secrets) = accepted {
+            if let Ok(secrets) = handshake.finish_confirmed(&element, &confirmation) {
                 tracing::info!("{remote_addr:?} entered the pairing code correctly");
                 pairing_state.lock().unwrap().remember_token(secrets.token_id, secrets.token);
                 send_on(
                     sink,
-                    &PreviewToLspMessage::PairingConfirm {
-                        confirmation: secrets.viewer_confirmation,
-                    },
+                    &PreviewToLspMessage::PairingConfirm { confirmation: secrets.confirmation() },
                 )
                 .await?;
                 // Tells the guard the incoming session is about to drive the
@@ -847,11 +852,7 @@ impl Connection {
             return Err(Denied::Gone);
         };
 
-        let accepted = handshake
-            .finish(&element)
-            .ok()
-            .filter(|secrets| confirmation.matches(&secrets.editor_confirmation));
-        let Some(secrets) = accepted else {
+        let Ok(secrets) = handshake.finish_confirmed(&element, &confirmation) else {
             tracing::info!("{remote_addr:?} announced a token it could not prove");
             return Ok(None);
         };
@@ -862,7 +863,7 @@ impl Connection {
         tracing::info!("{remote_addr:?} proved its token; no code needed");
         send_on(
             sink,
-            &PreviewToLspMessage::PairingConfirm { confirmation: secrets.viewer_confirmation },
+            &PreviewToLspMessage::PairingConfirm { confirmation: secrets.confirmation() },
         )
         .await?;
         Ok(Some(secrets.session()))
@@ -1578,14 +1579,14 @@ mod session_tests {
             client,
             &LspToPreviewMessage::PairingResponse {
                 element: ours,
-                confirmation: secrets.editor_confirmation,
+                confirmation: secrets.confirmation(),
             },
         )
         .await;
         match recv(client).await {
             Some(PreviewToLspMessage::PairingConfirm { confirmation }) => {
                 assert!(
-                    confirmation.matches(&secrets.viewer_confirmation),
+                    secrets.peer_confirms(&confirmation),
                     "the viewer confirmed with a key we did not derive"
                 );
                 Ok(secrets)
@@ -1758,7 +1759,7 @@ mod session_tests {
             &mut client,
             &LspToPreviewMessage::PairingResponse {
                 element: ours,
-                confirmation: secrets.editor_confirmation,
+                confirmation: secrets.confirmation(),
             },
         )
         .await;
@@ -2004,7 +2005,7 @@ mod session_tests {
             &mut client,
             &LspToPreviewMessage::PairingResponse {
                 element: pairing::Element::for_test(vec![0u8; 33]),
-                confirmation: secrets.editor_confirmation,
+                confirmation: secrets.confirmation(),
             },
         )
         .await;

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -4,12 +4,17 @@
 // cSpell: ignore alnum localdomain notlocalhost
 
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use crate::REBUILD_DEBOUNCE;
+use crate::protocol::pairing::{
+    self, CODE_TIMEOUT, Credential, MAX_ATTEMPTS, Nonce, PROMPT_RATE_LIMIT, PairingRejection,
+    Proof, Token,
+};
 use crate::protocol::{
     LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PreviewComponent, PreviewConfig,
     PreviewToLspMessage, SLINT_PROTOCOLS_HEADER, SLINT_VERSION, SLINT_VERSION_HEADER,
@@ -18,7 +23,10 @@ use crate::protocol::{
 #[cfg(not(target_vendor = "apple"))]
 use crate::protocol::{TXT_PROTOCOLS_KEY, TXT_SLINT_VERSION_KEY};
 use dashmap::{DashMap, Entry};
-use futures_util::{SinkExt as _, StreamExt as _, stream::SplitStream};
+use futures_util::{
+    SinkExt as _, StreamExt as _,
+    stream::{SplitSink, SplitStream},
+};
 use lsp_types::Url;
 use serde::Serialize;
 #[cfg(not(target_vendor = "apple"))]
@@ -33,8 +41,206 @@ use tokio_tungstenite::{
         Message,
         handshake::server::{ErrorResponse, Request, Response},
         http::{HeaderValue, StatusCode, header::SEC_WEBSOCKET_PROTOCOL},
+        protocol::{CloseFrame, frame::coding::CloseCode},
     },
 };
+
+/// Write half of an accepted connection.
+type Sink = SplitSink<WebSocketStream<TcpStream>, Message>;
+/// Read half of an accepted connection.
+type Source = SplitStream<WebSocketStream<TcpStream>>;
+
+/// How long a peer has to complete the WebSocket upgrade. A peer that opens
+/// a socket and then says nothing would otherwise hold a task and a file
+/// descriptor for as long as the viewer runs.
+const UPGRADE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How many connections may be part-way through admission at once. Beyond
+/// this the listener drops new sockets: accepting them without bound is how
+/// a flood reaches the process file-descriptor limit, and `accept` failing
+/// takes the whole listener down with it.
+const MAX_PENDING_ADMISSIONS: usize = 16;
+
+/// How long a client has to answer the challenge before we give up on it.
+/// Only covers the automatic first exchange, not the part where a human is
+/// reading a code off the screen; that gets [`CODE_TIMEOUT`].
+const HELLO_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Longest a cool-down can grow to. Each failed prompt doubles the wait,
+/// which is what bounds guessing against a code that never changes: a
+/// generated code is a fresh secret every prompt, but one pinned with
+/// `--pairing-code` is not, so per-prompt attempt limits alone would let
+/// an attacker walk the whole space given enough hours.
+const MAX_COOL_DOWN: Duration = Duration::from_secs(15 * 60);
+
+/// How many pairing tokens the viewer remembers. Reconnects reuse a token
+/// rather than minting one, so this only fills up if several editors pair
+/// with the same viewer, and the oldest falling out just means that editor
+/// pairs again.
+const MAX_REMEMBERED_TOKENS: usize = 8;
+
+/// How the viewer decides whether to admit a client.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum PairingPolicy {
+    /// Show a freshly generated code on screen and require the client to
+    /// echo it back. The default, and what the mobile viewers always use.
+    #[default]
+    Generated,
+    /// Require this code instead of a generated one, for devices with no
+    /// usable display and for scripted clients that know it up front.
+    Fixed(String),
+    /// Admit anyone who completes the WebSocket handshake. Restores the
+    /// behavior from before pairing existed, for trusted networks only.
+    Disabled,
+}
+
+/// Pairing bookkeeping shared by every incoming connection.
+///
+/// The screen is a single resource: two clients can't be shown a code at the
+/// same time, and a client that keeps knocking mustn't be able to keep the
+/// prompt up, which on a viewer that's mid-preview means interrupting it
+/// over and over.
+#[derive(Default)]
+struct PairingState {
+    screen: Screen,
+    /// Failed prompts since the last successful one, so the cool-down can
+    /// escalate against a code that doesn't rotate. Outlives any one
+    /// phase, which is why it isn't part of [`Screen`].
+    consecutive_failures: u32,
+    /// Tokens issued during this viewer run. Deliberately not persisted:
+    /// restarting the viewer makes every editor pair again.
+    tokens: VecDeque<Token>,
+}
+
+/// What the screen is doing about pairing.
+///
+/// The three are exclusive, and each carries exactly the instant it needs,
+/// so there is no way to be mid-prompt without a start time or to be
+/// cooling down while a code is up.
+#[derive(Default)]
+enum Screen {
+    /// Nothing on screen: a knocker can raise a prompt right now.
+    #[default]
+    Idle,
+    /// A code is up. How long it stays up is what its cool-down will be.
+    Prompting { since: tokio::time::Instant },
+    /// A prompt ended with nobody paired, so nothing may go up before this.
+    CoolingDown { until: tokio::time::Instant },
+}
+
+impl PairingState {
+    /// Whether `offered` proves possession of a token we handed out.
+    fn accepts_token(&self, offered: &Proof, nonce: &Nonce) -> bool {
+        // Bitwise `|` rather than `||`: checking every token regardless keeps
+        // the answer from depending on which one matched.
+        self.tokens.iter().fold(false, |found, token| {
+            found | pairing::proof(Credential::Token, token.as_bytes(), nonce).matches(offered)
+        })
+    }
+
+    /// Accept `token` on future connections from whoever just paired.
+    fn remember_token(&mut self, token: Token) {
+        self.tokens.push_back(token);
+        while self.tokens.len() > MAX_REMEMBERED_TOKENS {
+            self.tokens.pop_front();
+        }
+    }
+
+    /// Claim the screen for a pairing prompt.
+    fn begin_prompt(&mut self) -> Result<(), PairingRejection> {
+        let now = tokio::time::Instant::now();
+        match self.screen {
+            Screen::Prompting { .. } => return Err(PairingRejection::Busy),
+            Screen::CoolingDown { until } if now < until => {
+                // Round up, so the last fraction of a second never reports
+                // as "try again in 0 seconds".
+                let left = (until - now).as_millis().div_ceil(1000);
+                return Err(PairingRejection::TooSoon { retry_after_seconds: left as u16 });
+            }
+            // Idle, or a cool-down that has run out.
+            Screen::Idle | Screen::CoolingDown { .. } => {}
+        }
+        self.screen = Screen::Prompting { since: now };
+        Ok(())
+    }
+
+    /// Release the screen.
+    ///
+    /// Only a prompt that *failed* starts a cool-down: the limit exists to
+    /// stop an unauthenticated peer throwing prompts at the device, and
+    /// someone who just typed the right code is plainly not that.
+    ///
+    /// The cool-down is at least as long as the prompt held the screen. A
+    /// flat delay was not enough: a peer that knocks and then says nothing
+    /// occupies the device for [`CODE_TIMEOUT`], so a shorter gap let it
+    /// own the screen for most of every cycle, forever.
+    fn end_prompt(&mut self, accepted: bool) {
+        let Screen::Prompting { since } = self.screen else {
+            // Nothing was up, so there is nothing to end and no cool-down
+            // to earn. Only reachable if a guard outlives its prompt.
+            return;
+        };
+        if accepted {
+            self.consecutive_failures = 0;
+            self.screen = Screen::Idle;
+            return;
+        }
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        // Doubling per failure is what bounds guessing against a pinned
+        // code: it never rotates, so three tries per prompt would otherwise
+        // add up to the whole space over a long enough night.
+        let factor = 1u32.checked_shl(self.consecutive_failures - 1).unwrap_or(u32::MAX);
+        let held = since.elapsed();
+        let cool_down = PROMPT_RATE_LIMIT.max(held).checked_mul(factor).unwrap_or(MAX_COOL_DOWN);
+        self.screen = Screen::CoolingDown {
+            until: tokio::time::Instant::now() + cool_down.min(MAX_COOL_DOWN),
+        };
+    }
+}
+
+/// Releases the prompt slot and takes the code off the screen however the
+/// pairing exchange ends, including when the task is aborted mid-way.
+struct PromptGuard {
+    state: Arc<Mutex<PairingState>>,
+    message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
+    remote_addr: SocketAddr,
+    /// Set once the code has been entered correctly. Tells the viewer whether
+    /// it has to put back whatever the prompt displaced, or whether the
+    /// incoming session is about to drive the screen anyway.
+    accepted: bool,
+}
+
+impl PromptGuard {
+    /// Claim the screen and put `code` on it, or report why not.
+    ///
+    /// Claiming, displaying and tearing down are one thing rather than three
+    /// steps a caller has to sequence correctly.
+    fn begin(
+        state: &Arc<Mutex<PairingState>>,
+        message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
+        remote_addr: SocketAddr,
+        code: &str,
+    ) -> Result<Self, PairingRejection> {
+        state.lock().unwrap().begin_prompt()?;
+        tracing::info!("Showing a pairing code for {remote_addr:?}, valid for {CODE_TIMEOUT:?}");
+        message_handler(ConnectionMessage::PairingStarted {
+            remote_addr,
+            code: code.to_owned(),
+            expires_in: CODE_TIMEOUT,
+        });
+        Ok(Self { state: state.clone(), message_handler, remote_addr, accepted: false })
+    }
+}
+
+impl Drop for PromptGuard {
+    fn drop(&mut self) {
+        self.state.lock().unwrap().end_prompt(self.accepted);
+        (self.message_handler)(ConnectionMessage::PairingFinished {
+            remote_addr: self.remote_addr,
+            accepted: self.accepted,
+        });
+    }
+}
 
 #[cfg(not(target_vendor = "apple"))]
 use mdns_sd::ServiceInfo;
@@ -131,6 +337,21 @@ pub enum ConnectionMessage {
         url: Url,
         contents: Arc<[u8]>,
     },
+    /// Put `code` on screen: someone is trying to connect and needs to read
+    /// it off the device. Any preview currently shown is displaced until the
+    /// matching [`Self::PairingFinished`].
+    PairingStarted {
+        remote_addr: SocketAddr,
+        code: String,
+        expires_in: Duration,
+    },
+    /// Take the code back off the screen. When `accepted` is false nobody
+    /// connected, so the viewer restores what the prompt displaced; when it's
+    /// true the newly admitted session takes over from here.
+    PairingFinished {
+        remote_addr: SocketAddr,
+        accepted: bool,
+    },
 }
 
 pub struct Connection {
@@ -159,6 +380,50 @@ fn encode_and_send(
     Ok(())
 }
 
+/// Why a connection didn't make it past pairing.
+enum Denied {
+    /// Tell the client, then close.
+    Pairing(PairingRejection),
+    /// The socket died or the peer sent something that isn't part of the
+    /// handshake. Nobody to report to.
+    Gone,
+}
+
+/// Write one message straight to a socket, bypassing the shared outbound
+/// channel. Used during pairing, when the connection isn't the current
+/// session yet and its sink still belongs to the admitting task.
+async fn send_on(sink: &mut Sink, message: &impl Serialize) -> Result<(), Denied> {
+    let data: Vec<u8> = postcard::to_allocvec(message).map_err(|_| Denied::Gone)?;
+    sink.send(Message::Binary(data.into())).await.map_err(|_| Denied::Gone)
+}
+
+/// Read the next protocol message, or `None` if `timeout` elapsed, the peer
+/// hung up, or it sent something undecodable.
+async fn next_message(receiver: &mut Source, timeout: Duration) -> Option<LspToPreviewMessage> {
+    let read = async {
+        loop {
+            match receiver.next().await? {
+                Ok(Message::Binary(bin)) => match postcard::from_bytes(&bin) {
+                    Ok(message) => return Some(message),
+                    Err(err) => {
+                        tracing::warn!("Undecodable message during pairing: {err}");
+                        return None;
+                    }
+                },
+                // Keepalive traffic is fine in the middle of the exchange.
+                Ok(Message::Ping(_) | Message::Pong(_)) => continue,
+                Ok(Message::Text(text)) => {
+                    tracing::warn!("Ignoring text message during pairing: {text}");
+                    continue;
+                }
+                Ok(Message::Close(_)) | Err(_) => return None,
+                Ok(Message::Frame(_)) => unreachable!("raw frames are never yielded by read"),
+            }
+        }
+    };
+    tokio::time::timeout(timeout, read).await.ok().flatten()
+}
+
 /// Whether the connection can act on this URL. The remote preview protocol only handles
 /// `file://` URLs; the LSP can legitimately produce others (e.g. `vscode-remote://`), but
 /// they're silently ignored on this side.
@@ -174,6 +439,7 @@ impl Connection {
     pub async fn listen(
         address: Option<SocketAddr>,
         device_name_override: Option<String>,
+        pairing_policy: PairingPolicy,
         message_handler: impl Fn(ConnectionMessage) + 'static + Send + Sync,
     ) -> anyhow::Result<Self> {
         let file_cache = Arc::new(DashMap::<Url, CacheEntry>::new());
@@ -204,10 +470,18 @@ impl Connection {
                 local_addr_sender.send(listener.local_addr()).ok();
 
                 let message_handler = Arc::new(message_handler);
+                let pairing_state = Arc::new(Mutex::new(PairingState::default()));
+                let admissions = Arc::new(sync::Semaphore::new(MAX_PENDING_ADMISSIONS));
+                // Connections that finished the handshake and proved themselves. The
+                // work leading up to that happens off the accept loop, so a peer that
+                // stalls mid-handshake or never enters a code can't hold the listener
+                // up, and the running session survives until someone replaces it.
+                let (admitted_sender, mut admitted_receiver) =
+                    sync::mpsc::unbounded_channel::<(Sink, Source, SocketAddr)>();
                 // The sink is the write half; the JoinHandle is the read-half task. We keep
-                // both so the next accept can abort the in-flight task and reset shared state
-                // before its messages race with the new client's.
-                let mut current_session: Option<(_, tokio::task::JoinHandle<()>)> = None;
+                // both so an admitted connection can abort the in-flight task and reset shared
+                // state before its messages race with the new client's.
+                let mut current_session: Option<(Sink, tokio::task::JoinHandle<()>)> = None;
                 loop {
                     tokio::select! {
                         accept = listener.accept() => {
@@ -217,42 +491,56 @@ impl Connection {
                                     return;
                                 }
                                 Ok((stream, addr)) => {
+                                    let Ok(permit) = admissions.clone().try_acquire_owned() else {
+                                        // Dropping `stream` closes it, which is
+                                        // the point: better to refuse than to
+                                        // let a flood exhaust our descriptors.
+                                        tracing::warn!(
+                                            "Refusing {addr:?}: {MAX_PENDING_ADMISSIONS} connections are already mid-admission"
+                                        );
+                                        continue;
+                                    };
                                     tracing::info!("Connected to {addr:?}");
-                                    match tokio_tungstenite::accept_hdr_async(stream, handshake_callback).await {
-                                        Err(err) => {
-                                            tracing::error!("Failed to establish websocket connection: {err}")
-                                        }
-                                        Ok(stream) => {
-                                            tracing::info!("Websocket established with {addr:?}");
-                                            if let Some((_old_sink, old_handle)) = current_session.take() {
-                                                // A finished handle is just a stale session left
-                                                // behind by an earlier disconnect, not a takeover.
-                                                if !old_handle.is_finished() {
-                                                    tracing::warn!(
-                                                        "Second connection while we were already connected, dropping old connection"
-                                                    );
-                                                    old_handle.abort();
-                                                }
-                                                // An aborted task can't run its end-of-loop
-                                                // cleanup, so reset the shared state here so
-                                                // the new client starts from a clean cache.
-                                                inner_file_cache.clear();
-                                                inner_dependencies.lock().unwrap().clear();
-                                            }
-                                            let (sink, receiver) = stream.split();
-                                            let handle = tokio::spawn(Self::handle_connection(
-                                                receiver,
-                                                message_handler.clone(),
-                                                inner_file_cache.clone(),
-                                                inner_dependencies.clone(),
-                                                inner_message_sender.clone(),
-                                                addr,
-                                            ));
-                                            current_session = Some((sink, handle));
-                                        }
-                                    }
+                                    tokio::spawn(Self::admit(
+                                        stream,
+                                        addr,
+                                        pairing_policy.clone(),
+                                        pairing_state.clone(),
+                                        message_handler.clone(),
+                                        admitted_sender.clone(),
+                                        permit,
+                                    ));
                                 }
                             }
+                        }
+                        admitted = admitted_receiver.recv() => {
+                            // `admitted_sender` is held by this loop, so the channel
+                            // never closes while we're running.
+                            let Some((sink, receiver, addr)) = admitted else { continue };
+                            if let Some((_old_sink, old_handle)) = current_session.take() {
+                                // A finished handle is just a stale session left
+                                // behind by an earlier disconnect, not a takeover.
+                                if !old_handle.is_finished() {
+                                    tracing::warn!(
+                                        "Second connection while we were already connected, dropping old connection"
+                                    );
+                                    old_handle.abort();
+                                }
+                                // An aborted task can't run its end-of-loop
+                                // cleanup, so reset the shared state here so
+                                // the new client starts from a clean cache.
+                                inner_file_cache.clear();
+                                inner_dependencies.lock().unwrap().clear();
+                            }
+                            let handle = tokio::spawn(Self::handle_connection(
+                                receiver,
+                                message_handler.clone(),
+                                inner_file_cache.clone(),
+                                inner_dependencies.clone(),
+                                inner_message_sender.clone(),
+                                addr,
+                            ));
+                            current_session = Some((sink, handle));
                         }
                         _ = &mut quit_receiver => {
                             tracing::info!("Quit signal received, shutting down connection thread.");
@@ -313,6 +601,179 @@ impl Connection {
     /// `Compiler::build_from_source`.
     pub fn file_cache(&self) -> FileCache {
         self.file_cache.clone()
+    }
+
+    /// Take one incoming socket through the WebSocket handshake and the
+    /// pairing exchange, and hand it to the accept loop if it gets through.
+    ///
+    /// Runs off the accept loop on purpose: everything here waits on a peer
+    /// we have no reason to trust yet, and one of the waits is for a human to
+    /// read six digits off a screen.
+    async fn admit(
+        stream: TcpStream,
+        remote_addr: SocketAddr,
+        policy: PairingPolicy,
+        pairing_state: Arc<Mutex<PairingState>>,
+        message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
+        admitted: UnboundedSender<(Sink, Source, SocketAddr)>,
+        // Held for as long as this connection is being admitted, so the
+        // listener can bound how many are in flight.
+        _permit: sync::OwnedSemaphorePermit,
+    ) {
+        let upgrade = tokio_tungstenite::accept_hdr_async(stream, handshake_callback);
+        let stream = match tokio::time::timeout(UPGRADE_TIMEOUT, upgrade).await {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(err)) => {
+                tracing::error!("Failed to establish websocket connection: {err}");
+                return;
+            }
+            Err(_) => {
+                tracing::warn!("{remote_addr:?} never completed the WebSocket upgrade");
+                return;
+            }
+        };
+        tracing::info!("Websocket established with {remote_addr:?}");
+        let (mut sink, mut receiver) = stream.split();
+
+        match Self::authenticate(
+            &mut sink,
+            &mut receiver,
+            remote_addr,
+            &policy,
+            &pairing_state,
+            message_handler,
+        )
+        .await
+        {
+            Ok(()) => {
+                tracing::info!("Paired with {remote_addr:?}");
+                admitted.send((sink, receiver, remote_addr)).ok();
+            }
+            Err(Denied::Gone) => {
+                tracing::info!("{remote_addr:?} gave up before pairing completed");
+            }
+            Err(Denied::Pairing(reason)) => {
+                tracing::warn!("Refused {remote_addr:?}: {reason}");
+                send_on(&mut sink, &PreviewToLspMessage::PairingRejected { reason }).await.ok();
+                sink.send(Message::Close(Some(CloseFrame {
+                    code: CloseCode::Policy,
+                    reason: reason.to_string().as_str().into(),
+                })))
+                .await
+                .ok();
+                sink.close().await.ok();
+            }
+        }
+    }
+
+    /// Run the pairing exchange described in [`crate::protocol::pairing`].
+    ///
+    /// Deliberately touches none of the session state: until this returns
+    /// `Ok` the caller is just a peer on a socket, and the editor that is
+    /// already connected keeps its session and its file cache.
+    async fn authenticate(
+        sink: &mut Sink,
+        receiver: &mut Source,
+        remote_addr: SocketAddr,
+        policy: &PairingPolicy,
+        pairing_state: &Arc<Mutex<PairingState>>,
+        message_handler: Arc<dyn Fn(ConnectionMessage) + 'static + Send + Sync>,
+    ) -> Result<(), Denied> {
+        let nonce = pairing::generate::nonce();
+        send_on(sink, &PreviewToLspMessage::PairingChallenge { nonce }).await?;
+
+        // The client answers this much on its own; no human is involved yet.
+        let token_proof = match next_message(receiver, HELLO_TIMEOUT).await {
+            Some(LspToPreviewMessage::PairingHello { token_proof }) => token_proof,
+            Some(other) => {
+                tracing::warn!("Expected PairingHello from {remote_addr:?}, got {other:?}");
+                return Err(Denied::Gone);
+            }
+            None => return Err(Denied::Gone),
+        };
+
+        if *policy == PairingPolicy::Disabled {
+            // --no-pairing: everyone is admitted, so there is no token to
+            // derive and nothing for the client to remember.
+            send_on(sink, &PreviewToLspMessage::PairingAccepted).await?;
+            return Ok(());
+        }
+
+        if let Some(offered) = token_proof {
+            if pairing_state.lock().unwrap().accepts_token(&offered, &nonce) {
+                // An editor we already paired with, reconnecting. Keep the
+                // screen alone: this is the common case after a network blip
+                // or the viewer coming back to the foreground.
+                tracing::info!("{remote_addr:?} presented a valid token; no code needed");
+                send_on(sink, &PreviewToLspMessage::PairingAccepted).await?;
+                return Ok(());
+            }
+            tracing::info!("{remote_addr:?} presented a token we did not issue");
+            // Almost always a token from a previous run of this viewer. Say
+            // so, so the client forgets it, then fall through to the code.
+            let reason = PairingRejection::BadToken;
+            send_on(sink, &PreviewToLspMessage::PairingRejected { reason }).await?;
+        }
+
+        let code = match policy {
+            PairingPolicy::Fixed(code) => code.clone(),
+            _ => pairing::generate::code(),
+        };
+
+        // From here on the prompt is up, so every exit has to take it down.
+        let mut guard = PromptGuard::begin(pairing_state, message_handler, remote_addr, &code)
+            .map_err(Denied::Pairing)?;
+
+        let expected = pairing::proof(Credential::Code, code.as_bytes(), &nonce);
+        let deadline = tokio::time::Instant::now() + CODE_TIMEOUT;
+        let remaining = || deadline.saturating_duration_since(tokio::time::Instant::now());
+        let prompt = |attempts_left| PreviewToLspMessage::PairingRequired {
+            attempts_left,
+            expires_in_seconds: remaining().as_secs() as u16,
+        };
+        let mut attempts_left = MAX_ATTEMPTS;
+
+        send_on(sink, &prompt(attempts_left)).await?;
+
+        loop {
+            let Some(message) = next_message(receiver, remaining()).await else {
+                // End of stream covers both a deadline that lapsed and a peer
+                // that vanished. The clock is what tells them apart, and
+                // calling a disconnect a timeout makes logs read wrong.
+                return Err(if remaining().is_zero() {
+                    Denied::Pairing(PairingRejection::Expired)
+                } else {
+                    Denied::Gone
+                });
+            };
+            let LspToPreviewMessage::PairingCodeProof { proof } = message else {
+                tracing::warn!("Ignoring {message:?} from {remote_addr:?} during pairing");
+                continue;
+            };
+
+            if proof.matches(&expected) {
+                tracing::info!("{remote_addr:?} entered the pairing code correctly");
+                // Derived, not sent: the client computes the same value from
+                // the code it just proved and the nonce it was challenged with.
+                pairing_state.lock().unwrap().remember_token(pairing::derive_token(&code, &nonce));
+                send_on(sink, &PreviewToLspMessage::PairingAccepted).await?;
+                // Tells the guard the incoming session is about to drive the
+                // screen, so the viewer shouldn't restore what we displaced.
+                guard.accepted = true;
+                return Ok(());
+            }
+
+            attempts_left -= 1;
+            if attempts_left == 0 {
+                return Err(Denied::Pairing(PairingRejection::TooManyAttempts));
+            }
+            send_on(
+                sink,
+                &PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode },
+            )
+            .await?;
+            send_on(sink, &prompt(attempts_left)).await?;
+        }
     }
 
     async fn handle_connection(
@@ -472,6 +933,14 @@ impl Connection {
                                             );
                                         }
                                         LspToPreviewMessage::OpenProject { .. } => {}
+                                        // Pairing is settled before the session starts, so
+                                        // these can only be a confused or malicious peer.
+                                        LspToPreviewMessage::PairingHello { .. }
+                                        | LspToPreviewMessage::PairingCodeProof { .. } => {
+                                            tracing::warn!(
+                                                "Ignoring pairing message on an established session"
+                                            );
+                                        }
                                     }
                                 }
                                 Err(err) => {
@@ -750,43 +1219,565 @@ mod tests {
 }
 
 #[cfg(test)]
-mod keepalive_tests {
-    use super::Connection;
-    use crate::protocol::{LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PreviewToLspMessage};
+mod cool_down_tests {
+    use super::{PairingRejection, PairingState, Screen};
+    use crate::protocol::pairing::{CODE_TIMEOUT, PROMPT_RATE_LIMIT};
+    use std::time::Duration;
+
+    /// A peer that knocks and then says nothing holds the screen for the
+    /// whole deadline, so a flat gap shorter than that let it own the
+    /// device for most of every cycle.
+    #[tokio::test(start_paused = true)]
+    async fn an_abandoned_prompt_costs_as_long_as_it_held_the_screen() {
+        let mut state = PairingState::default();
+        state.begin_prompt().unwrap();
+        tokio::time::advance(CODE_TIMEOUT).await;
+        state.end_prompt(false);
+
+        tokio::time::advance(CODE_TIMEOUT / 2).await;
+        assert!(
+            matches!(state.begin_prompt(), Err(PairingRejection::TooSoon { .. })),
+            "the screen was free again before the prompt's own length had passed"
+        );
+        tokio::time::advance(CODE_TIMEOUT / 2).await;
+        assert!(state.begin_prompt().is_ok());
+    }
+
+    /// A user who fumbles their codes quickly should not be charged for
+    /// time nobody spent occupying the screen.
+    #[tokio::test(start_paused = true)]
+    async fn a_quick_failure_costs_only_the_base_limit() {
+        let mut state = PairingState::default();
+        state.begin_prompt().unwrap();
+        tokio::time::advance(Duration::from_secs(5)).await;
+        state.end_prompt(false);
+
+        tokio::time::advance(PROMPT_RATE_LIMIT - Duration::from_secs(1)).await;
+        assert!(matches!(state.begin_prompt(), Err(PairingRejection::TooSoon { .. })));
+        tokio::time::advance(Duration::from_secs(2)).await;
+        assert!(state.begin_prompt().is_ok());
+    }
+
+    /// A code pinned with `--pairing-code` never rotates, so the per-prompt
+    /// attempt limit does not bound total guesses on its own.
+    #[tokio::test(start_paused = true)]
+    async fn repeated_failures_escalate_the_wait() {
+        let mut state = PairingState::default();
+        let mut previous = Duration::ZERO;
+        for _ in 0..4 {
+            state.begin_prompt().unwrap();
+            state.end_prompt(false);
+            let waited = wait_out_cool_down(&mut state).await;
+            assert!(waited > previous, "the wait did not grow: {waited:?} after {previous:?}");
+            previous = waited;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pairing_successfully_clears_the_escalation() {
+        let mut state = PairingState::default();
+        for _ in 0..3 {
+            state.begin_prompt().unwrap();
+            state.end_prompt(false);
+            wait_out_cool_down(&mut state).await;
+        }
+        state.begin_prompt().unwrap();
+        state.end_prompt(true);
+
+        state.begin_prompt().unwrap();
+        state.end_prompt(false);
+        assert_eq!(
+            wait_out_cool_down(&mut state).await,
+            PROMPT_RATE_LIMIT,
+            "a successful pairing should put the escalation back to the start"
+        );
+    }
+
+    /// Advance until the screen is free again, returning how long that took.
+    async fn wait_out_cool_down(state: &mut PairingState) -> Duration {
+        let mut waited = Duration::ZERO;
+        loop {
+            match state.begin_prompt() {
+                Ok(()) => {
+                    state.screen = Screen::Idle;
+                    return waited;
+                }
+                Err(_) => {
+                    tokio::time::advance(Duration::from_secs(1)).await;
+                    waited += Duration::from_secs(1);
+                }
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pairing_successfully_costs_nothing() {
+        let mut state = PairingState::default();
+        state.begin_prompt().unwrap();
+        tokio::time::advance(CODE_TIMEOUT).await;
+        state.end_prompt(true);
+        assert!(state.begin_prompt().is_ok());
+    }
+}
+
+#[cfg(test)]
+mod session_tests {
+    use super::{Connection, ConnectionMessage, MAX_PENDING_ADMISSIONS, PairingPolicy};
+    use crate::protocol::pairing::{self, Credential, MAX_ATTEMPTS, Nonce, Token};
+    use crate::protocol::{
+        LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PairingRejection, PreviewToLspMessage,
+    };
     use futures_util::{SinkExt as _, StreamExt as _};
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
     use tokio_tungstenite::tungstenite::{
+        Message,
         client::IntoClientRequest as _,
         http::{HeaderValue, header::SEC_WEBSOCKET_PROTOCOL},
     };
 
-    #[tokio::test]
-    async fn ping_is_answered_with_pong() {
-        let connection =
-            Connection::listen(Some(std::net::SocketAddr::from(([127, 0, 0, 1], 0))), None, |_| {})
-                .await
+    /// Fails the test rather than hanging it if the viewer never answers.
+    const REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    type Client = tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >;
+
+    /// A viewer under test, plus the messages it pushed to its UI.
+    struct Viewer {
+        connection: Connection,
+        events: UnboundedReceiver<ConnectionMessage>,
+    }
+
+    impl Viewer {
+        async fn start(policy: PairingPolicy) -> Self {
+            let (sender, events) = unbounded_channel();
+            let connection = Connection::listen(
+                Some(std::net::SocketAddr::from(([127, 0, 0, 1], 0))),
+                None,
+                policy,
+                move |message| {
+                    let _ = sender.send(message);
+                },
+            )
+            .await
+            .unwrap();
+            Self { connection, events }
+        }
+
+        /// Open a socket and complete the WebSocket handshake, stopping short
+        /// of pairing.
+        async fn dial(&self) -> Client {
+            let mut request = format!("ws://127.0.0.1:{}", self.connection.local_port())
+                .into_client_request()
                 .unwrap();
+            request
+                .headers_mut()
+                .insert(SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_static(PROTOCOL_SUBPROTOCOL));
+            tokio_tungstenite::connect_async(request).await.unwrap().0
+        }
 
-        let mut request =
-            format!("ws://127.0.0.1:{}", connection.local_port()).into_client_request().unwrap();
-        request
-            .headers_mut()
-            .insert(SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_static(PROTOCOL_SUBPROTOCOL));
-        let (mut stream, _) = tokio_tungstenite::connect_async(request).await.unwrap();
+        /// Wait for the next event the viewer would have shown on screen.
+        async fn next_event(&mut self) -> ConnectionMessage {
+            tokio::time::timeout(REPLY_TIMEOUT, self.events.recv())
+                .await
+                .expect("viewer produced no event")
+                .expect("viewer event channel closed")
+        }
 
-        let ping = postcard::to_allocvec(&LspToPreviewMessage::Ping).unwrap();
-        stream.send(tokio_tungstenite::tungstenite::Message::Binary(ping.into())).await.unwrap();
-
-        let pong = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        /// Wait for a prompt to come down with the given outcome.
+        async fn expect_prompt_finished(&mut self, accepted: bool) {
             loop {
-                let msg = stream.next().await.expect("stream ended without a pong").unwrap();
-                if let tokio_tungstenite::tungstenite::Message::Binary(bytes) = msg {
-                    return postcard::from_bytes::<PreviewToLspMessage>(&bytes).unwrap();
+                if let ConnectionMessage::PairingFinished { accepted: got, .. } =
+                    self.next_event().await
+                {
+                    assert_eq!(got, accepted, "prompt ended with the wrong outcome");
+                    return;
+                }
+            }
+        }
+
+        /// The code from the next `PairingStarted`, skipping anything else.
+        async fn next_code(&mut self) -> String {
+            loop {
+                if let ConnectionMessage::PairingStarted { code, .. } = self.next_event().await {
+                    return code;
+                }
+            }
+        }
+    }
+
+    async fn send(client: &mut Client, message: &LspToPreviewMessage) {
+        let bytes = postcard::to_allocvec(message).unwrap();
+        client.send(Message::Binary(bytes.into())).await.unwrap();
+    }
+
+    /// Raw bytes of the next frame from the viewer, before decoding.
+    async fn recv_raw(client: &mut Client) -> Option<Vec<u8>> {
+        tokio::time::timeout(REPLY_TIMEOUT, async {
+            loop {
+                match client.next().await? {
+                    Ok(Message::Binary(bytes)) => return Some(bytes.to_vec()),
+                    Ok(Message::Close(_)) | Err(_) => return None,
+                    Ok(_) => continue,
                 }
             }
         })
         .await
-        .expect("no pong within 5 seconds");
-        assert!(matches!(pong, PreviewToLspMessage::Pong));
+        .expect("viewer sent no reply")
+    }
+
+    /// Next protocol message from the viewer, or `None` if it closed the socket.
+    async fn recv(client: &mut Client) -> Option<PreviewToLspMessage> {
+        tokio::time::timeout(REPLY_TIMEOUT, async {
+            loop {
+                match client.next().await? {
+                    Ok(Message::Binary(bytes)) => {
+                        return Some(postcard::from_bytes(&bytes).unwrap());
+                    }
+                    Ok(Message::Close(_)) | Err(_) => return None,
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await
+        .expect("viewer sent no reply")
+    }
+
+    /// Read the challenge and answer it with `token_proof`.
+    async fn hello(client: &mut Client, token: Option<&Token>) -> Nonce {
+        let Some(PreviewToLspMessage::PairingChallenge { nonce }) = recv(client).await else {
+            panic!("expected a challenge");
+        };
+        let token_proof =
+            token.map(|token| pairing::proof(Credential::Token, token.as_bytes(), &nonce));
+        send(client, &LspToPreviewMessage::PairingHello { token_proof }).await;
+        nonce
+    }
+
+    async fn offer_code(client: &mut Client, code: &str, nonce: &Nonce) {
+        let proof = pairing::proof(Credential::Code, code.as_bytes(), nonce);
+        send(client, &LspToPreviewMessage::PairingCodeProof { proof }).await;
+    }
+
+    /// Dial as a stranger and wait for the viewer to put a code on screen.
+    async fn knock(viewer: &Viewer) -> (Client, Nonce) {
+        let mut client = viewer.dial().await;
+        let nonce = hello(&mut client, None).await;
+        assert!(
+            matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingRequired { .. })),
+            "expected a code prompt"
+        );
+        (client, nonce)
+    }
+
+    /// Dial, pair with the code the viewer displays, and return the socket
+    /// plus the token it was issued.
+    async fn pair(viewer: &mut Viewer) -> (Client, Token) {
+        let (mut client, nonce) = knock(viewer).await;
+        let code = viewer.next_code().await;
+        offer_code(&mut client, &code, &nonce).await;
+        assert!(
+            matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingAccepted)),
+            "expected to be accepted"
+        );
+        (client, pairing::derive_token(&code, &nonce))
+    }
+
+    #[tokio::test]
+    async fn correct_code_is_accepted_and_session_works() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let (mut client, _token) = pair(&mut viewer).await;
+
+        // The prompt comes down, and the viewer is told the newcomer took over.
+        assert!(matches!(
+            viewer.next_event().await,
+            ConnectionMessage::PairingFinished { accepted: true, .. }
+        ));
+        assert!(matches!(viewer.next_event().await, ConnectionMessage::Connected { .. }));
+
+        // The session is live: the keepalive round trip works.
+        send(&mut client, &LspToPreviewMessage::Ping).await;
+        assert!(matches!(recv(&mut client).await, Some(PreviewToLspMessage::Pong)));
+    }
+
+    #[tokio::test]
+    async fn wrong_code_burns_attempts_then_closes() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let mut client = viewer.dial().await;
+        let nonce = hello(&mut client, None).await;
+
+        let Some(PreviewToLspMessage::PairingRequired { attempts_left, .. }) =
+            recv(&mut client).await
+        else {
+            panic!("expected a code prompt");
+        };
+        assert_eq!(attempts_left, MAX_ATTEMPTS);
+        let code = viewer.next_code().await;
+        assert_eq!(code.len(), pairing::CODE_DIGITS as usize);
+        assert!(code.chars().all(|c| c.is_ascii_digit()), "generated code {code} is not digits");
+        let wrong = if code == "0000" { "1111" } else { "0000" };
+
+        for expected_left in (1..MAX_ATTEMPTS).rev() {
+            offer_code(&mut client, wrong, &nonce).await;
+            assert!(matches!(
+                recv(&mut client).await,
+                Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode })
+            ));
+            let Some(PreviewToLspMessage::PairingRequired { attempts_left, .. }) =
+                recv(&mut client).await
+            else {
+                panic!("expected another code prompt");
+            };
+            assert_eq!(attempts_left, expected_left);
+        }
+
+        offer_code(&mut client, wrong, &nonce).await;
+        assert!(matches!(
+            recv(&mut client).await,
+            Some(PreviewToLspMessage::PairingRejected {
+                reason: PairingRejection::TooManyAttempts
+            })
+        ));
+        assert!(recv(&mut client).await.is_none(), "viewer should close the socket");
+    }
+
+    /// Peers that open a socket and say nothing used to accumulate a task
+    /// and a descriptor each, without limit, until `accept` failed and took
+    /// the listener down. They are bounded now, and the listener keeps
+    /// serving real clients underneath them.
+    #[tokio::test]
+    async fn silent_peers_do_not_stop_the_listener() {
+        let viewer = Viewer::start(PairingPolicy::Generated).await;
+        let addr = format!("127.0.0.1:{}", viewer.connection.local_port());
+
+        let mut silent = Vec::new();
+        for _ in 0..MAX_PENDING_ADMISSIONS - 1 {
+            silent.push(tokio::net::TcpStream::connect(&addr).await.unwrap());
+        }
+
+        let mut client = viewer.dial().await;
+        hello(&mut client, None).await;
+        assert!(
+            matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingRequired { .. })),
+            "the listener stopped serving while silent peers were connected"
+        );
+        drop(silent);
+    }
+
+    /// The reconnect token must never be transmitted. Sending it would put
+    /// the credential itself on a plaintext socket, where anyone listening
+    /// could lift it and reconnect silently for the viewer's whole run.
+    #[tokio::test]
+    async fn nothing_secret_reaches_the_wire() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let mut client = viewer.dial().await;
+
+        let mut frames: Vec<Vec<u8>> = Vec::new();
+        frames.push(recv_raw(&mut client).await.expect("challenge"));
+        let nonce =
+            match postcard::from_bytes::<PreviewToLspMessage>(frames.last().unwrap()).unwrap() {
+                PreviewToLspMessage::PairingChallenge { nonce } => nonce,
+                other => panic!("expected a challenge, got {other:?}"),
+            };
+        send(&mut client, &LspToPreviewMessage::PairingHello { token_proof: None }).await;
+        frames.push(recv_raw(&mut client).await.expect("prompt"));
+
+        let code = viewer.next_code().await;
+        offer_code(&mut client, &code, &nonce).await;
+        frames.push(recv_raw(&mut client).await.expect("acceptance"));
+
+        let token = pairing::derive_token(&code, &nonce);
+        for frame in &frames {
+            assert!(
+                !frame.windows(token.as_bytes().len()).any(|w| w == token.as_bytes()),
+                "the viewer put the reconnect token on the wire"
+            );
+            assert!(
+                !frame.windows(code.len()).any(|w| w == code.as_bytes()),
+                "the viewer put the pairing code on the wire"
+            );
+        }
+
+        // ... and the token both sides derived is the one that works.
+        drop(client);
+        let mut again = viewer.dial().await;
+        hello(&mut again, Some(&token)).await;
+        assert!(matches!(recv(&mut again).await, Some(PreviewToLspMessage::PairingAccepted)));
+    }
+
+    #[tokio::test]
+    async fn a_token_reconnects_without_a_prompt() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let (first, token) = pair(&mut viewer).await;
+        drop(first);
+
+        let mut client = viewer.dial().await;
+        hello(&mut client, Some(&token)).await;
+        assert!(matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingAccepted)));
+        // No code was ever generated for the second connection.
+        assert!(
+            !viewer
+                .events
+                .try_recv()
+                .is_ok_and(|event| matches!(event, ConnectionMessage::PairingStarted { .. }))
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_token_falls_back_to_the_code() {
+        let viewer = Viewer::start(PairingPolicy::Generated).await;
+        let mut client = viewer.dial().await;
+        // A token from some other viewer, or from a previous run of this one.
+        hello(&mut client, Some(&pairing::derive_token("9999", &Nonce::for_test(9)))).await;
+
+        assert!(matches!(
+            recv(&mut client).await,
+            Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadToken })
+        ));
+        assert!(matches!(
+            recv(&mut client).await,
+            Some(PreviewToLspMessage::PairingRequired { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_knocker_cannot_displace_a_live_session() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let (mut established, _token) = pair(&mut viewer).await;
+        // Clear the setup pairing's own prompt, so the wait below can only
+        // match the intruder's.
+        viewer.expect_prompt_finished(true).await;
+
+        // Someone else turns up and gets as far as a code prompt, which is
+        // the furthest an unauthenticated peer can go.
+        let mut intruder = viewer.dial().await;
+        hello(&mut intruder, None).await;
+        assert!(matches!(
+            recv(&mut intruder).await,
+            Some(PreviewToLspMessage::PairingRequired { .. })
+        ));
+        // ... and gives up without ever entering the code.
+        drop(intruder);
+        viewer.expect_prompt_finished(false).await;
+
+        // The original session is untouched.
+        send(&mut established, &LspToPreviewMessage::Ping).await;
+        assert!(matches!(recv(&mut established).await, Some(PreviewToLspMessage::Pong)));
+    }
+
+    #[tokio::test]
+    async fn a_second_knocker_is_turned_away_while_a_prompt_is_up() {
+        let viewer = Viewer::start(PairingPolicy::Generated).await;
+        let mut first = viewer.dial().await;
+        hello(&mut first, None).await;
+        assert!(matches!(
+            recv(&mut first).await,
+            Some(PreviewToLspMessage::PairingRequired { .. })
+        ));
+
+        let mut second = viewer.dial().await;
+        hello(&mut second, None).await;
+        assert!(matches!(
+            recv(&mut second).await,
+            Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::Busy })
+        ));
+        assert!(recv(&mut second).await.is_none(), "viewer should close the second socket");
+    }
+
+    /// A prompt nobody completed starts the cool-down, and retrying inside
+    /// it is told so specifically rather than blamed on another computer
+    /// that isn't there.
+    #[tokio::test]
+    async fn a_failed_prompt_holds_off_the_next_one() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+
+        let mut abandoned = viewer.dial().await;
+        hello(&mut abandoned, None).await;
+        assert!(matches!(
+            recv(&mut abandoned).await,
+            Some(PreviewToLspMessage::PairingRequired { .. })
+        ));
+        // Walk away from it: the prompt comes down unanswered.
+        drop(abandoned);
+        viewer.expect_prompt_finished(false).await;
+
+        let mut knocker = viewer.dial().await;
+        hello(&mut knocker, None).await;
+        assert!(matches!(
+            recv(&mut knocker).await,
+            Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::TooSoon { .. } })
+        ));
+    }
+
+    /// Pairing correctly must not cost the user a cool-down. Reloading an
+    /// editor drops its token, so this is the path straight back to a code.
+    #[tokio::test]
+    async fn a_successful_pairing_does_not_hold_off_the_next_one() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let (client, _token) = pair(&mut viewer).await;
+        drop(client);
+
+        // A brand new editor, with no token, pairing straight afterwards.
+        let mut fresh = viewer.dial().await;
+        let nonce = hello(&mut fresh, None).await;
+        assert!(
+            matches!(recv(&mut fresh).await, Some(PreviewToLspMessage::PairingRequired { .. })),
+            "a successful pairing must not lock out the next one"
+        );
+        let code = viewer.next_code().await;
+        offer_code(&mut fresh, &code, &nonce).await;
+        assert!(matches!(recv(&mut fresh).await, Some(PreviewToLspMessage::PairingAccepted)));
+    }
+
+    #[tokio::test]
+    async fn a_fixed_code_is_accepted_without_reading_the_screen() {
+        let viewer = Viewer::start(PairingPolicy::Fixed("135791".into())).await;
+        let (mut client, nonce) = knock(&viewer).await;
+
+        offer_code(&mut client, "135791", &nonce).await;
+        assert!(matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingAccepted)));
+    }
+
+    #[tokio::test]
+    async fn pairing_disabled_admits_without_a_code() {
+        let mut viewer = Viewer::start(PairingPolicy::Disabled).await;
+        let mut client = viewer.dial().await;
+        hello(&mut client, None).await;
+
+        assert!(matches!(recv(&mut client).await, Some(PreviewToLspMessage::PairingAccepted)));
+        assert!(matches!(viewer.next_event().await, ConnectionMessage::Connected { .. }));
+    }
+
+    #[tokio::test]
+    async fn a_proof_for_the_wrong_nonce_is_refused() {
+        let mut viewer = Viewer::start(PairingPolicy::Generated).await;
+        let (mut client, _nonce) = knock(&viewer).await;
+        let code = viewer.next_code().await;
+
+        // Right code, replayed against a nonce from some other exchange.
+        offer_code(&mut client, &code, &Nonce::for_test(0)).await;
+        assert!(matches!(
+            recv(&mut client).await,
+            Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode })
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_garbage_proof_is_refused() {
+        let viewer = Viewer::start(PairingPolicy::Generated).await;
+        let mut client = viewer.dial().await;
+        hello(&mut client, None).await;
+        assert!(matches!(
+            recv(&mut client).await,
+            Some(PreviewToLspMessage::PairingRequired { .. })
+        ));
+
+        let bogus = pairing::proof(Credential::Code, b"nonsense", &Nonce::for_test(0));
+        send(&mut client, &LspToPreviewMessage::PairingCodeProof { proof: bogus }).await;
+        assert!(matches!(
+            recv(&mut client).await,
+            Some(PreviewToLspMessage::PairingRejected { reason: PairingRejection::BadCode })
+        ));
     }
 }
 

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -638,7 +638,7 @@ impl Connection {
     ///
     /// Runs off the accept loop on purpose: everything here waits on a peer
     /// we have no reason to trust yet, and one of the waits is for a human to
-    /// read six digits off a screen.
+    /// read a code off a screen.
     async fn admit(
         stream: TcpStream,
         remote_addr: SocketAddr,

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -427,6 +427,7 @@ async fn handle_preview_message(
         | Pong
         | PairingChallenge { .. }
         | PairingRequired { .. }
+        | PairingConfirm { .. }
         | PairingAccepted
         | PairingRejected { .. } => {
             tracing::debug!("Ignoring message from preview: {msg:?}");

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -422,7 +422,13 @@ async fn handle_preview_message(
         | TelemetryEvent(..)
         | ConnectRemote { .. }
         | DisconnectRemote
-        | Pong => {
+        | SubmitPairingCode { .. }
+        | CancelPairing
+        | Pong
+        | PairingChallenge { .. }
+        | PairingRequired { .. }
+        | PairingAccepted
+        | PairingRejected { .. } => {
             tracing::debug!("Ignoring message from preview: {msg:?}");
         }
         SendWorkspaceEdit { label, edit } => {

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -424,6 +424,7 @@ async fn handle_preview_message(
         | DisconnectRemote
         | SubmitPairingCode { .. }
         | CancelPairing
+        | AcceptUnpairedConnection
         | Pong
         | PairingReady
         | PairingRequired { .. }

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -425,8 +425,9 @@ async fn handle_preview_message(
         | SubmitPairingCode { .. }
         | CancelPairing
         | Pong
-        | PairingChallenge { .. }
+        | PairingReady
         | PairingRequired { .. }
+        | PairingTokenChallenge { .. }
         | PairingConfirm { .. }
         | PairingAccepted
         | PairingRejected { .. } => {

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -135,7 +135,7 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         // Part of the remote pairing handshake, which the LSP's WebSocket
         // connector completes before a session exists. A local preview is
         // never on the receiving end of one.
-        M::PairingHello { .. } | M::PairingCodeProof { .. } => {
+        M::PairingHello { .. } | M::PairingResponse { .. } => {
             tracing::warn!("Ignoring a pairing message addressed to a local preview");
         }
     }

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -2268,6 +2268,7 @@ pub fn set_remote_connection_state(
                 R::Disconnected => ui::RemoteConnectionState::Disconnected,
                 R::Connecting => ui::RemoteConnectionState::Connecting,
                 R::PairingRequired => ui::RemoteConnectionState::PairingRequired,
+                R::UnpairedWarning => ui::RemoteConnectionState::UnpairedWarning,
                 R::Connected => ui::RemoteConnectionState::Connected,
                 R::Failed => ui::RemoteConnectionState::Failed,
             };

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -132,6 +132,12 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         M::Ping => {
             // Keepalive for the remote-preview WebSocket; local previews never see it.
         }
+        // Part of the remote pairing handshake, which the LSP's WebSocket
+        // connector completes before a session exists. A local preview is
+        // never on the receiving end of one.
+        M::PairingHello { .. } | M::PairingCodeProof { .. } => {
+            tracing::warn!("Ignoring a pairing message addressed to a local preview");
+        }
     }
 }
 
@@ -2248,8 +2254,8 @@ fn set_preview_factory(
     api.set_resize_to_preferred_size(behavior != LoadBehavior::Reload);
 }
 
-/// Highlight the element pointed at the offset in the path.
-/// When the URL is None, remove the highlight.
+/// Push the remote connection's state to the Remote Preview pane, which
+/// shows it and, while pairing, collects the code from the user.
 pub fn set_remote_connection_state(
     state: i_slint_live_preview::protocol::RemoteConnectionState,
     target: String,
@@ -2261,6 +2267,7 @@ pub fn set_remote_connection_state(
             let ui_state = match state {
                 R::Disconnected => ui::RemoteConnectionState::Disconnected,
                 R::Connecting => ui::RemoteConnectionState::Connecting,
+                R::PairingRequired => ui::RemoteConnectionState::PairingRequired,
                 R::Connected => ui::RemoteConnectionState::Connected,
                 R::Failed => ui::RemoteConnectionState::Failed,
             };

--- a/tools/editor/preview/remote.rs
+++ b/tools/editor/preview/remote.rs
@@ -116,6 +116,13 @@ pub fn setup(
             tracing::error!("Failed sending CancelPairing to LSP: {err}");
         }
     });
+
+    let lsp = to_lsp.clone();
+    api.on_remote_accept_unpaired(move || {
+        if let Err(err) = lsp.send(&PreviewToLspMessage::AcceptUnpairedConnection) {
+            tracing::error!("Failed sending AcceptUnpairedConnection to LSP: {err}");
+        }
+    });
 }
 
 /// Surface a manual-entry / discovery error in the dialog. Skipped when

--- a/tools/editor/preview/remote.rs
+++ b/tools/editor/preview/remote.rs
@@ -30,10 +30,22 @@ pub fn setup(
     to_lsp: &Rc<dyn i_slint_editor_preview::PreviewToLsp>,
 ) {
     api.set_remote_discovered_viewers(ModelRc::new(VecModel::<RemoteViewerInfo>::default()));
+    // The code field is fixed-length, so the UI needs the same number the
+    // viewer generates against.
+    api.set_remote_pairing_code_length(i_slint_live_preview::protocol::pairing::CODE_DIGITS as i32);
 
     let discovery_api_weak = api_weak.clone();
     api.on_remote_start_discovery(move || {
         let api_weak = discovery_api_weak.clone();
+        // Opening the pane shouldn't greet the user with whatever went wrong
+        // last time: a code that expired while they were away is not news on
+        // the way back in. Anything live keeps its state.
+        if let Some(api) = api_weak.upgrade()
+            && api.get_remote_connection_state() == RemoteConnectionState::Failed
+        {
+            api.set_remote_connection_state(RemoteConnectionState::Disconnected);
+            api.set_remote_connection_error(SharedString::default());
+        }
         crate::preview::PREVIEW_STATE.with_borrow(|preview_state| {
             preview_state.remote_discovery.start(api_weak);
         });
@@ -83,6 +95,25 @@ pub fn setup(
     api.on_remote_disconnect(move || {
         if let Err(err) = lsp.send(&PreviewToLspMessage::DisconnectRemote) {
             tracing::error!("Failed sending DisconnectRemote to LSP: {err}");
+        }
+    });
+
+    let lsp = to_lsp.clone();
+    api.on_remote_submit_pairing_code(move |code| {
+        let code = code.trim().to_owned();
+        if !i_slint_live_preview::protocol::pairing::is_valid_code(&code) {
+            tracing::warn!("Ignoring malformed pairing code");
+            return;
+        }
+        if let Err(err) = lsp.send(&PreviewToLspMessage::SubmitPairingCode { code }) {
+            tracing::error!("Failed sending SubmitPairingCode to LSP: {err}");
+        }
+    });
+
+    let lsp = to_lsp.clone();
+    api.on_remote_cancel_pairing(move || {
+        if let Err(err) = lsp.send(&PreviewToLspMessage::CancelPairing) {
+            tracing::error!("Failed sending CancelPairing to LSP: {err}");
         }
     });
 }

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -69,6 +69,9 @@ export enum RemoteConnectionState {
     /// The viewer is showing a pairing code and is waiting for it to be
     /// typed in here.
     PairingRequired,
+    /// The viewer has pairing disabled; waiting for the user to accept the
+    /// unencrypted connection or cancel.
+    UnpairedWarning,
     Connected,
     Failed,
 }
@@ -726,6 +729,8 @@ export global Api {
     callback remote-disconnect();
     callback remote-submit-pairing-code(code: string);
     callback remote-cancel-pairing();
+    /// Connect to the pairing-disabled viewer the warning is about.
+    callback remote-accept-unpaired();
     /// Digits in a pairing code, from `pairing::CODE_DIGITS`.
     in-out property <int> remote-pairing-code-length;
 

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -66,6 +66,9 @@ export struct RemoteViewerInfo {
 export enum RemoteConnectionState {
     Disconnected,
     Connecting,
+    /// The viewer is showing a pairing code and is waiting for it to be
+    /// typed in here.
+    PairingRequired,
     Connected,
     Failed,
 }
@@ -721,6 +724,10 @@ export global Api {
     callback remote-connect(addresses: [string], port: int);
     callback remote-connect-manual(host-port: string);
     callback remote-disconnect();
+    callback remote-submit-pairing-code(code: string);
+    callback remote-cancel-pairing();
+    /// Digits in a pairing code, from `pairing::CODE_DIGITS`.
+    in-out property <int> remote-pairing-code-length;
 
     // ## SlintPad related APIs
     in-out property <bool> runs-in-slintpad;

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -152,6 +152,8 @@ spin_on = { workspace = true }
 tempfile = "3"
 # The remote connector tests talk to the real viewer-side connection.
 i-slint-live-preview = { path = "../../internal/live-preview", features = ["remote"] }
+tokio-tungstenite = "0.30.0"
+tokio = { version = "1.50.0", features = ["test-util"] }
 
 [build-dependencies]
 slint-build = { workspace = true, optional = true }

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -43,12 +43,17 @@ const RECONNECT_DELAY: Duration = Duration::from_secs(3);
 /// A device that blocks network for a backgrounded viewer can swallow
 /// packets; an uncapped dial would then hang for minutes on TCP retransmissions.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-/// How long the editor waits for each automatic step of the pairing
-/// handshake. The viewer enforces its own deadlines and closes the socket,
-/// but a dropped connection or a hostile peer delivers no close, so without
-/// this the editor's read would park forever and wedge the dialog on
-/// "Connecting" until the LSP is restarted. Generous: every automatic step
-/// is a local computation and a send, never a human.
+/// How long the editor gives one round of automatic handshake steps. The
+/// viewer enforces its own deadlines and closes the socket, but a dropped
+/// connection or a hostile peer delivers no close, so without a deadline
+/// the editor's read would park forever and wedge the dialog on
+/// "Connecting" until the LSP is restarted.
+///
+/// It bounds a whole round, not each read, so a peer can't dodge it by
+/// dribbling one ignorable frame just under the limit. The clock is reset
+/// only when the user makes progress -- typing a code, accepting a warning
+/// -- which is the one thing that legitimately takes real time. Generous:
+/// an automatic round is a couple of local computations and sends.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// What the user did with the pairing prompt.
@@ -487,7 +492,14 @@ impl RemoteLspToPreview {
         target: &str,
         keys: &[String],
     ) -> std::result::Result<(session::Sealing, session::Opening), ConnectError> {
-        let PreviewToLspMessage::PairingReady = Self::next_handshake_message(stream).await? else {
+        // One deadline for the automatic steps, reset whenever the user
+        // makes progress. A peer that dribbles ignorable frames can't push
+        // it back; only a human legitimately does.
+        let mut deadline = Self::handshake_deadline();
+
+        let PreviewToLspMessage::PairingReady =
+            Self::next_handshake_message(stream, deadline).await?
+        else {
             return Err(ConnectError::Transient(
                 "The viewer did not start the pairing handshake".into(),
             ));
@@ -501,7 +513,7 @@ impl RemoteLspToPreview {
         .await?;
 
         loop {
-            match Self::next_handshake_message(stream).await? {
+            match Self::next_handshake_message(stream, deadline).await? {
                 PreviewToLspMessage::PairingAccepted => {
                     // Only ever legitimate as "pairing is disabled on this
                     // viewer". A viewer that accepted our token proves so in
@@ -529,9 +541,12 @@ impl RemoteLspToPreview {
                     };
                     // `None` is a refused token: the viewer has told us to
                     // forget it and follows up with a code prompt, which the
-                    // next turn of this loop takes.
-                    if let Some(session) =
-                        Self::token_exchange(shared, stream, target, keys, &token, &element).await?
+                    // next turn of this loop takes. Shares the round's
+                    // deadline, so a peer can't reset it by re-challenging.
+                    if let Some(session) = Self::token_exchange(
+                        shared, stream, target, keys, &token, &element, deadline,
+                    )
+                    .await?
                     {
                         return Ok(session);
                     }
@@ -566,6 +581,9 @@ impl RemoteLspToPreview {
                     {
                         return Ok(session);
                     }
+                    // The user just typed a code, so the next automatic round
+                    // starts from a clean clock.
+                    deadline = Self::handshake_deadline();
                 }
                 other => {
                     tracing::warn!("Ignoring {other:?} from {target} during pairing");
@@ -595,8 +613,13 @@ impl RemoteLspToPreview {
         )
         .await?;
 
+        // The user just typed, so the viewer's confirmation is a fresh
+        // automatic round with its own clock.
         let handshake = pairing::Handshake::with_code(pairing::Role::Editor, &code);
-        match Self::run_exchange(stream, handshake, &prompt.element).await? {
+        let verdict =
+            Self::run_exchange(stream, handshake, &prompt.element, Self::handshake_deadline())
+                .await?;
+        match verdict {
             ExchangeVerdict::Confirmed(secrets) => {
                 tracing::info!("Paired with remote viewer at {target}");
                 shared.remember_token(keys, (secrets.token_id, secrets.token));
@@ -620,9 +643,10 @@ impl RemoteLspToPreview {
         keys: &[String],
         token: &Token,
         viewer_element: &pairing::Element,
+        deadline: tokio::time::Instant,
     ) -> std::result::Result<Option<(session::Sealing, session::Opening)>, ConnectError> {
         let handshake = pairing::Handshake::with_token(pairing::Role::Editor, token);
-        match Self::run_exchange(stream, handshake, viewer_element).await? {
+        match Self::run_exchange(stream, handshake, viewer_element, deadline).await? {
             ExchangeVerdict::Confirmed(secrets) => {
                 tracing::info!("Reconnected to remote viewer at {target} by token");
                 Ok(Some(secrets.session()))
@@ -648,6 +672,7 @@ impl RemoteLspToPreview {
         stream: &mut WebSocketStream,
         handshake: pairing::Handshake,
         viewer_element: &pairing::Element,
+        deadline: tokio::time::Instant,
     ) -> std::result::Result<ExchangeVerdict, ConnectError> {
         let our_element = handshake.element().clone();
         let secrets = handshake
@@ -666,7 +691,7 @@ impl RemoteLspToPreview {
         // The viewer answers with its own confirmation only if it derived
         // the same key, so this is where a wrong secret surfaces. Anything
         // else means it refused us.
-        match Self::next_handshake_message(stream).await? {
+        match Self::next_handshake_message(stream, deadline).await? {
             PreviewToLspMessage::PairingConfirm { confirmation }
                 if secrets.peer_confirms(&confirmation) =>
             {
@@ -791,16 +816,18 @@ impl RemoteLspToPreview {
             .map_err(|err| ConnectError::Transient(format!("Failed sending to the viewer: {err}")))
     }
 
-    /// The next handshake message, or a transient error if the viewer goes
-    /// silent for [`HANDSHAKE_TIMEOUT`]. Every automatic step of the
-    /// handshake reads through this, so a dropped connection or a peer that
-    /// stops answering fails the connect instead of hanging it forever. The
-    /// waits a human drives use [`Self::next_message`] directly: there the
-    /// user's Cancel and the viewer's own deadline bound the wait.
+    /// The next handshake message, or a transient error once `deadline`
+    /// passes. Every automatic step reads through this against a shared
+    /// per-round deadline, so a dropped connection or a peer that stops
+    /// answering -- or dribbles ignorable frames -- fails the connect
+    /// instead of hanging it forever. The waits a human drives use
+    /// [`Self::next_message`] directly: there the user's Cancel and the
+    /// viewer's own deadline bound the wait.
     async fn next_handshake_message(
         stream: &mut WebSocketStream,
+        deadline: tokio::time::Instant,
     ) -> std::result::Result<PreviewToLspMessage, ConnectError> {
-        match tokio::time::timeout(HANDSHAKE_TIMEOUT, Self::next_message(stream)).await {
+        match tokio::time::timeout_at(deadline, Self::next_message(stream)).await {
             Ok(Some(message)) => Ok(message),
             Ok(None) => Err(ConnectError::Transient(
                 "The viewer closed the connection during pairing".into(),
@@ -809,6 +836,11 @@ impl RemoteLspToPreview {
                 Err(ConnectError::Transient("The viewer stopped responding during pairing".into()))
             }
         }
+    }
+
+    /// A fresh deadline for the next round of automatic steps.
+    fn handshake_deadline() -> tokio::time::Instant {
+        tokio::time::Instant::now() + HANDSHAKE_TIMEOUT
     }
 
     /// Next protocol message, or `None` if the socket ended or carried
@@ -1943,20 +1975,23 @@ mod tests {
             .await;
     }
 
-    /// A hand-rolled viewer that completes the WebSocket upgrade and then
-    /// goes quiet, to stand in for a peer whose connection dropped without a
-    /// close: a sleeping laptop, a backgrounded phone, or a hostile host.
-    /// Optionally sends `PairingReady` first, to stall a step deeper in.
-    ///
-    /// Returns the port it listens on; the spawned task holds the socket for
-    /// the test's lifetime.
-    async fn silent_viewer(send_ready: bool) -> u16 {
+    type RawViewer = tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>;
+
+    /// Stand in for a peer that completes the WebSocket upgrade and then
+    /// misbehaves in a way the real viewer never would, so its handshake
+    /// can't be driven by the real `Connection`. `behavior` gets the
+    /// upgraded socket to do as it likes; the spawned task holds it for the
+    /// test's lifetime. Returns the port to dial.
+    async fn raw_viewer<Fut>(behavior: impl FnOnce(RawViewer) -> Fut + 'static) -> u16
+    where
+        Fut: Future<Output = ()>,
+    {
         use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
         use tokio_tungstenite::tungstenite::http::{HeaderValue, header::SEC_WEBSOCKET_PROTOCOL};
 
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
         let port = listener.local_addr().unwrap().port();
-        tokio::spawn(async move {
+        tokio::task::spawn_local(async move {
             let (stream, _) = listener.accept().await.unwrap();
             // Echo the subprotocol back, or the client refuses the upgrade.
             let select_protocol = |_req: &Request, mut response: Response| {
@@ -1965,19 +2000,26 @@ mod tests {
                     .insert(SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_static(PROTOCOL_SUBPROTOCOL));
                 Ok::<_, ErrorResponse>(response)
             };
-            let mut ws =
-                tokio_tungstenite::accept_hdr_async(stream, select_protocol).await.unwrap();
-            if send_ready {
-                let ready = postcard::to_allocvec(&PreviewToLspMessage::PairingReady).unwrap();
-                ws.send(tokio_tungstenite::tungstenite::Message::Binary(ready.into()))
-                    .await
-                    .unwrap();
-            }
-            // Say nothing more, ever, but keep the socket open so the client
-            // gets no close frame to react to.
-            std::future::pending::<()>().await;
+            let ws = tokio_tungstenite::accept_hdr_async(stream, select_protocol).await.unwrap();
+            behavior(ws).await;
         });
         port
+    }
+
+    async fn send_frame(ws: &mut RawViewer, message: &PreviewToLspMessage) {
+        let bytes = postcard::to_allocvec(message).unwrap();
+        ws.send(tokio_tungstenite::tungstenite::Message::Binary(bytes.into())).await.unwrap();
+    }
+
+    /// Fail every dialed connection and expect the dialog to be told, so the
+    /// user is never stuck on "Connecting".
+    async fn expect_connect_failure(port: u16) {
+        let (_previews, connector, mut state_rx, _to_lsp_rx) = connector_with_states();
+        connector
+            .connect(["127.0.0.1"], port)
+            .await
+            .expect_err("a misbehaving viewer must not produce a connection");
+        expect_state(&mut state_rx, RemoteConnectionState::Failed).await;
     }
 
     /// A viewer that answers the upgrade and then falls silent must not wedge
@@ -1988,17 +2030,39 @@ mod tests {
     async fn a_silent_viewer_does_not_hang_the_connector() {
         tokio::task::LocalSet::new()
             .run_until(async {
-                for send_ready in [false, true] {
-                    let port = silent_viewer(send_ready).await;
-                    let (_previews, connector, mut state_rx, _to_lsp_rx) = connector_with_states();
+                // Silent from the very first read.
+                let port = raw_viewer(|_ws| std::future::pending()).await;
+                expect_connect_failure(port).await;
 
-                    connector
-                        .connect(["127.0.0.1"], port)
-                        .await
-                        .expect_err("a silent viewer must not produce a connection");
-                    // The dialog is told, so the user isn't stuck on "Connecting".
-                    expect_state(&mut state_rx, RemoteConnectionState::Failed).await;
-                }
+                // Silent after one legitimate message, a step deeper in.
+                let port = raw_viewer(|mut ws| async move {
+                    send_frame(&mut ws, &PreviewToLspMessage::PairingReady).await;
+                    std::future::pending::<()>().await;
+                })
+                .await;
+                expect_connect_failure(port).await;
+            })
+            .await;
+    }
+
+    /// A per-read timeout alone would let a peer keep the handshake alive
+    /// forever by dribbling one ignorable frame just under the limit. The
+    /// deadline bounds the whole round, so this fails all the same.
+    #[tokio::test(start_paused = true)]
+    async fn a_dribbling_viewer_does_not_hang_the_connector() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let port = raw_viewer(|mut ws| async move {
+                    send_frame(&mut ws, &PreviewToLspMessage::PairingReady).await;
+                    // An ignorable frame, forever, each just inside the read
+                    // budget a per-read timeout would have reset to.
+                    loop {
+                        send_frame(&mut ws, &PreviewToLspMessage::Pong).await;
+                        tokio::time::sleep(HANDSHAKE_TIMEOUT - Duration::from_secs(1)).await;
+                    }
+                })
+                .await;
+                expect_connect_failure(port).await;
             })
             .await;
     }

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -20,7 +20,7 @@ use futures_util::{
     lock::Mutex,
     stream::{SplitSink, SplitStream, StreamExt as _},
 };
-use i_slint_live_preview::protocol::pairing::{self, MAX_ATTEMPTS, Token};
+use i_slint_live_preview::protocol::pairing::{self, MAX_ATTEMPTS, Token, TokenId};
 use i_slint_live_preview::protocol::session;
 use i_slint_live_preview::protocol::{
     LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PairingRejection, PreviewToLspMessage,
@@ -152,10 +152,11 @@ struct SharedState {
     /// Bumped on every user-driven connect or disconnect.
     /// Tasks spawned for an older generation stand down.
     generation: Rc<Cell<u64>>,
-    /// Pairing tokens, stored under every `address:port` the viewer that
-    /// issued them was known by. Held in memory only, mirroring the viewer:
-    /// it forgets them when it restarts, and re-pairing is one prompt.
-    tokens: Rc<RefCell<HashMap<String, Token>>>,
+    /// Pairing tokens and their public ids, stored under every
+    /// `address:port` the viewer that issued them was known by. Held in
+    /// memory only, mirroring the viewer: it forgets them when it restarts,
+    /// and re-pairing is one prompt.
+    tokens: Rc<RefCell<HashMap<String, (TokenId, Token)>>>,
     /// Set while a viewer is showing a code and we're waiting for the user
     /// to type it. The preview UI's submission arrives through here.
     pairing_input: Rc<RefCell<Option<mpsc::UnboundedSender<PairingSubmission>>>>,
@@ -415,42 +416,59 @@ impl RemoteLspToPreview {
     /// Complete the pairing exchange on a freshly connected socket.
     ///
     /// See [`i_slint_live_preview::protocol::pairing`] for the shape of it.
-    /// A reconnect where we still hold the viewer's token finishes in one
-    /// round trip and never reaches the user.
+    /// A reconnect where we still hold the viewer's token runs the exchange
+    /// with the token as the secret and never reaches the user.
     async fn authenticate(
         shared: &SharedState,
         stream: &mut WebSocketStream,
         target: &str,
         keys: &[String],
     ) -> std::result::Result<(session::Sealing, session::Opening), ConnectError> {
-        let Some(PreviewToLspMessage::PairingChallenge { nonce }) =
-            Self::next_message(stream).await
-        else {
+        let Some(PreviewToLspMessage::PairingReady) = Self::next_message(stream).await else {
             return Err(ConnectError::Transient(
                 "The viewer did not start the pairing handshake".into(),
             ));
         };
 
         let held = keys.iter().find_map(|key| shared.tokens.borrow().get(key).copied());
-        let token_proof = held.map(|token| pairing::token_proof(&token, &nonce));
-        Self::send_message(stream, &LspToPreviewMessage::PairingHello { token_proof }).await?;
+        Self::send_message(
+            stream,
+            &LspToPreviewMessage::PairingHello { token: held.map(|(id, _)| id) },
+        )
+        .await?;
 
         loop {
             match Self::next_message(stream).await {
                 Some(PreviewToLspMessage::PairingAccepted) => {
-                    tracing::info!("Paired with remote viewer at {target}");
-                    // A token we hold was accepted, or the viewer runs with
-                    // `--no-pairing` and there is no secret to key a session.
-                    return Ok(match held {
-                        Some(token) => {
-                            pairing::session_from_token(pairing::Role::Editor, &token, &nonce)
-                        }
-                        None => (session::Sealing::Plaintext, session::Opening::Plaintext),
-                    });
+                    // Only ever legitimate as "pairing is disabled on this
+                    // viewer". A viewer that accepted our token proves so in
+                    // the exchange instead, so nothing gets to skip it.
+                    if held.is_some() {
+                        return Err(ConnectError::Transient(
+                            "The viewer skipped the reconnect exchange".into(),
+                        ));
+                    }
+                    tracing::info!("Viewer at {target} has pairing disabled");
+                    return Ok((session::Sealing::Plaintext, session::Opening::Plaintext));
+                }
+                Some(PreviewToLspMessage::PairingTokenChallenge { element }) => {
+                    let Some((_, token)) = held else {
+                        return Err(ConnectError::Transient(
+                            "The viewer opened an exchange for a token we never announced".into(),
+                        ));
+                    };
+                    // `None` is a refused token: the viewer has told us to
+                    // forget it and follows up with a code prompt, which the
+                    // next turn of this loop takes.
+                    if let Some(session) =
+                        Self::token_exchange(shared, stream, target, keys, &token, &element).await?
+                    {
+                        return Ok(session);
+                    }
                 }
                 Some(PreviewToLspMessage::PairingConfirm { .. }) => {
                     // Only meaningful as the answer to a response we sent;
-                    // the exchange below handles it inline.
+                    // the exchanges handle it inline.
                     tracing::warn!("Unexpected pairing confirmation from {target}");
                 }
                 Some(PreviewToLspMessage::PairingRejected { reason }) => {
@@ -520,7 +538,7 @@ impl RemoteLspToPreview {
         // The code never goes on the wire, and neither does anything an
         // observer could test a guess against: the exchange only reveals
         // whether both sides agreed.
-        let handshake = pairing::Handshake::start(pairing::Role::Editor, &code);
+        let handshake = pairing::Handshake::with_code(pairing::Role::Editor, &code);
         let our_element = handshake.element().clone();
         let secrets = handshake
             .finish(&prompt.element)
@@ -543,10 +561,10 @@ impl RemoteLspToPreview {
                 if confirmation.matches(&secrets.viewer_confirmation) =>
             {
                 tracing::info!("Paired with remote viewer at {target}");
-                let token = secrets.token;
+                let issued = (secrets.token_id, secrets.token);
                 let mut tokens = shared.tokens.borrow_mut();
                 for key in keys {
-                    tokens.insert(key.clone(), token);
+                    tokens.insert(key.clone(), issued);
                 }
                 Ok(Some(secrets.session()))
             }
@@ -557,6 +575,63 @@ impl RemoteLspToPreview {
             }
             Some(PreviewToLspMessage::PairingRejected { reason }) => {
                 if reason == PairingRejection::BadCode {
+                    return Ok(None);
+                }
+                Err(from_rejection(reason))
+            }
+            _ => Err(ConnectError::Transient(
+                "The viewer closed the connection during pairing".into(),
+            )),
+        }
+    }
+
+    /// The editor's half of the reconnect exchange: prove the token, check
+    /// the viewer proved it too, and key the session from the fresh secrets.
+    ///
+    /// `Ok(None)` is a refused token; the caller forgets it and falls
+    /// through to the code prompt the viewer sends next.
+    async fn token_exchange(
+        shared: &SharedState,
+        stream: &mut WebSocketStream,
+        target: &str,
+        keys: &[String],
+        token: &Token,
+        viewer_element: &pairing::Element,
+    ) -> std::result::Result<Option<(session::Sealing, session::Opening)>, ConnectError> {
+        let handshake = pairing::Handshake::with_token(pairing::Role::Editor, token);
+        let our_element = handshake.element().clone();
+        let secrets = handshake
+            .finish(viewer_element)
+            .map_err(|_| ConnectError::Transient("The viewer sent a malformed handshake".into()))?;
+
+        Self::send_message(
+            stream,
+            &LspToPreviewMessage::PairingResponse {
+                element: our_element,
+                confirmation: secrets.editor_confirmation,
+            },
+        )
+        .await?;
+
+        match Self::next_message(stream).await {
+            Some(PreviewToLspMessage::PairingConfirm { confirmation })
+                if confirmation.matches(&secrets.viewer_confirmation) =>
+            {
+                tracing::info!("Reconnected to remote viewer at {target} by token");
+                Ok(Some(secrets.session()))
+            }
+            // The real viewer knows the token it issued, so a failed
+            // confirmation means someone else is answering. Keep the token:
+            // it is still good against the real viewer.
+            Some(PreviewToLspMessage::PairingConfirm { .. }) => {
+                Err(ConnectError::Transient("The viewer could not confirm the reconnect".into()))
+            }
+            Some(PreviewToLspMessage::PairingRejected { reason }) => {
+                if reason == PairingRejection::BadToken {
+                    let mut tokens = shared.tokens.borrow_mut();
+                    for key in keys {
+                        tokens.remove(key);
+                    }
                     return Ok(None);
                 }
                 Err(from_rejection(reason))
@@ -1249,6 +1324,85 @@ mod tests {
                 };
                 let PreviewToLspMessage::RequestState { files, .. } = asked else { unreachable!() };
                 assert_eq!(files, vec![url]);
+
+                connector.disconnect().await;
+            })
+            .await;
+    }
+
+    /// A second connect to a viewer we already paired with rides the token:
+    /// the reconnect exchange runs on its own, no code reaches any screen,
+    /// and the replacing session is sealed with fresh keys.
+    #[tokio::test]
+    async fn a_second_connect_needs_no_code() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+                pair(&connector, &mut viewer_rx, port).await.expect("pairing failed");
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Connected { .. }),
+                    "the first connection",
+                )
+                .await;
+
+                // Nobody is around to type a code: a reconnect that put up
+                // a prompt would hang here until the timeout fails the test.
+                tokio::time::timeout(
+                    Duration::from_secs(15),
+                    connector.connect(["127.0.0.1"], port),
+                )
+                .await
+                .expect("the reconnect waited for a code")
+                .expect("the token reconnect failed");
+
+                // The viewer admitted it without touching the screen ...
+                let event = expect_message(
+                    &mut viewer_rx,
+                    |m| {
+                        matches!(
+                            m,
+                            ConnectionMessage::Connected { .. }
+                                | ConnectionMessage::PairingStarted { .. }
+                        )
+                    },
+                    "the second connection",
+                )
+                .await;
+                assert!(
+                    matches!(event, ConnectionMessage::Connected { .. }),
+                    "the reconnect put a code on the screen"
+                );
+
+                // ... and both ends agree on the fresh keys: a frame crosses
+                // the new session in each direction.
+                connector.send(&LspToPreviewMessage::ShowPreview(PreviewComponent {
+                    url: Url::parse("file:///fresh.slint").unwrap(),
+                    component: None,
+                }));
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::ShowPreview { .. }),
+                    "ShowPreview to arrive over the new session",
+                )
+                .await;
+                viewer
+                    .send(PreviewToLspMessage::Diagnostics {
+                        uri: Url::parse("file:///fresh.slint").unwrap(),
+                        version: None,
+                        diagnostics: Vec::new(),
+                    })
+                    .unwrap();
+                expect_message(
+                    &mut to_lsp_rx,
+                    |m| matches!(m, PreviewToLspMessage::Diagnostics { .. }),
+                    "diagnostics to arrive over the new session",
+                )
+                .await;
 
                 connector.disconnect().await;
             })

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -8,7 +8,7 @@
 //! [`crate::preview::remote`].
 
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
@@ -180,10 +180,6 @@ struct SharedState {
     /// memory only, mirroring the viewer: it forgets them when it restarts,
     /// and re-pairing is one prompt.
     tokens: Rc<RefCell<HashMap<String, (TokenId, Token)>>>,
-    /// Every `address:port` the user has agreed to talk to unencrypted,
-    /// because the viewer there has pairing disabled. Held for the LSP's
-    /// run, like `tokens`, so a reconnect doesn't ask the same question.
-    unpaired_ok: Rc<RefCell<HashSet<String>>>,
     /// Set while a viewer is showing a code and we're waiting for the user
     /// to type it. The preview UI's submission arrives through here.
     pairing_input: Rc<RefCell<Option<mpsc::UnboundedSender<PairingSubmission>>>>,
@@ -222,19 +218,6 @@ impl SharedState {
         }
     }
 
-    /// Remember the user's ok to talk to this viewer unencrypted.
-    fn allow_unpaired(&self, keys: &[String]) {
-        let mut unpaired_ok = self.unpaired_ok.borrow_mut();
-        for key in keys {
-            unpaired_ok.insert(key.clone());
-        }
-    }
-
-    fn unpaired_allowed(&self, keys: &[String]) -> bool {
-        let unpaired_ok = self.unpaired_ok.borrow();
-        keys.iter().any(|key| unpaired_ok.contains(key))
-    }
-
     /// Forward a connection-state transition to the local preview dialog.
     fn emit_state(&self, state: RemoteConnectionState, target: String, error: Option<String>) {
         RemoteLspToPreview::emit_state(&self.to_previews, state, target, error);
@@ -257,7 +240,6 @@ impl RemoteLspToPreview {
                 to_previews,
                 generation: Rc::default(),
                 tokens: Rc::default(),
-                unpaired_ok: Rc::default(),
                 pairing_input: Rc::default(),
                 connected_target: Rc::default(),
             },
@@ -523,13 +505,13 @@ impl RemoteLspToPreview {
                             "The viewer skipped the reconnect exchange".into(),
                         ));
                     }
-                    // Anyone can claim this, so the user gets asked before
-                    // anything is sent over what would be a plaintext
-                    // session -- once per target, not on every reconnect.
-                    if !shared.unpaired_allowed(keys) {
-                        Self::confirm_unpaired(shared, stream, target).await?;
-                        shared.allow_unpaired(keys);
-                    }
+                    // Anyone can claim this, so the user is asked every time
+                    // before anything is sent over what would be a plaintext
+                    // session. Not remembered: the endpoint at an address can
+                    // change between reconnects, and there is no key to bind
+                    // consent to, so each unencrypted connection is its own
+                    // decision.
+                    Self::confirm_unpaired(shared, stream, target).await?;
                     tracing::info!("Viewer at {target} has pairing disabled");
                     return Ok((session::Sealing::Plaintext, session::Opening::Plaintext));
                 }
@@ -1374,20 +1356,29 @@ mod tests {
                 drop(viewer_rx);
                 let (_viewer, mut viewer_rx) = listen(port, PairingPolicy::Disabled).await;
 
-                // The connector reconnects on its own ...
-                expect_message(
-                    &mut viewer_rx,
-                    |m| matches!(m, ConnectionMessage::Connected { .. }),
-                    "viewer reconnection",
-                )
-                .await;
-                // ... and asks the LSP to re-push the preview state.
-                expect_message(
-                    &mut to_lsp_rx,
-                    |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
-                    "RequestState after reconnecting",
-                )
-                .await;
+                // The connector reconnects on its own, but an unpaired viewer
+                // is never silently trusted, so the reconnect warns again and
+                // the user accepts.
+                let accept = async {
+                    wait_for_prompt(&connector).await;
+                    connector.accept_unpaired_connection();
+                };
+                let observe = async {
+                    expect_message(
+                        &mut viewer_rx,
+                        |m| matches!(m, ConnectionMessage::Connected { .. }),
+                        "viewer reconnection",
+                    )
+                    .await;
+                    // ... and asks the LSP to re-push the preview state.
+                    expect_message(
+                        &mut to_lsp_rx,
+                        |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
+                        "RequestState after reconnecting",
+                    )
+                    .await;
+                };
+                tokio::join!(accept, observe);
 
                 connector.disconnect().await;
             })
@@ -1852,7 +1843,9 @@ mod tests {
     }
 
     /// A viewer with pairing disabled cannot be connected to silently: the
-    /// user is warned first, and their answer holds for reconnects.
+    /// user is warned first. Consent is never remembered, so a fresh
+    /// connection warns again -- there is no stored answer for a peer to
+    /// slip past or for a reused address to inherit.
     #[tokio::test]
     async fn an_unpaired_viewer_needs_the_users_ok() {
         tokio::task::LocalSet::new()
@@ -1862,6 +1855,7 @@ mod tests {
 
                 let (_previews, connector, mut state_rx, _to_lsp_rx) = connector_with_states();
 
+                // Warned, accepted, connected.
                 let connect = connector.connect(["127.0.0.1"], port);
                 let accept = async {
                     expect_state(&mut state_rx, RemoteConnectionState::UnpairedWarning).await;
@@ -1875,25 +1869,17 @@ mod tests {
                     "viewer connection",
                 )
                 .await;
+                while state_rx.try_recv().is_ok() {}
 
-                // The viewer restarts. The reconnect must not ask again: if
-                // it did, nobody would answer and this would time out.
-                drop(viewer);
-                drop(viewer_rx);
-                let (_viewer, mut viewer_rx) = listen(port, PairingPolicy::Disabled).await;
-                expect_message(
-                    &mut viewer_rx,
-                    |m| matches!(m, ConnectionMessage::Connected { .. }),
-                    "viewer reconnection",
-                )
-                .await;
-                while let Ok((state, _)) = state_rx.try_recv() {
-                    assert_ne!(
-                        state,
-                        RemoteConnectionState::UnpairedWarning,
-                        "the reconnect asked the user again"
-                    );
-                }
+                // A second connection to the same viewer must warn again: the
+                // earlier acceptance was not stored.
+                let connect = connector.connect(["127.0.0.1"], port);
+                let accept = async {
+                    expect_state(&mut state_rx, RemoteConnectionState::UnpairedWarning).await;
+                    connector.accept_unpaired_connection();
+                };
+                let (result, ()) = tokio::join!(connect, accept);
+                result.expect("the second connection should warn, then complete once accepted");
 
                 connector.disconnect().await;
             })

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -20,7 +20,8 @@ use futures_util::{
     lock::Mutex,
     stream::{SplitSink, SplitStream, StreamExt as _},
 };
-use i_slint_live_preview::protocol::pairing::{self, Credential, MAX_ATTEMPTS, Token};
+use i_slint_live_preview::protocol::pairing::{self, MAX_ATTEMPTS, Token};
+use i_slint_live_preview::protocol::session;
 use i_slint_live_preview::protocol::{
     LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PairingRejection, PreviewToLspMessage,
     RemoteConnectionState, SLINT_PROTOCOLS_HEADER, SLINT_VERSION, SLINT_VERSION_HEADER,
@@ -47,6 +48,14 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 enum PairingSubmission {
     Code(String),
     Cancel,
+}
+
+/// One `PairingRequired` message's worth of prompt, as handed to
+/// [`RemoteLspToPreview::answer_prompt`].
+struct Prompt {
+    attempts_left: u8,
+    expires_in_seconds: u16,
+    element: pairing::Element,
 }
 
 /// Why a dial attempt produced no session.
@@ -106,11 +115,28 @@ impl Drop for PairingInputGuard {
 
 struct RemoteLspConnection {
     sender: SplitSink<WebSocketStream, Message>,
+    /// Seals outbound frames; a passthrough with `--no-pairing`, which
+    /// establishes no shared secret.
+    sealing: session::Sealing,
     task: tokio::task::JoinHandle<()>,
     /// Set when this connection is being replaced, so the old handle's
     /// `Drop` skips its `Disconnected` emission and the UI doesn't see
     /// Disconnected racing Connected for the new peer.
     replaced: Arc<AtomicBool>,
+}
+
+impl RemoteLspConnection {
+    /// Seal `bytes` into a frame for this connection. `None` only on counter
+    /// exhaustion, which is logged here so every send path handles it alike.
+    fn seal(&mut self, bytes: Vec<u8>) -> Option<Message> {
+        match self.sealing.seal(bytes) {
+            Ok(sealed) => Some(Message::binary(sealed)),
+            Err(err) => {
+                tracing::error!("Cannot seal outbound frame: {err:?}");
+                None
+            }
+        }
+    }
 }
 
 /// State shared between the connector and its spawned tasks.
@@ -232,7 +258,8 @@ impl RemoteLspToPreview {
             let Some(connection) = connection.as_mut() else {
                 return;
             };
-            if let Err(err) = connection.sender.send(Message::binary(message)).await {
+            let Some(frame) = connection.seal(message) else { return };
+            if let Err(err) = connection.sender.send(frame).await {
                 tracing::error!("Error sending message to remote preview server: {err}");
             }
         });
@@ -340,7 +367,7 @@ impl RemoteLspToPreview {
         // the dial varies between attempts. Remember its token under all of
         // them, or a reconnect that lands elsewhere asks for a code again.
         let keys: Vec<String> = addresses.iter().map(|a| format!("{a}:{port}")).collect();
-        Self::authenticate(shared, &mut stream, &target, &keys).await?;
+        let (sealing, opening) = Self::authenticate(shared, &mut stream, &target, &keys).await?;
 
         if shared.generation.get() != generation {
             tracing::info!("Discarding connection to {target}: superseded during pairing");
@@ -358,9 +385,11 @@ impl RemoteLspToPreview {
             port,
             replaced.clone(),
             generation,
+            opening,
         ));
         if let Some(mut old) = shared.connection.lock().await.replace(RemoteLspConnection {
             sender: socket_sender,
+            sealing,
             task,
             replaced,
         }) {
@@ -393,7 +422,7 @@ impl RemoteLspToPreview {
         stream: &mut WebSocketStream,
         target: &str,
         keys: &[String],
-    ) -> std::result::Result<(), ConnectError> {
+    ) -> std::result::Result<(session::Sealing, session::Opening), ConnectError> {
         let Some(PreviewToLspMessage::PairingChallenge { nonce }) =
             Self::next_message(stream).await
         else {
@@ -402,31 +431,27 @@ impl RemoteLspToPreview {
             ));
         };
 
-        let token_proof = keys
-            .iter()
-            .find_map(|key| shared.tokens.borrow().get(key).copied())
-            .map(|token| pairing::proof(Credential::Token, token.as_bytes(), &nonce));
+        let held = keys.iter().find_map(|key| shared.tokens.borrow().get(key).copied());
+        let token_proof = held.map(|token| pairing::token_proof(&token, &nonce));
         Self::send_message(stream, &LspToPreviewMessage::PairingHello { token_proof }).await?;
-
-        // The code we last offered, kept so the token can be derived from it
-        // once the viewer accepts.
-        let mut submitted_code: Option<String> = None;
 
         loop {
             match Self::next_message(stream).await {
                 Some(PreviewToLspMessage::PairingAccepted) => {
-                    // Derived from what we just proved, so the viewer never
-                    // had to send it. Absent when the token we already held
-                    // was the thing accepted, or when pairing is disabled.
-                    if let Some(code) = &submitted_code {
-                        let token = pairing::derive_token(code, &nonce);
-                        let mut tokens = shared.tokens.borrow_mut();
-                        for key in keys {
-                            tokens.insert(key.clone(), token);
-                        }
-                    }
                     tracing::info!("Paired with remote viewer at {target}");
-                    return Ok(());
+                    // A token we hold was accepted, or the viewer runs with
+                    // `--no-pairing` and there is no secret to key a session.
+                    return Ok(match held {
+                        Some(token) => {
+                            pairing::session_from_token(pairing::Role::Editor, &token, &nonce)
+                        }
+                        None => (session::Sealing::Plaintext, session::Opening::Plaintext),
+                    });
+                }
+                Some(PreviewToLspMessage::PairingConfirm { .. }) => {
+                    // Only meaningful as the answer to a response we sent;
+                    // the exchange below handles it inline.
+                    tracing::warn!("Unexpected pairing confirmation from {target}");
                 }
                 Some(PreviewToLspMessage::PairingRejected { reason }) => {
                     tracing::info!("Viewer at {target} rejected us: {reason}");
@@ -448,19 +473,16 @@ impl RemoteLspToPreview {
                 Some(PreviewToLspMessage::PairingRequired {
                     attempts_left,
                     expires_in_seconds,
+                    element,
                 }) => {
-                    let code = Self::prompt_for_code(
-                        shared,
-                        stream,
-                        target,
-                        attempts_left,
-                        expires_in_seconds,
-                    )
-                    .await?;
-                    let proof = pairing::proof(Credential::Code, code.as_bytes(), &nonce);
-                    submitted_code = Some(code);
-                    Self::send_message(stream, &LspToPreviewMessage::PairingCodeProof { proof })
-                        .await?;
+                    let prompt = Prompt { attempts_left, expires_in_seconds, element };
+                    // `None` is a wrong code: the viewer follows up with a
+                    // fresh prompt, which the next turn of this loop takes.
+                    if let Some(session) =
+                        Self::answer_prompt(shared, stream, target, keys, prompt).await?
+                    {
+                        return Ok(session);
+                    }
                 }
                 Some(other) => {
                     tracing::warn!("Ignoring {other:?} from {target} during pairing");
@@ -471,6 +493,77 @@ impl RemoteLspToPreview {
                     ));
                 }
             }
+        }
+    }
+
+    /// Answer one code prompt: ask the user, run the editor's half of the
+    /// SPAKE2 exchange, and check the viewer's confirmation.
+    ///
+    /// `Ok(None)` is a wrong code with attempts left; the viewer sends a
+    /// fresh prompt and the caller goes around again.
+    async fn answer_prompt(
+        shared: &SharedState,
+        stream: &mut WebSocketStream,
+        target: &str,
+        keys: &[String],
+        prompt: Prompt,
+    ) -> std::result::Result<Option<(session::Sealing, session::Opening)>, ConnectError> {
+        let code = Self::prompt_for_code(
+            shared,
+            stream,
+            target,
+            prompt.attempts_left,
+            prompt.expires_in_seconds,
+        )
+        .await?;
+
+        // The code never goes on the wire, and neither does anything an
+        // observer could test a guess against: the exchange only reveals
+        // whether both sides agreed.
+        let handshake = pairing::Handshake::start(pairing::Role::Editor, &code);
+        let our_element = handshake.element().clone();
+        let secrets = handshake
+            .finish(&prompt.element)
+            .map_err(|_| ConnectError::Transient("The viewer sent a malformed handshake".into()))?;
+
+        Self::send_message(
+            stream,
+            &LspToPreviewMessage::PairingResponse {
+                element: our_element,
+                confirmation: secrets.editor_confirmation,
+            },
+        )
+        .await?;
+
+        // The viewer answers with its own confirmation only if it derived
+        // the same key, so this is where a wrong code surfaces. Anything
+        // else means it refused us.
+        match Self::next_message(stream).await {
+            Some(PreviewToLspMessage::PairingConfirm { confirmation })
+                if confirmation.matches(&secrets.viewer_confirmation) =>
+            {
+                tracing::info!("Paired with remote viewer at {target}");
+                let token = secrets.token;
+                let mut tokens = shared.tokens.borrow_mut();
+                for key in keys {
+                    tokens.insert(key.clone(), token);
+                }
+                Ok(Some(secrets.session()))
+            }
+            Some(PreviewToLspMessage::PairingConfirm { .. }) => {
+                // Same code space, different key: either we typed the wrong
+                // code or something is in the middle.
+                Err(ConnectError::Transient("The viewer could not confirm the pairing".into()))
+            }
+            Some(PreviewToLspMessage::PairingRejected { reason }) => {
+                if reason == PairingRejection::BadCode {
+                    return Ok(None);
+                }
+                Err(from_rejection(reason))
+            }
+            _ => Err(ConnectError::Transient(
+                "The viewer closed the connection during pairing".into(),
+            )),
         }
     }
 
@@ -565,6 +658,7 @@ impl RemoteLspToPreview {
         port: u16,
         replaced: Arc<AtomicBool>,
         generation: u64,
+        opening: session::Opening,
     ) {
         let last_pong = Cell::new(Instant::now());
         let receive = Self::receive_task(
@@ -574,6 +668,7 @@ impl RemoteLspToPreview {
             port,
             replaced,
             &last_pong,
+            opening,
         );
         let keepalive = Self::keepalive_task(&shared, &last_pong);
         tokio::select! {
@@ -587,7 +682,6 @@ impl RemoteLspToPreview {
     /// session — when pongs stay out for [`PONG_TIMEOUT`] or sending fails.
     async fn keepalive_task(shared: &SharedState, last_pong: &Cell<Instant>) {
         let Ok(ping) = postcard::to_allocvec(&LspToPreviewMessage::Ping) else { return };
-        let ping = Message::binary(ping);
         loop {
             tokio::time::sleep(PING_INTERVAL).await;
             if last_pong.get().elapsed() > PONG_TIMEOUT {
@@ -598,9 +692,12 @@ impl RemoteLspToPreview {
             }
             let mut guard = shared.connection.lock().await;
             let Some(connection) = guard.as_mut() else { return };
+            // Sealed like any other payload; a fresh nonce each time, so the
+            // repeated plaintext doesn't repeat on the wire.
+            let Some(frame) = connection.seal(ping.clone()) else { return };
             // Bound the send: it holds the connection lock, which would
             // otherwise block all LSP→viewer sends behind a stalled socket.
-            match tokio::time::timeout(PONG_TIMEOUT, connection.sender.send(ping.clone())).await {
+            match tokio::time::timeout(PONG_TIMEOUT, connection.sender.send(frame)).await {
                 Ok(Ok(())) => {}
                 Ok(Err(err)) => {
                     tracing::warn!("Failed sending keepalive ping to remote viewer: {err}");
@@ -663,6 +760,7 @@ impl RemoteLspToPreview {
         port: u16,
         replaced: Arc<AtomicBool>,
         last_pong: &Cell<Instant>,
+        mut opening: session::Opening,
     ) {
         let mut connection_state_handle =
             ConnectionStateHandle::new(shared.to_previews.clone(), address, port, replaced);
@@ -677,7 +775,16 @@ impl RemoteLspToPreview {
                             );
                         }
                         Message::Binary(bytes) => {
-                            match postcard::from_bytes::<PreviewToLspMessage>(&bytes) {
+                            let Ok(plain) = opening.open(&bytes) else {
+                                // Tampered, reordered, or from a peer that
+                                // derived a different key. The counters
+                                // can't recover, so the session is over.
+                                tracing::error!(
+                                    "Dropping a frame from the remote viewer that failed to open"
+                                );
+                                return;
+                            };
+                            match postcard::from_bytes::<PreviewToLspMessage>(&plain) {
                                 Ok(PreviewToLspMessage::Pong) => {
                                     last_pong.set(Instant::now());
                                 }
@@ -894,7 +1001,9 @@ fn describe_version_mismatch(err: &tokio_tungstenite_wasm::Error) -> Option<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+    use i_slint_live_preview::protocol::PreviewComponent;
     use i_slint_live_preview::remote::{Connection, ConnectionMessage, PairingPolicy};
+    use lsp_types::Url;
 
     async fn listen(
         port: u16,
@@ -1082,6 +1191,64 @@ mod tests {
                     "RequestState after pairing",
                 )
                 .await;
+
+                connector.disconnect().await;
+            })
+            .await;
+    }
+
+    /// A code exchange leaves both ends holding session keys, so from there on
+    /// every frame has to survive the cipher. The `PairingPolicy::Disabled`
+    /// tests can't cover this: no keys, no sealing, so a missing seal or open
+    /// passes them.
+    #[tokio::test]
+    async fn traffic_over_a_paired_session_is_sealed_both_ways() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+                pair(&connector, &mut viewer_rx, port).await.expect("pairing failed");
+
+                // The connector pushes this one locally on connect. Take it
+                // out of the way so the one asserted below can only have come
+                // off the wire.
+                expect_message(
+                    &mut to_lsp_rx,
+                    |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
+                    "the local RequestState after pairing",
+                )
+                .await;
+
+                let url = Url::parse("file:///sealed.slint").unwrap();
+                connector.send(&LspToPreviewMessage::ShowPreview(PreviewComponent {
+                    url: url.clone(),
+                    component: None,
+                }));
+
+                // The viewer opened the sealed frame ...
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::ShowPreview { .. }),
+                    "ShowPreview to arrive at the viewer",
+                )
+                .await;
+                // ... and its own request comes back the other way, which
+                // the connector only sees if it opens the answer.
+                // Nobody answers the request, so polling it is only how the
+                // send happens.
+                let asked = tokio::select! {
+                    _ = viewer.request_file(url.clone()) => unreachable!("nobody sent the file"),
+                    msg = expect_message(
+                        &mut to_lsp_rx,
+                        |m| matches!(m, PreviewToLspMessage::RequestState { files, .. } if !files.is_empty()),
+                        "the viewer's request for a file",
+                    ) => msg,
+                };
+                let PreviewToLspMessage::RequestState { files, .. } = asked else { unreachable!() };
+                assert_eq!(files, vec![url]);
 
                 connector.disconnect().await;
             })

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -8,7 +8,7 @@
 //! [`crate::preview::remote`].
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
@@ -47,6 +47,9 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// What the user did with the pairing prompt.
 enum PairingSubmission {
     Code(String),
+    /// Connect to a pairing-disabled viewer even though the session will
+    /// not be encrypted.
+    AcceptUnpaired,
     Cancel,
 }
 
@@ -157,6 +160,10 @@ struct SharedState {
     /// memory only, mirroring the viewer: it forgets them when it restarts,
     /// and re-pairing is one prompt.
     tokens: Rc<RefCell<HashMap<String, (TokenId, Token)>>>,
+    /// Every `address:port` the user has agreed to talk to unencrypted,
+    /// because the viewer there has pairing disabled. Held for the LSP's
+    /// run, like `tokens`, so a reconnect doesn't ask the same question.
+    unpaired_ok: Rc<RefCell<HashSet<String>>>,
     /// Set while a viewer is showing a code and we're waiting for the user
     /// to type it. The preview UI's submission arrives through here.
     pairing_input: Rc<RefCell<Option<mpsc::UnboundedSender<PairingSubmission>>>>,
@@ -195,6 +202,7 @@ impl RemoteLspToPreview {
                 to_previews,
                 generation: Rc::default(),
                 tokens: Rc::default(),
+                unpaired_ok: Rc::default(),
                 pairing_input: Rc::default(),
                 connected_target: Rc::default(),
             },
@@ -211,6 +219,11 @@ impl RemoteLspToPreview {
     /// Abandon the pairing attempt the user was prompted for.
     pub fn cancel_pairing(&self) {
         self.deliver_pairing(PairingSubmission::Cancel);
+    }
+
+    /// Connect to the pairing-disabled viewer the user was warned about.
+    pub fn accept_unpaired_connection(&self) {
+        self.deliver_pairing(PairingSubmission::AcceptUnpaired);
     }
 
     fn deliver_pairing(&self, submission: PairingSubmission) {
@@ -448,6 +461,16 @@ impl RemoteLspToPreview {
                             "The viewer skipped the reconnect exchange".into(),
                         ));
                     }
+                    // Anyone can claim this, so the user gets asked before
+                    // anything is sent over what would be a plaintext
+                    // session -- once per target, not on every reconnect.
+                    if !keys.iter().any(|key| shared.unpaired_ok.borrow().contains(key)) {
+                        Self::confirm_unpaired(shared, stream, target).await?;
+                        let mut unpaired_ok = shared.unpaired_ok.borrow_mut();
+                        for key in keys {
+                            unpaired_ok.insert(key.clone());
+                        }
+                    }
                     tracing::info!("Viewer at {target} has pairing disabled");
                     return Ok((session::Sealing::Plaintext, session::Opening::Plaintext));
                 }
@@ -681,9 +704,55 @@ impl RemoteLspToPreview {
         match submission {
             Some(PairingSubmission::Code(code)) => Ok(code),
             // Cancelling is the user's decision, so don't reconnect behind
-            // their back.
-            Some(PairingSubmission::Cancel) | None => {
+            // their back. An unpaired-acceptance is no answer to a code
+            // prompt, so it is taken the conservative way.
+            Some(PairingSubmission::Cancel | PairingSubmission::AcceptUnpaired) | None => {
                 Err(ConnectError::Fatal("Pairing cancelled".into()))
+            }
+        }
+    }
+
+    /// Warn the user that the viewer has pairing disabled, and wait for
+    /// them to accept the unencrypted connection or cancel.
+    ///
+    /// Waits on the socket at the same time, like the code prompt: the
+    /// viewer hanging up takes the question off the screen.
+    async fn confirm_unpaired(
+        shared: &SharedState,
+        stream: &mut WebSocketStream,
+        target: &str,
+    ) -> std::result::Result<(), ConnectError> {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let _guard = PairingInputGuard::arm(&shared.pairing_input, sender);
+
+        // The dialog owns the wording; this only says which question is up.
+        shared.emit_state(RemoteConnectionState::UnpairedWarning, target.to_owned(), None);
+
+        loop {
+            tokio::select! {
+                submission = receiver.recv() => {
+                    return match submission {
+                        Some(PairingSubmission::AcceptUnpaired) => {
+                            tracing::info!("User accepted the unencrypted connection to {target}");
+                            Ok(())
+                        }
+                        // Only a decision answers a warning; a stray code
+                        // counts as not making one.
+                        Some(PairingSubmission::Code(_) | PairingSubmission::Cancel) | None => {
+                            Err(ConnectError::Fatal("Connection cancelled".into()))
+                        }
+                    };
+                }
+                message = Self::next_message(stream) => {
+                    let Some(message) = message else {
+                        return Err(ConnectError::Transient(
+                            "The viewer closed the connection while waiting for the user".into(),
+                        ));
+                    };
+                    // The session on the viewer's side is already running,
+                    // so traffic may arrive; none of it is for us yet.
+                    tracing::debug!("Ignoring {message:?} while the user decides");
+                }
             }
         }
     }
@@ -984,6 +1053,10 @@ impl crate::editor_preview::RemoteTransport for RemoteLspToPreview {
     fn cancel_pairing(&self) {
         RemoteLspToPreview::cancel_pairing(self);
     }
+
+    fn accept_unpaired_connection(&self) {
+        RemoteLspToPreview::accept_unpaired_connection(self);
+    }
 }
 
 struct ConnectionStateHandle {
@@ -1170,7 +1243,15 @@ mod tests {
 
         let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
         let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
-        connector.connect(["127.0.0.1"], viewer.local_port()).await.unwrap();
+        // A pairing-disabled viewer needs the user's ok before the first
+        // connection goes through.
+        let connect = connector.connect(["127.0.0.1"], viewer.local_port());
+        let accept = async {
+            wait_for_prompt(&connector).await;
+            connector.accept_unpaired_connection();
+        };
+        let (result, ()) = tokio::join!(connect, accept);
+        result.unwrap();
         expect_message(
             &mut viewer_rx,
             |m| matches!(m, ConnectionMessage::Connected { .. }),
@@ -1693,6 +1774,87 @@ mod tests {
                     connector.shared.tokens.borrow().is_empty(),
                     "cancelling should not leave a token behind"
                 );
+            })
+            .await;
+    }
+
+    /// A viewer with pairing disabled cannot be connected to silently: the
+    /// user is warned first, and their answer holds for reconnects.
+    #[tokio::test]
+    async fn an_unpaired_viewer_needs_the_users_ok() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Disabled).await;
+                let port = viewer.local_port();
+
+                let (_previews, connector, mut state_rx, _to_lsp_rx) = connector_with_states();
+
+                let connect = connector.connect(["127.0.0.1"], port);
+                let accept = async {
+                    expect_state(&mut state_rx, RemoteConnectionState::UnpairedWarning).await;
+                    connector.accept_unpaired_connection();
+                };
+                let (result, ()) = tokio::join!(connect, accept);
+                result.expect("accepting the warning should complete the connection");
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Connected { .. }),
+                    "viewer connection",
+                )
+                .await;
+
+                // The viewer restarts. The reconnect must not ask again: if
+                // it did, nobody would answer and this would time out.
+                drop(viewer);
+                drop(viewer_rx);
+                let (_viewer, mut viewer_rx) = listen(port, PairingPolicy::Disabled).await;
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Connected { .. }),
+                    "viewer reconnection",
+                )
+                .await;
+                while let Ok((state, _)) = state_rx.try_recv() {
+                    assert_ne!(
+                        state,
+                        RemoteConnectionState::UnpairedWarning,
+                        "the reconnect asked the user again"
+                    );
+                }
+
+                connector.disconnect().await;
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn declining_the_unpaired_warning_gives_up() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Disabled).await;
+                let port = viewer.local_port();
+
+                let (_previews, connector, mut state_rx, _to_lsp_rx) = connector_with_states();
+
+                let connect = connector.connect(["127.0.0.1"], port);
+                let decline = async {
+                    expect_state(&mut state_rx, RemoteConnectionState::UnpairedWarning).await;
+                    connector.cancel_pairing();
+                };
+                let (result, ()) = tokio::join!(connect, decline);
+                result.expect_err("declining must not produce a connection");
+                let failed = expect_state(&mut state_rx, RemoteConnectionState::Failed).await;
+                assert_eq!(failed.as_deref(), Some("Connection cancelled"));
+
+                // The viewer admits an unpaired session on its own side the
+                // moment it accepts, so declining shows up there as the
+                // editor hanging up before sending anything.
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Disconnected { .. }),
+                    "the editor to hang up",
+                )
+                .await;
             })
             .await;
     }

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -43,6 +43,13 @@ const RECONNECT_DELAY: Duration = Duration::from_secs(3);
 /// A device that blocks network for a backgrounded viewer can swallow
 /// packets; an uncapped dial would then hang for minutes on TCP retransmissions.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long the editor waits for each automatic step of the pairing
+/// handshake. The viewer enforces its own deadlines and closes the socket,
+/// but a dropped connection or a hostile peer delivers no close, so without
+/// this the editor's read would park forever and wedge the dialog on
+/// "Connecting" until the LSP is restarted. Generous: every automatic step
+/// is a local computation and a send, never a human.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// What the user did with the pairing prompt.
 enum PairingSubmission {
@@ -480,7 +487,7 @@ impl RemoteLspToPreview {
         target: &str,
         keys: &[String],
     ) -> std::result::Result<(session::Sealing, session::Opening), ConnectError> {
-        let Some(PreviewToLspMessage::PairingReady) = Self::next_message(stream).await else {
+        let PreviewToLspMessage::PairingReady = Self::next_handshake_message(stream).await? else {
             return Err(ConnectError::Transient(
                 "The viewer did not start the pairing handshake".into(),
             ));
@@ -494,8 +501,8 @@ impl RemoteLspToPreview {
         .await?;
 
         loop {
-            match Self::next_message(stream).await {
-                Some(PreviewToLspMessage::PairingAccepted) => {
+            match Self::next_handshake_message(stream).await? {
+                PreviewToLspMessage::PairingAccepted => {
                     // Only ever legitimate as "pairing is disabled on this
                     // viewer". A viewer that accepted our token proves so in
                     // the exchange instead, so nothing gets to skip it.
@@ -514,7 +521,7 @@ impl RemoteLspToPreview {
                     tracing::info!("Viewer at {target} has pairing disabled");
                     return Ok((session::Sealing::Plaintext, session::Opening::Plaintext));
                 }
-                Some(PreviewToLspMessage::PairingTokenChallenge { element }) => {
+                PreviewToLspMessage::PairingTokenChallenge { element } => {
                     let Some((_, token)) = held else {
                         return Err(ConnectError::Transient(
                             "The viewer opened an exchange for a token we never announced".into(),
@@ -529,12 +536,12 @@ impl RemoteLspToPreview {
                         return Ok(session);
                     }
                 }
-                Some(PreviewToLspMessage::PairingConfirm { .. }) => {
+                PreviewToLspMessage::PairingConfirm { .. } => {
                     // Only meaningful as the answer to a response we sent;
                     // the exchanges handle it inline.
                     tracing::warn!("Unexpected pairing confirmation from {target}");
                 }
-                Some(PreviewToLspMessage::PairingRejected { reason }) => {
+                PreviewToLspMessage::PairingRejected { reason } => {
                     tracing::info!("Viewer at {target} rejected us: {reason}");
                     match reason {
                         // Issued by an earlier run of that viewer. Forget it;
@@ -546,11 +553,11 @@ impl RemoteLspToPreview {
                         _ => return Err(from_rejection(reason)),
                     }
                 }
-                Some(PreviewToLspMessage::PairingRequired {
+                PreviewToLspMessage::PairingRequired {
                     attempts_left,
                     expires_in_seconds,
                     element,
-                }) => {
+                } => {
                     let prompt = Prompt { attempts_left, expires_in_seconds, element };
                     // `None` is a wrong code: the viewer follows up with a
                     // fresh prompt, which the next turn of this loop takes.
@@ -560,13 +567,8 @@ impl RemoteLspToPreview {
                         return Ok(session);
                     }
                 }
-                Some(other) => {
+                other => {
                     tracing::warn!("Ignoring {other:?} from {target} during pairing");
-                }
-                None => {
-                    return Err(ConnectError::Transient(
-                        "The viewer closed the connection during pairing".into(),
-                    ));
                 }
             }
         }
@@ -664,23 +666,23 @@ impl RemoteLspToPreview {
         // The viewer answers with its own confirmation only if it derived
         // the same key, so this is where a wrong secret surfaces. Anything
         // else means it refused us.
-        match Self::next_message(stream).await {
-            Some(PreviewToLspMessage::PairingConfirm { confirmation })
+        match Self::next_handshake_message(stream).await? {
+            PreviewToLspMessage::PairingConfirm { confirmation }
                 if secrets.peer_confirms(&confirmation) =>
             {
                 Ok(ExchangeVerdict::Confirmed(secrets))
             }
-            Some(PreviewToLspMessage::PairingConfirm { .. }) => {
+            PreviewToLspMessage::PairingConfirm { .. } => {
                 // Same secret space, different key: a mistyped code, or
                 // someone in the middle answering for a token it can't know.
                 Err(ConnectError::Transient("The viewer could not confirm the pairing".into()))
             }
-            Some(PreviewToLspMessage::PairingRejected { reason }) => {
+            PreviewToLspMessage::PairingRejected { reason } => {
                 Ok(ExchangeVerdict::Rejected(reason))
             }
-            _ => Err(ConnectError::Transient(
-                "The viewer closed the connection during pairing".into(),
-            )),
+            other => Err(ConnectError::Transient(format!(
+                "The viewer sent an unexpected {other:?} during pairing"
+            ))),
         }
     }
 
@@ -787,6 +789,26 @@ impl RemoteLspToPreview {
             .send(Message::binary(bytes))
             .await
             .map_err(|err| ConnectError::Transient(format!("Failed sending to the viewer: {err}")))
+    }
+
+    /// The next handshake message, or a transient error if the viewer goes
+    /// silent for [`HANDSHAKE_TIMEOUT`]. Every automatic step of the
+    /// handshake reads through this, so a dropped connection or a peer that
+    /// stops answering fails the connect instead of hanging it forever. The
+    /// waits a human drives use [`Self::next_message`] directly: there the
+    /// user's Cancel and the viewer's own deadline bound the wait.
+    async fn next_handshake_message(
+        stream: &mut WebSocketStream,
+    ) -> std::result::Result<PreviewToLspMessage, ConnectError> {
+        match tokio::time::timeout(HANDSHAKE_TIMEOUT, Self::next_message(stream)).await {
+            Ok(Some(message)) => Ok(message),
+            Ok(None) => Err(ConnectError::Transient(
+                "The viewer closed the connection during pairing".into(),
+            )),
+            Err(_) => {
+                Err(ConnectError::Transient("The viewer stopped responding during pairing".into()))
+            }
+        }
     }
 
     /// Next protocol message, or `None` if the socket ended or carried
@@ -1917,6 +1939,66 @@ mod tests {
                 );
 
                 connector.disconnect().await;
+            })
+            .await;
+    }
+
+    /// A hand-rolled viewer that completes the WebSocket upgrade and then
+    /// goes quiet, to stand in for a peer whose connection dropped without a
+    /// close: a sleeping laptop, a backgrounded phone, or a hostile host.
+    /// Optionally sends `PairingReady` first, to stall a step deeper in.
+    ///
+    /// Returns the port it listens on; the spawned task holds the socket for
+    /// the test's lifetime.
+    async fn silent_viewer(send_ready: bool) -> u16 {
+        use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+        use tokio_tungstenite::tungstenite::http::{HeaderValue, header::SEC_WEBSOCKET_PROTOCOL};
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            // Echo the subprotocol back, or the client refuses the upgrade.
+            let select_protocol = |_req: &Request, mut response: Response| {
+                response
+                    .headers_mut()
+                    .insert(SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_static(PROTOCOL_SUBPROTOCOL));
+                Ok::<_, ErrorResponse>(response)
+            };
+            let mut ws =
+                tokio_tungstenite::accept_hdr_async(stream, select_protocol).await.unwrap();
+            if send_ready {
+                let ready = postcard::to_allocvec(&PreviewToLspMessage::PairingReady).unwrap();
+                ws.send(tokio_tungstenite::tungstenite::Message::Binary(ready.into()))
+                    .await
+                    .unwrap();
+            }
+            // Say nothing more, ever, but keep the socket open so the client
+            // gets no close frame to react to.
+            std::future::pending::<()>().await;
+        });
+        port
+    }
+
+    /// A viewer that answers the upgrade and then falls silent must not wedge
+    /// the connector on "Connecting" forever: the handshake reads are bounded,
+    /// so the attempt fails and the dialog can recover. Checked at two points
+    /// in the handshake, before and after the first message.
+    #[tokio::test(start_paused = true)]
+    async fn a_silent_viewer_does_not_hang_the_connector() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                for send_ready in [false, true] {
+                    let port = silent_viewer(send_ready).await;
+                    let (_previews, connector, mut state_rx, _to_lsp_rx) = connector_with_states();
+
+                    connector
+                        .connect(["127.0.0.1"], port)
+                        .await
+                        .expect_err("a silent viewer must not produce a connection");
+                    // The dialog is told, so the user isn't stuck on "Connecting".
+                    expect_state(&mut state_rx, RemoteConnectionState::Failed).await;
+                }
             })
             .await;
     }

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -7,7 +7,8 @@
 //! Discovery and the dialog live in the preview process; see
 //! [`crate::preview::remote`].
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
@@ -19,9 +20,10 @@ use futures_util::{
     lock::Mutex,
     stream::{SplitSink, SplitStream, StreamExt as _},
 };
+use i_slint_live_preview::protocol::pairing::{self, Credential, MAX_ATTEMPTS, Token};
 use i_slint_live_preview::protocol::{
-    LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PreviewToLspMessage, RemoteConnectionState,
-    SLINT_PROTOCOLS_HEADER, SLINT_VERSION, SLINT_VERSION_HEADER,
+    LspToPreviewMessage, PROTOCOL_SUBPROTOCOL, PairingRejection, PreviewToLspMessage,
+    RemoteConnectionState, SLINT_PROTOCOLS_HEADER, SLINT_VERSION, SLINT_VERSION_HEADER,
 };
 use tokio::sync::mpsc;
 use tokio_tungstenite_wasm::{Message, WebSocketStream};
@@ -40,6 +42,67 @@ const RECONNECT_DELAY: Duration = Duration::from_secs(3);
 /// A device that blocks network for a backgrounded viewer can swallow
 /// packets; an uncapped dial would then hang for minutes on TCP retransmissions.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the user did with the pairing prompt.
+enum PairingSubmission {
+    Code(String),
+    Cancel,
+}
+
+/// Why a dial attempt produced no session.
+enum ConnectError {
+    /// Worth retrying on a timer: nothing listening, socket died, superseded.
+    Transient(String),
+    /// Retrying won't help until the user acts, so the reconnect loop stops
+    /// and hands back to the dialog.
+    Fatal(String),
+}
+
+/// Classify a rejection the viewer sent. The rule itself lives on
+/// [`PairingRejection::is_terminal`], next to the variants it judges.
+fn from_rejection(reason: PairingRejection) -> ConnectError {
+    let text = reason.to_string();
+    if reason.is_terminal() { ConnectError::Fatal(text) } else { ConnectError::Transient(text) }
+}
+
+impl std::fmt::Display for ConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transient(reason) | Self::Fatal(reason) => f.write_str(reason),
+        }
+    }
+}
+
+/// Clears the pairing input slot when the prompt is over, so a code typed
+/// too late can't land in an unrelated attempt.
+struct PairingInputGuard {
+    slot: Rc<RefCell<Option<mpsc::UnboundedSender<PairingSubmission>>>>,
+    /// The sender this guard installed, so it can tell whether the slot is
+    /// still its own.
+    mine: mpsc::UnboundedSender<PairingSubmission>,
+}
+
+impl PairingInputGuard {
+    fn arm(
+        slot: &Rc<RefCell<Option<mpsc::UnboundedSender<PairingSubmission>>>>,
+        sender: mpsc::UnboundedSender<PairingSubmission>,
+    ) -> Self {
+        *slot.borrow_mut() = Some(sender.clone());
+        Self { slot: slot.clone(), mine: sender }
+    }
+}
+
+impl Drop for PairingInputGuard {
+    fn drop(&mut self) {
+        let mut slot = self.slot.borrow_mut();
+        // Only ever clear our own. A newer prompt may have replaced it
+        // already, and taking theirs would leave them waiting for a code
+        // that can no longer be delivered.
+        if slot.as_ref().is_some_and(|current| current.same_channel(&self.mine)) {
+            slot.take();
+        }
+    }
+}
 
 struct RemoteLspConnection {
     sender: SplitSink<WebSocketStream, Message>,
@@ -63,6 +126,17 @@ struct SharedState {
     /// Bumped on every user-driven connect or disconnect.
     /// Tasks spawned for an older generation stand down.
     generation: Rc<Cell<u64>>,
+    /// Pairing tokens, stored under every `address:port` the viewer that
+    /// issued them was known by. Held in memory only, mirroring the viewer:
+    /// it forgets them when it restarts, and re-pairing is one prompt.
+    tokens: Rc<RefCell<HashMap<String, Token>>>,
+    /// Set while a viewer is showing a code and we're waiting for the user
+    /// to type it. The preview UI's submission arrives through here.
+    pairing_input: Rc<RefCell<Option<mpsc::UnboundedSender<PairingSubmission>>>>,
+    /// `address:port` of the session currently installed, so a failed
+    /// attempt elsewhere can put the dialog back to the truth instead of
+    /// leaving it on whatever it was saying.
+    connected_target: Rc<RefCell<Option<String>>>,
 }
 
 impl SharedState {
@@ -93,7 +167,31 @@ impl RemoteLspToPreview {
                 preview_to_lsp_sender: RemotePreviewSender(preview_to_lsp_sender),
                 to_previews,
                 generation: Rc::default(),
+                tokens: Rc::default(),
+                pairing_input: Rc::default(),
+                connected_target: Rc::default(),
             },
+        }
+    }
+
+    /// Hand the code the user typed to the pairing attempt waiting for it.
+    /// Does nothing if no prompt is up, which is what happens when the code
+    /// arrives after the viewer's deadline passed.
+    pub fn submit_pairing_code(&self, code: String) {
+        self.deliver_pairing(PairingSubmission::Code(code));
+    }
+
+    /// Abandon the pairing attempt the user was prompted for.
+    pub fn cancel_pairing(&self) {
+        self.deliver_pairing(PairingSubmission::Cancel);
+    }
+
+    fn deliver_pairing(&self, submission: PairingSubmission) {
+        match self.shared.pairing_input.borrow().as_ref() {
+            Some(sender) => {
+                let _ = sender.send(submission);
+            }
+            None => tracing::debug!("Ignoring pairing input: no prompt is waiting for one"),
         }
     }
 
@@ -159,21 +257,26 @@ impl RemoteLspToPreview {
             if let Err(reason) = Self::connect_impl(&shared, &addresses, port, generation).await {
                 // A superseded attempt no longer owns the dialog state.
                 if shared.generation.get() == generation {
-                    // Don't flip the UI to `Failed` if a live peer is still routing;
-                    // that would contradict Connected and disable the Disconnect button.
-                    if shared.connection.lock().await.is_some() {
-                        tracing::warn!(
-                            "Connect attempt to {target} failed but previous remote connection is still active: {reason}"
-                        );
-                    } else {
-                        shared.emit_state(
+                    let still_connected = shared.connected_target.borrow().clone();
+                    match still_connected {
+                        // `Failed` would contradict the peer that is still
+                        // routing and hide its Disconnect button, but saying
+                        // nothing leaves the dialog stuck on `Connecting`
+                        // with no way back. Report what is actually true.
+                        Some(live) => {
+                            tracing::warn!(
+                                "Connect attempt to {target} failed but {live} is still connected: {reason}"
+                            );
+                            shared.emit_state(RemoteConnectionState::Connected, live, None);
+                        }
+                        None => shared.emit_state(
                             RemoteConnectionState::Failed,
                             target,
                             Some(reason.to_string()),
-                        );
+                        ),
                     }
                 }
-                return Err(reason);
+                return Err(reason.to_string().into());
             }
             Ok(())
         }
@@ -186,7 +289,7 @@ impl RemoteLspToPreview {
         addresses: &[String],
         port: u16,
         generation: u64,
-    ) -> crate::editor_preview::Result<()> {
+    ) -> std::result::Result<(), ConnectError> {
         let mut last_error: Option<String> = None;
         let mut connected = None;
         for address in addresses {
@@ -219,16 +322,29 @@ impl RemoteLspToPreview {
                 }
             }
         }
-        let Some((stream, address)) = connected else {
-            return Err(last_error
-                .unwrap_or_else(|| "Unable to connect to remote viewer".into())
-                .into());
+        let Some((mut stream, address)) = connected else {
+            return Err(ConnectError::Transient(
+                last_error.unwrap_or_else(|| "Unable to connect to remote viewer".into()),
+            ));
         };
 
         if shared.generation.get() != generation {
             // The user disconnected or connected elsewhere while we dialed.
             tracing::info!("Discarding connection to {address}:{port}: superseded");
-            return Err("Connection superseded".into());
+            return Err(ConnectError::Transient("Connection superseded".into()));
+        }
+
+        // Nothing is pushed to the viewer until it has admitted us.
+        let target = format!("{address}:{port}");
+        // A viewer usually advertises several addresses, and which one wins
+        // the dial varies between attempts. Remember its token under all of
+        // them, or a reconnect that lands elsewhere asks for a code again.
+        let keys: Vec<String> = addresses.iter().map(|a| format!("{a}:{port}")).collect();
+        Self::authenticate(shared, &mut stream, &target, &keys).await?;
+
+        if shared.generation.get() != generation {
+            tracing::info!("Discarding connection to {target}: superseded during pairing");
+            return Err(ConnectError::Transient("Connection superseded".into()));
         }
 
         let (socket_sender, socket_receiver) = stream.split();
@@ -256,6 +372,8 @@ impl RemoteLspToPreview {
             old.task.abort();
         }
 
+        *shared.connected_target.borrow_mut() = Some(target.clone());
+
         // Have the LSP push configuration, file contents, and the previewed
         // component, so the viewer leaves its idle screen on its own.
         shared
@@ -263,6 +381,176 @@ impl RemoteLspToPreview {
             .send(PreviewToLspMessage::RequestState { files: Vec::new(), settings: Vec::new() });
 
         Ok(())
+    }
+
+    /// Complete the pairing exchange on a freshly connected socket.
+    ///
+    /// See [`i_slint_live_preview::protocol::pairing`] for the shape of it.
+    /// A reconnect where we still hold the viewer's token finishes in one
+    /// round trip and never reaches the user.
+    async fn authenticate(
+        shared: &SharedState,
+        stream: &mut WebSocketStream,
+        target: &str,
+        keys: &[String],
+    ) -> std::result::Result<(), ConnectError> {
+        let Some(PreviewToLspMessage::PairingChallenge { nonce }) =
+            Self::next_message(stream).await
+        else {
+            return Err(ConnectError::Transient(
+                "The viewer did not start the pairing handshake".into(),
+            ));
+        };
+
+        let token_proof = keys
+            .iter()
+            .find_map(|key| shared.tokens.borrow().get(key).copied())
+            .map(|token| pairing::proof(Credential::Token, token.as_bytes(), &nonce));
+        Self::send_message(stream, &LspToPreviewMessage::PairingHello { token_proof }).await?;
+
+        // The code we last offered, kept so the token can be derived from it
+        // once the viewer accepts.
+        let mut submitted_code: Option<String> = None;
+
+        loop {
+            match Self::next_message(stream).await {
+                Some(PreviewToLspMessage::PairingAccepted) => {
+                    // Derived from what we just proved, so the viewer never
+                    // had to send it. Absent when the token we already held
+                    // was the thing accepted, or when pairing is disabled.
+                    if let Some(code) = &submitted_code {
+                        let token = pairing::derive_token(code, &nonce);
+                        let mut tokens = shared.tokens.borrow_mut();
+                        for key in keys {
+                            tokens.insert(key.clone(), token);
+                        }
+                    }
+                    tracing::info!("Paired with remote viewer at {target}");
+                    return Ok(());
+                }
+                Some(PreviewToLspMessage::PairingRejected { reason }) => {
+                    tracing::info!("Viewer at {target} rejected us: {reason}");
+                    match reason {
+                        // Issued by an earlier run of that viewer. Forget it;
+                        // the code prompt follows on the same connection.
+                        PairingRejection::BadToken => {
+                            let mut tokens = shared.tokens.borrow_mut();
+                            for key in keys {
+                                tokens.remove(key);
+                            }
+                        }
+                        // The retry count comes with the prompt that follows.
+                        PairingRejection::BadCode => {}
+                        // Everything else ends this attempt, one way or another.
+                        _ => return Err(from_rejection(reason)),
+                    }
+                }
+                Some(PreviewToLspMessage::PairingRequired {
+                    attempts_left,
+                    expires_in_seconds,
+                }) => {
+                    let code = Self::prompt_for_code(
+                        shared,
+                        stream,
+                        target,
+                        attempts_left,
+                        expires_in_seconds,
+                    )
+                    .await?;
+                    let proof = pairing::proof(Credential::Code, code.as_bytes(), &nonce);
+                    submitted_code = Some(code);
+                    Self::send_message(stream, &LspToPreviewMessage::PairingCodeProof { proof })
+                        .await?;
+                }
+                Some(other) => {
+                    tracing::warn!("Ignoring {other:?} from {target} during pairing");
+                }
+                None => {
+                    return Err(ConnectError::Transient(
+                        "The viewer closed the connection during pairing".into(),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Put the code prompt in front of the user and wait for them.
+    ///
+    /// Waits on the socket at the same time: the viewer owns the deadline,
+    /// and when it passes it closes the connection. Noticing that beats
+    /// leaving a prompt up for a code that can no longer be used.
+    async fn prompt_for_code(
+        shared: &SharedState,
+        stream: &mut WebSocketStream,
+        target: &str,
+        attempts_left: u8,
+        expires_in_seconds: u16,
+    ) -> std::result::Result<String, ConnectError> {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let _guard = PairingInputGuard::arm(&shared.pairing_input, sender);
+
+        let hint = if attempts_left < MAX_ATTEMPTS {
+            format!(
+                "Incorrect code. {attempts_left} attempts left, {expires_in_seconds}s remaining"
+            )
+        } else {
+            format!("Enter the code shown on the viewer within {expires_in_seconds}s")
+        };
+        shared.emit_state(RemoteConnectionState::PairingRequired, target.to_owned(), Some(hint));
+
+        let submission = tokio::select! {
+            submission = receiver.recv() => submission,
+            message = Self::next_message(stream) => {
+                return Err(match message {
+                    Some(PreviewToLspMessage::PairingRejected { reason }) => from_rejection(reason),
+                    _ => ConnectError::Transient(
+                        "The viewer closed the connection while waiting for the code".into(),
+                    ),
+                });
+            }
+        };
+
+        match submission {
+            Some(PairingSubmission::Code(code)) => Ok(code),
+            // Cancelling is the user's decision, so don't reconnect behind
+            // their back.
+            Some(PairingSubmission::Cancel) | None => {
+                Err(ConnectError::Fatal("Pairing cancelled".into()))
+            }
+        }
+    }
+
+    async fn send_message(
+        stream: &mut WebSocketStream,
+        message: &LspToPreviewMessage,
+    ) -> std::result::Result<(), ConnectError> {
+        let bytes = postcard::to_allocvec(message).map_err(|err| {
+            ConnectError::Transient(format!("Failed encoding {message:?}: {err}"))
+        })?;
+        stream
+            .send(Message::binary(bytes))
+            .await
+            .map_err(|err| ConnectError::Transient(format!("Failed sending to the viewer: {err}")))
+    }
+
+    /// Next protocol message, or `None` if the socket ended or carried
+    /// something undecodable.
+    async fn next_message(stream: &mut WebSocketStream) -> Option<PreviewToLspMessage> {
+        loop {
+            match stream.next().await? {
+                Ok(Message::Binary(bytes)) => match postcard::from_bytes(&bytes) {
+                    Ok(message) => return Some(message),
+                    Err(err) => {
+                        tracing::error!("Failed decoding message from remote viewer: {err}");
+                        return None;
+                    }
+                },
+                Ok(Message::Text(text)) => {
+                    tracing::warn!("Ignoring text message from remote viewer: {text}");
+                }
+                Ok(Message::Close(_)) | Err(_) => return None,
+            }
+        }
     }
 
     /// Drive one established connection.
@@ -339,6 +627,7 @@ impl RemoteLspToPreview {
         }
         // Drop the dead connection's write half; its task is this very task.
         drop(shared.connection.lock().await.take());
+        shared.connected_target.borrow_mut().take();
         let target =
             format!("{}:{port}", addresses.first().map(String::as_str).unwrap_or_default());
         tracing::info!("Connection to remote viewer lost; reconnecting to {target}");
@@ -349,7 +638,14 @@ impl RemoteLspToPreview {
                     tracing::info!("Reconnected to remote viewer at {target}");
                     return;
                 }
-                Err(err) => {
+                Err(ConnectError::Fatal(reason)) => {
+                    // Retrying would put the same prompt back up, or spin on a
+                    // refusal. Hand it back to the user instead.
+                    tracing::warn!("Giving up reconnecting to {target}: {reason}");
+                    shared.emit_state(RemoteConnectionState::Failed, target, Some(reason));
+                    return;
+                }
+                Err(ConnectError::Transient(err)) => {
                     tracing::debug!("Reconnect attempt to {target} failed: {err}");
                 }
             }
@@ -430,6 +726,7 @@ impl RemoteLspToPreview {
         let shared = self.shared.clone();
         async move {
             shared.bump_generation();
+            shared.connected_target.borrow_mut().take();
             if let Some(mut connection) = shared.connection.lock().await.take() {
                 // Close handshake so the viewer sees a clean end of session
                 // instead of a connection reset.
@@ -496,6 +793,14 @@ impl crate::editor_preview::RemoteTransport for RemoteLspToPreview {
 
     fn disconnect(&self) -> Pin<Box<dyn Future<Output = ()>>> {
         Box::pin(RemoteLspToPreview::disconnect(self))
+    }
+
+    fn submit_pairing_code(&self, code: String) {
+        RemoteLspToPreview::submit_pairing_code(self, code);
+    }
+
+    fn cancel_pairing(&self) {
+        RemoteLspToPreview::cancel_pairing(self);
     }
 }
 
@@ -589,13 +894,17 @@ fn describe_version_mismatch(err: &tokio_tungstenite_wasm::Error) -> Option<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use i_slint_live_preview::remote::{Connection, ConnectionMessage};
+    use i_slint_live_preview::remote::{Connection, ConnectionMessage, PairingPolicy};
 
-    async fn listen(port: u16) -> (Connection, mpsc::UnboundedReceiver<ConnectionMessage>) {
+    async fn listen(
+        port: u16,
+        policy: PairingPolicy,
+    ) -> (Connection, mpsc::UnboundedReceiver<ConnectionMessage>) {
         let (tx, rx) = mpsc::unbounded_channel();
         let connection = Connection::listen(
             Some(std::net::SocketAddr::from(([127, 0, 0, 1], port))),
             None,
+            policy,
             move |msg| {
                 let _ = tx.send(msg);
             },
@@ -605,22 +914,64 @@ mod tests {
         (connection, rx)
     }
 
-    /// Wait until `rx` yields a message matching `pred`.
+    /// The code from the viewer's next `PairingStarted`.
+    async fn expect_code(rx: &mut mpsc::UnboundedReceiver<ConnectionMessage>) -> String {
+        let event = expect_message(
+            rx,
+            |m| matches!(m, ConnectionMessage::PairingStarted { .. }),
+            "the viewer to show a pairing code",
+        )
+        .await;
+        let ConnectionMessage::PairingStarted { code, .. } = event else { unreachable!() };
+        code
+    }
+
+    /// Spin until the connector is (or is no longer) waiting for a code.
+    ///
+    /// Everything runs on one thread, so the connect future only moves at its
+    /// await points; yielding is what lets it get there.
+    async fn wait_for_prompt(connector: &RemoteLspToPreview) {
+        for _ in 0..2000 {
+            if connector.shared.pairing_input.borrow().is_some() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("connector never started waiting for a pairing code");
+    }
+
+    /// Wait until `rx` yields a message matching `pred`, and return it.
     async fn expect_message<T>(
         rx: &mut mpsc::UnboundedReceiver<T>,
         pred: impl Fn(&T) -> bool,
         what: &str,
-    ) {
+    ) -> T {
         tokio::time::timeout(Duration::from_secs(15), async {
             loop {
                 let msg = rx.recv().await.expect("message channel closed");
                 if pred(&msg) {
-                    return;
+                    return msg;
                 }
             }
         })
         .await
-        .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+    }
+
+    /// Connect and answer the code prompt, the way a user would.
+    async fn pair(
+        connector: &RemoteLspToPreview,
+        viewer_rx: &mut mpsc::UnboundedReceiver<ConnectionMessage>,
+        port: u16,
+    ) -> crate::editor_preview::Result<()> {
+        let connect = connector.connect(["127.0.0.1"], port);
+        let enter_code = async {
+            let code = expect_code(viewer_rx).await;
+            wait_for_prompt(connector).await;
+            connector.submit_pairing_code(code);
+        };
+        let (result, ()) = tokio::join!(connect, enter_code);
+        result
     }
 
     /// A viewer on an arbitrary port with a connector attached to it, past the
@@ -631,7 +982,7 @@ mod tests {
         RemoteLspToPreview,
         mpsc::UnboundedReceiver<PreviewToLspMessage>,
     ) {
-        let (viewer, mut viewer_rx) = listen(0).await;
+        let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Disabled).await;
 
         let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
         let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
@@ -652,6 +1003,26 @@ mod tests {
         (viewer, viewer_rx, connector, to_lsp_rx)
     }
 
+    /// Two attempts can overlap: the device list stays clickable while a
+    /// prompt is up. The older one standing down must not disarm the newer.
+    #[test]
+    fn a_finished_prompt_only_clears_its_own_input_slot() {
+        let slot: Rc<RefCell<Option<mpsc::UnboundedSender<PairingSubmission>>>> = Rc::default();
+
+        let (first, _first_rx) = mpsc::unbounded_channel();
+        let first_guard = PairingInputGuard::arm(&slot, first);
+        let (second, mut second_rx) = mpsc::unbounded_channel();
+        let _second_guard = PairingInputGuard::arm(&slot, second);
+
+        drop(first_guard);
+
+        let armed = slot.borrow().clone().expect("the newer prompt was disarmed");
+        armed.send(PairingSubmission::Code("4321".into())).expect("channel closed");
+        assert!(
+            matches!(second_rx.try_recv(), Ok(PairingSubmission::Code(code)) if code == "4321")
+        );
+    }
+
     #[tokio::test]
     async fn reconnects_after_connection_loss() {
         tokio::task::LocalSet::new()
@@ -663,7 +1034,7 @@ mod tests {
                 // connection the OS cut while backgrounded.
                 drop(viewer);
                 drop(viewer_rx);
-                let (_viewer, mut viewer_rx) = listen(port).await;
+                let (_viewer, mut viewer_rx) = listen(port, PairingPolicy::Disabled).await;
 
                 // The connector reconnects on its own ...
                 expect_message(
@@ -681,6 +1052,326 @@ mod tests {
                 .await;
 
                 connector.disconnect().await;
+            })
+            .await;
+    }
+
+    /// A viewer is on the far end of the network: it may not drive the editor.
+    #[tokio::test]
+    async fn a_code_read_off_the_viewer_completes_the_connection() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, mut to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+
+                let result = pair(&connector, &mut viewer_rx, port).await;
+                result.expect("pairing should have succeeded");
+
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Connected { .. }),
+                    "viewer connection",
+                )
+                .await;
+                expect_message(
+                    &mut to_lsp_rx,
+                    |m| matches!(m, PreviewToLspMessage::RequestState { .. }),
+                    "RequestState after pairing",
+                )
+                .await;
+
+                connector.disconnect().await;
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn a_wrong_code_can_be_followed_by_the_right_one() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, _to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+
+                // One attempt throughout: a second `connect` would be refused
+                // by the viewer's rate limit on prompts.
+                let connect = connector.connect(["127.0.0.1"], port);
+                tokio::pin!(connect);
+                let mut code: Option<String> = None;
+                let mut wrong_code_sent = false;
+
+                let result = tokio::time::timeout(Duration::from_secs(20), async {
+                    loop {
+                        tokio::select! {
+                            result = &mut connect => break result,
+                            event = viewer_rx.recv() => {
+                                if let Some(ConnectionMessage::PairingStarted { code: shown, .. }) = event {
+                                    code = Some(shown);
+                                }
+                            }
+                            _ = tokio::time::sleep(Duration::from_millis(5)) => {
+                                let Some(code) = code.clone() else { continue };
+                                if connector.shared.pairing_input.borrow().is_none() {
+                                    continue;
+                                }
+                                if wrong_code_sent {
+                                    // Offered until a prompt takes it: the moment
+                                    // the viewer re-arms isn't observable from here.
+                                    connector.submit_pairing_code(code);
+                                } else {
+                                    let wrong = if code == "0000" { "1111" } else { "0000" };
+                                    connector.submit_pairing_code(wrong.to_owned());
+                                    wrong_code_sent = true;
+                                }
+                            }
+                        }
+                    }
+                })
+                .await
+                .expect("timed out pairing");
+
+                assert!(wrong_code_sent, "the wrong code was never offered");
+                result.expect("the second code should have been accepted");
+
+                connector.disconnect().await;
+            })
+            .await;
+    }
+
+    /// mDNS commonly offers a viewer under several addresses, and which one
+    /// wins the dial varies. Landing on a different one must not cost the
+    /// user another trip to the device.
+    #[tokio::test]
+    async fn a_token_survives_reconnecting_on_another_address() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, _to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+
+                // Paired having dialled the first of two addresses.
+                let connect = connector.connect(["127.0.0.1", "localhost"], port);
+                let enter_code = async {
+                    let code = expect_code(&mut viewer_rx).await;
+                    wait_for_prompt(&connector).await;
+                    connector.submit_pairing_code(code);
+                };
+                let (result, ()) = tokio::join!(connect, enter_code);
+                result.expect("pairing should have succeeded");
+
+                // The other address is the one that works next time.
+                let tokens = connector.shared.tokens.borrow();
+                assert_eq!(
+                    tokens.get(&format!("127.0.0.1:{port}")),
+                    tokens.get(&format!("localhost:{port}")),
+                    "the token was only remembered for the address that happened to answer"
+                );
+                assert!(tokens.get(&format!("localhost:{port}")).is_some());
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn a_restarted_viewer_asks_for_a_code_again() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, _to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+
+                let result = pair(&connector, &mut viewer_rx, port).await;
+                result.expect("pairing should have succeeded");
+                let target = format!("127.0.0.1:{port}");
+                assert!(
+                    connector.shared.tokens.borrow().contains_key(&target),
+                    "a successful pairing should leave a token behind"
+                );
+
+                // The viewer restarts: it has forgotten every token it issued,
+                // so the one we hold is no longer worth anything.
+                drop(viewer);
+                drop(viewer_rx);
+                let (_viewer, mut viewer_rx) = listen(port, PairingPolicy::Generated).await;
+
+                // The reconnect offers the stale token, is turned away, and
+                // ends up back at a code prompt.
+                let code = expect_code(&mut viewer_rx).await;
+                wait_for_prompt(&connector).await;
+                // Reaching a code prompt means the rejection has been handled.
+                assert!(
+                    !connector.shared.tokens.borrow().contains_key(&target),
+                    "a rejected token should have been forgotten"
+                );
+                connector.submit_pairing_code(code);
+
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::Connected { .. }),
+                    "viewer reconnection after re-pairing",
+                )
+                .await;
+
+                connector.disconnect().await;
+            })
+            .await;
+    }
+
+    /// A local preview that records the connection-state updates the
+    /// connector pushes to the dialog, which is the only place the client's
+    /// own view of pairing is observable.
+    struct RecordingPreview(mpsc::UnboundedSender<(RemoteConnectionState, Option<String>)>);
+
+    impl i_slint_live_preview::protocol::LspToPreview for RecordingPreview {
+        fn send(&self, message: &LspToPreviewMessage) {
+            if let LspToPreviewMessage::RemoteConnectionState { state, error, .. } = message {
+                let _ = self.0.send((*state, error.clone()));
+            }
+        }
+        fn preview_target(&self) -> i_slint_live_preview::protocol::PreviewTarget {
+            i_slint_live_preview::protocol::PreviewTarget::Dummy
+        }
+    }
+
+    /// Wait for the connector to push `wanted` to the dialog, returning the
+    /// error text that came with it.
+    async fn expect_state(
+        rx: &mut mpsc::UnboundedReceiver<(RemoteConnectionState, Option<String>)>,
+        wanted: RemoteConnectionState,
+    ) -> Option<String> {
+        let what = format!("the connector to report {wanted:?}");
+        expect_message(rx, |(state, _)| *state == wanted, &what).await.1
+    }
+
+    fn connector_with_states() -> (
+        std::rc::Rc<LspToPreviews>,
+        Rc<RemoteLspToPreview>,
+        mpsc::UnboundedReceiver<(RemoteConnectionState, Option<String>)>,
+        mpsc::UnboundedReceiver<PreviewToLspMessage>,
+    ) {
+        let (state_tx, state_rx) = mpsc::unbounded_channel();
+        let (to_lsp_tx, to_lsp_rx) = mpsc::unbounded_channel();
+        let locals = std::iter::once((
+            i_slint_live_preview::protocol::PreviewTarget::Dummy,
+            Box::new(RecordingPreview(state_tx))
+                as Box<dyn i_slint_live_preview::protocol::LspToPreview>,
+        ))
+        .collect();
+        // The transport the previews own is the one the tests drive, so
+        // hold on to it as the concrete type on the way through.
+        let mut connector = None;
+        let previews = LspToPreviews::new(
+            locals,
+            i_slint_live_preview::protocol::PreviewTarget::Dummy,
+            |to_previews| {
+                let remote = Rc::new(RemoteLspToPreview::new(to_lsp_tx, to_previews));
+                connector = Some(remote.clone());
+                remote as Rc<dyn crate::editor_preview::RemoteTransport>
+            },
+        )
+        .unwrap();
+        (previews, connector.unwrap(), state_rx, to_lsp_rx)
+    }
+
+    /// Running out of attempts has to end the reconnect loop.
+    ///
+    /// Reproduces what a user hits after restarting the viewer: the stale
+    /// token is refused, they fumble the code, and the loop must hand back
+    /// to them rather than keep re-prompting the device.
+    #[tokio::test]
+    async fn running_out_of_attempts_stops_reconnecting() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (_previews, connector, mut state_rx, _to_lsp_rx) = connector_with_states();
+
+                // Pair once, the way a user would.
+                let result = pair(&connector, &mut viewer_rx, port).await;
+                result.expect("first pairing should have succeeded");
+
+                // Everything above is setup. Drop its states, or the burn
+                // loop below matches the prompt we already answered.
+                while state_rx.try_recv().is_ok() {}
+
+                // The viewer restarts, so the token we hold is worthless and
+                // the reconnect lands on a fresh code prompt.
+                drop(viewer);
+                drop(viewer_rx);
+                let (_viewer, mut viewer_rx) = listen(port, PairingPolicy::Generated).await;
+                let code = expect_code(&mut viewer_rx).await;
+                let wrong = if code == "0000" { "1111" } else { "0000" };
+
+                // Burn every attempt. `pairing_input` is armed before the
+                // state goes out, so a prompt seen here is ready for a code.
+                for _ in 0..MAX_ATTEMPTS {
+                    expect_state(&mut state_rx, RemoteConnectionState::PairingRequired).await;
+                    connector.submit_pairing_code(wrong.to_owned());
+                }
+
+                // The dialog has to be told, so the user can act.
+                let failed = expect_state(&mut state_rx, RemoteConnectionState::Failed).await;
+                assert_eq!(failed.as_deref(), Some("Too many incorrect pairing codes"));
+
+                // And nothing may knock again: a retry is the user's call.
+                //
+                // Watching the *current* viewer would prove nothing, because
+                // the failed prompt leaves a cool-down that turns knocks away
+                // before they reach a prompt. A replacement viewer has no
+                // such history, so a loop that is still running shows up as a
+                // code on screen, and a loop that stopped shows up as silence.
+                drop(_viewer);
+                drop(viewer_rx);
+                let (_fresh, mut fresh_rx) = listen(port, PairingPolicy::Generated).await;
+                let retried =
+                    tokio::time::timeout(RECONNECT_DELAY * 3, expect_code(&mut fresh_rx)).await;
+                assert!(
+                    retried.is_err(),
+                    "the reconnect loop kept going and put another code on the viewer"
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn cancelling_the_prompt_gives_up() {
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let (viewer, mut viewer_rx) = listen(0, PairingPolicy::Generated).await;
+                let port = viewer.local_port();
+
+                let (to_lsp_tx, _to_lsp_rx) = mpsc::unbounded_channel();
+                let connector = RemoteLspToPreview::new(to_lsp_tx, Weak::new());
+
+                let connect = connector.connect(["127.0.0.1"], port);
+                let cancel = async {
+                    let _code = expect_code(&mut viewer_rx).await;
+                    wait_for_prompt(&connector).await;
+                    connector.cancel_pairing();
+                };
+                let (result, ()) = tokio::join!(connect, cancel);
+                result.expect_err("cancelling should not produce a connection");
+
+                // The viewer takes the code back off its screen.
+                expect_message(
+                    &mut viewer_rx,
+                    |m| matches!(m, ConnectionMessage::PairingFinished { accepted: false, .. }),
+                    "the prompt coming down",
+                )
+                .await;
+                assert!(
+                    connector.shared.tokens.borrow().is_empty(),
+                    "cancelling should not leave a token behind"
+                );
             })
             .await;
     }

--- a/tools/lsp/connector/remote.rs
+++ b/tools/lsp/connector/remote.rs
@@ -61,6 +61,14 @@ struct Prompt {
     element: pairing::Element,
 }
 
+/// How one run of the editor's half of the exchange ended.
+enum ExchangeVerdict {
+    /// The viewer proved it derived the same key.
+    Confirmed(pairing::Secrets),
+    /// The viewer turned the secret down.
+    Rejected(PairingRejection),
+}
+
 /// Why a dial attempt produced no session.
 enum ConnectError {
     /// Worth retrying on a timer: nothing listening, socket died, superseded.
@@ -178,6 +186,41 @@ impl SharedState {
         let generation = self.generation.get() + 1;
         self.generation.set(generation);
         generation
+    }
+
+    /// The token held for any of the viewer's addresses.
+    fn held_token(&self, keys: &[String]) -> Option<(TokenId, Token)> {
+        let tokens = self.tokens.borrow();
+        keys.iter().find_map(|key| tokens.get(key).copied())
+    }
+
+    /// Store a token under every address the viewer is known by, so a
+    /// reconnect that lands on another one doesn't ask for a code again.
+    fn remember_token(&self, keys: &[String], issued: (TokenId, Token)) {
+        let mut tokens = self.tokens.borrow_mut();
+        for key in keys {
+            tokens.insert(key.clone(), issued);
+        }
+    }
+
+    fn forget_token(&self, keys: &[String]) {
+        let mut tokens = self.tokens.borrow_mut();
+        for key in keys {
+            tokens.remove(key);
+        }
+    }
+
+    /// Remember the user's ok to talk to this viewer unencrypted.
+    fn allow_unpaired(&self, keys: &[String]) {
+        let mut unpaired_ok = self.unpaired_ok.borrow_mut();
+        for key in keys {
+            unpaired_ok.insert(key.clone());
+        }
+    }
+
+    fn unpaired_allowed(&self, keys: &[String]) -> bool {
+        let unpaired_ok = self.unpaired_ok.borrow();
+        keys.iter().any(|key| unpaired_ok.contains(key))
     }
 
     /// Forward a connection-state transition to the local preview dialog.
@@ -443,7 +486,7 @@ impl RemoteLspToPreview {
             ));
         };
 
-        let held = keys.iter().find_map(|key| shared.tokens.borrow().get(key).copied());
+        let held = shared.held_token(keys);
         Self::send_message(
             stream,
             &LspToPreviewMessage::PairingHello { token: held.map(|(id, _)| id) },
@@ -464,12 +507,9 @@ impl RemoteLspToPreview {
                     // Anyone can claim this, so the user gets asked before
                     // anything is sent over what would be a plaintext
                     // session -- once per target, not on every reconnect.
-                    if !keys.iter().any(|key| shared.unpaired_ok.borrow().contains(key)) {
+                    if !shared.unpaired_allowed(keys) {
                         Self::confirm_unpaired(shared, stream, target).await?;
-                        let mut unpaired_ok = shared.unpaired_ok.borrow_mut();
-                        for key in keys {
-                            unpaired_ok.insert(key.clone());
-                        }
+                        shared.allow_unpaired(keys);
                     }
                     tracing::info!("Viewer at {target} has pairing disabled");
                     return Ok((session::Sealing::Plaintext, session::Opening::Plaintext));
@@ -499,12 +539,7 @@ impl RemoteLspToPreview {
                     match reason {
                         // Issued by an earlier run of that viewer. Forget it;
                         // the code prompt follows on the same connection.
-                        PairingRejection::BadToken => {
-                            let mut tokens = shared.tokens.borrow_mut();
-                            for key in keys {
-                                tokens.remove(key);
-                            }
-                        }
+                        PairingRejection::BadToken => shared.forget_token(keys),
                         // The retry count comes with the prompt that follows.
                         PairingRejection::BadCode => {}
                         // Everything else ends this attempt, one way or another.
@@ -537,8 +572,8 @@ impl RemoteLspToPreview {
         }
     }
 
-    /// Answer one code prompt: ask the user, run the editor's half of the
-    /// SPAKE2 exchange, and check the viewer's confirmation.
+    /// Answer one code prompt: ask the user, then run the exchange with
+    /// what they typed.
     ///
     /// `Ok(None)` is a wrong code with attempts left; the viewer sends a
     /// fresh prompt and the caller goes around again.
@@ -558,58 +593,21 @@ impl RemoteLspToPreview {
         )
         .await?;
 
-        // The code never goes on the wire, and neither does anything an
-        // observer could test a guess against: the exchange only reveals
-        // whether both sides agreed.
         let handshake = pairing::Handshake::with_code(pairing::Role::Editor, &code);
-        let our_element = handshake.element().clone();
-        let secrets = handshake
-            .finish(&prompt.element)
-            .map_err(|_| ConnectError::Transient("The viewer sent a malformed handshake".into()))?;
-
-        Self::send_message(
-            stream,
-            &LspToPreviewMessage::PairingResponse {
-                element: our_element,
-                confirmation: secrets.editor_confirmation,
-            },
-        )
-        .await?;
-
-        // The viewer answers with its own confirmation only if it derived
-        // the same key, so this is where a wrong code surfaces. Anything
-        // else means it refused us.
-        match Self::next_message(stream).await {
-            Some(PreviewToLspMessage::PairingConfirm { confirmation })
-                if confirmation.matches(&secrets.viewer_confirmation) =>
-            {
+        match Self::run_exchange(stream, handshake, &prompt.element).await? {
+            ExchangeVerdict::Confirmed(secrets) => {
                 tracing::info!("Paired with remote viewer at {target}");
-                let issued = (secrets.token_id, secrets.token);
-                let mut tokens = shared.tokens.borrow_mut();
-                for key in keys {
-                    tokens.insert(key.clone(), issued);
-                }
+                shared.remember_token(keys, (secrets.token_id, secrets.token));
                 Ok(Some(secrets.session()))
             }
-            Some(PreviewToLspMessage::PairingConfirm { .. }) => {
-                // Same code space, different key: either we typed the wrong
-                // code or something is in the middle.
-                Err(ConnectError::Transient("The viewer could not confirm the pairing".into()))
-            }
-            Some(PreviewToLspMessage::PairingRejected { reason }) => {
-                if reason == PairingRejection::BadCode {
-                    return Ok(None);
-                }
-                Err(from_rejection(reason))
-            }
-            _ => Err(ConnectError::Transient(
-                "The viewer closed the connection during pairing".into(),
-            )),
+            // A wrong code with attempts left: the fresh prompt follows.
+            ExchangeVerdict::Rejected(PairingRejection::BadCode) => Ok(None),
+            ExchangeVerdict::Rejected(reason) => Err(from_rejection(reason)),
         }
     }
 
-    /// The editor's half of the reconnect exchange: prove the token, check
-    /// the viewer proved it too, and key the session from the fresh secrets.
+    /// The reconnect exchange: like a code prompt, with the token as the
+    /// secret and nobody asked.
     ///
     /// `Ok(None)` is a refused token; the caller forgets it and falls
     /// through to the code prompt the viewer sends next.
@@ -622,6 +620,33 @@ impl RemoteLspToPreview {
         viewer_element: &pairing::Element,
     ) -> std::result::Result<Option<(session::Sealing, session::Opening)>, ConnectError> {
         let handshake = pairing::Handshake::with_token(pairing::Role::Editor, token);
+        match Self::run_exchange(stream, handshake, viewer_element).await? {
+            ExchangeVerdict::Confirmed(secrets) => {
+                tracing::info!("Reconnected to remote viewer at {target} by token");
+                Ok(Some(secrets.session()))
+            }
+            // Refused after all: forget it, like a token the viewer never
+            // knew, and take the code prompt that follows.
+            ExchangeVerdict::Rejected(PairingRejection::BadToken) => {
+                shared.forget_token(keys);
+                Ok(None)
+            }
+            ExchangeVerdict::Rejected(reason) => Err(from_rejection(reason)),
+        }
+    }
+
+    /// The editor's half of one SPAKE2 exchange, whatever the secret:
+    /// answer the viewer's element, then require its proof of having
+    /// derived the same key.
+    ///
+    /// The secret never goes on the wire, and neither does anything an
+    /// observer could test a guess against: the exchange only reveals
+    /// whether both sides agreed.
+    async fn run_exchange(
+        stream: &mut WebSocketStream,
+        handshake: pairing::Handshake,
+        viewer_element: &pairing::Element,
+    ) -> std::result::Result<ExchangeVerdict, ConnectError> {
         let our_element = handshake.element().clone();
         let secrets = handshake
             .finish(viewer_element)
@@ -631,33 +656,27 @@ impl RemoteLspToPreview {
             stream,
             &LspToPreviewMessage::PairingResponse {
                 element: our_element,
-                confirmation: secrets.editor_confirmation,
+                confirmation: secrets.confirmation(),
             },
         )
         .await?;
 
+        // The viewer answers with its own confirmation only if it derived
+        // the same key, so this is where a wrong secret surfaces. Anything
+        // else means it refused us.
         match Self::next_message(stream).await {
             Some(PreviewToLspMessage::PairingConfirm { confirmation })
-                if confirmation.matches(&secrets.viewer_confirmation) =>
+                if secrets.peer_confirms(&confirmation) =>
             {
-                tracing::info!("Reconnected to remote viewer at {target} by token");
-                Ok(Some(secrets.session()))
+                Ok(ExchangeVerdict::Confirmed(secrets))
             }
-            // The real viewer knows the token it issued, so a failed
-            // confirmation means someone else is answering. Keep the token:
-            // it is still good against the real viewer.
             Some(PreviewToLspMessage::PairingConfirm { .. }) => {
-                Err(ConnectError::Transient("The viewer could not confirm the reconnect".into()))
+                // Same secret space, different key: a mistyped code, or
+                // someone in the middle answering for a token it can't know.
+                Err(ConnectError::Transient("The viewer could not confirm the pairing".into()))
             }
             Some(PreviewToLspMessage::PairingRejected { reason }) => {
-                if reason == PairingRejection::BadToken {
-                    let mut tokens = shared.tokens.borrow_mut();
-                    for key in keys {
-                        tokens.remove(key);
-                    }
-                    return Ok(None);
-                }
-                Err(from_rejection(reason))
+                Ok(ExchangeVerdict::Rejected(reason))
             }
             _ => Err(ConnectError::Transient(
                 "The viewer closed the connection during pairing".into(),

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -860,8 +860,9 @@ async fn handle_preview_to_lsp_message(
         }
         // The connector completes pairing before a session exists, so these
         // never reach the LSP's message loop.
-        M::PairingChallenge { .. }
+        M::PairingReady
         | M::PairingRequired { .. }
+        | M::PairingTokenChallenge { .. }
         | M::PairingConfirm { .. }
         | M::PairingAccepted
         | M::PairingRejected { .. } => {

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -837,12 +837,34 @@ async fn handle_preview_to_lsp_message(
                 crate::editor_preview::spawn_local(remote.disconnect());
             }
         }
+        M::SubmitPairingCode { code } => {
+            tracing::debug!("Preview submitted a pairing code");
+            #[cfg(feature = "preview-remote")]
+            if let Some(remote) = ctx.session.to_preview.remote() {
+                remote.submit_pairing_code(code);
+            }
+        }
+        M::CancelPairing => {
+            tracing::debug!("Preview cancelled pairing");
+            #[cfg(feature = "preview-remote")]
+            if let Some(remote) = ctx.session.to_preview.remote() {
+                remote.cancel_pairing();
+            }
+        }
         M::Pong => {
             // The remote connector consumes pongs; local previews never send them.
             tracing::debug!("Ignoring unexpected Pong message from a local preview");
         }
         M::RequestPreview { .. } => {
             tracing::debug!("Ignoring preview request from a preview client");
+        }
+        // The connector completes pairing before a session exists, so these
+        // never reach the LSP's message loop.
+        M::PairingChallenge { .. }
+        | M::PairingRequired { .. }
+        | M::PairingAccepted
+        | M::PairingRejected { .. } => {
+            tracing::debug!("Ignoring a pairing message outside the pairing handshake");
         }
     }
     Ok(())

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -862,6 +862,7 @@ async fn handle_preview_to_lsp_message(
         // never reach the LSP's message loop.
         M::PairingChallenge { .. }
         | M::PairingRequired { .. }
+        | M::PairingConfirm { .. }
         | M::PairingAccepted
         | M::PairingRejected { .. } => {
             tracing::debug!("Ignoring a pairing message outside the pairing handshake");

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -851,6 +851,13 @@ async fn handle_preview_to_lsp_message(
                 remote.cancel_pairing();
             }
         }
+        M::AcceptUnpairedConnection => {
+            tracing::debug!("Preview accepted an unpaired connection");
+            #[cfg(feature = "preview-remote")]
+            if let Some(remote) = ctx.session.to_preview.remote() {
+                remote.accept_unpaired_connection();
+            }
+        }
         M::Pong => {
             // The remote connector consumes pongs; local previews never send them.
             tracing::debug!("Ignoring unexpected Pong message from a local preview");

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -131,6 +131,12 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         }
         Message::Ping => {}
         Message::OpenProject { .. } => {}
+        // Part of the remote pairing handshake, which the LSP's WebSocket
+        // connector completes before a session exists. A local preview is
+        // never on the receiving end of one.
+        Message::PairingHello { .. } | Message::PairingCodeProof { .. } => {
+            tracing::warn!("Ignoring a pairing message addressed to a local preview");
+        }
     }
 }
 
@@ -1757,8 +1763,8 @@ fn set_preview_factory(
     api.set_resize_to_preferred_size(behavior != LoadBehavior::Reload);
 }
 
-/// Highlight the element pointed at the offset in the path.
-/// When the URL is None, remove the highlight.
+/// Push the remote connection's state to the Remote Preview pane, which
+/// shows it and, while pairing, collects the code from the user.
 pub fn set_remote_connection_state(
     state: i_slint_live_preview::protocol::RemoteConnectionState,
     target: String,
@@ -1770,6 +1776,7 @@ pub fn set_remote_connection_state(
             let ui_state = match state {
                 R::Disconnected => ui::RemoteConnectionState::Disconnected,
                 R::Connecting => ui::RemoteConnectionState::Connecting,
+                R::PairingRequired => ui::RemoteConnectionState::PairingRequired,
                 R::Connected => ui::RemoteConnectionState::Connected,
                 R::Failed => ui::RemoteConnectionState::Failed,
             };

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -134,7 +134,7 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         // Part of the remote pairing handshake, which the LSP's WebSocket
         // connector completes before a session exists. A local preview is
         // never on the receiving end of one.
-        Message::PairingHello { .. } | Message::PairingCodeProof { .. } => {
+        Message::PairingHello { .. } | Message::PairingResponse { .. } => {
             tracing::warn!("Ignoring a pairing message addressed to a local preview");
         }
     }

--- a/tools/lsp/preview.rs
+++ b/tools/lsp/preview.rs
@@ -1777,6 +1777,7 @@ pub fn set_remote_connection_state(
                 R::Disconnected => ui::RemoteConnectionState::Disconnected,
                 R::Connecting => ui::RemoteConnectionState::Connecting,
                 R::PairingRequired => ui::RemoteConnectionState::PairingRequired,
+                R::UnpairedWarning => ui::RemoteConnectionState::UnpairedWarning,
                 R::Connected => ui::RemoteConnectionState::Connected,
                 R::Failed => ui::RemoteConnectionState::Failed,
             };

--- a/tools/lsp/preview/remote.rs
+++ b/tools/lsp/preview/remote.rs
@@ -28,10 +28,22 @@ use crate::preview::ui::{Api, AppWindow, RemoteConnectionState, RemoteViewerInfo
 pub fn setup(app_window: &AppWindow, to_lsp: &Rc<dyn editor_preview::PreviewToLsp>) {
     let api = app_window.api();
     api.set_remote_discovered_viewers(ModelRc::new(VecModel::<RemoteViewerInfo>::default()));
+    // The code field is fixed-length, so the UI needs the same number the
+    // viewer generates against.
+    api.set_remote_pairing_code_length(i_slint_live_preview::protocol::pairing::CODE_DIGITS as i32);
 
     let api_weak = app_window.api_weak();
     api.on_remote_start_discovery(move || {
         let api_weak = api_weak.clone();
+        // Opening the pane shouldn't greet the user with whatever went wrong
+        // last time: a code that expired while they were away is not news on
+        // the way back in. Anything live keeps its state.
+        if let Some(api) = api_weak.upgrade()
+            && api.get_remote_connection_state() == RemoteConnectionState::Failed
+        {
+            api.set_remote_connection_state(RemoteConnectionState::Disconnected);
+            api.set_remote_connection_error(SharedString::default());
+        }
         crate::preview::PREVIEW_STATE.with_borrow(|preview_state| {
             preview_state.remote_discovery.start(api_weak);
         });
@@ -81,6 +93,25 @@ pub fn setup(app_window: &AppWindow, to_lsp: &Rc<dyn editor_preview::PreviewToLs
     api.on_remote_disconnect(move || {
         if let Err(err) = lsp.send(&PreviewToLspMessage::DisconnectRemote) {
             tracing::error!("Failed sending DisconnectRemote to LSP: {err}");
+        }
+    });
+
+    let lsp = to_lsp.clone();
+    api.on_remote_submit_pairing_code(move |code| {
+        let code = code.trim().to_owned();
+        if !i_slint_live_preview::protocol::pairing::is_valid_code(&code) {
+            tracing::warn!("Ignoring malformed pairing code");
+            return;
+        }
+        if let Err(err) = lsp.send(&PreviewToLspMessage::SubmitPairingCode { code }) {
+            tracing::error!("Failed sending SubmitPairingCode to LSP: {err}");
+        }
+    });
+
+    let lsp = to_lsp.clone();
+    api.on_remote_cancel_pairing(move || {
+        if let Err(err) = lsp.send(&PreviewToLspMessage::CancelPairing) {
+            tracing::error!("Failed sending CancelPairing to LSP: {err}");
         }
     });
 }

--- a/tools/lsp/preview/remote.rs
+++ b/tools/lsp/preview/remote.rs
@@ -114,6 +114,13 @@ pub fn setup(app_window: &AppWindow, to_lsp: &Rc<dyn editor_preview::PreviewToLs
             tracing::error!("Failed sending CancelPairing to LSP: {err}");
         }
     });
+
+    let lsp = to_lsp.clone();
+    api.on_remote_accept_unpaired(move || {
+        if let Err(err) = lsp.send(&PreviewToLspMessage::AcceptUnpairedConnection) {
+            tracing::error!("Failed sending AcceptUnpairedConnection to LSP: {err}");
+        }
+    });
 }
 
 /// Surface a manual-entry / discovery error in the dialog. Skipped when

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -55,6 +55,9 @@ export enum RemoteConnectionState {
     /// The viewer is showing a pairing code and is waiting for it to be
     /// typed in here.
     PairingRequired,
+    /// The viewer has pairing disabled; waiting for the user to accept the
+    /// unencrypted connection or cancel.
+    UnpairedWarning,
     Connected,
     Failed,
 }
@@ -640,6 +643,8 @@ export global Api {
     callback remote-disconnect();
     callback remote-submit-pairing-code(code: string);
     callback remote-cancel-pairing();
+    /// Connect to the pairing-disabled viewer the warning is about.
+    callback remote-accept-unpaired();
     /// Digits in a pairing code, from `pairing::CODE_DIGITS`.
     in-out property <int> remote-pairing-code-length;
 

--- a/tools/lsp/ui/api.slint
+++ b/tools/lsp/ui/api.slint
@@ -52,6 +52,9 @@ export struct RemoteViewerInfo {
 export enum RemoteConnectionState {
     Disconnected,
     Connecting,
+    /// The viewer is showing a pairing code and is waiting for it to be
+    /// typed in here.
+    PairingRequired,
     Connected,
     Failed,
 }
@@ -635,6 +638,10 @@ export global Api {
     callback remote-connect(addresses: [string], port: int);
     callback remote-connect-manual(host-port: string);
     callback remote-disconnect();
+    callback remote-submit-pairing-code(code: string);
+    callback remote-cancel-pairing();
+    /// Digits in a pairing code, from `pairing::CODE_DIGITS`.
+    in-out property <int> remote-pairing-code-length;
 
     // ## SlintPad related APIs
     in-out property <bool> runs-in-slintpad;

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -96,7 +96,29 @@ export component RemotePreviewView inherits Rectangle {
     property <bool> pairing: Api.remote-connection-state == RemoteConnectionState.PairingRequired;
     /// The viewer has pairing disabled; the user has to accept or cancel.
     property <bool> unpaired-warning: Api.remote-connection-state == RemoteConnectionState.UnpairedWarning;
+    /// A question is up that only the user can answer. Starting another
+    /// connection attempt would take the answer slot away from it.
+    property <bool> prompt-active: root.pairing || root.unpaired-warning;
     property <string> pairing-code-entry;
+
+    /// The headline states, most specific first: a prompt isn't a discovery
+    /// state, and falling through to those would claim we're still
+    /// searching while a question is up.
+    pure function headline() -> string {
+        if root.pairing {
+            return @tr("Pairing with {}.", best-device-name);
+        }
+        if root.unpaired-warning {
+            return @tr("Connect to {}?", best-device-name);
+        }
+        if Api.remote-connection-state == RemoteConnectionState.Connected {
+            return @tr("Connected to {}.", best-device-name);
+        }
+        if Api.remote-discovered-viewers.length > 0 {
+            return @tr("Select a discovered device to connect.");
+        }
+        return @tr("Searching for a device…");
+    }
 
     function submit-pairing-code() {
         if root.pairing-code-entry.character-count == Api.remote-pairing-code-length {
@@ -113,8 +135,7 @@ export component RemotePreviewView inherits Rectangle {
         // `Busy`, which flips the state to `Failed` and takes the code field
         // away from the attempt still waiting for it.
         if !root.connecting
-            && !root.pairing
-            && !root.unpaired-warning
+            && !root.prompt-active
             && index >= 0
             && index < Api.remote-discovered-viewers.length
             && Api.remote-discovered-viewers[index].compatible
@@ -171,17 +192,7 @@ export component RemotePreviewView inherits Rectangle {
             VerticalLayout {
                 spacing: 6px;
                 Text {
-                    // Pairing has to come before the discovery cases: it isn't
-                    // a discovery state, and falling through to them claims
-                    // we're still searching while a code is on the device.
-                    text: root.pairing
-                        ? @tr("Pairing with {}.", best-device-name)
-                        : (root.unpaired-warning
-                        ? @tr("Connect to {}?", best-device-name)
-                        : (Api.remote-connection-state == RemoteConnectionState.Connected
-                        ? @tr("Connected to {}.", best-device-name)
-                        : (Api.remote-discovered-viewers.length > 0 ? @tr("Select a discovered device to connect.")
-                        : @tr("Searching for a device…"))));
+                    text: root.headline();
                     font-size: 24px;
                     font-weight: FontWeight.bold;
                     color: Palette.foreground;
@@ -319,7 +330,7 @@ export component RemotePreviewView inherits Rectangle {
                         }
                     }
 
-                    if !root.pairing && !root.unpaired-warning: SunkenField {
+                    if !root.prompt-active: SunkenField {
                         dark-color-scheme: root.dark-color-scheme;
                         min-width: manual-le.preferred-width;
                         manual-le := LineEdit {
@@ -439,7 +450,7 @@ export component RemotePreviewView inherits Rectangle {
                         }
                     }
 
-                    if !root.pairing && !root.unpaired-warning: HorizontalLayout {
+                    if !root.prompt-active: HorizontalLayout {
                         spacing: EditorSpaceSettings.default-spacing;
                         alignment: end;
 

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -94,6 +94,8 @@ export component RemotePreviewView inherits Rectangle {
 
     /// The viewer is showing a code and is waiting for it to be typed here.
     property <bool> pairing: Api.remote-connection-state == RemoteConnectionState.PairingRequired;
+    /// The viewer has pairing disabled; the user has to accept or cancel.
+    property <bool> unpaired-warning: Api.remote-connection-state == RemoteConnectionState.UnpairedWarning;
     property <string> pairing-code-entry;
 
     function submit-pairing-code() {
@@ -112,6 +114,7 @@ export component RemotePreviewView inherits Rectangle {
         // away from the attempt still waiting for it.
         if !root.connecting
             && !root.pairing
+            && !root.unpaired-warning
             && index >= 0
             && index < Api.remote-discovered-viewers.length
             && Api.remote-discovered-viewers[index].compatible
@@ -173,10 +176,12 @@ export component RemotePreviewView inherits Rectangle {
                     // we're still searching while a code is on the device.
                     text: root.pairing
                         ? @tr("Pairing with {}.", best-device-name)
+                        : (root.unpaired-warning
+                        ? @tr("Connect to {}?", best-device-name)
                         : (Api.remote-connection-state == RemoteConnectionState.Connected
                         ? @tr("Connected to {}.", best-device-name)
                         : (Api.remote-discovered-viewers.length > 0 ? @tr("Select a discovered device to connect.")
-                        : @tr("Searching for a device…")));
+                        : @tr("Searching for a device…"))));
                     font-size: 24px;
                     font-weight: FontWeight.bold;
                     color: Palette.foreground;
@@ -314,7 +319,7 @@ export component RemotePreviewView inherits Rectangle {
                         }
                     }
 
-                    if !root.pairing: SunkenField {
+                    if !root.pairing && !root.unpaired-warning: SunkenField {
                         dark-color-scheme: root.dark-color-scheme;
                         min-width: manual-le.preferred-width;
                         manual-le := LineEdit {
@@ -328,7 +333,7 @@ export component RemotePreviewView inherits Rectangle {
                     }
 
                     Text {
-                        text: @tr("Connecting sends this project's .slint files, images and fonts to the device over the local network, without encryption. Only connect to a trusted device.");
+                        text: @tr("Connecting sends this project's .slint files, images and fonts to the device over the local network. Pairing encrypts them.");
                         color: Palette.foreground;
                         opacity: 0.7;
                         font-size: 11px;
@@ -405,7 +410,36 @@ export component RemotePreviewView inherits Rectangle {
                         }
                     }
 
-                    if !root.pairing: HorizontalLayout {
+                    if root.unpaired-warning: VerticalLayout {
+                        spacing: EditorSpaceSettings.default-spacing;
+
+                        Text {
+                            text: @tr("{} has pairing disabled. The connection will not be encrypted.", Api.remote-connection-target);
+                            color: Palette.foreground;
+                            wrap: word-wrap;
+                        }
+
+                        HorizontalLayout {
+                            spacing: EditorSpaceSettings.default-spacing;
+                            alignment: end;
+
+                            Button {
+                                text: @tr("Cancel");
+                                clicked => {
+                                    Api.remote-cancel-pairing();
+                                }
+                            }
+
+                            Button {
+                                text: @tr("Connect anyway");
+                                clicked => {
+                                    Api.remote-accept-unpaired();
+                                }
+                            }
+                        }
+                    }
+
+                    if !root.pairing && !root.unpaired-warning: HorizontalLayout {
                         spacing: EditorSpaceSettings.default-spacing;
                         alignment: end;
 

--- a/tools/lsp/ui/components/remote-preview-view.slint
+++ b/tools/lsp/ui/components/remote-preview-view.slint
@@ -60,6 +60,20 @@ component PhonePreview {
     }
 }
 
+/// The inset well the text inputs sit in.
+component SunkenField inherits Rectangle {
+    in property <bool> dark-color-scheme;
+
+    border-radius: 4px;
+    inner-shadow-blur: 5px;
+    inner-shadow-color: black.with-alpha(0.15);
+    inner-shadow-offset-x: 5px;
+    inner-shadow-offset-y: 5px;
+    background: root.dark-color-scheme ? #1C1C1C : #D7D9DD;
+
+    @children
+}
+
 export component RemotePreviewView inherits Rectangle {
     background: Palette.background;
     preferred-width: 850px;
@@ -78,8 +92,26 @@ export component RemotePreviewView inherits Rectangle {
 
     property <bool> connecting: Api.remote-connection-state == RemoteConnectionState.Connecting;
 
+    /// The viewer is showing a code and is waiting for it to be typed here.
+    property <bool> pairing: Api.remote-connection-state == RemoteConnectionState.PairingRequired;
+    property <string> pairing-code-entry;
+
+    function submit-pairing-code() {
+        if root.pairing-code-entry.character-count == Api.remote-pairing-code-length {
+            Api.remote-submit-pairing-code(root.pairing-code-entry);
+            // Cleared so a rejected code doesn't have to be selected away
+            // before the next attempt.
+            root.pairing-code-entry = "";
+        }
+    }
+
     function connect-to-device(index: int) {
+        // `connecting` is false during a prompt, and the device list stays
+        // clickable while one is up. A second attempt would be refused as
+        // `Busy`, which flips the state to `Failed` and takes the code field
+        // away from the attempt still waiting for it.
         if !root.connecting
+            && !root.pairing
             && index >= 0
             && index < Api.remote-discovered-viewers.length
             && Api.remote-discovered-viewers[index].compatible
@@ -136,10 +168,15 @@ export component RemotePreviewView inherits Rectangle {
             VerticalLayout {
                 spacing: 6px;
                 Text {
-                    text: Api.remote-connection-state == RemoteConnectionState.Connected
+                    // Pairing has to come before the discovery cases: it isn't
+                    // a discovery state, and falling through to them claims
+                    // we're still searching while a code is on the device.
+                    text: root.pairing
+                        ? @tr("Pairing with {}.", best-device-name)
+                        : (Api.remote-connection-state == RemoteConnectionState.Connected
                         ? @tr("Connected to {}.", best-device-name)
                         : (Api.remote-discovered-viewers.length > 0 ? @tr("Select a discovered device to connect.")
-                        : @tr("Searching for a device…"));
+                        : @tr("Searching for a device…")));
                     font-size: 24px;
                     font-weight: FontWeight.bold;
                     color: Palette.foreground;
@@ -277,13 +314,8 @@ export component RemotePreviewView inherits Rectangle {
                         }
                     }
 
-                    Rectangle {
-                        border-radius: 4px;
-                        inner-shadow-blur: 5px;
-                        inner-shadow-color: black.with-alpha(0.15);
-                        inner-shadow-offset-x: 5px;
-                        inner-shadow-offset-y: 5px;
-                        background: root.dark-color-scheme ? #1C1C1C : #D7D9DD;
+                    if !root.pairing: SunkenField {
+                        dark-color-scheme: root.dark-color-scheme;
                         min-width: manual-le.preferred-width;
                         manual-le := LineEdit {
                             width: 100%;
@@ -315,7 +347,65 @@ export component RemotePreviewView inherits Rectangle {
                         wrap: word-wrap;
                     }
 
-                    HorizontalLayout {
+                    if root.pairing: VerticalLayout {
+                        spacing: EditorSpaceSettings.default-spacing;
+
+                        init => {
+                            // The entry survives the block being torn down,
+                            // and a prompt that ends by expiry or rejection
+                            // never clears it. Left over, its digits would
+                            // auto-submit part-way through the next code.
+                            root.pairing-code-entry = "";
+                            pairing-le.focus();
+                        }
+
+                        Text {
+                            text: @tr("{} is showing a pairing code. Enter it here to connect.", Api.remote-connection-target);
+                            color: Palette.foreground;
+                            wrap: word-wrap;
+                        }
+
+                        SunkenField {
+                            dark-color-scheme: root.dark-color-scheme;
+                            min-width: pairing-le.preferred-width;
+                            pairing-le := LineEdit {
+                                width: 100%;
+                                // Restricts typing to 0-9 and gets a numeric
+                                // keyboard where there is one.
+                                input-type: number;
+                                placeholder-text: @tr("{}-digit code", Api.remote-pairing-code-length);
+                                text <=> root.pairing-code-entry;
+                                edited => {
+                                    // The code is fixed-length, so the last
+                                    // digit is the whole gesture: there is no
+                                    // separate confirm step to reach.
+                                    root.submit-pairing-code();
+                                }
+                            }
+                        }
+
+                        if Api.remote-connection-error != "": Text {
+                            text: Api.remote-connection-error;
+                            color: Palette.foreground;
+                            opacity: 0.8;
+                            wrap: word-wrap;
+                        }
+
+                        HorizontalLayout {
+                            spacing: EditorSpaceSettings.default-spacing;
+                            alignment: end;
+
+                            Button {
+                                text: @tr("Cancel");
+                                clicked => {
+                                    root.pairing-code-entry = "";
+                                    Api.remote-cancel-pairing();
+                                }
+                            }
+                        }
+                    }
+
+                    if !root.pairing: HorizontalLayout {
                         spacing: EditorSpaceSettings.default-spacing;
                         alignment: end;
 

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -359,6 +359,7 @@ impl SlintServer {
             | M::RequestPreview { .. }
             | M::PairingChallenge { .. }
             | M::PairingRequired { .. }
+            | M::PairingConfirm { .. }
             | M::PairingAccepted
             | M::PairingRejected { .. } => {
                 tracing::debug!("Ignoring remote-preview control message in WASM LSP");

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -357,8 +357,9 @@ impl SlintServer {
             | M::CancelPairing
             | M::Pong
             | M::RequestPreview { .. }
-            | M::PairingChallenge { .. }
+            | M::PairingReady
             | M::PairingRequired { .. }
+            | M::PairingTokenChallenge { .. }
             | M::PairingConfirm { .. }
             | M::PairingAccepted
             | M::PairingRejected { .. } => {

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -351,7 +351,16 @@ impl SlintServer {
             M::DebugMessage { location, message } => {
                 log(&editor_preview::preview_log_message_to_string(&location, &message));
             }
-            M::ConnectRemote { .. } | M::DisconnectRemote | M::Pong | M::RequestPreview { .. } => {
+            M::ConnectRemote { .. }
+            | M::DisconnectRemote
+            | M::SubmitPairingCode { .. }
+            | M::CancelPairing
+            | M::Pong
+            | M::RequestPreview { .. }
+            | M::PairingChallenge { .. }
+            | M::PairingRequired { .. }
+            | M::PairingAccepted
+            | M::PairingRejected { .. } => {
                 tracing::debug!("Ignoring remote-preview control message in WASM LSP");
             }
         }

--- a/tools/lsp/wasm_main.rs
+++ b/tools/lsp/wasm_main.rs
@@ -355,6 +355,7 @@ impl SlintServer {
             | M::DisconnectRemote
             | M::SubmitPairingCode { .. }
             | M::CancelPairing
+            | M::AcceptUnpairedConnection
             | M::Pong
             | M::RequestPreview { .. }
             | M::PairingReady

--- a/tools/viewer/lib.rs
+++ b/tools/viewer/lib.rs
@@ -22,7 +22,7 @@ fn android_main(app: i_slint_backend_android_activity::android_activity::Android
         i_slint_backend_android_activity::AndroidPlatform::new(app),
     ))
     .unwrap();
-    remote::run(None, true).unwrap();
+    remote::run(None, true, i_slint_live_preview::remote::PairingPolicy::Generated).unwrap();
 }
 
 /// Read the user-set device name from `Settings.Global.DEVICE_NAME` via JNI.

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -79,6 +79,17 @@ struct Cli {
     #[arg(long, value_name = "address")]
     remote_address: Option<std::net::SocketAddr>,
 
+    /// Always require this pairing code, given as four digits, instead of showing a
+    /// freshly generated one. For devices without a usable display, and for scripted
+    /// clients.
+    #[arg(long, value_name = "code", requires = "remote", conflicts_with = "no_pairing")]
+    pairing_code: Option<String>,
+
+    /// Accept any connection without pairing. Anyone who can reach this viewer can
+    /// then drive what it displays, so only use this on a network you control.
+    #[arg(long, requires = "remote")]
+    no_pairing: bool,
+
     /// The style name. Defaults to 'fluent' if not specified
     #[arg(long, value_name = "style name", action)]
     style: Option<String>,
@@ -195,7 +206,17 @@ fn main() -> Result<()> {
     if args.remote {
         #[cfg(feature = "remote")]
         {
-            remote::run(args.remote_address, true)?;
+            use i_slint_live_preview::protocol::pairing;
+            let pairing_policy = match (args.no_pairing, args.pairing_code) {
+                (true, _) => i_slint_live_preview::remote::PairingPolicy::Disabled,
+                (false, Some(code)) if !pairing::is_valid_code(&code) => {
+                    eprintln!("--pairing-code must be exactly {} digits", pairing::CODE_DIGITS);
+                    std::process::exit(2);
+                }
+                (false, Some(code)) => i_slint_live_preview::remote::PairingPolicy::Fixed(code),
+                (false, None) => i_slint_live_preview::remote::PairingPolicy::Generated,
+            };
+            remote::run(args.remote_address, true, pairing_policy)?;
             return Ok(());
         }
         #[cfg(not(feature = "remote"))]

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -10,7 +10,7 @@ use i_slint_core::SharedString;
 use i_slint_core::textlayout::sharedparley::fontique;
 use i_slint_core::window::WindowInner;
 use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage, lsp_types};
-use i_slint_live_preview::remote::{Connection, ConnectionMessage, init_compiler};
+use i_slint_live_preview::remote::{Connection, ConnectionMessage, PairingPolicy, init_compiler};
 use slint::ComponentHandle as _;
 
 slint::slint! {
@@ -87,9 +87,13 @@ use apple::announce_mdns;
 #[cfg(target_os = "ios")]
 use apple::observe_foregrounding;
 
-pub fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Result<()> {
+pub fn run(
+    address: Option<SocketAddr>,
+    enable_mdns: bool,
+    pairing_policy: PairingPolicy,
+) -> anyhow::Result<()> {
     slint_interpreter::spawn_local(async_compat::Compat::new(async move {
-        if let Err(err) = run_async(address, enable_mdns).await {
+        if let Err(err) = run_async(address, enable_mdns, pairing_policy).await {
             tracing::error!("Remote viewer error: {err}");
             slint_interpreter::quit_event_loop().ok();
         }
@@ -98,14 +102,26 @@ pub fn run(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Result<()>
     Ok(())
 }
 
-async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Result<()> {
+async fn run_async(
+    address: Option<SocketAddr>,
+    enable_mdns: bool,
+    pairing_policy: PairingPolicy,
+) -> anyhow::Result<()> {
     let (event_sender, mut event_receiver) = tokio::sync::mpsc::unbounded_channel();
 
     #[cfg(target_os = "ios")]
     observe_foregrounding(event_sender.clone());
 
+    let pairing_disabled = pairing_policy == PairingPolicy::Disabled;
+    if pairing_disabled {
+        tracing::warn!(
+            "Pairing is disabled: any host that can reach this viewer can drive it. \
+             Only use --no-pairing on a network you control."
+        );
+    }
+
     let connection = Rc::new(
-        Connection::listen(address, device_name_override(), move |msg| {
+        Connection::listen(address, device_name_override(), pairing_policy, move |msg| {
             let _ = event_sender.send(Event::Connection(msg));
         })
         .await?,
@@ -162,17 +178,25 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
             }
         })
         .collect();
-    let address = local_ip_str.join("\n");
-
-    placeholder.set_address(SharedString::from(address.as_str()));
-    // Read after the Apple Bonjour overwrite above so the UI label matches the
-    // advertised mDNS instance.
-    placeholder.set_name(SharedString::from(connection.device_name().as_str()));
-    placeholder.set_slint_version(SharedString::from(SLINT_VERSION));
-    placeholder.set_build_info(build_info());
-    placeholder.set_third_party_licenses(third_party_licenses());
+    // Only the Apple resume path renames the device, so on other targets
+    // this is never mutated.
+    #[cfg_attr(not(target_vendor = "apple"), allow(unused_mut))]
+    let mut chrome = Chrome {
+        address: local_ip_str.join("\n"),
+        // Read after the Apple Bonjour overwrite above so the UI label matches
+        // the advertised mDNS instance.
+        name: connection.device_name(),
+        licenses: third_party_licenses(),
+        pairing_disabled,
+    };
+    chrome.apply(&placeholder);
     placeholder.show()?;
 
+    // Set while a pairing code is on screen. The established session keeps
+    // running underneath, and its traffic must not repaint over a code the
+    // user is still reading: the code is only worth anything for as long as
+    // it is legible on the device.
+    let mut prompt_on_screen = false;
     let mut last_connection = None;
     let mut user_instance: Option<slint_interpreter::ComponentInstance> = None;
     let mut current_preview: Option<PreviewComponent> = None;
@@ -187,7 +211,8 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     // still alive would trigger Bonjour's conflict rename.
                     drop(mdns.take());
                     mdns = announce_mdns(&connection).await;
-                    placeholder.set_name(SharedString::from(connection.device_name().as_str()));
+                    chrome.name = connection.device_name();
+                    chrome.apply(&placeholder);
                 }
                 continue;
             }
@@ -200,30 +225,31 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
             }
             ConnectionMessage::SetUserSettings { .. } => {}
             ConnectionMessage::ShowPreview { preview_component } => {
-                build_and_show(
-                    &compiler,
-                    &preview_component,
-                    &mut placeholder,
-                    &mut user_instance,
-                    &connection,
-                    &address,
-                    &connection.device_name(),
-                )
-                .await?;
                 current_preview = Some(preview_component);
+                if !prompt_on_screen {
+                    show_current(
+                        &compiler,
+                        &current_preview,
+                        &mut placeholder,
+                        &mut user_instance,
+                        &connection,
+                        &chrome,
+                    )
+                    .await?;
+                }
             }
             ConnectionMessage::ContentsChanged => {
-                let Some(preview_component) = current_preview.clone() else { continue };
-                build_and_show(
-                    &compiler,
-                    &preview_component,
-                    &mut placeholder,
-                    &mut user_instance,
-                    &connection,
-                    &address,
-                    &connection.device_name(),
-                )
-                .await?;
+                if !prompt_on_screen {
+                    show_current(
+                        &compiler,
+                        &current_preview,
+                        &mut placeholder,
+                        &mut user_instance,
+                        &connection,
+                        &chrome,
+                    )
+                    .await?;
+                }
             }
             ConnectionMessage::HighlightFromEditor { .. } => {}
             ConnectionMessage::RegisterFont { url, contents } => {
@@ -243,23 +269,72 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                 tracing::debug!("Registered font {url} ({len} bytes)");
             }
             ConnectionMessage::Connected { remote_addr } => {
-                placeholder.set_message(SharedString::from(format!("Connected to {remote_addr}")));
-                placeholder.set_state(RemoteViewerState::Connected);
                 last_connection = Some(remote_addr);
+                if !prompt_on_screen {
+                    placeholder
+                        .set_message(SharedString::from(format!("Connected to {remote_addr}")));
+                    placeholder.set_state(RemoteViewerState::Connected);
+                }
             }
             ConnectionMessage::Disconnected { remote_addr } => {
                 if last_connection == Some(remote_addr) {
                     last_connection = None;
                     current_preview = None;
                     connection.set_dependencies(Vec::new());
-                    swap_to_placeholder(
-                        &mut placeholder,
-                        &mut user_instance,
-                        &address,
-                        &connection.device_name(),
-                        "",
-                        RemoteViewerState::WaitingForConnection,
-                    )?;
+                    if !prompt_on_screen {
+                        swap_to_placeholder(
+                            &mut placeholder,
+                            &mut user_instance,
+                            &chrome,
+                            "",
+                            RemoteViewerState::WaitingForConnection,
+                        )?;
+                    }
+                }
+            }
+            ConnectionMessage::PairingStarted { remote_addr, code, expires_in } => {
+                prompt_on_screen = true;
+                // Takes the screen even from a running preview. The code is
+                // only worth anything if it can be read off this device, so
+                // it has to be the thing on screen.
+                swap_to_placeholder(
+                    &mut placeholder,
+                    &mut user_instance,
+                    &chrome,
+                    "",
+                    RemoteViewerState::Pairing,
+                )?;
+                placeholder.set_pairing_code(SharedString::from(code));
+                placeholder.set_pairing_peer(SharedString::from(
+                    remote_addr.ip().to_canonical().to_string(),
+                ));
+                placeholder.set_pairing_seconds_left(expires_in.as_secs() as i32);
+            }
+            // The admitted session takes it from here: it pushes its
+            // configuration and asks for a component to show.
+            ConnectionMessage::PairingFinished { accepted: true, .. } => {
+                prompt_on_screen = false;
+            }
+            ConnectionMessage::PairingFinished { accepted: false, .. } => {
+                prompt_on_screen = false;
+                // Nobody got in, so restore whatever the prompt displaced,
+                // including anything the session changed meanwhile.
+                let restored = show_current(
+                    &compiler,
+                    &current_preview,
+                    &mut placeholder,
+                    &mut user_instance,
+                    &connection,
+                    &chrome,
+                )
+                .await?;
+                if !restored {
+                    let state = if last_connection.is_some() {
+                        RemoteViewerState::Connected
+                    } else {
+                        RemoteViewerState::WaitingForConnection
+                    };
+                    swap_to_placeholder(&mut placeholder, &mut user_instance, &chrome, "", state)?;
                 }
             }
         }
@@ -277,6 +352,24 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     Ok(())
 }
 
+/// Rebuild and show whatever component is currently being previewed.
+///
+/// Returns whether there was one, so callers that have to fall back to a
+/// placeholder can tell.
+async fn show_current(
+    compiler: &slint_interpreter::Compiler,
+    current_preview: &Option<PreviewComponent>,
+    placeholder: &mut RemoteViewerWindow,
+    user_instance: &mut Option<slint_interpreter::ComponentInstance>,
+    connection: &Rc<Connection>,
+    chrome: &Chrome,
+) -> anyhow::Result<bool> {
+    let Some(preview_component) = current_preview.clone() else { return Ok(false) };
+    build_and_show(compiler, &preview_component, placeholder, user_instance, connection, chrome)
+        .await?;
+    Ok(true)
+}
+
 /// Returns `Err` only on unrecoverable platform failure; compile errors and missing
 /// components reinstall the placeholder and return `Ok(())`.
 async fn build_and_show(
@@ -285,8 +378,7 @@ async fn build_and_show(
     placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
     connection: &Rc<Connection>,
-    address: &str,
-    name: &str,
+    chrome: &Chrome,
 ) -> anyhow::Result<()> {
     tracing::debug!("build_and_show");
 
@@ -323,8 +415,7 @@ async fn build_and_show(
         swap_to_placeholder(
             placeholder,
             user_instance,
-            address,
-            name,
+            chrome,
             &message,
             RemoteViewerState::PreviewError,
         )?;
@@ -343,8 +434,7 @@ async fn build_and_show(
         swap_to_placeholder(
             placeholder,
             user_instance,
-            address,
-            name,
+            chrome,
             "Component not found",
             RemoteViewerState::PreviewError,
         )?;
@@ -365,22 +455,45 @@ async fn build_and_show(
     Ok(())
 }
 
+/// Everything on the placeholder screen that doesn't depend on what the
+/// connection is doing.
+///
+/// [`swap_to_placeholder`] builds a whole new window each time, so anything
+/// missing from [`Chrome::apply`] silently disappears the first time the
+/// preview is swapped out.
+struct Chrome {
+    /// Newline-separated `ip:port` list the editor can be pointed at.
+    address: String,
+    /// Friendly device name. Bonjour can rename us on iOS resume, so this
+    /// isn't fixed for the life of the process.
+    name: String,
+    licenses: slint::ModelRc<AttributionItem>,
+    pairing_disabled: bool,
+}
+
+impl Chrome {
+    fn apply(&self, window: &RemoteViewerWindow) {
+        window.set_address(SharedString::from(self.address.as_str()));
+        window.set_name(SharedString::from(self.name.as_str()));
+        window.set_slint_version(SharedString::from(SLINT_VERSION));
+        window.set_build_info(build_info());
+        window.set_third_party_licenses(self.licenses.clone());
+        window.set_pairing_disabled(self.pairing_disabled);
+    }
+}
+
 /// Reinstall a fresh placeholder onto the existing window and drop the user instance.
 fn swap_to_placeholder(
     placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
-    address: &str,
-    name: &str,
+    chrome: &Chrome,
     message: &str,
     state: RemoteViewerState,
 ) -> anyhow::Result<()> {
     let fresh = RemoteViewerWindow::new_with_existing_window(placeholder.window())
         .map_err(|err| anyhow::anyhow!("Cannot create placeholder: {err}"))?;
-    fresh.set_address(SharedString::from(address));
-    fresh.set_name(SharedString::from(name));
+    chrome.apply(&fresh);
     fresh.set_message(SharedString::from(message));
-    fresh.set_slint_version(SharedString::from(SLINT_VERSION));
-    fresh.set_build_info(build_info());
     fresh.set_state(state);
     fresh.show().map_err(|err| anyhow::anyhow!("Cannot show placeholder: {err}"))?;
     *placeholder = fresh;

--- a/tools/viewer/remote/main.slint
+++ b/tools/viewer/remote/main.slint
@@ -13,6 +13,10 @@ export enum RemoteViewerState {
     previewing,
     /// The last build failed; `message` holds the error text.
     preview-error,
+    /// Someone is trying to connect and has to type `pairing-code`, which is
+    /// only readable here on the device. Displaces whatever was on screen
+    /// until the attempt is over.
+    pairing,
 }
 
 export component RemoteViewerWindow inherits Window {
@@ -24,10 +28,26 @@ export component RemoteViewerWindow inherits Window {
     in property <RemoteViewerState> state;
     in property <[AttributionItem]> third-party-licenses;
 
+    /// The code to be typed into the editor, while `state` is `pairing`.
+    in property <string> pairing-code;
+    /// Who is asking, so the user can tell an expected attempt from a stray one.
+    in property <string> pairing-peer;
+    /// Counts down while the code is on screen. Cosmetic: the deadline is
+    /// enforced on the connection, which drops the peer when it passes.
+    in-out property <int> pairing-seconds-left;
+    /// Set when the viewer was started with `--no-pairing`, so it's obvious
+    /// from the device that anyone on the network can connect.
+    in property <bool> pairing-disabled;
+
     property <bool> show-licenses: false;
 
     property <bool> has-name: name != "";
     property <bool> showing-name: true;
+
+    /// Whether the name/address screen is the one on show. The other states
+    /// each take the whole window.
+    property <bool> showing-idle-screen: root.state != RemoteViewerState.preview-error
+        && root.state != RemoteViewerState.pairing;
 
     property <bool> dark-color-scheme: Palette.color-scheme == ColorScheme.dark;
     property <bool> landscape-layout: root.width > root.height;
@@ -84,7 +104,9 @@ export component RemoteViewerWindow inherits Window {
     TouchArea {
         y: 0;
         height: root.safe-area-insets.top + 246px;
-        enabled: root.state != RemoteViewerState.preview-error;
+        // Covers the band the pairing code sits in, and copying the address
+        // is not what anyone is trying to do while reading a code.
+        enabled: root.showing-idle-screen;
 
         clicked => {
             root.showing-name = !root.showing-name;
@@ -116,7 +138,7 @@ export component RemoteViewerWindow inherits Window {
         padding-right: max(root.safe-area-insets.right, 24px);
         padding-top: root.safe-area-insets.top + 146px;
         padding-bottom: root.safe-area-insets.bottom;
-        visible: root.state != RemoteViewerState.preview-error;
+        visible: root.showing-idle-screen;
         VerticalLayout {
             alignment: start;
             spacing: 8px;
@@ -154,6 +176,15 @@ export component RemoteViewerWindow inherits Window {
                 text: root.build-info;
                 font-size: 0.71rem;
                 font-weight: 400;
+            }
+
+            if root.pairing-disabled: Text {
+                text: @tr("Pairing disabled: anyone on this network can connect");
+                font-size: 0.71rem;
+                font-weight: 400;
+                color: #e5484d;
+                horizontal-alignment: center;
+                wrap: word-wrap;
             }
         }
     }
@@ -219,6 +250,74 @@ export component RemoteViewerWindow inherits Window {
             text: message;
             horizontal-alignment: center;
             wrap: word-wrap;
+        }
+    }
+
+    pairing-countdown := Timer {
+        interval: 1s;
+        running: root.state == RemoteViewerState.pairing && root.pairing-seconds-left > 0;
+        triggered => {
+            root.pairing-seconds-left -= 1;
+        }
+    }
+
+    if root.state == RemoteViewerState.pairing: VerticalLayout {
+        alignment: center;
+        spacing: 32px;
+        padding-left: max(root.safe-area-insets.left, 24px);
+        padding-right: max(root.safe-area-insets.right, 24px);
+        padding-top: root.safe-area-insets.top;
+        padding-bottom: root.safe-area-insets.bottom;
+
+        VerticalLayout {
+            alignment: center;
+            spacing: 4px;
+
+            Text {
+                text: @tr("A computer wants to connect");
+                font-size: 1.41rem;
+                font-weight: 100;
+                horizontal-alignment: center;
+                wrap: word-wrap;
+            }
+
+            if root.pairing-peer != "": Text {
+                text: @tr("from {}", root.pairing-peer);
+                font-size: 0.95rem;
+                font-weight: 400;
+                horizontal-alignment: center;
+                opacity: 0.7;
+                wrap: word-wrap;
+            }
+        }
+
+        VerticalLayout {
+            alignment: center;
+            spacing: 8px;
+
+            Text {
+                text: @tr("Enter this code");
+                font-size: 0.82rem;
+                font-weight: 400;
+                horizontal-alignment: center;
+                opacity: 0.7;
+            }
+
+            Text {
+                text: root.pairing-code;
+                font-size: 2.8rem;
+                font-weight: 500;
+                letter-spacing: 0.35rem;
+                horizontal-alignment: center;
+            }
+        }
+
+        Text {
+            text: root.pairing-seconds-left > 0 ? @tr("Expires in {}s", root.pairing-seconds-left) : @tr("Expired");
+            font-size: 0.82rem;
+            font-weight: 400;
+            horizontal-alignment: center;
+            opacity: 0.6;
         }
     }
 

--- a/tools/viewer/tests/cli.rs
+++ b/tools/viewer/tests/cli.rs
@@ -95,6 +95,47 @@ fn screenshot_and_remote_conflict() {
     assert!(!out.exists(), "screenshot file should not have been written");
 }
 
+#[cfg(feature = "remote")]
+#[test]
+fn pairing_code_requires_remote() {
+    let file = write_slint("export component Main inherits Window {}");
+    let (code, _stdout, stderr) = run(&["--pairing-code", "4321", file.path().to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("--remote"), "stderr was:\n{stderr}");
+}
+
+#[cfg(feature = "remote")]
+#[test]
+fn no_pairing_requires_remote() {
+    let file = write_slint("export component Main inherits Window {}");
+    let (code, _stdout, stderr) = run(&["--no-pairing", file.path().to_str().unwrap()]);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("--remote"), "stderr was:\n{stderr}");
+}
+
+#[cfg(feature = "remote")]
+#[test]
+fn pairing_code_and_no_pairing_conflict() {
+    let (code, _stdout, stderr) = run(&["--remote", "--pairing-code", "4321", "--no-pairing"]);
+    assert_eq!(code, 2);
+    assert!(stderr.contains("cannot be used with '--no-pairing'"), "stderr was:\n{stderr}");
+}
+
+#[cfg(feature = "remote")]
+#[test]
+fn malformed_pairing_codes_are_rejected() {
+    // A pinned code has to have the same shape as a generated one, so the
+    // editor can keep a fixed-length numeric field.
+    for bad in ["", "123", "12345", "12a4", "abcd"] {
+        let (code, _stdout, stderr) = run(&["--remote", "--pairing-code", bad]);
+        assert_eq!(code, 2, "{bad:?} should have been rejected");
+        assert!(
+            stderr.contains("--pairing-code must be exactly 4 digits"),
+            "for {bad:?} stderr was:\n{stderr}"
+        );
+    }
+}
+
 #[test]
 fn auto_reload_and_save_data_conflict() {
     let (code, _stdout, stderr) = run(&["--auto-reload", "--save-data", "x.json", "x.slint"]);


### PR DESCRIPTION
A client is now admitted only once it has proven it can see the viewer's
screen: the viewer displays a four-digit code, and the user types it into
the editor.

The code is established through SPAKE2, a password-authenticated key
exchange. Nothing that crosses the wire can be used to test a guess
against, so there is no offline attack on the four digits: every guess
costs an online attempt, and both sides must prove they derived the same
key, so a host pretending to be a viewer learns nothing either. Each
prompt allows three attempts within 60s, and a prompt that nobody
completes earns a cool-down at least as long as it held the screen,
doubling with each consecutive failure — so no sequence of knocks can
occupy the device more than half the time, and a code pinned with
`--pairing-code` still can't be walked.

The exchange also yields per-direction session keys, and every frame
after pairing is sealed with ChaCha20-Poly1305. The `.slint` sources,
images and fonts crossing the local network can no longer be read,
tampered with, replayed or reordered.

A successful pairing leaves a reconnect token in memory on both sides, so
a network drop or a backgrounded app reconnects without a prompt, while
restarting the viewer pairs again. Reconnects run the same exchange with
the token as the secret, so every session gets fresh keys: recorded
traffic stays sealed even if the token were to leak later. The token
itself never crosses the wire; the editor only announces a public token
id so the viewer knows which token to run the exchange with.

`--no-pairing` restores the previous open, unencrypted behaviour behind a
startup warning and an on-screen badge. Since anyone could claim to be
such a viewer, the editor asks the user before connecting to one — once
per viewer and editor run, so reconnects stay silent.

While a code is up, nothing else may take the window: edits arriving from
the connected editor are recorded but not built, so a save can't overwrite
a code the user is still reading. The accept loop no longer runs the
handshake inline: a peer that stalls mid-handshake can't wedge the
listener, admissions are bounded so a flood can't exhaust the file
descriptors, and the running session keeps its connection and file cache
until a newcomer has fully authenticated, so a stranger can no longer
displace an editor.