### PR TITLE
Remove the auto_enums dependency in the core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,18 +648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_enums"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3091d68264354f211516b91dce6f71046e444fab1867716035f736667243affb"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,17 +1794,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.119",
  "unicode-xid",
-]
-
-[[package]]
-name = "derive_utils"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc05a5d33db20c784f873e84934ad94bb209a090987ac5f62fede2c178234f23"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -3477,7 +3454,6 @@ dependencies = [
  "accesskit",
  "async-channel",
  "async-compat",
- "auto_enums",
  "bitflags 2.13.1",
  "cfg-if",
  "chrono",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -615,18 +615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_enums"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4487600931c9a89f8db7ffbdf3fbdd45bb7bd85e26861f659a463cd0dff966"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,17 +1306,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.119",
  "unicode-xid",
-]
-
-[[package]]
-name = "derive_utils"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2542,7 +2519,6 @@ version = "1.18.0"
 dependencies = [
  "accesskit",
  "async-channel 2.5.0",
- "auto_enums",
  "bitflags 2.13.1",
  "cfg-if",
  "chrono",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -882,18 +882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_enums"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4487600931c9a89f8db7ffbdf3fbdd45bb7bd85e26861f659a463cd0dff966"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,17 +3742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_utils"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6144,7 +6121,6 @@ version = "1.18.0"
 dependencies = [
  "accesskit",
  "async-channel",
- "auto_enums",
  "bitflags 2.13.1",
  "cfg-if",
  "chrono",

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -93,7 +93,7 @@ accessibility-text = ["std", "shared-parley", "dep:accesskit", "parley?/accesski
 
 shared-swash = ["dep:swash"]
 
-path = ["dep:auto_enums", "dep:lyon_path", "dep:lyon_geom", "dep:lyon_algorithms", "dep:lyon_extra"]
+path = ["dep:lyon_path", "dep:lyon_geom", "dep:lyon_algorithms", "dep:lyon_extra"]
 
 [dependencies]
 i-slint-common = { workspace = true, features = ["default"] }
@@ -103,7 +103,6 @@ const-field-offset = { version = "0.2.0", path = "../../helper_crates/const-fiel
 vtable = { workspace = true }
 
 portable-atomic = { version = "1", features = ["critical-section"] }
-auto_enums = { version = "0.8.0", optional = true }
 cfg-if = "1"
 derive_more = { workspace = true, features = ["error", "deref", "deref_mut"] }
 euclid = { workspace = true }

--- a/internal/core/graphics/path.rs
+++ b/internal/core/graphics/path.rs
@@ -10,7 +10,6 @@ use crate::items::{ImageFit, PathEvent};
 use crate::lengths::{LogicalPx, LogicalVector};
 #[cfg(feature = "rtti")]
 use crate::rtti::*;
-use auto_enums::auto_enum;
 use const_field_offset::FieldOffsets;
 use euclid::Point2D;
 use i_slint_core_macros::*;
@@ -206,6 +205,30 @@ impl<EventIt: Iterator<Item = lyon_path::Event<lyon_path::math::Point, lyon_path
 {
 }
 
+/// The two sources of lyon path events a `PathDataIterator` can iterate over, unified into
+/// one type so that `PathDataIterator::iter()` doesn't need to box its return value.
+enum LyonPathEventIterator<'a> {
+    FromPath(lyon_path::path::Iter<'a>),
+    FromEvents(ToLyonPathEventIterator<'a>),
+}
+
+impl Iterator for LyonPathEventIterator<'_> {
+    type Item = lyon_path::Event<lyon_path::math::Point, lyon_path::math::Point>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::FromPath(it) => it.next(),
+            Self::FromEvents(it) => it.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::FromPath(it) => it.size_hint(),
+            Self::FromEvents(it) => it.size_hint(),
+        }
+    }
+}
+
 /// PathDataIterator is a data structure that acts as starting point for iterating
 /// through the low-level events of a path. If the path was constructed from said
 /// events, then it is a very thin abstraction. If the path was created from higher-level
@@ -222,26 +245,25 @@ enum LyonPathIteratorVariant {
 
 impl PathDataIterator {
     /// Create a new iterator for path traversal.
-    #[auto_enum(Iterator)]
     pub fn iter(
         &self,
     ) -> impl Iterator<Item = lyon_path::Event<lyon_path::math::Point, lyon_path::math::Point>> + '_
     {
-        match &self.it {
-            LyonPathIteratorVariant::FromPath(path) => {
-                TransformedLyonPathIterator { it: path.iter(), transform: self.transform }
-            }
-            LyonPathIteratorVariant::FromEvents(events, coordinates) => {
-                TransformedLyonPathIterator {
-                    it: ToLyonPathEventIterator {
+        TransformedLyonPathIterator {
+            it: match &self.it {
+                LyonPathIteratorVariant::FromPath(path) => {
+                    LyonPathEventIterator::FromPath(path.iter())
+                }
+                LyonPathIteratorVariant::FromEvents(events, coordinates) => {
+                    LyonPathEventIterator::FromEvents(ToLyonPathEventIterator {
                         events_it: events.iter(),
                         coordinates_it: coordinates.iter(),
                         first: coordinates.first(),
                         last: coordinates.last(),
-                    },
-                    transform: self.transform,
+                    })
                 }
-            }
+            },
+            transform: self.transform,
         }
     }
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -611,18 +611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_enums"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4487600931c9a89f8db7ffbdf3fbdd45bb7bd85e26861f659a463cd0dff966"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,17 +1418,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.119",
  "unicode-xid",
-]
-
-[[package]]
-name = "derive_utils"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2481,7 +2458,6 @@ version = "1.18.0"
 dependencies = [
  "accesskit",
  "async-channel",
- "auto_enums",
  "bitflags 2.13.1",
  "cfg-if",
  "chrono",


### PR DESCRIPTION
The only use was `#[auto_enum(Iterator)]` on `PathDataIterator::iter()`, to unify the two concrete iterator types of its match arms. Replace it with a small hand-written sum type that implements Iterator, which keeps the return type unboxed and drops a proc-macro dependency (along with derive_utils) from the build.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
