### PR TITLE
Generator: reach an item of a parent component with a single walk

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3937,15 +3937,24 @@ enum MemberAccess {
 impl MemberAccess {
     /// Used for code that is meant to return `()`
     fn then(&self, f: impl FnOnce(&str) -> String) -> String {
+        self.then_named("x", f)
+    }
+
+    /// Like [`Self::then`], but names the binding the member is spliced from, so that this access
+    /// can be nested inside another one without shadowing it.
+    fn then_named(&self, binding: &str, f: impl FnOnce(&str) -> String) -> String {
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                format!("slint::private_api::optional_then({t}, [&](auto&&x) {{ {}; }})", f("x"))
+                format!(
+                    "slint::private_api::optional_then({t}, [&](auto&&{binding}) {{ {}; }})",
+                    f(binding)
+                )
             }
             MemberAccess::OptionWithMember(t, m) => {
                 format!(
-                    "slint::private_api::optional_then({t}, [&](auto&&x) {{ {}; }})",
-                    f(&format!("x{}", m))
+                    "slint::private_api::optional_then({t}, [&](auto&&{binding}) {{ {}; }})",
+                    f(&format!("{binding}{m}"))
                 )
             }
         }
@@ -5196,10 +5205,9 @@ fn compile_builtin_function_call(
                     }
                     _ => "[](bool) {}".to_string(),
                 };
-                item_owner(anchor_ref).then(|owner| {
-                    // Bind the owner before the inner guard, which shadows the lambda parameter
-                    let (_, parent_component) = native_item_from_owner(anchor_ref, ctx, "anchor_owner->");
-                    let show = component_access.then(|component_access| {
+                item_owner(anchor_ref).then_named("anchor_owner", |owner| {
+                    let (_, parent_component) = native_item_from_owner(anchor_ref, ctx, owner);
+                    component_access.then(|component_access| {
                     let compo_ptr = if compo_path.is_empty() {
                         format!("&*({component_access})")
                     } else {
@@ -5216,8 +5224,7 @@ fn compile_builtin_function_call(
                                                                             {window_kind},  \
                                                                             {is_open_setter})"
                     )
-                    });
-                    format!("auto &&anchor_owner = {}; {show}", owner.trim_end_matches("->"))
+                    })
                 })
                 })
             } else {
@@ -5270,17 +5277,15 @@ fn compile_builtin_function_call(
             let access_activated = access_member(&popup.activated, &popup_ctx).unwrap();
             let access_close = access_member(&popup.close, &popup_ctx).unwrap();
 
-            item_owner(context_menu_ref).then(|owner| {
-            // Bind the owner before `close_popup`/`set_id`, which guard the same reference and
-            // shadow the lambda parameter
-            let (_, context_menu_rc) = native_item_from_owner(context_menu_ref, ctx, "context_menu_owner->");
+            item_owner(context_menu_ref).then_named("context_menu_owner", |owner| {
+            let (_, context_menu_rc) = native_item_from_owner(context_menu_ref, ctx, owner);
             let close_popup = context_menu.then(|context_menu| {
                 format!("{window}.close_popup({context_menu}.popup_id)")
             });
             let set_id = context_menu
                 .then(|context_menu| format!("{context_menu}.popup_id = id"));
 
-            let show = if let llr::Expression::NumberLiteral(tree_index) = entries {
+            if let llr::Expression::NumberLiteral(tree_index) = entries {
                 // We have an MenuItem tree
                 let current_sub_component = ctx.current_sub_component().unwrap();
                 let item_tree_id = ident(&ctx.compilation_unit.sub_components[current_sub_component.menu_item_trees[*tree_index as usize].root].name);
@@ -5328,8 +5333,7 @@ fn compile_builtin_function_call(
                     }});
                     {set_id};
                 ", globals = ctx.generator_state.global_access)
-            };
-            format!("auto &&context_menu_owner = {}; {show}", owner.trim_end_matches("->"))
+            }
             })
         }
         BuiltinFunction::SetSelectionOffsets => {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -62,44 +62,48 @@ pub fn concatenate_ident(ident: &str) -> SmolStr {
     if ident.contains('-') { ident.replace_smolstr("-", "_") } else { ident.into() }
 }
 
-/// Given a property reference to a native item (eg, the property name is empty)
-/// return tokens to the `ItemRc`
+/// The component instance that holds the native item `pr` refers to, as an expression ready to be
+/// followed by `->`.
 ///
-/// This walks the parent chain with `value()`, so it must only be spliced inside a guard on the
-/// same reference — a `then`/`map_or_default` of [`access_member`] — because the chain can die
-/// while a callback of a repeated element is still running (the enclosing popup closes itself,
-/// or the model drops the row the element belongs to).
-fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> String {
-    let mut component_access = "self->".into();
+/// This is an `std::optional` when the item lives in an ancestor component: that chain can die
+/// while a callback of a repeated element is still running — the enclosing popup closed itself, or
+/// the model dropped the row the element belongs to — and then nothing must be emitted at all.
+fn item_owner(pr: &llr::MemberReference) -> MemberAccess {
+    let llr::MemberReference::Relative { parent_level, .. } = pr else { unreachable!() };
+    parent_access_path(*parent_level).with_member("->".into())
+}
 
+/// Expressions for the native item `pr` is about, relative to the component instance holding it
+/// (see [`item_owner`]): the member `pr` designates — the item itself or one of its functions —
+/// and the arguments to build the item's `ItemRc` from.
+///
+/// Taking the owner as a parameter is what lets a caller that needs both get them out of a single
+/// walk of the parent chain.
+fn native_item_from_owner(
+    pr: &llr::MemberReference,
+    ctx: &EvaluationContext,
+    owner: &str,
+) -> (String, String) {
     let llr::MemberReference::Relative { parent_level, local_reference } = pr else {
         unreachable!()
     };
     let llr::LocalMemberIndex::Native { item_index, .. } = &local_reference.reference else {
         unreachable!()
     };
-
-    for _ in 0..*parent_level {
-        component_access = format!("{component_access}parent.lock().value()->");
-    }
-
-    let (sub_compo_path, sub_component) = follow_sub_component_path(
+    let (compo_path, sub_component) = follow_sub_component_path(
         ctx.compilation_unit,
         ctx.parent_sub_component_idx(*parent_level).unwrap(),
         &local_reference.sub_component_path,
     );
-    if !local_reference.sub_component_path.is_empty() {
-        component_access += &sub_compo_path;
-    }
-    let component_rc = format!("{component_access}self_weak.lock()->into_dyn()");
+    let compo = format!("{owner}{compo_path}");
+    let item_name = field_name(&sub_component.items[*item_index].name);
     let item_index_in_tree = sub_component.items[*item_index].index_in_tree;
     let item_index = if item_index_in_tree == 0 {
-        format!("{component_access}tree_index")
+        format!("{compo}tree_index")
     } else {
-        format!("{component_access}tree_index_of_first_child + {item_index_in_tree} - 1")
+        format!("{compo}tree_index_of_first_child + {item_index_in_tree} - 1")
     };
-
-    format!("{component_rc}, {item_index}")
+    (format!("{compo}{item_name}"), format!("{compo}self_weak.lock()->into_dyn(), {item_index}"))
 }
 
 /// This module contains some data structure that helps represent a C++ code.
@@ -3936,14 +3940,11 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                format!(
-                    "slint::private_api::optional_then({t}, [&]([[maybe_unused]] auto&&x) {{ {}; }})",
-                    f("x")
-                )
+                format!("slint::private_api::optional_then({t}, [&](auto&&x) {{ {}; }})", f("x"))
             }
             MemberAccess::OptionWithMember(t, m) => {
                 format!(
-                    "slint::private_api::optional_then({t}, [&]([[maybe_unused]] auto&&x) {{ {}; }})",
+                    "slint::private_api::optional_then({t}, [&](auto&&x) {{ {}; }})",
                     f(&format!("x{}", m))
                 )
             }
@@ -3955,13 +3956,13 @@ impl MemberAccess {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
                 format!(
-                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }}))",
+                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&](auto&&x) {{ return {}; }}))",
                     f("x")
                 )
             }
             MemberAccess::OptionWithMember(t, m) => {
                 format!(
-                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }}))",
+                    "slint::private_api::optional_or_default(slint::private_api::optional_transform({t}, [&](auto&&x) {{ return {}; }}))",
                     f(&format!("x{}", m))
                 )
             }
