### PR TITLE
compiler: don't let default values force a bigger native item

### DIFF
--- a/internal/compiler/passes/resolve_native_classes.rs
+++ b/internal/compiler/passes/resolve_native_classes.rs
@@ -3,17 +3,19 @@
 
 //! After inlining and moving declarations, all Element::base_type should be Type::BuiltinElement. This pass resolves them
 //! to NativeClass and picking a variant that only contains the used properties.
+//! The default values of the properties the variant doesn't have are dropped along with them.
 
 use smol_str::SmolStr;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use crate::langtype::{ElementType, NativeClass};
+use crate::expression_tree::{BindingExpression, Expression};
+use crate::langtype::{BuiltinElement, BuiltinPropertyDefault, ElementType, NativeClass};
 use crate::object_tree::{Component, recurse_elem_including_sub_components};
 
 pub fn resolve_native_classes(component: &Component) {
     recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
-        let new_native_class = {
+        let (new_native_class, unused_defaults) = {
             let elem = elem.borrow();
 
             let base_type = match &elem.base_type {
@@ -31,10 +33,17 @@ pub fn resolve_native_classes(component: &Component) {
                 }
             };
 
+            let defaults: Vec<&SmolStr> = elem
+                .bindings_including_synthetic()
+                .filter(|(name, binding)| is_default_value(base_type, name, &binding.borrow()))
+                .map(|(name, _)| name)
+                .collect();
+
             let analysis = elem.property_analysis.borrow();
             let native_properties_used: HashSet<_> = elem
                 .bindings_including_synthetic()
                 .map(|(k, _)| k)
+                .filter(|k| !defaults.contains(k))
                 .chain(analysis.iter().filter(|(_, v)| v.is_used()).map(|(k, _)| k))
                 .filter(|k| {
                     !elem.property_declarations.contains_key(*k)
@@ -42,14 +51,61 @@ pub fn resolve_native_classes(component: &Component) {
                 })
                 .collect();
 
-            select_minimal_class_based_on_property_usage(
-                &elem.base_type.as_builtin().native_class,
+            let new_native_class = select_minimal_class_based_on_property_usage(
+                &base_type.native_class,
                 native_properties_used.into_iter(),
-            )
+            );
+
+            // A referenced property keeps its default: the reference materializes it in the
+            // enclosing component, which is how a lowered layout still reads its own alignment.
+            let unused_defaults: Vec<SmolStr> = defaults
+                .into_iter()
+                .filter(|name| {
+                    new_native_class.lookup_property(name).is_none()
+                        && !elem.named_references.is_referenced(name)
+                })
+                .cloned()
+                .collect();
+
+            (new_native_class, unused_defaults)
         };
 
-        elem.borrow_mut().base_type = ElementType::Native(new_native_class);
+        let mut elem = elem.borrow_mut();
+        for name in unused_defaults {
+            elem.take_binding_including_synthetic(&name);
+        }
+        elem.base_type = ElementType::Native(new_native_class);
     })
+}
+
+/// Whether this binding just sets the property to the default value declared in
+/// `builtins.slint`, so that nothing changes if it goes away.
+fn is_default_value(base_type: &BuiltinElement, name: &str, binding: &BindingExpression) -> bool {
+    let Some(BuiltinPropertyDefault::Expr(default)) =
+        base_type.properties.get(name).map(|p| &p.default_value)
+    else {
+        return false;
+    };
+    binding.animation.is_none()
+        && binding.two_way_bindings.is_empty()
+        && same_literal(binding.value_expression(), default)
+}
+
+/// Anything that isn't a literal compares as different, so a computed binding counts as a use.
+fn same_literal(a: &Expression, b: &Expression) -> bool {
+    match (a, b) {
+        (Expression::NumberLiteral(a, a_unit), Expression::NumberLiteral(b, b_unit)) => {
+            a == b && a_unit == b_unit
+        }
+        (Expression::BoolLiteral(a), Expression::BoolLiteral(b)) => a == b,
+        (Expression::StringLiteral(a), Expression::StringLiteral(b)) => a == b,
+        (Expression::EnumerationValue(a), Expression::EnumerationValue(b)) => a == b,
+        // Colors and other converted literals arrive wrapped in a cast.
+        (Expression::Cast { from: a, to: a_type }, Expression::Cast { from: b, to: b_type }) => {
+            a_type == b_type && same_literal(a, b)
+        }
+        _ => false,
+    }
 }
 
 fn lookup_property_distance(mut class: Arc<NativeClass>, name: &str) -> (usize, Arc<NativeClass>) {
@@ -120,6 +176,26 @@ fn test_select_minimal_class_based_on_property_usage() {
     );
 
     assert_eq!(reduce_to_second.class_name, second.class_name);
+}
+
+#[test]
+fn builtin_defaults_are_comparable() {
+    let tr = crate::typeregister::TypeRegister::builtin(
+        &crate::symbol_counters::SymbolCounters::shared(),
+    );
+    let tr = tr.borrow();
+    for (name, element) in tr.all_elements() {
+        let ElementType::Builtin(element) = element else { continue };
+        for (property, info) in &element.properties {
+            if let BuiltinPropertyDefault::Expr(default) = &info.default_value {
+                assert!(
+                    same_literal(default, &default.clone()),
+                    "the default of {name}::{property} is a shape same_literal doesn't compare, \
+                     so the property always counts as used: {default:?}"
+                );
+            }
+        }
+    }
 }
 
 #[test]

