### PR TITLE
Add accessibility tree tests for widgets

### DIFF
--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -213,10 +213,17 @@ pub fn block_on<R>(future: impl Future<Output = R>) -> R {
 ///
 /// Each line represents one element that's exposed to assistive technologies, indented by
 /// its depth in the accessibility tree: the accessible role, followed by the label in
-/// double quotes (if any), the value (if any), and the `checkable`, `checked` and
-/// `disabled` states when they apply. Elements with `accessible-role: none` don't appear,
-/// but their accessible descendants do, just like in the tree presented to screen
-/// readers: the traversal is the same one the AccessKit integration uses.
+/// double quotes (if any), all other accessible properties that are set, and the supported
+/// accessibility actions. Boolean states appear as bare flags when true (`checkable`,
+/// `checked`, `expanded`, ...), a false `enabled` appears as `disabled`, and everything
+/// else as `name=value`. Elements with `accessible-role: none` don't appear, but their
+/// accessible descendants do, just like in the tree presented to screen readers: the
+/// traversal is the same one the AccessKit integration uses.
+///
+/// Values that are apparent from the structure of the tree are left out to keep the
+/// output readable: `item-index` when it matches the element's position among its
+/// siblings, `item-count` when it matches the number of accessible children, and the
+/// supported actions when they consist of just the default action.
 ///
 /// This is used by the test driver to verify the accessibility tree of an entire user
 /// interface as one assertion, for example to ensure that widgets don't expose their
@@ -228,30 +235,41 @@ pub fn block_on<R>(future: impl Future<Output = R>) -> R {
 ///   button "Log in"
 /// ```
 pub fn accessibility_tree(component: &impl crate::ElementRoot) -> String {
-    use i_slint_core::accessibility::{AccessibleStringProperty, accessible_descendents};
+    use i_slint_core::accessibility::{
+        AccessibleStringProperty, SupportedAccessibilityAction, accessible_descendents,
+    };
     use std::fmt::Write;
 
     fn visit(item: &i_slint_core::items::ItemRc, indent: usize, out: &mut String) {
-        for child in accessible_descendents(item) {
+        let children = accessible_descendents(item).collect::<Vec<_>>();
+        for (position, child) in children.iter().enumerate() {
+            let property =
+                |property| child.accessible_string_property(property).filter(|v| !v.is_empty());
             write!(out, "{:indent$}{}", "", child.accessible_role()).unwrap();
-            if let Some(label) = child
-                .accessible_string_property(AccessibleStringProperty::Label)
-                .filter(|label| !label.is_empty())
-            {
+            if let Some(label) = property(AccessibleStringProperty::Label) {
                 write!(out, " \"{label}\"").unwrap();
             }
-            if let Some(value) = child
-                .accessible_string_property(AccessibleStringProperty::Value)
-                .filter(|value| !value.is_empty())
-            {
-                write!(out, " value=\"{value}\"").unwrap();
-            }
-            for (property, name) in [
-                (AccessibleStringProperty::Checkable, "checkable"),
-                (AccessibleStringProperty::Checked, "checked"),
+            for p in [
+                AccessibleStringProperty::Value,
+                AccessibleStringProperty::Description,
+                AccessibleStringProperty::PlaceholderText,
+                AccessibleStringProperty::Id,
             ] {
-                if child.accessible_string_property(property).as_deref() == Some("true") {
-                    write!(out, " {name}").unwrap();
+                if let Some(value) = property(p) {
+                    write!(out, " {p}=\"{value}\"").unwrap();
+                }
+            }
+            for p in [
+                AccessibleStringProperty::Checkable,
+                AccessibleStringProperty::Checked,
+                AccessibleStringProperty::Expandable,
+                AccessibleStringProperty::Expanded,
+                AccessibleStringProperty::ItemSelectable,
+                AccessibleStringProperty::ItemSelected,
+                AccessibleStringProperty::ReadOnly,
+            ] {
+                if child.accessible_string_property(p).as_deref() == Some("true") {
+                    write!(out, " {p}").unwrap();
                 }
             }
             if child.accessible_string_property(AccessibleStringProperty::Enabled).as_deref()
@@ -259,8 +277,47 @@ pub fn accessibility_tree(component: &impl crate::ElementRoot) -> String {
             {
                 out.push_str(" disabled");
             }
+            if let Some(index) = property(AccessibleStringProperty::ItemIndex)
+                .filter(|index| index.as_str() != position.to_string())
+            {
+                write!(out, " item-index={index}").unwrap();
+            }
+            if let Some(count) = property(AccessibleStringProperty::ItemCount)
+                .filter(|count| count.as_str() != accessible_descendents(child).count().to_string())
+            {
+                write!(out, " item-count={count}").unwrap();
+            }
+            for p in [
+                AccessibleStringProperty::Orientation,
+                AccessibleStringProperty::DelegateFocus,
+                AccessibleStringProperty::LiveRegion,
+                AccessibleStringProperty::ValueMinimum,
+                AccessibleStringProperty::ValueMaximum,
+                AccessibleStringProperty::ValueStep,
+            ] {
+                if let Some(value) = property(p) {
+                    write!(out, " {p}={value}").unwrap();
+                }
+            }
+            let actions = child.supported_accessibility_actions();
+            if actions != SupportedAccessibilityAction::Default && !actions.is_empty() {
+                let action_names = [
+                    (SupportedAccessibilityAction::Default, "default"),
+                    (SupportedAccessibilityAction::Decrement, "decrement"),
+                    (SupportedAccessibilityAction::Increment, "increment"),
+                    (SupportedAccessibilityAction::Expand, "expand"),
+                    (SupportedAccessibilityAction::ReplaceSelectedText, "replace-selected-text"),
+                    (SupportedAccessibilityAction::SetValue, "set-value"),
+                    (SupportedAccessibilityAction::SetSelection, "set-selection"),
+                ]
+                .iter()
+                .filter(|(action, _)| actions.contains(*action))
+                .map(|(_, name)| *name)
+                .collect::<Vec<_>>();
+                write!(out, " actions={}", action_names.join(",")).unwrap();
+            }
             out.push('\n');
-            visit(&child, indent + 2, out);
+            visit(child, indent + 2, out);
         }
     }
 

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore descendents
+
 //! This module contains helper functions that are used for our internal tests within Slint
 
 use crate::TestingWindow;
@@ -205,4 +207,64 @@ pub fn block_on<R>(future: impl Future<Output = R>) -> R {
             .unwrap_or(core::time::Duration::from_secs(1));
         crate::testing_backend::mock_elapsed_time(duration.as_millis() as u64);
     }
+}
+
+/// Returns a textual representation of the accessibility tree of the component's window.
+///
+/// Each line represents one element that's exposed to assistive technologies, indented by
+/// its depth in the accessibility tree: the accessible role, followed by the label in
+/// double quotes (if any), the value (if any), and the `checkable`, `checked` and
+/// `disabled` states when they apply. Elements with `accessible-role: none` don't appear,
+/// but their accessible descendants do, just like in the tree presented to screen
+/// readers: the traversal is the same one the AccessKit integration uses.
+///
+/// This is used by the test driver to verify the accessibility tree of an entire user
+/// interface as one assertion, for example to ensure that widgets don't expose their
+/// internal composition:
+///
+/// ```text
+/// window
+///   checkbox "Remember me" checkable
+///   button "Log in"
+/// ```
+pub fn accessibility_tree(component: &impl crate::ElementRoot) -> String {
+    use i_slint_core::accessibility::{AccessibleStringProperty, accessible_descendents};
+    use std::fmt::Write;
+
+    fn visit(item: &i_slint_core::items::ItemRc, indent: usize, out: &mut String) {
+        for child in accessible_descendents(item) {
+            write!(out, "{:indent$}{}", "", child.accessible_role()).unwrap();
+            if let Some(label) = child
+                .accessible_string_property(AccessibleStringProperty::Label)
+                .filter(|label| !label.is_empty())
+            {
+                write!(out, " \"{label}\"").unwrap();
+            }
+            if let Some(value) = child
+                .accessible_string_property(AccessibleStringProperty::Value)
+                .filter(|value| !value.is_empty())
+            {
+                write!(out, " value=\"{value}\"").unwrap();
+            }
+            for (property, name) in [
+                (AccessibleStringProperty::Checkable, "checkable"),
+                (AccessibleStringProperty::Checked, "checked"),
+            ] {
+                if child.accessible_string_property(property).as_deref() == Some("true") {
+                    write!(out, " {name}").unwrap();
+                }
+            }
+            if child.accessible_string_property(AccessibleStringProperty::Enabled).as_deref()
+                == Some("false")
+            {
+                out.push_str(" disabled");
+            }
+            out.push('\n');
+            visit(&child, indent + 2, out);
+        }
+    }
+
+    let mut out = String::from("window\n");
+    visit(&i_slint_core::items::ItemRc::new_root(component.item_tree()), 2, &mut out);
+    out
 }

--- a/tests/cases/widgets/button.slint
+++ b/tests/cases/widgets/button.slint
@@ -166,8 +166,8 @@ assert_eq(instance.get_a_focused(), true);
 
 ```a11y-tree
 window
-  button "Aaa" checkable
-  button "Bbb"
+  button "Aaa" description="Checkable Button" checkable
+  button "Bbb" description="Normal Button"
   button "Ccc"
 ```
 

--- a/tests/cases/widgets/button.slint
+++ b/tests/cases/widgets/button.slint
@@ -24,6 +24,7 @@ export component TestCase inherits Window {
 
         b := Button {
             text: "Bbb";
+            icon: @image-url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC");
             accessible-description: "Normal Button";
             clicked => {clicked += "b"; }
         }
@@ -161,6 +162,13 @@ assert_eq(bbb.accessible_checked().value(), false);
 assert_eq(instance.get_a_focused(), true);
 
 
+```
+
+```a11y-tree
+window
+  button "Aaa" checkable
+  button "Bbb"
+  button "Ccc"
 ```
 
 */

--- a/tests/cases/widgets/checkbox.slint
+++ b/tests/cases/widgets/checkbox.slint
@@ -96,4 +96,10 @@ checkbox.invoke_accessible_default_action();
 assert_eq(instance.get_toggled(), "a");
 ```
 
+```a11y-tree
+window
+  checkbox "Aaa" checkable
+  checkbox "Custom font" checkable
+```
+
 */

--- a/tests/cases/widgets/groupbox.slint
+++ b/tests/cases/widgets/groupbox.slint
@@ -34,4 +34,10 @@ let mut gb_disabled_search = slint_testing::ElementHandle::find_by_element_id(&i
 let gb_disabled = gb_disabled_search.next().unwrap();
 assert_eq!(gb_disabled.accessible_enabled(), Some(false));
 ```
+
+```a11y-tree
+window
+  groupbox "Group Title"
+  groupbox "Disabled Group" disabled
+```
 */

--- a/tests/cases/widgets/radiogroup.slint
+++ b/tests/cases/widgets/radiogroup.slint
@@ -181,4 +181,12 @@ assert_eq!(instance.get_blue_checked(), false);
 
 ```
 
+```a11y-tree
+window
+  radio-group "Colors"
+    radio-button "Red" checkable
+    radio-button "Green" checkable
+    radio-button "Blue" checkable disabled
+```
+
 */

--- a/tests/cases/widgets/radiogroup.slint
+++ b/tests/cases/widgets/radiogroup.slint
@@ -183,7 +183,7 @@ assert_eq!(instance.get_blue_checked(), false);
 
 ```a11y-tree
 window
-  radio-group "Colors"
+  radio-group "Colors" orientation=vertical
     radio-button "Red" checkable
     radio-button "Green" checkable
     radio-button "Blue" checkable disabled

--- a/tests/cases/widgets/switch.slint
+++ b/tests/cases/widgets/switch.slint
@@ -83,4 +83,9 @@ aaa.invoke_accessible_default_action();
 assert_eq(instance.get_toggled(), "a");
 ```
 
+```a11y-tree
+window
+  switch "Aaa" checkable
+```
+
 */

--- a/tests/driver/driverlib/lib.rs
+++ b/tests/driver/driverlib/lib.rs
@@ -112,7 +112,7 @@ pub struct TestFunction<'a> {
 /// Extract the test functions from
 pub fn extract_test_functions(source: &str) -> impl Iterator<Item = TestFunction<'_>> {
     static RX: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?sU)\r?\n```([a-z]+)\r?\n(.+)\r?\n```\r?\n").unwrap());
+        LazyLock::new(|| Regex::new(r"(?sU)\r?\n```([a-z0-9-]+)\r?\n(.+)\r?\n```\r?\n").unwrap());
     RX.captures_iter(source).map(|mat| TestFunction {
         language_id: mat.get(1).unwrap().as_str(),
         source: mat.get(2).unwrap().as_str(),

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -203,6 +203,36 @@ fn process_case(
         )?;
     }
 
+    // The `a11y-tree` block declares the expected accessibility tree of the instantiated
+    // TestCase; it applies to all styles except qt, whose native widgets expose different
+    // trees.
+    let a11y_tree = if testcase.requested_style != Some("qt") {
+        test_driver_lib::extract_test_functions(&source).find(|x| x.language_id == "a11y-tree")
+    } else {
+        None
+    };
+    if let Some(expected) = a11y_tree {
+        write!(
+            output,
+            r#"
+#[rust_analyzer::skip]
+#[test] {} fn accessibility_tree() {{
+    i_slint_backend_testing::init_no_event_loop();
+    i_slint_backend_testing::configure_test_fonts();
+    let instance = TestCase::new().unwrap();
+    let expected = {:?};
+    let actual = i_slint_backend_testing::accessibility_tree(&instance);
+    assert!(
+        actual.trim_end() == expected.trim_end(),
+        "accessibility tree mismatch\nexpected:\n{{expected}}\nactual (paste into the a11y-tree block if intended):\n{{actual}}"
+    );
+}}"#,
+            ignored,
+            // Windows checkouts have \r\n line endings, but the tree is rendered with \n.
+            expected.source.replace("\r\n", "\n")
+        )?;
+    }
+
     output.flush()?;
     Ok(module_line)
 }


### PR DESCRIPTION
Widget test cases can now declare the expected accessibility tree in an a11y-tree block, which is verified for every style except qt. This catches widgets accidentally exposing internal elements to assistive technologies.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
