### PR TITLE
Check the ISO references in the safety manual

### DIFF
--- a/docs/safety/src/content/docs/evaluation-report/safety-analysis.mdx
+++ b/docs/safety/src/content/docs/evaluation-report/safety-analysis.mdx
@@ -3,7 +3,7 @@ title: Safety Analysis
 description: Safety-oriented analysis of the Slint SC software architecture.
 ---
 
-## Safety Analysis Report (ISO 26262:6 7.4.10)
+## Safety Analysis Report (ISO 26262-6 7.4.10)
 
 Safety-oriented analysis shall be carried out at the software architectural level in accordance with ISO 26262-9:2018, Clause 8, in order to:
 

--- a/docs/safety/src/content/docs/evaluation-report/safety-analysis.mdx
+++ b/docs/safety/src/content/docs/evaluation-report/safety-analysis.mdx
@@ -7,6 +7,7 @@ description: Safety-oriented analysis of the Slint SC software architecture.
 
 Safety-oriented analysis shall be carried out at the software architectural level in accordance with ISO 26262-9:2018, Clause 8, in order to:
 
+* provide evidence for the suitability of the software to provide the specified safety-related functions and properties as required by the respective ASIL;
 * identify or confirm the safety-related parts of the software; and
 * support the specification and verify the effectiveness of the safety measures.
 

--- a/docs/safety/src/content/docs/evaluation-report/tool-classification.mdx
+++ b/docs/safety/src/content/docs/evaluation-report/tool-classification.mdx
@@ -26,8 +26,12 @@ Clause 7.4.4, and state the class it falls into.)
 
 ## Slint Compiler, IEC 62304
 
-(TODO: classify the compiler as a software tool under IEC 62304, and state
-what its use requires.)
+IEC 62304 has no tool classification scheme: nothing in it corresponds to a TCL or to an offline support tool class.
+What it asks instead is that 5.1.4 name the tools used to develop the software, and that anything the device software itself contains be handled as SOUP.
+The compiler is a tool and doesn't ship, so only 5.1.4 reaches it.
+
+(TODO: write the 5.1.4 tool list, and say whether the 26262 or 61508 argument
+is offered to a medical integrator as supporting evidence.)
 
 ## Rust Toolchain
 

--- a/docs/safety/src/content/docs/evaluation-report/use-cases.mdx
+++ b/docs/safety/src/content/docs/evaluation-report/use-cases.mdx
@@ -3,7 +3,7 @@ title: Use Cases
 description: The use cases of Slint SC that the evaluation analyzes.
 ---
 
-## Use Cases (ISO 26262:8 11.4.5.1)
+## Use Cases (ISO 26262-8 11.4.5.1)
 
 ### Using Slint SC in a project
 

--- a/docs/safety/src/content/docs/qualification-plan/architecture.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/architecture.mdx
@@ -26,16 +26,17 @@ invocation.)
 
 ## Slint SC Architecture Design (ISO 26262:6 7.4)
 
-During the development of the software architectural design, the following should be considered:
+During the development of the software architectural design, 7.4.2 says the following shall be considered:
 
 1. Verifiability of the software architectural design.
     This implies bi-directional traceability between the software architectural design and the
     software safety requirements.
-2. Simplicity of the design/software (restricted size and complexity)
-3. Modularity, Encapsulation, Reusability, Maintainability
-4. Feasibility for the design and implementation of the software units
-5. Testability of the software
-6. Maintainability of the software architectural design
+2. Suitability for configurable software.
+3. Feasibility for the design and implementation of the software units.
+4. Testability of the software architecture during software integration testing.
+5. Maintainability of the software architectural design.
+
+7.4.1 and 7.4.3 add the characteristics the design itself has to show: comprehensibility, consistency, simplicity, verifiability, modularity, abstraction, encapsulation, and maintainability.
 
 ### Properties
 
@@ -50,15 +51,15 @@ Two properties of the design hold by construction, so nothing has to be done to 
 
 ### Static Design
 
-The software architectural design should have a static design part which
-addresses:
+7.4.5 says the software architectural design shall describe its static design
+aspects, which address:
 
 - the software structure including its hierarchical levels;
