### PR TITLE
Sort bundled translation languages

### DIFF
--- a/internal/compiler/translations.rs
+++ b/internal/compiler/translations.rs
@@ -50,10 +50,15 @@ impl TranslationsBuilder {
         let mut catalogs = Vec::new();
         let mut plural_rules =
             vec![Some(plural_rule_parser::parse_rule_expression("n!=1").unwrap())];
-        for l in std::fs::read_dir(path)
+        // Sort the entries so the bundled language order doesn't depend on the
+        // filesystem's directory order.
+        // Otherwise the same sources produce different string tables on
+        // different machines, which breaks reproducible builds.
+        let mut entries = std::fs::read_dir(path)
             .map_err(|e| std::io::Error::other(format!("Error reading directory {path:?}: {e}")))?
-        {
-            let l = l?;
+            .collect::<Result<Vec<_>, _>>()?;
+        entries.sort_by_key(|l| l.file_name());
+        for l in entries {
             let path = l.path().join("LC_MESSAGES").join(format!("{domain}.po"));
             if path.exists() {
                 let catalog = rspolib::pofile(path.as_path()).map_err(|e| {


### PR DESCRIPTION
`TranslationsBuilder::load_translations` iterates the language directory with
`read_dir` and pushes each language in the order the filesystem returns it.
That order isn't stable across machines, so the bundled language list, and with
it the generated string tables, differ between builds of identical sources.

Sorting the entries by file name makes the generated output depend only on the
sources.

## How this shows up

Building the same commit of an app on two machines produces two different
binaries.
The strings are identical, only their order and layout differ.

I hit this getting a Slint app verified for F-Droid, which rebuilds the tagged
commit and compares it byte for byte against the published APK.
Everything matched except `libmeditate_android.so`, which differed by 8 bytes,
and the diff was the bundled translation strings in a different order.

The same ten language directories, read on three filesystems:

| | order |
| --- | --- |
| ext4 | `pt_BR zh_CN es fr pl de nl ru it` |
| tmpfs | `zh_CN ru pt_BR pl nl it fr es de` |
| after this change | `de es fr it nl pl pt_BR ru zh_CN` |

Creation order doesn't help: creating the directories in sorted order on ext4
still returns the hashed order above, because the hash seed is per filesystem.

## Notes

- Behavior is unchanged, since languages are selected by name rather than index.
- Verified against my app: the generated language order goes from
  `pt_BR, zh_CN, es, ...` to alphabetical, and stays that way regardless of the
  filesystem the sources sit on.
- `cargo check -p i-slint-compiler` passes and `cargo fmt` is clean.
