### PR TITLE
Update publish.rs to Cargo 1.90

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,24 +2,33 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-cargo publish --manifest-path internal/common/Cargo.toml
-cargo publish --manifest-path internal/core-macros/Cargo.toml
-cargo publish --manifest-path internal/compiler/Cargo.toml
-cargo publish --manifest-path internal/core/Cargo.toml
-cargo publish --manifest-path api/rs/macros/Cargo.toml
-cargo publish --manifest-path internal/renderers/skia/Cargo.toml --features x11
-cargo publish --manifest-path internal/renderers/femtovg/Cargo.toml
-cargo publish --manifest-path internal/renderers/software/Cargo.toml
-cargo publish --manifest-path internal/backends/winit/Cargo.toml --features x11,renderer-femtovg
-cargo publish --manifest-path api/rs/build/Cargo.toml
-cargo publish --manifest-path internal/backends/qt/Cargo.toml
-cargo publish --manifest-path internal/backends/linuxkms/Cargo.toml
-cargo publish --manifest-path internal/backends/android-activity/Cargo.toml --features native-activity
-cargo publish --manifest-path internal/backends/testing/Cargo.toml
-cargo publish --manifest-path internal/backends/selector/Cargo.toml --features backend-winit-x11,renderer-femtovg
-cargo publish --manifest-path internal/interpreter/Cargo.toml
-cargo publish --manifest-path internal/live-preview/Cargo.toml
-cargo publish --manifest-path api/rs/slint/Cargo.toml
-cargo publish --manifest-path tools/lsp/Cargo.toml
-cargo publish --manifest-path tools/viewer/Cargo.toml
-cargo publish --manifest-path tools/tr-extractor/Cargo.toml
+# Since Cargo 1.90, Cargo can resolve the dependency order by itself
+# We do not have to worry about the order here.
+cargo publish --manifest-path Cargo.toml \
+    --package i-slint-common \
+    --package i-slint-core-macros \
+    --package i-slint-compiler \
+    --package i-slint-core \
+    --package slint-macros \
+    --package i-slint-renderer-skia \
+    --package i-slint-renderer-femtovg \
+    --package i-slint-renderer-software \
+    --package i-slint-backend-winit \
+    --package slint-build \
+    --package i-slint-backend-qt \
+    --package i-slint-backend-linuxkms \
+    --package i-slint-backend-android-activity \
+    --package i-slint-backend-testing \
+    --package i-slint-backend-selector \
+    --package slint-interpreter \
+    --package i-slint-live-preview \
+    --package slint \
+    --package slint-lsp \
+    --package slint-viewer \
+    --package slint-tr-extractor \
+    --features i-slint-renderer-skia/x11 \
+    --features i-slint-backend-winit/x11 \
+    --features i-slint-backend-winit/renderer-femtovg \
+    --features i-slint-backend-android-activity/native-activity \
+    --features i-slint-backend-selector/backend-winit-x11 \
+    --features i-slint-backend-selector/renderer-femtovg


### PR DESCRIPTION
Newer versions of cargo can automatically choose the dependency order
between packages, so we can just list the packages in one publish
command without worrying about the publish order.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
