### PR TITLE
Share the box shadow and SVG size rules between renderers

### DIFF
--- a/internal/core/graphics/boxshadowcache.rs
+++ b/internal/core/graphics/boxshadowcache.rs
@@ -88,7 +88,48 @@ impl PartialOrd for BoxShadowOptions {
     }
 }
 
+/// The geometry of a box shadow, derived from [`BoxShadowOptions`].
+///
+/// The CSS rules the renderers agree on: the shadow shape is the element's geometry
+/// grown by the spread, its corner radii grow with it, and the texture it is rendered
+/// into is padded by the blur on every side so the Gaussian can fade out to
+/// transparency within it.
 impl BoxShadowOptions {
+    /// The size of the shadow shape: the element's size grown by the spread on each
+    /// side. A negative spread shrinks it, down to nothing.
+    pub fn shape_size(&self) -> euclid::Size2D<f32, PhysicalPx> {
+        euclid::size2(
+            (self.width.get() + 2. * self.spread.get()).max(0.),
+            (self.height.get() + 2. * self.spread.get()).max(0.),
+        )
+    }
+
+    /// The size of the texture a drop shadow is rendered into: the shape padded by the
+    /// blur on each side.
+    pub fn drop_texture_size(&self) -> euclid::Size2D<f32, PhysicalPx> {
+        self.shape_size() + euclid::size2(2. * self.blur.get(), 2. * self.blur.get())
+    }
+
+    /// Where the shape sits within the drop shadow texture, i.e. the blur padding.
+    pub fn shape_origin(&self) -> euclid::Point2D<f32, PhysicalPx> {
+        euclid::point2(self.blur.get(), self.blur.get())
+    }
+
+    /// The corner radii of the shadow shape: `max(0, radius + spread)`.
+    pub fn outer_radius(&self) -> PhysicalBorderRadius {
+        (self.radius + PhysicalBorderRadius::new_uniform(self.spread.get())).max(Default::default())
+    }
+
+    /// The corner radii of the hole an inset shadow leaves: `max(0, radius - spread)`.
+    pub fn inner_radius(&self) -> PhysicalBorderRadius {
+        (self.radius - PhysicalBorderRadius::new_uniform(self.spread.get())).max(Default::default())
+    }
+
+    /// The Gaussian sigma corresponding to the CSS blur radius.
+    pub fn blur_sigma(&self) -> f32 {
+        self.blur.get() / 2.
+    }
+
     /// Extracts the rendering specific properties from the BoxShadow item and scales the logical
     /// coordinates to physical pixels used in the BoxShadowOptions. Returns None if for example the
     /// alpha on the box shadow would imply that no shadow is to be rendered.

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -1512,6 +1512,38 @@ pub fn fit(
     .adjust_for_tiling(ratio, alignment, tiling)
 }
 
+/// The pixel size a scalable image (an SVG) needs to be rasterized at to fill `target`
+/// under `image_fit`, i.e. its intrinsic size scaled by what [`fit`] would scale it by.
+///
+/// Returns `None` when the source has no area to scale from, or when the fitted size
+/// collapses to nothing.
+pub fn scalable_render_size(
+    source_size: IntSize,
+    image_fit: ImageFit,
+    target: euclid::Size2D<f32, PhysicalPx>,
+    scale_factor: ScaleFactor,
+    tiling: (ImageTiling, ImageTiling),
+) -> Option<euclid::Size2D<u32, PhysicalPx>> {
+    let source = source_size.cast::<f32>();
+    if source.is_empty() {
+        return None;
+    }
+    let fit = fit(
+        image_fit,
+        target,
+        IntRect::from_size(source_size.cast()),
+        scale_factor,
+        // Only the size is of interest here, so the alignment doesn't matter.
+        Default::default(),
+        tiling,
+    );
+    let size = euclid::size2(
+        (source.width * fit.source_to_target_x) as u32,
+        (source.height * fit.source_to_target_y) as u32,
+    );
+    (!size.is_empty()).then_some(size)
+}
+
 /// Generate an iterator of  [`FitResult`] for each slice of a nine-slice border image
 pub fn fit9slice(
     source_rect: IntSize,

--- a/internal/renderers/anyrender/itemrenderer.rs
+++ b/internal/renderers/anyrender/itemrenderer.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyrender::PaintScene;
 use i_slint_core::graphics::ResolvedBrush;
 use i_slint_core::graphics::euclid;
-use i_slint_core::graphics::{Image, ImageCacheKey, IntRect, SharedImageBuffer, SharedPixelBuffer};
+use i_slint_core::graphics::{Image, ImageCacheKey, SharedImageBuffer, SharedPixelBuffer};
 use i_slint_core::item_rendering::{
     BorderRectLayout, CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle,
     RenderImage, RenderRectangle, RenderText,
@@ -1180,21 +1180,13 @@ fn load_image(
         ),
         ImageInner::Svg(svg) => {
             // Query target_width/height here again to ensure that changes will invalidate the item rendering cache.
-            let svg_size = svg.size();
-            let fit = i_slint_core::graphics::fit(
+            let render_size = i_slint_core::graphics::scalable_render_size(
+                svg.size(),
                 image_fit,
                 target_size_fn() * scale_factor,
-                IntRect::from_size(svg_size.cast()),
                 scale_factor,
-                Default::default(), // We only care about the size, so alignments don't matter
                 Default::default(),
-            );
-            let target_size = PhysicalSize::new(
-                svg_size.cast::<f32>().width * fit.source_to_target_x,
-                svg_size.cast::<f32>().height * fit.source_to_target_y,
-            );
-            let render_size: euclid::Size2D<u32, i_slint_core::lengths::PhysicalPx> =
-                target_size.cast();
+            )?;
             image_cache.borrow_mut().get_or_insert(
                 ImageCacheKey::new(image_inner),
                 ImageVariant::Sized { width: render_size.width, height: render_size.height },

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -406,9 +406,10 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         {
             return;
         }
-        // TODO: implement inset shadows and spread for femtovg. Until then, skip rendering inset
-        // shadows entirely (otherwise they'd render incorrectly as a drop shadow). Spread is
-        // silently ignored.
+        // TODO: implement inset shadows and spread for femtovg, using the shape_size,
+        // outer_radius and inner_radius of the BoxShadowOptions. Until then, skip rendering
+        // inset shadows entirely (otherwise they'd render incorrectly as a drop shadow).
+        // Spread is silently ignored.
         if box_shadow.inset() {
             return;
         }
@@ -456,7 +457,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
 
                     let shadow_path = rect_with_radius_to_path(
                         PhysicalRect::new(
-                            PhysicalPoint::from_lengths(blur, blur),
+                            shadow_options.shape_origin(),
                             PhysicalSize::from_lengths(width, height),
                         ),
                         radius,
@@ -468,8 +469,9 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
                 }
 
                 let shadow_image = if blur.get() > 0. {
-                    let blurred_image = shadow_image
-                        .filter(femtovg::ImageFilter::GaussianBlur { sigma: blur.get() / 2. });
+                    let blurred_image = shadow_image.filter(femtovg::ImageFilter::GaussianBlur {
+                        sigma: shadow_options.blur_sigma(),
+                    });
 
                     self.canvas.borrow_mut().set_render_target(blurred_image.as_render_target());
 

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1219,23 +1219,13 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                 let tiling = item.tiling();
 
                 let target_size_for_scalable_source = if image_inner.is_svg() {
-                    let image_size = image.size().cast::<f32>();
-                    if image_size.is_empty() {
-                        return None;
-                    }
-                    let t = item.target_size() * self.scale_factor;
-                    let fit = i_slint_core::graphics::fit(
+                    Some(i_slint_core::graphics::scalable_render_size(
+                        image.size(),
                         item.image_fit(),
-                        t,
-                        IntRect::from_size(image_size.cast()),
+                        item.target_size() * self.scale_factor,
                         self.scale_factor,
-                        Default::default(), // We only care about the size, so alignments don't matter
                         tiling,
-                    );
-                    Some(euclid::size2(
-                        (image_size.width * fit.source_to_target_x) as u32,
-                        (image_size.height * fit.source_to_target_y) as u32,
-                    ))
+                    )?)
                 } else {
                     None
                 };

--- a/internal/renderers/skia/cached_image.rs
+++ b/internal/renderers/skia/cached_image.rs
@@ -1,10 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use crate::PhysicalSize;
 use i_slint_core::graphics::{
-    Image, ImageCacheKey, ImageInner, IntRect, IntSize, OpaqueImage, OpaqueImageVTable,
-    SharedImageBuffer, cache as core_cache,
+    Image, ImageCacheKey, ImageInner, IntSize, OpaqueImage, OpaqueImageVTable, SharedImageBuffer,
+    cache as core_cache,
 };
 use i_slint_core::items::ImageFit;
 use i_slint_core::lengths::{LogicalSize, ScaleFactor};
@@ -53,20 +52,14 @@ pub(crate) fn as_skia_image(
         }
         ImageInner::Svg(svg) => {
             // Query target_width/height here again to ensure that changes will invalidate the item rendering cache.
-            let svg_size = svg.size();
-            let fit = i_slint_core::graphics::fit(
+            let target_size = i_slint_core::graphics::scalable_render_size(
+                svg.size(),
                 image_fit,
                 target_size_fn() * scale_factor,
-                IntRect::from_size(svg_size.cast()),
                 scale_factor,
-                Default::default(), // We only care about the size, so alignments don't matter
                 Default::default(),
-            );
-            let target_size = PhysicalSize::new(
-                svg_size.cast::<f32>().width * fit.source_to_target_x,
-                svg_size.cast::<f32>().height * fit.source_to_target_y,
-            );
-            let pixels = match svg.render(Some(target_size.cast())).ok()? {
+            )?;
+            let pixels = match svg.render(Some(target_size)).ok()? {
                 SharedImageBuffer::RGB8(_) => unreachable!(),
                 SharedImageBuffer::RGBA8(_) => unreachable!(),
                 SharedImageBuffer::RGBA8Premultiplied(pixels) => pixels,

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -90,19 +90,15 @@ impl<'a> SkiaItemRenderer<'a> {
         canvas: &skia_safe::Canvas,
         shadow_options: &i_slint_core::graphics::boxshadowcache::BoxShadowOptions,
     ) -> Option<skia_safe::Image> {
-        let blur = shadow_options.blur.get();
-        let spread = shadow_options.spread.get();
-
-        let shape_w = (shadow_options.width.get() + 2. * spread).max(0.);
-        let shape_h = (shadow_options.height.get() + 2. * spread).max(0.);
-        if shape_w <= 0. || shape_h <= 0. {
+        let shape_size = shadow_options.shape_size();
+        if shape_size.is_empty() {
             return None;
         }
-        // CSS rule: outer corner radius after spread = max(0, r + spread).
-        let shape_radius = (shadow_options.radius + PhysicalBorderRadius::new_uniform(spread))
-            .max(Default::default());
 
-        let canvas_size: skia_safe::Size = (shape_w + 2. * blur, shape_h + 2. * blur).into();
+        let canvas_size: skia_safe::Size = {
+            let size = shadow_options.drop_texture_size();
+            (size.width, size.height).into()
+        };
 
         let image_info = crate::image_info(
             canvas_size.to_ceil(),
@@ -110,19 +106,17 @@ impl<'a> SkiaItemRenderer<'a> {
             skia_safe::AlphaType::Premul,
         );
 
-        // The shape is centered in the canvas with `blur` padding on all sides so the Gaussian blur
-        // has room to fade out into transparency.
         let rounded_rect = to_skia_rrect(
-            &PhysicalRect::new(PhysicalPoint::new(blur, blur), PhysicalSize::new(shape_w, shape_h)),
-            &shape_radius,
+            &PhysicalRect::new(shadow_options.shape_origin(), shape_size),
+            &shadow_options.outer_radius(),
         );
 
         let mut paint = crate::solid_paint(&shadow_options.color);
         paint.set_anti_alias(true);
-        if blur > 0. {
+        if shadow_options.blur.get() > 0. {
             paint.set_mask_filter(skia_safe::MaskFilter::blur(
                 skia_safe::BlurStyle::Normal,
-                blur / 2.,
+                shadow_options.blur_sigma(),
                 None,
             ));
         }
@@ -164,15 +158,13 @@ impl<'a> SkiaItemRenderer<'a> {
         );
 
         // Inner "hole" rrect: geometry inset by spread on each side, translated by offset.
-        // CSS: inner radius = max(0, radius - spread).
         let inner_rect = skia_safe::Rect::new(
             spread + offset_x,
             spread + offset_y,
             width - spread + offset_x,
             height - spread + offset_y,
         );
-        let inner_radius =
-            (radius - PhysicalBorderRadius::new_uniform(spread)).max(Default::default());
+        let inner_radius = shadow_options.inner_radius();
         let inner_rrect = to_skia_rrect(
             &PhysicalRect::new(
                 PhysicalPoint::new(inner_rect.left, inner_rect.top),
@@ -197,7 +189,7 @@ impl<'a> SkiaItemRenderer<'a> {
         if blur > 0. {
             paint.set_mask_filter(skia_safe::MaskFilter::blur(
                 skia_safe::BlurStyle::Normal,
-                blur / 2.,
+                shadow_options.blur_sigma(),
                 None,
             ));
         }


### PR DESCRIPTION
Two rules were written out once per renderer, with comments repeating them.

The box shadow geometry — shape, radii, blur padding, blur sigma — now lives in `BoxShadowOptions`. Skia uses all of it; femtovg takes the blur padding and sigma, since the rest grows with the spread it still ignores.

The size to rasterize an SVG at is now `scalable_render_size`, next to `fit()`, used by all three renderers. Only femtovg checked for a source with no area; the helper checks for everyone.

The renderers still disagree on the tiling argument, so it stays a parameter rather than being settled here.