### PR TITLE
core: Use the default cursor while a DropArea accepts a move

### DIFF
--- a/internal/core/items/drag_n_drop.rs
+++ b/internal/core/items/drag_n_drop.rs
@@ -474,7 +474,7 @@ pub(crate) fn clamp_action_to_allowed(
 /// The cursor shown while a DropArea is hovering an accepted drag.
 pub(crate) fn cursor_for_action(action: DragAction) -> BuiltInMouseCursor {
     match action {
-        DragAction::Move => BuiltInMouseCursor::Move,
+        DragAction::Move => BuiltInMouseCursor::Default,
         DragAction::Copy => BuiltInMouseCursor::Copy,
         DragAction::Link => BuiltInMouseCursor::Alias,
         DragAction::None => BuiltInMouseCursor::NoDrop,

--- a/tests/cases/elements/dragarea_actions.slint
+++ b/tests/cases/elements/dragarea_actions.slint
@@ -62,7 +62,7 @@ assert_eq!(instance.get_dragging(), true);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(22.0, 120.0) });
 slint_testing::mock_elapsed_time(20);
 assert_eq!(instance.get_current_action(), DragAction::Move);
-assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor()), MouseCursorInner::BuiltIn(BuiltInMouseCursor::Move));
+assert_eq!(slint_testing::access_testing_window(instance.window(), |window| window.mouse_cursor()), MouseCursorInner::BuiltIn(BuiltInMouseCursor::Default));
 
 instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(22.0, 120.0), button: PointerEventButton::Left });
 slint_testing::mock_elapsed_time(20);


### PR DESCRIPTION
The `Move` cursor is a four-way arrow on most platforms, which looks
out of place while dragging over a drop target.
Keep the default arrow instead, and leave `Copy` and `Alias` to signal
the actions that differ from a plain move.

This was originally added by @NigelBreslaw for the Visual Editor.

Extracted this into a separate PR, as it affects `core` and deserves a proper decision over whether this is always the right choice.
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
