### PR TITLE
Add support for RGB565 images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,7 +289,7 @@ jobs:
               with:
                   cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
                   cmakeListsTxtPath: CMakeLists.txt
-                  cmakeAppendedArgs: "-DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_RENDERER_SKIA=ON -DSLINT_FEATURE_BACKEND_QT=ON -DSLINT_FEATURE_EXPERIMENTAL=ON -DSLINT_FEATURE_TESTING=ON"
+                  cmakeAppendedArgs: "-DSLINT_BUILD_TESTING=ON -DSLINT_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Debug -DSLINT_FEATURE_RENDERER_SKIA=ON -DSLINT_FEATURE_BACKEND_QT=ON -DSLINT_FEATURE_EXPERIMENTAL=ON -DSLINT_FEATURE_TESTING=ON -DSLINT_FEATURE_IMAGE_PIXEL_FORMAT_RGB565=ON"
                   buildDirectory: ${{ runner.workspace }}/cppbuild
                   buildWithCMakeArgs: "--config Debug"
             - name: ctest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,7 @@ dependencies = [
  "async-channel",
  "async-compat",
  "bitflags 2.13.1",
+ "bytemuck",
  "cfg-if",
  "chrono",
  "clru",

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -48,6 +48,11 @@ renderer-vello = ["i-slint-backend-selector/renderer-vello"]
 renderer-software = ["i-slint-backend-selector/renderer-software", "dep:i-slint-renderer-software"]
 software-renderer-path = ["i-slint-renderer-software/path"]
 gettext = ["i-slint-core/gettext-rs"]
+image-pixel-format-rgb565 = [
+  "i-slint-core/image-pixel-format-rgb565",
+  "i-slint-backend-selector?/image-pixel-format-rgb565",
+  "i-slint-renderer-software?/image-pixel-format-rgb565",
+]
 accessibility = ["i-slint-backend-selector/accessibility"]
 # Enable the `SystemTrayIcon` element (pulls `ksni` on Linux/BSD).
 system-tray = ["i-slint-core/system-tray"]

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -379,6 +379,10 @@ fn default_config() -> cbindgen::Config {
         ("target_arch = wasm32".into(), "SLINT_TARGET_WASM".into()),
         ("target_os = android".into(), "__ANDROID__".into()),
         // Disable Rust WGPU specific API feature
+        (
+            "feature = image-pixel-format-rgb565".into(),
+            "SLINT_FEATURE_IMAGE_PIXEL_FORMAT_RGB565".into(),
+        ),
         ("feature = unstable-wgpu-29".into(), "SLINT_DISABLED_CODE".into()),
         ("feature = unstable-wgpu-30".into(), "SLINT_DISABLED_CODE".into()),
     ]
@@ -1346,6 +1350,7 @@ declare_features! {
     renderer_skia_vulkan
     renderer_software
     gettext
+    image_pixel_format_rgb565
     accessibility
     system_testing
     mcp

--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -672,7 +672,7 @@ fn gen_corelib(
                 "PHYSICAL_REGION_MAX_SIZE",
             ],
             "slint_image_internal.h",
-            "#include \"private/slint_color.h\"\nnamespace slint::cbindgen_private { struct ParsedSVG{}; struct HTMLImage{}; struct PhysicalPx; using namespace vtable; namespace types{ struct NineSliceImage{}; } }",
+            "#include \"private/slint_color.h\"\n#include \"private/slint_rgb565pixel.h\"\nnamespace slint::cbindgen_private { struct ParsedSVG{}; struct HTMLImage{}; struct PhysicalPx; using namespace vtable; namespace types{ struct NineSliceImage{}; using slint::Rgb565Pixel; } }",
         ),
         (
             vec!["Color", "slint_color_brighter", "slint_color_darker",
@@ -818,6 +818,8 @@ fn gen_corelib(
             "slint_windowrc_nsview_appkit",
             "GradientStop",
             "ConicGradientBrush",
+            // Handwritten in private/slint_rgb565pixel.h
+            "Rgb565Pixel",
             "slint_conic_gradient_normalize_stops",
             "slint_conic_gradient_apply_rotation",
             "slint_brush_compare_equal",
@@ -1192,9 +1194,9 @@ fn gen_platform(
         .with_include("private/slint_internal.h")
         .with_after_include(
             r"
-namespace slint::platform { struct Rgb565Pixel; }
+namespace slint { struct Rgb565Pixel; }
 namespace slint::cbindgen_private {
-    struct WindowProperties; using slint::platform::Rgb565Pixel;
+    struct WindowProperties; using slint::Rgb565Pixel;
     using slint::cbindgen_private::types::TexturePixelFormat;
     struct DrawTextureArgs;
     struct DrawRectangleArgs;

--- a/api/cpp/cmake/SlintFeatures.cmake
+++ b/api/cpp/cmake/SlintFeatures.cmake
@@ -48,6 +48,8 @@ endfunction()
 
 define_cargo_feature(freestanding "Enable use of freestanding environment. This is only for bare-metal systems. Most other features are incompatible with this one" OFF)
 
+define_cargo_feature(image-pixel-format-rgb565 "Enable support for images in the RGB565 pixel format, the native format of many embedded displays" OFF)
+
 # Compat options (must be declared after the STD feature, but before the options they replace)
 function(define_compat_option deprecated replacement)
     cmake_dependent_option("SLINT_FEATURE_${deprecated}" "Compat option equivalent to SLINT_FEATURE_${replacement}" OFF "NOT SLINT_FEATURE_FREESTANDING" OFF)

--- a/api/cpp/include/private/slint_image.h
+++ b/api/cpp/include/private/slint_image.h
@@ -6,6 +6,7 @@
 #include <span>
 #include "private/slint_generated_public.h"
 #include "private/slint_size.h"
+#include "private/slint_rgb565pixel.h"
 #include "private/slint_image_internal.h"
 #include "private/slint_string.h"
 #include "private/slint_sharedvector.h"
@@ -209,6 +210,21 @@ public:
                   cbindgen_private::types::ImageCacheKey::Invalid(),
                   cbindgen_private::types::SharedImageBuffer::RGBA8(
                           cbindgen_private::types::SharedPixelBuffer<Rgba8Pixel> {
+                                  .width = buffer.width(),
+                                  .height = buffer.height(),
+                                  .data = buffer.m_data })))
+    {
+    }
+
+    /// Construct an image from a SharedPixelBuffer of RGB565 pixels.
+    ///
+    /// This is the native format of many embedded displays. The software
+    /// renderer can draw such images without any pixel conversion.
+    Image(SharedPixelBuffer<Rgb565Pixel> buffer)
+        : data(Data::ImageInner_EmbeddedImage(
+                  cbindgen_private::types::ImageCacheKey::Invalid(),
+                  cbindgen_private::types::SharedImageBuffer::RGB565(
+                          cbindgen_private::types::SharedPixelBuffer<Rgb565Pixel> {
                                   .width = buffer.width(),
                                   .height = buffer.height(),
                                   .data = buffer.m_data })))

--- a/api/cpp/include/private/slint_image.h
+++ b/api/cpp/include/private/slint_image.h
@@ -216,10 +216,14 @@ public:
     {
     }
 
+#ifdef SLINT_FEATURE_IMAGE_PIXEL_FORMAT_RGB565
     /// Construct an image from a SharedPixelBuffer of RGB565 pixels.
     ///
     /// This is the native format of many embedded displays. The software
     /// renderer can draw such images without any pixel conversion.
+    ///
+    /// This constructor is only available when Slint was configured with
+    /// SLINT_FEATURE_IMAGE_PIXEL_FORMAT_RGB565.
     Image(SharedPixelBuffer<Rgb565Pixel> buffer)
         : data(Data::ImageInner_EmbeddedImage(
                   cbindgen_private::types::ImageCacheKey::Invalid(),
@@ -230,6 +234,8 @@ public:
                                   .data = buffer.m_data })))
     {
     }
+
+#endif
 
     /// Returns the size of the Image in pixels.
     Size<uint32_t> size() const { return cbindgen_private::types::slint_image_size(&data); }

--- a/api/cpp/include/private/slint_rgb565pixel.h
+++ b/api/cpp/include/private/slint_rgb565pixel.h
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+#pragma once
+#include <cstdint>
+#include "private/slint_generated_public.h"
+
+namespace slint {
+
+/// A 16bit pixel that has 5 red bits, 6 green bits and 5 blue bits
+struct Rgb565Pixel
+{
+    /// The blue component, encoded in 5 bits.
+    uint16_t b : 5;
+    /// The green component, encoded in 6 bits.
+    uint16_t g : 6;
+    /// The red component, encoded in 5 bits.
+    uint16_t r : 5;
+
+    /// Default constructor.
+    constexpr Rgb565Pixel() : b(0), g(0), r(0) { }
+
+    /// \brief Constructor that constructs from an Rgb8Pixel.
+    explicit constexpr Rgb565Pixel(const Rgb8Pixel &pixel)
+        : b(pixel.b >> 3), g(pixel.g >> 2), r(pixel.r >> 3)
+    {
+    }
+
+    /// \brief Get the red component as an 8-bit value.
+    ///
+    /// The bits are shifted so that the result is between 0 and 255.
+    /// \return The red component as an 8-bit value.
+    constexpr uint8_t red() const { return (r << 3) | (r >> 2); }
+
+    /// \brief Get the green component as an 8-bit value.
+    ///
+    /// The bits are shifted so that the result is between 0 and 255.
+    /// \return The green component as an 8-bit value.
+    constexpr uint8_t green() const { return (g << 2) | (g >> 4); }
+
+    /// \brief Get the blue component as an 8-bit value.
+    ///
+    /// The bits are shifted so that the result is between 0 and 255.
+    /// \return The blue component as an 8-bit value.
+    constexpr uint8_t blue() const { return (b << 3) | (b >> 2); }
+
+    /// \brief Convert to Rgb8Pixel.
+    constexpr operator Rgb8Pixel() const { return { red(), green(), blue() }; }
+
+    /// Returns true if \a lhs \a rhs are pixels with identical colors.
+    friend bool operator==(const Rgb565Pixel &lhs, const Rgb565Pixel &rhs) = default;
+};
+
+}

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -495,49 +495,8 @@ inline void set_platform(std::unique_ptr<Platform> platform)
 
 #ifdef SLINT_FEATURE_RENDERER_SOFTWARE
 
-/// A 16bit pixel that has 5 red bits, 6 green bits and 5 blue bits
-struct Rgb565Pixel
-{
-    /// The blue component, encoded in 5 bits.
-    uint16_t b : 5;
-    /// The green component, encoded in 6 bits.
-    uint16_t g : 6;
-    /// The red component, encoded in 5 bits.
-    uint16_t r : 5;
-
-    /// Default constructor.
-    constexpr Rgb565Pixel() : b(0), g(0), r(0) { }
-
-    /// \brief Constructor that constructs from an Rgb8Pixel.
-    explicit constexpr Rgb565Pixel(const Rgb8Pixel &pixel)
-        : b(pixel.b >> 3), g(pixel.g >> 2), r(pixel.r >> 3)
-    {
-    }
-
-    /// \brief Get the red component as an 8-bit value.
-    ///
-    /// The bits are shifted so that the result is between 0 and 255.
-    /// \return The red component as an 8-bit value.
-    constexpr uint8_t red() const { return (r << 3) | (r >> 2); }
-
-    /// \brief Get the green component as an 8-bit value.
-    ///
-    /// The bits are shifted so that the result is between 0 and 255.
-    /// \return The green component as an 8-bit value.
-    constexpr uint8_t green() const { return (g << 2) | (g >> 4); }
-
-    /// \brief Get the blue component as an 8-bit value.
-    ///
-    /// The bits are shifted so that the result is between 0 and 255.
-    /// \return The blue component as an 8-bit value.
-    constexpr uint8_t blue() const { return (b << 3) | (b >> 2); }
-
-    /// \brief Convert to Rgb8Pixel.
-    constexpr operator Rgb8Pixel() const { return { red(), green(), blue() }; }
-
-    /// Returns true if \a lhs \a rhs are pixels with identical colors.
-    friend bool operator==(const Rgb565Pixel &lhs, const Rgb565Pixel &rhs) = default;
-};
+/// Backwards-compatibility alias: Rgb565Pixel lives in the slint namespace.
+using slint::Rgb565Pixel;
 
 /// Slint's software renderer.
 ///

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -273,6 +273,7 @@ TEST_CASE("Image")
         REQUIRE(size.height == 2);
         REQUIRE(!img.path().has_value());
     }
+#ifdef SLINT_FEATURE_IMAGE_PIXEL_FORMAT_RGB565
     auto red565 = Rgb565Pixel(red);
     auto blu565 = Rgb565Pixel(blu);
     Rgb565Pixel some_565_data[] = { red565, red565, blu565, red565, blu565, blu565 };
@@ -287,6 +288,7 @@ TEST_CASE("Image")
         // The conversion truncates the low bits, so 0xff comes back as 0xf8.
         REQUIRE(*rgba8->begin() == Rgba8Pixel { 0xf8, 0, 0, 0xff });
     }
+#endif
 }
 
 TEST_CASE("Image buffer access")

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -273,6 +273,20 @@ TEST_CASE("Image")
         REQUIRE(size.height == 2);
         REQUIRE(!img.path().has_value());
     }
