### PR TITLE
winit: Release native menus so they don't leak the window adapter

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -395,6 +395,24 @@ inline void setup_popup_menu_from_menu_item_tree(
             [shared](const auto &entry) { shared.vtable()->activate(shared.borrow(), &entry); });
 }
 
+// Set up a menu bar from a menu item tree: register its shortcuts, install the native menu bar when
+// the platform provides one, and always wire the fallback handlers, which also keep the tree alive
+// on the component (the native menu bar holds only a weak reference to it).
+inline void setup_menu_bar_from_menu_item_tree(
+        const cbindgen_private::WindowAdapterRcOpaque *window_handle, bool no_native,
+        const vtable::VRc<cbindgen_private::MenuVTable> &shared,
+        Property<std::shared_ptr<Model<cbindgen_private::MenuEntry>>> &entries,
+        Callback<std::shared_ptr<Model<cbindgen_private::MenuEntry>>(cbindgen_private::MenuEntry)>
+                &sub_menu,
+        Callback<void(cbindgen_private::MenuEntry)> &activated)
+{
+    cbindgen_private::slint_windowrc_setup_menu_bar_shortcuts(window_handle, &shared);
+    if (!no_native && cbindgen_private::slint_windowrc_supports_native_menu_bar(window_handle)) {
+        cbindgen_private::slint_windowrc_setup_native_menu_bar(window_handle, &shared);
+    }
+    setup_popup_menu_from_menu_item_tree(shared, entries, sub_menu, activated);
+}
+
 inline SharedString translate(const SharedString &original, const SharedString &context,
                               const SharedString &domain,
                               cbindgen_private::Slice<SharedString> arguments, int n,

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1136,6 +1136,13 @@ impl WinitWindowAdapter {
     }
 
     fn set_visibility(&self, visibility: WindowVisibility) -> Result<(), PlatformError> {
+        // Release the native menus that keep this adapter alive through the globals.
+        #[cfg(muda)]
+        if visibility == WindowVisibility::Hidden {
+            self.menubar.take();
+            self.context_menu.take();
+        }
+
         if visibility == self.shown.get() {
             return Ok(());
         }
@@ -1226,13 +1233,6 @@ impl WinitWindowAdapter {
 
             Ok(())
         } else {
-            // Release the native menus: their item trees keep this adapter alive through the globals.
-            #[cfg(muda)]
-            {
-                self.menubar.take();
-                self.context_menu.take();
-            }
-
             // Wayland doesn't support hiding a window, only destroying it entirely.
             if self.winit_window_or_none.borrow().as_window().is_some_and(|winit_window| {
                 use raw_window_handle::HasWindowHandle;

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1226,6 +1226,13 @@ impl WinitWindowAdapter {
 
             Ok(())
         } else {
+            // Release the native menus: their item trees keep this adapter alive through the globals.
+            #[cfg(muda)]
+            {
+                self.menubar.take();
+                self.context_menu.take();
+            }
+
             // Wayland doesn't support hiding a window, only destroying it entirely.
             if self.winit_window_or_none.borrow().as_window().is_some_and(|winit_window| {
                 use raw_window_handle::HasWindowHandle;
@@ -1675,6 +1682,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
             return false;
         }
 
+        // Set before showing: on Windows the activation event can arrive before this returns.
         self.context_menu.replace(Some(context_menu_item));
 
         if let WinitWindowOrNone::HasWindow { context_menu_muda_adapter, .. } =
@@ -1692,6 +1700,9 @@ impl WindowAdapterInternal for WinitWindowAdapter {
                 return true;
             }
         }
+
+        // No native menu shown; release it so it doesn't keep the adapter alive.
+        self.context_menu.take();
         false
     }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -18,6 +18,8 @@ use euclid::approxeq::ApproxEq;
 use i_slint_core::api::LogicalPosition;
 use i_slint_core::cursor::{MouseCursorInner, scaled_hotspot};
 use i_slint_core::lengths::{PhysicalPx, ScaleFactor};
+#[cfg(muda)]
+use i_slint_core::menus::MenuVTable;
 use i_slint_core::renderer::DrawOutcome;
 use winit::event_loop::ActiveEventLoop;
 #[cfg(target_arch = "wasm32")]
@@ -394,11 +396,13 @@ pub struct WinitWindowAdapter {
         objc2::rc::Retained<objc2::runtime::ProtocolObject<dyn objc2::runtime::NSObjectProtocol>>,
     >,
 
+    // The component owns the menu item tree, which reaches this adapter through the globals. Holding
+    // it weakly here keeps the adapter out of that ownership cycle.
     #[cfg(muda)]
-    menubar: RefCell<Option<vtable::VRc<i_slint_core::menus::MenuVTable>>>,
+    menubar_weak: RefCell<Option<vtable::VWeak<MenuVTable>>>,
 
     #[cfg(muda)]
-    context_menu: RefCell<Option<vtable::VRc<i_slint_core::menus::MenuVTable>>>,
+    context_menu: RefCell<Option<vtable::VRc<MenuVTable>>>,
 
     #[cfg(all(muda, target_os = "macos"))]
     muda_enable_default_menu_bar: bool,
@@ -445,7 +449,7 @@ impl WinitWindowAdapter {
             #[cfg(target_os = "macos")]
             macos_color_observer: OnceCell::new(),
             #[cfg(muda)]
-            menubar: Default::default(),
+            menubar_weak: Default::default(),
             #[cfg(muda)]
             context_menu: Default::default(),
             #[cfg(all(muda, target_os = "macos"))]
@@ -530,7 +534,7 @@ impl WinitWindowAdapter {
 
         // Work around issue with menu bar appearing translucent in fullscreen (#8793)
         #[cfg(all(muda, target_os = "windows"))]
-        if self.menubar.borrow().is_some() {
+        if self.menubar().is_some() {
             window_attributes = window_attributes.with_transparent(false);
         }
 
@@ -655,7 +659,8 @@ impl WinitWindowAdapter {
 
         #[cfg(muda)]
         {
-            let new_muda_adapter = self.menubar.borrow().as_ref().map(|menubar| {
+            let menubar = self.menubar();
+            let new_muda_adapter = menubar.as_ref().map(|menubar| {
                 crate::muda::MudaAdapter::setup(
                     menubar,
                     &winit_window,
@@ -808,6 +813,11 @@ impl WinitWindowAdapter {
     }
 
     #[cfg(muda)]
+    fn menubar(&self) -> Option<vtable::VRc<MenuVTable>> {
+        self.menubar_weak.borrow().as_ref().and_then(vtable::VWeak::upgrade)
+    }
+
+    #[cfg(muda)]
     pub fn rebuild_menubar(&self) {
         let WinitWindowOrNone::HasWindow {
             window: winit_window,
@@ -819,7 +829,8 @@ impl WinitWindowAdapter {
         };
         let mut maybe_muda_adapter = maybe_muda_adapter.borrow_mut();
         let Some(muda_adapter) = maybe_muda_adapter.as_mut() else { return };
-        muda_adapter.rebuild_menu(winit_window, self.menubar.borrow().as_ref(), MudaType::Menubar);
+        let menubar = self.menubar();
+        muda_adapter.rebuild_menu(winit_window, menubar.as_ref(), MudaType::Menubar);
     }
 
     #[cfg(muda)]
@@ -841,13 +852,17 @@ impl WinitWindowAdapter {
         };
         let maybe_muda_adapter = maybe_muda_adapter.borrow();
         let Some(muda_adapter) = maybe_muda_adapter.as_ref() else { return };
-        let menu = match muda_type {
-            MudaType::Menubar => &self.menubar,
-            MudaType::Context => &self.context_menu,
-        };
-        let menu = menu.borrow();
-        let Some(menu) = menu.as_ref() else { return };
-        muda_adapter.invoke(menu, entry_id);
+        match muda_type {
+            MudaType::Menubar => {
+                let Some(menu) = self.menubar() else { return };
+                muda_adapter.invoke(&menu, entry_id);
+            }
+            MudaType::Context => {
+                let menu = self.context_menu.borrow();
+                let Some(menu) = menu.as_ref() else { return };
+                muda_adapter.invoke(menu, entry_id);
+            }
+        }
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -1120,7 +1135,7 @@ impl WinitWindowAdapter {
             {
                 if muda_adapter.borrow().is_none()
                     && self.muda_enable_default_menu_bar
-                    && self.menubar.borrow().is_none()
+                    && self.menubar().is_none()
                 {
                     *muda_adapter.borrow_mut() =
                         Some(crate::muda::MudaAdapter::setup_default_menu_bar()?);
@@ -1136,13 +1151,6 @@ impl WinitWindowAdapter {
     }
 
     fn set_visibility(&self, visibility: WindowVisibility) -> Result<(), PlatformError> {
-        // Release the native menus that keep this adapter alive through the globals.
-        #[cfg(muda)]
-        if visibility == WindowVisibility::Hidden {
-            self.menubar.take();
-            self.context_menu.take();
-        }
-
         if visibility == self.shown.get() {
             return Ok(());
         }
@@ -1233,6 +1241,10 @@ impl WinitWindowAdapter {
 
             Ok(())
         } else {
+            // Release the context menu; it holds the menu item tree that keeps this adapter alive.
+            #[cfg(muda)]
+            self.context_menu.take();
+
             // Wayland doesn't support hiding a window, only destroying it entirely.
             if self.winit_window_or_none.borrow().as_window().is_some_and(|winit_window| {
                 use raw_window_handle::HasWindowHandle;
@@ -1655,8 +1667,8 @@ impl WindowAdapterInternal for WinitWindowAdapter {
     }
 
     #[cfg(muda)]
-    fn setup_menubar(&self, menubar: vtable::VRc<i_slint_core::menus::MenuVTable>) {
-        self.menubar.replace(Some(menubar));
+    fn setup_menubar(&self, menubar: vtable::VRc<MenuVTable>) {
+        self.menubar_weak.replace(Some(vtable::VRc::downgrade(&menubar)));
 
         if let WinitWindowOrNone::HasWindow { muda_adapter, .. } =
             &*self.winit_window_or_none.borrow()
@@ -1664,7 +1676,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
             // On Windows, we must destroy the muda menu before re-creating a new one
             drop(muda_adapter.borrow_mut().take());
             muda_adapter.replace(Some(crate::muda::MudaAdapter::setup(
-                self.menubar.borrow().as_ref().unwrap(),
+                &menubar,
                 &self.winit_window().unwrap(),
                 self.event_loop_proxy.clone(),
                 self.self_weak.clone(),
@@ -1675,7 +1687,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
     #[cfg(muda)]
     fn show_native_popup_menu(
         &self,
-        context_menu_item: vtable::VRc<i_slint_core::menus::MenuVTable>,
+        context_menu_item: vtable::VRc<MenuVTable>,
         position: LogicalPosition,
     ) -> bool {
         if crate::muda::is_disabled() {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5043,14 +5043,8 @@ fn compile_builtin_function_call(
             let access_entries = access_member(entries_r, ctx).unwrap();
             let access_sub_menu = access_member(sub_menu_r, ctx).unwrap();
             let access_activated = access_member(activated_r, ctx).unwrap();
-            if *no_native {
-                format!(r"{{
-                    auto item_tree = {item_tree_id}::create(self);
-                    auto item_tree_dyn = item_tree.into_dyn();
-                    auto menu_wrapper = slint::private_api::create_menu_wrapper(item_tree_dyn);
-                    slint::private_api::slint_windowrc_setup_menu_bar_shortcuts(&{window}.handle(), &menu_wrapper);
-                    slint::private_api::setup_popup_menu_from_menu_item_tree(menu_wrapper, {access_entries}, {access_sub_menu}, {access_activated});
-                }}")
+            let menu_wrapper = if *no_native {
+                "slint::private_api::create_menu_wrapper(item_tree_dyn)".into()
             } else {
                 let compile_prop = |prop_expr: &llr::Expression| {
                     let binding = compile_expression(prop_expr, ctx);
@@ -5060,23 +5054,17 @@ fn compile_builtin_function_call(
                                 return {binding};
                             }}")
                 };
-
                 let condition = compile_prop(condition);
                 let visible = compile_prop(visible);
+                format!("slint::private_api::create_menu_wrapper(item_tree_dyn, {condition}, {visible})")
+            };
 
-                format!(r"{{
+            format!(r"{{
                     auto item_tree = {item_tree_id}::create(self);
                     auto item_tree_dyn = item_tree.into_dyn();
-                    auto menu_wrapper = slint::private_api::create_menu_wrapper(item_tree_dyn, {condition}, {visible});
-                    slint::private_api::slint_windowrc_setup_menu_bar_shortcuts(&{window}.handle(), &menu_wrapper);
-                    if ({window}.supports_native_menu_bar()) {{
-                        slint::cbindgen_private::slint_windowrc_setup_native_menu_bar(&{window}.handle(), &menu_wrapper);
-                    }}
-                    // These handlers keep the menu item tree alive on the component; the native menu
-                    // bar holds only a weak reference to it.
-                    slint::private_api::setup_popup_menu_from_menu_item_tree(menu_wrapper, {access_entries}, {access_sub_menu}, {access_activated});
+                    auto menu_wrapper = {menu_wrapper};
+                    slint::private_api::setup_menu_bar_from_menu_item_tree(&{window}.handle(), {no_native}, menu_wrapper, {access_entries}, {access_sub_menu}, {access_activated});
                 }}")
-            }
         }
         BuiltinFunction::SetupSystemTrayIcon => {
             let [

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5071,9 +5071,10 @@ fn compile_builtin_function_call(
                     slint::private_api::slint_windowrc_setup_menu_bar_shortcuts(&{window}.handle(), &menu_wrapper);
                     if ({window}.supports_native_menu_bar()) {{
                         slint::cbindgen_private::slint_windowrc_setup_native_menu_bar(&{window}.handle(), &menu_wrapper);
-                    }} else {{
-                        slint::private_api::setup_popup_menu_from_menu_item_tree(menu_wrapper, {access_entries}, {access_sub_menu}, {access_activated});
                     }}
+                    // These handlers keep the menu item tree alive on the component; the native menu
+                    // bar holds only a weak reference to it.
+                    slint::private_api::setup_popup_menu_from_menu_item_tree(menu_wrapper, {access_entries}, {access_sub_menu}, {access_activated});
                 }}")
             }
         }

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5016,7 +5016,7 @@ fn compile_builtin_function_call(
                         if sp::WindowInner::from_pub(#window_adapter_tokens.window()).supports_native_menu_bar() {
                             let menu_item_tree_dyn = sp::VRc::into_dyn(sp::VRc::clone(&menu_item_tree));
                             sp::WindowInner::from_pub(#window_adapter_tokens.window()).setup_menubar(menu_item_tree_dyn);
-                        } else
+                        }
                     }
                 }
             };
@@ -5024,7 +5024,9 @@ fn compile_builtin_function_call(
             quote!({
                 let menu_item_tree_instance = #item_tree_id::new(_self.self_weak.get().unwrap().clone()).unwrap();
                 #native_impl
-                /*else*/ {
+                // These handlers keep the menu item tree alive on the component; the native menu bar
+                // holds only a weak reference to it.
+                {
                     let menu_item_tree_ = sp::VRc::clone(&menu_item_tree);
                     #access_entries.set_binding(move || {
                         let mut entries = sp::SharedVector::default();

--- a/internal/interpreter/popup.rs
+++ b/internal/interpreter/popup.rs
@@ -208,13 +208,14 @@ pub(crate) fn setup_menubar(ctx: &mut EvalContext, arguments: &[Expression]) -> 
     let menubar = vtable::VRc::into_dyn(vtable::VRc::clone(&menu_item_tree));
     window_inner.setup_menubar_shortcuts(vtable::VRc::clone(&menubar));
 
+    // Keep the menubar alive on the owning sub-component: the native menu bar only holds a weak
+    // reference to it.
+    *current.menubar.borrow_mut() = Some(vtable::VRc::clone(&menubar));
+
     if !no_native && window_inner.supports_native_menu_bar() {
         window_inner.setup_menubar(menubar);
         return Value::Void;
     }
-
-    // Keep the menubar alive on the owning sub-component.
-    *current.menubar.borrow_mut() = Some(menubar);
 
     // Wire up entries/sub_menu/activated for the fallback menu bar widget.
     wire_menu_from_item_tree(ctx, entries_ref, sub_menu_ref, activated_ref, menu_item_tree);

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -5571,6 +5571,7 @@ version = "1.18.0"
 dependencies = [
  "i-slint-backend-qt",
  "i-slint-backend-winit",
+ "i-slint-core",
  "libtest-mimic",
  "linkme",
  "satchel",

--- a/tests/backends/Cargo.toml
+++ b/tests/backends/Cargo.toml
@@ -20,6 +20,7 @@ publish = false
 slint = { workspace = true, default-features = false, features = ["std", "compat-1-2", "renderer-software"] }
 i-slint-backend-winit = { workspace = true, features = ["x11", "wayland", "renderer-software"] }
 i-slint-backend-qt = { workspace = true, features = ["default"] }
+i-slint-core = { workspace = true }
 
 # TODO: Add additional test for LinuxKMS, but that requires root permissions.
 # TODO: Add additional test for Android Activity, but that requires an Android device and the Android SDK setup.

--- a/tests/backends/tests/cases/context_menu.rs
+++ b/tests/backends/tests/cases/context_menu.rs
@@ -1,0 +1,38 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// The native context menu is kept alive by the window adapter so that a later menu event can still
+// be delivered. But the menu owns an item tree, which owns a strong reference back to the adapter
+// through the globals: unless the adapter releases it, it outlives its own component and leaks. (#12971)
+//
+// The window is deliberately never shown: without a native window there is nothing to pop the menu
+// up in, so the backend falls back to the Slint popup instead of entering the platform's modal menu
+// loop, which no test could dismiss.
+#[satchel::test]
+fn native_context_menu_does_not_leak_the_window_adapter() {
+    slint::slint! {
+        export component App inherits Window {
+            menu := ContextMenuArea {
+                Menu {
+                    MenuItem { title: "Item"; }
+                }
+            }
+            public function show-menu() { menu.show({ x: 0, y: 0 }); }
+            public function close-menu() { menu.close(); }
+        }
+    }
+
+    let app = App::new().unwrap();
+    app.invoke_show_menu();
+    // An open popup keeps the adapter alive on its own, so close it: the menu is what's tested.
+    app.invoke_close_menu();
+
+    let adapter = std::rc::Rc::downgrade(
+        &i_slint_core::window::WindowInner::from_pub(app.window()).window_adapter(),
+    );
+
+    app.hide().unwrap();
+    drop(app);
+
+    assert!(adapter.upgrade().is_none(), "the window adapter outlived its component");
+}

--- a/tests/backends/tests/cases/menubar.rs
+++ b/tests/backends/tests/cases/menubar.rs
@@ -1,0 +1,31 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A native menu bar is kept alive by the window adapter so that a later menu event can activate the
+// selected entry. But the menu owns an item tree, which owns a strong reference back to the adapter
+// through the globals: unless the adapter releases it, it outlives its own component and leaks its
+// resources (including the GPU objects held by the renderer). (#12971)
+#[satchel::test]
+fn native_menu_bar_does_not_leak_the_window_adapter() {
+    slint::slint! {
+        export component App inherits Window {
+            MenuBar {
+                Menu {
+                    title: "File";
+                    MenuItem { title: "Quit"; }
+                }
+            }
+        }
+    }
+
+    let app = App::new().unwrap();
+
+    let adapter = std::rc::Rc::downgrade(
+        &i_slint_core::window::WindowInner::from_pub(app.window()).window_adapter(),
+    );
+
+    app.hide().unwrap();
+    drop(app);
+
+    assert!(adapter.upgrade().is_none(), "the window adapter outlived its component");
+}

--- a/tests/backends/tests/cases/mod.rs
+++ b/tests/backends/tests/cases/mod.rs
@@ -1,7 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+pub mod context_menu;
 pub mod harness;
+pub mod menubar;
 pub mod platform_is_app;
 pub mod text_input_password;
 use std::sync::{


### PR DESCRIPTION
The native menu bar and context menu are kept in the window adapter so a
later muda event can activate the selected entry. But each owns a menu
item tree, which owns the globals, which own a strong reference back to
this very adapter. Nothing ever let go of them, so once a menu bar or a
context menu was set up the adapter could never be destroyed, leaking it
and everything it holds (including the renderer's GPU objects).

Release the menus when hiding the window, and release the context menu
right away when no native menu was shown and the caller falls back to a
Slint popup.

Fixes #12971
