### PR TITLE
python: Don't let an ignored SIGINT fail the Ctrl-C test

### DIFF
--- a/api/python/slint/tests/test_async.py
+++ b/api/python/slint/tests/test_async.py
@@ -340,11 +340,15 @@ if sys.platform != "win32":
             _start_quit_watchdog(interrupted)
             await asyncio.Event().wait()
 
+        # A shell that starts the test run as a background job leaves SIGINT ignored, and
+        # run_event_loop() then rightly declines to claim a signal the caller opted out of.
+        previous = signal.signal(signal.SIGINT, signal.default_int_handler)
         try:
             with pytest.raises(KeyboardInterrupt):
                 slint.run_event_loop(run())
         finally:
             interrupted[0] = True
+            signal.signal(signal.SIGINT, previous)
 
 
 def test_sleep_does_not_leak_timers() -> None:


### PR DESCRIPTION
A shell that starts the test run as a background job leaves SIGINT set to SIG_IGN, so run_event_loop() rightly declines to claim it and the signal the test sends itself does nothing. Set the default disposition first, and put the old one back afterwards.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
