### PR TITLE
Allow redeclaring a property inherited from a Component base

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1311,6 +1311,20 @@ pub struct RepeatedElementInfo {
 pub type ElementRc = Rc<RefCell<Element>>;
 pub type ElementWeak = Weak<RefCell<Element>>;
 
+/// Whether `name` is a `property <type> ...;` declaration somewhere along `base_type`'s chain of
+/// user-component bases (as opposed to a builtin/native item member, which is a flat, single-slot
+/// namespace with no per-level identity to preserve).
+fn is_declared_in_component_base(base_type: &ElementType, name: &str) -> bool {
+    match base_type {
+        ElementType::Component(c) => {
+            let root = c.root_element.borrow();
+            root.property_declarations.contains_key(name)
+                || is_declared_in_component_base(&root.base_type, name)
+        }
+        _ => false,
+    }
+}
+
 impl Element {
     pub fn make_rc(self) -> ElementRc {
         let r = ElementRc::new(RefCell::new(self));
@@ -1474,10 +1488,18 @@ impl Element {
             let PropertyLookupResult {
                 resolved_name: prop_name,
                 property_type: maybe_existing_prop_type,
+                is_local_to_component,
                 is_shadowable,
                 ..
             } = r.lookup_property(&unresolved_prop_name);
             let shadows_builtin = maybe_existing_prop_type != Type::Invalid && is_shadowable;
+            // Redeclaring a property inherited from a user-component base creates an independent
+            // slot rather than overriding the base's; a plain value override is unaffected and
+            // keeps sharing the base's slot. Builtin/native members stay a hard error since they
+            // have no per-level identity.
+            let shadows_base_property = maybe_existing_prop_type != Type::Invalid
+                && !is_local_to_component
+                && is_declared_in_component_base(&r.base_type, &unresolved_prop_name);
             match maybe_existing_prop_type {
                 Type::Invalid => {} // Ok to proceed with a new declaration
                 // The declaration shadows a shadowable builtin member;
@@ -1497,6 +1519,7 @@ impl Element {
                     );
                     continue;
                 }
+                _ if shadows_base_property => {}
                 _ => {
                     diag.push_error(
                         format!("Cannot override property '{unresolved_prop_name}'"),

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -249,7 +249,18 @@ pub async fn run_passes(
         {
             optimize_useless_rectangles::optimize_useless_rectangles(component);
         }
-        move_declarations::move_declarations(component);
+    });
+
+    // Two passes sharing one document-wide rename map: a reference to a private element can live
+    // in another component's tree, so all renames must be known before any component moves
+    // declarations, regardless of visitation order.
+    #[allow(clippy::mutable_key_type)] // ByAddress<ElementRc> keys rely on Rc identity semantics
+    let mut declaration_renames = move_declarations::RenameMap::default();
+    doc.visit_all_used_components(|component| {
+        move_declarations::prepare_move_declarations(component, &mut declaration_renames);
+    });
+    doc.visit_all_used_components(|component| {
+        move_declarations::move_declarations(component, &declaration_renames);
     });
 
     remove_aliases::remove_aliases(doc, diag);

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -96,17 +96,35 @@ fn inline_element(
 
     let mut elem_mut = elem.borrow_mut();
     let priority_delta = 1 + elem_mut.inline_depth;
+
+    // A property the derived element independently redeclared (`shadows_base_property` in
+    // object_tree.rs) must keep its own identity after inlining instead of flattening onto the
+    // derived element's same-named slot. Give the base's copy a `$`-prefixed synthetic name
+    // (unreachable by user identifiers). Plain value overrides are unaffected.
+    let renamed_properties: HashMap<SmolStr, SmolStr> = inlined_component
+        .root_element
+        .borrow()
+        .property_declarations
+        .iter()
+        .filter(|(name, _decl)| elem_mut.property_declarations.contains_key(*name))
+        .map(|(name, _)| {
+            (name.clone(), SmolStr::from(format!("$private-base-{priority_delta}-{name}")))
+        })
+        .collect();
+
     elem_mut.base_type = inlined_component.root_element.borrow().base_type.clone();
     elem_mut.property_declarations.extend(
         inlined_component.root_element.borrow().property_declarations.iter().map(|(name, decl)| {
             let mut decl = decl.clone();
             decl.expose_in_public_api = false;
-            (name.clone(), decl)
+            let name = renamed_properties.get(name).cloned().unwrap_or_else(|| name.clone());
+            (name, decl)
         }),
     );
 
     for (p, a) in inlined_component.root_element.borrow().property_analysis.borrow().iter() {
-        elem_mut.property_analysis.borrow_mut().entry(p.clone()).or_default().merge_with_base(a);
+        let p = renamed_properties.get(p).cloned().unwrap_or_else(|| p.clone());
+        elem_mut.property_analysis.borrow_mut().entry(p).or_default().merge_with_base(a);
     }
 
     // states and transitions must be lowered before inlining
@@ -447,7 +465,9 @@ fn inline_element(
     for (property, root_binding) in
         inlined_component.root_element.borrow().bindings_including_synthetic()
     {
-        match elem_mut.binding_cell_including_synthetic(property) {
+        let property =
+            renamed_properties.get(property).cloned().unwrap_or_else(|| property.clone());
+        match elem_mut.binding_cell_including_synthetic(&property) {
             Some(elem_binding) => {
                 let mut binding = elem_binding.borrow_mut();
                 if binding.merge_with(&root_binding.borrow()) {
@@ -457,7 +477,7 @@ fn inline_element(
             None => {
                 let mut elem_binding = root_binding.borrow().clone();
                 elem_binding.priority = elem_binding.priority.saturating_add(priority_delta);
-                elem_mut.set_binding(property.clone(), elem_binding);
+                elem_mut.set_binding(property, elem_binding);
             }
         }
     }
@@ -496,11 +516,22 @@ fn inline_element(
 
     core::mem::drop(elem_mut);
 
+    // Like `fixup_reference`, but also applies `renamed_properties` to references landing on
+    // `elem` itself, so a disambiguated base property stays disambiguated here too.
+    let mut fixup_reference_renamed = |nr: &mut NamedReference| {
+        if let Some(e) = mapping.get(&element_key(nr.element())) {
+            let name = if Rc::ptr_eq(e, elem) {
+                renamed_properties.get(nr.name()).cloned().unwrap_or_else(|| nr.name().clone())
+            } else {
+                nr.name().clone()
+            };
+            *nr = NamedReference::new(e, name);
+        }
+    };
+
     let fixup_init_expression = |mut init_code: Expression| {
         // Fix up any property references from within already collected init code.
-        visit_named_references_in_expression(&mut init_code, &mut |nr| {
-            fixup_reference(nr, &mapping)
-        });
+        visit_named_references_in_expression(&mut init_code, &mut fixup_reference_renamed);
         fixup_element_references(&mut init_code, &mapping);
         init_code
     };
@@ -532,19 +563,19 @@ fn inline_element(
                 grid.clone_cells();
             }
         }
-        visit_all_named_references_in_element(e, |nr| fixup_reference(nr, &mapping));
+        visit_all_named_references_in_element(e, fixup_reference_renamed);
     }
     for p in root_component.popup_windows.borrow_mut().iter_mut() {
-        fixup_reference(&mut p.x, &mapping);
-        fixup_reference(&mut p.y, &mapping);
+        fixup_reference_renamed(&mut p.x);
+        fixup_reference_renamed(&mut p.y);
         if let Some(is_open) = &mut p.is_open {
-            fixup_reference(is_open, &mapping);
+            fixup_reference_renamed(is_open);
         }
     }
     for t in root_component.timers.borrow_mut().iter_mut() {
-        fixup_reference(&mut t.interval, &mapping);
-        fixup_reference(&mut t.running, &mapping);
-        fixup_reference(&mut t.triggered, &mapping);
+        fixup_reference_renamed(&mut t.interval);
+        fixup_reference_renamed(&mut t.running);
+        fixup_reference_renamed(&mut t.triggered);
     }
     // If some element were moved into PopupWindow, we need to report error if they are used outside of the popup window.
     if !moved_into_popup.is_empty() {

--- a/internal/compiler/passes/move_declarations.rs
+++ b/internal/compiler/passes/move_declarations.rs
@@ -19,7 +19,11 @@ use std::rc::Rc;
 /// Concatenating the element id and the declared name alone can give the same name to two
 /// different declarations: the ids `a-2` and `a-2-b-4` with the properties `b-4-c` and `c`
 /// both concatenate to `a-2-b-4-c`.
-type RenameMap = HashMap<(ByAddress<ElementRc>, SmolStr), SmolStr>;
+///
+/// Built document-wide (shared across every component, see `prepare_move_declarations`) rather
+/// than per-component: a `NamedReference` to a private element's declaration can live in another
+/// component's tree, so the map must know about every component's moves before any are applied.
+pub(crate) type RenameMap = HashMap<(ByAddress<ElementRc>, SmolStr), SmolStr>;
 
 struct Declarations {
     property_declarations: BTreeMap<SmolStr, PropertyDeclaration>,
@@ -30,11 +34,18 @@ impl Declarations {
     }
 }
 
-pub fn move_declarations(component: &Rc<Component>) {
+/// First half of `move_declarations`: decide the new root-level names without moving anything yet.
+/// Must be called for every used component, into the same `renames` map, before `move_declarations`
+/// is called for any of them.
+pub fn prepare_move_declarations(component: &Rc<Component>, renames: &mut RenameMap) {
     simplify_optimized_items_recursive(component);
-    let mut renames = RenameMap::new();
-    collect_renames(component, &mut renames);
-    do_move_declarations(component, &renames);
+    collect_renames(component, renames);
+}
+
+/// Second half of `move_declarations`: move the declarations and fix up references using the
+/// complete `renames` map built by `prepare_move_declarations`.
+pub fn move_declarations(component: &Rc<Component>, renames: &RenameMap) {
+    do_move_declarations(component, renames);
 }
 
 /// Pick a unique root-level name for every declaration that `do_move_declarations` moves
@@ -199,14 +210,15 @@ fn do_move_declarations(component: &Rc<Component>, renames: &RenameMap) {
 }
 
 /// Map the reference to the previous properties to the new moved property at the root
+///
+/// Consults the frozen `renames` map rather than live `property_declarations`: by the time a
+/// cross-component reference is fixed up, the owning component may have already taken its
+/// declarations away (see `Declarations::take_from_element`), so a live check would miss it.
 fn fixup_reference(nr: &mut NamedReference, renames: &RenameMap) {
     let e = nr.element();
-    let parent_component = e.borrow().enclosing_component.upgrade().unwrap();
-    if !Rc::ptr_eq(&e, &parent_component.root_element)
-        && e.borrow().property_declarations.contains_key(nr.name())
-    {
-        *nr =
-            NamedReference::new(&parent_component.root_element, moved_name(renames, &e, nr.name()));
+    if let Some(new_name) = renames.get(&(ByAddress(e.clone()), nr.name().clone())) {
+        let parent_component = e.borrow().enclosing_component.upgrade().unwrap();
+        *nr = NamedReference::new(&parent_component.root_element, new_name.clone());
     }
 }
 

--- a/internal/compiler/tests/syntax/lookup/issue_12881.slint
+++ b/internal/compiler/tests/syntax/lookup/issue_12881.slint
@@ -1,0 +1,17 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A derived component should be able to introduce its own property of the same name as one
+// declared (and used) by its base component, without the base component's own internal
+// references being hijacked by the derived declaration.
+
+component Base {
+    property <string> name: "Hello";
+    Text {
+        text: name;
+    }
+}
+
+export component TestCase inherits Base {
+    property <string> name: "World";
+}

--- a/internal/compiler/tests/syntax/lookup/issue_1937.slint
+++ b/internal/compiler/tests/syntax/lookup/issue_1937.slint
@@ -1,0 +1,14 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `private` property should not be visible outside of the component that declares it, so a
+// derived component redeclaring the same name should not conflict with it at all: the two
+// declarations should coexist as independent properties.
+
+component Base {
+    private property <string> foo;
+}
+
+export component TestCase inherits Base {
+    property <string> foo;
+}

--- a/tests/cases/properties/issue12881_base_redeclare_public_property.slint
+++ b/tests/cases/properties/issue12881_base_redeclare_public_property.slint
@@ -1,0 +1,54 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Unlike issue1937_base_redeclare_private_property.slint (which
+// covers a base property that is private, including by default visibility), this is a
+// base property with an explicit non-private visibility (`in-out`, part of the base's own
+// public API) that a derived component redeclares with its own `property <type> ...;`.
+// This must also introduce a genuinely new, independent property rather than overriding
+// the base's one -- the base component's own internal bindings must keep reading its own
+// value, regardless of what the derived component declares.
+
+component Base {
+    in-out property <string> name: "Hello";
+    // Base's own internal reference to its own "name": must always read Base's own value.
+    the-text := Text {
+        text: name;
+    }
+    // A non-colliding property that exposes Base's own "name" for the test to observe
+    // (properties declared directly on a base component are not part of a derived, exported
+    // component's public Rust/C++/JS API, so this indirection is needed purely for
+    // observability, not because of anything the fix changes).
+    out property <string> base-own-name: name;
+}
+
+export component TestCase inherits Base {
+    // Redeclares "name" independently. Before the fix this was a hard compile error
+    // ("Cannot override property 'name'"); now it creates a separate slot, even though
+    // Base's own "name" is not private.
+    property <string> name: "World";
+
+    out property <string> derived-own-name: name;
+    out property <string> base-name-via-inherited-property: self.base-own-name;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_derived_own_name(), "World");
+assert_eq!(instance.get_base_name_via_inherited_property(), "Hello");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_derived_own_name(), "World");
+assert_eq(instance.get_base_name_via_inherited_property(), "Hello");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.derived_own_name, "World");
+assert.equal(instance.base_name_via_inherited_property, "Hello");
+```
+*/

--- a/tests/cases/properties/issue1937_base_redeclare_private_property.slint
+++ b/tests/cases/properties/issue1937_base_redeclare_private_property.slint
@@ -1,0 +1,51 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company , info@kdab.com, author Robin Cramer <robin.cramer@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A `private` property (including one that is private only by the default visibility of a
+// property declared without an explicit `in`/`out`/`private` keyword,
+// is not part of a base component's public surface, so a derived component redeclaring
+// the same name introduces a genuinely new, independent property rather than overriding the
+// base's one. The base component's own internal bindings must keep reading its own value,
+// regardless of what the derived component declares.
+
+component Base {
+    private property <string> name: "Hello";
+    // Base's own internal reference to its private "name": must always read Base's own value.
+    the-text := Text {
+        text: name;
+    }
+    // A non-colliding, non-private property that exposes Base's own "name" for the test to
+    // observe (properties declared directly on a base component are not part of a derived,
+    // exported component's public Rust/C++/JS API, so this indirection is needed purely for
+    // observability, not because of anything the fix changes).
+    out property <string> base-own-name: name;
+}
+
+export component TestCase inherits Base {
+    // Redeclares "name" independently
+    property <string> name: "World";
+
+    out property <string> derived-own-name: name;
+    out property <string> base-name-via-inherited-property: self.base-own-name;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_derived_own_name(), "World");
+assert_eq!(instance.get_base_name_via_inherited_property(), "Hello");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_derived_own_name(), "World");
+assert_eq(instance.get_base_name_via_inherited_property(), "Hello");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.derived_own_name, "World");
+assert.equal(instance.base_name_via_inherited_property, "Hello");
+```
+*/


### PR DESCRIPTION
Closes #12881 and #1937

Redeclares properties with new names so they can be shadowed/redeclared in base classes. Requires `move_declarations` to be split into two passes because a reference to a moved property can live in a different component's tree than the one declaring it, so all renames must be computed up front. Otherwise this results in a cross-component reference being fixed up after the declaring component's own declarations have already been taken, leaving it dangling.

This doesn't fix #1461 so #12865 is still needed