### PR TITLE
FlexboxLayout: rename flex-order to layout-order

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/flexbox-item-properties.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/flexbox-item-properties.mdx
@@ -3,24 +3,23 @@ title: Flexbox Item Properties
 description: Experimental per-item properties for FlexboxLayout children.
 ---
 
-The children of a `FlexboxLayout` can set `flex-order` to control their visual
+The children of a `FlexboxLayout` can set `layout-order` to control their visual
 order individually.
 
 > **Note**: this property is experimental and subject to change.
 > Nothing in it is specific to flexbox — it could apply to `HorizontalLayout` and
-> `VerticalLayout` too — so expect it to be renamed (e.g. `layout-order`) and
-> extended to the box layouts.
+> `VerticalLayout` too — so expect it to be extended to the box layouts.
 >
 > The Experimental Features overview page explains how to enable it.
 
 ```slint no-test
 FlexboxLayout {
-    Rectangle { flex-order: 2; }
-    Rectangle { flex-order: 1; }  // appears first
+    Rectangle { layout-order: 2; }
+    Rectangle { layout-order: 1; }  // appears first
 }
 ```
 
-`flex-order` behaves like the CSS `order` property, with the same default (`0`):
+`layout-order` behaves like the CSS `order` property, with the same default (`0`):
 items are laid out in ascending order value, and items with the same value keep
 their declaration order.
 

--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: MIT
 
-// The per-item flex-order property is experimental, so this needs
+// The per-item layout-order property is experimental, so this needs
 // SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 in the environment of the viewer.
 
 import { ComboBox } from "std-widgets.slint";
@@ -250,18 +250,18 @@ export component MainWindow inherits Window {
                     height: 30phx;
                     background: #d35400;
                 }
