### PR TITLE
wasm-interpreter: let the host register a font

### DIFF
--- a/api/wasm-interpreter/src/lib.rs
+++ b/api/wasm-interpreter/src/lib.rs
@@ -318,6 +318,44 @@ impl WrappedInstance {
     }
 }
 
+/// Register a font for use by the `font-family` property.
+///
+/// `data` is the content of a TrueType or OpenType file.
+/// The families it declares become available to the components compiled afterwards,
+/// under the names the font itself carries,
+/// so a page that registers JetBrains Mono can then use `font-family: "JetBrains Mono"`.
+///
+/// The browser build has no system fonts to query,
+/// so this is the only way to draw a component in a font of the host page's choosing.
+/// A font the page loaded through `@font-face` doesn't count:
+/// the canvas renderer doesn't consult the CSS font database.
+///
+/// Text that was already laid out keeps the font it was shaped with,
+/// so register the font before compiling the component that uses it.
+///
+/// Throws if the platform isn't initialized yet, or if the data declares no font family.
+#[wasm_bindgen]
+pub fn register_font_from_memory(data: Vec<u8>) -> Result<(), JsValue> {
+    use i_slint_core::textlayout::sharedparley::fontique;
+
+    // The shared collection holds the bytes through its own `Arc`, so the font doesn't need the
+    // `&'static [u8]` that `Renderer::register_font_from_memory` asks for, and nothing is leaked.
+    // Taking the `Vec` by value hands over the copy wasm-bindgen already made.
+    let blob = fontique::Blob::new(std::sync::Arc::new(data));
+
+    let registered = i_slint_core::with_global_context(
+        || Err(i_slint_core::platform::PlatformError::NoPlatform),
+        |ctx| ctx.font_context().borrow_mut().collection.register_fonts(blob, None),
+    )?;
+
+    if registered.is_empty() {
+        return Err("the data declares no font family, \
+                    expected a TrueType or OpenType file"
+            .into());
+    }
+    Ok(())
+}
+
 /// Register DOM event handlers on all instance and set up the event loop for that.
 /// You can call this function only once. It will throw an exception but that is safe
 /// to ignore.


### PR DESCRIPTION
## Problem

A component compiled in the browser can only be drawn in the faces embedded in the
binary. A page hosting the WASM interpreter cannot give it a font of its own:

- Fonts the page loaded through `@font-face` are invisible — the canvas renderer
  doesn't consult the CSS font database.
- `import "…/font.ttf"` from a snippet fails: the interpreter resolves it through
  `register_font_from_path` (`internal/interpreter/eval.rs:2256`), which reads a
  filesystem the browser build doesn't have, and it doesn't consult the JS import
  callback either.
- The WASM module exports nothing about fonts.

## Change

`register_font_from_memory(data: Uint8Array)` hands the bytes to the shared
fontique collection. That collection holds them through its own `Arc`, so the
`&'static [u8]` in `Renderer::register_font_from_memory` is not needed on this
path and nothing is leaked. Taking the `Vec` by value hands over the copy
wasm-bindgen already made, so the font is copied once rather than twice.

The doc comment says outright that this API is not stable — the crate is
`publish = false` and its JS surface ships as an unversioned snapshot.

Registration doesn't re-shape text that was already laid out: the paragraph cache
is keyed by item and invalidated by property dependencies, and a font registration
is neither. The documentation says to register before compiling the component.
Making it retroactive would mean a cache-wide invalidation; happy to add it if
you'd rather have it.

This registers a font under the names it carries. It does not map the generic
families — the monospace generic is handled separately in #XXXX.

## Validation

- `cargo check -p slint-wasm-interpreter --target wasm32-unknown-unknown`.
- In a browser, against a `wasm-pack --release` build: a host-registered
  JetBrains Mono renders in that face, an unknown family still falls back to the
  sans, the generated `.d.ts` carries
  `register_font_from_memory(data: Uint8Array): void`, and malformed input is
  rejected with an error rather than a panic.

There is no wasm test harness in this crate (`wasm-bindgen-test` is commented out
in its `Cargo.toml`), so the browser check was manual.