-- the dependencies;
 - the data types and their characteristics;
-- the global variables;
-- the external interfaces of the software components; and
-- the constraints including the scope of the architecture
+- the external interfaces of the software components;
+- the external interfaces of the embedded software;
+- the global variables; and
+- the constraints including the scope of the architecture and external dependencies.
 
 The whole binary, the runtime included, is compiled by the integrator's Rust toolchain: the `slint-sc` crate ships as source.
 Our own builds and test evidence use Ferrocene; the toolchain of the final build is the integrator's choice, and choosing a qualified one is on them.
@@ -95,7 +96,7 @@ flowchart TD
 
 ### Dynamic Design
 
-In addition, the software architectural design should have a dynamic design part which addresses:
+It shall also describe its dynamic design aspects, which address:
 
 - the functional chain of events and behavior;
 - the logical sequence of data processing;

--- a/docs/safety/src/content/docs/qualification-plan/architecture.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/architecture.mdx
@@ -3,7 +3,7 @@ title: Architecture Design
 description: Software units of Slint SC and their static and dynamic architecture.
 ---
 
-## Slint SC Software Units (ISO 26262:6 7.4.4)
+## Slint SC Software Units (ISO 26262-6 7.4.4)
 
 Slint SC consists of three units.
 
@@ -24,7 +24,7 @@ integration; the compiler binary is invoked directly. Decide whether
 `slint_build` gains a safety-critical mode or the manual documents the direct
 invocation.)
 
-## Slint SC Architecture Design (ISO 26262:6 7.4)
+## Slint SC Architecture Design (ISO 26262-6 7.4)
 
 During the development of the software architectural design, 7.4.2 says the following shall be considered:
 

--- a/docs/safety/src/content/docs/qualification-plan/development-process.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/development-process.mdx
@@ -4,9 +4,16 @@ description: Tools, processes, and infrastructure used for Slint SC development.
 ---
 
 
-## The Development Process (ISO 26262-8 11.4.8)
+## The Development Process (ISO 26262-8)
 
-This section describes the tools we use and the processes we follow to develop Slint SC, aiming to fulfill the supporting process requirements of ISO 26262 Part 8 (Clauses 5-13).
+This section describes the tools we use and the processes we follow to develop Slint SC, aiming to fulfill the supporting process requirements of ISO 26262 Part 8 (Clauses 5-16).
+
+(TODO: ISO 26262-8 11.4.8, "evaluation of the tool development process", is a
+qualification method for the compiler in its own right, and 11.4.8.3 wants that
+evaluation based on a recognized standard such as Automotive SPICE, the
+ISO/IEC 33000 series, or CMMI. The [Qualification Method](/evaluation-report/qualification-method/)
+chapter picks validation instead. Decide whether 11.4.8 is also claimed, and if
+it is, say which standard the evaluation is against.)
 
 ### Language and Compiler
 
@@ -80,6 +87,6 @@ of the interface.)
 
 (TODO: add release schedule)
 
-### Hardware Qualification (ISO 26262-8 13.x)
+### Evaluation of Hardware Elements (ISO 26262-8 13.x)
 
-*Note: Section 13 is Out of Scope.* Slint SC is a purely software-based UI toolkit. Qualification of the underlying hardware elements (e.g., MCU/MPU, memory, display controllers) operating the safety-critical UI is the responsibility of the system integrator.
+*Note: Clause 13 is out of scope.* Slint SC is a purely software-based UI toolkit. Evaluating the underlying hardware elements (e.g., MCU/MPU, memory, display controllers) operating the safety-critical UI is the responsibility of the system integrator.

--- a/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
@@ -7,9 +7,11 @@ description: The standards Slint SC targets, and which clause is addressed where
 
 Slint SC targets three functional safety standards:
 