--- a/internal/compiler/tests/native_class_selection.rs
+++ b/internal/compiler/tests/native_class_selection.rs
@@ -1,0 +1,124 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! `resolve_native_classes` picks the most minimal native class that still has every property the
+//! element uses, and a binding that just repeats the default value from `builtins.slint` isn't a
+//! use of it.
+//!
+//! The other half of the pass, keeping the default of a property that's only read through a
+//! `NamedReference`, is covered by the flexbox cases in `tests/cases/layout`: their layout is
+//! lowered away and then reads its `alignment` default from the element it left behind.
+
+use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::generator::OutputFormat;
+use i_slint_compiler::object_tree::{ElementRc, recurse_elem};
+use i_slint_compiler::parser::parse;
+use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
+use smol_str::{SmolStr, ToSmolStr};
+
+fn compile(source: &str) -> ElementRc {
+    let mut diagnostics = BuildDiagnostics::default();
+    let syntax_node = parse(source.into(), None, &mut diagnostics);
+    let compiler_config = CompilerConfiguration::new(OutputFormat::Interpreter);
+    let (doc, diagnostics, _) =
+        spin_on::spin_on(compile_syntax_node(syntax_node, diagnostics, compiler_config));
+    assert!(!diagnostics.has_errors(), "{:?}", diagnostics.to_string_vec());
+    doc.last_exported_component().unwrap().root_element.clone()
+}
+
+/// The compiler appends a unique number to the id, so match on the name before it.
+fn find_by_id(root: &ElementRc, id: &str) -> ElementRc {
+    let mut result = None;
+    recurse_elem(root, &(), &mut |element, _| {
+        if element.borrow().id.rsplit_once('-').is_some_and(|(name, _)| name == id) {
+            result = Some(element.clone());
+        }
+    });
+    result.unwrap_or_else(|| panic!("no element with id {id}"))
+}
+
+fn class_of(root: &ElementRc, id: &str) -> SmolStr {
+    find_by_id(root, id).borrow().base_type.to_smolstr()
+}
+
+fn has_line_height_factor(root: &ElementRc, id: &str) -> bool {
+    find_by_id(root, id).borrow().is_binding_set("line-height-factor", false)
+}
+
+#[test]
+fn text_without_complex_properties_is_a_simple_text() {
+    let root = compile(
+        r#"
+export component TestCase inherits Window {
+    plain := Text { text: "hello"; }
+}
+"#,
+    );
+    assert_eq!(class_of(&root, "plain"), "SimpleText");
+    assert!(!has_line_height_factor(&root, "plain"));
+}
+
+#[test]
+fn complex_text_keeps_the_default_line_height_factor() {
+    let root = compile(
+        r#"
+export component TestCase inherits Window {
+    fancy := Text { text: "hello"; font-family: "Arial"; }
+}
+"#,
+    );
+    assert_eq!(class_of(&root, "fancy"), "ComplexText");
+    // Without the binding the item would keep its zero default and collapse the lines.
+    assert!(has_line_height_factor(&root, "fancy"));
+}
+
+#[test]
+fn setting_the_line_height_factor_to_its_default_is_still_a_simple_text() {
+    let root = compile(
+        r#"
+export component TestCase inherits Window {
+    plain := Text { text: "hello"; line-height-factor: 1; }
+}
+"#,
+    );
+    assert_eq!(class_of(&root, "plain"), "SimpleText");
+}
+
+#[test]
+fn a_computed_line_height_factor_selects_complex_text() {
+    let root = compile(
+        r#"
+export component TestCase inherits Window {
+    in property <float> factor: 1;
+    computed := Text { text: "hello"; line-height-factor: root.factor; }
+}
+"#,
+    );
+    assert_eq!(class_of(&root, "computed"), "ComplexText");
+}
+
+#[test]
+fn setting_the_line_height_factor_selects_complex_text() {
+    let root = compile(
+        r#"
+export component TestCase inherits Window {
+    spaced := Text { text: "hello"; line-height-factor: 1.5; }
+}
+"#,
+    );
+    assert_eq!(class_of(&root, "spaced"), "ComplexText");
+}
+
+#[test]
+fn reading_the_line_height_factor_selects_complex_text() {
+    let root = compile(
+        r#"
+export component TestCase inherits Window {
+    source := Text { text: "hello"; }
+    reader := Text { text: source.line-height-factor; }
+}
+"#,
+    );
+    assert_eq!(class_of(&root, "source"), "ComplexText");
+    assert_eq!(class_of(&root, "reader"), "SimpleText");
+}


### PR DESCRIPTION
Every default from builtins.slint becomes a real binding on the element, and the pass that picks the native item counted those bindings as uses. So once Text got a line-height-factor default, every Text became a ComplexText.

Compare the binding against the declared default instead: if it sets the same value, the property isn't in use. A default the chosen item doesn't have is dropped with it, unless something still refers to it.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
