### PR TITLE
compiler: reduce Element::from_node stack usage

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1335,6 +1335,500 @@ impl Element {
         r
     }
 
+    // The `parse_*` helpers below hold the bodies of `from_node`'s member-parsing loops. They are
+    // kept out of line so their locals do not enlarge `from_node`'s stack frame, which is held
+    // while it recurses into child elements — an unoptimized build reserves space for every
+    // arm/block at once, and the element tree can nest deeply.
+    #[cfg_attr(not(feature = "slint-sc"), allow(unused_variables))]
+    fn parse_callback_declarations(
+        r: &mut Element,
+        node: &syntax_nodes::Element,
+        is_component_root: bool,
+        diag: &mut BuildDiagnostics,
+        tr: &TypeRegister,
+    ) {
+        for sig_decl in node.CallbackDeclaration() {
+            let name =
+                unwrap_or_continue!(parser::identifier_text(&sig_decl.DeclaredIdentifier()); diag);
+
+            let pure = Some(
+                sig_decl.child_token(SyntaxKind::Identifier).is_some_and(|t| t.text() == "pure"),
+            );
+
+            #[cfg(feature = "slint-sc")]
+            {
+                // Only the root element's callbacks become part of the component's API
+                if !is_component_root {
+                    diag.slint_sc_error(
+                        "Declaring a callback on an element other than the root is",
+                        &sig_decl,
+                    );
+                }
+                if pure == Some(true) {
+                    diag.slint_sc_error("Pure callbacks are", &sig_decl);
+                }
+                if let Some(param) = sig_decl.CallbackDeclarationParameter().next() {
+                    diag.slint_sc_error("Callback parameters are", &param);
+                }
+                if let Some(ret) = sig_decl.ReturnType() {
+                    diag.slint_sc_error("Callback return types are", &ret);
+                }
+            }
+
+            let PropertyLookupResult {
+                resolved_name: existing_name,
+                property_type: maybe_existing_prop_type,
+                is_shadowable,
+                ..
+            } = r.lookup_property(&name);
+            // When the declaration shadows a shadowable builtin member, proceed;
+            // the check_builtin_shadowing pass emits the diagnostic
+            let shadows_builtin = !matches!(maybe_existing_prop_type, Type::Invalid);
+            if shadows_builtin && !is_shadowable {
+                if matches!(maybe_existing_prop_type, Type::Callback { .. }) {
+                    if r.property_declarations.contains_key(&name) {
+                        diag.push_error(
+                            "Duplicated callback declaration".into(),
+                            &sig_decl.DeclaredIdentifier(),
+                        );
+                    } else {
+                        diag.push_error(
+                            format!("Cannot override callback '{existing_name}'"),
+                            &sig_decl.DeclaredIdentifier(),
+                        )
+                    }
+                } else {
+                    diag.push_error(
+                        format!(
+                            "Cannot declare callback '{existing_name}' when a {} with the same name exists",
+                            if matches!(maybe_existing_prop_type, Type::Function { .. }) { "function" } else { "property" }
+                        ),
+                        &sig_decl.DeclaredIdentifier(),
+                    );
+                }
+                continue;
+            }
+
+            if let Some(csn) = sig_decl.TwoWayBinding() {
+                #[cfg(feature = "slint-sc")]
+                diag.slint_sc_error("Callback aliases are", &csn);
+                r.bindings
+                    .0
+                    .insert(name.clone(), BindingExpression::new_uncompiled(csn.into()).into());
+                r.property_declarations.insert(
+                    name,
+                    PropertyDeclaration {
+                        property_type: Type::InferredCallback,
+                        node: Some(sig_decl.into()),
+                        visibility: PropertyVisibility::InOut,
+                        pure,
+                        shadows_builtin,
+                        ..Default::default()
+                    },
+                );
+                continue;
+            }
+
+            let args = sig_decl
+                .CallbackDeclarationParameter()
+                .map(|p| type_from_node(p.Type(), diag, tr))
+                .collect();
+            let return_type = sig_decl
+                .ReturnType()
+                .map(|ret_ty| type_from_node(ret_ty.Type(), diag, tr))
+                .unwrap_or(Type::Void);
+            let arg_names = sig_decl
+                .CallbackDeclarationParameter()
+                .map(|a| {
+                    a.DeclaredIdentifier()
+                        .and_then(|x| parser::identifier_text(&x))
+                        .unwrap_or_default()
+                })
+                .collect();
+            r.property_declarations.insert(
+                name,
+                PropertyDeclaration {
+                    property_type: Type::Callback(Arc::new(Function {
+                        return_type,
+                        args,
+                        arg_names,
+                    })),
+                    node: Some(sig_decl.into()),
+                    visibility: PropertyVisibility::InOut,
+                    pure,
+                    shadows_builtin,
+                    ..Default::default()
+                },
+            );
+        }
+    }
+
+    #[cfg_attr(not(feature = "slint-sc"), allow(unused_variables))]
+    fn parse_callback_connections(
+        r: &mut Element,
+        node: &syntax_nodes::Element,
+        is_component_root: bool,
+        diag: &mut BuildDiagnostics,
+    ) {
+        for con_node in node.CallbackConnection() {
+            let unresolved_name = unwrap_or_continue!(parser::identifier_text(&con_node); diag);
+            let lookup_result = r.lookup_property(&unresolved_name);
+            #[cfg(feature = "slint-sc")]
+            {
+                // A callback declared in the file is in the subset by construction;
+                // a builtin one only when marked in builtins.slint, which keeps
+                // `init` and the rest of TouchArea out.
+                if !r.is_user_declared_member(&unresolved_name) && !lookup_result.is_slint_sc {
+                    diag.slint_sc_error(
+                        &format!("The callback '{unresolved_name}' is"),
+                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
+                    );
+                }
+                // The application implements the callbacks of the root element,
+                // so a handler here would be a second answer to one invocation.
+                if is_component_root
+                    && r.property_declarations
+                        .get(&*lookup_result.resolved_name)
+                        .is_some_and(|d| d.node.is_some())
+                {
+                    diag.slint_sc_error(
+                        "A handler for a callback declared on the root element is",
+                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
+                    );
+                }
+                if let Some(param) = con_node.DeclaredIdentifier().next() {
+                    diag.slint_sc_error("Callback handler parameters are", &param);
+                }
+            }
+            let PropertyLookupResult { resolved_name, property_type, .. } = lookup_result;
+            if let Type::Callback(callback) = &property_type {
+                let num_arg = con_node.DeclaredIdentifier().count();
+                if num_arg > callback.args.len() {
+                    diag.push_error(
+                        format!(
+                            "'{}' only has {} arguments, but {} were provided",
+                            unresolved_name,
+                            callback.args.len(),
+                            num_arg
+                        ),
+                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
+                    );
+                }
+            } else if property_type == Type::InferredCallback {
+                // argument matching will happen later
+            } else {
+                if r.base_type != ElementType::Error {
+                    diag.push_error(
+                        format!("'{}' is not a callback in {}", unresolved_name, r.base_type),
+                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
+                    );
+                }
+                continue;
+            }
+            match r.bindings.0.entry(resolved_name.into()) {
+                Entry::Vacant(e) => {
+                    e.insert(BindingExpression::new_uncompiled(con_node.clone().into()).into());
+                }
+                Entry::Occupied(mut e) => {
+                    // A global may implement a callback declared in another global: the
+                    // callback is declared as a two-way alias (`callback foo <=> Other.foo;`)
+                    // and also given a handler (`foo => { ... }`). The alias node stays on
+                    // the declaration, and the handler takes the binding expression slot.
+                    let is_global_alias = r.base_type == ElementType::Global
+                        && matches!(
+                            &e.get().borrow().expression,
+                            Expression::Uncompiled(node) if node.kind() == SyntaxKind::TwoWayBinding
+                        );
+                    if is_global_alias {
+                        // Keep the handler as the binding and point its span at the handler
+                        // name, so a duplicate-implementation error refers to the
+                        // implementation rather than the alias. The alias is recovered from
+                        // the declaration node, so dropping it from the binding is fine.
+                        let mut handler =
+                            BindingExpression::new_uncompiled(con_node.clone().into());
+                        if let Some(name) = con_node.child_token(SyntaxKind::Identifier) {
+                            handler.span = Some(name.to_source_location());
+                        }
+                        e.insert(handler.into());
+                    } else {
+                        diag.push_error(
+                            "Duplicated callback".into(),
+                            &con_node.child_token(SyntaxKind::Identifier).unwrap(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn parse_animations(
+        r: &mut Element,
+        node: &syntax_nodes::Element,
+        diag: &mut BuildDiagnostics,
+        tr: &TypeRegister,
+    ) {
+        for anim in node.PropertyAnimation() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Animations are", &anim);
+            if let Some(star) = anim.child_token(SyntaxKind::Star) {
+                diag.push_error(
+                    "catch-all property is only allowed within transitions".into(),
+                    &star,
+                )
+            };
+            for prop_name_token in anim.QualifiedName() {
+                match QualifiedTypeName::from_node(prop_name_token.clone()).members.as_slice() {
+                    [unresolved_prop_name] => {
+                        if r.base_type == ElementType::Error {
+                            continue;
+                        };
+                        let lookup_result = r.lookup_property(unresolved_prop_name);
+                        let valid_assign = lookup_result.is_valid_for_assignment();
+                        if let Some(anim_element) = animation_element_from_node(
+                            &anim,
+                            &prop_name_token,
+                            lookup_result.property_type,
+                            diag,
+                            tr,
+                        ) {
+                            if !valid_assign {
+                                diag.push_error(
+                                    format!(
+                                        "Cannot animate '{}' property '{}'",
+                                        lookup_result.property_visibility, unresolved_prop_name
+                                    ),
+                                    &prop_name_token,
+                                );
+                            }
+
+                            if unresolved_prop_name != lookup_result.resolved_name.as_ref() {
+                                diag.push_property_deprecation_warning(
+                                    unresolved_prop_name,
+                                    &lookup_result.resolved_name,
+                                    &prop_name_token,
+                                );
+                            } else if let Some(message) = lookup_result
+                                .deprecated
+                                .as_ref()
+                                .filter(|_| !lookup_result.is_local_to_component)
+                            {
+                                diag.push_property_deprecation_warning_with_message(
+                                    unresolved_prop_name,
+                                    message,
+                                    &prop_name_token,
+                                );
+                            }
+
+                            let expr_binding = r
+                                .bindings
+                                .0
+                                .entry(lookup_result.resolved_name.into())
+                                .or_insert_with(|| {
+                                    let mut r = BindingExpression::from(Expression::Invalid);
+                                    r.priority = 1;
+                                    r.span = Some(prop_name_token.to_source_location());
+                                    r.into()
+                                });
+                            if expr_binding
+                                .get_mut()
+                                .animation
+                                .replace(PropertyAnimation::Static(anim_element))
+                                .is_some()
+                            {
+                                diag.push_error("Duplicated animation".into(), &prop_name_token)
+                            }
+                        }
+                    }
+                    _ => diag.push_error(
+                        "Can only refer to property in the current element".into(),
+                        &prop_name_token,
+                    ),
+                }
+            }
+        }
+    }
+
+    fn parse_changed_callbacks(
+        r: &mut Element,
+        node: &syntax_nodes::Element,
+        diag: &mut BuildDiagnostics,
+    ) {
+        for ch in node.PropertyChangedCallback() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Change callbacks are", &ch);
+            let Some(prop) = parser::identifier_text(&ch.DeclaredIdentifier()) else { continue };
+            let lookup_result = r.lookup_property(&prop);
+            if !lookup_result.is_valid() {
+                if r.base_type != ElementType::Error {
+                    diag.push_error(
+                        format!("Property '{prop}' does not exist"),
+                        &ch.DeclaredIdentifier(),
+                    );
+                }
+            } else if !lookup_result.property_type.is_property_type() {
+                let what = match lookup_result.property_type {
+                    Type::Function { .. } => "a function",
+                    Type::Callback { .. } => "a callback",
+                    _ => "not a property",
+                };
+                diag.push_error(
+                    format!(
+                        "Change callback can only be set on properties, and '{prop}' is {what}"
+                    ),
+                    &ch.DeclaredIdentifier(),
+                );
+            } else if lookup_result.property_visibility == PropertyVisibility::Private
+                && !lookup_result.is_local_to_component
+            {
+                diag.push_error(
+                    format!("Change callback on a private property '{prop}'"),
+                    &ch.DeclaredIdentifier(),
+                );
+            }
+            let handler = Expression::Uncompiled(ch.clone().into());
+            match r.change_callbacks.entry(prop) {
+                Entry::Vacant(e) => {
+                    e.insert(vec![handler].into());
+                }
+                Entry::Occupied(mut e) => {
+                    diag.push_error(
+                        format!("Duplicated change callback on '{}'", e.key()),
+                        &ch.DeclaredIdentifier(),
+                    );
+                    e.get_mut().get_mut().push(handler);
+                }
+            }
+        }
+    }
+
+    // Parse the `function` declarations of an element. Kept out of `from_node` so its locals do
+    // not enlarge that function's (already large) stack frame, which is held while `from_node`
+    // recurses into child elements.
+    fn parse_functions(
+        r: &mut Element,
+        node: &syntax_nodes::Element,
+        base_type: &ElementType,
+        is_interface: bool,
+        diag: &mut BuildDiagnostics,
+        tr: &TypeRegister,
+    ) {
+        for func in node.Function() {
+            #[cfg(feature = "slint-sc")]
+            diag.slint_sc_error("Function declarations are", &func);
+            let name =
+                unwrap_or_continue!(parser::identifier_text(&func.DeclaredIdentifier()); diag);
+
+            let PropertyLookupResult {
+                resolved_name: existing_name,
+                property_type: maybe_existing_prop_type,
+                is_shadowable,
+                ..
+            } = r.lookup_property(&name);
+            // When the declaration shadows a shadowable builtin member, proceed;
+            // the check_builtin_shadowing pass emits the diagnostic
+            let shadows_builtin = !matches!(maybe_existing_prop_type, Type::Invalid);
+            if shadows_builtin && !is_shadowable {
+                if matches!(maybe_existing_prop_type, Type::Callback { .. } | Type::Function { .. })
+                {
+                    diag.push_error(
+                        format!("Cannot override '{existing_name}'"),
+                        &func.DeclaredIdentifier(),
+                    )
+                } else {
+                    diag.push_error(
+                        format!("Cannot declare function '{existing_name}' when a property with the same name exists"),
+                        &func.DeclaredIdentifier(),
+                    );
+                }
+                continue;
+            }
+
+            let mut args = Vec::new();
+            let mut arg_names = Vec::new();
+            for a in func.ArgumentDeclaration() {
+                args.push(type_from_node(a.Type(), diag, tr));
+                let name =
+                    unwrap_or_continue!(parser::identifier_text(&a.DeclaredIdentifier()); diag);
+                if arg_names.contains(&name) {
+                    diag.push_error(
+                        format!("Duplicated argument name '{name}'"),
+                        &a.DeclaredIdentifier(),
+                    );
+                }
+                arg_names.push(name);
+            }
+            let return_type = func
+                .ReturnType()
+                .map_or(Type::Void, |ret_ty| type_from_node(ret_ty.Type(), diag, tr));
+
+            let mut visibility = PropertyVisibility::Private;
+            let mut pure = None;
+            for token in func.children_with_tokens() {
+                if token.kind() != SyntaxKind::Identifier {
+                    continue;
+                }
+                match token.as_token().unwrap().text() {
+                    "pure" => pure = Some(true),
+                    "public" => {
+                        visibility = PropertyVisibility::Public;
+                        pure = pure.or(Some(false));
+                    }
+                    "protected" => {
+                        visibility = PropertyVisibility::Protected;
+                        pure = pure.or(Some(false));
+                    }
+                    _ => (),
+                }
+            }
+
+            if is_interface && visibility != PropertyVisibility::Public {
+                diag.push_error(
+                    "Function declarations in an interface must be public".into(),
+                    &func,
+                );
+            }
+
+            let declaration = PropertyDeclaration {
+                property_type: Type::Function(Arc::new(Function { return_type, args, arg_names })),
+                node: Some(func.clone().into()),
+                visibility,
+                pure,
+                shadows_builtin,
+                ..Default::default()
+            };
+
+            match (base_type.clone(), func.CodeBlock()) {
+                (ElementType::Interface, Some(code_block)) => {
+                    diag.push_error(
+                        "Function declarations in interfaces must not have a body".into(),
+                        &code_block,
+                    );
+                    continue;
+                }
+                (ElementType::Interface, None) => {
+                    // Do not create a binding for this function, as it is just a declaration without body. It will be
+                    // implemented by the component that implements the interface.
+                    r.property_declarations.insert(name, declaration);
+                    continue;
+                }
+                (_, None) => {
+                    diag.push_error("Functions must have a code block".into(), &func);
+                }
+                (_, Some(_)) => {}
+            }
+
+            if r.bindings
+                .0
+                .insert(name.clone(), BindingExpression::new_uncompiled(func.clone().into()).into())
+                .is_some()
+            {
+                assert!(diag.has_errors());
+            }
+
+            r.property_declarations.insert(name, declaration);
+        }
+    }
+
     pub fn from_node(
         node: syntax_nodes::Element,
         id: SmolStr,
@@ -1347,7 +1841,6 @@ impl Element {
     ) -> ElementRc {
         // A child element's parent_type is the type of its parent; the root
         // gets a sentinel from Component::from_node
-        #[cfg(feature = "slint-sc")]
         let is_component_root =
             !matches!(parent_type, ElementType::Builtin(_) | ElementType::Component(_));
         let base_type = if let Some(base_node) = node.QualifiedName() {
@@ -1683,453 +2176,15 @@ impl Element {
 
         apply_default_type_properties(&mut r);
 
-        for sig_decl in node.CallbackDeclaration() {
-            let name =
-                unwrap_or_continue!(parser::identifier_text(&sig_decl.DeclaredIdentifier()); diag);
+        Self::parse_callback_declarations(&mut r, &node, is_component_root, diag, tr);
 
-            let pure = Some(
-                sig_decl.child_token(SyntaxKind::Identifier).is_some_and(|t| t.text() == "pure"),
-            );
+        Self::parse_functions(&mut r, &node, &base_type, is_interface, diag, tr);
 
-            #[cfg(feature = "slint-sc")]
-            {
-                // Only the root element's callbacks become part of the component's API
-                if !is_component_root {
-                    diag.slint_sc_error(
-                        "Declaring a callback on an element other than the root is",
-                        &sig_decl,
-                    );
-                }
-                if pure == Some(true) {
-                    diag.slint_sc_error("Pure callbacks are", &sig_decl);
-                }
-                if let Some(param) = sig_decl.CallbackDeclarationParameter().next() {
-                    diag.slint_sc_error("Callback parameters are", &param);
-                }
-                if let Some(ret) = sig_decl.ReturnType() {
-                    diag.slint_sc_error("Callback return types are", &ret);
-                }
-            }
+        Self::parse_callback_connections(&mut r, &node, is_component_root, diag);
 
-            let PropertyLookupResult {
-                resolved_name: existing_name,
-                property_type: maybe_existing_prop_type,
-                is_shadowable,
-                ..
-            } = r.lookup_property(&name);
-            // When the declaration shadows a shadowable builtin member, proceed;
-            // the check_builtin_shadowing pass emits the diagnostic
-            let shadows_builtin = !matches!(maybe_existing_prop_type, Type::Invalid);
-            if shadows_builtin && !is_shadowable {
-                if matches!(maybe_existing_prop_type, Type::Callback { .. }) {
-                    if r.property_declarations.contains_key(&name) {
-                        diag.push_error(
-                            "Duplicated callback declaration".into(),
-                            &sig_decl.DeclaredIdentifier(),
-                        );
-                    } else {
-                        diag.push_error(
-                            format!("Cannot override callback '{existing_name}'"),
-                            &sig_decl.DeclaredIdentifier(),
-                        )
-                    }
-                } else {
-                    diag.push_error(
-                        format!(
-                            "Cannot declare callback '{existing_name}' when a {} with the same name exists",
-                            if matches!(maybe_existing_prop_type, Type::Function { .. }) { "function" } else { "property" }
-                        ),
-                        &sig_decl.DeclaredIdentifier(),
-                    );
-                }
-                continue;
-            }
+        Self::parse_animations(&mut r, &node, diag, tr);
 
-            if let Some(csn) = sig_decl.TwoWayBinding() {
-                #[cfg(feature = "slint-sc")]
-                diag.slint_sc_error("Callback aliases are", &csn);
-                r.bindings
-                    .0
-                    .insert(name.clone(), BindingExpression::new_uncompiled(csn.into()).into());
-                r.property_declarations.insert(
-                    name,
-                    PropertyDeclaration {
-                        property_type: Type::InferredCallback,
-                        node: Some(sig_decl.into()),
-                        visibility: PropertyVisibility::InOut,
-                        pure,
-                        shadows_builtin,
-                        ..Default::default()
-                    },
-                );
-                continue;
-            }
-
-            let args = sig_decl
-                .CallbackDeclarationParameter()
-                .map(|p| type_from_node(p.Type(), diag, tr))
-                .collect();
-            let return_type = sig_decl
-                .ReturnType()
-                .map(|ret_ty| type_from_node(ret_ty.Type(), diag, tr))
-                .unwrap_or(Type::Void);
-            let arg_names = sig_decl
-                .CallbackDeclarationParameter()
-                .map(|a| {
-                    a.DeclaredIdentifier()
-                        .and_then(|x| parser::identifier_text(&x))
-                        .unwrap_or_default()
-                })
-                .collect();
-            r.property_declarations.insert(
-                name,
-                PropertyDeclaration {
-                    property_type: Type::Callback(Arc::new(Function {
-                        return_type,
-                        args,
-                        arg_names,
-                    })),
-                    node: Some(sig_decl.into()),
-                    visibility: PropertyVisibility::InOut,
-                    pure,
-                    shadows_builtin,
-                    ..Default::default()
-                },
-            );
-        }
-
-        for func in node.Function() {
-            #[cfg(feature = "slint-sc")]
-            diag.slint_sc_error("Function declarations are", &func);
-            let name =
-                unwrap_or_continue!(parser::identifier_text(&func.DeclaredIdentifier()); diag);
-
-            let PropertyLookupResult {
-                resolved_name: existing_name,
-                property_type: maybe_existing_prop_type,
-                is_shadowable,
-                ..
-            } = r.lookup_property(&name);
-            // When the declaration shadows a shadowable builtin member, proceed;
-            // the check_builtin_shadowing pass emits the diagnostic
-            let shadows_builtin = !matches!(maybe_existing_prop_type, Type::Invalid);
-            if shadows_builtin && !is_shadowable {
-                if matches!(maybe_existing_prop_type, Type::Callback { .. } | Type::Function { .. })
-                {
-                    diag.push_error(
-                        format!("Cannot override '{existing_name}'"),
-                        &func.DeclaredIdentifier(),
-                    )
-                } else {
-                    diag.push_error(
-                        format!("Cannot declare function '{existing_name}' when a property with the same name exists"),
-                        &func.DeclaredIdentifier(),
-                    );
-                }
-                continue;
-            }
-
-            let mut args = Vec::new();
-            let mut arg_names = Vec::new();
-            for a in func.ArgumentDeclaration() {
-                args.push(type_from_node(a.Type(), diag, tr));
-                let name =
-                    unwrap_or_continue!(parser::identifier_text(&a.DeclaredIdentifier()); diag);
-                if arg_names.contains(&name) {
-                    diag.push_error(
-                        format!("Duplicated argument name '{name}'"),
-                        &a.DeclaredIdentifier(),
-                    );
-                }
-                arg_names.push(name);
-            }
-            let return_type = func
-                .ReturnType()
-                .map_or(Type::Void, |ret_ty| type_from_node(ret_ty.Type(), diag, tr));
-
-            let mut visibility = PropertyVisibility::Private;
-            let mut pure = None;
-            for token in func.children_with_tokens() {
-                if token.kind() != SyntaxKind::Identifier {
-                    continue;
-                }
-                match token.as_token().unwrap().text() {
-                    "pure" => pure = Some(true),
-                    "public" => {
-                        visibility = PropertyVisibility::Public;
-                        pure = pure.or(Some(false));
-                    }
-                    "protected" => {
-                        visibility = PropertyVisibility::Protected;
-                        pure = pure.or(Some(false));
-                    }
-                    _ => (),
-                }
-            }
-
-            if is_interface && visibility != PropertyVisibility::Public {
-                diag.push_error(
-                    "Function declarations in an interface must be public".into(),
-                    &func,
-                );
-            }
-
-            let declaration = PropertyDeclaration {
-                property_type: Type::Function(Arc::new(Function { return_type, args, arg_names })),
-                node: Some(func.clone().into()),
-                visibility,
-                pure,
-                shadows_builtin,
-                ..Default::default()
-            };
-
-            match (base_type.clone(), func.CodeBlock()) {
-                (ElementType::Interface, Some(code_block)) => {
-                    diag.push_error(
-                        "Function declarations in interfaces must not have a body".into(),
-                        &code_block,
-                    );
-                    continue;
-                }
-                (ElementType::Interface, None) => {
-                    // Do not create a binding for this function, as it is just a declaration without body. It will be
-                    // implemented by the component that implements the interface.
-                    r.property_declarations.insert(name, declaration);
-                    continue;
-                }
-                (_, None) => {
-                    diag.push_error("Functions must have a code block".into(), &func);
-                }
-                (_, Some(_)) => {}
-            }
-
-            if r.bindings
-                .0
-                .insert(name.clone(), BindingExpression::new_uncompiled(func.clone().into()).into())
-                .is_some()
-            {
-                assert!(diag.has_errors());
-            }
-
-            r.property_declarations.insert(name, declaration);
-        }
-
-        for con_node in node.CallbackConnection() {
-            let unresolved_name = unwrap_or_continue!(parser::identifier_text(&con_node); diag);
-            let lookup_result = r.lookup_property(&unresolved_name);
-            #[cfg(feature = "slint-sc")]
-            {
-                // A callback declared in the file is in the subset by construction;
-                // a builtin one only when marked in builtins.slint, which keeps
-                // `init` and the rest of TouchArea out.
-                if !r.is_user_declared_member(&unresolved_name) && !lookup_result.is_slint_sc {
-                    diag.slint_sc_error(
-                        &format!("The callback '{unresolved_name}' is"),
-                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                    );
-                }
-                // The application implements the callbacks of the root element,
-                // so a handler here would be a second answer to one invocation.
-                if is_component_root
-                    && r.property_declarations
-                        .get(&*lookup_result.resolved_name)
-                        .is_some_and(|d| d.node.is_some())
-                {
-                    diag.slint_sc_error(
-                        "A handler for a callback declared on the root element is",
-                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                    );
-                }
-                if let Some(param) = con_node.DeclaredIdentifier().next() {
-                    diag.slint_sc_error("Callback handler parameters are", &param);
-                }
-            }
-            let PropertyLookupResult { resolved_name, property_type, .. } = lookup_result;
-            if let Type::Callback(callback) = &property_type {
-                let num_arg = con_node.DeclaredIdentifier().count();
-                if num_arg > callback.args.len() {
-                    diag.push_error(
-                        format!(
-                            "'{}' only has {} arguments, but {} were provided",
-                            unresolved_name,
-                            callback.args.len(),
-                            num_arg
-                        ),
-                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                    );
-                }
-            } else if property_type == Type::InferredCallback {
-                // argument matching will happen later
-            } else {
-                if r.base_type != ElementType::Error {
-                    diag.push_error(
-                        format!("'{}' is not a callback in {}", unresolved_name, r.base_type),
-                        &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                    );
-                }
-                continue;
-            }
-            match r.bindings.0.entry(resolved_name.into()) {
-                Entry::Vacant(e) => {
-                    e.insert(BindingExpression::new_uncompiled(con_node.clone().into()).into());
-                }
-                Entry::Occupied(mut e) => {
-                    // A global may implement a callback declared in another global: the
-                    // callback is declared as a two-way alias (`callback foo <=> Other.foo;`)
-                    // and also given a handler (`foo => { ... }`). The alias node stays on
-                    // the declaration, and the handler takes the binding expression slot.
-                    let is_global_alias = r.base_type == ElementType::Global
-                        && matches!(
-                            &e.get().borrow().expression,
-                            Expression::Uncompiled(node) if node.kind() == SyntaxKind::TwoWayBinding
-                        );
-                    if is_global_alias {
-                        // Keep the handler as the binding and point its span at the handler
-                        // name, so a duplicate-implementation error refers to the
-                        // implementation rather than the alias. The alias is recovered from
-                        // the declaration node, so dropping it from the binding is fine.
-                        let mut handler =
-                            BindingExpression::new_uncompiled(con_node.clone().into());
-                        if let Some(name) = con_node.child_token(SyntaxKind::Identifier) {
-                            handler.span = Some(name.to_source_location());
-                        }
-                        e.insert(handler.into());
-                    } else {
-                        diag.push_error(
-                            "Duplicated callback".into(),
-                            &con_node.child_token(SyntaxKind::Identifier).unwrap(),
-                        );
-                    }
-                }
-            }
-        }
-
-        for anim in node.PropertyAnimation() {
-            #[cfg(feature = "slint-sc")]
-            diag.slint_sc_error("Animations are", &anim);
-            if let Some(star) = anim.child_token(SyntaxKind::Star) {
-                diag.push_error(
-                    "catch-all property is only allowed within transitions".into(),
-                    &star,
-                )
-            };
-            for prop_name_token in anim.QualifiedName() {
-                match QualifiedTypeName::from_node(prop_name_token.clone()).members.as_slice() {
-                    [unresolved_prop_name] => {
-                        if r.base_type == ElementType::Error {
-                            continue;
-                        };
-                        let lookup_result = r.lookup_property(unresolved_prop_name);
-                        let valid_assign = lookup_result.is_valid_for_assignment();
-                        if let Some(anim_element) = animation_element_from_node(
-                            &anim,
-                            &prop_name_token,
-                            lookup_result.property_type,
-                            diag,
-                            tr,
-                        ) {
-                            if !valid_assign {
-                                diag.push_error(
-                                    format!(
-                                        "Cannot animate '{}' property '{}'",
-                                        lookup_result.property_visibility, unresolved_prop_name
-                                    ),
-                                    &prop_name_token,
-                                );
-                            }
-
-                            if unresolved_prop_name != lookup_result.resolved_name.as_ref() {
-                                diag.push_property_deprecation_warning(
-                                    unresolved_prop_name,
-                                    &lookup_result.resolved_name,
-                                    &prop_name_token,
-                                );
-                            } else if let Some(message) = lookup_result
-                                .deprecated
-                                .as_ref()
-                                .filter(|_| !lookup_result.is_local_to_component)
-                            {
-                                diag.push_property_deprecation_warning_with_message(
-                                    unresolved_prop_name,
-                                    message,
-                                    &prop_name_token,
-                                );
-                            }
-
-                            let expr_binding = r
-                                .bindings
-                                .0
-                                .entry(lookup_result.resolved_name.into())
-                                .or_insert_with(|| {
-                                    let mut r = BindingExpression::from(Expression::Invalid);
-                                    r.priority = 1;
-                                    r.span = Some(prop_name_token.to_source_location());
-                                    r.into()
-                                });
-                            if expr_binding
-                                .get_mut()
-                                .animation
-                                .replace(PropertyAnimation::Static(anim_element))
-                                .is_some()
-                            {
-                                diag.push_error("Duplicated animation".into(), &prop_name_token)
-                            }
-                        }
-                    }
-                    _ => diag.push_error(
-                        "Can only refer to property in the current element".into(),
-                        &prop_name_token,
-                    ),
-                }
-            }
-        }
-
-        for ch in node.PropertyChangedCallback() {
-            #[cfg(feature = "slint-sc")]
-            diag.slint_sc_error("Change callbacks are", &ch);
-            let Some(prop) = parser::identifier_text(&ch.DeclaredIdentifier()) else { continue };
-            let lookup_result = r.lookup_property(&prop);
-            if !lookup_result.is_valid() {
-                if r.base_type != ElementType::Error {
-                    diag.push_error(
-                        format!("Property '{prop}' does not exist"),
-                        &ch.DeclaredIdentifier(),
-                    );
-                }
-            } else if !lookup_result.property_type.is_property_type() {
-                let what = match lookup_result.property_type {
-                    Type::Function { .. } => "a function",
-                    Type::Callback { .. } => "a callback",
-                    _ => "not a property",
-                };
-                diag.push_error(
-                    format!(
-                        "Change callback can only be set on properties, and '{prop}' is {what}"
-                    ),
-                    &ch.DeclaredIdentifier(),
-                );
-            } else if lookup_result.property_visibility == PropertyVisibility::Private
-                && !lookup_result.is_local_to_component
-            {
-                diag.push_error(
-                    format!("Change callback on a private property '{prop}'"),
-                    &ch.DeclaredIdentifier(),
-                );
-            }
-            let handler = Expression::Uncompiled(ch.clone().into());
-            match r.change_callbacks.entry(prop) {
-                Entry::Vacant(e) => {
-                    e.insert(vec![handler].into());
-                }
-                Entry::Occupied(mut e) => {
-                    diag.push_error(
-                        format!("Duplicated change callback on '{}'", e.key()),
-                        &ch.DeclaredIdentifier(),
-                    );
-                    e.get_mut().get_mut().push(handler);
-                }
-            }
-        }
+        Self::parse_changed_callbacks(&mut r, &node, diag);
 
         let r = r.make_rc();
 


### PR DESCRIPTION
Element::from_node is a large function that recurses into child elements. In debug builds the compiler reserves stack for every block's locals on each frame, so one frame was about 32kB, and a deeply nested element or import chain could overflow the small stack the build-time test driver runs the compiler on.

Move the member-parsing loops (functions, callbacks, callback handlers, animations and change callbacks) into their own methods so their locals no longer add to from_node's frame, roughly halving it.

This is a prospective fix for a stack overflow seen on CI when building the live-preview rust test on Windows.
