### PR TITLE
swr text layout: divide instead of counting lines one by one

### DIFF
--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -54,7 +54,7 @@ mod shaping;
 /// cbindgen:ignore
 pub mod sharedparley;
 use shaping::ShapeBuffer;
-pub use shaping::{AbstractFont, CheckedAdd, FontMetrics, Glyph, TextShaper};
+pub use shaping::{AbstractFont, CheckedAdd, DivCount, FontMetrics, Glyph, TextShaper};
 
 mod linebreaker;
 pub use linebreaker::TextLine;
@@ -422,13 +422,7 @@ impl<Font: AbstractFont> TextParagraphLayout<'_, Font> {
         if line_height <= Font::Length::zero() {
             return usize::MAX;
         }
-        let mut lines = 0usize;
-        let mut height = Font::Length::zero();
-        while height + line_height <= self.max_height {
-            height += line_height;
-            lines += 1;
-        }
-        lines
+        self.max_height.div_count(line_height)
     }
 
     /// Returns the leading edge of the glyph at the given byte offset

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -89,6 +89,7 @@ pub trait TextShaper {
         + core::cmp::PartialOrd
         + core::ops::Mul<Self::LengthPrimitive, Output = Self::Length>
         + core::ops::Div<Self::LengthPrimitive, Output = Self::Length>
+        + DivCount
         + core::fmt::Debug;
     // Shapes the given string and emits the result into the given glyphs buffer.
     fn shape_text<GlyphStorage: core::iter::Extend<Glyph<Self::Length>>>(
@@ -97,6 +98,35 @@ pub trait TextShaper {
         glyphs: &mut GlyphStorage,
     );
     fn glyph_for_char(&self, ch: char) -> Option<Glyph<Self::Length>>;
+}
+
+/// How many times one length fits into another of the same unit.
+/// euclid's `Length / Length` produces a `Scale` rather than a plain number, so the division the
+/// paragraph layout needs is spelled out here instead of as a `core::ops::Div` bound.
+pub trait DivCount {
+    /// The number of whole `divisor`s in `self`, truncated, and zero when that count is negative.
+    /// `divisor` must not be zero.
+    fn div_count(self, divisor: Self) -> usize;
+}
+
+impl DivCount for f32 {
+    fn div_count(self, divisor: Self) -> usize {
+        // Casts from float saturate, so a negative or NaN ratio ends up at zero.
+        (self / divisor) as usize
+    }
+}
+
+impl DivCount for i16 {
+    fn div_count(self, divisor: Self) -> usize {
+        // Widen so that i16::MIN / -1 can't overflow.
+        (i32::from(self) / i32::from(divisor)).max(0) as usize
+    }
+}
+
+impl<T: DivCount + Clone, U> DivCount for euclid::Length<T, U> {
+    fn div_count(self, divisor: Self) -> usize {
+        self.get().div_count(divisor.get())
+    }
 }
 
 pub trait FontMetrics<Length: Copy + core::ops::Sub<Output = Length>> {
@@ -257,6 +287,24 @@ impl<Length> ShapeBuffer<Length> {
 
         Self { glyphs, text_runs }
     }
+}
+
+#[test]
+fn test_div_count() {
+    assert_eq!(9.0_f32.div_count(3.0), 3);
+    assert_eq!(10.0_f32.div_count(3.0), 3);
+    assert_eq!((-10.0_f32).div_count(3.0), 0);
+    assert_eq!(3.0_f32.div_count(10.0), 0);
+    assert_eq!(f32::NAN.div_count(16.0), 0);
+
+    assert_eq!(i16::MIN.div_count(-1), 32768);
+
+    type IntLen = euclid::Length<i16, euclid::UnknownUnit>;
+    assert_eq!(IntLen::new(10).div_count(IntLen::new(3)), 3);
+    assert_eq!(IntLen::new(-10).div_count(IntLen::new(3)), 0);
+
+    type FloatLen = euclid::Length<f32, euclid::UnknownUnit>;
+    assert_eq!(FloatLen::new(10.).div_count(FloatLen::new(3.)), 3);
 }
 
 #[test]


### PR DESCRIPTION
max_lines_that_fit added up line heights in a loop because TextShaper::Length had no length by length division: euclid's Length / Length gives a Scale, not a number. Add a small LengthDiv trait for that, with impls for f32, i16 and any euclid Length whose primitive implements it, and do a single division.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
