### PR TITLE
compiler: skip the identifier rebuild when already normalized

### DIFF
--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -1066,6 +1066,10 @@ pub fn identifier_text(node: &SyntaxNode) -> Option<SmolStr> {
 }
 
 pub fn normalize_identifier(ident: &str) -> SmolStr {
+    if is_identifier_normalized(ident) {
+        // one bulk copy instead of the char-by-char builder below
+        return SmolStr::new(ident);
+    }
     let mut builder = smol_str::SmolStrBuilder::default();
     for (pos, c) in ident.chars().enumerate() {
         match (pos, c) {


### PR DESCRIPTION
normalize_identifier ran the char-by-char builder even when the input
was already in normalized form, the common case since Slint code is
usually kebab-case. Return a bulk copy of the input instead: measured
~2x for short names, ~6x for names over SmolStr's 23-byte inline limit.

A previous commit (https://github.com/slint-ui/slint/pull/12897) optimized Struct::get_field to not do any copy at all
if the input is already optimized, this commit is for other call sites
(the get_field commit still makes sense: no copy is still better than a fast copy).