### PR TITLE
Don't panic if `build_new_tree()` is called with a window without a component

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -623,8 +623,16 @@ impl NodeCollection {
         let window = window_adapter.window();
         let window_inner = i_slint_core::window::WindowInner::from_pub(window);
         window_inner.ensure_tree_instantiated();
-
-        let root_item = ItemRc::new_root(window_inner.component());
+		
+        let Some(component) = window_inner.try_component() else {
+            return TreeUpdate {
+                nodes: Default::default(),
+                tree: Default::default(),
+                tree_id: TreeId::ROOT,
+                focus: self.root_node_id,
+            };
+		};
+        let root_item = ItemRc::new_root(component);
 
         let popups = window_inner
             .active_popups()

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -623,7 +623,7 @@ impl NodeCollection {
         let window = window_adapter.window();
         let window_inner = i_slint_core::window::WindowInner::from_pub(window);
         window_inner.ensure_tree_instantiated();
-		
+
         let Some(component) = window_inner.try_component() else {
             return TreeUpdate {
                 nodes: Default::default(),
@@ -631,7 +631,7 @@ impl NodeCollection {
                 tree_id: TreeId::ROOT,
                 focus: self.root_node_id,
             };
-		};
+        };
         let root_item = ItemRc::new_root(component);
 
         let popups = window_inner


### PR DESCRIPTION
This is a fix to the proximate issue described in https://github.com/slint-ui/slint/issues/12917.  It is very possible that there is a bigger problem that needs to be addressed, but with this fix this will become an "empty" update (which can happen for other reasons) rather than panicking.