+    auto red565 = Rgb565Pixel(red);
+    auto blu565 = Rgb565Pixel(blu);
+    Rgb565Pixel some_565_data[] = { red565, red565, blu565, red565, blu565, blu565 };
+    img = Image(SharedPixelBuffer<Rgb565Pixel>(3, 2, some_565_data));
+    {
+        auto size = img.size();
+        REQUIRE(size.width == 3);
+        REQUIRE(size.height == 2);
+        REQUIRE(!img.path().has_value());
+        auto rgba8 = img.to_rgba8();
+        REQUIRE(rgba8.has_value());
+        // The conversion truncates the low bits, so 0xff comes back as 0xf8.
+        REQUIRE(*rgba8->begin() == Rgba8Pixel { 0xf8, 0, 0, 0xff });
+    }
 }
 
 TEST_CASE("Image buffer access")

--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -58,8 +58,8 @@ mcp = ["dep:i-slint-backend-testing", "i-slint-backend-selector/mcp"]
 napi = { version = "3", default-features = false, features = ["napi8"] }
 napi-derive = "3"
 i-slint-compiler = { workspace = true, features = ["default"] }
-i-slint-core = { workspace = true, features = ["default", "gettext-rs"] }
-i-slint-backend-selector = { workspace = true }
+i-slint-core = { workspace = true, features = ["default", "gettext-rs", "image-pixel-format-rgb565"] }
+i-slint-backend-selector = { workspace = true, features = ["image-pixel-format-rgb565"] }
 slint-interpreter = { workspace = true, default-features = false, features = ["display-diagnostics", "internal", "compat-1-18", "system-tray"] }
 spin_on = { workspace = true }
 css-color-parser2 = { workspace = true }

--- a/api/node/rust/types/image_data.rs
+++ b/api/node/rust/types/image_data.rs
@@ -68,6 +68,14 @@ impl SlintImageData {
                         (self.width() * self.height()) as usize,
                     ));
                 }
+                SharedImageBuffer::RGB565(buffer) => {
+                    let rgba = buffer
+                        .as_slice()
+                        .iter()
+                        .flat_map(|p| [p.red(), p.green(), p.blue(), 255])
+                        .collect::<Vec<_>>();
+                    return Buffer::from(rgba);
+                }
             }
         }
 

