### PR TITLE
core: thread macOS activation clicks ("first mouse") through the input pipeline

### DIFF
--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -582,8 +582,8 @@ public:
     void dispatch_pointer_press_event(LogicalPosition pos, PointerEventButton button)
     {
         private_api::assert_main_thread();
-        inner.dispatch_pointer_event(
-                slint::cbindgen_private::MouseEvent::Pressed({ pos.x, pos.y }, button, 0, 0));
+        inner.dispatch_pointer_event(slint::cbindgen_private::MouseEvent::Pressed(
+                { pos.x, pos.y }, button, 0, 0, false));
     }
     /// Dispatches a pointer or mouse release event to the scene.
     ///
@@ -595,8 +595,8 @@ public:
     void dispatch_pointer_release_event(LogicalPosition pos, PointerEventButton button)
     {
         private_api::assert_main_thread();
-        inner.dispatch_pointer_event(
-                slint::cbindgen_private::MouseEvent::Released({ pos.x, pos.y }, button, 0, 0));
+        inner.dispatch_pointer_event(slint::cbindgen_private::MouseEvent::Released(
+                { pos.x, pos.y }, button, 0, 0, false));
     }
     /// Dispatches a pointer exit event to the scene.
     ///

--- a/api/node/__test__/api.spec.mts
+++ b/api/node/__test__/api.spec.mts
@@ -385,6 +385,7 @@ test("language builtin structs: factory defaults", () => {
     expect(evt.button).toStrictEqual("other");
     expect(evt.kind).toStrictEqual("cancel");
     expect(evt.touch_finger_id).toStrictEqual(0);
+    expect(evt.is_activation_click).toStrictEqual(false);
     expect(evt.modifiers).toStrictEqual(language.KeyboardModifiers());
 });
 

--- a/docs/development/input-event-system.md
+++ b/docs/development/input-event-system.md
@@ -36,6 +36,7 @@ pub enum MouseEvent {
         button: PointerEventButton,
         click_count: u8,
         touch_finger_id: i32,  // Set for touch input, 0 for mouse
+        is_activation_click: bool,  // macOS "first mouse", see below
     },
 
     /// Mouse/finger released
@@ -44,6 +45,7 @@ pub enum MouseEvent {
         button: PointerEventButton,
         click_count: u8,
         touch_finger_id: i32,
+        is_activation_click: bool,
     },
 
     /// Pointer moved
