### PR TITLE
NPM security alert fix

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,7 @@ overrides:
   js-yaml@<=4.1.1: '>=4.2.0 <5.0.0'
   sharp@<0.35.0: '>=0.35.0'
   nanoid@<3.3.17: '>=3.3.17 <4.0.0'
+  deepmerge-ts@<8.0.0: '>=8.0.0'
 
 importers:
 
@@ -4973,8 +4974,8 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   defer-to-connect@2.0.1:
@@ -10336,7 +10337,7 @@ snapshots:
   '@playform/pipe@0.1.5':
     dependencies:
       '@types/node': 24.12.0
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       fast-glob: 3.3.3
 
   '@playwright/test@1.61.1':
@@ -11796,7 +11797,7 @@ snapshots:
       astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@24.12.0)(jiti@2.7.0)(rollup@4.62.0)(terser@5.46.1)(yaml@2.9.0)
       commander: 14.0.3
       csso: 5.0.5
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       fast-glob: 3.3.3
       html-minifier-terser: 7.2.0
       kleur: 4.1.5
@@ -12714,7 +12715,7 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   defer-to-connect@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,7 @@ overrides:
   'js-yaml@<=4.1.1': '>=4.2.0 <5.0.0'
   'sharp@<0.35.0': '>=0.35.0'
   'nanoid@<3.3.17': '>=3.3.17 <4.0.0'
+  'deepmerge-ts@<8.0.0': '>=8.0.0'
 
 catalog:
   '@astrojs/check': 0.9.9


### PR DESCRIPTION
## Summary

- override vulnerable `deepmerge-ts` releases with the patched 8.x line
- update the lockfile to resolve `deepmerge-ts` 8.0.1 for `astro-compress` and `@playform/pipe`

## Why

`pnpm audit` reported GHSA-ggr8-5vv4-36mx, a high-severity stack-exhaustion issue affecting `deepmerge-ts` versions before 8.0.0.

## Validation

- `pnpm audit --json` — zero advisories
- `pnpm --filter ./ui-libraries/material/docs type-check` — zero diagnostics
- `astro-compress` merge smoke test
