### PR TITLE
Fix ComponentContainer in SLINT_LIVE_PREVIEW

### DIFF
--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -636,7 +636,22 @@ pub fn default_value_for_type(ty: &Type) -> Value {
             let default = en.clone().default_value();
             Value::EnumerationValue(en.name.to_string(), default.to_string())
         }
-        _ => Value::Void,
+        Type::ComponentFactory => Value::ComponentFactory(Default::default()),
+        Type::MouseCursor => Value::MouseCursorInner(Default::default()),
+        Type::Void => Value::Void,
+        // Types that should never appear in this situation (e.g. are not expressible
+        // by users, so cannot be returned from an unset callback or model property)
+        Type::Invalid
+        | Type::InferredProperty
+        | Type::InferredCallback
+        | Type::Callback(_)
+        | Type::Function(_)
+        | Type::PathData
+        | Type::Easing
+        | Type::ElementReference
+        | Type::ArrayOfU16
+        | Type::LayoutCache
+        | Type::Closure => Value::Void,
     }
 }
 


### PR DESCRIPTION
Otherwise, using a component-container inside of an accessible property
crashes the interpreter with:

```
thread 'main' (2358798) panicked at internal/core/rtti.rs:205:54:
  binding was of the wrong type: ()
```

(e.g. this occured when using the component container with the slint
editor).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
