### PR TITLE
Changing a `borrow_mut()` to `try_burrow_mut()` for defensive reasons

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1698,7 +1698,9 @@ impl WindowAdapterInternal for WinitWindowAdapter {
     #[cfg(enable_accesskit)]
     fn handle_focus_change(&self, _old: Option<ItemRc>, _new: Option<ItemRc>) {
         let Some(accesskit_adapter_cell) = self.accesskit_adapter() else { return };
-        accesskit_adapter_cell.borrow_mut().handle_focus_item_change();
+        if let Ok(mut a) = accesskit_adapter_cell.try_borrow_mut() {
+            a.handle_focus_item_change();
+        }
     }
 
     #[cfg(enable_accesskit)]


### PR DESCRIPTION
This is something that I have observed, even if a reliable reproduction scenario could not be identified.  This is almost certainly a workaround for other bad behavior that should be fixed, but avoiding a panic is a good thing.
