### PR TITLE
Use property forwarding for Debug Hooks

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,7 @@
         "fullscreen",
         "glutin",
         "glutin's",
+        "hookable",
         "maxx",
         "maxy",
         "minx",

--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::rc::{Rc, Weak};
 
+use crate::expression_tree::Expression;
 use crate::langtype::{ElementType, PropertyLookupMode, Type};
 use crate::object_tree::{Element, ElementRc, PropertyAnalysis, PropertyVisibility};
 
@@ -94,6 +95,11 @@ impl NamedReference {
             return false;
         }
         if e.property_analysis.borrow().get(self.name()).is_some_and(|a| a.is_set_externally) {
+            return false;
+        }
+        if e.binding_cell_including_synthetic(self.name()).is_some_and(|binding| {
+            matches!(binding.borrow().expression, Expression::DebugHook { .. })
+        }) {
             return false;
         }
         drop(e);

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3475,31 +3475,49 @@ impl Element {
     /// Synthetic debug hooks (materialized for unbound properties) are never considered set
     /// (`has_binding` treats them as "no expression").
     pub fn is_binding_set(self: &Element, property_name: &str, need_explicit: bool) -> bool {
-        if self.bindings.0.get(property_name).is_some_and(|b| {
-            b.borrow().has_binding() && (!need_explicit || b.borrow().priority > 0)
-        }) {
-            true
-        } else if let ElementType::Component(base) = &self.base_type {
-            base.root_element.borrow().is_binding_set(property_name, need_explicit)
-        } else {
-            false
-        }
+        self.any_in_inheritance_chain(|element| {
+            element.bindings.0.get(property_name).is_some_and(|binding| {
+                let binding = binding.borrow();
+                binding.has_binding() && (!need_explicit || binding.priority > 0)
+            })
+        })
     }
 
     /// Returns true if the property is set by a binding or an assignment expression
     ///
     /// Synthetic debug hooks (materialized for unbound properties) are not considered set.
     pub fn is_property_set(self: &Element, property_name: &str) -> bool {
-        self.bindings
-            .0
-            .get(property_name)
-            .is_some_and(|b| !b.borrow().expression.is_synthetic_debug_hook())
-            || self
+        self.any_in_inheritance_chain(|element| {
+            element
+                .bindings
+                .0
+                .get(property_name)
+                .is_some_and(|binding| !binding.borrow().expression.is_synthetic_debug_hook())
+                || element
+                    .property_analysis
+                    .borrow()
+                    .get(property_name)
+                    .is_some_and(|analysis| analysis.is_set || analysis.is_linked)
+        })
+    }
+
+    pub(crate) fn is_property_target_of_two_way_binding(&self, property_name: &str) -> bool {
+        self.any_in_inheritance_chain(|element| {
+            element
                 .property_analysis
                 .borrow()
                 .get(property_name)
-                .is_some_and(|a| a.is_set || a.is_linked)
-            || matches!(&self.base_type, ElementType::Component(base) if base.root_element.borrow().is_property_set(property_name))
+                .is_some_and(|analysis| analysis.is_linked)
+        })
+    }
+
+    fn any_in_inheritance_chain(&self, predicate: impl Fn(&Element) -> bool + Copy) -> bool {
+        predicate(self)
+            || matches!(
+                &self.base_type,
+                ElementType::Component(base)
+                    if base.root_element.borrow().any_in_inheritance_chain(predicate)
+            )
     }
 
     /// The binding for `property_name`, if one exists and is not a synthetic debug hook.

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -30,6 +30,7 @@ use std::path::PathBuf;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
+pub(crate) mod forward_inherited_expression;
 mod interfaces;
 
 macro_rules! unwrap_or_continue {

--- a/internal/compiler/object_tree/forward_inherited_expression.rs
+++ b/internal/compiler/object_tree/forward_inherited_expression.rs
@@ -1,0 +1,143 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use super::{BindingExpression, ElementRc, ElementType, PropertyDeclaration};
+use crate::expression_tree::{Callable, Expression};
+use crate::langtype::Type;
+use crate::namedreference::NamedReference;
+use crate::symbol_counters::SymbolCounters;
+use std::collections::HashMap;
+use std::rc::{Rc, Weak};
+
+#[derive(Default)]
+pub(crate) struct ForwardedReferenceCache {
+    forwarded_references: HashMap<NamedReference, NamedReference>,
+}
+
+pub(crate) enum InheritedExpression {
+    Expression(Expression),
+    TwoWayBinding,
+    Unbound,
+}
+
+pub(crate) fn forward_inherited_expression(
+    element: &ElementRc,
+    property_name: &str,
+    symbol_counters: &SymbolCounters,
+    forwarded_references: &mut ForwardedReferenceCache,
+) -> InheritedExpression {
+    let ElementType::Component(base_component) = &element.borrow().base_type else {
+        return InheritedExpression::Unbound;
+    };
+    let mut current_base_root = base_component.root_element.clone();
+
+    loop {
+        let binding = current_base_root
+            .borrow()
+            .binding(property_name)
+            .map(|binding| (!binding.two_way_bindings.is_empty(), binding.expression.clone()));
+        if let Some((is_two_way_binding, mut expression)) = binding {
+            if is_two_way_binding {
+                return InheritedExpression::TwoWayBinding;
+            }
+            if !matches!(expression, Expression::Invalid) {
+                rebase_expression_to_instance(
+                    &mut expression,
+                    &current_base_root,
+                    element,
+                    symbol_counters,
+                    forwarded_references,
+                );
+                return InheritedExpression::Expression(expression);
+            }
+        }
+
+        let next_source_root = {
+            let source_root = current_base_root.borrow();
+            let ElementType::Component(base_component) = &source_root.base_type else {
+                return InheritedExpression::Unbound;
+            };
+            base_component.root_element.clone()
+        };
+        current_base_root = next_source_root;
+    }
+}
+
+fn rebase_expression_to_instance(
+    expression: &mut Expression,
+    base_root_element: &ElementRc,
+    target_instance: &ElementRc,
+    symbol_counters: &SymbolCounters,
+    forwarded_references: &mut ForwardedReferenceCache,
+) {
+    expression.visit_recursive_mut(&mut |expression| match expression {
+        Expression::PropertyReference(named_reference)
+        | Expression::FunctionCall {
+            function: Callable::Callback(named_reference) | Callable::Function(named_reference),
+            ..
+        } => {
+            let referenced_element = named_reference.element();
+            if Rc::ptr_eq(&referenced_element, base_root_element) {
+                *named_reference =
+                    NamedReference::new(target_instance, named_reference.name().clone());
+            } else if Weak::ptr_eq(
+                &referenced_element.borrow().enclosing_component,
+                &base_root_element.borrow().enclosing_component,
+            ) {
+                let forwarded_reference = forward_reference(
+                    named_reference,
+                    base_root_element,
+                    symbol_counters,
+                    forwarded_references,
+                );
+                *named_reference =
+                    NamedReference::new(target_instance, forwarded_reference.name().clone());
+            }
+        }
+        _ => (),
+    });
+}
+
+fn forward_reference(
+    original: &NamedReference,
+    base_root: &ElementRc,
+    symbol_counters: &SymbolCounters,
+    forwarded_references: &mut ForwardedReferenceCache,
+) -> NamedReference {
+    if let Some(existing) = forwarded_references.forwarded_references.get(original) {
+        return existing.clone();
+    }
+
+    let property_type = original.ty();
+    let property_name = symbol_counters.generate_name("forward_reference_");
+    let binding = match &property_type {
+        Type::Callback(function) | Type::Function(function) => {
+            let arguments = function
+                .args
+                .iter()
+                .enumerate()
+                .map(|(index, argument_type)| Expression::FunctionParameterReference {
+                    index,
+                    ty: argument_type.clone(),
+                })
+                .collect();
+            let function = if matches!(property_type, Type::Callback(_)) {
+                Callable::Callback(original.clone())
+            } else {
+                Callable::Function(original.clone())
+            };
+            Expression::FunctionCall { function, arguments, source_location: None }
+        }
+        _ => Expression::PropertyReference(original.clone()),
+    };
+
+    base_root.borrow_mut().property_declarations.insert(
+        property_name.clone(),
+        PropertyDeclaration { property_type, ..PropertyDeclaration::default() },
+    );
+    base_root.borrow_mut().set_binding(property_name.clone(), BindingExpression::from(binding));
+
+    let forwarded_reference = NamedReference::new(base_root, property_name);
+    forwarded_references.forwarded_references.insert(original.clone(), forwarded_reference.clone());
+    forwarded_reference
+}

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -115,12 +115,19 @@ pub async fn run_passes(
     let raw_type_loader =
         keep_raw.then(|| crate::typeloader::snapshot_with_extra_doc(type_loader, doc).unwrap());
 
+    let mut forwarded_references =
+        crate::object_tree::forward_inherited_expression::ForwardedReferenceCache::default();
+
     // Inject debug hooks early — before any lowering or inlining — so source element identity
     // is preserved and hooks can be attributed to the correct source location.
     if let Some(random_state) = &type_loader.compiler_config.debug_hooks {
-        for root_component in doc.exported_roots() {
-            inject_debug_hooks::inject_debug_hooks(&root_component, random_state);
-        }
+        let root_components = doc.exported_roots().collect::<Vec<_>>();
+        inject_debug_hooks::inject_debug_hooks(
+            &root_components,
+            random_state,
+            &symbol_counters,
+            &mut forwarded_references,
+        );
     }
 
     collect_libraries::collect_libraries(doc);
@@ -132,7 +139,6 @@ pub async fn run_passes(
     lower_component_container::lower_component_container(doc, type_loader, diag);
     collect_subcomponents::collect_subcomponents(doc);
 
-    let mut lower_states_forwarded_cache = Default::default();
     doc.visit_all_used_components(|component| {
         apply_default_properties_from_style::apply_default_properties_from_style(
             component,
@@ -140,12 +146,7 @@ pub async fn run_passes(
             &palette,
             diag,
         );
-        lower_states::lower_states(
-            component,
-            &symbol_counters,
-            &mut lower_states_forwarded_cache,
-            diag,
-        );
+        lower_states::lower_states(component, &symbol_counters, &mut forwarded_references, diag);
         lower_text_input_interface::lower_text_input_interface(component);
         compile_paths::compile_paths(component, &doc.local_registry, diag);
         repeater_component::process_repeater_components(component);
@@ -224,13 +225,7 @@ pub async fn run_passes(
     // Must be done before passes that rely on `NamedReference::is_constant`.
     collect_globals::mark_library_globals(doc);
 
-    // Debug hooks rely on full inlining: the synthetic hooks injected on component-instance
-    // elements are only upgraded with the component's real default bindings when the component
-    // is inlined (see `BindingExpression::merge_with`). Without inlining they would shadow the
-    // definition's defaults at runtime. This overrides a `SLINT_INLINING=false` env override.
-    if type_loader.compiler_config.inline_all_elements
-        || type_loader.compiler_config.debug_hooks.is_some()
-    {
+    if type_loader.compiler_config.inline_all_elements {
         inlining::inline(doc, inlining::InlineSelection::InlineAllComponents, diag);
         doc.used_types.borrow_mut().sub_components.clear();
     }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -62,20 +62,9 @@ mod visible;
 mod windows;
 mod z_order;
 
-use crate::expression_tree::Expression;
 use smol_str::SmolStr;
 
 pub use binding_analysis::GlobalAnalysis;
-
-pub fn ignore_debug_hooks(expr: &Expression) -> &Expression {
-    let mut expr = expr;
-    loop {
-        match expr {
-            Expression::DebugHook { expression, .. } => expr = expression.as_ref(),
-            _ => return expr,
-        }
-    }
-}
 
 pub async fn run_passes(
     doc: &mut crate::object_tree::Document,

--- a/internal/compiler/passes/focus_handling.rs
+++ b/internal/compiler/passes/focus_handling.rs
@@ -87,7 +87,7 @@ impl<'a> LocalFocusForwards<'a> {
             };
 
             let Expression::ElementReference(focus_target) =
-                super::ignore_debug_hooks(&forward_focus_binding.expression)
+                forward_focus_binding.expression.ignore_debug_hooks()
             else {
                 // resolve expressions pass has produced type errors
                 debug_assert!(diag.has_errors());

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -292,6 +292,7 @@ fn add_hooks_for_non_existent_bindings(
         elem.binding_cell_including_synthetic(name).is_none()
             // Filter invalid reserved properties (e.g. x/y on a Timer, etc.)
             && elem.lookup_property(name, PropertyLookupMode::InternalName).property_type != crate::langtype::Type::Invalid
+            && !elem.is_property_target_of_two_way_binding(name)
     });
 
     for (name, default_expression, synthetic) in unbound_properties {
@@ -627,8 +628,8 @@ mod tests {
         let doc = compile(
             r#"
             component Item inherits Rectangle {
-                in-out property <length> linked <=> inner.width;
-                inner := Rectangle { }
+                in-out property <length> linked <=> target;
+                in-out property <length> target: 42px;
             }
             export component Win inherits Window {
                 item := Item { }
@@ -639,6 +640,7 @@ mod tests {
         let item = child(&win.root_element, "item");
 
         assert!(item.borrow().binding_cell_including_synthetic("linked").is_none());
+        assert!(item.borrow().binding_cell_including_synthetic("target").is_none());
         assert!(matches!(item.borrow().base_type, crate::langtype::ElementType::Component(_)));
     }
 

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -12,8 +12,8 @@
 //! 1. **Wrap existing bindings** in a non-synthetic `Expression::DebugHook` so the editor can
 //!    read and override the live value.
 //!
-//! 2. **Materialize synthetic hooks** for every *unbound* settable property, wrapping the
-//!    type default.  These are marked `synthetic: true` (and inserted with `priority = 0`).
+//! 2. **Materialize synthetic hooks** for every *unbound* settable property.
+//!    These are marked `synthetic: true` (and inserted with `priority = 0`).
 //!    The accessors in `object_tree.rs` treat synthetic hooks as "no binding", so later passes
 //!    must opt-in to seeing bindings with a synthetic hook.
 //!    Exception: transform properties are marked non-synthetic, as they must force the transform
@@ -21,17 +21,37 @@
 
 use crate::expression_tree::Expression;
 use crate::langtype::PropertyLookupMode;
+use crate::object_tree::forward_inherited_expression::{
+    ForwardedReferenceCache, InheritedExpression, forward_inherited_expression,
+};
 use crate::object_tree::{self, Element, ElementDebugInfo, ElementRc, PropertyVisibility};
+use crate::symbol_counters::SymbolCounters;
+use std::rc::Rc;
 
 pub fn inject_debug_hooks(
-    component: &std::rc::Rc<object_tree::Component>,
+    root_components: &[Rc<object_tree::Component>],
     random_state: &std::hash::RandomState,
+    symbol_counters: &SymbolCounters,
+    forwarded_references: &mut ForwardedReferenceCache,
 ) {
-    let root = component.root_element.clone();
-    object_tree::recurse_elem(&root, &(), &mut |elem, &()| {
-        let is_root = std::rc::Rc::ptr_eq(elem, &root);
-        process_element(elem, random_state, is_root);
-    });
+    for component in root_components {
+        let root = component.root_element.clone();
+        object_tree::recurse_elem(&root, &(), &mut |element, &()| {
+            process_existing_bindings(element, random_state);
+        });
+    }
+
+    // Process the missing bindings after the existing bindings.
+    // Injecting missing bindings will insert new forwarding bindings & properties.
+    // These should not be hooked as "existing", which is why we need to insert them
+    // after all existing bindings are processed.
+    for component in root_components {
+        let root = component.root_element.clone();
+        object_tree::recurse_elem(&root, &(), &mut |element, &()| {
+            let is_root = Rc::ptr_eq(element, &root);
+            process_missing_bindings(element, symbol_counters, forwarded_references, is_root);
+        });
+    }
 }
 
 pub fn property_id(element_id: u64, name: &smol_str::SmolStr) -> smol_str::SmolStr {
@@ -232,7 +252,13 @@ fn transform_properties<'a>(
     })
 }
 
-fn add_hooks_for_non_existent_bindings(element: &ElementRc, element_hash: u64, is_root: bool) {
+fn add_hooks_for_non_existent_bindings(
+    element: &ElementRc,
+    element_hash: u64,
+    symbol_counters: &SymbolCounters,
+    forwarded_references: &mut ForwardedReferenceCache,
+    is_root: bool,
+) {
     let elem = element.borrow();
     let mut properties: Vec<_> = property_defaults(&elem).collect();
 
@@ -268,10 +294,22 @@ fn add_hooks_for_non_existent_bindings(element: &ElementRc, element_hash: u64, i
             && elem.lookup_property(name, PropertyLookupMode::InternalName).property_type != crate::langtype::Type::Invalid
     });
 
-    for (name, default, synthetic) in unbound_properties {
+    for (name, default_expression, synthetic) in unbound_properties {
+        let expression = match forward_inherited_expression(
+            element,
+            &name,
+            symbol_counters,
+            forwarded_references,
+        ) {
+            InheritedExpression::Expression(expression) => {
+                super::ignore_debug_hooks(&expression).clone()
+            }
+            InheritedExpression::TwoWayBinding => continue,
+            InheritedExpression::Unbound => default_expression,
+        };
         let id = property_id(element_hash, &name);
         let mut binding: crate::expression_tree::BindingExpression =
-            Expression::DebugHook { expression: Box::new(default), id, synthetic }.into();
+            Expression::DebugHook { expression: Box::new(expression), id, synthetic }.into();
         binding.priority = 0;
         let mut elem = element.borrow_mut();
         if elem.binding_cell_including_synthetic(&name).is_none() {
@@ -280,23 +318,49 @@ fn add_hooks_for_non_existent_bindings(element: &ElementRc, element_hash: u64, i
     }
 }
 
-fn process_element(element: &ElementRc, random_state: &std::hash::RandomState, is_root: bool) {
-    {
-        let element = element.borrow();
-        // Skip the @children placeholder (the generator skips these too).
-        if element.is_component_placeholder {
-            return;
-        }
-        if element.debug.is_empty() {
-            return;
-        }
+fn is_hookable(element: &ElementRc) -> bool {
+    let element = element.borrow();
+    // Skip the @children placeholder (the generator skips these too).
+    if element.is_component_placeholder {
+        return false;
+    }
+    if element.debug.is_empty() {
+        return false;
+    }
+
+    true
+}
+
+fn process_existing_bindings(element: &ElementRc, random_state: &std::hash::RandomState) {
+    if !is_hookable(element) {
+        return;
     }
 
     let element_hash = assign_element_hash(element, random_state);
 
     hook_existing_bindings(element, element_hash);
+}
 
-    add_hooks_for_non_existent_bindings(element, element_hash, is_root);
+fn process_missing_bindings(
+    element: &ElementRc,
+    symbol_counters: &SymbolCounters,
+    forwarded_references: &mut ForwardedReferenceCache,
+    is_root: bool,
+) {
+    if !is_hookable(element) {
+        return;
+    }
+
+    let element_hash = element.borrow().debug[0].element_hash;
+    debug_assert_ne!(element_hash, 0);
+
+    add_hooks_for_non_existent_bindings(
+        element,
+        element_hash,
+        symbol_counters,
+        forwarded_references,
+        is_root,
+    );
 }
 
 #[cfg(test)]
@@ -310,6 +374,7 @@ mod tests {
             crate::CompilerConfiguration::new(crate::generator::OutputFormat::Interpreter);
         config.style = Some("fluent".into());
         config.debug_hooks = Some(std::hash::RandomState::new());
+        config.inline_all_elements = false;
         let mut diags = crate::diagnostics::BuildDiagnostics::default();
         let doc_node = crate::parser::parse(
             source.into(),
@@ -410,13 +475,8 @@ mod tests {
         assert_ne!(txt.borrow().debug.first().unwrap().element_hash, 0);
     }
 
-    /// Component-instance elements are hooked too. The synthetic hooks injected on the
-    /// instance for the component's unbound properties must be upgraded with the definition's
-    /// real default bindings when the component is inlined (`merge_with`) — NOT clobber them.
-    /// Regression: repeated instances used to lose `tint: blue` / `background: tint` and
-    /// render transparent.
     #[test]
-    fn instance_defaults_upgraded_into_hooks() {
+    fn instance_defaults_forwarded_into_hooks() {
         let doc = compile(
             r#"
             component Item inherits Rectangle {
@@ -441,10 +501,7 @@ mod tests {
             let Expression::DebugHook { expression: inner, id, synthetic } = expression else {
                 panic!("{what}: background must be a DebugHook, got {expression:?}");
             };
-            assert!(!synthetic, "{what}: hook must be upgraded with the definition's binding");
-            // The definition's `background: tint` must survive as the hook's inner expression
-            // (a reference to the — possibly moved/renamed — tint property, not the
-            // transparent type default).
+            assert!(synthetic, "{what}: inherited hook must remain synthetic");
             let mut references_tint = false;
             inner.visit_recursive(&mut |expression| {
                 if let Expression::PropertyReference(named_reference) = expression
@@ -454,23 +511,23 @@ mod tests {
                 }
             });
             assert!(references_tint, "{what}: background must still reference tint, got {inner:?}");
-            // The hook id must belong to one of the merged source elements (the instance
-            // element's hash — hooks were injected before inlining).
-            assert!(
-                borrowed.debug.iter().any(|d| property_id(
-                    d.element_hash,
+            assert_eq!(
+                property_id(
+                    borrowed.debug[0].element_hash,
                     &smol_str::SmolStr::new_static("background")
-                ) == id),
-                "{what}: hook id {id} must match a merged element hash"
+                ),
+                id,
+                "{what}: hook id must use the instance element hash"
+            );
+            assert!(
+                matches!(borrowed.base_type, crate::langtype::ElementType::Component(_)),
+                "{what}: component boundary must remain"
             );
         };
 
-        // Non-repeated instance: `plain` is the merged element after inlining.
         let plain = child(&win.root_element, "plain");
         assert_background_preserved(&plain, "plain instance");
 
-        // Repeated instance: the repeated element's base is the generated repeater component;
-        // the merged instance element is inside it.
         let repeated = win
             .root_element
             .borrow()
@@ -488,6 +545,103 @@ mod tests {
         });
         let repeated_item = found.expect("repeated Item element with background binding");
         assert_background_preserved(&repeated_item, "repeated instance");
+    }
+
+    #[test]
+    fn reuses_forwarded_references_for_hooks_and_states() {
+        let doc = compile(
+            r#"
+            component Item inherits Rectangle {
+                in-out property <int> property-value: inner.width / 1px;
+                in-out property <int> function-value: inner.compute-value(3);
+                in-out property <int> callback-value: inner.compute-callback(5);
+                inner := Rectangle {
+                    width: 10px;
+                    pure function compute-value(value: int) -> int { value + 10 }
+                    pure callback compute-callback(int) -> int;
+                    compute-callback(value) => value * 2;
+                }
+            }
+            export component Win inherits Window {
+                in property <bool> active;
+                first := Item { }
+                second := Item { }
+                states [
+                    active when root.active: {
+                        first.property-value: 42;
+                        first.function-value: 43;
+                        first.callback-value: 44;
+                    }
+                ]
+            }
+            "#,
+        );
+        let item = component(&doc, "Item");
+        let win = component(&doc, "Win");
+        let first = child(&win.root_element, "first");
+        let second = child(&win.root_element, "second");
+
+        let declarations = item
+            .root_element
+            .borrow()
+            .property_declarations
+            .keys()
+            .filter(|name| name.starts_with("forward_reference_"))
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(declarations.len(), 3);
+
+        let forwarded_references = |element: &ElementRc| {
+            let element = element.borrow();
+            let mut references = std::collections::HashSet::new();
+            for property_name in ["property-value", "function-value", "callback-value"] {
+                let binding = element
+                    .binding_cell_including_synthetic(property_name)
+                    .unwrap_or_else(|| panic!("{property_name} must be hooked"));
+                binding.borrow().expression.visit_recursive(&mut |expression| match expression {
+                    Expression::PropertyReference(named_reference)
+                    | Expression::FunctionCall {
+                        function:
+                            crate::expression_tree::Callable::Callback(named_reference)
+                            | crate::expression_tree::Callable::Function(named_reference),
+                        ..
+                    } if named_reference.name().starts_with("forward_reference_") => {
+                        references.insert(named_reference.name().clone());
+                    }
+                    _ => {}
+                });
+            }
+            references
+        };
+
+        let first_references = forwarded_references(&first);
+        let second_references = forwarded_references(&second);
+        assert!(!first_references.is_empty());
+        assert!(!second_references.is_empty());
+        assert!(first_references.is_subset(&declarations));
+        assert!(second_references.is_subset(&declarations));
+        assert!(matches!(first.borrow().base_type, crate::langtype::ElementType::Component(_)));
+        assert!(matches!(second.borrow().base_type, crate::langtype::ElementType::Component(_)));
+    }
+
+    #[test]
+    fn inherited_two_way_binding_has_no_hook() {
+        let doc = compile(
+            r#"
+            component Item inherits Rectangle {
+                in-out property <length> linked <=> inner.width;
+                inner := Rectangle { }
+            }
+            export component Win inherits Window {
+                item := Item { }
+            }
+            "#,
+        );
+        let win = component(&doc, "Win");
+        let item = child(&win.root_element, "item");
+
+        assert!(item.borrow().binding_cell_including_synthetic("linked").is_none());
+        assert!(matches!(item.borrow().base_type, crate::langtype::ElementType::Component(_)));
     }
 
     /// Direct unit tests for the synthetic-hook rules in `BindingExpression::merge_with`

--- a/internal/compiler/passes/inject_debug_hooks.rs
+++ b/internal/compiler/passes/inject_debug_hooks.rs
@@ -152,7 +152,7 @@ fn hook_existing_bindings(element: &ElementRc, element_hash: u64) {
         }
         let expr = std::mem::take(&mut be.borrow_mut().expression);
         be.borrow_mut().expression = {
-            let stripped = super::ignore_debug_hooks(&expr);
+            let stripped = expr.ignore_debug_hooks();
             if matches!(stripped, Expression::Invalid)
                 || matches!(expr, Expression::DebugHook { .. })
             {
@@ -301,9 +301,7 @@ fn add_hooks_for_non_existent_bindings(
             symbol_counters,
             forwarded_references,
         ) {
-            InheritedExpression::Expression(expression) => {
-                super::ignore_debug_hooks(&expression).clone()
-            }
+            InheritedExpression::Expression(expression) => expression.ignore_debug_hooks().clone(),
             InheritedExpression::TwoWayBinding => continue,
             InheritedExpression::Unbound => default_expression,
         };
@@ -448,7 +446,7 @@ mod tests {
         let text_inner = hooked(&txt, "text").expect("txt.text should be a DebugHook");
         assert!(is_synthetic(&txt, "text"), "txt.text hook should be synthetic (unbound property)");
         assert!(
-            matches!(super::super::ignore_debug_hooks(&text_inner), Expression::StringLiteral(s) if s.is_empty()),
+            matches!(text_inner.ignore_debug_hooks(), Expression::StringLiteral(s) if s.is_empty()),
             "txt.text default should be the empty-string sentinel, got {text_inner:?}"
         );
 
@@ -456,7 +454,7 @@ mod tests {
         let fs_inner = hooked(&txt, "font-size").expect("txt.font-size should be a DebugHook");
         assert!(is_synthetic(&txt, "font-size"), "txt.font-size hook should be synthetic");
         assert!(
-            matches!(super::super::ignore_debug_hooks(&fs_inner), Expression::NumberLiteral(v, _) if *v == 0.),
+            matches!(fs_inner.ignore_debug_hooks(), Expression::NumberLiteral(v, _) if *v == 0.),
             "txt.font-size default should be the 0 sentinel, got {fs_inner:?}"
         );
 
@@ -467,7 +465,7 @@ mod tests {
             "rect.background should be non-synthetic (was explicitly set)"
         );
         assert!(
-            !matches!(super::super::ignore_debug_hooks(&bg_inner), Expression::Invalid),
+            !matches!(bg_inner.ignore_debug_hooks(), Expression::Invalid),
             "rect.background should wrap its real value"
         );
 

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -2013,8 +2013,7 @@ fn lower_dialog_layout(
         let dialog_button_role_binding =
             layout_child.borrow_mut().take_binding("dialog-button-role");
         let is_button = if let Some(role_binding) = dialog_button_role_binding {
-            if let Expression::EnumerationValue(val) =
-                super::ignore_debug_hooks(&role_binding.expression)
+            if let Expression::EnumerationValue(val) = role_binding.expression.ignore_debug_hooks()
             {
                 let en = &val.enumeration;
                 debug_assert_eq!(en.name, "DialogButtonRole");
@@ -2042,7 +2041,7 @@ fn lower_dialog_layout(
                 ),
                 Some(binding) => {
                     if let Expression::EnumerationValue(val) =
-                        super::ignore_debug_hooks(&binding.expression)
+                        binding.expression.ignore_debug_hooks()
                     {
                         let en = &val.enumeration;
                         debug_assert_eq!(en.name, "StandardButtonKind");
@@ -2516,7 +2515,7 @@ fn check_number_literal_is_positive_integer(
     span: &dyn crate::diagnostics::Spanned,
     diag: &mut BuildDiagnostics,
 ) -> bool {
-    match super::ignore_debug_hooks(expression) {
+    match expression.ignore_debug_hooks() {
         Expression::NumberLiteral(v, Unit::None) => {
             if *v > u16::MAX as f64 || !v.trunc().approx_eq(v) {
                 diag.push_error(format!("'{name}' must be a positive integer"), span);
@@ -2524,7 +2523,7 @@ fn check_number_literal_is_positive_integer(
             true
         }
         Expression::UnaryOp { op: '-', sub } => {
-            if let Expression::NumberLiteral(_, Unit::None) = super::ignore_debug_hooks(sub) {
+            if let Expression::NumberLiteral(_, Unit::None) = sub.ignore_debug_hooks() {
                 diag.push_error(format!("'{name}' must be a positive integer"), span);
             }
             true

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -103,7 +103,7 @@ fn lower_popup_window(
     }
 
     let map_close_on_click_value = |b: &BindingExpression| {
-        let Expression::BoolLiteral(v) = super::ignore_debug_hooks(&b.expression) else {
+        let Expression::BoolLiteral(v) = b.expression.ignore_debug_hooks() else {
             assert!(diag.has_errors());
             return None;
         };
@@ -116,7 +116,7 @@ fn lower_popup_window(
     };
 
     let close_policy = popup_window_element.borrow_mut().take_binding(CLOSE_POLICY).and_then(|b| {
-        if let Expression::EnumerationValue(v) = super::ignore_debug_hooks(&b.expression) {
+        if let Expression::EnumerationValue(v) = b.expression.ignore_debug_hooks() {
             Some(v.clone())
         } else {
             assert!(diag.has_errors());

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -7,17 +7,15 @@ use crate::diagnostics::BuildDiagnostics;
 use crate::diagnostics::SourceLocation;
 use crate::diagnostics::Spanned;
 use crate::expression_tree::*;
-use crate::langtype::Type;
-use crate::langtype::{ElementType, PropertyLookupMode};
+use crate::langtype::{PropertyLookupMode, Type};
+use crate::object_tree::forward_inherited_expression::{
+    ForwardedReferenceCache, InheritedExpression, forward_inherited_expression,
+};
 use crate::object_tree::*;
 use crate::symbol_counters::SymbolCounters;
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
-use std::rc::{Rc, Weak};
-
-/// Maps a private reference to the forwarding property/callback synthesized for it by
-/// `forwarded_reference`, so it's only synthesized once per reference.
-type ForwardedReferenceCache = HashMap<NamedReference, NamedReference>;
+use std::rc::Rc;
 
 pub fn lower_states(
     component: &Rc<Component>,
@@ -211,112 +209,38 @@ fn expression_for_property(
     element: &ElementRc,
     name: &str,
     symbol_counters: &SymbolCounters,
-    forwarded_cache: &mut ForwardedReferenceCache,
+    forwarded_references: &mut ForwardedReferenceCache,
 ) -> ExpressionForProperty {
-    let mut element_it = Some(element.clone());
-    let mut in_base = false;
-    while let Some(elem) = element_it {
-        // Clone out of `elem` and drop the borrow: forwarding below needs to borrow `elem` mutably.
-        let existing_binding = elem
-            .borrow()
-            .binding(name)
-            .map(|e| (!e.two_way_bindings.is_empty(), e.expression.clone()));
-        if let Some((is_two_way_binding, mut expr)) = existing_binding {
-            if is_two_way_binding {
-                return ExpressionForProperty::TwoWayBinding;
-            }
-            if !matches!(expr, Expression::Invalid) {
-                if in_base {
-                    // Rewrite references from `elem`'s point of view to `element`'s.
-                    expr.visit_recursive_mut(&mut |ex| match ex {
-                        Expression::PropertyReference(nr)
-                        | Expression::FunctionCall {
-                            function: Callable::Callback(nr) | Callable::Function(nr),
-                            ..
-                        } => {
-                            let e = nr.element();
-                            if Rc::ptr_eq(&e, &elem) {
-                                *nr = NamedReference::new(element, nr.name().clone());
-                            } else if Weak::ptr_eq(
-                                &e.borrow().enclosing_component,
-                                &elem.borrow().enclosing_component,
-                            ) {
-                                // A private sibling of `elem`: not reachable from outside its
-                                // component, so forward it through a synthesized member on `elem`.
-                                let forwarded = forwarded_reference(
-                                    nr,
-                                    &elem,
-                                    symbol_counters,
-                                    forwarded_cache,
-                                );
-                                *nr = NamedReference::new(element, forwarded.name().clone());
-                            }
-                        }
-                        _ => (),
-                    });
-                }
-
-                return ExpressionForProperty::Expression(expr);
-            }
+    let local_binding = element
+        .borrow()
+        .binding(name)
+        .map(|binding| (!binding.two_way_bindings.is_empty(), binding.expression.clone()));
+    if let Some((is_two_way_binding, expression)) = local_binding {
+        if is_two_way_binding {
+            return ExpressionForProperty::TwoWayBinding;
         }
-        element_it = if let ElementType::Component(base) = &elem.borrow().base_type {
-            in_base = true;
-            Some(base.root_element.clone())
-        } else {
-            None
-        };
-    }
-    let expr = super::materialize_fake_properties::initialize(element, name).unwrap_or_else(|| {
-        Expression::default_value_for_type(
-            &element.borrow().lookup_property(name, PropertyLookupMode::InternalName).property_type,
-        )
-    });
-
-    ExpressionForProperty::Expression(expr)
-}
-
-fn forwarded_reference(
-    original: &NamedReference,
-    base_root: &ElementRc,
-    symbol_counters: &SymbolCounters,
-    forwarded_cache: &mut ForwardedReferenceCache,
-) -> NamedReference {
-    // reuse the forward if one exists
-    if let Some(existing) = forwarded_cache.get(original) {
-        return existing.clone();
+        if !matches!(expression, Expression::Invalid) {
+            return ExpressionForProperty::Expression(expression);
+        }
     }
 
-    // Create a property/callback on `base_root` that forwards to `original`
-    let ty = original.ty();
-    let new_name = symbol_counters.generate_name("forward_reference_");
-    let binding = match &ty {
-        Type::Callback(f) | Type::Function(f) => {
-            let arguments = f
-                .args
-                .iter()
-                .enumerate()
-                .map(|(index, arg_ty)| Expression::FunctionParameterReference {
-                    index,
-                    ty: arg_ty.clone(),
-                })
-                .collect();
-            let function = if matches!(ty, Type::Callback(_)) {
-                Callable::Callback(original.clone())
-            } else {
-                Callable::Function(original.clone())
-            };
-            Expression::FunctionCall { function, arguments, source_location: None }
+    match forward_inherited_expression(element, name, symbol_counters, forwarded_references) {
+        InheritedExpression::Expression(expression) => {
+            return ExpressionForProperty::Expression(expression);
         }
-        _ => Expression::PropertyReference(original.clone()),
-    };
+        InheritedExpression::TwoWayBinding => return ExpressionForProperty::TwoWayBinding,
+        InheritedExpression::Unbound => {}
+    }
 
-    base_root.borrow_mut().property_declarations.insert(
-        new_name.clone(),
-        PropertyDeclaration { property_type: ty, ..PropertyDeclaration::default() },
-    );
-    base_root.borrow_mut().set_binding(new_name.clone(), BindingExpression::from(binding));
+    let expression =
+        super::materialize_fake_properties::initialize(element, name).unwrap_or_else(|| {
+            Expression::default_value_for_type(
+                &element
+                    .borrow()
+                    .lookup_property(name, PropertyLookupMode::InternalName)
+                    .property_type,
+            )
+        });
 
-    let forwarded = NamedReference::new(base_root, new_name);
-    forwarded_cache.insert(original.clone(), forwarded.clone());
-    forwarded
+    ExpressionForProperty::Expression(expression)
 }

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -20,12 +20,12 @@ use std::rc::Rc;
 pub fn lower_states(
     component: &Rc<Component>,
     symbol_counters: &SymbolCounters,
-    forwarded_cache: &mut ForwardedReferenceCache,
+    forwarded_references: &mut ForwardedReferenceCache,
     diag: &mut BuildDiagnostics,
 ) {
     let state_info_type = crate::typeregister::BUILTIN.state_info_type.clone().into();
     recurse_elem(&component.root_element, &(), &mut |elem, _| {
-        lower_state_in_element(elem, &state_info_type, symbol_counters, forwarded_cache, diag)
+        lower_state_in_element(elem, &state_info_type, symbol_counters, forwarded_references, diag)
     });
 }
 
@@ -33,7 +33,7 @@ fn lower_state_in_element(
     root_element: &ElementRc,
     state_info_type: &Type,
     symbol_counters: &SymbolCounters,
-    forwarded_cache: &mut ForwardedReferenceCache,
+    forwarded_references: &mut ForwardedReferenceCache,
     diag: &mut BuildDiagnostics,
 ) {
     if root_element.borrow().states.is_empty() {
@@ -73,7 +73,7 @@ fn lower_state_in_element(
                 &element,
                 property_reference.name(),
                 symbol_counters,
-                forwarded_cache,
+                forwarded_references,
             ) {
                 ExpressionForProperty::TwoWayBinding => {
                     diag.push_error(

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -166,7 +166,7 @@ pub fn inherits_window(component: &Rc<Component>) -> bool {
 /// application sets, has none.
 #[cfg(feature = "slint-sc")]
 fn literal_alpha(expr: &Expression) -> Option<u8> {
-    match crate::passes::ignore_debug_hooks(expr) {
+    match expr.ignore_debug_hooks() {
         Expression::Cast { from, to: Type::Color | Type::Brush } => literal_alpha(from),
         // A color literal is a number carrying its channels, alpha highest
         Expression::NumberLiteral(value, _) => Some((*value as u32 >> 24) as u8),

--- a/internal/compiler/passes/z_order.rs
+++ b/internal/compiler/passes/z_order.rs
@@ -220,7 +220,7 @@ fn constant_z(child_elm: &ElementRc) -> Option<f64> {
 }
 
 fn try_eval_const_expr(expression: &Expression) -> Option<f64> {
-    match super::ignore_debug_hooks(expression) {
+    match expression.ignore_debug_hooks() {
         Expression::NumberLiteral(v, Unit::None) => Some(*v),
         Expression::Cast { from, .. } => try_eval_const_expr(from),
         Expression::UnaryOp { sub, op: '-' } => try_eval_const_expr(sub).map(|v| -v),

--- a/internal/interpreter/debug_hook.rs
+++ b/internal/interpreter/debug_hook.rs
@@ -141,11 +141,6 @@ export component Win inherits Window {
         assert!(reverted.size.width.approx_eq(&base.size.width), "width should revert");
     }
 
-    // Component-instance elements are hooked too: their unbound properties get synthetic hooks
-    // that must be upgraded with the definition's default bindings during inlining (keeping the
-    // *instance* element's hook id). Verifies that the defaults are preserved (regression: they
-    // used to be clobbered, rendering repeated items transparent) and that instance properties
-    // are live-overridable through the hook callback.
     #[test]
     fn debug_hook_component_instance_override() {
         let code = r#"
@@ -199,6 +194,53 @@ export component Win inherits Window {
             "rotation must not move the origin"
         );
         set_override(&store, element_hash, "transform-rotation", None);
+    }
+
+    #[test]
+    fn debug_hook_forwards_live_private_state_per_instance() {
+        let code = r#"
+component Sub inherits Rectangle {
+    in property <length> seed;
+    in property <bool> active;
+    in-out property <length> inherited-value: private-child.x;
+    private-child := Rectangle { x: root.seed; }
+    states [
+        active when root.active: {
+            private-child.x: 50px;
+        }
+    ]
+}
+export component Win inherits Window {
+    in-out property <length> first-seed: 10px;
+    in-out property <bool> first-active;
+    first := Sub { seed: root.first-seed; active: root.first-active; }
+    second := Sub { seed: 20px; }
+    out property <length> first-value: first.inherited-value;
+    out property <length> second-value: second.inherited-value;
+}"#;
+        let instance = compile_with_debug_hooks(code);
+        let store = install_debug_hook_store(&instance);
+        let (_, first_hash) = find_element(&instance, code, "Sub { seed: root.first-seed");
+
+        assert_eq!(instance.get_property("first-value").unwrap(), Value::Number(10.0));
+        assert_eq!(instance.get_property("second-value").unwrap(), Value::Number(20.0));
+
+        instance.set_property("first-seed", Value::Number(15.0)).unwrap();
+        assert_eq!(instance.get_property("first-value").unwrap(), Value::Number(15.0));
+        assert_eq!(instance.get_property("second-value").unwrap(), Value::Number(20.0));
+
+        instance.set_property("first-active", Value::Bool(true)).unwrap();
+        assert_eq!(instance.get_property("first-value").unwrap(), Value::Number(50.0));
+
+        set_override(&store, first_hash, "inherited-value", Some(Value::Number(90.0)));
+        instance.set_property("first-active", Value::Bool(false)).unwrap();
+        instance.set_property("first-seed", Value::Number(25.0)).unwrap();
+        assert_eq!(instance.get_property("first-value").unwrap(), Value::Number(90.0));
+        assert_eq!(instance.get_property("second-value").unwrap(), Value::Number(20.0));
+
+        set_override(&store, first_hash, "inherited-value", None);
+        assert_eq!(instance.get_property("first-value").unwrap(), Value::Number(25.0));
+        assert_eq!(instance.get_property("second-value").unwrap(), Value::Number(20.0));
     }
 
     // Regression test: debug hooks inject bindings for properties the element may not have

--- a/tests/cases/properties/states_with_inherited_two_way_binding.slint
+++ b/tests/cases/properties/states_with_inherited_two_way_binding.slint
@@ -1,0 +1,54 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Base {
+    in-out property <int> a <=> b;
+    in-out property <int> b: 10;
+}
+
+export component TestCase {
+    in-out property <bool> condition;
+    in-out property <int> a <=> base.a;
+    in-out property <int> b <=> base.b;
+
+    base := Base { }
+
+    states [
+        active when condition: {
+            base.b: 20;
+        }
+    ]
+}
+
+/*
+```rust
+let before_state = TestCase::new().unwrap();
+assert_eq!(before_state.get_a(), 10);
+assert_eq!(before_state.get_b(), 10);
+
+before_state.set_a(11);
+assert_eq!(before_state.get_a(), 11);
+assert_eq!(before_state.get_b(), 11);
+
+before_state.set_b(12);
+assert_eq!(before_state.get_a(), 12);
+assert_eq!(before_state.get_b(), 12);
+
+let after_state = TestCase::new().unwrap();
+after_state.set_condition(true);
+assert_eq!(after_state.get_a(), 20);
+assert_eq!(after_state.get_b(), 20);
+
+after_state.set_condition(false);
+assert_eq!(after_state.get_a(), 10);
+assert_eq!(after_state.get_b(), 10);
+
+after_state.set_a(13);
+assert_eq!(after_state.get_a(), 13);
+assert_eq!(after_state.get_b(), 13);
+
+after_state.set_b(14);
+assert_eq!(after_state.get_a(), 14);
+assert_eq!(after_state.get_b(), 14);
+```
+*/


### PR DESCRIPTION
Debug Hooks currently require full inlining to ensure we can "copy" the expressions from base components into their element instantiations, so they can be debug hooked.
This is necessary, as the base expressions may include NamedReference that do not resolve in the element instance, if they mention private children of the base component.

As mentioned in #12865, the inherited property forwarding introduced on this PR can solve the problem by exposing the inner children via forwarding properties.

This PR adapts this approach for debug hooks, which allows **disabling full inlining** for debug hooks.

From personal testing, this massively improve the performance of the Visual Editor.
In debug mode, clicking an element in the gallery.slint example goes from multiple seconds to basically instantaneous.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