-                // flex-order: these items appear before/after others despite declaration order
+                // layout-order: these items appear before/after others despite declaration order
                 FlexCell {
-                    cell_text: "U flex-order:-1";
-                    flex-order: -1;
+                    cell_text: "U layout-order:-1";
+                    layout-order: -1;
                     width: 80phx;
                     min-height: 40phx;
                     background: #8e44ad;
                 }
 
                 FlexCell {
-                    cell_text: "V flex-order:99";
-                    flex-order: 99;
+                    cell_text: "V layout-order:99";
+                    layout-order: 99;
                     width: 80phx;
                     min-height: 40phx;
                     background: #6c3483;

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -526,7 +526,7 @@ pub struct SubComponent {
     pub child_of_layout: bool,
     pub grid_layout_input_for_repeated: Option<MutExpression>,
     /// Expression that builds a FlexboxLayoutItemInfo for a repeated element in a FlexboxLayout.
-    /// Contains property references to cross-axis-self-alignment and flex-order.
+    /// Contains property references to cross-axis-self-alignment and layout-order.
     pub flexbox_layout_item_info_for_repeated: Option<MutExpression>,
     /// The root's `cross-axis-self-alignment` for a repeated element in a box
     /// layout, returned by the generated `layout_item_info` for the given

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1100,7 +1100,7 @@ fn make_flex_props_struct(fp: FlexItemProps) -> llr_Expression {
         BuiltinStruct::FlexItemProps,
         [
             ("cross-axis-self-alignment", align_self_ty, fp.align_self),
-            ("flex-order", Type::Int32, fp.order),
+            ("layout-order", Type::Int32, fp.order),
         ],
     )
 }
@@ -1976,7 +1976,7 @@ pub fn get_flexbox_layout_item_info_for_repeated(
     let (_, align_self_default) = default_align_self();
 
     let align_self = prop_ref("cross-axis-self-alignment").unwrap_or(align_self_default);
-    let order = prop_ref("flex-order").unwrap_or(llr_Expression::NumberLiteral(0.0));
+    let order = prop_ref("layout-order").unwrap_or(llr_Expression::NumberLiteral(0.0));
 
     make_struct(
         BuiltinStruct::FlexboxLayoutItemInfo,

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -692,7 +692,7 @@ fn lower_sub_component(
     .into();
     if component.root_element.borrow().child_of_flexbox {
         let root_elem = &component.root_element;
-        let has_flex_binding = ["cross-axis-self-alignment", "flex-order"]
+        let has_flex_binding = ["cross-axis-self-alignment", "layout-order"]
             .iter()
             .any(|name| crate::layout::binding_reference(root_elem, name).is_some());
         let v_constrained =

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -4441,8 +4441,8 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
     // bindings (and the layout's captured references keeping them alive), rather
     // than moving them, which would leave those references dangling.
     // cross-axis-self-alignment is read by both the flexbox and the box layout
-    // accessor; flex-order only by the flexbox one.
-    for prop in ["flex-order", "cross-axis-self-alignment"].iter() {
+    // accessor; layout-order only by the flexbox one.
+    for prop in ["layout-order", "cross-axis-self-alignment"].iter() {
         if old_root.borrow().binding(prop).is_some() {
             new_root.borrow_mut().set_binding(
                 SmolStr::new_static(prop),

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1906,7 +1906,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
                 diag,
             );
         }
-        let order = crate::layout::binding_reference(actual_elem, "flex-order");
+        let order = crate::layout::binding_reference(actual_elem, "layout-order");
         layout.elems.push(crate::layout::FlexboxLayoutItem { item: item.item, order });
     }
     layout_element.borrow_mut().children = layout_children;
@@ -2551,12 +2551,11 @@ fn check_no_layout_properties(
         {
             diag.push_error(format!("{prop} used outside of a GridLayout's cell"), &*expr.borrow());
         }
-        if prop == "flex-order" {
+        if prop == "layout-order" {
             if parent_layout_type.as_deref() != Some("FlexboxLayout") {
                 diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
             } else {
-                // Not stable API yet: whether it should be renamed (e.g. `layout-order`)
-                // and extended to the box layouts is still being discussed.
+                // Not stable API yet: extending it to the box layouts is still open.
                 crate::reject_experimental_feature(diag, type_register, prop, &*expr.borrow());
             }
         }

--- a/internal/compiler/tests/experimental_flex_item_properties.rs
+++ b/internal/compiler/tests/experimental_flex_item_properties.rs
@@ -1,7 +1,7 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! The per-item `flex-order` property of a `FlexboxLayout` is not stable API yet, so it is only
+//! The per-item `layout-order` property of a `FlexboxLayout` is not stable API yet, so it is only
 //! accepted with experimental features enabled. The syntax tests can't cover this because they
 //! always enable them. This also hosts the stable-API tests for `cross-axis-self-alignment`,
 //! which needs the same experimental-features control.
@@ -11,7 +11,7 @@ use i_slint_compiler::generator::OutputFormat;
 use i_slint_compiler::parser::parse;
 use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
 
-const FLEX_ITEM_PROPERTIES: &[&str] = &["flex-order: 3"];
+const FLEX_ITEM_PROPERTIES: &[&str] = &["layout-order: 3"];
 
 /// Compile `source` and return its errors (warnings are not of interest here).
 fn errors(source: String, enable_experimental: bool) -> Vec<String> {
@@ -131,12 +131,12 @@ fn repeated_and_conditional_cells_report_once() {
             r#"
 export component TestCase inherits Window {{
     FlexboxLayout {{
-        {cell} Rectangle {{ flex-order: 1; }}
+        {cell} Rectangle {{ layout-order: 1; }}
     }}
 }}
 "#
         );
-        assert_eq!(errors(source, false), ["'flex-order' is an experimental feature"]);
+        assert_eq!(errors(source, false), ["'layout-order' is an experimental feature"]);
     }
 }
 

--- a/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_outside_layout.slint
@@ -6,14 +6,14 @@ export component X inherits Rectangle {
     FlexboxLayout {
         Text {
             cross-axis-self-alignment: center;
-            flex-order: 3;
+            layout-order: 3;
         }
         Rectangle {
             Text {
                 cross-axis-self-alignment: center;
 //                                         >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
-                flex-order: 3;
-//                          ><error{flex-order used outside of a FlexboxLayout}
+                layout-order: 3;
+//                            ><error{layout-order used outside of a FlexboxLayout}
             }
         }
     }
@@ -22,8 +22,8 @@ export component X inherits Rectangle {
     Text {
         cross-axis-self-alignment: center;
 //                                 >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
-        flex-order: 3;
-//                  ><error{flex-order used outside of a FlexboxLayout}
+        layout-order: 3;
+//                    ><error{layout-order used outside of a FlexboxLayout}
     }
 
     GridLayout {
@@ -35,8 +35,8 @@ export component X inherits Rectangle {
 
     HorizontalLayout {
         Text {
-            flex-order: 5;
-//                      ><error{flex-order used outside of a FlexboxLayout}
+            layout-order: 5;
+//                        ><error{layout-order used outside of a FlexboxLayout}
             // valid in a box layout
             cross-axis-self-alignment: center;
         }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -50,7 +50,7 @@ pub const RESERVED_GRIDLAYOUT_PROPERTIES: &[(&str, Type)] = &[
 
 // Note: the per-item cross-axis-self-alignment (flexbox and box layouts) is added
 // in reserved_properties() because Type::Enumeration requires a runtime Arc allocation.
-pub const RESERVED_FLEXBOXLAYOUT_PROPERTIES: &[(&str, Type)] = &[("flex-order", Type::Int32)];
+pub const RESERVED_FLEXBOXLAYOUT_PROPERTIES: &[(&str, Type)] = &[("layout-order", Type::Int32)];
 
 macro_rules! declare_enums {
     ($( $(#[$enum_doc:meta])* $vis:vis enum $Name:ident { $( $(#[$value_doc:meta])* $Value:ident,)* })*) => {
@@ -122,7 +122,7 @@ impl BuiltinTypes {
         let flex_item_props_struct = Arc::new(Struct::new(
             IntoIterator::into_iter([
                 ("cross-axis-self-alignment".into(), align_self_type),
-                ("flex-order".into(), Type::Int32),
+                ("layout-order".into(), Type::Int32),
             ])
             .collect(),
             BuiltinStruct::FlexItemProps,

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1183,7 +1183,7 @@ pub struct FlexItemProps {
     /// Per-item cross-axis alignment override (Auto = use container's cross-axis-alignment)
     pub cross_axis_self_alignment: CrossAxisSelfAlignment,
     /// Visual ordering of flex items (lower values appear first, default 0)
-    pub flex_order: i32,
+    pub layout_order: i32,
 }
 
 #[repr(C)]
@@ -1636,11 +1636,11 @@ mod flexbox_taffy {
 
             // Sort children by CSS `order` property if any item has a non-zero order.
             // Build a mapping from sorted position -> original index.
-            let has_order = params.flex_props.iter().any(|f| f.flex_order != 0);
+            let has_order = params.flex_props.iter().any(|f| f.layout_order != 0);
             let order_map: Vec<usize> = if has_order {
                 let mut indices: Vec<usize> = (0..children.len()).collect();
                 // sort_by_key is a stable sort, as required by CSS
-                indices.sort_by_key(|&i| params.flex_props.get(i).map_or(0, |f| f.flex_order));
+                indices.sort_by_key(|&i| params.flex_props.get(i).map_or(0, |f| f.layout_order));
                 let sorted_children: Vec<NodeId> = indices.iter().map(|&i| children[i]).collect();
                 children = sorted_children;
                 indices

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -59,7 +59,7 @@ pub trait RepeatedItemTree:
     }
 
     /// Returns what's needed to perform a flexbox layout if this ItemTree is in a FlexboxLayout.
-    /// Includes flex-specific properties (cross-axis-self-alignment, flex-order).
+    /// Includes flex-specific properties (layout-order).
     fn flexbox_layout_item_info(
         self: Pin<&Self>,
         orientation: Orientation,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1349,7 +1349,7 @@ fn flex_props_to_value(props: i_slint_core::layout::FlexItemProps) -> Value {
             format!("{:?}", props.cross_axis_self_alignment).to_lowercase(),
         ),
     );
-    s.set_field("flex_order".to_string(), Value::Number(props.flex_order as f64));
+    s.set_field("layout_order".to_string(), Value::Number(props.layout_order as f64));
     Value::Struct(s)
 }
 

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -82,7 +82,7 @@ pub(crate) fn flex_props_from_struct(
             .get_field("cross-axis-self-alignment")
             .map(to_enum)
             .unwrap_or_default(),
-        flex_order: match s.get_field("flex-order") {
+        layout_order: match s.get_field("layout-order") {
             Some(Value::Number(n)) => *n as i32,
             _ => 0,
         },

--- a/tests/cases/layout/flexbox_order.slint
+++ b/tests/cases/layout/flexbox_order.slint
@@ -4,7 +4,7 @@
 // Test FlexboxLayout order per-item property
 
 // Test 1: order changes visual placement (row direction)
-// Items declared A, B, C but ordered C(flex-order:-1), A(0), B(1)
+// Items declared A, B, C but ordered C(layout-order:-1), A(0), B(1)
 component TestOrderRow inherits Rectangle {
     width: 300px;
     height: 50px;
@@ -14,19 +14,19 @@ component TestOrderRow inherits Rectangle {
         r_a := Rectangle {
             width: 100px;
             height: 50px;
-            flex-order: 0;
+            layout-order: 0;
             background: red;
         }
         r_b := Rectangle {
             width: 100px;
             height: 50px;
-            flex-order: 1;
+            layout-order: 1;
             background: green;
         }
         r_c := Rectangle {
             width: 100px;
             height: 50px;
-            flex-order: -1;
+            layout-order: -1;
             background: blue;
         }
     }
@@ -62,7 +62,7 @@ component TestOrderDefault inherits Rectangle {
         }
     }
 
-    // All flex-order=0 → declaration order: r1 at x=0, r2 at x=100, r3 at x=200
+    // All layout-order=0 → declaration order: r1 at x=0, r2 at x=100, r3 at x=200
     out property <bool> test_r1: r1.x == 0px;
     out property <bool> test_r2: r2.x == 100px;
     out property <bool> test_r3: r3.x == 200px;
@@ -80,19 +80,19 @@ component TestOrderColumn inherits Rectangle {
         r_a := Rectangle {
             width: 50px;
             height: 100px;
-            flex-order: 2;
+            layout-order: 2;
             background: red;
         }
         r_b := Rectangle {
             width: 50px;
             height: 100px;
-            flex-order: 0;
+            layout-order: 0;
             background: green;
         }
         r_c := Rectangle {
             width: 50px;
             height: 100px;
-            flex-order: 1;
+            layout-order: 1;
             background: blue;
         }
     }

--- a/tests/cases/layout/flexbox_repeater_flex_props.slint
+++ b/tests/cases/layout/flexbox_repeater_flex_props.slint
@@ -5,7 +5,7 @@
 //ignore: cpp-live-preview
 
 // Test that per-item flex properties (main-axis stretch, cross-axis-self-alignment,
-// flex-order) work on repeated items.
+// layout-order) work on repeated items.
 
 // Test 1: a stretchy repeated item pushes a static item to the right.
 // Repeated item with horizontal-stretch:1 before a 60px static item:
@@ -33,7 +33,7 @@ component TestStretchGrowRepeater inherits Rectangle {
 }
 
 // Test 2: order on a repeated item moves the static item.
-// Static (flex-order:1) declared first, repeated (flex-order:0) declared second.
+// Static (layout-order:1) declared first, repeated (layout-order:0) declared second.
 // With order working, repeated comes first visually → static at x=100.
 component TestOrderRepeater inherits Rectangle {
     width: 200px;
@@ -44,13 +44,13 @@ component TestOrderRepeater inherits Rectangle {
         r_static := Rectangle {
             width: 100px;
             height: 50px;
-            flex-order: 1;
+            layout-order: 1;
             background: gray;
         }
         for item in [1]: Rectangle {
             width: 100px;
             height: 50px;
-            flex-order: 0;
+            layout-order: 0;
             background: red;
         }
     }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -534,7 +534,7 @@ impl CompletionItemExt for CompletionItem {
 }
 
 /// Decide whether a reserved property should be offered as a completion in the given context.
-/// Reserved properties like row/col, flex-*, clip and drop-shadow-* are materialized on every
+/// Reserved properties like row/col, layout-order, clip and drop-shadow-* are materialized on every
 /// item even though they only make sense on specific layout children or element types.
 fn is_reserved_prop_valid(
     prop: &str,
@@ -1720,7 +1720,7 @@ mod tests {
         assert_eq!(res.iter().find(|ci| ci.label == "pressed"), None);
         assert_eq!(res.iter().find(|ci| ci.label == "pressed-x"), None);
         assert!(!res.iter().any(|ci| ci.label == "row"));
-        assert!(!res.iter().any(|ci| ci.label == "flex-order"));
+        assert!(!res.iter().any(|ci| ci.label == "layout-order"));
         assert!(!res.iter().any(|ci| ci.label == "clip"));
         assert!(!res.iter().any(|ci| ci.label == "drop-shadow-blur"));
 
@@ -1792,7 +1792,7 @@ mod tests {
         assert_eq!(res.iter().find(|ci| ci.label == "has-focus"), None);
         assert_eq!(res.iter().find(|ci| ci.label == "func"), None);
         assert!(!res.iter().any(|ci| ci.label == "row"));
-        assert!(!res.iter().any(|ci| ci.label == "flex-order"));
+        assert!(!res.iter().any(|ci| ci.label == "layout-order"));
         assert!(!res.iter().any(|ci| ci.label == "clip"));
         assert!(!res.iter().any(|ci| ci.label == "drop-shadow-blur"));
 
@@ -1820,10 +1820,10 @@ mod tests {
         assert!(res.iter().any(|ci| ci.label == "spacing-horizontal"));
         assert!(res.iter().any(|ci| ci.label == "spacing-vertical"));
         assert!(res.iter().any(|ci| ci.label == "padding"));
-        assert!(!res.iter().any(|ci| ci.label == "flex-order"));
+        assert!(!res.iter().any(|ci| ci.label == "layout-order"));
         assert!(!res.iter().any(|ci| ci.label == "cross-axis-self-alignment"));
 
-        // Even with experimental features enabled, flex-order stays
+        // Even with experimental features enabled, layout-order stays
         // flexbox-only: the context filter must reject it here, not the
         // experimental check.
         let res = get_completions_experimental(
@@ -1836,7 +1836,7 @@ mod tests {
         "#,
         )
         .unwrap();
-        assert!(!res.iter().any(|ci| ci.label == "flex-order"));
+        assert!(!res.iter().any(|ci| ci.label == "layout-order"));
     }
 
     #[test]
@@ -2958,14 +2958,14 @@ export component Foo {
 "#;
         let results = get_completions_experimental(source).unwrap();
         assert!(
-            results.iter().any(|completion| completion.label == "flex-order"),
-            "no 'flex-order' completion with experimental features"
+            results.iter().any(|completion| completion.label == "layout-order"),
+            "no 'layout-order' completion with experimental features"
         );
 
         let results = get_completions(source).unwrap();
         assert!(
-            !results.iter().any(|completion| completion.label.starts_with("flex-")),
-            "flex-* completions offered without experimental features"
+            !results.iter().any(|completion| completion.label == "layout-order"),
+            "'layout-order' completion offered without experimental features"
         );
         // cross-axis-self-alignment is stable, so it completes without experimental features.
         assert!(


### PR DESCRIPTION
Nothing in the property is flexbox-specific, so drop the flex- prefix to
allow implementing it for HorizontalLayout/VerticalLayout later without a
rename. Plain 'order' is too generic to reserve on every element, hence
the layout- prefix. Still experimental (until the next commit) and FlexboxLayout-only.