### PR TITLE
zephyr: Raise the input thread priority

### DIFF
--- a/demos/zephyr-common/prj.conf
+++ b/demos/zephyr-common/prj.conf
@@ -12,3 +12,8 @@ CONFIG_ASSERT=y
 
 CONFIG_DISPLAY=y
 CONFIG_INPUT=y
+
+# Let touch events through while a frame is rendering, the input thread runs at the lowest
+# priority by default and would not get to drain its queue until the frame is done
+CONFIG_INPUT_THREAD_PRIORITY_OVERRIDE=y
+CONFIG_INPUT_THREAD_PRIORITY=-1


### PR DESCRIPTION
Touch stopped working on the MIMXRT1170-EVKB: the pointer stayed down after the first tap and the demo ignored everything after that.

The input thread runs at the lowest application priority by default, while the demo renders on the main thread at priority 0. A frame takes a few hundred milliseconds, and the input thread cannot run until it is done. The touch controller reports every 10 ms from the system workqueue, so the 16 entry queue fills up long before that.

Since Zephyr 4.1 the input subsystem does not wait for room in the queue. It drops the event instead:

  https://github.com/zephyrproject-rtos/zephyr/pull/82130

The dropped event is often the release, which is why the pointer got stuck. Give the input thread a priority above the renderer so it can drain the queue while a frame is being drawn.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