@@ -86,6 +88,31 @@ pub struct ClickState {
 - If press occurs within `click_interval` of previous press, at same position, with same button → increment `click_count`
 - Otherwise reset to count 0
 - `click_count` is included in Press/Release events
+- An activation click (see below) resets the state and always carries `click_count` 0, so it neither continues nor starts a multi-click sequence
+
+### Activation Clicks (macOS "first mouse")
+
+On macOS, a click on an inactive window activates the window, and by
+convention only "safe" interactions (selection, scrolling, text-cursor
+placement) react to that click, while action-triggering controls (buttons)
+ignore it. The backend tags both the press and the matching release of such a
+click with `is_activation_click` (always false on other platforms and for
+events from the public `platform::WindowEvent` API).
+
+The policy is applied at delivery time by the items:
+
+- `TouchArea` suppresses the pressed state (and therefore `clicked` /
+  `double-clicked` / `moved`) for activation clicks, while keeping the grab
+  and still emitting `pointer-event` with the `is-activation-click` field
+  set. The `accepts-activation-clicks` property opts a `TouchArea` into
+  normal processing — used by selection surfaces (list/table rows) and
+  scrollbar thumbs in the std-widgets.
+- `Text` ignores an activation release for `link-clicked`.
+- `SliderBase` (std-widgets) returns early from its `pointer-event` handler,
+  since it changes the value on pointer-down directly.
+- `Flickable`, `TextInput`, `SwipeGestureHandler`, and `ContextMenuArea`
+  process activation clicks normally on purpose: panning, cursor placement,
+  and context menus are safe on a window-activating click.
 
 ### Mouse Input State
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -209,7 +209,7 @@ cpp! {{
             rust!(Slint_mousePressEvent [rust_window: &QtWindow as "void*", pos: qttypes::QPoint as "QPoint", button: u32 as "int" ] {
                 let position = LogicalPoint::new(pos.x as _, pos.y as _);
                 let button = from_qt_button(button);
-                rust_window.mouse_event(MouseEvent::Pressed{ position, button, click_count: 0, touch_finger_id: 0 })
+                rust_window.mouse_event(MouseEvent::Pressed{ position, button, click_count: 0, touch_finger_id: 0, is_activation_click: false })
             });
         }
         void mouseReleaseEvent(QMouseEvent *event) override {
@@ -239,7 +239,7 @@ cpp! {{
             rust!(Slint_mouseReleaseEvent [rust_window: &QtWindow as "void*", pos: qttypes::QPoint as "QPoint", button: u32 as "int" ] {
                 let position = LogicalPoint::new(pos.x as _, pos.y as _);
                 let button = from_qt_button(button);
-                rust_window.mouse_event(MouseEvent::Released{ position, button, click_count: 0, touch_finger_id: 0 })
+                rust_window.mouse_event(MouseEvent::Released{ position, button, click_count: 0, touch_finger_id: 0, is_activation_click: false })
             });
         }
         void mouseMoveEvent(QMouseEvent *event) override {

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -7,6 +7,7 @@ use crate::TestingWindow;
 use i_slint_core::SharedString;
 use i_slint_core::api::ComponentHandle;
 pub use i_slint_core::input::MouseEvent;
+pub use i_slint_core::input::PointerEventButton;
 pub use i_slint_core::input::TouchPhase;
 use i_slint_core::item_tree::ItemTreeVTable;
 pub use i_slint_core::lengths::LogicalPoint;

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -448,6 +448,9 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                             button,
                             click_count: 0,
                             touch_finger_id: 0,
+                            // winit 0.30 has no per-event activation-click
+                            // information; wired up with the 0.31 upgrade.
+                            is_activation_click: false,
                         }
                     }
                     winit::event::ElementState::Released => {
@@ -457,6 +460,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
                             button,
                             click_count: 0,
                             touch_finger_id: 0,
+                            is_activation_click: false,
                         }
                     }
                 };

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -83,6 +83,9 @@ macro_rules! for_each_builtin_structs {
                 modifiers: KeyboardModifiers,
                 /// The unique ID of the touch point, indicating the finger ID. 0 means it's not a touch event (e.g., mouse).
                 touch_finger_id: i32,
+                /// True when this press or release belongs to the click that activated the window
+                /// (called "first mouse" on macOS). Always false on other platforms and for other event kinds.
+                is_activation_click: bool,
             }
 
             /// Represents a Pointer scroll (or wheel) event sent by the windowing system.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -854,6 +854,16 @@ export component TouchArea {
     out property <length> pressed_y;
     /// Set to `true` by the `TouchArea` when the mouse is pressed over it.
     out property <bool> pressed;
+    /// On macOS, a click on an inactive window activates the window, and by convention only
+    /// interactions that are safe to trigger accidentally — such as selecting an item or placing a
+    /// text cursor — react to that click. By default, the `TouchArea` follows this convention and
+    /// ignores such a window-activating click: `clicked` isn't invoked and `pressed` stays false.
+    /// Set this property to true to process the activating click like any other click. Use this
+    /// for interactions like selection that users expect to work with the first click.
+    /// The `pointer-event` callback is invoked either way; its `is-activation-click` field tells
+    /// the two cases apart. On all other platforms every click behaves normally, regardless of
+    /// this property.
+    in property <bool> accepts-activation-clicks;
     /// Invoked when clicked: A finger or the left mouse button is pressed, then released on this element.
     callback clicked;
     /// Invoked when double-clicked. The left mouse button is pressed and released twice on this element in a short

--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -144,6 +144,9 @@ component StandardListViewBase inherits ListView {
         accessible-action-default => { i-touch-area.clicked(); }
 
         i-touch-area := TouchArea {
+            // Selection is safe to trigger from a window-activating click.
+            accepts-activation-clicks: true;
+
             clicked => {
                 root.set-current-item(index);
             }

--- a/internal/compiler/widgets/common/slider-base.slint
+++ b/internal/compiler/widgets/common/slider-base.slint
@@ -38,6 +38,13 @@ export component SliderBase {
                 return;
             }
 
+            // A window-activating click must not change the value: the slider
+            // acts on pointer-event directly, so the TouchArea default
+            // (`accepts-activation-clicks: false`) doesn't cover it.
+            if (event.is-activation-click) {
+                return;
+            }
+
             if (event.kind == PointerEventKind.up) {
                 if (root.handle-pressed) {
                     root.released(root.value);

--- a/internal/compiler/widgets/cosmic/scrollview.slint
+++ b/internal/compiler/widgets/cosmic/scrollview.slint
@@ -48,6 +48,9 @@ export component ScrollBar {
     }
 
     touch-area := TouchArea {
+        // macOS native scrollbars react to a window-activating click.
+        accepts-activation-clicks: true;
+
         property <{pressed-value: length, maximum: length, x:length, y: length}> saved-values;
 
         width: parent.width;

--- a/internal/compiler/widgets/cosmic/tableview.slint
+++ b/internal/compiler/widgets/cosmic/tableview.slint
@@ -115,6 +115,8 @@ component TableViewRow inherits Rectangle {
     }
 
     touch-area := TouchArea {
+        accepts-activation-clicks: true;
+
         pointer-event(pe) => {
             root.pointer-event(pe, {
                 x: self.absolute-position.x + self.mouse-x,

--- a/internal/compiler/widgets/cupertino/scrollview.slint
+++ b/internal/compiler/widgets/cupertino/scrollview.slint
@@ -56,6 +56,9 @@ export component ScrollBar inherits Rectangle {
     }
 
     touch-area := TouchArea {
+        // macOS native scrollbars react to a window-activating click.
+        accepts-activation-clicks: true;
+
         property <{pressed-value: length, maximum: length, x:length, y: length}> saved-values;
 
         width: parent.width;

--- a/internal/compiler/widgets/cupertino/tableview.slint
+++ b/internal/compiler/widgets/cupertino/tableview.slint
@@ -104,6 +104,8 @@ component TableViewRow inherits Rectangle {
     ]
 
     touch-area := TouchArea {
+        accepts-activation-clicks: true;
+
         pointer-event(pe) => {
             root.pointer-event(pe, {
                 x: self.absolute-position.x + self.mouse-x,

--- a/internal/compiler/widgets/fluent/scrollview.slint
+++ b/internal/compiler/widgets/fluent/scrollview.slint
@@ -7,6 +7,9 @@ component ScrollViewButton inherits TouchArea {
     in property <image> icon;
     in property <bool> horizontal;
 
+    // macOS native scrollbars react to a window-activating click.
+    accepts-activation-clicks: true;
+
     width: root.horizontal ? 6px : 8px;
     height: root.horizontal ? 8px : 6px;
 
@@ -77,6 +80,9 @@ component ScrollBar inherits Rectangle {
     }
 
     touch-area := TouchArea {
+        // macOS native scrollbars react to a window-activating click.
+        accepts-activation-clicks: true;
+
         property <{pressed-value: length, maximum: length, x:length, y: length}> saved-values;
 
         width: parent.width;

--- a/internal/compiler/widgets/fluent/tableview.slint
+++ b/internal/compiler/widgets/fluent/tableview.slint
@@ -120,6 +120,8 @@ component TableViewRow inherits Rectangle {
     ]
 
     touch-area := TouchArea {
+        accepts-activation-clicks: true;
+
         pointer-event(pe) => {
             root.pointer-event(pe, {
                 x: self.absolute-position.x + self.mouse-x,

--- a/internal/compiler/widgets/material/scrollview.slint
+++ b/internal/compiler/widgets/material/scrollview.slint
@@ -58,6 +58,9 @@ component ScrollBar inherits Rectangle {
     }
 
     touch-area := TouchArea {
+        // macOS native scrollbars react to a window-activating click.
+        accepts-activation-clicks: true;
+
         property <{pressed-value: length, maximum: length, x:length, y: length}> saved-values;
 
         width: parent.width;

--- a/internal/compiler/widgets/material/tableview.slint
+++ b/internal/compiler/widgets/material/tableview.slint
@@ -100,6 +100,8 @@ component TableViewRow inherits Rectangle {
     min-height: max(42px, layout.min-height);
 
     state-layer := StateLayer {
+        // Selection is safe to trigger from a window-activating click.
+        accepts-activation-clicks: true;
         checked: root.selected;
         background: MaterialPalette.accent-background;
         checked-background: MaterialPalette.control-background;

--- a/internal/compiler/widgets/qt/tableview.slint
+++ b/internal/compiler/widgets/qt/tableview.slint
@@ -75,6 +75,8 @@ export component StandardTableView {
         for row[i] in rows : Rectangle {
             width: max(row-layout.preferred-width, scroll-view.visible-width);
             row-ta := TouchArea {
+                accepts-activation-clicks: true;
+
                 clicked => {
                     root.focus();
                     root.set-current-row(i);

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -702,6 +702,8 @@ impl Window {
                     button,
                     click_count: 0,
                     touch_finger_id: 0,
+                    // The public platform API cannot report activation clicks yet.
+                    is_activation_click: false,
                 })
                 .into(),
             crate::platform::WindowEvent::PointerReleased { position, button } => self
@@ -711,6 +713,7 @@ impl Window {
                     button,
                     click_count: 0,
                     touch_finger_id: 0,
+                    is_activation_click: false,
                 })
                 .into(),
             crate::platform::WindowEvent::PointerMoved { position } => self

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -42,6 +42,9 @@ pub enum MouseEvent {
         click_count: u8,
         /// The touch ID if the event originated from touch input.
         touch_finger_id: i32,
+        /// True when this press is the click that activated the window
+        /// (macOS "first mouse"). Always false on other platforms.
+        is_activation_click: bool,
     },
     /// The mouse or finger was released
     Released {
@@ -53,6 +56,9 @@ pub enum MouseEvent {
         click_count: u8,
         /// The touch ID if the event originated from touch input.
         touch_finger_id: i32,
+        /// True when this release belongs to the click that activated the
+        /// window (macOS "first mouse"). Always false on other platforms.
+        is_activation_click: bool,
     },
     /// The position of the pointer has changed
     Moved {
@@ -125,6 +131,16 @@ impl MouseEvent {
     pub fn is_from_touch(&self) -> bool {
         // touch events carry the finger id + 1, events from a mouse carry 0
         self.touch_finger_id() != 0
+    }
+
+    /// Whether this press or release belongs to the click that activated the
+    /// window (macOS "first mouse"). Always false for other event kinds.
+    pub fn is_activation_click(&self) -> bool {
+        match self {
+            MouseEvent::Pressed { is_activation_click, .. } => *is_activation_click,
+            MouseEvent::Released { is_activation_click, .. } => *is_activation_click,
+            _ => false,
+        }
     }
 
     /// The position of the cursor for this event, if any
@@ -1202,7 +1218,23 @@ impl ClickState {
     pub fn check_repeat(&self, mouse_event: MouseEvent, ctx: &crate::SlintContext) -> MouseEvent {
         let click_interval = ctx.platform().click_interval();
         match mouse_event {
-            MouseEvent::Pressed { position, button, touch_finger_id, .. } => {
+            MouseEvent::Pressed {
+                position, button, touch_finger_id, is_activation_click, ..
+            } => {
+                // A window-activating click (macOS "first mouse") never joins a
+                // multi-click sequence: it is typically suppressed by the items,
+                // and counting it would turn the next actual click into a
+                // double-click. Also don't let the following click chain onto it.
+                if is_activation_click {
+                    self.reset();
+                    return MouseEvent::Pressed {
+                        position,
+                        button,
+                        click_count: 0,
+                        touch_finger_id,
+                        is_activation_click,
+                    };
+                }
                 let instant_now = crate::animations::Instant::now(ctx);
 
                 if let Some(click_count_time_stamp) = self.click_count_time_stamp.get() {
@@ -1224,14 +1256,18 @@ impl ClickState {
                     button,
                     click_count: self.click_count.get(),
                     touch_finger_id,
+                    is_activation_click,
                 };
             }
-            MouseEvent::Released { position, button, touch_finger_id, .. } => {
+            MouseEvent::Released {
+                position, button, touch_finger_id, is_activation_click, ..
+            } => {
                 return MouseEvent::Released {
                     position,
                     button,
-                    click_count: self.click_count.get(),
+                    click_count: if is_activation_click { 0 } else { self.click_count.get() },
                     touch_finger_id,
+                    is_activation_click,
                 };
             }
             _ => {}
@@ -2096,6 +2132,7 @@ impl TouchState {
                 button: PointerEventButton::Left,
                 click_count: 0,
                 touch_finger_id: id + 1,
+                is_activation_click: false,
             });
         } else if total == 2 {
             // Second finger: transition Idle → TwoFingersDown.
@@ -2123,6 +2160,7 @@ impl TouchState {
                 button: PointerEventButton::Left,
                 click_count: 0,
                 touch_finger_id: id + 1,
+                is_activation_click: false,
             });
         }
         // 3+ fingers: tracked in active_touches but ignored for gesture.
@@ -2240,6 +2278,7 @@ impl TouchState {
                         button: PointerEventButton::Left,
                         click_count: 0,
                         touch_finger_id: id + 1,
+                        is_activation_click: false,
                     });
                     events.push(MouseEvent::Exit);
                 }
@@ -2255,6 +2294,7 @@ impl TouchState {
                             button: PointerEventButton::Left,
                             click_count: 0,
                             touch_finger_id: remaining.id + 1,
+                            is_activation_click: false,
                         });
                     } else {
                         self.primary_touch_id = None;
@@ -2299,6 +2339,7 @@ impl TouchState {
                         button: PointerEventButton::Left,
                         click_count: 0,
                         touch_finger_id: rid + 1,
+                        is_activation_click: false,
                     });
                 } else {
                     events.push(MouseEvent::Exit);

--- a/internal/core/items/input_items.rs
+++ b/internal/core/items/input_items.rs
@@ -45,6 +45,7 @@ pub struct TouchArea {
     pub mouse_x: Property<LogicalLength>,
     pub mouse_y: Property<LogicalLength>,
     pub mouse_cursor: Property<MouseCursorInner>,
+    pub accepts_activation_clicks: Property<bool>,
     pub clicked: Callback<VoidArg>,
     pub double_clicked: Callback<VoidArg>,
     pub moved: Callback<VoidArg>,
@@ -54,6 +55,9 @@ pub struct TouchArea {
     pub cached_rendering_data: CachedRenderingData,
     /// true when we are currently grabbing the mouse
     grabbed: Cell<bool>,
+    /// true when the current grab originates from a window-activating press
+    /// that is suppressed because `accepts-activation-clicks` is false
+    suppressed_grab: Cell<bool>,
 }
 
 impl Item for TouchArea {
@@ -81,12 +85,14 @@ impl Item for TouchArea {
         if !self.enabled() {
             self.has_hover.set(false);
             if self.grabbed.replace(false) {
+                self.suppressed_grab.set(false);
                 self.pressed.set(false);
                 Self::FIELD_OFFSETS.pointer_event().apply_pin(self).call(&(PointerEvent {
                     button: PointerEventButton::Other,
                     kind: PointerEventKind::Cancel,
                     modifiers: window_adapter.window().0.context().0.modifiers.get().into(),
                     touch_finger_id: 0,
+                    is_activation_click: false,
                 },));
             }
             return InputEventFilterResult::ForwardAndIgnore;
@@ -121,9 +127,17 @@ impl Item for TouchArea {
             return InputEventResult::EventIgnored;
         }
         match event {
-            MouseEvent::Pressed { position, button, touch_finger_id, .. } => {
+            MouseEvent::Pressed {
+                position, button, touch_finger_id, is_activation_click, ..
+            } => {
+                // A window-activating click (macOS "first mouse") should not
+                // trigger actions by default: keep the grab so the matching
+                // release still arrives here and `pointer-event` still fires,
+                // but don't enter the pressed state that `clicked` depends on.
+                let suppressed = *is_activation_click && !self.accepts_activation_clicks();
                 self.grabbed.set(true);
-                if *button == PointerEventButton::Left {
+                self.suppressed_grab.set(suppressed);
+                if *button == PointerEventButton::Left && !suppressed {
                     Self::FIELD_OFFSETS.pressed_x().apply_pin(self).set(position.x_length());
                     Self::FIELD_OFFSETS.pressed_y().apply_pin(self).set(position.y_length());
                     Self::FIELD_OFFSETS.pressed().apply_pin(self).set(true);
@@ -133,6 +147,7 @@ impl Item for TouchArea {
                     kind: PointerEventKind::Down,
                     modifiers: window_adapter.window().0.context().0.modifiers.get().into(),
                     touch_finger_id: *touch_finger_id,
+                    is_activation_click: *is_activation_click,
                 },));
 
                 InputEventResult::GrabMouse
@@ -140,18 +155,26 @@ impl Item for TouchArea {
             MouseEvent::Exit => {
                 Self::FIELD_OFFSETS.pressed().apply_pin(self).set(false);
                 if self.grabbed.replace(false) {
+                    self.suppressed_grab.set(false);
                     Self::FIELD_OFFSETS.pointer_event().apply_pin(self).call(&(PointerEvent {
                         button: PointerEventButton::Other,
                         kind: PointerEventKind::Cancel,
                         modifiers: window_adapter.window().0.context().0.modifiers.get().into(),
                         touch_finger_id: 0,
+                        is_activation_click: false,
                     },));
                 }
 
                 InputEventResult::EventAccepted
             }
 
-            MouseEvent::Released { button, position, click_count, touch_finger_id } => {
+            MouseEvent::Released {
+                button,
+                position,
+                click_count,
+                touch_finger_id,
+                is_activation_click,
+            } => {
                 let geometry = self_rc.geometry();
                 if *button == PointerEventButton::Left
                     && LogicalRect::new(LogicalPoint::default(), geometry.size).contains(*position)
@@ -164,6 +187,7 @@ impl Item for TouchArea {
                 }
 
                 self.grabbed.set(false);
+                self.suppressed_grab.set(false);
                 if *button == PointerEventButton::Left {
                     Self::FIELD_OFFSETS.pressed().apply_pin(self).set(false);
                 }
@@ -172,6 +196,7 @@ impl Item for TouchArea {
                     kind: PointerEventKind::Up,
                     modifiers: window_adapter.window().0.context().0.modifiers.get().into(),
                     touch_finger_id: *touch_finger_id,
+                    is_activation_click: *is_activation_click,
                 },));
 
                 InputEventResult::EventAccepted
@@ -182,9 +207,15 @@ impl Item for TouchArea {
                     kind: PointerEventKind::Move,
                     modifiers: window_adapter.window().0.context().0.modifiers.get().into(),
                     touch_finger_id: *touch_finger_id,
+                    is_activation_click: false,
                 },));
                 if self.grabbed.get() {
-                    Self::FIELD_OFFSETS.moved().apply_pin(self).call(&());
+                    // A grab from a suppressed activation press never
+                    // initialized `pressed-x`/`pressed-y`, so don't report
+                    // drags relative to them.
+                    if !self.suppressed_grab.get() {
+                        Self::FIELD_OFFSETS.moved().apply_pin(self).call(&());
+                    }
                     InputEventResult::GrabMouse
                 } else {
                     InputEventResult::EventAccepted

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -309,8 +309,10 @@ impl Item for StyledTextItem {
             MouseEvent::Released {
                 position,
                 button: PointerEventButton::Left,
-                click_count: _,
-                touch_finger_id: _,
+                // Following a link is an action, so a window-activating click
+                // (macOS "first mouse") only updates the cursor.
+                is_activation_click: false,
+                ..
             } => {
                 if let Some(link) = find_link(position) {
                     *cursor = super::MouseCursorInner::BuiltIn(super::BuiltInMouseCursor::Pointer);

--- a/tests/cases/elements/toucharea_activation_click.slint
+++ b/tests/cases/elements/toucharea_activation_click.slint
@@ -1,0 +1,137 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test the handling of window-activating clicks (macOS "first mouse").
+// A `TouchArea` suppresses them by default, unless `accepts-activation-clicks`
+// is set. The `pointer-event` callback fires either way and reports the
+// activation state in `is-activation-click`.
+
+export component TestCase {
+    in-out property <string> log;
+    in-out property <int> clicks;
+    in-out property <int> double-clicks;
+    in-out property <int> moves;
+    in-out property <int> accepting-clicks;
+    out property <bool> is-pressed <=> default-ta.pressed;
+    out property <bool> accepting-is-pressed <=> accepting-ta.pressed;
+
+    default-ta := TouchArea {
+        x: 0phx;
+        y: 0phx;
+        width: 100phx;
+        height: 100phx;
+        clicked => { clicks += 1; }
+        double-clicked => { double-clicks += 1; }
+        moved => { moves += 1; }
+        pointer-event(e) => {
+            if (e.kind == PointerEventKind.down) {
+                log += e.is-activation-click ? "D*" : "D";
+            } else if (e.kind == PointerEventKind.up) {
+                log += e.is-activation-click ? "U*" : "U";
+            }
+        }
+    }
+
+    in-out property <int> accepting-double-clicks;
+
+    accepting-ta := TouchArea {
+        x: 100phx;
+        y: 0phx;
+        width: 100phx;
+        height: 100phx;
+        accepts-activation-clicks: true;
+        clicked => { accepting-clicks += 1; }
+        double-clicked => { accepting-double-clicks += 1; }
+    }
+}
+
+/*
+```rust
+use slint_testing::{LogicalPoint, MouseEvent, PointerEventButton, WindowInner};
+
+fn press(x: f32, y: f32, is_activation_click: bool) -> MouseEvent {
+    MouseEvent::Pressed {
+        position: LogicalPoint::new(x, y),
+        button: PointerEventButton::Left,
+        click_count: 0,
+        touch_finger_id: 0,
+        is_activation_click,
+    }
+}
+
+fn release(x: f32, y: f32, is_activation_click: bool) -> MouseEvent {
+    MouseEvent::Released {
+        position: LogicalPoint::new(x, y),
+        button: PointerEventButton::Left,
+        click_count: 0,
+        touch_finger_id: 0,
+        is_activation_click,
+    }
+}
+
+let instance = TestCase::new().unwrap();
+let window = instance.window();
+let inner = WindowInner::from_pub(&window);
+
+// An activation click is suppressed by default: `pressed` stays false, no
+// `clicked`, but `pointer-event` fires with the activation flag on both ends.
+inner.process_mouse_input(press(50., 50., true));
+assert!(!instance.get_is_pressed());
+inner.process_mouse_input(release(50., 50., true));
+assert_eq!(instance.get_clicks(), 0);
+assert_eq!(instance.get_log().as_str(), "D*U*");
+
+// The grab of a suppressed press withholds the `moved` callback (it would
+// report drags relative to uninitialized pressed-x/y).
+inner.process_mouse_input(press(50., 50., true));
+inner.process_mouse_input(MouseEvent::Moved { position: LogicalPoint::new(60., 60.), touch_finger_id: 0 });
+assert_eq!(instance.get_moves(), 0);
+assert!(!instance.get_is_pressed());
+inner.process_mouse_input(release(60., 60., true));
+assert_eq!(instance.get_clicks(), 0);
+
+// A suppressed activation click doesn't start a multi-click sequence: a quick
+// follow-up click is a single click, not a double-click.
+instance.set_log("".into());
+inner.process_mouse_input(press(50., 50., true));
+inner.process_mouse_input(release(50., 50., true));
+inner.process_mouse_input(press(50., 50., false));
+inner.process_mouse_input(release(50., 50., false));
+assert_eq!(instance.get_clicks(), 1);
+assert_eq!(instance.get_double_clicks(), 0);
+assert_eq!(instance.get_log().as_str(), "D*U*DU");
+
+// ... while two quick normal clicks are still a double-click.
+slint_testing::mock_elapsed_time(1000);
+inner.process_mouse_input(press(50., 50., false));
+inner.process_mouse_input(release(50., 50., false));
+inner.process_mouse_input(press(50., 50., false));
+inner.process_mouse_input(release(50., 50., false));
+assert_eq!(instance.get_clicks(), 3);
+assert_eq!(instance.get_double_clicks(), 1);
+
+// `accepts-activation-clicks: true` processes the activation click normally.
+inner.process_mouse_input(press(150., 50., true));
+assert!(instance.get_accepting_is_pressed());
+inner.process_mouse_input(release(150., 50., true));
+assert_eq!(instance.get_accepting_clicks(), 1);
+
+// Even on an accepting surface, an activation click doesn't start a
+// multi-click sequence: activation click + quick second click are two single
+// clicks, not a double-click. (Deliberate divergence from e.g. Finder's
+// open-on-double-click, see the discussion in #10451.)
+inner.process_mouse_input(press(150., 50., false));
+inner.process_mouse_input(release(150., 50., false));
+assert_eq!(instance.get_accepting_clicks(), 2);
+assert_eq!(instance.get_accepting_double_clicks(), 0);
+
+// Normal clicks on the default TouchArea are unaffected.
+slint_testing::mock_elapsed_time(1000);
+inner.process_mouse_input(press(50., 50., false));
+assert!(instance.get_is_pressed());
+inner.process_mouse_input(MouseEvent::Moved { position: LogicalPoint::new(60., 60.), touch_finger_id: 0 });
+assert!(instance.get_moves() > 0);
+inner.process_mouse_input(release(60., 60., false));
+assert_eq!(instance.get_clicks(), 4);
+```
+*/


### PR DESCRIPTION
## Summary

Part of #10451.

On macOS, a click on an inactive window activates the window, and by convention only interactions that are safe to trigger accidentally (selection, scrolling, text-cursor placement) react to that click.

This lands the version-independent core plumbing:

- Tag `MouseEvent::Pressed`/`Released` with `is_activation_click`, expose it as `is-activation-click` on `PointerEvent`.
- Apply the platform convention at delivery time: `TouchArea` suppresses `pressed`/`clicked`/`double-clicked`/`moved` for activation clicks unless the new `accepts-activation-clicks` property is set, `Text` ignores an activation release for `link-clicked`, and activation clicks never join multi-click sequences.
- Selection surfaces (`StandardListView`/`StandardTableView` rows) and scrollbar thumbs opt in; `SliderBase` returns early since it acts on pointer-down directly.

**This PR is a draft and not yet ready to land end-to-end.** Backends currently always pass `false` for `is_activation_click`: winit 0.30 has no per-event activation information. The actual wiring (winit backend passing the real flag) is gated on the winit 0.31 upgrade (#11243), whose `PointerButton` events carry `is_macos_activation_click` — that release is currently only available as a prerelease (`0.31.0-beta.2`). The public `platform::WindowEvent` API also can't report the flag yet, since adding fields to its variants would break existing platform implementations.

Opening now so the core plumbing can be reviewed independently; will mark ready for review and finish the backend wiring once winit 0.31 is adopted.

## Test plan

- [x] `cargo test -p i-slint-core` (click-state / activation-click logic)
- [x] New `.slint` test case: `tests/cases/elements/toucharea_activation_click.slint`, verified via `cargo test -p test-driver-rust toucharea_activation_click`
- [x] `cargo check -p i-slint-backend-winit --features renderer-skia`