--- a/api/rs/slint/Cargo.toml
+++ b/api/rs/slint/Cargo.toml
@@ -103,6 +103,15 @@ raw-window-handle-06 = ["dep:raw-window-handle-06", "i-slint-backend-selector/ra
 ## This feature has no effect on the web, where the browser decodes images.
 image-default-formats = ["i-slint-core/image-default-formats"]
 
+## Enable support for images in the RGB565 pixel format ([`Image::from_rgb565`]),
+## the native format of many embedded displays. The software renderer draws such
+## images without any per-pixel conversion when the render target is RGB565 too.
+image-pixel-format-rgb565 = [
+  "i-slint-core/image-pixel-format-rgb565",
+  "i-slint-renderer-software?/image-pixel-format-rgb565",
+  "i-slint-backend-selector/image-pixel-format-rgb565",
+]
+
 ## Enable the live preview feature
 ##
 ## Enable this feature to reload the .slint files at runtime and reload it whenever the files are modified on disk.
@@ -354,6 +363,7 @@ features = [
   "log",
   "gettext",
   "renderer-software",
+  "image-pixel-format-rgb565",
   "renderer-femtovg",
   "raw-window-handle-06",
   "unstable-wgpu-29",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2410,6 +2410,7 @@ dependencies = [
  "accesskit",
  "async-channel 2.5.0",
  "bitflags 2.13.1",
+ "bytemuck",
  "cfg-if",
  "chrono",
  "clru",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4739,6 +4739,7 @@ dependencies = [
  "accesskit",
  "async-channel",
  "bitflags 2.13.1",
+ "bytemuck",
  "cfg-if",
  "chrono",
  "clru",

--- a/internal/backends/linuxkms/Cargo.toml
+++ b/internal/backends/linuxkms/Cargo.toml
@@ -19,6 +19,12 @@ build = "build.rs"
 path = "lib.rs"
 
 [features]
+image-pixel-format-rgb565 = [
+  "i-slint-core/image-pixel-format-rgb565",
+  "i-slint-renderer-skia?/image-pixel-format-rgb565",
+  "i-slint-renderer-femtovg?/image-pixel-format-rgb565",
+  "i-slint-renderer-software?/image-pixel-format-rgb565",
+]
 renderer-skia = ["renderer-skia-opengl"]
 renderer-skia-vulkan = ["unstable-wgpu-30", "i-slint-renderer-skia/vulkan"]
 unstable-wgpu-29 = ["i-slint-renderer-skia/wgpu-29", "drm", "dep:memmap2"]

--- a/internal/backends/qt/Cargo.toml
+++ b/internal/backends/qt/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 links = "i_slint_backend_qt"                   # just so we can pass metadata to the dependencies's build script
 
 [features]
+image-pixel-format-rgb565 = ["i-slint-core/image-pixel-format-rgb565"]
 rtti = ["i-slint-core/rtti"]
 default = ["enable"]
 enable = ["dep:cpp", "dep:lyon_path", "dep:pin-project", "dep:pin-weak", "dep:qttypes", "dep:cpp_build"]

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1628,6 +1628,9 @@ fn shared_image_buffer_to_pixmap(buffer: &SharedImageBuffer) -> Option<qttypes::
         SharedImageBuffer::RGB8(img) => {
             (qttypes::ImageFormat::RGB888, img.width() * 3, img.as_bytes().as_ptr())
         }
+        SharedImageBuffer::RGB565(img) => {
+            (qttypes::ImageFormat::RGB16, img.width() * 2, img.as_bytes().as_ptr())
+        }
     };
     let width: i32 = buffer.width() as _;
     let height: i32 = buffer.height() as _;

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1628,9 +1628,13 @@ fn shared_image_buffer_to_pixmap(buffer: &SharedImageBuffer) -> Option<qttypes::
         SharedImageBuffer::RGB8(img) => {
             (qttypes::ImageFormat::RGB888, img.width() * 3, img.as_bytes().as_ptr())
         }
+        #[cfg(feature = "image-pixel-format-rgb565")]
         SharedImageBuffer::RGB565(img) => {
             (qttypes::ImageFormat::RGB16, img.width() * 2, img.as_bytes().as_ptr())
         }
+        #[cfg(not(feature = "image-pixel-format-rgb565"))]
+        #[allow(unreachable_patterns)]
+        _ => return None,
     };
     let width: i32 = buffer.width() as _;
     let height: i32 = buffer.height() as _;

--- a/internal/backends/selector/Cargo.toml
+++ b/internal/backends/selector/Cargo.toml
@@ -29,6 +29,15 @@ backend-linuxkms-noseat = ["backend-linuxkms-libinput"]
 backend-qt = ["i-slint-backend-qt/enable"]
 backend-testing = ["i-slint-backend-testing/internal"]
 
+image-pixel-format-rgb565 = [
+  "i-slint-core/image-pixel-format-rgb565",
+  "i-slint-backend-qt?/image-pixel-format-rgb565",
+  "i-slint-backend-winit?/image-pixel-format-rgb565",
+  "i-slint-backend-linuxkms?/image-pixel-format-rgb565",
+  "i-slint-renderer-femtovg?/image-pixel-format-rgb565",
+  "i-slint-renderer-skia?/image-pixel-format-rgb565",
+]
+
 renderer-femtovg = [
   "dep:i-slint-renderer-femtovg",
   "i-slint-backend-winit?/renderer-femtovg",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -20,6 +20,12 @@ path = "lib.rs"
 # Note, these features need to be kept in sync (along with their defaults) in
 # the C++ crate's CMakeLists.txt
 [features]
+image-pixel-format-rgb565 = [
+  "i-slint-core/image-pixel-format-rgb565",
+  "i-slint-renderer-femtovg?/image-pixel-format-rgb565",
+  "i-slint-renderer-skia?/image-pixel-format-rgb565",
+  "i-slint-renderer-software?/image-pixel-format-rgb565",
+]
 wayland = [
   "winit/wayland",
   "winit/wayland-csd-adwaita",

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -191,6 +191,7 @@ fn icon_to_winit(
             .flat_map(|rgb| IntoIterator::into_iter([rgb[0], rgb[1], rgb[2], 255]))
             .collect(),
         SharedImageBuffer::RGBA8(pixels) => pixels.as_bytes().to_vec(),
+        #[cfg(feature = "image-pixel-format-rgb565")]
         SharedImageBuffer::RGB565(pixels) => {
             pixels.as_slice().iter().flat_map(|p| [p.red(), p.green(), p.blue(), 255]).collect()
         }
@@ -205,6 +206,9 @@ fn icon_to_winit(
                     .chain(std::iter::once(alpha as u8))
             })
             .collect(),
+        #[cfg(not(feature = "image-pixel-format-rgb565"))]
+        #[allow(unreachable_patterns)]
+        _ => return None,
     };
 
     winit::window::Icon::from_rgba(rgba_pixels, pixel_buffer.width(), pixel_buffer.height()).ok()

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -191,6 +191,9 @@ fn icon_to_winit(
             .flat_map(|rgb| IntoIterator::into_iter([rgb[0], rgb[1], rgb[2], 255]))
             .collect(),
         SharedImageBuffer::RGBA8(pixels) => pixels.as_bytes().to_vec(),
+        SharedImageBuffer::RGB565(pixels) => {
+            pixels.as_slice().iter().flat_map(|p| [p.red(), p.green(), p.blue(), 255]).collect()
+        }
         SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels
             .as_bytes()
             .chunks(4)

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -54,6 +54,11 @@ image-decoders = ["dep:image", "dep:clru"]
 image-default-formats = ["image?/default-formats"]
 svg = ["dep:resvg", "i-slint-common/svg-text"]
 
+# Support for images in the RGB565 pixel format, the native format of many
+# embedded displays. Disabled by default so that applications that don't
+# need it don't pay for the extra rendering code.
+image-pixel-format-rgb565 = []
+
 box-shadow-cache = []
 
 testing = []
@@ -185,7 +190,7 @@ web-sys = { workspace = true, features = ["HtmlImageElement", "Navigator", "Blob
 
 
 [dev-dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "renderer-software"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["std", "compat-1-2", "renderer-software", "image-pixel-format-rgb565"] }
 i-slint-backend-testing = { path = "../backends/testing", features = ["internal"] }
 rustybuzz = { workspace = true }
 ttf-parser = { workspace = true }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -104,6 +104,7 @@ vtable = { workspace = true }
 
 portable-atomic = { version = "1", features = ["critical-section"] }
 cfg-if = "1"
+bytemuck = { workspace = true, features = ["derive"] }
 derive_more = { workspace = true, features = ["error", "deref", "deref_mut"] }
 euclid = { workspace = true }
 lyon_algorithms = { version = "1.0", optional = true, default-features = false }

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -17,7 +17,7 @@ pub use crate::data_transfer::DataTransfer;
 #[cfg(target_has_atomic = "ptr")]
 pub use crate::future::*;
 pub use crate::graphics::{
-    Brush, Color, Image, LoadImageError, OklchColor, Rgb8Pixel, Rgba8Pixel, RgbaColor,
+    Brush, Color, Image, LoadImageError, OklchColor, Rgb8Pixel, Rgb565Pixel, Rgba8Pixel, RgbaColor,
     SharedPixelBuffer,
 };
 pub use crate::input::Keys;

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -219,6 +219,9 @@ pub enum SharedImageBuffer {
     RGBA8Premultiplied(SharedPixelBuffer<Rgba8Pixel>),
     /// This variant holds the data for an image where each pixel is 16 bits: 5 red bits,
     /// 6 green bits, and 5 blue bits. This is the native format of many embedded displays.
+    ///
+    /// This variant is only available with the `image-pixel-format-rgb565` feature.
+    #[cfg(feature = "image-pixel-format-rgb565")]
     RGB565(SharedPixelBuffer<Rgb565Pixel>),
 }
 
@@ -230,6 +233,7 @@ impl SharedImageBuffer {
             Self::RGB8(buffer) => buffer.width(),
             Self::RGBA8(buffer) => buffer.width(),
             Self::RGBA8Premultiplied(buffer) => buffer.width(),
+            #[cfg(feature = "image-pixel-format-rgb565")]
             Self::RGB565(buffer) => buffer.width(),
         }
     }
@@ -241,6 +245,7 @@ impl SharedImageBuffer {
             Self::RGB8(buffer) => buffer.height(),
             Self::RGBA8(buffer) => buffer.height(),
             Self::RGBA8Premultiplied(buffer) => buffer.height(),
+            #[cfg(feature = "image-pixel-format-rgb565")]
             Self::RGB565(buffer) => buffer.height(),
         }
     }
@@ -252,6 +257,7 @@ impl SharedImageBuffer {
             Self::RGB8(buffer) => buffer.size(),
             Self::RGBA8(buffer) => buffer.size(),
             Self::RGBA8Premultiplied(buffer) => buffer.size(),
+            #[cfg(feature = "image-pixel-format-rgb565")]
             Self::RGB565(buffer) => buffer.size(),
         }
     }
@@ -269,6 +275,7 @@ impl PartialEq for SharedImageBuffer {
             Self::RGBA8Premultiplied(lhs_buffer) => {
                 matches!(other, Self::RGBA8Premultiplied(rhs_buffer) if lhs_buffer.data.as_ptr().eq(&rhs_buffer.data.as_ptr()))
             }
+            #[cfg(feature = "image-pixel-format-rgb565")]
             Self::RGB565(lhs_buffer) => {
                 matches!(other, Self::RGB565(rhs_buffer) if lhs_buffer.data.as_ptr().eq(&rhs_buffer.data.as_ptr()))
             }
@@ -294,6 +301,9 @@ pub enum TexturePixelFormat {
     /// The array must be width * height +1 bytes long. (the extra bit is read but never used)
     SignedDistanceField,
     /// 16 bits per pixel: 5 red bits, 6 green bits, and 5 blue bits, in native byte order.
+    ///
+    /// This variant is only available with the `image-pixel-format-rgb565` feature.
+    #[cfg(feature = "image-pixel-format-rgb565")]
     Rgb565,
 }
 
@@ -306,6 +316,7 @@ impl TexturePixelFormat {
             TexturePixelFormat::RgbaPremultiplied => 4,
             TexturePixelFormat::AlphaMap => 1,
             TexturePixelFormat::SignedDistanceField => 1,
+            #[cfg(feature = "image-pixel-format-rgb565")]
             TexturePixelFormat::Rgb565 => 2,
         }
     }
@@ -571,6 +582,7 @@ impl ImageInner {
                             TexturePixelFormat::SignedDistanceField => {
                                 todo!("converting from a signed distance field to an image")
                             }
+                            #[cfg(feature = "image-pixel-format-rgb565")]
                             TexturePixelFormat::Rgb565 => {
                                 let mut iter = source.as_chunks::<2>().0.iter().map(|chunk| {
                                     let p = Rgb565Pixel(u16::from_ne_bytes(*chunk));
@@ -914,6 +926,9 @@ impl Image {
     ///
     /// This is the native format of many embedded displays. The software renderer can draw such
     /// images without any pixel conversion when the target is also RGB565.
+    ///
+    /// This function is only available with the `image-pixel-format-rgb565` feature.
+    #[cfg(feature = "image-pixel-format-rgb565")]
     pub fn from_rgb565(buffer: SharedPixelBuffer<Rgb565Pixel>) -> Self {
         Image(ImageInner::EmbeddedImage {
             cache_key: ImageCacheKey::Invalid,
@@ -952,6 +967,7 @@ impl Image {
                 height: buffer.height,
                 data: buffer.data.into_iter().map(Image::premultiplied_rgba_to_rgba).collect(),
             },
+            #[cfg(feature = "image-pixel-format-rgb565")]
             SharedImageBuffer::RGB565(buffer) => SharedPixelBuffer::<Rgba8Pixel> {
                 width: buffer.width,
                 height: buffer.height,
@@ -980,6 +996,7 @@ impl Image {
                 data: buffer.data.into_iter().map(Image::rgba_to_premultiplied_rgba).collect(),
             },
             SharedImageBuffer::RGBA8Premultiplied(buffer) => buffer,
+            #[cfg(feature = "image-pixel-format-rgb565")]
             SharedImageBuffer::RGB565(buffer) => SharedPixelBuffer::<Rgba8Pixel> {
                 width: buffer.width,
                 height: buffer.height,
@@ -1889,7 +1906,9 @@ pub struct BorrowedOpenGLTexture {
 mod tests {
     use crate::graphics::Rgba8Pixel;
 
-    use super::{Image, Rgb565Pixel, SharedPixelBuffer};
+    #[cfg(feature = "image-pixel-format-rgb565")]
+    use super::SharedPixelBuffer;
+    use super::{Image, Rgb565Pixel};
 
     #[test]
     fn test_premultiplied_to_rgb_zero_alpha() {
@@ -1933,6 +1952,7 @@ mod tests {
         assert_eq!(converted, Rgba8Pixel::new(5, 10, 15, 128));
     }
 
+    #[cfg(feature = "image-pixel-format-rgb565")]
     #[test]
     fn test_image_from_rgb565() {
         let mut buffer = SharedPixelBuffer::<Rgb565Pixel>::new(2, 1);

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -92,20 +92,15 @@ impl<Pixel: Clone> SharedPixelBuffer<Pixel> {
     }
 }
 
-impl<Pixel: Clone + rgb::Pod> SharedPixelBuffer<Pixel>
-where
-    [Pixel]: rgb::ComponentBytes<u8>,
-{
+impl<Pixel: Clone + rgb::Pod> SharedPixelBuffer<Pixel> {
     /// Returns the pixels interpreted as raw bytes.
     pub fn as_bytes(&self) -> &[u8] {
-        use rgb::ComponentBytes;
-        self.data.as_slice().as_bytes()
+        rgb::bytemuck::cast_slice(self.data.as_slice())
     }
 
     /// Returns the pixels interpreted as raw bytes.
     pub fn make_mut_bytes(&mut self) -> &mut [u8] {
-        use rgb::ComponentBytes;
-        self.data.make_mut_slice().as_bytes_mut()
+        rgb::bytemuck::cast_slice_mut(self.data.make_mut_slice())
     }
 }
 
@@ -153,6 +148,54 @@ pub type Rgb8Pixel = rgb::RGB8;
 /// encoded as u8.
 pub type Rgba8Pixel = rgb::RGBA8;
 
+/// A 16bit pixel that has 5 red bits, 6 green bits and 5 blue bits
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Rgb565Pixel(pub u16);
+
+impl Rgb565Pixel {
+    const R_MASK: u16 = 0b1111_1000_0000_0000;
+    const G_MASK: u16 = 0b0000_0111_1110_0000;
+    const B_MASK: u16 = 0b0000_0000_0001_1111;
+
+    /// Create a pixel from 8-bit red, green, and blue components.
+    /// The low bits are truncated.
+    pub const fn from_rgb(r: u8, g: u8, b: u8) -> Self {
+        Self(((r as u16 & 0b11111000) << 8) | ((g as u16 & 0b11111100) << 3) | (b as u16 >> 3))
+    }
+
+    /// Return the red component as a u8.
+    ///
+    /// The bits are shifted so that the result is between 0 and 255
+    pub const fn red(self) -> u8 {
+        ((self.0 & Self::R_MASK) >> 8) as u8
+    }
+    /// Return the green component as a u8.
+    ///
+    /// The bits are shifted so that the result is between 0 and 255
+    pub const fn green(self) -> u8 {
+        ((self.0 & Self::G_MASK) >> 3) as u8
+    }
+    /// Return the blue component as a u8.
+    ///
+    /// The bits are shifted so that the result is between 0 and 255
+    pub const fn blue(self) -> u8 {
+        ((self.0 & Self::B_MASK) << 3) as u8
+    }
+}
+
+impl From<Rgb8Pixel> for Rgb565Pixel {
+    fn from(p: Rgb8Pixel) -> Self {
+        Self::from_rgb(p.r, p.g, p.b)
+    }
+}
+
+impl From<Rgb565Pixel> for Rgb8Pixel {
+    fn from(p: Rgb565Pixel) -> Self {
+        Rgb8Pixel { r: p.red(), g: p.green(), b: p.blue() }
+    }
+}
+
 /// SharedImageBuffer is a container for images that are stored in CPU accessible memory.
 ///
 /// The SharedImageBuffer's variants represent the different common formats for encoding
@@ -174,6 +217,9 @@ pub enum SharedImageBuffer {
     /// Only construct this format if you know that your pixels are encoded this way. It is more efficient
     /// for rendering.
     RGBA8Premultiplied(SharedPixelBuffer<Rgba8Pixel>),
+    /// This variant holds the data for an image where each pixel is 16 bits: 5 red bits,
+    /// 6 green bits, and 5 blue bits. This is the native format of many embedded displays.
+    RGB565(SharedPixelBuffer<Rgb565Pixel>),
 }
 
 impl SharedImageBuffer {
@@ -184,6 +230,7 @@ impl SharedImageBuffer {
             Self::RGB8(buffer) => buffer.width(),
             Self::RGBA8(buffer) => buffer.width(),
             Self::RGBA8Premultiplied(buffer) => buffer.width(),
+            Self::RGB565(buffer) => buffer.width(),
         }
     }
 
@@ -194,6 +241,7 @@ impl SharedImageBuffer {
             Self::RGB8(buffer) => buffer.height(),
             Self::RGBA8(buffer) => buffer.height(),
             Self::RGBA8Premultiplied(buffer) => buffer.height(),
+            Self::RGB565(buffer) => buffer.height(),
         }
     }
 
@@ -204,6 +252,7 @@ impl SharedImageBuffer {
             Self::RGB8(buffer) => buffer.size(),
             Self::RGBA8(buffer) => buffer.size(),
             Self::RGBA8Premultiplied(buffer) => buffer.size(),
+            Self::RGB565(buffer) => buffer.size(),
         }
     }
 }
@@ -219,6 +268,9 @@ impl PartialEq for SharedImageBuffer {
             }
             Self::RGBA8Premultiplied(lhs_buffer) => {
                 matches!(other, Self::RGBA8Premultiplied(rhs_buffer) if lhs_buffer.data.as_ptr().eq(&rhs_buffer.data.as_ptr()))
+            }
+            Self::RGB565(lhs_buffer) => {
+                matches!(other, Self::RGB565(rhs_buffer) if lhs_buffer.data.as_ptr().eq(&rhs_buffer.data.as_ptr()))
             }
         }
     }
@@ -241,6 +293,8 @@ pub enum TexturePixelFormat {
     /// and i8::MAX corresponds to 3 pixels inside the shape.
     /// The array must be width * height +1 bytes long. (the extra bit is read but never used)
     SignedDistanceField,
+    /// 16 bits per pixel: 5 red bits, 6 green bits, and 5 blue bits, in native byte order.
+    Rgb565,
 }
 
 impl TexturePixelFormat {
@@ -252,6 +306,7 @@ impl TexturePixelFormat {
             TexturePixelFormat::RgbaPremultiplied => 4,
             TexturePixelFormat::AlphaMap => 1,
             TexturePixelFormat::SignedDistanceField => 1,
+            TexturePixelFormat::Rgb565 => 2,
         }
     }
 }
@@ -515,6 +570,13 @@ impl ImageInner {
                             }
                             TexturePixelFormat::SignedDistanceField => {
                                 todo!("converting from a signed distance field to an image")
+                            }
+                            TexturePixelFormat::Rgb565 => {
+                                let mut iter = source.as_chunks::<2>().0.iter().map(|chunk| {
+                                    let p = Rgb565Pixel(u16::from_ne_bytes(*chunk));
+                                    Rgba8Pixel { r: p.red(), g: p.green(), b: p.blue(), a: 255 }
+                                });
+                                slice.fill_with(|| iter.next().unwrap());
                             }
                         };
                     }
@@ -847,6 +909,18 @@ impl Image {
         })
     }
 
+    /// Creates a new Image from the specified shared pixel buffer, where each pixel is 16 bits:
+    /// 5 red bits, 6 green bits, and 5 blue bits.
+    ///
+    /// This is the native format of many embedded displays. The software renderer can draw such
+    /// images without any pixel conversion when the target is also RGB565.
+    pub fn from_rgb565(buffer: SharedPixelBuffer<Rgb565Pixel>) -> Self {
+        Image(ImageInner::EmbeddedImage {
+            cache_key: ImageCacheKey::Invalid,
+            buffer: SharedImageBuffer::RGB565(buffer),
+        })
+    }
+
     /// Returns the pixel buffer for the Image if available in RGB format without alpha.
     /// Returns None if the pixels cannot be obtained, for example when the image was created from borrowed OpenGL textures.
     pub fn to_rgb8(&self) -> Option<SharedPixelBuffer<Rgb8Pixel>> {
@@ -878,6 +952,15 @@ impl Image {
                 height: buffer.height,
                 data: buffer.data.into_iter().map(Image::premultiplied_rgba_to_rgba).collect(),
             },
+            SharedImageBuffer::RGB565(buffer) => SharedPixelBuffer::<Rgba8Pixel> {
+                width: buffer.width,
+                height: buffer.height,
+                data: buffer
+                    .data
+                    .into_iter()
+                    .map(|p| Rgba8Pixel::new(p.red(), p.green(), p.blue(), 255))
+                    .collect(),
+            },
         })
     }
 
@@ -897,6 +980,15 @@ impl Image {
                 data: buffer.data.into_iter().map(Image::rgba_to_premultiplied_rgba).collect(),
             },
             SharedImageBuffer::RGBA8Premultiplied(buffer) => buffer,
+            SharedImageBuffer::RGB565(buffer) => SharedPixelBuffer::<Rgba8Pixel> {
+                width: buffer.width,
+                height: buffer.height,
+                data: buffer
+                    .data
+                    .into_iter()
+                    .map(|p| Rgba8Pixel::new(p.red(), p.green(), p.blue(), 255))
+                    .collect(),
+            },
         })
     }
 
@@ -1797,7 +1889,7 @@ pub struct BorrowedOpenGLTexture {
 mod tests {
     use crate::graphics::Rgba8Pixel;
 
-    use super::Image;
+    use super::{Image, Rgb565Pixel, SharedPixelBuffer};
 
     #[test]
     fn test_premultiplied_to_rgb_zero_alpha() {
@@ -1839,5 +1931,36 @@ mod tests {
         let pixel = Rgba8Pixel::new(10, 20, 30, 128);
         let converted = Image::rgba_to_premultiplied_rgba(pixel);
         assert_eq!(converted, Rgba8Pixel::new(5, 10, 15, 128));
+    }
+
+    #[test]
+    fn test_image_from_rgb565() {
+        let mut buffer = SharedPixelBuffer::<Rgb565Pixel>::new(2, 1);
+        buffer.make_mut_slice()[0] = Rgb565Pixel::from_rgb(0xff, 0, 0);
+        buffer.make_mut_slice()[1] = Rgb565Pixel(0b00000_111111_00000);
+        let image = Image::from_rgb565(buffer);
+        assert_eq!(image.size(), crate::graphics::IntSize::new(2, 1));
+
+        // Like for RGBA8 sources, to_rgb8 does not convert.
+        assert!(image.to_rgb8().is_none());
+
+        // The conversion truncates the low bits, so 0xff comes back as 0xf8.
+        let rgba = image.to_rgba8().unwrap();
+        assert_eq!(rgba.as_slice()[0], Rgba8Pixel::new(0xf8, 0, 0, 0xff));
+        assert_eq!(rgba.as_slice()[1], Rgba8Pixel::new(0, 0xfc, 0, 0xff));
+
+        // RGB565 has no alpha, so the premultiplied form is the same.
+        let premultiplied = image.to_rgba8_premultiplied().unwrap();
+        assert_eq!(premultiplied.as_slice(), rgba.as_slice());
+    }
+
+    #[test]
+    fn test_rgb565_pixel_conversions() {
+        for &(r, g, b) in &[(0xffu8, 0x25u8, 0u8), (0x56, 0x42, 0xe3), (0, 0, 0), (255, 255, 255)] {
+            let pix565 = Rgb565Pixel::from_rgb(r, g, b);
+            let pix888: super::Rgb8Pixel = pix565.into();
+            // 565 -> 888 -> 565 is lossless.
+            assert_eq!(pix565, pix888.into(), "mismatch for ({r}, {g}, {b})");
+        }
     }
 }

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1956,7 +1956,7 @@ mod tests {
 
     #[test]
     fn test_rgb565_pixel_conversions() {
-        for &(r, g, b) in &[(0xffu8, 0x25u8, 0u8), (0x56, 0x42, 0xe3), (0, 0, 0), (255, 255, 255)] {
+        for &(r, g, b) in &[(0xff, 0x25, 0u8), (0x56, 0x42, 0xe3), (0, 0, 0), (255, 255, 255)] {
             let pix565 = Rgb565Pixel::from_rgb(r, g, b);
             let pix888: super::Rgb8Pixel = pix565.into();
             // 565 -> 888 -> 565 is lossless.

--- a/internal/core/graphics/image/cache.rs
+++ b/internal/core/graphics/image/cache.rs
@@ -20,6 +20,7 @@ impl clru::WeightScale<ImageCacheKey, ImageInner> for ImageWeightInBytes {
                 SharedImageBuffer::RGB8(pixels) => pixels.as_bytes().len(),
                 SharedImageBuffer::RGBA8(pixels) => pixels.as_bytes().len(),
                 SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels.as_bytes().len(),
+                SharedImageBuffer::RGB565(pixels) => pixels.as_bytes().len(),
             },
             #[cfg(feature = "svg")]
             ImageInner::Svg(svg) => svg.weight_in_bytes(),

--- a/internal/core/graphics/image/cache.rs
+++ b/internal/core/graphics/image/cache.rs
@@ -20,6 +20,7 @@ impl clru::WeightScale<ImageCacheKey, ImageInner> for ImageWeightInBytes {
                 SharedImageBuffer::RGB8(pixels) => pixels.as_bytes().len(),
                 SharedImageBuffer::RGBA8(pixels) => pixels.as_bytes().len(),
                 SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels.as_bytes().len(),
+                #[cfg(feature = "image-pixel-format-rgb565")]
                 SharedImageBuffer::RGB565(pixels) => pixels.as_bytes().len(),
             },
             #[cfg(feature = "svg")]

--- a/internal/renderers/anyrender/Cargo.toml
+++ b/internal/renderers/anyrender/Cargo.toml
@@ -19,6 +19,7 @@ path = "lib.rs"
 default = []
 ## Render through vello on WGPU, using Slint's own WGPU initialization.
 vello = ["dep:anyrender_vello", "dep:vello", "i-slint-core/unstable-wgpu-29"]
+image-pixel-format-rgb565 = ["i-slint-core/image-pixel-format-rgb565"]
 
 [dependencies]
 i-slint-core = { workspace = true, features = ["default", "shared-fontique", "shared-parley", "image-decoders", "svg"] }

--- a/internal/renderers/anyrender/itemrenderer.rs
+++ b/internal/renderers/anyrender/itemrenderer.rs
@@ -1208,6 +1208,7 @@ fn load_image(
                     let pixels = match svg.render(Some(render_size)).ok()? {
                         SharedImageBuffer::RGB8(_) => unreachable!(),
                         SharedImageBuffer::RGBA8(_) => unreachable!(),
+                        SharedImageBuffer::RGB565(_) => unreachable!(),
                         SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels,
                     };
 
@@ -1302,6 +1303,22 @@ fn image_buffer_to_peniko_image(buffer: &SharedImageBuffer) -> Option<peniko::Im
                 .0
                 .iter()
                 .flat_map(|rgb| [rgb[0], rgb[1], rgb[2], 255])
+                .collect();
+            let width = shared_pixel_buffer.width();
+            let height = shared_pixel_buffer.height();
+            return Some(peniko::ImageData {
+                data: peniko::Blob::new(Arc::new(rgba)),
+                format: peniko::ImageFormat::Rgba8,
+                alpha_type: peniko::ImageAlphaType::Alpha,
+                width,
+                height,
+            });
+        }
+        SharedImageBuffer::RGB565(shared_pixel_buffer) => {
+            let rgba: Vec<u8> = shared_pixel_buffer
+                .as_slice()
+                .iter()
+                .flat_map(|p| [p.red(), p.green(), p.blue(), 255])
                 .collect();
             let width = shared_pixel_buffer.width();
             let height = shared_pixel_buffer.height();

--- a/internal/renderers/anyrender/itemrenderer.rs
+++ b/internal/renderers/anyrender/itemrenderer.rs
@@ -1206,10 +1206,8 @@ fn load_image(
                 ImageVariant::Sized { width: render_size.width, height: render_size.height },
                 || {
                     let pixels = match svg.render(Some(render_size)).ok()? {
-                        SharedImageBuffer::RGB8(_) => unreachable!(),
-                        SharedImageBuffer::RGBA8(_) => unreachable!(),
-                        SharedImageBuffer::RGB565(_) => unreachable!(),
                         SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels,
+                        _ => unreachable!(),
                     };
 
                     let width = pixels.width();
@@ -1314,6 +1312,7 @@ fn image_buffer_to_peniko_image(buffer: &SharedImageBuffer) -> Option<peniko::Im
                 height,
             });
         }
+        #[cfg(feature = "image-pixel-format-rgb565")]
         SharedImageBuffer::RGB565(shared_pixel_buffer) => {
             let rgba: Vec<u8> = shared_pixel_buffer
                 .as_slice()
@@ -1342,6 +1341,9 @@ fn image_buffer_to_peniko_image(buffer: &SharedImageBuffer) -> Option<peniko::Im
             peniko::ImageFormat::Rgba8,
             peniko::ImageAlphaType::AlphaPremultiplied,
         ),
+        #[cfg(not(feature = "image-pixel-format-rgb565"))]
+        #[allow(unreachable_patterns)]
+        _ => return None,
     };
 
     Some(peniko::ImageData {

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 path = "lib.rs"
 
 [features]
+image-pixel-format-rgb565 = ["i-slint-core/image-pixel-format-rgb565"]
 default = []
 opengl = []
 # wgpu-30 enables the wgpu backend for internal use (e.g. linuxkms DRM rendering).

--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -211,6 +211,7 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
             _ => {
                 let buffer = image.render_to_buffer(target_size_for_scalable_source)?;
                 // femtovg has no 16-bit texture format; expand to RGB8 for the upload.
+                #[cfg(feature = "image-pixel-format-rgb565")]
                 let buffer = match buffer {
                     SharedImageBuffer::RGB565(b) => {
                         let mut rgb = i_slint_core::graphics::SharedPixelBuffer::<
@@ -318,6 +319,7 @@ fn image_buffer_to_image_source(
 ) -> (femtovg::ImageSource<'_>, femtovg::ImageFlags) {
     match buffer {
         // Expanded to RGB8 before upload; see Texture::new_from_image.
+        #[cfg(feature = "image-pixel-format-rgb565")]
         SharedImageBuffer::RGB565(..) => {
             unreachable!("RGB565 buffers are converted to RGB8 before the femtovg upload")
         }
@@ -341,6 +343,11 @@ fn image_buffer_to_image_source(
                     .into()
             },
             femtovg::ImageFlags::PREMULTIPLIED,
+        ),
+        #[cfg(not(feature = "image-pixel-format-rgb565"))]
+        #[allow(unreachable_patterns)]
+        _ => unimplemented!(
+            "enable the image-pixel-format-rgb565 feature of i-slint-renderer-femtovg"
         ),
     }
 }

--- a/internal/renderers/femtovg/images.rs
+++ b/internal/renderers/femtovg/images.rs
@@ -210,6 +210,19 @@ impl<R: femtovg::Renderer + TextureImporter> Texture<R> {
             }
             _ => {
                 let buffer = image.render_to_buffer(target_size_for_scalable_source)?;
+                // femtovg has no 16-bit texture format; expand to RGB8 for the upload.
+                let buffer = match buffer {
+                    SharedImageBuffer::RGB565(b) => {
+                        let mut rgb = i_slint_core::graphics::SharedPixelBuffer::<
+                            i_slint_core::graphics::Rgb8Pixel,
+                        >::new(b.width(), b.height());
+                        for (dst, src) in rgb.make_mut_slice().iter_mut().zip(b.as_slice()) {
+                            *dst = (*src).into();
+                        }
+                        SharedImageBuffer::RGB8(rgb)
+                    }
+                    other => other,
+                };
                 let (image_source, flags) = image_buffer_to_image_source(&buffer);
                 canvas.borrow_mut().create_image(image_source, image_flags | flags).unwrap()
             }
@@ -304,6 +317,10 @@ fn image_buffer_to_image_source(
     buffer: &SharedImageBuffer,
 ) -> (femtovg::ImageSource<'_>, femtovg::ImageFlags) {
     match buffer {
+        // Expanded to RGB8 before upload; see Texture::new_from_image.
+        SharedImageBuffer::RGB565(..) => {
+            unreachable!("RGB565 buffers are converted to RGB8 before the femtovg upload")
+        }
         SharedImageBuffer::RGB8(buffer) => (
             {
                 imgref::ImgRef::new(buffer.as_slice(), buffer.width() as _, buffer.height() as _)

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -20,6 +20,7 @@ path = "lib.rs"
 # Note, these features need to be kept in sync (along with their defaults) in
 # the C++ crate's CMakeLists.txt
 [features]
+image-pixel-format-rgb565 = ["i-slint-core/image-pixel-format-rgb565"]
 wayland = ["glutin/wayland", "softbuffer/wayland", "softbuffer/wayland-dlopen"]
 x11 = ["glutin/x11", "glutin/glx", "softbuffer/x11", "softbuffer/x11-dlopen"]
 opengl = []

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -63,6 +63,7 @@ pub(crate) fn as_skia_image(
                 SharedImageBuffer::RGB8(_) => unreachable!(),
                 SharedImageBuffer::RGBA8(_) => unreachable!(),
                 SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels,
+                SharedImageBuffer::RGB565(_) => unreachable!(),
             };
 
             let image_info = crate::image_info(
@@ -145,6 +146,13 @@ fn image_buffer_to_skia_image(buffer: &SharedImageBuffer) -> Option<skia_safe::I
             pixels.size(),
             skia_safe::ColorType::RGBA8888,
             opaque_or(pixels.as_bytes(), skia_safe::AlphaType::Premul),
+        ),
+        SharedImageBuffer::RGB565(pixels) => (
+            skia_safe::Data::new_copy(pixels.as_bytes()),
+            pixels.width() as usize * 2,
+            pixels.size(),
+            skia_safe::ColorType::RGB565,
+            skia_safe::AlphaType::Opaque,
         ),
     };
     let image_info = crate::image_info(

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -60,10 +60,8 @@ pub(crate) fn as_skia_image(
                 Default::default(),
             )?;
             let pixels = match svg.render(Some(target_size)).ok()? {
-                SharedImageBuffer::RGB8(_) => unreachable!(),
-                SharedImageBuffer::RGBA8(_) => unreachable!(),
                 SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels,
-                SharedImageBuffer::RGB565(_) => unreachable!(),
+                _ => unreachable!(),
             };
 
             let image_info = crate::image_info(
@@ -147,12 +145,18 @@ fn image_buffer_to_skia_image(buffer: &SharedImageBuffer) -> Option<skia_safe::I
             skia_safe::ColorType::RGBA8888,
             opaque_or(pixels.as_bytes(), skia_safe::AlphaType::Premul),
         ),
+        #[cfg(feature = "image-pixel-format-rgb565")]
         SharedImageBuffer::RGB565(pixels) => (
             skia_safe::Data::new_copy(pixels.as_bytes()),
             pixels.width() as usize * 2,
             pixels.size(),
             skia_safe::ColorType::RGB565,
             skia_safe::AlphaType::Opaque,
+        ),
+        #[cfg(not(feature = "image-pixel-format-rgb565"))]
+        #[allow(unreachable_patterns)]
+        _ => unimplemented!(
+            "RGB565 images need the image-pixel-format-rgb565 feature of this renderer"
         ),
     };
     let image_info = crate::image_info(

--- a/internal/renderers/software/Cargo.toml
+++ b/internal/renderers/software/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 path = "lib.rs"
 
 [features]
+image-pixel-format-rgb565 = ["i-slint-core/image-pixel-format-rgb565"]
 systemfonts = [
   "i-slint-core/shared-fontique",
   "i-slint-common/shared-fontique",

--- a/internal/renderers/software/draw_functions.rs
+++ b/internal/renderers/software/draw_functions.rs
@@ -205,6 +205,7 @@ pub(super) fn draw_texture_line(
                     }
                 }
             }
+            #[cfg(feature = "image-pixel-format-rgb565")]
             TexturePixelFormat::Rgb565 => {
                 for pix in line_buffer {
                     let pos = pos(2).0;
@@ -324,6 +325,11 @@ pub(super) fn draw_texture_line(
                     pix.blend(c);
                 }
             }
+            #[cfg(not(feature = "image-pixel-format-rgb565"))]
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(
+                "RGB565 textures need the image-pixel-format-rgb565 feature of the renderer"
+            ),
         };
     }
 }

--- a/internal/renderers/software/draw_functions.rs
+++ b/internal/renderers/software/draw_functions.rs
@@ -205,6 +205,23 @@ pub(super) fn draw_texture_line(
                     }
                 }
             }
+            TexturePixelFormat::Rgb565 => {
+                for pix in line_buffer {
+                    let pos = pos(2).0;
+                    let value = u16::from_ne_bytes([data[pos], data[pos + 1]]);
+                    if alpha == 0xff {
+                        *pix = TargetPixel::from_rgb565(value);
+                    } else {
+                        let p = i_slint_core::graphics::Rgb565Pixel(value);
+                        pix.blend(PremultipliedRgbaColor::premultiply(Color::from_argb_u8(
+                            alpha,
+                            p.red(),
+                            p.green(),
+                            p.blue(),
+                        )))
+                    }
+                }
+            }
             TexturePixelFormat::Rgba => {
                 if color.alpha() == 0 {
                     for pix in line_buffer {
@@ -852,6 +869,19 @@ pub trait TargetPixel: Sized + Copy {
     /// Create a pixel from the red, gree, blue component in the range 0..=255
     fn from_rgb(red: u8, green: u8, blue: u8) -> Self;
 
+    /// Create a pixel from a 16-bit RGB565 value in native byte order
+    /// (5 red bits, 6 green bits, 5 blue bits).
+    ///
+    /// The default implementation expands the components. RGB565 pixel
+    /// types override this and use the value as-is.
+    fn from_rgb565(value: u16) -> Self {
+        Self::from_rgb(
+            ((value & 0xf800) >> 8) as u8,
+            ((value & 0x07e0) >> 3) as u8,
+            ((value & 0x001f) << 3) as u8,
+        )
+    }
+
     /// Pixel which will be filled as the background in case the slint view has transparency
     fn background() -> Self {
         Self::from_rgb(0, 0, 0)
@@ -890,35 +920,11 @@ impl TargetPixel for PremultipliedRgbaColor {
     }
 }
 
-/// A 16bit pixel that has 5 red bits, 6 green bits and  5 blue bits
-#[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, bytemuck::Pod, bytemuck::Zeroable)]
-pub struct Rgb565Pixel(pub u16);
+pub use i_slint_core::graphics::Rgb565Pixel;
 
-impl Rgb565Pixel {
-    const R_MASK: u16 = 0b1111_1000_0000_0000;
-    const G_MASK: u16 = 0b0000_0111_1110_0000;
-    const B_MASK: u16 = 0b0000_0000_0001_1111;
-
-    /// Return the red component as a u8.
-    ///
-    /// The bits are shifted so that the result is between 0 and 255
-    fn red(self) -> u8 {
-        ((self.0 & Self::R_MASK) >> 8) as u8
-    }
-    /// Return the green component as a u8.
-    ///
-    /// The bits are shifted so that the result is between 0 and 255
-    fn green(self) -> u8 {
-        ((self.0 & Self::G_MASK) >> 3) as u8
-    }
-    /// Return the blue component as a u8.
-    ///
-    /// The bits are shifted so that the result is between 0 and 255
-    fn blue(self) -> u8 {
-        ((self.0 & Self::B_MASK) << 3) as u8
-    }
-}
+const R_MASK: u16 = 0b1111_1000_0000_0000;
+const G_MASK: u16 = 0b0000_0111_1110_0000;
+const B_MASK: u16 = 0b0000_0000_0001_1111;
 
 impl TargetPixel for Rgb565Pixel {
     fn blend(&mut self, color: PremultipliedRgbaColor) {
@@ -927,8 +933,7 @@ impl TargetPixel for Rgb565Pixel {
         let a = (a + 4) >> 3;
 
         // 00000ggg_ggg00000_rrrrr000_000bbbbb
-        let expanded = (self.0 & (Self::R_MASK | Self::B_MASK)) as u32
-            | (((self.0 & Self::G_MASK) as u32) << 16);
+        let expanded = (self.0 & (R_MASK | B_MASK)) as u32 | (((self.0 & G_MASK) as u32) << 16);
 
         // gggggggg_000rrrrr_rrr000bb_bbbbbb00
         let c =
@@ -938,24 +943,16 @@ impl TargetPixel for Rgb565Pixel {
 
         let res = expanded * a + c;
 
-        self.0 = ((res >> 21) as u16 & Self::G_MASK)
-            | ((res >> 5) as u16 & (Self::R_MASK | Self::B_MASK));
+        self.0 = ((res >> 21) as u16 & G_MASK) | ((res >> 5) as u16 & (R_MASK | B_MASK));
     }
 
     fn from_rgb(r: u8, g: u8, b: u8) -> Self {
-        Self(((r as u16 & 0b11111000) << 8) | ((g as u16 & 0b11111100) << 3) | (b as u16 >> 3))
+        // This calls the inherent from_rgb, not this trait method.
+        Rgb565Pixel::from_rgb(r, g, b)
     }
-}
 
-impl From<Rgb8Pixel> for Rgb565Pixel {
-    fn from(p: Rgb8Pixel) -> Self {
-        Self::from_rgb(p.r, p.g, p.b)
-    }
-}
-
-impl From<Rgb565Pixel> for Rgb8Pixel {
-    fn from(p: Rgb565Pixel) -> Self {
-        Rgb8Pixel { r: p.red(), g: p.green(), b: p.blue() }
+    fn from_rgb565(value: u16) -> Self {
+        Self(value)
     }
 }
 
@@ -1009,6 +1006,11 @@ impl TargetPixel for Rgb565BigEndianPixel {
     fn from_rgb(r: u8, g: u8, b: u8) -> Self {
         Self(Rgb565Pixel::from_rgb(r, g, b).0.to_be())
     }
+
+    fn from_rgb565(value: u16) -> Self {
+        // Same 565 bit layout, only the byte order differs.
+        Self(value.to_be())
+    }
 }
 
 impl From<Rgb8Pixel> for Rgb565BigEndianPixel {
@@ -1051,6 +1053,24 @@ fn rgb565_be() {
     let pix_be = Rgb565BigEndianPixel::from_rgb(0x56, 0x42, 0xe3);
     let pix888: Rgb8Pixel = pix_be.into();
     assert_eq!(pix_be, pix888.into());
+}
+
+#[test]
+fn target_pixel_from_rgb565() {
+    let value = Rgb565Pixel::from_rgb(0x56, 0x42, 0xe3).0;
+
+    // Native-endian 565 targets take the value as-is.
+    assert_eq!(Rgb565Pixel::from_rgb565(value), Rgb565Pixel(value));
+
+    // Big-endian 565 targets only swap the bytes.
+    let be = Rgb565BigEndianPixel::from_rgb565(value);
+    assert_eq!(be.0, value.to_be());
+    assert_eq!(be, Rgb565BigEndianPixel::from_rgb(0x56, 0x42, 0xe3));
+
+    // The default implementation expands like the accessors.
+    let p = Rgb565Pixel(value);
+    let rgb8 = Rgb8Pixel::from_rgb565(value);
+    assert_eq!(rgb8, Rgb8Pixel { r: p.red(), g: p.green(), b: p.blue() });
 }
 
 #[test]

--- a/internal/renderers/software/draw_functions.rs
+++ b/internal/renderers/software/draw_functions.rs
@@ -875,11 +875,8 @@ pub trait TargetPixel: Sized + Copy {
     /// The default implementation expands the components. RGB565 pixel
     /// types override this and use the value as-is.
     fn from_rgb565(value: u16) -> Self {
-        Self::from_rgb(
-            ((value & 0xf800) >> 8) as u8,
-            ((value & 0x07e0) >> 3) as u8,
-            ((value & 0x001f) << 3) as u8,
-        )
+        let pixel = Rgb565Pixel(value);
+        Self::from_rgb(pixel.red(), pixel.green(), pixel.blue())
     }
 
     /// Pixel which will be filled as the background in case the slint view has transparency

--- a/internal/renderers/software/scene.rs
+++ b/internal/renderers/software/scene.rs
@@ -491,6 +491,7 @@ impl SharedBufferCommand {
                     extra: self.extra,
                 }
             }
+            #[cfg(feature = "image-pixel-format-rgb565")]
             SharedBufferData::SharedImage(SharedImageBuffer::RGB565(b)) => SceneTexture {
                 data: &b.as_bytes()[start * 2..end * 2],
                 pixel_stride: stride as u16,
@@ -503,6 +504,11 @@ impl SharedBufferCommand {
                 format: TexturePixelFormat::AlphaMap,
                 extra: self.extra,
             },
+            #[cfg(not(feature = "image-pixel-format-rgb565"))]
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(
+                "RGB565 images need the image-pixel-format-rgb565 feature of the renderer"
+            ),
         }
     }
 }

--- a/internal/renderers/software/scene.rs
+++ b/internal/renderers/software/scene.rs
@@ -491,6 +491,12 @@ impl SharedBufferCommand {
                     extra: self.extra,
                 }
             }
+            SharedBufferData::SharedImage(SharedImageBuffer::RGB565(b)) => SceneTexture {
+                data: &b.as_bytes()[start * 2..end * 2],
+                pixel_stride: stride as u16,
+                format: TexturePixelFormat::Rgb565,
+                extra: self.extra,
+            },
             SharedBufferData::AlphaMap { data, width } => SceneTexture {
                 data: &data[start..end],
                 pixel_stride: *width,

--- a/internal/renderers/software/target_pixel_buffer.rs
+++ b/internal/renderers/software/target_pixel_buffer.rs
@@ -119,6 +119,7 @@ impl DrawTextureArgs {
                             size,
                         )
                     }
+                    #[cfg(feature = "image-pixel-format-rgb565")]
                     SharedBufferData::SharedImage(SharedImageBuffer::RGB565(b)) => {
                         TextureData::new(
                             &b.as_bytes()[start * 2..end * 2],
@@ -132,6 +133,11 @@ impl DrawTextureArgs {
                         TexturePixelFormat::AlphaMap,
                         stride,
                         size,
+                    ),
+                    #[cfg(not(feature = "image-pixel-format-rgb565"))]
+                    #[allow(unreachable_patterns)]
+                    _ => unimplemented!(
+                        "RGB565 images need the image-pixel-format-rgb565 feature of the renderer"
                     ),
                 }
             }

--- a/internal/renderers/software/target_pixel_buffer.rs
+++ b/internal/renderers/software/target_pixel_buffer.rs
@@ -119,6 +119,14 @@ impl DrawTextureArgs {
                             size,
                         )
                     }
+                    SharedBufferData::SharedImage(SharedImageBuffer::RGB565(b)) => {
+                        TextureData::new(
+                            &b.as_bytes()[start * 2..end * 2],
+                            TexturePixelFormat::Rgb565,
+                            stride,
+                            size,
+                        )
+                    }
                     SharedBufferData::AlphaMap { data, .. } => TextureData::new(
                         &data[start..end],
                         TexturePixelFormat::AlphaMap,

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "accesskit",
  "async-channel",
  "bitflags 2.13.1",
+ "bytemuck",
  "cfg-if",
  "chrono",
  "clru",

--- a/xtask/src/generate_cppdocs_headers.rs
+++ b/xtask/src/generate_cppdocs_headers.rs
@@ -38,6 +38,7 @@ pub fn generate(experimental: bool) -> Result<(), Box<dyn std::error::Error>> {
         renderer_skia_vulkan: false,
         renderer_software: true,
         gettext: true,
+        image_pixel_format_rgb565: true,
         accessibility: true,
         system_testing: true,
         mcp: false,


### PR DESCRIPTION
RGB565 is the native format of most embedded displays and of the software renderer's Rgb565Pixel target. Add
Image::from_rgb565(SharedPixelBuffer<Rgb565Pixel>) and a SharedImageBuffer::RGB565 variant so such buffers can be displayed without converting them to RGB8 first.

The software renderer draws RGB565 textures directly, with no per-pixel conversion at all when the target pixel is also RGB565 (new TargetPixel::from_rgb565, identity for Rgb565Pixel). Qt uploads as QImage::Format_RGB16 (zero-copy), Skia uses ColorType::RGB565, femtovg and anyrender expand to RGB(A)8 at texture upload.

Rgb565Pixel moves from i-slint-renderer-software to i-slint-core (the old path keeps a re-export), and in C++ from slint-platform.h to the slint namespace (slint::platform::Rgb565Pixel stays as an alias). SharedPixelBuffer::as_bytes' bound is relaxed from rgb::ComponentBytes to rgb::Pod with bytemuck casting, so pixel types outside the rgb crate can use it.

Same file-by-file structure as the pending Gray8 support (#11331).

Fixes #12830

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
