### PR TITLE
tests: extend flexbox test coverage

### DIFF
--- a/tests/cases/layout/flexbox_if_preferred_size.slint
+++ b/tests/cases/layout/flexbox_if_preferred_size.slint
@@ -1,0 +1,59 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression: items inside `if cond:` (a repeater body of 0 or 1 items)
+// were excluded from a FlexboxLayout's preferred-size aggregation. The
+// `WithFlexboxLayoutItemInfo` codegen iterated `repeater.instance_at(i)`
+// for `i in 0..repeater.len()`, but `len()` only counts already-created
+// instances and the layout-info path didn't first `ensure_updated` the
+// repeater, so the loop ran zero times.
+//
+// The same bug applied to `WithLayoutItemInfo` (BoxLayout/Grid).
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    flex := FlexboxLayout {
+        flex-direction: column;
+        flex-wrap: no-wrap;
+        spacing: 6px;
+        padding: 8px;
+        Rectangle { width: 60px; height: 30px; background: red; }
+        if true: Rectangle { width: 60px; height: 40px; background: green; }
+        Rectangle { width: 60px; height: 50px; background: blue; }
+    }
+    box := VerticalLayout {
+        x: 200px;
+        spacing: 6px;
+        padding: 8px;
+        Rectangle { width: 60px; height: 30px; background: red; }
+        if true: Rectangle { width: 60px; height: 40px; background: green; }
+        Rectangle { width: 60px; height: 50px; background: blue; }
+    }
+
+    // Expected: 30 + 6 + 40 + 6 + 50 + 8*2 = 148px
+    out property <int> flex_pref: flex.preferred-height / 1px;
+    out property <int> box_pref: box.preferred-height / 1px;
+    out property <bool> flex_ok: flex.preferred-height == 148px;
+    out property <bool> box_ok: box.preferred-height == 148px;
+
+    out property <bool> test: flex_ok && box_ok;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_order.slint
+++ b/tests/cases/layout/flexbox_order.slint
@@ -104,6 +104,39 @@ component TestOrderColumn inherits Rectangle {
     out property <bool> test: test_a && test_b && test_c;
 }
 
+// Test 4: changing layout-order at runtime re-runs the layout
+component TestOrderDynamic inherits Rectangle {
+    width: 300px;
+    height: 50px;
+    in-out property <int> order-a: 0;
+    FlexboxLayout {
+        flex-wrap: no-wrap;
+
+        d_a := Rectangle {
+            width: 100px;
+            height: 50px;
+            layout-order: root.order-a;
+            background: red;
+        }
+        d_b := Rectangle {
+            width: 100px;
+            height: 50px;
+            layout-order: 1;
+            background: green;
+        }
+        d_c := Rectangle {
+            width: 100px;
+            height: 50px;
+            layout-order: 2;
+            background: blue;
+        }
+    }
+
+    out property <length> a-x: d_a.x;
+    // Initial order: A(0), B(1), C(2)
+    out property <bool> test: d_a.x == 0px && d_b.x == 100px && d_c.x == 200px;
+}
+
 export component TestCase inherits Window {
     width: 400px;
     height: 500px;
@@ -112,24 +145,37 @@ export component TestCase inherits Window {
         t1 := TestOrderRow { }
         t2 := TestOrderDefault { }
         t3 := TestOrderColumn { }
+        t4 := TestOrderDynamic { }
     }
 
-    out property <bool> test: t1.test && t2.test && t3.test;
+    in-out property <int> dynamic-order <=> t4.order-a;
+    out property <length> dynamic-a-x <=> t4.a-x;
+
+    out property <bool> test: t1.test && t2.test && t3.test && t4.test;
 }
 
 /*
 ```cpp
 auto handle = TestCase::create();
 assert(handle->get_test());
+// Move A last at runtime: visual order becomes B(1), C(2), A(3)
+handle->set_dynamic_order(3);
+assert_eq(handle->get_dynamic_a_x(), 200.);
 ```
 
 ```rust
 let instance = TestCase::new().unwrap();
 assert!(instance.get_test());
+// Move A last at runtime: visual order becomes B(1), C(2), A(3)
+instance.set_dynamic_order(3);
+assert_eq!(instance.get_dynamic_a_x(), 200.);
 ```
 
 ```js
 var instance = new slint.TestCase();
 assert(instance.test);
+// Move A last at runtime: visual order becomes B(1), C(2), A(3)
+instance.dynamic_order = 3;
+assert.equal(instance.dynamic_a_x, 200);
 ```
 */


### PR DESCRIPTION
Two test-only commits, follow-up to #12923 now that `layout-order` is stable:

- `flexbox_order`: cover changing `layout-order` at runtime.
- New `flexbox_if_preferred_size`: verify that `if cond:` items contribute to the preferred-size aggregation of `FlexboxLayout` and `VerticalLayout` (regression test for the normal access path; the init-time variant is a separate known issue).