### PR TITLE
python: Fix high CPU use from asyncio socket traffic

### DIFF
--- a/api/python/slint/async_adapter.rs
+++ b/api/python/slint/async_adapter.rs
@@ -1,7 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::{PyTraverseError, gc::PyVisit};
@@ -26,10 +28,47 @@ impl std::os::windows::io::AsSocket for PyFdWrapper {
     }
 }
 
+/// A readiness future for one direction of the fd.
+///
+/// Must come from `readable_owned()` / `writable_owned()`: `poll_readable()` / `poll_writable()`
+/// discard readiness when the poll is deferred to another thread, and the reactor then spins.
+/// See https://github.com/slint-ui/slint/issues/12962 and smol-rs/async-io#78.
+type ReadinessFuture = smol::future::BoxedLocal<std::io::Result<()>>;
+
+/// One kind of readiness the selector asked to be told about.
+#[derive(Default)]
+struct ReadinessWatch {
+    callback: Option<Py<PyAny>>,
+    // Lives here, not in the polling task: the task outlives the adapter, and a lingering
+    // `Async` keeps the fd registered.
+    future: RefCell<Option<ReadinessFuture>>,
+}
+
+impl ReadinessWatch {
+    /// `None` when nothing is watching this direction, otherwise whether it became ready.
+    fn poll(
+        &self,
+        cx: &mut std::task::Context<'_>,
+        arm: impl FnOnce() -> ReadinessFuture,
+    ) -> Option<std::task::Poll<Py<PyAny>>> {
+        let mut future = self.future.borrow_mut();
+        let Some(callback) = self.callback.as_ref() else {
+            *future = None;
+            return None;
+        };
+        if future.get_or_insert_with(arm).as_mut().poll(cx).is_ready() {
+            *future = None;
+            Some(std::task::Poll::Ready(Python::attach(|py| callback.clone_ref(py))))
+        } else {
+            Some(std::task::Poll::Pending)
+        }
+    }
+}
+
 struct AdapterInner {
-    adapter: smol::Async<PyFdWrapper>,
-    readable_callback: Option<Py<PyAny>>,
-    writable_callback: Option<Py<PyAny>>,
+    adapter: Arc<smol::Async<PyFdWrapper>>,
+    readable: ReadinessWatch,
+    writable: ReadinessWatch,
 }
 
 #[pyclass(unsendable)]
@@ -46,9 +85,9 @@ impl AsyncAdapter {
         let fd = u64::try_from(fd).unwrap();
         AsyncAdapter {
             inner: Some(Rc::new(AdapterInner {
-                adapter: smol::Async::new(PyFdWrapper(fd)).unwrap(),
-                readable_callback: Default::default(),
-                writable_callback: Default::default(),
+                adapter: Arc::new(smol::Async::new(PyFdWrapper(fd)).unwrap()),
+                readable: Default::default(),
+                writable: Default::default(),
             })),
             task: None,
         }
@@ -56,13 +95,13 @@ impl AsyncAdapter {
 
     fn wait_for_readable(&mut self, callback: Py<PyAny>) {
         self.restart_after_mut_inner_access(|inner| {
-            inner.readable_callback.replace(callback);
+            inner.readable.callback.replace(callback);
         });
     }
 
     fn wait_for_writable(&mut self, callback: Py<PyAny>) {
         self.restart_after_mut_inner_access(|inner| {
-            inner.writable_callback.replace(callback);
+            inner.writable.callback.replace(callback);
         });
     }
 
@@ -73,7 +112,7 @@ impl AsyncAdapter {
         // collectable.
         if let Some(inner) = self.inner.as_ref() {
             for callback in
-                [&inner.readable_callback, &inner.writable_callback].into_iter().flatten()
+                [&inner.readable.callback, &inner.writable.callback].into_iter().flatten()
             {
                 visit.call(callback)?;
             }
@@ -117,23 +156,12 @@ impl AsyncAdapter {
                         return std::task::Poll::Ready(());
                     };
 
-                    let readable_poll_status: Option<std::task::Poll<Py<PyAny>>> =
-                        inner.readable_callback.as_ref().map(|callback| {
-                            if inner.adapter.poll_readable(cx).is_ready() {
-                                std::task::Poll::Ready(Python::attach(|py| callback.clone_ref(py)))
-                            } else {
-                                std::task::Poll::Pending
-                            }
-                        });
-
-                    let writable_poll_status: Option<std::task::Poll<Py<PyAny>>> =
-                        inner.writable_callback.as_ref().map(|callback| {
-                            if inner.adapter.poll_writable(cx).is_ready() {
-                                std::task::Poll::Ready(Python::attach(|py| callback.clone_ref(py)))
-                            } else {
-                                std::task::Poll::Pending
-                            }
-                        });
+                    let readable_poll_status = inner
+                        .readable
+                        .poll(cx, || Box::pin(inner.adapter.clone().readable_owned()));
+                    let writable_poll_status = inner
+                        .writable
+                        .poll(cx, || Box::pin(inner.adapter.clone().writable_owned()));
 
                     let fd = inner.adapter.get_ref().0;
 

--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -4,11 +4,13 @@
 # cSpell:ignore socketpair
 
 import asyncio
+import contextlib
 import gc
 import platform
 import socket
 import sys
 import threading
+import time
 import typing
 import weakref
 from datetime import timedelta
@@ -443,6 +445,56 @@ def test_cancelling_handle_disarms_native_timer() -> None:
 
         await asyncio.sleep(0.05)
         assert not called
+
+        slint.quit_event_loop()
+
+    slint.run_event_loop(run())
+
+
+def test_socket_traffic_does_not_busy_loop() -> None:
+    """A trickle of socket data must not keep the event loop awake.
+
+    See https://github.com/slint-ui/slint/issues/12962.
+    """
+    duration = 2.0
+    interval = 0.1
+
+    async def send_periodically(
+        _reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        with contextlib.suppress(ConnectionResetError, BrokenPipeError):
+            while True:
+                writer.write(b"x")
+                await asyncio.sleep(interval)
+
+    async def run() -> None:
+        received = 0
+
+        server = await asyncio.start_server(send_periodically, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+        async def drain() -> None:
+            nonlocal received
+            while chunk := await reader.read(4096):
+                received += len(chunk)
+
+        drainer = asyncio.create_task(drain())
+        cpu_before = time.process_time()
+        await asyncio.sleep(duration)
+        cpu_seconds = time.process_time() - cpu_before
+
+        drainer.cancel()
+        writer.close()
+        server.close()
+
+        # Liveness only, so that the CPU assert can't pass vacuously. Not a rate check:
+        # timer granularity makes the rate unreliable on a loaded CI runner.
+        assert received > 0, "no data received"
+        # Before the fix: 60-100% of a core. Idle: under 5%.
+        assert cpu_seconds < duration * 0.25, (
+            f"burned {cpu_seconds:.2f}s of CPU over {duration}s ({received} bytes)"
+        )
 
         slint.quit_event_loop()
 


### PR DESCRIPTION
`Async::poll_readable()` / `poll_writable()` discard readiness when the poll is deferred to another thread, which is what happens when Slint wakes the task through the platform's event loop. The fd was never drained, so the reactor re-armed and fired again at full speed: a socket receiving 10 bytes per second kept a core 60-100% busy. Drive readiness with `readable_owned()` / `writable_owned()` instead, which settle on the next event.

changelog: Python: Fixed high CPU usage while an asyncio socket receives data

Fixes #12962

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
