### PR TITLE
tests: use the Key enum instead of raw key codes

### DIFF
--- a/tests/cases/text/cursor_move.slint
+++ b/tests/cases/text/cursor_move.slint
@@ -13,34 +13,23 @@ export component TestCase inherits TextInput {
 
 /*
 ```rust
+use slint::platform::Key;
+use slint::SharedString;
 
-const UP_CODE: char = '\u{F700}';
-const DOWN_CODE: char = '\u{F701}';
-const LEFT_CODE: char = '\u{F702}';
-const RIGHT_CODE: char = '\u{F703}';
-const DEL_CODE: char = '\u{007f}';
-const BACK_CODE: char = '\u{0008}'; // backspace \b
-
-fn send_move_mod_modifier(instance: &TestCase, pressed: bool) {
-    if cfg!(not(target_os = "macos")) {
-        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), pressed);
-    }
-
-    if cfg!(target_os = "macos") {
-        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Alt.into(), pressed);
+fn press(instance: &TestCase, key: Key, times: usize) {
+    for _ in 0..times {
+        slint_testing::send_keyboard_string_sequence(instance, &SharedString::from(key));
     }
 }
 
+fn send_move_mod_modifier(instance: &TestCase, pressed: bool) {
+    let modifier = if cfg!(target_os = "macos") { Key::Alt } else { Key::Control };
+    slint_testing::send_keyboard_char(instance, modifier.into(), pressed);
+}
+
 fn send_move_mod_shift_modifier(instance: &TestCase, pressed: bool) {
-    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), pressed);
-
-    if cfg!(not(target_os = "macos")) {
-        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), pressed);
-    }
-
-    if cfg!(target_os = "macos") {
-        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Alt.into(), pressed);
-    }
+    slint_testing::send_keyboard_char(instance, Key::Shift.into(), pressed);
+    send_move_mod_modifier(instance, pressed);
 }
 
 let instance = TestCase::new().unwrap();
@@ -51,192 +40,165 @@ slint_testing::send_keyboard_string_sequence(&instance, "Test");
 assert_eq!(instance.get_test_text(), "Test");
 assert!(!instance.get_has_selection());
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+press(&instance, Key::LeftArrow, 1);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+press(&instance, Key::Backspace, 1);
 assert!(!instance.get_has_selection());
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+press(&instance, Key::Backspace, 1);
 
 assert_eq!(instance.get_test_text(), "Te");
 
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+press(&instance, Key::RightArrow, 4);
 assert_eq!(instance.get_test_cursor_pos(), 2);
 
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+press(&instance, Key::LeftArrow, 4);
 assert_eq!(instance.get_test_cursor_pos(), 0);
 
 send_move_mod_shift_modifier(&instance, true);
-slint_testing::send_keyboard_string_sequence(&instance, &DOWN_CODE.to_string());
+press(&instance, Key::DownArrow, 1);
 send_move_mod_shift_modifier(&instance, false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 2);
 assert_eq!(instance.get_test_anchor_pos(), 0);
 
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+press(&instance, Key::RightArrow, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 2);
 assert_eq!(instance.get_test_anchor_pos(), 2);
 
 send_move_mod_shift_modifier(&instance, true);
-slint_testing::send_keyboard_string_sequence(&instance, &UP_CODE.to_string());
+press(&instance, Key::UpArrow, 1);
 send_move_mod_shift_modifier(&instance, false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 0);
 assert_eq!(instance.get_test_anchor_pos(), 2);
 
 // Select all and start over
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &"a");
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "a");
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), false);
+press(&instance, Key::Backspace, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_text(), "");
 
 slint_testing::send_keyboard_string_sequence(&instance, "abcdefghi");
 assert_eq!(instance.get_test_text(), "abcdefghi");
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+press(&instance, Key::LeftArrow, 3);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+press(&instance, Key::LeftArrow, 2);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 4);
 assert_eq!(instance.get_test_anchor_pos(), 6);
 
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+press(&instance, Key::RightArrow, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 6);
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+press(&instance, Key::LeftArrow, 2);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 4);
 assert_eq!(instance.get_test_anchor_pos(), 6);
 
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+press(&instance, Key::LeftArrow, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 4);
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+press(&instance, Key::RightArrow, 2);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 6);
 assert_eq!(instance.get_test_anchor_pos(), 4);
 
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+press(&instance, Key::LeftArrow, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 4);
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+press(&instance, Key::RightArrow, 2);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 6);
 assert_eq!(instance.get_test_anchor_pos(), 4);
 
-slint_testing::send_keyboard_string_sequence(&instance, &RIGHT_CODE.to_string());
+press(&instance, Key::RightArrow, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 6);
 
 // Select all and start over
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &"a");
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "a");
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), false);
+press(&instance, Key::Backspace, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_text(), "");
 
 slint_testing::send_keyboard_string_sequence(&instance, "First Word Third Word Fifth");
 assert_eq!(instance.get_test_text(), "First Word Third Word Fifth");
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+press(&instance, Key::LeftArrow, 5);
 assert_eq!(instance.get_test_cursor_pos(), 22);
 
 // Delete word backwards when the cursor is between the 'F' of Fifth and the leading space.
 // -> Delete "Word"
 send_move_mod_modifier(&instance, true);
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+press(&instance, Key::Backspace, 1);
 send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Word Third Fifth");
 
 // Once more :-)
 send_move_mod_modifier(&instance, true);
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+press(&instance, Key::Backspace, 1);
 send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Word Fifth");
 
 // Move cursor between the "d" of "Word" and the trailing space
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+press(&instance, Key::LeftArrow, 6);
 
 // Delete word forwards
 send_move_mod_modifier(&instance, true);
-slint_testing::send_keyboard_string_sequence(&instance, &DEL_CODE.to_string());
+press(&instance, Key::Delete, 1);
 send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Fifth");
 
 // Select all and start over
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &"a");
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, "a");
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), false);
+press(&instance, Key::Backspace, 1);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_text(), "");
 
 slint_testing::send_keyboard_string_sequence(&instance, "First Second");
 assert_eq!(instance.get_test_text(), "First Second");
 
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+press(&instance, Key::LeftArrow, 2);
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+press(&instance, Key::LeftArrow, 2);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 
 // When there's an existing selection, always just delete that
 send_move_mod_modifier(&instance, true);
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+press(&instance, Key::Backspace, 1);
 send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "First Send");
 
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+press(&instance, Key::LeftArrow, 5);
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+press(&instance, Key::LeftArrow, 1);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
 
 // When there's an existing selection, always just delete that
 send_move_mod_modifier(&instance, true);
-slint_testing::send_keyboard_string_sequence(&instance, &DEL_CODE.to_string());
+press(&instance, Key::Delete, 1);
 send_move_mod_modifier(&instance, false);
 assert_eq!(instance.get_test_text(), "Fist Send");
 ```

--- a/tests/cases/text/cursor_move_grapheme.slint
+++ b/tests/cases/text/cursor_move_grapheme.slint
@@ -13,9 +13,8 @@ export component TestCase inherits TextInput {
 
 /*
 ```rust
-
-const LEFT_CODE: char = '\u{F702}';
-const BACK_CODE: char = '\u{0008}'; // backspace \b
+use slint::platform::Key;
+use slint::SharedString;
 
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 50., 50.);
@@ -26,11 +25,11 @@ assert_eq!(instance.get_test_text(), "e\u{0301}");
 assert!(!instance.get_has_selection());
 
 // Test that selecting the grapheme works
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::LeftArrow));
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
 assert!(instance.get_has_selection());
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backspace));
 
 assert_eq!(instance.get_test_text(), "");
 
@@ -38,7 +37,7 @@ slint_testing::send_keyboard_string_sequence(&instance, "e\u{0301}");
 
 // Test that backspace does not operate on the grapheme and just removes the
 // diacritic.
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backspace));
 assert_eq!(instance.get_test_cursor_pos(), 1);
 assert_eq!(instance.get_test_text(), "e");
 ```

--- a/tests/cases/text/cursor_move_wrapped.slint
+++ b/tests/cases/text/cursor_move_wrapped.slint
@@ -12,7 +12,8 @@ export component TestCase inherits TextInput {
 
 /*
 ```rust
-const UP_CODE: char = '\u{F700}';
+use slint::platform::Key;
+use slint::SharedString;
 
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 30., 10.);
@@ -26,7 +27,7 @@ assert_eq!(instance.get_test_cursor_pos(), text.len() as i32);
 let mut pos = instance.get_test_cursor_pos();
 let mut steps = 0;
 while pos != 0 {
-    slint_testing::send_keyboard_string_sequence(&instance, &UP_CODE.to_string());
+    slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::UpArrow));
     let next = instance.get_test_cursor_pos();
     assert!(next < pos, "Up did not move the caret backwards; stuck at {next}");
     pos = next;

--- a/tests/cases/text/cut.slint
+++ b/tests/cases/text/cut.slint
@@ -13,8 +13,8 @@ export component TestCase inherits TextInput {
 
 /*
 ```rust
-
-const LEFT_CODE: char = '\u{F702}';
+use slint::platform::Key;
+use slint::SharedString;
 
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 50., 50.);
@@ -24,16 +24,16 @@ slint_testing::send_keyboard_string_sequence(&instance, "Test");
 assert_eq!(instance.get_test_text(), "Test");
 assert!(!instance.get_has_selection());
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "a");
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::LeftArrow));
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::LeftArrow));
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "x");
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), false);
 assert!(!instance.get_has_selection());
 assert_eq!(instance.get_test_text(), "st");
 assert_eq!(instance.get_test_cursor_pos(), 0);

--- a/tests/cases/text/select_all.slint
+++ b/tests/cases/text/select_all.slint
@@ -13,6 +13,7 @@ export component TestCase inherits TextInput {
 
 /*
 ```rust
+use slint::platform::Key;
 
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 50., 50.);
@@ -22,9 +23,9 @@ slint_testing::send_keyboard_string_sequence(&instance, "Test");
 assert_eq!(instance.get_test_text(), "Test");
 assert!(!instance.get_has_selection());
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, "a");
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 4);
 assert_eq!(instance.get_test_anchor_pos(), 0);

--- a/tests/cases/text/surrogate_cursor.slint
+++ b/tests/cases/text/surrogate_cursor.slint
@@ -13,9 +13,8 @@ export component TestCase inherits TextInput {
 
 /*
 ```rust
-
-const LEFT_CODE: char = '\u{F702}';
-const BACK_CODE: char = '\u{0008}'; // backspace \b
+use slint::platform::Key;
+use slint::SharedString;
 
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 50., 50.);
@@ -25,12 +24,12 @@ slint_testing::send_keyboard_string_sequence(&instance, "😍");
 assert_eq!(instance.get_test_text(), "😍");
 assert!(!instance.get_has_selection());
 
-slint_testing::send_keyboard_char(&instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_char(&instance, Key::Shift.into(), true);
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::LeftArrow));
 assert!(instance.get_has_selection());
 assert_eq!(instance.get_test_cursor_pos(), 0);
 assert_eq!(instance.get_test_anchor_pos(), 4);
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backspace));
 assert!(!instance.get_has_selection());
 
 assert_eq!(instance.get_test_text(), "");

--- a/tests/cases/text/text_change.slint
+++ b/tests/cases/text/text_change.slint
@@ -18,8 +18,8 @@ export component TestCase inherits Window {
 
 /*
 ```rust
-
-const LEFT_CODE: char = '\u{F702}';
+use slint::platform::Key;
+use slint::SharedString;
 
 let instance = TestCase::new().unwrap();
 slint_testing::send_mouse_click(&instance, 5., 5.);
@@ -36,7 +36,7 @@ instance.set_text("Yo".into());
 // The realignment runs in a change handler, so pump them before observing the offset.
 slint_testing::mock_elapsed_time(0);
 assert_eq!(instance.get_test_cursor_pos(), 2);
-slint_testing::send_keyboard_string_sequence(&instance, &LEFT_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::LeftArrow));
 assert_eq!(instance.get_test_cursor_pos(), 1);
 ```
 */

--- a/tests/cases/text/undo_redo.slint
+++ b/tests/cases/text/undo_redo.slint
@@ -23,19 +23,20 @@ export component TestCase inherits TextInput {
 
 /*
 ```rust
-const BACK_CODE: char = '\u{0008}'; // backspace \b
+use slint::platform::Key;
+use slint::SharedString;
 
 fn ctrl_key(instance: &TestCase, key: &str, shift: bool) {
-    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), true);
+    slint_testing::send_keyboard_char(instance, Key::Control.into(), true);
     if shift {
-        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), true);
+        slint_testing::send_keyboard_char(instance, Key::Shift.into(), true);
     }
     slint_testing::send_keyboard_string_sequence(instance, key);
 
     // release
-    slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Control.into(), false);
+    slint_testing::send_keyboard_char(instance, Key::Control.into(), false);
     if shift {
-        slint_testing::send_keyboard_char(instance, slint::private_unstable_api::re_exports::Key::Shift.into(), false);
+        slint_testing::send_keyboard_char(instance, Key::Shift.into(), false);
     }
 }
 
@@ -63,7 +64,7 @@ assert_eq!(instance.get_test_text(), "First line\nSecond line");
 instance.invoke_do_select_all();
 assert!(instance.get_has_selection());
 
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backspace));
 assert_eq!(instance.get_test_text(), "");
 assert!(!instance.get_has_selection());
 
@@ -75,7 +76,7 @@ assert!(instance.get_has_selection());
 
 // clear and type fresh text
 instance.invoke_do_select_all();
-slint_testing::send_keyboard_string_sequence(&instance, &BACK_CODE.to_string());
+slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Backspace));
 assert_eq!(instance.get_test_text(), "");
 // undo the delete + select to get back to clean slate
 ctrl_key(&instance, "z", false);


### PR DESCRIPTION
The text tests spelled arrow keys, backspace and delete as characters from the Unicode private use area. Use `slint::platform::Key` instead, which is what the other tests do.

In cursor_move.slint, replace the long runs of repeated keystroke lines with a small `press()` helper.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
