### PR TITLE
Member shadowing follow-up: a private shadow is transparent from outside

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -3,7 +3,8 @@
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::langtype::{
-    BuiltinElement, BuiltinStruct, EnumerationValue, Function, Keys, Struct, Type,
+    BuiltinElement, BuiltinStruct, EnumerationValue, Function, Keys, PropertyLookupMode, Struct,
+    Type,
 };
 use crate::layout::Orientation;
 use crate::lookup::LookupCtx;
@@ -1905,7 +1906,10 @@ impl Expression {
         match self {
             Expression::PropertyReference(nr) => {
                 nr.mark_as_set();
-                let mut lookup = nr.element().borrow().lookup_property_by_internal_name(nr.name());
+                let mut lookup = nr
+                    .element()
+                    .borrow()
+                    .lookup_property(nr.name(), PropertyLookupMode::InternalName);
                 lookup.is_local_to_component &= ctx.is_local_element(&nr.element());
                 if lookup.property_visibility == PropertyVisibility::Constexpr {
                     ctx.diag.push_error(

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -481,25 +481,16 @@ impl PartialEq for ElementType {
 
 impl ElementType {
     /// Resolve a name written in `.slint` source.
-    pub fn lookup_property<'a>(&self, name: &'a str) -> PropertyLookupResult<'a> {
+    /// Resolve `name` in the given [`PropertyLookupMode`]. See
+    /// [`crate::object_tree::Element::lookup_property`]. Only a component can have shadowed members,
+    /// so the other bases ignore the mode.
+    pub fn lookup_property<'a>(
+        &self,
+        name: &'a str,
+        mode: PropertyLookupMode,
+    ) -> PropertyLookupResult<'a> {
         match self {
-            Self::Component(c) => c.root_element.borrow().lookup_property(name),
-            _ => self.lookup_non_component_property(name),
-        }
-    }
-
-    /// Resolve an internal name, see [`crate::object_tree::Element::lookup_property_by_internal_name`].
-    pub fn lookup_property_by_internal_name<'a>(&self, name: &'a str) -> PropertyLookupResult<'a> {
-        match self {
-            Self::Component(c) => c.root_element.borrow().lookup_property_by_internal_name(name),
-            _ => self.lookup_non_component_property(name),
-        }
-    }
-
-    /// Only a component can have shadowed members, so the other bases resolve either name the same.
-    fn lookup_non_component_property<'a>(&self, name: &'a str) -> PropertyLookupResult<'a> {
-        match self {
-            Self::Component(_) => unreachable!("handled by the callers"),
+            Self::Component(c) => c.root_element.borrow().lookup_property(name, mode),
             Self::Builtin(b) => {
                 let resolved_name =
                     if let Some(alias_name) = b.native_class.lookup_alias(name.as_ref()) {
@@ -575,9 +566,11 @@ impl ElementType {
             Self::Component(c) => {
                 let root = c.root_element.borrow();
                 let mut r = root.base_type.property_list();
-                // A shadowing declaration replaces the inherited entry of the same name
+                // A visible shadowing declaration replaces the inherited entry of the same name.
                 if !root.shadowing_members.is_empty() {
-                    r.retain(|(name, _)| !root.shadowing_members.contains_key(name));
+                    let hidden: std::collections::HashSet<_> =
+                        root.visible_shadowing_members().collect();
+                    r.retain(|(name, _)| !hidden.contains(name));
                 }
                 r.extend(
                     root.property_declarations
@@ -939,6 +932,18 @@ impl BuiltinElement {
     pub fn new(native_class: Arc<NativeClass>) -> Self {
         Self { name: native_class.class_name.clone(), native_class, ..Default::default() }
     }
+}
+
+/// How [`crate::object_tree::Element::lookup_property`] resolves a name.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum PropertyLookupMode {
+    /// A source name resolved from within the declaring component: a private shadow is visible.
+    ComponentLocal,
+    /// A source name resolved from outside the component: a private shadow is invisible, so the name
+    /// resolves to the member it shadows.
+    FromOutside,
+    /// A storage key, as a `NamedReference` carries: no shadow resolution.
+    InternalName,
 }
 
 #[derive(PartialEq, Debug)]

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -5,7 +5,7 @@
 
 use crate::diagnostics::{BuildDiagnostics, DiagnosticLevel, Spanned};
 use crate::expression_tree::*;
-use crate::langtype::{ElementType, PropertyLookupResult, Type};
+use crate::langtype::{ElementType, PropertyLookupMode, PropertyLookupResult, Type};
 use crate::object_tree::{Component, ElementRc};
 
 use smol_str::{SmolStr, ToSmolStr};
@@ -132,8 +132,10 @@ impl RowChildTemplate {
 impl LayoutItem {
     pub fn rect(&self) -> LayoutRect {
         let p = |unresolved_name: &str| {
-            let PropertyLookupResult { resolved_name, property_type, .. } =
-                self.element.borrow().lookup_property(unresolved_name);
+            let PropertyLookupResult { resolved_name, property_type, .. } = self
+                .element
+                .borrow()
+                .lookup_property(unresolved_name, PropertyLookupMode::ComponentLocal);
             if property_type == Type::LogicalLength {
                 Some(NamedReference::new(&self.element, resolved_name.to_smolstr()))
             } else {
@@ -1003,7 +1005,7 @@ pub fn static_native_stretch(elem: &ElementRc) -> Option<Expression> {
 /// Create a new property based on the name. (it might get a different name if that property exist)
 pub fn create_new_prop(elem: &ElementRc, tentative_name: SmolStr, ty: Type) -> NamedReference {
     let mut e = elem.borrow_mut();
-    let name = if e.lookup_property_by_internal_name(&tentative_name).is_valid() {
+    let name = if e.lookup_property(&tentative_name, PropertyLookupMode::InternalName).is_valid() {
         e.unique_member_name(&tentative_name)
     } else {
         tentative_name

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use super::lower_expression::{ExpressionLoweringCtx, ExpressionLoweringCtxInner};
 use crate::CompilerConfiguration;
 use crate::expression_tree::Expression as tree_Expression;
-use crate::langtype::{BuiltinStruct, ElementType, Struct, StructName, Type};
+use crate::langtype::{BuiltinStruct, ElementType, PropertyLookupMode, Struct, StructName, Type};
 use crate::llr::item_tree::*;
 use crate::namedreference::NamedReference;
 use crate::object_tree::{self, Component, ElementRc, PropertyAnalysis};
@@ -174,7 +174,7 @@ impl LoweredSubComponentMapping {
                 // callback tables.
                 let kind = match element
                     .borrow()
-                    .lookup_property_by_internal_name(from.name())
+                    .lookup_property(from.name(), PropertyLookupMode::InternalName)
                     .property_type
                 {
                     Type::Callback(..) => super::NativeMemberKind::Callback,
@@ -587,7 +587,7 @@ fn lower_sub_component(
             );
 
             let kind = if matches!(
-                e.borrow().lookup_property_by_internal_name(p).property_type,
+                e.borrow().lookup_property(p, PropertyLookupMode::InternalName).property_type,
                 Type::Struct(s) if matches!(s.name, StructName::Builtin(BuiltinStruct::StateInfo))
             ) {
                 BindingKind::State

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -11,7 +11,7 @@ use crate::expression_tree::{
     BuiltinFunction, BuiltinMacroFunction, Callable, EasingCurve, Expression, MouseCursorInner,
     Unit,
 };
-use crate::langtype::{ElementType, Enumeration, EnumerationValue, Type};
+use crate::langtype::{ElementType, Enumeration, EnumerationValue, PropertyLookupMode, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{ElementRc, PropertyVisibility};
 use crate::parser::NodeOrToken;
@@ -504,7 +504,10 @@ impl LookupObject for ElementRc {
                 continue;
             }
             // Resolve the source name to the storage key so a shadow in a base resolves correctly.
-            let key = self.borrow().lookup_property(&name).internal_or_resolved_name();
+            let key = self
+                .borrow()
+                .lookup_property(&name, PropertyLookupMode::ComponentLocal)
+                .internal_or_resolved_name();
             let e = expression_from_reference(NamedReference::new(self, key), &ty, None);
             if let Some(r) = f(&name, e) {
                 return Some(r);
@@ -533,7 +536,7 @@ impl LookupObject for ElementRc {
     }
 
     fn lookup(&self, ctx: &LookupCtx, name: &SmolStr) -> Option<LookupResult> {
-        let lookup_result = self.borrow().lookup_property(name);
+        let lookup_result = self.borrow().lookup_property(name, PropertyLookupMode::ComponentLocal);
         if lookup_result.property_type != Type::Invalid
             && (lookup_result.is_local_to_component
                 || lookup_result.property_visibility != PropertyVisibility::Private)

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -503,7 +503,9 @@ impl LookupObject for ElementRc {
             if has_shadows && self.borrow().shadowing_members.contains_key(&name) {
                 continue;
             }
-            let e = expression_from_reference(NamedReference::new(self, name.clone()), &ty, None);
+            // Resolve the source name to the storage key so a shadow in a base resolves correctly.
+            let key = self.borrow().lookup_property(&name).internal_or_resolved_name();
+            let e = expression_from_reference(NamedReference::new(self, key), &ty, None);
             if let Some(r) = f(&name, e) {
                 return Some(r);
             }

--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::{Rc, Weak};
 
-use crate::langtype::{ElementType, Type};
+use crate::langtype::{ElementType, PropertyLookupMode, Type};
 use crate::object_tree::{Element, ElementRc, PropertyAnalysis, PropertyVisibility};
 
 /// Reference to a property or callback of a given name within an element.
@@ -56,7 +56,10 @@ impl NamedReference {
             .unwrap_or_else(|| panic!("{}: NamedReference to a dead element", self.0.name))
     }
     pub fn ty(&self) -> Type {
-        self.element().borrow().lookup_property_by_internal_name(self.name()).property_type
+        self.element()
+            .borrow()
+            .lookup_property(self.name(), PropertyLookupMode::InternalName)
+            .property_type
     }
 
     /// The name the member is declared under, un-mangled. [`Self::name`] is the internal name,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -13,7 +13,7 @@ use crate::langtype::{
     BuiltinElement, BuiltinPropertyDefault, Enumeration, EnumerationValue, Function, NativeClass,
     Struct, StructName, Type,
 };
-use crate::langtype::{ElementType, PropertyLookupResult};
+use crate::langtype::{ElementType, PropertyLookupMode, PropertyLookupResult};
 use crate::layout::{LayoutConstraints, Orientation};
 use crate::namedreference::NamedReference;
 use crate::parser::{SyntaxKind, SyntaxNode, syntax_nodes};
@@ -801,6 +801,12 @@ impl PropertyDeclaration {
     /// The name the member is declared under, un-mangled, given its internal key.
     pub fn declared_name<'a>(&'a self, internal_name: &'a SmolStr) -> &'a SmolStr {
         self.shadowed_name.as_ref().unwrap_or(internal_name)
+    }
+
+    /// A declaration that shadows an inherited member but is private: it is invisible outside its
+    /// component, so from there the inherited member stays reachable instead.
+    pub fn is_private_shadow(&self) -> bool {
+        self.shadowed_name.is_some() && self.visibility == PropertyVisibility::Private
     }
 
     /// True when declared `@deprecated` without a custom message, so the hint in
@@ -2022,7 +2028,8 @@ impl Element {
 
         for con_node in node.CallbackConnection() {
             let unresolved_name = unwrap_or_continue!(parser::identifier_text(&con_node); diag);
-            let lookup_result = r.lookup_property(&unresolved_name);
+            let lookup_result =
+                r.lookup_property(&unresolved_name, PropertyLookupMode::ComponentLocal);
             #[cfg(feature = "slint-sc")]
             {
                 // A callback declared in the file is in the subset by construction;
@@ -2137,7 +2144,10 @@ impl Element {
                         if r.base_type == ElementType::Error {
                             continue;
                         };
-                        let lookup_result = r.lookup_property(unresolved_prop_name);
+                        let lookup_result = r.lookup_property(
+                            unresolved_prop_name,
+                            PropertyLookupMode::ComponentLocal,
+                        );
                         let valid_assign = lookup_result.is_valid_for_assignment();
                         let binding_name = lookup_result.internal_or_resolved_name();
                         if let Some(anim_element) = animation_element_from_node(
@@ -2204,7 +2214,7 @@ impl Element {
             #[cfg(feature = "slint-sc")]
             diag.slint_sc_error("Change callbacks are", &ch);
             let Some(prop) = parser::identifier_text(&ch.DeclaredIdentifier()) else { continue };
-            let lookup_result = r.lookup_property(&prop);
+            let lookup_result = r.lookup_property(&prop, PropertyLookupMode::ComponentLocal);
             if !lookup_result.is_valid() {
                 if r.base_type != ElementType::Error {
                     diag.push_error(
@@ -2756,7 +2766,7 @@ impl Element {
                     "visible-width",
                 ]
                 .iter()
-                .all(|p| parent.lookup_property_by_internal_name(p).property_type == Type::LogicalLength)
+                .all(|p| parent.lookup_property(p, PropertyLookupMode::InternalName).property_type == Type::LogicalLength)
         };
         let is_listview = if parent_is_listview
             && let Some(geometry_props) = e.borrow().geometry_props.as_ref()
@@ -2925,16 +2935,6 @@ impl Element {
         cases
     }
 
-    /// Resolve `name` as a `property_declarations` key (the form a `NamedReference` carries),
-    /// following aliases; `Type::Invalid` if absent. A shadowing member is under a mangled key here;
-    /// to resolve a name as written in `.slint` source, use [`Self::lookup_property`].
-    pub fn lookup_property_by_internal_name<'a>(&self, name: &'a str) -> PropertyLookupResult<'a> {
-        self.property_declarations.get(name).map_or_else(
-            || from_base(self.base_type.lookup_property_by_internal_name(name)),
-            |p| self.lookup_result_for_declaration(name.into(), p),
-        )
-    }
-
     /// Whether the member is declared in the source, on this element or on the
     /// root element of a component it inherits from, rather than coming from a
     /// builtin element. Follows the same chain as [`Self::lookup_property`].
@@ -2949,17 +2949,37 @@ impl Element {
         }
     }
 
-    /// Resolve `name` as written in `.slint` source, following aliases; `Type::Invalid` if absent.
-    /// For a shadowing member, the result's `internal_name` carries its `property_declarations` key.
-    pub fn lookup_property<'a>(&self, name: &'a str) -> PropertyLookupResult<'a> {
-        if let Some((internal_name, decl)) = self.declaration(name) {
+    /// Resolve `name` in the given [`PropertyLookupMode`], following aliases; `Type::Invalid` if absent.
+    /// For a shadowing member the result's `internal_name` carries its storage key.
+    pub fn lookup_property<'a>(
+        &self,
+        name: &'a str,
+        mode: PropertyLookupMode,
+    ) -> PropertyLookupResult<'a> {
+        let declaration = match mode {
+            PropertyLookupMode::InternalName => self.property_declarations.get_key_value(name),
+            PropertyLookupMode::ComponentLocal | PropertyLookupMode::FromOutside => {
+                self.declaration(name)
+            }
+        };
+        if let Some((internal_name, decl)) = declaration {
+            if mode == PropertyLookupMode::FromOutside && decl.is_private_shadow() {
+                return from_base(
+                    self.base_type.lookup_property(name, PropertyLookupMode::FromOutside),
+                );
+            }
             let mut r = self.lookup_result_for_declaration(name.into(), decl);
             if internal_name != name {
                 r.internal_name = Some(internal_name.clone());
             }
             return r;
         }
-        from_base(self.base_type.lookup_property(name))
+        // A base component's private members are invisible from here.
+        let base_mode = match mode {
+            PropertyLookupMode::InternalName => PropertyLookupMode::InternalName,
+            _ => PropertyLookupMode::FromOutside,
+        };
+        from_base(self.base_type.lookup_property(name, base_mode))
     }
 
     /// The declaration for a member written as `name` in `.slint` source, with its internal key.
@@ -2970,6 +2990,18 @@ impl Element {
             return self.property_declarations.get_key_value(internal_name);
         }
         self.property_declarations.get_key_value(name).filter(|(_, d)| d.shadowed_name.is_none())
+    }
+
+    /// Source names of shadowing declarations that are visible from outside the component, so they
+    /// hide the inherited member of the same name. A private shadow is excluded: it stays transparent
+    /// from outside, leaving the inherited member reachable there.
+    pub fn visible_shadowing_members(&self) -> impl Iterator<Item = &SmolStr> {
+        self.shadowing_members.iter().filter_map(|(source, internal)| {
+            self.property_declarations
+                .get(internal)
+                .filter(|d| !d.is_private_shadow())
+                .map(|_| source)
+        })
     }
 
     /// How a declaration of `name` relates to a member of the same name already reachable here.
@@ -2984,7 +3016,7 @@ impl Element {
                 warning: None,
             };
         }
-        let existing = self.lookup_property(name);
+        let existing = self.lookup_property(name, PropertyLookupMode::ComponentLocal);
         if !existing.is_valid() {
             return MemberDeclaration::New;
         }
@@ -3023,7 +3055,7 @@ impl Element {
     pub fn unique_member_name(&self, base: &str) -> SmolStr {
         (1..)
             .map(|counter| format_smolstr!("{base}-{counter}"))
-            .find(|n| !self.lookup_property_by_internal_name(n).is_valid())
+            .find(|n| !self.lookup_property(n, PropertyLookupMode::InternalName).is_valid())
             .unwrap()
     }
 
@@ -3074,7 +3106,8 @@ impl Element {
     ) {
         for (name_token, b) in bindings {
             let unresolved_name = crate::parser::normalize_identifier(name_token.text());
-            let lookup_result = self.lookup_property(&unresolved_name);
+            let lookup_result =
+                self.lookup_property(&unresolved_name, PropertyLookupMode::ComponentLocal);
             #[cfg(feature = "slint-sc")]
             if lookup_result.is_valid() && !lookup_result.is_slint_sc {
                 diag.slint_sc_error(&format!("The property '{unresolved_name}' is"), &name_token);
@@ -3873,7 +3906,9 @@ fn lookup_property_from_qualified_name_for_state(
     let qualname = QualifiedTypeName::from_node(node.clone());
     match qualname.members.as_slice() {
         [unresolved_prop_name] => {
-            let lookup_result = r.borrow().lookup_property(unresolved_prop_name.as_ref());
+            let lookup_result = r
+                .borrow()
+                .lookup_property(unresolved_prop_name.as_ref(), PropertyLookupMode::ComponentLocal);
             if !lookup_result.property_type.is_property_type() {
                 diag.push_error(format!("'{qualname}' is not a valid property"), &node);
             } else if !lookup_result.is_valid_for_assignment() {
@@ -3892,7 +3927,10 @@ fn lookup_property_from_qualified_name_for_state(
         }
         [elem_id, unresolved_prop_name] => {
             if let Some(element) = find_element_by_id(r, elem_id.as_ref()) {
-                let lookup_result = element.borrow().lookup_property(unresolved_prop_name.as_ref());
+                let lookup_result = element.borrow().lookup_property(
+                    unresolved_prop_name.as_ref(),
+                    PropertyLookupMode::ComponentLocal,
+                );
                 if !lookup_result.is_valid() {
                     diag.push_error(
                         format!("'{unresolved_prop_name}' not found in '{elem_id}'"),
@@ -4089,7 +4127,7 @@ pub fn visit_element_expressions_excluding_repeater_model(
     ) {
         for (name, expr) in elem.borrow().bindings_including_synthetic() {
             vis(&mut expr.borrow_mut(), Some(name.as_str()), &|| {
-                elem.borrow().lookup_property_by_internal_name(name).property_type
+                elem.borrow().lookup_property(name, PropertyLookupMode::InternalName).property_type
             });
 
             for twb in &mut expr.borrow_mut().two_way_bindings {
@@ -4131,7 +4169,10 @@ pub fn visit_element_expressions_excluding_repeater_model(
         }
         for (ne, e, _) in &mut s.property_changes {
             vis(e, Some(ne.name()), &|| {
-                ne.element().borrow().lookup_property_by_internal_name(ne.name()).property_type
+                ne.element()
+                    .borrow()
+                    .lookup_property(ne.name(), PropertyLookupMode::InternalName)
+                    .property_type
             });
         }
     }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -12,7 +12,7 @@ use smol_str::SmolStr;
 
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::expression_tree::{BindingExpression, Callable, Expression};
-use crate::langtype::{ElementType, Function, PropertyLookupResult, Type};
+use crate::langtype::{ElementType, Function, PropertyLookupMode, PropertyLookupResult, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{
     Element, ElementRc, PropertyDeclaration, PropertyVisibility, QualifiedTypeName,
@@ -378,7 +378,7 @@ fn validate_interface_member_implementation(
         return None;
     }
 
-    let lookup_result = element.lookup_property(member_name);
+    let lookup_result = element.lookup_property(member_name, PropertyLookupMode::ComponentLocal);
     let Err(violations) =
         property_matches_interface(&lookup_result, interface_member, member_name, binding)
     else {
@@ -443,7 +443,10 @@ pub(super) fn apply_child_implement_statements(
         let mut conflicts = Vec::new();
         let mut notes = Vec::new();
         for (name, prop_decl) in interface.borrow().property_declarations.iter() {
-            let lookup_result = element.borrow().base_type.lookup_property(name);
+            let lookup_result = element
+                .borrow()
+                .base_type
+                .lookup_property(name, PropertyLookupMode::ComponentLocal);
             if let Err(message) =
                 check_property_declaration_conflicts(&lookup_result, &element.borrow().base_type)
             {

--- a/internal/compiler/passes/apply_default_properties_from_style.rs
+++ b/internal/compiler/passes/apply_default_properties_from_style.rs
@@ -7,7 +7,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};
-use crate::langtype::{ElementType, Type};
+use crate::langtype::{ElementType, PropertyLookupMode, Type};
 use crate::object_tree::Component;
 use smol_str::SmolStr;
 use std::rc::Rc;
@@ -102,7 +102,7 @@ pub fn apply_default_properties_from_style(
                             style_metrics
                                 .root_element
                                 .borrow()
-                                .lookup_property(property_name)
+                                .lookup_property(property_name, PropertyLookupMode::ComponentLocal)
                                 .property_type,
                             Type::Invalid,
                         ) {

--- a/internal/compiler/passes/default_geometry.rs
+++ b/internal/compiler/passes/default_geometry.rs
@@ -15,7 +15,7 @@ use crate::diagnostics::{BuildDiagnostics, DiagnosticLevel, SourceLocation, Span
 use crate::expression_tree::{
     BindingExpression, BuiltinFunction, Expression, MinMaxOp, NamedReference, Unit,
 };
-use crate::langtype::{BuiltinElement, DefaultSizeBinding, Type};
+use crate::langtype::{BuiltinElement, DefaultSizeBinding, PropertyLookupMode, Type};
 use crate::layout::{BuiltinFilter, LayoutConstraints, Orientation, implicit_layout_info_call};
 use crate::object_tree::{Component, ElementRc};
 use crate::symbol_counters::SymbolCounters;
@@ -108,7 +108,9 @@ pub fn default_geometry(
                     DefaultSizeBinding::ImplicitSize => {
                         let has_length_property_binding = |elem: &ElementRc, property: &str| {
                             debug_assert_eq!(
-                                elem.borrow().lookup_property(property).property_type,
+                                elem.borrow()
+                                    .lookup_property(property, PropertyLookupMode::ComponentLocal)
+                                    .property_type,
                                 Type::LogicalLength
                             );
 
@@ -136,7 +138,10 @@ pub fn default_geometry(
                             // If an image is in a layout and has no explicit width or height specified, change the default for image-fit
                             // to `contain`
                             if !width_specified || !height_specified {
-                                let image_fit_lookup = elem.borrow().lookup_property("image-fit");
+                                let image_fit_lookup = elem.borrow().lookup_property(
+                                    "image-fit",
+                                    PropertyLookupMode::ComponentLocal,
+                                );
 
                                 elem.borrow_mut().set_binding_if_not_set(
                                     image_fit_lookup.resolved_name.into(),
@@ -418,7 +423,10 @@ fn fix_percent_size(
                     parent = crate::object_tree::find_parent_element(&parent).unwrap_or(parent)
                 }
                 debug_assert_eq!(
-                    parent.borrow().lookup_property(property).property_type,
+                    parent
+                        .borrow()
+                        .lookup_property(property, PropertyLookupMode::ComponentLocal)
+                        .property_type,
                     Type::LogicalLength
                 );
                 // do not ignore debug hooks here, the debug hook may overwrite the expression
@@ -525,7 +533,10 @@ fn make_default_aspect_ratio_preserving_binding(
         return;
     }
 
-    debug_assert_eq!(elem.borrow().lookup_property("source").property_type, Type::Image);
+    debug_assert_eq!(
+        elem.borrow().lookup_property("source", PropertyLookupMode::ComponentLocal).property_type,
+        Type::Image
+    );
 
     let missing_size_property = SmolStr::new_static(missing_size_property);
     let given_size_property = SmolStr::new_static(given_size_property);

--- a/internal/compiler/passes/infer_aliases_types.rs
+++ b/internal/compiler/passes/infer_aliases_types.rs
@@ -9,7 +9,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::TwoWayBinding;
-use crate::langtype::Type;
+use crate::langtype::{PropertyLookupMode, Type};
 use crate::lookup::LookupCtx;
 use crate::object_tree::{Document, ElementRc};
 use crate::symbol_counters::SymbolCounters;
@@ -72,7 +72,7 @@ fn resolve_alias(
         None => {
             // Unresolved callback from a base component?
             debug_assert!(matches!(
-                borrow_mut.lookup_property_by_internal_name(prop).property_type,
+                borrow_mut.lookup_property(prop, PropertyLookupMode::InternalName).property_type,
                 Type::InferredCallback | Type::InferredProperty
             ));
             // It is still unresolved because there is an error in that component
@@ -152,8 +152,11 @@ fn resolve_alias(
         } else if let Some(nr) = twb.unwrap().property() {
             let target_is_global =
                 nr.element().borrow().base_type == crate::langtype::ElementType::Global;
-            let purity =
-                nr.element().borrow().lookup_property_by_internal_name(nr.name()).declared_pure;
+            let purity = nr
+                .element()
+                .borrow()
+                .lookup_property(nr.name(), PropertyLookupMode::InternalName)
+                .declared_pure;
             // A global aliasing another global's callback is the supported way for one
             // global to implement another's callback, so it isn't deprecated.
             let aliasing_global = elem.borrow().base_type == crate::langtype::ElementType::Global;

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -20,6 +20,7 @@
 //!    pass to inject a wrapper element for the transform.
 
 use crate::expression_tree::Expression;
+use crate::langtype::PropertyLookupMode;
 use crate::object_tree::{self, Element, ElementDebugInfo, ElementRc, PropertyVisibility};
 
 pub fn inject_debug_hooks(
@@ -122,7 +123,11 @@ fn hook_existing_bindings(element: &ElementRc, element_hash: u64) {
         // Only hook properties — callback handlers and functions also live in
         // `bindings`, but hook ids are a property-only namespace and overriding a code
         // block with a value makes no sense.
-        if !elem.lookup_property_by_internal_name(name).property_type.is_property_type() {
+        if !elem
+            .lookup_property(name, PropertyLookupMode::InternalName)
+            .property_type
+            .is_property_type()
+        {
             return;
         }
         let expr = std::mem::take(&mut be.borrow_mut().expression);
@@ -162,7 +167,7 @@ fn property_defaults(
         .filter(|(name, _)| elem.binding_cell_including_synthetic(name.as_str()).is_none())
         .filter_map(|(name, _ty)| {
             let name_str = name.clone();
-            let lookup = elem.lookup_property_by_internal_name(&name_str);
+            let lookup = elem.lookup_property(&name_str, PropertyLookupMode::InternalName);
             // Skip functions/callbacks exposed as builtin functions.
             if lookup.builtin_function.is_some() {
                 return None;
@@ -260,7 +265,7 @@ fn add_hooks_for_non_existent_bindings(element: &ElementRc, element_hash: u64, i
         let elem = element.borrow();
         elem.binding_cell_including_synthetic(name).is_none()
             // Filter invalid reserved properties (e.g. x/y on a Timer, etc.)
-            && elem.lookup_property_by_internal_name(name).property_type != crate::langtype::Type::Invalid
+            && elem.lookup_property(name, PropertyLookupMode::InternalName).property_type != crate::langtype::Type::Invalid
     });
 
     for (name, default, synthetic) in unbound_properties {

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -7,7 +7,7 @@
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};
-use crate::langtype::{ElementType, Type};
+use crate::langtype::{ElementType, PropertyLookupMode, Type};
 use crate::object_tree::*;
 use by_address::ByAddress;
 use smol_str::SmolStr;
@@ -950,7 +950,8 @@ fn component_requires_inlining(component: &Rc<Component>) -> bool {
             return true;
         }
         if binding.animation.is_some() {
-            let lookup_result = root_element.borrow().lookup_property_by_internal_name(prop);
+            let lookup_result =
+                root_element.borrow().lookup_property(prop, PropertyLookupMode::InternalName);
             if !lookup_result.is_valid()
                 || !lookup_result.is_local_to_component
                 || !matches!(

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 
 use crate::diagnostics::{BuildDiagnostics, DiagnosticLevel, Spanned};
 use crate::expression_tree::*;
-use crate::langtype::ElementType;
 use crate::langtype::Type;
+use crate::langtype::{ElementType, PropertyLookupMode};
 use crate::layout::*;
 use crate::object_tree::*;
 use crate::typeloader::TypeLoader;
@@ -521,7 +521,7 @@ fn lower_element_layout(
     // Create fake properties for the layout properties
     // like alignment, spacing, spacing-horizontal, spacing-vertical
     for (p, ty) in prev_base.property_list() {
-        if !elem.base_type.lookup_property(&p).is_valid()
+        if !elem.base_type.lookup_property(&p, PropertyLookupMode::ComponentLocal).is_valid()
             && !elem.property_declarations.contains_key(&p)
         {
             elem.property_declarations.insert(p, ty.into());
@@ -2032,7 +2032,7 @@ fn lower_dialog_layout(
                 );
             }
             true
-        } else if matches!(&layout_child.borrow().lookup_property("kind").property_type, Type::Enumeration(e) if e.name == "StandardButtonKind")
+        } else if matches!(&layout_child.borrow().lookup_property("kind", PropertyLookupMode::ComponentLocal).property_type, Type::Enumeration(e) if e.name == "StandardButtonKind")
         {
             // layout_child is a StandardButton
             match layout_child.borrow().binding("kind") {
@@ -2073,8 +2073,10 @@ fn lower_dialog_layout(
                                 .unwrap()
                                 .root_element,
                         ) {
-                            let clicked_ty =
-                                layout_child.borrow().lookup_property("clicked").property_type;
+                            let clicked_ty = layout_child
+                                .borrow()
+                                .lookup_property("clicked", PropertyLookupMode::ComponentLocal)
+                                .property_type;
                             if matches!(&clicked_ty, Type::Callback { .. })
                                 && layout_child.borrow().binding("clicked").is_none_or(|c| {
                                     matches!(c.value_expression(), Expression::Invalid)

--- a/internal/compiler/passes/lower_menus.rs
+++ b/internal/compiler/passes/lower_menus.rs
@@ -99,7 +99,7 @@
 
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::{BuiltinFunction, Callable, Expression, NamedReference};
-use crate::langtype::{ElementType, Type};
+use crate::langtype::{ElementType, PropertyLookupMode, Type};
 use crate::object_tree::*;
 use core::cell::RefCell;
 use i_slint_common::MENU_SEPARATOR_PLACEHOLDER_TITLE;
@@ -541,7 +541,10 @@ fn process_window(
 
     for prop in [ENTRIES, SUB_MENU, ACTIVATED] {
         // materialize the properties and callbacks
-        let ty = components.menubar_impl.lookup_property(prop).property_type;
+        let ty = components
+            .menubar_impl
+            .lookup_property(prop, PropertyLookupMode::ComponentLocal)
+            .property_type;
         assert_ne!(ty, Type::Invalid, "Can't lookup type for {prop}");
         let nr = NamedReference::new(&menu_bar, SmolStr::new_static(prop));
         let forward_expr = if let Type::Callback(cb) = &ty {

--- a/internal/compiler/passes/lower_property_to_element.rs
+++ b/internal/compiler/passes/lower_property_to_element.rs
@@ -6,7 +6,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{BindingExpression, Expression, NamedReference};
-use crate::langtype::Type;
+use crate::langtype::{PropertyLookupMode, Type};
 use crate::object_tree::{self, Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
 use smol_str::{SmolStr, ToSmolStr, format_smolstr};
@@ -49,7 +49,11 @@ pub(crate) fn lower_property_to_element(
 
         let has_property_binding = |e: &ElementRc| {
             property_names.clone().any(|property_name| {
-                e.borrow().base_type.lookup_property(property_name).property_type != Type::Invalid
+                e.borrow()
+                    .base_type
+                    .lookup_property(property_name, PropertyLookupMode::ComponentLocal)
+                    .property_type
+                    != Type::Invalid
                     && (e.borrow().binding(property_name).is_some()
                         || e.borrow()
                             .property_analysis

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -7,8 +7,8 @@ use crate::diagnostics::BuildDiagnostics;
 use crate::diagnostics::SourceLocation;
 use crate::diagnostics::Spanned;
 use crate::expression_tree::*;
-use crate::langtype::ElementType;
 use crate::langtype::Type;
+use crate::langtype::{ElementType, PropertyLookupMode};
 use crate::object_tree::*;
 use crate::symbol_counters::SymbolCounters;
 use smol_str::SmolStr;
@@ -192,7 +192,7 @@ fn compute_state_property_name(root_element: &ElementRc) -> SmolStr {
     let mut property_name = "state".to_owned();
     while root_element
         .borrow()
-        .lookup_property_by_internal_name(property_name.as_ref())
+        .lookup_property(property_name.as_ref(), PropertyLookupMode::InternalName)
         .property_type
         != Type::Invalid
     {
@@ -268,7 +268,7 @@ fn expression_for_property(
     }
     let expr = super::materialize_fake_properties::initialize(element, name).unwrap_or_else(|| {
         Expression::default_value_for_type(
-            &element.borrow().lookup_property_by_internal_name(name).property_type,
+            &element.borrow().lookup_property(name, PropertyLookupMode::InternalName).property_type,
         )
     });
 

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -7,7 +7,7 @@
 
 use crate::diagnostics::Spanned;
 use crate::expression_tree::{BindingExpression, Expression, Unit};
-use crate::langtype::{ElementType, Type};
+use crate::langtype::{ElementType, PropertyLookupMode, Type};
 use crate::layout::Orientation;
 use crate::namedreference::NamedReference;
 use crate::object_tree::*;
@@ -129,7 +129,10 @@ pub(crate) fn should_materialize(
                 crate::typeregister::BUILTIN.enums.PopupClosePolicy.clone(),
             ));
         } else {
-            let ty = base_type.lookup_property_by_internal_name(prop).property_type.clone();
+            let ty = base_type
+                .lookup_property(prop, PropertyLookupMode::InternalName)
+                .property_type
+                .clone();
             return (ty != Type::Invalid).then_some(ty);
         }
     }

--- a/internal/compiler/passes/purity_check.rs
+++ b/internal/compiler/passes/purity_check.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Callable, Expression, NamedReference};
+use crate::langtype::PropertyLookupMode;
 
 /// Check that pure expression only call pure functions
 pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnostics) {
@@ -19,7 +20,8 @@ pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnost
                 };
                 crate::object_tree::visit_element_expressions(elem, |expr, name, _| {
                     if let Some(name) = name {
-                        let lookup = elem.borrow().lookup_property_by_internal_name(name);
+                        let lookup =
+                            elem.borrow().lookup_property(name, PropertyLookupMode::InternalName);
                         if lookup.declared_pure.unwrap_or(false)
                             || lookup.property_type.is_property_type()
                         {
@@ -47,7 +49,7 @@ fn ensure_pure(
             if !nr
                 .element()
                 .borrow()
-                .lookup_property_by_internal_name(nr.name())
+                .lookup_property(nr.name(), PropertyLookupMode::InternalName)
                 .declared_pure
                 .unwrap_or(false) =>
         {
@@ -61,7 +63,12 @@ fn ensure_pure(
             r = false;
         }
         Expression::FunctionCall { function: Callable::Function(nr), source_location, .. } => {
-            match nr.element().borrow().lookup_property_by_internal_name(nr.name()).declared_pure {
+            match nr
+                .element()
+                .borrow()
+                .lookup_property(nr.name(), PropertyLookupMode::InternalName)
+                .declared_pure
+            {
                 Some(true) => (),
                 Some(false) => {
                     if let Some(diag) = diag.as_deref_mut() {

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -12,7 +12,9 @@
 use crate::diagnostics::{BuildDiagnostics, Spanned};
 use crate::expression_tree::*;
 use crate::langtype;
-use crate::langtype::{ElementType, KeyboardModifiers, Struct, StructName, Type};
+use crate::langtype::{
+    ElementType, KeyboardModifiers, PropertyLookupMode, Struct, StructName, Type,
+};
 use crate::lookup::{LookupCtx, LookupObject, LookupResult, LookupResultCallable};
 use crate::object_tree::*;
 use crate::parser::{NodeOrToken, SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
@@ -2530,8 +2532,14 @@ fn continue_lookup_within_element(
     };
     let prop_name = crate::parser::normalize_identifier(second.text());
 
-    let lookup_result = elem.borrow().lookup_property(&prop_name);
-    let local_to_component = lookup_result.is_local_to_component && ctx.is_local_element(elem);
+    let is_local_element = ctx.is_local_element(elem);
+    let mode = if is_local_element {
+        PropertyLookupMode::ComponentLocal
+    } else {
+        PropertyLookupMode::FromOutside
+    };
+    let lookup_result = elem.borrow().lookup_property(&prop_name, mode);
+    let local_to_component = lookup_result.is_local_to_component && is_local_element;
     // A property or function whose type is outside the Slint SC subset
     // doesn't resolve; callbacks do, so a handler can invoke them.
     let sc_resolves = !ctx.diag.is_slint_sc() || lookup_result.property_type.is_slint_sc();
@@ -2648,7 +2656,10 @@ fn continue_lookup_within_element(
             // Attempt to recover if the user wanted to write "-"
             if elem
                 .borrow()
-                .lookup_property(&crate::parser::normalize_identifier(&second.text()[0..minus_pos]))
+                .lookup_property(
+                    &crate::parser::normalize_identifier(&second.text()[0..minus_pos]),
+                    mode,
+                )
                 .property_type
                 != Type::Invalid
             {
@@ -2763,7 +2774,8 @@ fn resolve_two_way_bindings_for_element(
             .or_else(|| elem.borrow().callback_alias_declaration_node(prop_name));
         if let Some(n) = twb_node {
             let node: SyntaxNode = n.clone().into();
-            let lhs_lookup = elem.borrow().lookup_property_by_internal_name(prop_name);
+            let lhs_lookup =
+                elem.borrow().lookup_property(prop_name, PropertyLookupMode::InternalName);
             if !lhs_lookup.is_valid() {
                 // An attempt to resolve this already failed when trying to resolve the property type
                 assert!(diag.has_errors());
@@ -2824,8 +2836,10 @@ fn resolve_two_way_bindings_for_element(
                 }
 
                 // Check the compatibility.
-                let mut rhs_lookup =
-                    nr.element().borrow().lookup_property_by_internal_name(nr.name());
+                let mut rhs_lookup = nr
+                    .element()
+                    .borrow()
+                    .lookup_property(nr.name(), PropertyLookupMode::InternalName);
                 if rhs_lookup.property_type == Type::Invalid {
                     // An attempt to resolve this already failed when trying to resolve the property type
                     assert!(diag.has_errors());

--- a/internal/compiler/passes/visible.rs
+++ b/internal/compiler/passes/visible.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::{Expression, NamedReference};
-use crate::langtype::{ElementType, NativeClass, Type};
+use crate::langtype::{ElementType, NativeClass, PropertyLookupMode, Type};
 use crate::object_tree::{self, Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
 
@@ -67,7 +67,11 @@ pub fn handle_visible(
             };
 
             let has_visible_binding = |e: &ElementRc| {
-                e.borrow().base_type.lookup_property("visible").property_type != Type::Invalid
+                e.borrow()
+                    .base_type
+                    .lookup_property("visible", PropertyLookupMode::ComponentLocal)
+                    .property_type
+                    != Type::Invalid
                     && (e.borrow().binding("visible").is_some()
                         || e.borrow()
                             .property_analysis

--- a/tests/cases/properties/shadow_private_member.slint
+++ b/tests/cases/properties/shadow_private_member.slint
@@ -1,0 +1,77 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A private declaration that shadows a public `@shadowable` member is invisible outside its
+// component: external code still reaches the inherited public member, while inside the component the
+// private declaration wins.
+
+component PublicBase {
+    @shadowable in-out property <int> value: 1;
+    out property <int> base-sees: self.value;
+}
+
+component PrivateShadow inherits PublicBase {
+    private property <int> value: 2;
+    out property <int> derived-sees: self.value;
+}
+
+// The private shadow can be more than one level up: `Leaf` inherits `MidPrivate`, whose private
+// `deep` shadows `DeepBase`. From `Leaf` (a different component) and from outside, `deep` is the
+// inherited public property; only `MidPrivate`'s own code sees the private one.
+component DeepBase {
+    @shadowable in-out property <int> deep: 10;
+}
+component MidPrivate inherits DeepBase {
+    private property <int> deep: 20;
+    out property <int> mid-sees: self.deep;
+}
+component Leaf inherits MidPrivate {
+    out property <int> leaf-sees: self.deep;
+}
+
+export component TestCase inherits Window {
+    ps := PrivateShadow { }
+
+    // From outside `ps`, `value` is the inherited public property, not the private shadow.
+    out property <int> external-value: ps.value;
+    out property <int> derived-sees: ps.derived-sees;
+    out property <int> base-sees: ps.base-sees;
+
+    lf := Leaf { }
+    out property <int> leaf-external: lf.deep;
+    out property <int> leaf-sees: lf.leaf-sees;
+    out property <int> mid-sees: lf.mid-sees;
+
+    out property <bool> test: external-value == 1 && derived-sees == 2 && base-sees == 1
+        && leaf-external == 10 && leaf-sees == 10 && mid-sees == 20;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_external_value(), 1);
+assert_eq!(instance.get_derived_sees(), 2);
+assert_eq!(instance.get_base_sees(), 1);
+assert_eq!(instance.get_leaf_external(), 10);
+assert_eq!(instance.get_leaf_sees(), 10);
+assert_eq!(instance.get_mid_sees(), 20);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_external_value(), 1);
+assert_eq(instance.get_derived_sees(), 2);
+assert_eq(instance.get_base_sees(), 1);
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.external_value, 1);
+assert.equal(instance.derived_sees, 2);
+assert.equal(instance.base_sees, 1);
+assert(instance.test);
+```
+*/

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -11,7 +11,7 @@ use crate::util::{lookup_current_element_type, text_size_to_lsp_position, with_l
 use crate::wasm_prelude::*;
 use i_slint_compiler::diagnostics::Spanned;
 use i_slint_compiler::expression_tree::{Callable, Expression};
-use i_slint_compiler::langtype::{ElementType, Type};
+use i_slint_compiler::langtype::{ElementType, PropertyLookupMode, Type};
 use i_slint_compiler::lookup::{LookupCtx, LookupObject, LookupResult, LookupResultCallable};
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken, TextSize, syntax_nodes};
@@ -678,7 +678,7 @@ fn resolve_element_scope(
             if shadowing_names.contains(&i_slint_compiler::parser::normalize_identifier(k)) {
                 return false;
             }
-            let mut lk = element_type.lookup_property(k);
+            let mut lk = element_type.lookup_property(k, PropertyLookupMode::ComponentLocal);
             lk.is_local_to_component = false;
             lk.is_valid_for_assignment()
         })
@@ -2763,6 +2763,29 @@ export component TestWindow inherits Window {
         let results = get_completions_experimental(source).unwrap();
         let prop = results.iter().find(|c| c.label == "prop").unwrap();
         assert_eq!(prop.detail.as_deref(), Some("string"), "should show the overriding type");
+    }
+
+    #[test]
+    fn private_shadow_is_transparent_in_completion() {
+        // A private declaration shadowing a public `@shadowable` member is invisible from outside
+        // the component, so `foo.` completion offers the inherited public member (with its type).
+        let source = r#"
+            component Base {
+                @shadowable in-out property <int> prop;
+            }
+            component Derived inherits Base {
+                private property <string> prop;
+            }
+            export component Main {
+                foo := Derived { }
+                the-text := Text {
+                    text: foo.pr🔺;
+                }
+            }
+        "#;
+        let results = get_completions_experimental(source).unwrap();
+        let prop = results.iter().find(|c| c.label == "prop").expect("'prop' should be offered");
+        assert_eq!(prop.detail.as_deref(), Some("int"), "should show the inherited public type");
     }
 
     #[test]

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -656,17 +656,35 @@ fn resolve_element_scope(
         .unwrap_or(&global_tr);
     let element_type = lookup_current_element_type((*element).clone(), tr).unwrap_or_default();
     let parent_element_type = element.parent().and_then(|p| lookup_current_element_type(p, tr));
-    // Members declared on this element shadow inherited ones of the same name, so the inherited
-    // entry is dropped to avoid offering the name twice.
-    let shadowing_names: std::collections::HashSet<SmolStr> = element
+    // Members declared on this element, offered as-is; an inherited member of the same name is
+    // dropped below so the name isn't offered twice.
+    let local_declarations = element
         .PropertyDeclaration()
-        .filter_map(|pr| pr.DeclaredIdentifier().child_text(SyntaxKind::Identifier))
-        .chain(
-            element
-                .CallbackDeclaration()
-                .filter_map(|cd| cd.DeclaredIdentifier().child_text(SyntaxKind::Identifier)),
-        )
-        .map(|n| i_slint_compiler::parser::normalize_identifier(&n))
+        .filter_map(|pr| {
+            let name = pr.DeclaredIdentifier().child_text(SyntaxKind::Identifier)?;
+            Some(
+                CompletionItem::new_simple(
+                    name.to_string(),
+                    pr.Type().map(|t| t.text().into()).unwrap_or_else(|| "property".to_owned()),
+                )
+                .with_kind(CompletionItemKind::PROPERTY)
+                .with_sort_text(format!("#{name}"))
+                .with_insert_text(format!("{name}: "), with_snippets),
+            )
+        })
+        .chain(element.CallbackDeclaration().filter_map(|cd| {
+            let name = cd.DeclaredIdentifier().child_text(SyntaxKind::Identifier)?;
+            Some(
+                CompletionItem::new_simple(name.to_string(), "callback".into())
+                    .with_kind(CompletionItemKind::METHOD)
+                    .with_sort_text(format!("#{name}"))
+                    .with_insert_text(format!("{name} => {{$1}}"), with_snippets),
+            )
+        }))
+        .collect::<Vec<_>>();
+    let shadowing_names: std::collections::HashSet<SmolStr> = local_declarations
+        .iter()
+        .map(|c| i_slint_compiler::parser::normalize_identifier(&c.label))
         .collect();
     let mut result = element_type
         .property_list()
@@ -701,27 +719,7 @@ fn resolve_element_scope(
             c.sort_text = Some(format!("#{}", c.label));
             apply_property_ty(c, &ty, cb_args)
         })
-        .chain(element.PropertyDeclaration().filter_map(|pr| {
-            let name = pr.DeclaredIdentifier().child_text(SyntaxKind::Identifier)?;
-            Some(
-                CompletionItem::new_simple(
-                    name.to_string(),
-                    pr.Type().map(|t| t.text().into()).unwrap_or_else(|| "property".to_owned()),
-                )
-                .with_kind(CompletionItemKind::PROPERTY)
-                .with_sort_text(format!("#{name}"))
-                .with_insert_text(format!("{name}: "), with_snippets),
-            )
-        }))
-        .chain(element.CallbackDeclaration().filter_map(|cd| {
-            let name = cd.DeclaredIdentifier().child_text(SyntaxKind::Identifier)?;
-            Some(
-                CompletionItem::new_simple(name.to_string(), "callback".into())
-                    .with_kind(CompletionItemKind::METHOD)
-                    .with_sort_text(format!("#{name}"))
-                    .with_insert_text(format!("{name} => {{$1}}"), with_snippets),
-            )
-        }))
+        .chain(local_declarations)
         .collect::<Vec<_>>();
 
     if !matches!(element_type, ElementType::Global) {

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -2745,6 +2745,27 @@ export component TestWindow inherits Window {
     }
 
     #[test]
+    fn shadowed_member_dot_completion_type() {
+        let source = r#"
+            component Base {
+                @shadowable in-out property <int> prop;
+            }
+            component Derived inherits Base {
+                in-out property <string> prop;
+            }
+            export component Main {
+                foo := Derived { }
+                the-text := Text {
+                    text: foo.pr🔺;
+                }
+            }
+        "#;
+        let results = get_completions_experimental(source).unwrap();
+        let prop = results.iter().find(|c| c.label == "prop").unwrap();
+        assert_eq!(prop.detail.as_deref(), Some("string"), "should show the overriding type");
+    }
+
+    #[test]
     fn shadowed_member_completed_once() {
         // A member that shadows an inherited one must be offered a single time, not once for the
         // inherited declaration and once for the shadow.

--- a/tools/lsp/preview/properties.rs
+++ b/tools/lsp/preview/properties.rs
@@ -5,7 +5,7 @@ use crate::common::{self, Result};
 use crate::util;
 use i_slint_compiler::diagnostics::Spanned;
 use i_slint_compiler::expression_tree::{Expression, TwoWayBinding, Unit};
-use i_slint_compiler::langtype::{ElementType, Type};
+use i_slint_compiler::langtype::{ElementType, PropertyLookupMode, Type};
 use i_slint_compiler::object_tree::{Element, ElementRc, PropertyDeclaration, PropertyVisibility};
 use i_slint_compiler::parser::{
     SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TextSize, syntax_nodes,
@@ -296,7 +296,9 @@ fn find_property_binding_offset(
     let element = element.element.borrow();
 
     // A member that shadows an inherited one is stored under a mangled internal key.
-    let key = element.lookup_property(property_name).internal_or_resolved_name();
+    let key = element
+        .lookup_property(property_name, PropertyLookupMode::ComponentLocal)
+        .internal_or_resolved_name();
     if let Some(v) = element.binding_cell_including_synthetic(&key)
         && let Some(span) = &v.borrow().span
     {
@@ -332,7 +334,10 @@ fn insert_property_definitions(
         }
 
         // A member that shadows an inherited one is stored under a mangled internal key.
-        let key = element.borrow().lookup_property(prop).internal_or_resolved_name();
+        let key = element
+            .borrow()
+            .lookup_property(prop, PropertyLookupMode::ComponentLocal)
+            .internal_or_resolved_name();
         if let Some(binding) = element.borrow().binding(&key) {
             let e = binding.expression.ignore_debug_hooks().clone();
             if !matches!(e, Expression::Invalid) {
@@ -405,7 +410,7 @@ pub(super) fn get_properties(
                 {
                     let current = current_element.borrow();
                     add_element_properties(&current, &c.id, depth, false, &shadowed, &mut result);
-                    shadowed.extend(current.shadowing_members.keys().cloned());
+                    shadowed.extend(current.visible_shadowing_members().cloned());
                 }
                 continue;
             }
@@ -1071,6 +1076,33 @@ export component Main {
         assert_eq!(prop.ty, Type::Int32);
         // Its binding is found despite the mangled key, so it reads as defined, not as a fresh
         // property waiting for a value.
+        assert!(prop.defined_at.is_some());
+    }
+
+    #[test]
+    fn test_get_properties_private_shadow_transparent() {
+        // A private declaration shadowing a public `@shadowable` member is invisible from outside
+        // the component, so the property editor lists the inherited public member, under its type.
+        let (dc, url, _) = loaded_document_cache_with_experimental(
+            r#"
+component Base {
+    @shadowable in-out property <int> prop: 1;
+}
+component Derived inherits Base {
+    private property <string> prop: "x";
+}
+export component Main {
+    the-derived := Derived {
+        prop: 5;
+    }
+}
+"#
+            .into(),
+        );
+        let (_, result) = properties_at_position_in_cache(9, 8, &dc, &url).unwrap();
+        let prop = find_property(&result, "prop").expect("'prop' should be listed");
+        assert_eq!(prop.ty, Type::Int32, "should be the inherited public type, not the shadow");
+        // The external binding of the inherited property is found (round-trip works).
         assert!(prop.defined_at.is_some());
     }
 

--- a/tools/lsp/util.rs
+++ b/tools/lsp/util.rs
@@ -4,7 +4,7 @@
 // cSpell: ignore qualname
 use i_slint_compiler::diagnostics::{ByteFormat, SourceFile, Spanned};
 use i_slint_compiler::expression_tree::Expression;
-use i_slint_compiler::langtype::{ElementType, Type};
+use i_slint_compiler::langtype::{ElementType, PropertyLookupMode, Type};
 use i_slint_compiler::lookup::LookupCtx;
 use i_slint_compiler::object_tree::{self, type_from_node};
 use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken, syntax_nodes};
@@ -239,7 +239,13 @@ pub fn with_property_lookup_ctx<R>(
         })
         .and_then(|p| p.Type())
         .map(|n| object_tree::type_from_node(n, &mut Default::default(), tr))
-        .or_else(|| scope.last().map(|e| e.borrow().lookup_property(prop_name).property_type));
+        .or_else(|| {
+            scope.last().map(|e| {
+                e.borrow()
+                    .lookup_property(prop_name, PropertyLookupMode::ComponentLocal)
+                    .property_type
+            })
+        });
 
     // try to match properties from `PropertyAnimation`
     if is_animate {


### PR DESCRIPTION
Follow-up of the member shadowing PR #12927

  - A private property that shadows an inherited public `@shadowable` member no
    longer hides it. From outside the component the name resolves to the inherited
    member; inside the component the private one is still used.
  - Fix the type shown in auto-completion for a member shadowed in a base
    component (it showed the base type instead of the overriding one).
  - Small cleanup of the completion code that avoided offering a shadowed member
    twice.

