### PR TITLE
Rust codegen: don't panic when a GridLayout repeater becomes empty

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -4266,9 +4266,10 @@ fn compile_grid_repeater_cache_access(expr: &Expression, ctx: &EvaluationContext
 
         quote!({
             let cache = #cache.get();
-            let base = cache[#index] as usize;
-            let data_idx = base + #offset as usize * (#stride_val as usize) + #child_offset #inner_offset;
-            *cache.get(data_idx).unwrap_or(&(0 as _))
+            cache.get(#index)
+                .and_then(|base| cache.get(*base as usize + #offset as usize * (#stride_val as usize) + #child_offset #inner_offset))
+                .copied()
+                .unwrap_or(0 as _)
         })
     })
 }

--- a/tests/cases/issues/issue_12944_gridlayout_empty_repeater.slint
+++ b/tests/cases/issues/issue_12944_gridlayout_empty_repeater.slint
@@ -1,0 +1,41 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #12944: clicking a repeated item inside a GridLayout that
+// empties its model must not panic while reading the now-empty layout cache.
+
+export component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+    in-out property <[string]> items: ["a"];
+    out property <int> count: items.length;
+    GridLayout {
+        for item in items: TouchArea {
+            clicked => { items = []; }
+        }
+    }
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_count(), 1);
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq(instance.get_count(), 0);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_count(), 1);
+slint_testing::send_mouse_click(&instance, 50., 50.);
+assert_eq!(instance.get_count(), 0);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.count, 1);
+slintlib.private_api.send_mouse_click(instance, 50., 50.);
+assert.equal(instance.count, 0);
+```
+*/


### PR DESCRIPTION
When a `for` inside a GridLayout has its model emptied while a pointer grab is active on one of its items, the item's geometry binding reads the grid layout cache after it became empty. The generated Rust code indexed `cache[base]` directly, panicking with "index out of bounds" when the cache has zero length. Guard the read with and_then like the C++ helper and interpreter already do.

Fixes: #12944
