### PR TITLE
Hide redundant elements of compound widgets in the a11y tree

### DIFF
--- a/internal/compiler/widgets/common/internal-components.slint
+++ b/internal/compiler/widgets/common/internal-components.slint
@@ -88,6 +88,7 @@ export component IconButton {
             x: (parent.width - self.width) / 2;
             width: root.style.icon-size;
             colorize: root.style.foreground;
+            accessible-role: none;
         }
     }
 
@@ -154,6 +155,7 @@ export component SelectionButton {
             font-weight: root.style.font-weight;
             color: root.style.foreground;
             vertical-alignment: center;
+            accessible-role: none;
         }
 
         icon-image := Image {
@@ -161,6 +163,7 @@ export component SelectionButton {
             width: root.style.icon-size;
             colorize: root.style.foreground;
             transform-rotation: root.checked ? 180deg : 0;
+            accessible-role: none;
 
             animate transform-rotation { duration: 250ms; }
         }

--- a/internal/compiler/widgets/common/radiogroup-base.slint
+++ b/internal/compiler/widgets/common/radiogroup-base.slint
@@ -163,6 +163,7 @@ export component RadioGroupImplBase {
             font-size: root.title-font-size;
             font-weight: root.title-font-weight;
             text: root.title;
+            accessible-role: none;
         }
 
         GridLayout {

--- a/internal/compiler/widgets/cosmic/button.slint
+++ b/internal/compiler/widgets/cosmic/button.slint
@@ -59,6 +59,7 @@ export component Button {
                 width: root.icon-size;
                 min-height: root.icon-size;
                 colorize: root.colorize-icon ? root.text-color : transparent;
+                accessible-role: none;
             }
 
             if (root.text != ""): Text {

--- a/internal/compiler/widgets/cosmic/checkbox.slint
+++ b/internal/compiler/widgets/cosmic/checkbox.slint
@@ -92,6 +92,7 @@ export component CheckBox {
             font-weight: root.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 }

--- a/internal/compiler/widgets/cosmic/groupbox.slint
+++ b/internal/compiler/widgets/cosmic/groupbox.slint
@@ -23,6 +23,7 @@ export component GroupBox {
             font-size: CosmicFontSettings.body-strong.font-size;
             font-weight: CosmicFontSettings.body-strong.font-weight;
             text: root.title;
+            accessible-role: none;
         }
 
         Rectangle {

--- a/internal/compiler/widgets/cosmic/radiogroup.slint
+++ b/internal/compiler/widgets/cosmic/radiogroup.slint
@@ -53,6 +53,7 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
             color: root.text-color;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 }

--- a/internal/compiler/widgets/cosmic/spinbox.slint
+++ b/internal/compiler/widgets/cosmic/spinbox.slint
@@ -26,6 +26,7 @@ export component SpinBoxButton {
             vertical-alignment: center;
             text: root.text;
             color:CosmicPalette.control-foreground;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/cosmic/switch.slint
+++ b/internal/compiler/widgets/cosmic/switch.slint
@@ -102,6 +102,7 @@ export component Switch {
             color: root.text-color;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 }

--- a/internal/compiler/widgets/cupertino/button.slint
+++ b/internal/compiler/widgets/cupertino/button.slint
@@ -123,6 +123,7 @@ export component Button {
             min-height: root.icon-size;
             opacity: root.enabled ? 1 : 0.5;
             colorize: root.colorize-icon ? root.text-color : transparent;
+            accessible-role: none;
         }
 
         if (root.text != "") : Text {

--- a/internal/compiler/widgets/cupertino/checkbox.slint
+++ b/internal/compiler/widgets/cupertino/checkbox.slint
@@ -127,6 +127,7 @@ export component CheckBox {
             font-weight: root.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/cupertino/groupbox.slint
+++ b/internal/compiler/widgets/cupertino/groupbox.slint
@@ -23,6 +23,7 @@ export component GroupBox {
             font-size: CupertinoFontSettings.body-strong.font-size;
             font-weight: CupertinoFontSettings.body-strong.font-weight;
             text: root.title;
+            accessible-role: none;
         }
 
         Rectangle {

--- a/internal/compiler/widgets/cupertino/radiogroup.slint
+++ b/internal/compiler/widgets/cupertino/radiogroup.slint
@@ -48,6 +48,7 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
             color: CupertinoPalette.foreground;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/cupertino/switch.slint
+++ b/internal/compiler/widgets/cupertino/switch.slint
@@ -106,6 +106,7 @@ export component Switch {
             color: root.text-color;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/fluent/button.slint
+++ b/internal/compiler/widgets/fluent/button.slint
@@ -80,6 +80,7 @@ export component Button {
                 width: root.icon-size;
                 min-height: root.icon-size;
                 colorize: root.colorize-icon ? root.text-color : transparent;
+                accessible-role: none;
             }
 
             if (root.text != ""): Text {

--- a/internal/compiler/widgets/fluent/checkbox.slint
+++ b/internal/compiler/widgets/fluent/checkbox.slint
@@ -89,6 +89,7 @@ export component CheckBox {
             font-weight: root.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/fluent/groupbox.slint
+++ b/internal/compiler/widgets/fluent/groupbox.slint
@@ -23,6 +23,7 @@ export component GroupBox {
             font-size: FluentFontSettings.body-strong.font-size;
             font-weight: FluentFontSettings.body-strong.font-weight;
             text: root.title;
+            accessible-role: none;
         }
 
         Rectangle {

--- a/internal/compiler/widgets/fluent/radiogroup.slint
+++ b/internal/compiler/widgets/fluent/radiogroup.slint
@@ -63,6 +63,7 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
             color: root.text-color;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/fluent/switch.slint
+++ b/internal/compiler/widgets/fluent/switch.slint
@@ -110,6 +110,7 @@ export component Switch {
             color: root.text-color;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/material/button.slint
+++ b/internal/compiler/widgets/material/button.slint
@@ -49,6 +49,7 @@ component MaterialButtonBase {
             min-height: root.icon-size;
             opacity: root.text-opacity;
             colorize: root.colorize-icon ? root.text-color : transparent;
+            accessible-role: none;
         }
 
         if root.text != "": Text {

--- a/internal/compiler/widgets/material/checkbox.slint
+++ b/internal/compiler/widgets/material/checkbox.slint
@@ -135,6 +135,7 @@ export component CheckBox {
             vertical-stretch: 1;
             font-size: root.font-size;
             font-weight: root.font-weight;
+            accessible-role: none;
         }
     }
 

--- a/internal/compiler/widgets/material/groupbox.slint
+++ b/internal/compiler/widgets/material/groupbox.slint
@@ -32,6 +32,7 @@ export component GroupBox {
             overflow: elide;
             horizontal-alignment: center;
             text: root.title;
+            accessible-role: none;
 
             states [
                 disabled when !root.enabled : {

--- a/internal/compiler/widgets/material/radiogroup.slint
+++ b/internal/compiler/widgets/material/radiogroup.slint
@@ -62,6 +62,7 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
             font-weight: MaterialFontSettings.title-small.font-weight;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 }

--- a/internal/compiler/widgets/material/switch.slint
+++ b/internal/compiler/widgets/material/switch.slint
@@ -150,6 +150,7 @@ export component Switch {
                 vertical-stretch: 0;
                 font-size: MaterialFontSettings.title-small.font-size;
                 font-weight: MaterialFontSettings.title-small.font-weight;
+                accessible-role: none;
             }
         }
     }

--- a/internal/compiler/widgets/qt/radiogroup.slint
+++ b/internal/compiler/widgets/qt/radiogroup.slint
@@ -46,6 +46,7 @@ export component RadioButtonImpl inherits RadioButtonImplBase {
             color: #202020;
             vertical-alignment: center;
             horizontal-alignment: left;
+            accessible-role: none;
         }
     }
 


### PR DESCRIPTION
Widgets made of several simpler widgets should preferably appear as one in the accessibility tree unless the compounding widgets provide some functionality.

Removes labels of checkboxes, groupboxes, radio buttons, radio groups and switches. Removes images inside buttons.