@@ -3972,11 +3973,11 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => MemberAccess::Option(f(t)),
             MemberAccess::Option(t) => MemberAccess::Option(format!(
-                "slint::private_api::optional_and_then({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }})",
+                "slint::private_api::optional_and_then({t}, [&](auto&&x) {{ return {}; }})",
                 f("x")
             )),
             MemberAccess::OptionWithMember(t, m) => MemberAccess::Option(format!(
-                "slint::private_api::optional_and_then({t}, [&]([[maybe_unused]] auto&&x) {{ return {}; }})",
+                "slint::private_api::optional_and_then({t}, [&](auto&&x) {{ return {}; }})",
                 f(&format!("x{}", m))
             )),
         }
@@ -4127,8 +4128,6 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             }
         }
         Expression::ItemMemberFunctionCall { function } => {
-            let item = access_member(function, ctx);
-            let item_rc = access_item_rc(function, ctx);
             let window = access_window_field(ctx);
             let (native, name) = native_prop_info(function, ctx);
             let function_name = format!(
@@ -4136,14 +4135,14 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                 native.class_name.to_lowercase(),
                 ident(name).to_lowercase()
             );
+            let call = |owner: &str| {
+                let (item, item_rc) = native_item_from_owner(function, ctx, owner);
+                format!("{function_name}(&{item}, &{window}.handle(), &{item_rc})")
+            };
             if expr.ty(ctx) == Type::Void {
-                item.then(|item| {
-                    format!("{function_name}(&{item}, &{window}.handle(), &{item_rc})")
-                })
+                item_owner(function).then(call)
             } else {
-                item.map_or_default(|item| {
-                    format!("{function_name}(&{item}, &{window}.handle(), &{item_rc})")
-                })
+                item_owner(function).map_or_default(call)
             }
         }
         Expression::ExtraBuiltinFunctionCall { function, arguments, return_ty: _ } => {
@@ -4867,8 +4866,10 @@ fn compile_builtin_function_call(
         BuiltinFunction::SetFocusItem => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let window = access_window_field(ctx);
-                let focus_item = access_item_rc(pr, ctx);
-                access_member(pr, ctx).then(|_| format!("{window}.set_focus_item({focus_item}, true, slint::cbindgen_private::FocusReason::Programmatic)"))
+                item_owner(pr).then(|owner| {
+                    let (_, focus_item) = native_item_from_owner(pr, ctx, owner);
+                    format!("{window}.set_focus_item({focus_item}, true, slint::cbindgen_private::FocusReason::Programmatic)")
+                })
             } else {
                 panic!("internal error: invalid args to SetFocusItem {arguments:?}")
             }
@@ -4876,8 +4877,10 @@ fn compile_builtin_function_call(
         BuiltinFunction::ClearFocusItem => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {
                 let window = access_window_field(ctx);
-                let focus_item = access_item_rc(pr, ctx);
-                access_member(pr, ctx).then(|_| format!("{window}.set_focus_item({focus_item}, false, slint::cbindgen_private::FocusReason::Programmatic)"))
+                item_owner(pr).then(|owner| {
+                    let (_, focus_item) = native_item_from_owner(pr, ctx, owner);
+                    format!("{window}.set_focus_item({focus_item}, false, slint::cbindgen_private::FocusReason::Programmatic)")
+                })
             } else {
                 panic!("internal error: invalid args to ClearFocusItem {arguments:?}")
             }
@@ -5072,7 +5075,7 @@ fn compile_builtin_function_call(
                     .name,
             );
             let system_tray = access_member(system_tray_ref, ctx).unwrap();
-            let system_tray_rc = access_item_rc(system_tray_ref, ctx);
+            let (_, system_tray_rc) = native_item_from_owner(system_tray_ref, ctx, "self->");
 
             // `if cond : Menu { ... }` is lowered to a condition lambda passed
             // alongside the menu wrapper. `create_menu_wrapper` already accepts
@@ -5154,10 +5157,7 @@ fn compile_builtin_function_call(
                     ctx.parent_sub_component_idx(*parent_level).unwrap(),
                     &local_reference.sub_component_path,
                 );
-                let parent_component = access_item_rc(anchor_ref, ctx);
-                // `access_item_rc` unwraps the anchor's parent chain, so only emit the show when
-                // the very same reference is reachable
-                let anchor_reachable = access_member(anchor_ref, ctx);
+
                 ctx.with_reference_scope(*parent_level, &local_reference.sub_component_path, |parent_ctx| {
                 let popup = &ctx.compilation_unit.sub_components[parent_ctx.sub_component]
                     .popup_windows[*popup_index as usize];
@@ -5196,7 +5196,10 @@ fn compile_builtin_function_call(
                     }
                     _ => "[](bool) {}".to_string(),
                 };
-                let show = component_access.then(|component_access| {
+                item_owner(anchor_ref).then(|owner| {
+                    // Bind the owner before the inner guard, which shadows the lambda parameter
+                    let (_, parent_component) = native_item_from_owner(anchor_ref, ctx, "anchor_owner->");
+                    let show = component_access.then(|component_access| {
                     let compo_ptr = if compo_path.is_empty() {
                         format!("&*({component_access})")
                     } else {
@@ -5213,8 +5216,9 @@ fn compile_builtin_function_call(
                                                                             {window_kind},  \
                                                                             {is_open_setter})"
                     )
-                });
-                anchor_reachable.then(|_| show)
+                    });
+                    format!("auto &&anchor_owner = {}; {show}", owner.trim_end_matches("->"))
+                })
                 })
             } else {
                 panic!("internal error: invalid args to ShowPopupWindow {arguments:?}")
@@ -5246,7 +5250,6 @@ fn compile_builtin_function_call(
             };
 
             let context_menu = access_member(context_menu_ref, ctx);
-            let context_menu_rc = access_item_rc(context_menu_ref, ctx);
             let position = compile_expression(position, ctx);
             let popup = ctx
                 .compilation_unit
@@ -5267,6 +5270,10 @@ fn compile_builtin_function_call(
             let access_activated = access_member(&popup.activated, &popup_ctx).unwrap();
             let access_close = access_member(&popup.close, &popup_ctx).unwrap();
 
+            item_owner(context_menu_ref).then(|owner| {
+            // Bind the owner before `close_popup`/`set_id`, which guard the same reference and
+            // shadow the lambda parameter
+            let (_, context_menu_rc) = native_item_from_owner(context_menu_ref, ctx, "context_menu_owner->");
             let close_popup = context_menu.then(|context_menu| {
                 format!("{window}.close_popup({context_menu}.popup_id)")
             });
@@ -5322,16 +5329,16 @@ fn compile_builtin_function_call(
                     {set_id};
                 ", globals = ctx.generator_state.global_access)
             };
-            context_menu.then(|_| show)
+            format!("auto &&context_menu_owner = {}; {show}", owner.trim_end_matches("->"))
+            })
         }
         BuiltinFunction::SetSelectionOffsets => {
             if let [llr::Expression::PropertyReference(pr), from, to] = arguments {
-                let item = access_member(pr, ctx);
-                let item_rc = access_item_rc(pr, ctx);
                 let window = access_window_field(ctx);
                 let start = compile_expression(from, ctx);
                 let end = compile_expression(to, ctx);
-                item.then(|item| {
+                item_owner(pr).then(|owner| {
+                    let (item, item_rc) = native_item_from_owner(pr, ctx, owner);
                     format!("slint_textinput_set_selection_offsets(&{item}, &{window}.handle(), &{item_rc}, static_cast<int>({start}), static_cast<int>({end}))")
                 })
             } else {
@@ -5340,19 +5347,23 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::ItemFontMetrics => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {
-                let item_rc = access_item_rc(pr, ctx);
                 let window = access_window_field(ctx);
-                access_member(pr, ctx).map_or_default(|_| format!(
-                    "[&]{{ slint::cbindgen_private::FontMetrics fm; slint_cpp_text_item_fontmetrics(&{window}.handle(), &{item_rc}, &fm); return fm; }}()"
-                ))
+                item_owner(pr).map_or_default(|owner| {
+                    let (_, item_rc) = native_item_from_owner(pr, ctx, owner);
+                    format!(
+                        "[&]{{ slint::cbindgen_private::FontMetrics fm; slint_cpp_text_item_fontmetrics(&{window}.handle(), &{item_rc}, &fm); return fm; }}()"
+                    )
+                })
             } else {
                 panic!("internal error: invalid args to ItemFontMetrics {arguments:?}")
             }
         }
         BuiltinFunction::ItemAbsolutePosition => {
             if let [llr::Expression::PropertyReference(pr)] = arguments {
-                let item_rc = access_item_rc(pr, ctx);
-                access_member(pr, ctx).map_or_default(|_| format!("slint::LogicalPosition(slint::cbindgen_private::slint_item_absolute_position(&{item_rc}))"))
+                item_owner(pr).map_or_default(|owner| {
+                    let (_, item_rc) = native_item_from_owner(pr, ctx, owner);
+                    format!("slint::LogicalPosition(slint::cbindgen_private::slint_item_absolute_position(&{item_rc}))")
+                })
             } else {
                 panic!("internal error: invalid args to ItemAbsolutePosition {arguments:?}")
             }
@@ -5390,16 +5401,17 @@ fn compile_builtin_function_call(
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
             if let [llr::Expression::PropertyReference(pr), constraint_expr] = arguments {
                 let native = native_prop_info(pr, ctx).0;
-                let item_rc = access_item_rc(pr, ctx);
                 let constraint = compile_expression(constraint_expr, ctx);
-                access_member(pr, ctx).then(|item|
-                format!(
-                    "slint::private_api::item_layout_info({vt}, const_cast<slint::cbindgen_private::{ty}*>(&{item}), {o}, {constraint}, &{window}, {item_rc})",
-                    vt = native.cpp_vtable_getter,
-                    ty = native.class_name,
-                    o = to_cpp_orientation(orient),
-                    window = access_window_field(ctx),
-                ))
+                item_owner(pr).map_or_default(|owner| {
+                    let (item, item_rc) = native_item_from_owner(pr, ctx, owner);
+                    format!(
+                        "slint::private_api::item_layout_info({vt}, const_cast<slint::cbindgen_private::{ty}*>(&{item}), {o}, {constraint}, &{window}, {item_rc})",
+                        vt = native.cpp_vtable_getter,
+                        ty = native.class_name,
+                        o = to_cpp_orientation(orient),
+                        window = access_window_field(ctx),
+                    )
+                })
             } else {
                 panic!("internal error: invalid args to ImplicitLayoutInfo {arguments:?}")
             }
@@ -5447,22 +5459,26 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::PathPointAt => {
             if let [llr::Expression::PropertyReference(pr), t] = arguments {
-                let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                access_member(pr, ctx).map_or_default(|_| format!(
-                    "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at(&{item_rc}, static_cast<float>({t})))"
-                ))
+                item_owner(pr).map_or_default(|owner| {
+                    let (_, item_rc) = native_item_from_owner(pr, ctx, owner);
+                    format!(
+                        "slint::LogicalPosition(slint::cbindgen_private::slint_path_point_at(&{item_rc}, static_cast<float>({t})))"
+                    )
+                })
             } else {
                 panic!("internal error: invalid args to PathPointAt {arguments:?}")
             }
         }
         BuiltinFunction::PathAngleAt => {
             if let [llr::Expression::PropertyReference(pr), t] = arguments {
-                let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                access_member(pr, ctx).map_or_default(|_| format!(
-                    "slint::cbindgen_private::slint_path_angle_at(&{item_rc}, static_cast<float>({t}))"
-                ))
+                item_owner(pr).map_or_default(|owner| {
+                    let (_, item_rc) = native_item_from_owner(pr, ctx, owner);
+                    format!(
+                        "slint::cbindgen_private::slint_path_angle_at(&{item_rc}, static_cast<float>({t}))"
+                    )
+                })
             } else {
                 panic!("internal error: invalid args to PathAngleAt {arguments:?}")
             }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3237,11 +3237,18 @@ enum MemberAccess {
 impl MemberAccess {
     /// Used for code that is meant to return `()`
     fn then(self, f: impl FnOnce(TokenStream) -> TokenStream) -> TokenStream {
+        self.then_named("x", f)
+    }
+
+    /// Like [`Self::then`], but names the binding the member is spliced from, so that this access
+    /// can be nested inside another one without shadowing it.
+    fn then_named(self, binding: &str, f: impl FnOnce(TokenStream) -> TokenStream) -> TokenStream {
+        let binding = format_ident!("{binding}");
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                let r = f(quote!(x));
-                quote!({ let _ = #t.map(|x| #r); })
+                let r = f(quote!(#binding));
+                quote!({ let _ = #t.map(|#binding| #r); })
             }
             MemberAccess::OptionFn(opt, inner) => {
                 let r = f(inner);
@@ -4427,9 +4434,9 @@ fn compile_builtin_function_call(
                     };
                     access_member(is_open_ref, ctx).then(|p| quote!(#p.set(value)))
                 });
-                item_owner(anchor_ref).then(|owner| {
+                item_owner(anchor_ref).then_named("anchor_owner", |owner| {
                     let (_, parent_item) = native_item_from_owner(anchor_ref, ctx, &owner);
-                    let show = component_access_tokens.then(|component_access_tokens| {
+                    component_access_tokens.then(|component_access_tokens| {
                     let compo = quote!(#component_access_tokens #suffix);
                     // Keep the parent's `is-open` in sync: `show_popup` invokes this setter with `true`
                     // immediately and with `false` from every close path (see window.rs). Passing it
@@ -4450,6 +4457,7 @@ fn compile_builtin_function_call(
                         None => (quote!(), quote!(sp::Box::new(|_| {}))),
                     };
                     quote!({
+                        let parent_item = &#parent_item;
                         // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one
                         let shared_global = #compo.globals.get().unwrap();
                         let window_adapter = shared_global.window_adapter_impl();
@@ -4479,8 +4487,7 @@ fn compile_builtin_function_call(
                         #compo.#popup_id_name.set(Some(popup_id));
                         #popup_window_id::user_init(popup_instance_vrc.clone());
                     })
-                    });
-                    quote!({ let parent_item = &#parent_item; #show })
+                    })
                 })
                     },
                 )
@@ -4572,11 +4579,8 @@ fn compile_builtin_function_call(
             let set_id = context_menu
                 .clone()
                 .then(|context_menu| quote!(#context_menu.popup_id.set(Some(id))));
-            item_owner(context_menu_ref).then(|owner| {
-                // Bind the `ItemRc` before `close_popup`/`set_id`, which guard the same reference
-                // and shadow the closure parameter it is spliced from
-                let (_, context_menu_rc_expr) = native_item_from_owner(context_menu_ref, ctx, &owner);
-                let context_menu_rc = quote!(context_menu_rc);
+            item_owner(context_menu_ref).then_named("context_menu_owner", |owner| {
+                let (_, context_menu_rc) = native_item_from_owner(context_menu_ref, ctx, &owner);
                 let slint_show = quote! {
                     #close_popup
                     let access_position = sp::Box::new(move || position);
@@ -4600,7 +4604,7 @@ fn compile_builtin_function_call(
                     let window_adapter = #window_adapter_tokens;
                 };
 
-                let show = if let Expression::NumberLiteral(tree_index) = entries {
+                if let Expression::NumberLiteral(tree_index) = entries {
                     // We have an MenuItem tree
                     let current_sub_component = ctx.current_sub_component().unwrap();
                     let item_tree_id = inner_component_id(
@@ -4679,8 +4683,7 @@ fn compile_builtin_function_call(
                         }
                         #slint_show
                     }}
-                };
-                quote!({ let context_menu_rc = #context_menu_rc_expr; #show })
+                }
             })
         }
         BuiltinFunction::SetSelectionOffsets => {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -3240,9 +3240,8 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                // `_x` so that `f` may ignore the member and only use this as a reachability guard
-                let r = f(quote!(_x));
-                quote!({ let _ = #t.map(|_x| #r); })
+                let r = f(quote!(x));
+                quote!({ let _ = #t.map(|x| #r); })
             }
             MemberAccess::OptionFn(opt, inner) => {
                 let r = f(inner);
@@ -3255,8 +3254,8 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => f(t),
             MemberAccess::Option(t) => {
-                let r = f(quote!(_x));
-                quote!(#t.map(|_x| #r).unwrap_or_default())
+                let r = f(quote!(x));
+                quote!(#t.map(|x| #r).unwrap_or_default())
             }
             MemberAccess::OptionFn(opt, inner) => {
                 let r = f(inner);
@@ -3269,7 +3268,7 @@ impl MemberAccess {
         match self {
             MemberAccess::Direct(t) => quote!(#t.get()),
             MemberAccess::Option(t) => {
-                quote!(#t.map(|_x| _x.get()).unwrap_or_default())
+                quote!(#t.map(|x| x.get()).unwrap_or_default())
             }
             MemberAccess::OptionFn(..) => panic!("function is not a property"),
         }
@@ -3324,43 +3323,65 @@ fn access_window_adapter_field(ctx: &EvaluationContext) -> TokenStream {
     quote!(&#global_access.window_adapter_impl())
 }
 
-/// Given a property reference to a native item (eg, the property name is empty)
-/// return tokens to the `ItemRc`
+/// The component instance that holds the native item `pr` refers to.
 ///
-/// This walks the parent chain with `unwrap`, so it must only be spliced inside a guard on the
-/// same reference — a `then`/`map_or_default` of [`access_member`] — because the chain can die
-/// while a callback of a repeated element is still running (the enclosing popup closes itself,
-/// or the model drops the row the element belongs to).
-fn access_item_rc(pr: &llr::MemberReference, ctx: &EvaluationContext) -> TokenStream {
-    let mut component_access_tokens = quote!(_self);
+/// This is an `Option` when the item lives in an ancestor component: that chain can die while a
+/// callback of a repeated element is still running — the enclosing popup closed itself, or the
+/// model dropped the row the element belongs to — and then nothing must be emitted at all.
+fn item_owner(pr: &llr::MemberReference) -> MemberAccess {
+    let llr::MemberReference::Relative { parent_level, .. } = pr else { unreachable!() };
+    match parent_access_path(*parent_level) {
+        None => MemberAccess::Direct(quote!(_self)),
+        Some(parent_path) => {
+            MemberAccess::Option(quote!(#parent_path.as_ref().map(|x| x.as_pin_ref())))
+        }
+    }
+}
 
+/// Tokens for the native item `pr` is about, relative to the component instance holding it (see
+/// [`item_owner`]): the member `pr` designates — the item itself or one of its functions — and the
+/// item's `ItemRc`.
+///
+/// Taking the owner as a parameter is what lets a caller that needs both get them out of a single
+/// walk of the parent chain.
+fn native_item_from_owner(
+    pr: &llr::MemberReference,
+    ctx: &EvaluationContext,
+    owner: &TokenStream,
+) -> (TokenStream, TokenStream) {
     let llr::MemberReference::Relative { parent_level, local_reference } = pr else {
         unreachable!()
     };
-    let llr::LocalMemberIndex::Native { item_index, .. } = &local_reference.reference else {
+    let llr::LocalMemberIndex::Native { item_index, prop_name, .. } = &local_reference.reference
+    else {
         unreachable!()
     };
-
-    for _ in 0..*parent_level {
-        component_access_tokens =
-            quote!(#component_access_tokens.parent.upgrade().unwrap().as_pin_ref());
+    let root = ctx.parent_sub_component_idx(*parent_level).unwrap();
+    let (compo_path, sub_component) =
+        follow_sub_component_path(ctx.compilation_unit, root, &local_reference.sub_component_path);
+    let component_id = inner_component_id(sub_component);
+    let item_name = ident(&sub_component.items[*item_index].name);
+    let item_field = access_component_field_offset(&component_id, &item_name);
+    let mut member = quote!((#compo_path #item_field).apply_pin(#owner));
+    if !prop_name.is_empty() {
+        // a builtin member function of the item, like `TextInput::select-all`
+        let property_name = ident(prop_name);
+        member = quote!(#member.#property_name);
     }
 
-    let (suffix, sub_component) = follow_sub_component_path_fields(
+    let (suffix, _) = follow_sub_component_path_fields(
         ctx.compilation_unit,
-        ctx.parent_sub_component_idx(*parent_level).unwrap(),
+        root,
         &local_reference.sub_component_path,
     );
-    let component_access_tokens = quote!(#component_access_tokens #suffix);
-    let component_rc_tokens = quote!(#component_access_tokens.origin_rc());
+    let compo = quote!(#owner #suffix);
     let item_index_in_tree = sub_component.items[*item_index].index_in_tree;
     let item_index_tokens = if item_index_in_tree == 0 {
-        quote!(#component_access_tokens.tree_index.get())
+        quote!(#compo.tree_index.get())
     } else {
-        quote!(#component_access_tokens.tree_index_of_first_child.get() + #item_index_in_tree - 1)
+        quote!(#compo.tree_index_of_first_child.get() + #item_index_in_tree - 1)
     };
-
-    quote!(&sp::ItemRc::new(#component_rc_tokens, #item_index_tokens))
+    (member, quote!(sp::ItemRc::new(#compo.origin_rc(), #item_index_tokens)))
 }
 
 /// Compile `expr` to a Rust expression returning an owned value.
@@ -3819,10 +3840,11 @@ fn compile_function_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStr
 #[inline(never)]
 fn compile_item_member_function_call(expr: &Expression, ctx: &EvaluationContext) -> TokenStream {
     let Expression::ItemMemberFunctionCall { function } = expr else { unreachable!() };
-    let fun = access_member(function, ctx);
-    let item_rc = access_item_rc(function, ctx);
     let window_adapter_tokens = access_window_adapter_field(ctx);
-    fun.map_or_default(|fun| quote!(#fun(#window_adapter_tokens, #item_rc)))
+    item_owner(function).map_or_default(|owner| {
+        let (fun, item_rc) = native_item_from_owner(function, ctx, &owner);
+        quote!(#fun(#window_adapter_tokens, &#item_rc))
+    })
 }
 
 /// Compile builtin-call arguments: structs are passed by reference.
@@ -4314,10 +4336,10 @@ fn compile_builtin_function_call(
         BuiltinFunction::SetFocusItem => {
             if let [Expression::PropertyReference(pr)] = arguments {
                 let window_tokens = access_window_adapter_field(ctx);
-                let focus_item = access_item_rc(pr, ctx);
-                access_member(pr, ctx).then(|_| quote!(
-                    sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(#focus_item, true, sp::FocusReason::Programmatic)
-                ))
+                item_owner(pr).then(|owner| {
+                    let (_, focus_item) = native_item_from_owner(pr, ctx, &owner);
+                    quote!(sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(&#focus_item, true, sp::FocusReason::Programmatic))
+                })
             } else {
                 panic!("internal error: invalid args to SetFocusItem {arguments:?}")
             }
@@ -4325,10 +4347,10 @@ fn compile_builtin_function_call(
         BuiltinFunction::ClearFocusItem => {
             if let [Expression::PropertyReference(pr)] = arguments {
                 let window_tokens = access_window_adapter_field(ctx);
-                let focus_item = access_item_rc(pr, ctx);
-                access_member(pr, ctx).then(|_| quote!(
-                    sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(#focus_item, false, sp::FocusReason::Programmatic)
-                ))
+                item_owner(pr).then(|owner| {
+                    let (_, focus_item) = native_item_from_owner(pr, ctx, &owner);
+                    quote!(sp::WindowInner::from_pub(#window_tokens.window()).set_focus_item(&#focus_item, false, sp::FocusReason::Programmatic))
+                })
             } else {
                 panic!("internal error: invalid args to ClearFocusItem {arguments:?}")
             }
@@ -4365,11 +4387,6 @@ fn compile_builtin_function_call(
                     ctx.parent_sub_component_idx(*parent_level).unwrap(),
                     &local_reference.sub_component_path,
                 );
-                let parent_item = access_item_rc(anchor_ref, ctx);
-                // `access_item_rc` unwraps the anchor's parent chain, so only emit the show when
-                // the very same reference is reachable
-                let anchor_reachable = access_member(anchor_ref, ctx);
-
                 ctx.with_reference_scope(
                     *parent_level,
                     &local_reference.sub_component_path,
@@ -4410,7 +4427,9 @@ fn compile_builtin_function_call(
                     };
                     access_member(is_open_ref, ctx).then(|p| quote!(#p.set(value)))
                 });
-                let show = component_access_tokens.then(|component_access_tokens| {
+                item_owner(anchor_ref).then(|owner| {
+                    let (_, parent_item) = native_item_from_owner(anchor_ref, ctx, &owner);
+                    let show = component_access_tokens.then(|component_access_tokens| {
                     let compo = quote!(#component_access_tokens #suffix);
                     // Keep the parent's `is-open` in sync: `show_popup` invokes this setter with `true`
                     // immediately and with `false` from every close path (see window.rs). Passing it
@@ -4431,7 +4450,6 @@ fn compile_builtin_function_call(
                         None => (quote!(), quote!(sp::Box::new(|_| {}))),
                     };
                     quote!({
-                        let parent_item = #parent_item;
                         // Use the newly created window adapter if we are able to create one. Otherwise use the parent's one
                         let shared_global = #compo.globals.get().unwrap();
                         let window_adapter = shared_global.window_adapter_impl();
@@ -4461,8 +4479,9 @@ fn compile_builtin_function_call(
                         #compo.#popup_id_name.set(Some(popup_id));
                         #popup_window_id::user_init(popup_instance_vrc.clone());
                     })
-                });
-                anchor_reachable.then(|_| show)
+                    });
+                    quote!({ let parent_item = &#parent_item; #show })
+                })
                     },
                 )
             } else {
@@ -4522,7 +4541,6 @@ fn compile_builtin_function_call(
             };
 
             let context_menu = access_member(context_menu_ref, ctx);
-            let context_menu_rc = access_item_rc(context_menu_ref, ctx);
             let position = compile_expression(position, ctx);
 
             let popup = ctx
@@ -4554,133 +4572,140 @@ fn compile_builtin_function_call(
             let set_id = context_menu
                 .clone()
                 .then(|context_menu| quote!(#context_menu.popup_id.set(Some(id))));
-            let slint_show = quote! {
-                #close_popup
-                let access_position = sp::Box::new(move || position);
-                let id = sp::WindowInner::from_pub(window_adapter.window()).show_popup(
-                    &sp::VRc::into_dyn(popup_instance.into()),
-                    access_position,
-                    sp::PopupClosePolicy::CloseOnClickOutside,
-                    #context_menu_rc,
-                    sp::WindowKind::Menu,
-                    sp::Box::new(|_| {}),
-                );
-                #set_id;
-                #popup_id::user_init(popup_instance_vrc);
-            };
-
-            let common_init = quote! {
-                let position = #position;
-                let popup_instance = #popup_id::new(_self.globals.get().unwrap().clone()).unwrap();
-                let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);
-                let parent_weak = _self.self_weak.get().unwrap().clone();
-                let window_adapter = #window_adapter_tokens;
-            };
-
-            let show = if let Expression::NumberLiteral(tree_index) = entries {
-                // We have an MenuItem tree
-                let current_sub_component = ctx.current_sub_component().unwrap();
-                let item_tree_id = inner_component_id(
-                    &ctx.compilation_unit.sub_components
-                        [current_sub_component.menu_item_trees[*tree_index as usize].root],
-                );
-                quote! {{
-                    #common_init
-                    let menu_item_tree_instance = #item_tree_id::new(_self.self_weak.get().unwrap().clone()).unwrap();
-                    let context_menu_item_tree = sp::VRc::new(sp::MenuFromItemTree::new(sp::VRc::into_dyn(menu_item_tree_instance)));
-                    let context_menu_item_tree_ = context_menu_item_tree.clone();
-                    {
-                        let mut entries = sp::SharedVector::default();
-                        sp::Menu::sub_menu(&*context_menu_item_tree, sp::Option::None, &mut entries);
-                        let _self = popup_instance_vrc.as_pin_ref();
-                        #access_entries.set(sp::ModelRc::new(sp::SharedVectorModel::from(entries)));
-                        let context_menu_item_tree = context_menu_item_tree_.clone();
-                        #access_sub_menu.set_handler(move |entry| {
-                            let mut entries = sp::SharedVector::default();
-                            sp::Menu::sub_menu(&*context_menu_item_tree, sp::Option::Some(&entry.0), &mut entries);
-                            sp::ModelRc::new(sp::SharedVectorModel::from(entries))
-                        });
-                        let context_menu_item_tree = context_menu_item_tree_.clone();
-                        #access_activated.set_handler(move |entry| {
-                            sp::Menu::activate(&*context_menu_item_tree_, &entry.0);
-                        });
-                        let self_weak = parent_weak.clone();
-                        #access_close.set_handler(move |()| {
-                            let Some(self_rc) = self_weak.upgrade() else { return };
-                            let _self = self_rc.as_pin_ref();
-                            #close_popup
-                        });
-                    }
-                    let context_menu_item_tree = sp::VRc::into_dyn(context_menu_item_tree);
-                    if !sp::WindowInner::from_pub(window_adapter.window()).show_native_popup_menu(context_menu_item_tree, position, #context_menu_rc) {
-                        #slint_show
-                    }
-                }}
-            } else {
-                // ShowPopupMenuInternal: entries should be an expression of type array of MenuEntry
-                debug_assert!(
-                    matches!(entries.ty(ctx), Type::Array(ty) if matches!(&*ty, Type::Struct{..}))
-                );
-                let entries = compile_expression(entries, ctx);
-                let forward_callback = |access, cb| {
-                    let call = context_menu
-                        .clone()
-                        .map_or_default(|context_menu| quote!(#context_menu.#cb.call(entry)));
-                    quote!(
-                        let self_weak = parent_weak.clone();
-                        #access.set_handler(move |entry| {
-                            if let Some(self_rc) = self_weak.upgrade() {
-                                let _self = self_rc.as_pin_ref();
-                                #call
-                            } else { ::core::default::Default::default() }
-                        });
-                    )
+            item_owner(context_menu_ref).then(|owner| {
+                // Bind the `ItemRc` before `close_popup`/`set_id`, which guard the same reference
+                // and shadow the closure parameter it is spliced from
+                let (_, context_menu_rc_expr) = native_item_from_owner(context_menu_ref, ctx, &owner);
+                let context_menu_rc = quote!(context_menu_rc);
+                let slint_show = quote! {
+                    #close_popup
+                    let access_position = sp::Box::new(move || position);
+                    let id = sp::WindowInner::from_pub(window_adapter.window()).show_popup(
+                        &sp::VRc::into_dyn(popup_instance.into()),
+                        access_position,
+                        sp::PopupClosePolicy::CloseOnClickOutside,
+                        &#context_menu_rc,
+                        sp::WindowKind::Menu,
+                        sp::Box::new(|_| {}),
+                    );
+                    #set_id;
+                    #popup_id::user_init(popup_instance_vrc);
                 };
-                let fw_sub_menu = forward_callback(access_sub_menu.clone(), quote!(sub_menu));
-                let fw_activated = forward_callback(access_activated.clone(), quote!(activated));
-                quote! {{
-                    #common_init
-                    let entries = #entries;
-                    {
-                        let _self = popup_instance_vrc.as_pin_ref();
-                        #access_entries.set(entries.clone());
-                        #fw_sub_menu
-                        #fw_activated
-                        let self_weak = parent_weak.clone();
-                        #access_close.set_handler(move |()| {
-                            let Some(self_rc) = self_weak.upgrade() else { return };
-                            let _self = self_rc.as_pin_ref();
-                            #close_popup
-                        });
-                    }
-                    #slint_show
-                }}
-            };
-            context_menu.then(|_| show)
+
+                let common_init = quote! {
+                    let position = #position;
+                    let popup_instance = #popup_id::new(_self.globals.get().unwrap().clone()).unwrap();
+                    let popup_instance_vrc = sp::VRc::map(popup_instance.clone(), |x| x);
+                    let parent_weak = _self.self_weak.get().unwrap().clone();
+                    let window_adapter = #window_adapter_tokens;
+                };
+
+                let show = if let Expression::NumberLiteral(tree_index) = entries {
+                    // We have an MenuItem tree
+                    let current_sub_component = ctx.current_sub_component().unwrap();
+                    let item_tree_id = inner_component_id(
+                        &ctx.compilation_unit.sub_components
+                            [current_sub_component.menu_item_trees[*tree_index as usize].root],
+                    );
+                    quote! {{
+                        #common_init
+                        let menu_item_tree_instance = #item_tree_id::new(_self.self_weak.get().unwrap().clone()).unwrap();
+                        let context_menu_item_tree = sp::VRc::new(sp::MenuFromItemTree::new(sp::VRc::into_dyn(menu_item_tree_instance)));
+                        let context_menu_item_tree_ = context_menu_item_tree.clone();
+                        {
+                            let mut entries = sp::SharedVector::default();
+                            sp::Menu::sub_menu(&*context_menu_item_tree, sp::Option::None, &mut entries);
+                            let _self = popup_instance_vrc.as_pin_ref();
+                            #access_entries.set(sp::ModelRc::new(sp::SharedVectorModel::from(entries)));
+                            let context_menu_item_tree = context_menu_item_tree_.clone();
+                            #access_sub_menu.set_handler(move |entry| {
+                                let mut entries = sp::SharedVector::default();
+                                sp::Menu::sub_menu(&*context_menu_item_tree, sp::Option::Some(&entry.0), &mut entries);
+                                sp::ModelRc::new(sp::SharedVectorModel::from(entries))
+                            });
+                            let context_menu_item_tree = context_menu_item_tree_.clone();
+                            #access_activated.set_handler(move |entry| {
+                                sp::Menu::activate(&*context_menu_item_tree_, &entry.0);
+                            });
+                            let self_weak = parent_weak.clone();
+                            #access_close.set_handler(move |()| {
+                                let Some(self_rc) = self_weak.upgrade() else { return };
+                                let _self = self_rc.as_pin_ref();
+                                #close_popup
+                            });
+                        }
+                        let context_menu_item_tree = sp::VRc::into_dyn(context_menu_item_tree);
+                        if !sp::WindowInner::from_pub(window_adapter.window()).show_native_popup_menu(context_menu_item_tree, position, &#context_menu_rc) {
+                            #slint_show
+                        }
+                    }}
+                } else {
+                    // ShowPopupMenuInternal: entries should be an expression of type array of MenuEntry
+                    debug_assert!(
+                        matches!(entries.ty(ctx), Type::Array(ty) if matches!(&*ty, Type::Struct{..}))
+                    );
+                    let entries = compile_expression(entries, ctx);
+                    let forward_callback = |access, cb| {
+                        let call = context_menu
+                            .clone()
+                            .map_or_default(|context_menu| quote!(#context_menu.#cb.call(entry)));
+                        quote!(
+                            let self_weak = parent_weak.clone();
+                            #access.set_handler(move |entry| {
+                                if let Some(self_rc) = self_weak.upgrade() {
+                                    let _self = self_rc.as_pin_ref();
+                                    #call
+                                } else { ::core::default::Default::default() }
+                            });
+                        )
+                    };
+                    let fw_sub_menu = forward_callback(access_sub_menu.clone(), quote!(sub_menu));
+                    let fw_activated =
+                        forward_callback(access_activated.clone(), quote!(activated));
+                    quote! {{
+                        #common_init
+                        let entries = #entries;
+                        {
+                            let _self = popup_instance_vrc.as_pin_ref();
+                            #access_entries.set(entries.clone());
+                            #fw_sub_menu
+                            #fw_activated
+                            let self_weak = parent_weak.clone();
+                            #access_close.set_handler(move |()| {
+                                let Some(self_rc) = self_weak.upgrade() else { return };
+                                let _self = self_rc.as_pin_ref();
+                                #close_popup
+                            });
+                        }
+                        #slint_show
+                    }}
+                };
+                quote!({ let context_menu_rc = #context_menu_rc_expr; #show })
+            })
         }
         BuiltinFunction::SetSelectionOffsets => {
             if let [llr::Expression::PropertyReference(pr), from, to] = arguments {
-                let item = access_member(pr, ctx);
-                let item_rc = access_item_rc(pr, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 let start = compile_expression(from, ctx);
                 let end = compile_expression(to, ctx);
 
-                item.then(|item| quote!(
-                    #item.set_selection_offsets(#window_adapter_tokens, #item_rc, #start as i32, #end as i32)
-                ))
+                item_owner(pr).then(|owner| {
+                    let (item, item_rc) = native_item_from_owner(pr, ctx, &owner);
+                    quote!(
+                        #item.set_selection_offsets(#window_adapter_tokens, &#item_rc, #start as i32, #end as i32)
+                    )
+                })
             } else {
                 panic!("internal error: invalid args to set-selection-offsets {arguments:?}")
             }
         }
         BuiltinFunction::ItemFontMetrics => {
             if let [Expression::PropertyReference(pr)] = arguments {
-                let item = access_member(pr, ctx);
-                let item_rc = access_item_rc(pr, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
-                item.map_or_default(|item| {
+                item_owner(pr).map_or_default(|owner| {
+                    let (item, item_rc) = native_item_from_owner(pr, ctx, &owner);
                     quote!(
-                        #item.font_metrics(#window_adapter_tokens, #item_rc)
+                        #item.font_metrics(#window_adapter_tokens, &#item_rc)
                     )
                 })
             } else {
@@ -4689,11 +4714,10 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::ImplicitLayoutInfo(orient) => {
             if let [Expression::PropertyReference(pr), constraint_expr] = arguments {
-                let item = access_member(pr, ctx);
                 let window_adapter_tokens = access_window_adapter_field(ctx);
                 let constraint = compile_expression(constraint_expr, ctx);
-                item.then(|item| {
-                    let item_rc = access_item_rc(pr, ctx);
+                item_owner(pr).map_or_default(|owner| {
+                    let (item, item_rc) = native_item_from_owner(pr, ctx, &owner);
                     quote!(
                         sp::Item::layout_info(#item, #orient, #constraint as _, #window_adapter_tokens, &#item_rc)
                     )
@@ -5031,7 +5055,7 @@ fn compile_builtin_function_call(
             );
 
             let system_tray = access_member(system_tray_ref, ctx).unwrap();
-            let system_tray_rc = access_item_rc(system_tray_ref, ctx);
+            let (_, system_tray_rc) = native_item_from_owner(system_tray_ref, ctx, &quote!(_self));
 
             // `if cond : Menu { ... }` lowers the condition into a closure that
             // gates the menu's shadow tree.
@@ -5058,7 +5082,7 @@ fn compile_builtin_function_call(
             quote!({
                 let menu_item_tree_instance = #item_tree_id::new(_self.self_weak.get().unwrap().clone()).unwrap();
                 let menu_vrc = sp::VRc::into_dyn(sp::VRc::new(#menu_from_item_tree));
-                #system_tray.set_menu(#system_tray_rc, menu_vrc);
+                #system_tray.set_menu(&#system_tray_rc, menu_vrc);
             })
         }
         BuiltinFunction::MonthDayCount => {
@@ -5101,10 +5125,13 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::ItemAbsolutePosition => {
             if let [Expression::PropertyReference(pr)] = arguments {
-                let item_rc = access_item_rc(pr, ctx);
-                access_member(pr, ctx).map_or_default(|_| quote!(
-                    sp::logical_position_to_api((*#item_rc).map_to_window((*#item_rc).geometry().origin))
-                ))
+                item_owner(pr).map_or_default(|owner| {
+                    let (_, item_rc) = native_item_from_owner(pr, ctx, &owner);
+                    quote!({
+                        let item_rc = #item_rc;
+                        sp::logical_position_to_api(item_rc.map_to_window(item_rc.geometry().origin))
+                    })
+                })
             } else {
                 panic!("internal error: invalid args to MapPointToWindow {arguments:?}")
             }
@@ -5148,9 +5175,9 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::PathPointAt => {
             if let [Expression::PropertyReference(pr), t] = arguments {
-                let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                access_member(pr, ctx).map_or_default(|_| {
+                item_owner(pr).map_or_default(|owner| {
+                    let (_, item_rc) = native_item_from_owner(pr, ctx, &owner);
                     quote!({
                         let item_rc = #item_rc;
                         sp::logical_position_to_api(
@@ -5168,9 +5195,9 @@ fn compile_builtin_function_call(
         }
         BuiltinFunction::PathAngleAt => {
             if let [Expression::PropertyReference(pr), t] = arguments {
-                let item_rc = access_item_rc(pr, ctx);
                 let t = compile_expression(t, ctx);
-                access_member(pr, ctx).map_or_default(|_| {
+                item_owner(pr).map_or_default(|owner| {
+                    let (_, item_rc) = native_item_from_owner(pr, ctx, &owner);
                     quote!({
                         let item_rc = #item_rc;
                         item_rc


### PR DESCRIPTION

  Follow-up to #12877, no change in behavior.

  To reach an item of a parent component, the generated code walked up the parent                                   
  chain three times: once for the guard added in #12877, and twice inside                                                                                                            
  `access_item_rc`, once for the item tree and once for the index.
  Each step is a weak upgrade, so it costs a few atomic operations.

  `access_item_rc` is now `item_owner`, which walks up once and gives the
  component that holds the item, plus `native_item_from_owner`, which builds the
  item and its `ItemRc` from it.
  That walk returns an `Option` when the item is in a parent, so it is the guard
  too and the call sites no longer need their own.

  `fs.focus()` from a repeated element two levels down now does two upgrades
  instead of six.

  The second commit is needed for the first: `then`/`map_or_default` always named
  the closure parameter `x`, so nesting two of them hid the outer one.
  It can now be named.                                                                                                                                                               
