### PR TITLE
skia: Register the window background as a rendering dependency

### DIFF
--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -576,13 +576,15 @@ impl ItemRenderer for SkiaItemRenderer<'_> {
 
     fn draw_window_background(
         &mut self,
-        _rect: Pin<&dyn i_slint_core::item_rendering::RenderRectangle>,
+        rect: Pin<&dyn i_slint_core::item_rendering::RenderRectangle>,
         _self_rc: &ItemRc,
         _size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
-        // The window background is cleared (solid color) or drawn (gradient)
-        // by SkiaRenderer before the item tree is rendered.
+        // Register a dependency for the partial renderer's dirty tracker. The actual rendering
+        // is done earlier in SkiaRenderer, which clears (solid color) or draws (gradient) the
+        // background before the item tree is rendered.
+        let _ = rect.background();
     }
 
     fn draw_image(


### PR DESCRIPTION
The partial renderer evaluates each item's draw call inside that item's property tracker, so the properties read there decide when the item repaints. Skia's draw_window_background read nothing, so changing Window.background did not mark the window item dirty.

Gradients broke too: drawing one calls draw_rectangle on the window item, which does register the dependency, but the later draw_window_background call re-evaluates the same tracker and clears it. The software and femtovg renderers paint the background themselves, so their tracker is evaluated only once, by the same one-line stub adopted here.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