-* **ISO 26262**, for automotive.
-* **IEC 61508**, for industrial.
-* **IEC 62304**, for medical device software.
+* **ISO 26262:2018**, for automotive.
+* **IEC 61508:2010**, for industrial.
+* **IEC 62304:2006+A1:2015**, for medical device software.
+
+Every clause number in this package refers to those editions.
 
 The analysis and the evidence are the same for all three.
 What differs is the integrity level each one asks for and the clauses each one imposes, so the [Tool Classification](/evaluation-report/tool-classification/) is done once per standard.
@@ -41,8 +43,6 @@ Instead it's developed to be capable of the level below, and the integrator conf
 Where an application isn't safety related at all, the full Slint framework can be used instead, and none of this applies.
 
 ## ISO 26262 Clause Map
-
-All ISO26262 references below are valid for the 2018 edition of the standard.
 
 (TODO: the equivalent maps for IEC 61508 and IEC 62304.)
 

--- a/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
@@ -46,7 +46,7 @@ All ISO26262 references below are valid for the 2018 edition of the standard.
 
 (TODO: the equivalent maps for IEC 61508 and IEC 62304.)
 
-* ISO 26262-4 9.x: Safety validation is at the vehicle level, so it belongs to the integrator. See [User Responsibility](/safety-manual/#user-responsibility). Our own verification is in [Verification](/qualification-plan/verification/).
+* ISO 26262-4 8.x: Safety validation is at the vehicle level, so it belongs to the integrator. See [User Responsibility](/safety-manual/#user-responsibility). Our own verification is in [Verification](/qualification-plan/verification/).
 * ISO 26262-6 7.x: See [Architecture Design](/qualification-plan/architecture/#slint-sc-architecture-design-iso-262626-74)
 * ISO 26262-8 5.x: See [Distributed Development](/qualification-plan/development-process/#distributed-development-iso-26262-8-5x)
 * ISO 26262-8 6.4: The safety requirements shall be traceable to the safety goals and to the safety concept. The traceability shall be documented and maintained.

--- a/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
@@ -53,6 +53,6 @@ All ISO26262 references below are valid for the 2018 edition of the standard.
 * ISO 26262-8 7.x: See [Configuration Management](/qualification-plan/development-process/#configuration-management-iso-26262-8-7x)
 * ISO 26262-8 8.x: See [Change Management](/qualification-plan/development-process/#change-management-iso-26262-8-8x), and [Development Phases](/qualification-plan/development-phases/) for the change workflow itself.
 * ISO 26262-8 9.4.x: See [Verification](/qualification-plan/verification/).
-* ISO 26262-8 11.4.8: See [The Development Process](/qualification-plan/development-process/#the-development-process-iso-26262-8-1148)
+* ISO 26262-8 11.x: See [Tool Classification](/evaluation-report/tool-classification/) for the confidence level, and [Qualification Method](/evaluation-report/qualification-method/) for how it's reached. The process the tool is built with is in [The Development Process](/qualification-plan/development-process/#the-development-process-iso-26262-8).
 * ISO 26262-8 12.x: See [Software Component Qualification](/qualification-plan/development-process/#software-component-qualification-iso-26262-8-12x)
 

--- a/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
@@ -17,7 +17,7 @@ What differs is the integrity level each one asks for and the clauses each one i
 Nothing in this package is specific to one application domain.
 Slint SC renders a safety-related user interface; what that interface controls or reports is the integrator's concern.
 
-## Specification and Management of Safety Requirements (ISO 26262-6 6.x)
+## Specification and Management of Safety Requirements (ISO 26262-8 6.x)
 
 The standards tell us what properties a safety-critical system must have (traceability, freedom from interference, determinism, etc.), but they don't tell us how to write those requirements for a GUI toolkit.
 
@@ -49,7 +49,7 @@ All ISO26262 references below are valid for the 2018 edition of the standard.
 * ISO 26262-4 8.x: Safety validation is at the vehicle level, so it belongs to the integrator. See [User Responsibility](/safety-manual/#user-responsibility). Our own verification is in [Verification](/qualification-plan/verification/).
 * ISO 26262-6 7.x: See [Architecture Design](/qualification-plan/architecture/#slint-sc-architecture-design-iso-262626-74)
 * ISO 26262-8 5.x: See [Distributed Development](/qualification-plan/development-process/#distributed-development-iso-26262-8-5x)
-* ISO 26262-8 6.4: The safety requirements shall be traceable to the safety goals and to the safety concept. The traceability shall be documented and maintained.
+* ISO 26262-8 6.4: See [Specification and Management of Safety Requirements](#specification-and-management-of-safety-requirements-iso-26262-8-6x). 6.4.3.2 asks each safety requirement to reference its source one level up, what realizes it one level down, and the verification specification that checks it.
 * ISO 26262-8 7.x: See [Configuration Management](/qualification-plan/development-process/#configuration-management-iso-26262-8-7x)
 * ISO 26262-8 8.x: See [Change Management](/qualification-plan/development-process/#change-management-iso-26262-8-8x), and [Development Phases](/qualification-plan/development-phases/) for the change workflow itself.
 * ISO 26262-8 9.4.x: See [Verification](/qualification-plan/verification/).

--- a/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/standards-compliance.mdx
@@ -47,7 +47,7 @@ All ISO26262 references below are valid for the 2018 edition of the standard.
 (TODO: the equivalent maps for IEC 61508 and IEC 62304.)
 
 * ISO 26262-4 8.x: Safety validation is at the vehicle level, so it belongs to the integrator. See [User Responsibility](/safety-manual/#user-responsibility). Our own verification is in [Verification](/qualification-plan/verification/).
-* ISO 26262-6 7.x: See [Architecture Design](/qualification-plan/architecture/#slint-sc-architecture-design-iso-262626-74)
+* ISO 26262-6 7.x: See [Architecture Design](/qualification-plan/architecture/#slint-sc-architecture-design-iso-26262-6-74)
 * ISO 26262-8 5.x: See [Distributed Development](/qualification-plan/development-process/#distributed-development-iso-26262-8-5x)
 * ISO 26262-8 6.4: See [Specification and Management of Safety Requirements](#specification-and-management-of-safety-requirements-iso-26262-8-6x). 6.4.3.2 asks each safety requirement to reference its source one level up, what realizes it one level down, and the verification specification that checks it.
 * ISO 26262-8 7.x: See [Configuration Management](/qualification-plan/development-process/#configuration-management-iso-26262-8-7x)

--- a/docs/safety/src/content/docs/qualification-plan/test-coverage.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/test-coverage.mdx
@@ -7,4 +7,10 @@ Slint SC must support headless or offline automated testing frameworks capable o
 
 Code coverage is measured with LLVM source-based coverage via `cargo-llvm-cov`.
 The measured coverage of the current test suite is reported in the [Test Coverage](/qualification-report/test-coverage/) chapter of the qualification report.
-The goal for ASIL D is typically strict structural coverage, requiring >90% statement/branch coverage and often Modified Condition/Decision Coverage (MC/DC).
+
+ISO 26262-6:2018 Table 9 lists the structural coverage metrics at the software unit level: statement coverage, branch coverage, and Modified Condition/Decision Coverage (MC/DC).
+At the ASIL B we target, statement and branch coverage are highly recommended and MC/DC is recommended.
+The standard sets no percentage. 9.4.4 says only that coverage judged insufficient needs either more test cases or a rationale, and that no target value, or a low one without a rationale, counts as insufficient.
+
+Slint SC holds the runtime at complete line, function, and region coverage, and the build fails below it.
+Whether MC/DC is needed on top of that is still open; see the TODO in [Verification](/qualification-plan/verification/).

--- a/docs/safety/src/content/docs/qualification-plan/verification.mdx
+++ b/docs/safety/src/content/docs/qualification-plan/verification.mdx
@@ -9,7 +9,7 @@ It's covered by ISO 26262-6 Clause 9 for the software units, Clause 10 for their
 Validating that the finished system is safe isn't something Slint SC can do.
 Slint SC is a Safety Element out of Context, so it has no safety goals of its own to validate against.
 That activity belongs to the integrator, and is stated in the [Safety Manual](/safety-manual/#user-responsibility).
-Under ISO 26262 it's the safety validation of Clause 9 in Part 4.
+Under ISO 26262 it's the safety validation of Clause 8 in Part 4.
 
 ## What Is Verified
 

--- a/docs/safety/src/content/docs/safety-manual/compiler/constraints.mdx
+++ b/docs/safety/src/content/docs/safety-manual/compiler/constraints.mdx
@@ -3,7 +3,10 @@ title: Constraints
 description: Boundary conditions the user must respect when compiling with Slint SC.
 ---
 
-The standard essentially views a **Requirement** as what the system *must do* (or a property it must have), whereas a **Constraint** is a boundary condition that *limits the solution space*.
+This package uses two words for two different things.
+A **requirement** is what Slint SC *must do*, or a property it must have.
+A **constraint** is a boundary condition that *limits the solution space*, so it says how Slint SC may be used rather than what it does.
+Neither term is defined this way by ISO 26262, IEC 61508, or IEC 62304; it's our own split.
 
 For APIs, the Constraints might explain that some functions are experimental and can not be used safely yet. Or, that certain values passed as parameters into functions are not supported in Slint SC. In other words, certain features can only be used a certain way to be safe.
 

--- a/docs/safety/src/content/docs/safety-manual/compiler/constraints.mdx
+++ b/docs/safety/src/content/docs/safety-manual/compiler/constraints.mdx
@@ -7,7 +7,7 @@ The standard essentially views a **Requirement** as what the system *must do* (o
 
 For APIs, the Constraints might explain that some functions are experimental and can not be used safely yet. Or, that certain values passed as parameters into functions are not supported in Slint SC. In other words, certain features can only be used a certain way to be safe.
 
-The "Slint SC" compiler is the regular Slint compiler with the argument `--safety-critical`.
+The "Slint SC" compiler is the regular Slint compiler built with the `slint-sc` feature and invoked with `--slint-sc`.
 When the Slint Compiler is used in a safety-critical project, it should impose constraints
 on the input programs so that only safe parts of Slint SC can be used, and it should report a proper error message
 when an unsafe feature is found.

--- a/docs/safety/src/content/docs/safety-manual/index.mdx
+++ b/docs/safety/src/content/docs/safety-manual/index.mdx
@@ -11,7 +11,7 @@ Slint SC is a Safety Element out of Context.
 It's developed without knowing the function it will serve, so the assumptions it makes about its environment are yours to confirm.
 
 Validating that the finished system is safe is your responsibility, because Slint SC has no safety goals of its own to validate against.
-Under ISO 26262 that's the safety validation of Clause 9 in Part 4.
+Under ISO 26262 that's the safety validation of Clause 8 in Part 4.
 
 The constraints in this manual are the other half of that.
 Each one exists because no measure inside Slint SC can rule out the matching failure, so only you can.


### PR DESCRIPTION
I checked every ISO and IEC reference in `docs/safety` against the text of
ISO 26262-6:2018, ISO 26262-8:2018 and IEC 62304.

Wrong:

- Safety validation is ISO 26262-4 Clause 8, not Clause 9. That was the 2011
  number. Three places.
- "Specification and management of safety requirements" is Part 8 Clause 6,
  not Part 6.
- The clause map quoted a traceability rule that isn't in the 2018 text.
- The ">90% coverage" figure has no source. Table 9 sets no percentage, and
  the page quoted the ASIL D goal while we target ASIL B.

Wrong scope:

- 11.4.8 is a qualification method, not a heading for our own process, and we
  pick validation instead. TODO left to settle it.
- Part 8 runs to Clause 16, not 13, and Clause 13 is "Evaluation of hardware
  elements".
- IEC 62304 has no tool classification scheme, so that TODO had no target.

Quotes that had drifted: the 7.4.2 and 7.4.5 lists each lost and gained items,
both said "should" where the standard says "shall", and the 7.4.10 quote listed
two of its three goals.

Also: the flag is `--slint-sc`, not `--safety-critical`. The requirement and
constraint split is our own wording. All three standards now name their edition.

One commit per fix. IEC 61508-3 7.4.4 is unverified, I had no copy of 61508.
