### PR TITLE
core: a few simplification so the dynamic z-order implementation and a bug fix for partial rendering

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -1320,37 +1320,10 @@ public:
         return std::numeric_limits<uint64_t>::max();
     }
 
-    /// Call the visitor for the root of the given instance.
-    /// Used when the repeated element has a dynamic z binding and the instances are
-    /// visited in the z order of the parent's children.
-    uint64_t visit_instance(uint32_t instance, TraversalOrder order,
-                            private_api::ItemVisitorRefMut visitor) const
-    {
-        if (inner && instance < inner->data.size() && inner->data[instance].ptr) {
-            auto ref = item_at(instance);
-            if (ref.vtable->visit_children_item(ref, -1, order, visitor)
-                != std::numeric_limits<uint64_t>::max()) {
-                return instance;
-            }
-        }
-        return std::numeric_limits<uint64_t>::max();
-    }
-
-    /// Visit a single instance when `instance` is a specific index (coming from a
-    /// z-ordered traversal), or all the instances when it is the maximum value.
-    uint64_t visit_maybe_instance(uint32_t instance, TraversalOrder order,
-                                  private_api::ItemVisitorRefMut visitor) const
-    {
-        if (instance == std::numeric_limits<uint32_t>::max()) {
-            return visit(order, visitor);
-        } else {
-            return visit_instance(instance, order, visitor);
-        }
-    }
-
-    /// Call `cb` with the index and the z value of every instance, when the repeated
-    /// element has a dynamic z binding (the generated component has a `z_order()`
-    /// member function).
+    /// Call `cb` with the model row index and the z value of every instance, when the
+    /// repeated element has a dynamic z binding (the generated component has a
+    /// `z_order()` member function). The row index is the one accepted by
+    /// `instance_at` (and thus by the `get_subtree` vtable entry).
     /// Also registers model dependencies so the current tracking scope is notified
     /// when the model changes.
     template<typename F>
@@ -1359,8 +1332,9 @@ public:
         track_model_changes();
         if (!inner)
             return;
+        const auto offset = inner->layout_state.offset;
         for (std::size_t i = 0; i < inner->data.size(); ++i) {
-            cb(uint32_t(i), inner->data[i].ptr ? (*inner->data[i].ptr)->z_order() : 0.f);
+            cb(uint32_t(offset + i), inner->data[i].ptr ? (*inner->data[i].ptr)->z_order() : 0.f);
         }
     }
 
@@ -1508,14 +1482,6 @@ public:
             }
         }
         return std::numeric_limits<uint64_t>::max();
-    }
-
-    /// Same as visit: a conditional has at most one instance, so a specific
-    /// `instance` from a z-ordered traversal can only be 0.
-    uint64_t visit_maybe_instance(uint32_t, TraversalOrder order,
-                                  private_api::ItemVisitorRefMut visitor) const
-    {
-        return visit(order, visitor);
     }
 
     /// Call `cb` with the index and the z value of the instance if the condition is

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -186,7 +186,7 @@ pub mod re_exports {
     };
     pub use i_slint_core::item_tree::{
         ItemTreeNode, ItemVisitorRefMut, ItemVisitorVTable, ItemWeak, TraversalOrder,
-        VisitChildrenResult, ZSortedChild, sort_z_entries, visit_item_tree,
+        VisitChildrenResult, visit_item_tree, visit_item_tree_z_sorted,
     };
     pub use i_slint_core::items::{Transform, *};
     pub use i_slint_core::layout::*;

--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -804,6 +804,86 @@ fn dynamic_z_order_repeater() {
 }
 
 #[test]
+/// Reversing the z order of three siblings in one frame must repaint the overlap of
+/// every pair whose relative order flipped — including a pair where neither member's
+/// rank *decreased*: here B keeps its middle rank and A only rises, yet A slides on
+/// top of B, so the A∩B overlap must be repainted (via A's rect).
+fn dynamic_z_order_reversal() {
+    slint::slint! {
+        export component Ui inherits Window {
+            in property <bool> rev: false;
+            background: black;
+            // A and B overlap each other; C is far away from both.
+            Rectangle { x: 10phx; y: 10phx; width: 30phx; height: 30phx; background: red; z: rev ? 30 : 10; } // A
+            Rectangle { x: 25phx; y: 25phx; width: 30phx; height: 30phx; background: blue; z: 20; } // B
+            Rectangle { x: 150phx; y: 150phx; width: 30phx; height: 30phx; background: green; z: rev ? 10 : 30; } // C
+        }
+    }
+
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    let ui = Ui::new().unwrap();
+    let window = WINDOW.with(|x| x.clone());
+    window.set_size(slint::PhysicalSize::new(300, 300));
+    ui.show().unwrap();
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 300, 300);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+
+    // Reverse the stacking order: A (rank 0→2) and C (rank 2→0) change rank, B stays
+    // at rank 1. The dirty region is A ∪ C, which covers both flipped overlaps
+    // (A∩B is within A, B∩C within C).
+    ui.set_rev(true);
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 10, 10, 180, 180);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+
+    // And back.
+    ui.set_rev(false);
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 10, 10, 180, 180);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+}
+
+#[test]
+/// A sibling appearing in the same frame as a z swap must not mask the swap: the
+/// conditional element enters the stacking order below everything, shifting the
+/// following ranks up, so the demoted rectangle's rank does not decrease — but the
+/// overlap of the swapped pair must still be repainted.
+fn dynamic_z_order_swap_with_appearing_sibling() {
+    slint::slint! {
+        export component Ui inherits Window {
+            in property <bool> front: false;
+            background: black;
+            // Appears below everything, away from the overlapping pair.
+            if front: Rectangle { x: 140phx; y: 140phx; width: 8phx; height: 8phx; background: green; z: -1; }
+            Rectangle { x: 20phx; y: 20phx; width: 30phx; height: 30phx; background: red; z: front ? 0 : 10; }
+            Rectangle { x: 20phx; y: 20phx; width: 30phx; height: 30phx; background: blue; z: 5; }
+        }
+    }
+
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    let ui = Ui::new().unwrap();
+    let window = WINDOW.with(|x| x.clone());
+    window.set_size(slint::PhysicalSize::new(200, 200));
+    ui.show().unwrap();
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 200, 200);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+
+    // One property flip shows the green rectangle and swaps red below blue.
+    // The dirty region is the swapped pair's rect plus the appearing rectangle.
+    ui.set_front(true);
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 20, 20, 148, 148);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+}
+
+#[test]
 fn shadow_redraw_beyond_geometry() {
     slint::slint! {
         export component Ui inherits Window {

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1772,66 +1772,43 @@ fn generate_item_tree(
         visit_children_statements.push("switch (index) {".into());
         for (node_idx, node) in &z_sorted_nodes {
             let sources = node.z_sort_order_property.as_ref().unwrap();
-            let compile_z = |e: &llr::MutExpression| {
-                format!("float({})", compile_expression(&e.borrow(), &ctx))
-            };
             visit_children_statements.push(format!("case {node_idx}: {{"));
-            if sources.iter().any(|s| matches!(s, llr::ZSource::RepeaterInstances)) {
-                // Repeated children are expanded to one entry per instance, so the
-                // number of entries is only known at runtime
-                visit_children_statements
-                    .push("    std::vector<slint::cbindgen_private::ZSortedChild> sorted;".into());
-                for (k, (source, child)) in sources.iter().zip(&node.children).enumerate() {
-                    match source {
-                        llr::ZSource::Expression(e) => {
-                            let e = compile_z(e);
-                            visit_children_statements.push(format!(
-                                "    sorted.push_back({{ {e}, {k}, std::numeric_limits<uint32_t>::max() }});"
-                            ));
-                        }
-                        llr::ZSource::RepeaterInstances => {
-                            let Either::Right(repeater_index) = child.item_index else {
-                                unreachable!("per-instance z is only set on repeated children")
-                            };
-                            let (compo_path, _) = follow_sub_component_path(
-                                root,
-                                sub_tree.root,
-                                &child.sub_component_path,
-                            );
-                            visit_children_statements.push(format!(
-                                "    self->{compo_path}repeater_{repeater_index}.for_each_instance_z([&](uint32_t instance, float z) {{ sorted.push_back({{ z, {k}, instance }}); }});"
-                            ));
-                        }
+            // The collect_z callback pushes one (child_offset, instance, z) entry per
+            // child, or one per instance for repeated children with per-instance z;
+            // the runtime sorts the entries and visits them in z order.
+            visit_children_statements.push(
+                "    static const auto collect_z = [] (const void *base, void *push_ctx, void (*push)(void *, uint32_t, uint32_t, float)) {".into(),
+            );
+            visit_children_statements.push(format!(
+                "        [[maybe_unused]] auto self = reinterpret_cast<const {item_tree_class_name}*>(base);"
+            ));
+            for (k, (source, child)) in sources.iter().zip(&node.children).enumerate() {
+                match source {
+                    llr::ZSource::Expression(e) => {
+                        let e = compile_expression(&e.borrow(), &ctx);
+                        visit_children_statements.push(format!(
+                            "        push(push_ctx, {k}, std::numeric_limits<uint32_t>::max(), float({e}));"
+                        ));
+                    }
+                    llr::ZSource::RepeaterInstances => {
+                        let Either::Right(repeater_index) = child.item_index else {
+                            unreachable!("per-instance z is only set on repeated children")
+                        };
+                        let (compo_path, _) = follow_sub_component_path(
+                            root,
+                            sub_tree.root,
+                            &child.sub_component_path,
+                        );
+                        visit_children_statements.push(format!(
+                            "        self->{compo_path}repeater_{repeater_index}.for_each_instance_z([&](uint32_t instance, float z) {{ push(push_ctx, {k}, instance, z); }});"
+                        ));
                     }
                 }
-                visit_children_statements.push(
-                    "    slint::cbindgen_private::slint_sort_z_entries(sorted.data(), sorted.size());".into(),
-                );
-                visit_children_statements.push(
-                    "    return slint::cbindgen_private::slint_visit_item_tree_with_sorted_children(&self_rc, get_item_tree(component), index, order, visitor, dyn_visit, slint::cbindgen_private::Slice<slint::cbindgen_private::ZSortedChild>{sorted.data(), sorted.size()});".into(),
-                );
-            } else {
-                let count = sources.len();
-                let entries: Vec<String> = sources
-                    .iter()
-                    .map(|source| {
-                        let llr::ZSource::Expression(e) = source else { unreachable!() };
-                        compile_z(e)
-                    })
-                    .enumerate()
-                    .map(|(k, e)| format!("{{ {e}, {k}, std::numeric_limits<uint32_t>::max() }}"))
-                    .collect();
-                let entries = entries.join(", ");
-                visit_children_statements.push(format!(
-                    "    slint::cbindgen_private::ZSortedChild sorted[{count}] = {{{entries}}};"
-                ));
-                visit_children_statements.push(format!(
-                    "    slint::cbindgen_private::slint_sort_z_entries(sorted, {count});"
-                ));
-                visit_children_statements.push(format!(
-                    "    return slint::cbindgen_private::slint_visit_item_tree_with_sorted_children(&self_rc, get_item_tree(component), index, order, visitor, dyn_visit, slint::cbindgen_private::Slice<slint::cbindgen_private::ZSortedChild>{{sorted, {count}}});"
-                ));
             }
+            visit_children_statements.push("    };".into());
+            visit_children_statements.push(
+                "    return slint::cbindgen_private::slint_visit_item_tree_z_sorted(&self_rc, get_item_tree(component), index, order, visitor, dyn_visit, collect_z);".into(),
+            );
             visit_children_statements.push("}".into());
         }
         visit_children_statements.push("}".into());

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1732,7 +1732,7 @@ fn generate_item_tree(
     });
 
     let mut visit_children_statements = vec![
-        "static const auto dyn_visit = [] (const void *base,  [[maybe_unused]] slint::private_api::TraversalOrder order, [[maybe_unused]] slint::private_api::ItemVisitorRefMut visitor, [[maybe_unused]] uint32_t dyn_index, [[maybe_unused]] uint32_t instance) -> uint64_t {".to_owned(),
+        "static const auto dyn_visit = [] (const void *base,  [[maybe_unused]] slint::private_api::TraversalOrder order, [[maybe_unused]] slint::private_api::ItemVisitorRefMut visitor, [[maybe_unused]] uint32_t dyn_index) -> uint64_t {".to_owned(),
         format!("    [[maybe_unused]] auto self = reinterpret_cast<const {}*>(base);", item_tree_class_name)];
     let mut subtree_range_statement = vec!["    std::abort();".into()];
     let mut subtree_component_statement = vec!["    std::abort();".into()];
@@ -1741,7 +1741,7 @@ fn generate_item_tree(
         matches!(&declaration, Declaration::Function(func @ Function { .. }) if func.name == "visit_dynamic_children")
     }) {
         visit_children_statements.push(
-            "    return self->visit_dynamic_children(dyn_index, order, visitor, instance);"
+            "    return self->visit_dynamic_children(dyn_index, order, visitor);"
                 .into(),
         );
         subtree_range_statement = vec![
@@ -2477,7 +2477,7 @@ fn generate_sub_component(
 
             children_visitor_cases.push(format!(
                 "\n        {case_code} {{
-                        return self->{sub_field}.visit_dynamic_children(dyn_index - {repeater_offset}, order, visitor, instance);
+                        return self->{sub_field}.visit_dynamic_children(dyn_index - {repeater_offset}, order, visitor);
                     }}",
             ));
             subtrees_ranges_cases.push(format!(
@@ -2606,7 +2606,7 @@ fn generate_sub_component(
             children_visitor_cases.push(format!(
                 "\n        case {idx}: {{
                 self->{repeater_id}.track_changes_listview({content_w}, {content_h}, &{content_y}, {lv_w}.get(), &{lv_h});
-                return self->{repeater_id}.visit_maybe_instance(instance, order, visitor);
+                return self->{repeater_id}.visit(order, visitor);
             }}",
             ));
             ensure_instantiated_stmts.push(format!(
@@ -2615,7 +2615,7 @@ fn generate_sub_component(
         } else {
             children_visitor_cases.push(format!(
                 "\n        case {idx}: {{
-                return self->{repeater_id}.visit_maybe_instance(instance, order, visitor);
+                return self->{repeater_id}.visit(order, visitor);
             }}",
             ));
             ensure_instantiated_stmts
@@ -2915,7 +2915,7 @@ fn generate_sub_component(
             field_access,
             Declaration::Function(Function {
                 name: "visit_dynamic_children".into(),
-                signature: "(uint32_t dyn_index, [[maybe_unused]] slint::private_api::TraversalOrder order, [[maybe_unused]] slint::private_api::ItemVisitorRefMut visitor, [[maybe_unused]] uint32_t instance) const -> uint64_t".into(),
+                signature: "(uint32_t dyn_index, [[maybe_unused]] slint::private_api::TraversalOrder order, [[maybe_unused]] slint::private_api::ItemVisitorRefMut visitor) const -> uint64_t".into(),
                 statements: Some(vec![
                     "    auto self = this;".to_owned(),
                     format!("    switch(dyn_index) {{ {} }};", children_visitor_cases.join("")),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2491,20 +2491,17 @@ fn generate_item_tree(
         )
     };
 
-    let visit_call = |sorted: TokenStream| {
-        quote!(sp::visit_item_tree(
-            &sp::VRcMapped::origin(&self.as_ref().self_weak.get().unwrap().upgrade().unwrap()),
-            self.get_item_tree().as_slice(),
-            index,
-            order,
-            visitor,
-            &mut |order, visitor, dyn_index, instance| self.visit_dynamic_children(dyn_index, order, visitor, instance),
-            #sorted,
-        ))
-    };
+    let default_call = quote!(sp::visit_item_tree(
+        &sp::VRcMapped::origin(&self.as_ref().self_weak.get().unwrap().upgrade().unwrap()),
+        self.get_item_tree().as_slice(),
+        index,
+        order,
+        visitor,
+        &mut |order, visitor, dyn_index, instance| self
+            .visit_dynamic_children(dyn_index, order, visitor, instance),
+    ));
     let z_sorted_visit_body = if z_sorted_nodes.is_empty() {
-        let call = visit_call(quote!(None));
-        quote!(return #call;)
+        quote!(return #default_call;)
     } else {
         let ctx = EvaluationContext::new_sub_component(
             root,
@@ -2512,60 +2509,44 @@ fn generate_item_tree(
             RustGeneratorContext { global_access: quote!(_self.globals.get().unwrap()) },
             parent_ctx,
         );
-        let sorted_call = visit_call(quote!(Some(sorted.as_slice())));
-        let default_call = visit_call(quote!(None));
         let z_match_arms = z_sorted_nodes.iter().map(|(node_idx, node)| {
             let idx_lit = *node_idx as isize;
             let sources = node.z_sort_order_property.as_ref().unwrap();
-            let compile_z = |e: &llr::MutExpression| {
-                let e = compile_expression(&e.borrow(), &ctx);
-                quote!(#e as f32)
-            };
-            let sorted_setup = if sources
-                .iter()
-                .any(|s| matches!(s, llr::ZSource::RepeaterInstances))
-            {
-                // Repeated children are expanded to one entry per instance, so the
-                // number of entries is only known at runtime
-                let pushes = sources.iter().zip(&node.children).enumerate().map(|(k, (source, child))| {
-                    let k = k as u32;
-                    match source {
-                        llr::ZSource::Expression(e) => {
-                            let e = compile_z(e);
-                            quote!(sorted.push(sp::ZSortedChild { z: #e, child_offset: #k, instance: u32::MAX });)
-                        }
-                        llr::ZSource::RepeaterInstances => {
-                            let itertools::Either::Right(repeater_index) = child.item_index else {
-                                unreachable!("per-instance z is only set on repeated children")
-                            };
-                            let (compo_path, sub_component) =
-                                follow_sub_component_path(root, sub_tree.root, &child.sub_component_path);
-                            let rep_field = access_component_field_offset(
-                                &self::inner_component_id(sub_component),
-                                &format_ident!("repeater{}", repeater_index),
-                            );
-                            quote!((#compo_path #rep_field).apply_pin(_self).for_each_instance_z(&mut |instance, z| sorted.push(sp::ZSortedChild { z, child_offset: #k, instance }));)
-                        }
+            // The closure pushes one (child_offset, instance, z) entry per child, or one
+            // per instance for repeated children with per-instance z; the runtime sorts
+            // the entries and visits them in z order.
+            let pushes = sources.iter().zip(&node.children).enumerate().map(|(k, (source, child))| {
+                let k = k as u32;
+                match source {
+                    llr::ZSource::Expression(e) => {
+                        let e = compile_expression(&e.borrow(), &ctx);
+                        quote!(push(#k, sp::None, #e as f32);)
                     }
-                });
-                quote! {
-                    let mut sorted = sp::Vec::<sp::ZSortedChild>::new();
-                    #(#pushes)*
+                    llr::ZSource::RepeaterInstances => {
+                        let itertools::Either::Right(repeater_index) = child.item_index else {
+                            unreachable!("per-instance z is only set on repeated children")
+                        };
+                        let (compo_path, sub_component) =
+                            follow_sub_component_path(root, sub_tree.root, &child.sub_component_path);
+                        let rep_field = access_component_field_offset(
+                            &self::inner_component_id(sub_component),
+                            &format_ident!("repeater{}", repeater_index),
+                        );
+                        quote!((#compo_path #rep_field).apply_pin(_self).for_each_instance_z(&mut |instance, z| push(#k, sp::Some(instance), z));)
+                    }
                 }
-            } else {
-                let entries = sources.iter().enumerate().map(|(k, source)| {
-                    let k = k as u32;
-                    let llr::ZSource::Expression(e) = source else { unreachable!() };
-                    let e = compile_z(e);
-                    quote!(sp::ZSortedChild { z: #e, child_offset: #k, instance: u32::MAX })
-                });
-                quote!(let mut sorted = [#(#entries),*];)
-            };
+            });
             quote! {
                 #idx_lit => {
-                    #sorted_setup
-                    sp::sort_z_entries(&mut sorted);
-                    return #sorted_call;
+                    return sp::visit_item_tree_z_sorted(
+                        &sp::VRcMapped::origin(&self.as_ref().self_weak.get().unwrap().upgrade().unwrap()),
+                        self.get_item_tree().as_slice(),
+                        index,
+                        order,
+                        visitor,
+                        &mut |order, visitor, dyn_index, instance| self.visit_dynamic_children(dyn_index, order, visitor, instance),
+                        &mut |push| { #(#pushes)* },
+                    );
                 }
             }
         });

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1473,7 +1473,7 @@ fn generate_sub_component(
                         #inner_component_id::FIELD_OFFSETS.#repeater_id().apply_pin(_self).track_changes_listview(
                             #content_w, #content_h, #content_y, #lv_w.get(), #lv_h
                         );
-                        #inner_component_id::FIELD_OFFSETS.#repeater_id().apply_pin(_self).visit_maybe_instance(instance, order, visitor)
+                        #inner_component_id::FIELD_OFFSETS.#repeater_id().apply_pin(_self).visit(order, visitor)
                     }
                 ));
                 ensure_instantiated_stmts.push(quote!({
@@ -1485,7 +1485,7 @@ fn generate_sub_component(
             } else {
                 repeated_visit_branch.push(quote!(
                     #idx => {
-                        #inner_component_id::FIELD_OFFSETS.#repeater_id().apply_pin(_self).visit_maybe_instance(instance, order, visitor)
+                        #inner_component_id::FIELD_OFFSETS.#repeater_id().apply_pin(_self).visit(order, visitor)
                     }
                 ));
                 ensure_instantiated_stmts.push(quote!({
@@ -1604,7 +1604,7 @@ fn generate_sub_component(
             let last_repeater = repeater_offset + sub_component_repeater_count - 1;
             repeated_visit_branch.push(quote!(
                 #repeater_offset..=#last_repeater => {
-                    #sub_compo_field.apply_pin(_self).visit_dynamic_children(dyn_index - #repeater_offset, order, visitor, instance)
+                    #sub_compo_field.apply_pin(_self).visit_dynamic_children(dyn_index - #repeater_offset, order, visitor)
                 }
             ));
             repeated_subtree_ranges.push(quote!(
@@ -1911,8 +1911,7 @@ fn generate_sub_component(
                 self: ::core::pin::Pin<&Self>,
                 dyn_index: u32,
                 order: sp::TraversalOrder,
-                visitor: sp::ItemVisitorRefMut<'_>,
-                instance: ::core::option::Option<u32>,
+                visitor: sp::ItemVisitorRefMut<'_>
             ) -> sp::VisitChildrenResult {
                 #![allow(unused)]
                 let _self = self;
@@ -2497,8 +2496,7 @@ fn generate_item_tree(
         index,
         order,
         visitor,
-        &mut |order, visitor, dyn_index, instance| self
-            .visit_dynamic_children(dyn_index, order, visitor, instance),
+        &mut |order, visitor, dyn_index| self.visit_dynamic_children(dyn_index, order, visitor),
     ));
     let z_sorted_visit_body = if z_sorted_nodes.is_empty() {
         quote!(return #default_call;)
@@ -2544,7 +2542,7 @@ fn generate_item_tree(
                         index,
                         order,
                         visitor,
-                        &mut |order, visitor, dyn_index, instance| self.visit_dynamic_children(dyn_index, order, visitor, instance),
+                        &mut |order, visitor, dyn_index| self.visit_dynamic_children(dyn_index, order, visitor),
                         &mut |push| { #(#pushes)* },
                     );
                 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -174,7 +174,7 @@ pub async fn run_passes(
         lower_layout::synthesize_layoutinfo_v_with_constraint(component);
         lower_layout::synthesize_layoutinfo_h_with_constraint(component);
         lower_absolute_coordinates::lower_absolute_coordinates(component);
-        z_order::reorder_by_z_order(component, diag);
+        z_order::reorder_by_z_order(component);
         lower_property_to_element::lower_property_to_element(
             component,
             core::iter::once("opacity"),

--- a/internal/compiler/passes/lower_shadows.rs
+++ b/internal/compiler/passes/lower_shadows.rs
@@ -267,7 +267,8 @@ pub fn lower_shadow_properties(
                 )
             {
                 shadow_elem.geometry_props.clone_from(&child.borrow().geometry_props);
-                // Sort the shadow with the same z as its element; the stable sort keeps it beneath
+                // Sort the shadow with the same z as its element: ties keep declaration
+                // order and the shadow is inserted right before its element, so it stays beneath.
                 shadow_elem.z_order = child.borrow().z_order.clone();
                 elem.borrow_mut().children.push(ElementRc::new(shadow_elem.into()));
             }

--- a/internal/compiler/passes/z_order.rs
+++ b/internal/compiler/passes/z_order.rs
@@ -9,25 +9,22 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::diagnostics::{BuildDiagnostics, Spanned};
+use crate::diagnostics::Spanned;
 use crate::expression_tree::{BindingExpression, Expression, Unit};
 use crate::langtype::ElementType;
 use crate::object_tree::{Component, ElementRc};
 
-pub fn reorder_by_z_order(root_component: &Rc<Component>, diag: &mut BuildDiagnostics) {
+pub fn reorder_by_z_order(root_component: &Rc<Component>) {
     crate::object_tree::recurse_elem_including_sub_components(
         root_component,
         &(),
         &mut |elem: &ElementRc, _| {
-            reorder_children_by_zorder(elem, diag);
+            reorder_children_by_zorder(elem);
         },
     )
 }
 
-fn reorder_children_by_zorder(
-    elem: &Rc<RefCell<crate::object_tree::Element>>,
-    diag: &mut BuildDiagnostics,
-) {
+fn reorder_children_by_zorder(elem: &Rc<RefCell<crate::object_tree::Element>>) {
     let mut has_any_z = false;
     let mut has_dynamic_z = false;
 
@@ -46,9 +43,9 @@ fn reorder_children_by_zorder(
     }
 
     if has_dynamic_z {
-        setup_dynamic_z_order(elem, diag);
+        setup_dynamic_z_order(elem);
     } else {
-        reorder_static_z(elem, diag);
+        reorder_static_z(elem);
     }
 }
 
@@ -88,20 +85,25 @@ fn mark_per_instance_z(child_elm: &ElementRc) -> bool {
 }
 
 /// Static z-order: evaluate all z values at compile time and reorder children.
-fn reorder_static_z(elem: &Rc<RefCell<crate::object_tree::Element>>, diag: &mut BuildDiagnostics) {
+/// All z bindings are constant here: a non-constant one makes `reorder_children_by_zorder`
+/// take the dynamic path instead.
+fn reorder_static_z(elem: &Rc<RefCell<crate::object_tree::Element>>) {
+    let take_constant_z = |elem: &ElementRc| -> Option<f64> {
+        // Only take real bindings; `binding()` filters synthetic debug hooks,
+        // which the detection did not see either.
+        elem.borrow().binding("z")?;
+        let e = elem.borrow_mut().take_binding("z")?;
+        let z = try_eval_const_expr(&e.expression);
+        debug_assert!(z.is_some(), "non-constant z on the static path");
+        Some(z.unwrap_or(0.))
+    };
     let mut children_z_order = Vec::new();
     for (idx, child_elm) in elem.borrow().children.iter().enumerate() {
-        let z = child_elm
-            .borrow_mut()
-            .take_binding("z")
-            .and_then(|e| eval_const_expr(&e.expression, "z", &e, diag));
+        let z = take_constant_z(child_elm);
         let z = z.or_else(|| {
             child_elm.borrow().repeated.as_ref()?;
             if let ElementType::Component(c) = &child_elm.borrow().base_type {
-                c.root_element
-                    .borrow_mut()
-                    .take_binding("z")
-                    .and_then(|e| eval_const_expr(&e.expression, "z", &e, diag))
+                take_constant_z(&c.root_element)
             } else {
                 None
             }
@@ -133,10 +135,7 @@ fn reorder_static_z(elem: &Rc<RefCell<crate::object_tree::Element>>, diag: &mut 
 /// Dynamic z-order: set the `z_order` of every child. Children whose z is a runtime
 /// value get a NamedReference to their z property (materialized as a runtime property),
 /// the other children a compile-time constant.
-fn setup_dynamic_z_order(
-    elem: &Rc<RefCell<crate::object_tree::Element>>,
-    diag: &mut BuildDiagnostics,
-) {
+fn setup_dynamic_z_order(elem: &Rc<RefCell<crate::object_tree::Element>>) {
     use crate::namedreference::NamedReference;
     use crate::object_tree::ZOrder;
 
@@ -152,12 +151,12 @@ fn setup_dynamic_z_order(
             // is ordered among its siblings.
             let mut z_val = 0.;
             if let ElementType::Component(c) = &child_elm.borrow().base_type {
-                let binding = c.root_element.borrow_mut().take_binding("z");
-                if let Some(e) = binding {
-                    z_val = try_eval_const_expr(&e.expression).unwrap_or_else(|| {
-                        diag.push_error("'z' in a repeated element must be a constant".into(), &e);
-                        0.
-                    });
+                // Only take real bindings; `binding()` filters synthetic debug hooks
+                let has_binding = c.root_element.borrow().binding("z").is_some();
+                if has_binding && let Some(e) = c.root_element.borrow_mut().take_binding("z") {
+                    let z = try_eval_const_expr(&e.expression);
+                    debug_assert!(z.is_some(), "handled by mark_per_instance_z otherwise");
+                    z_val = z.unwrap_or(0.);
                 }
             }
             ZOrder::Constant(z_val as f32)
@@ -227,17 +226,4 @@ fn try_eval_const_expr(expression: &Expression) -> Option<f64> {
         Expression::UnaryOp { sub, op: '+' } => try_eval_const_expr(sub),
         _ => None,
     }
-}
-
-fn eval_const_expr(
-    expression: &Expression,
-    name: &str,
-    span: &dyn crate::diagnostics::Spanned,
-    diag: &mut BuildDiagnostics,
-) -> Option<f64> {
-    let result = try_eval_const_expr(expression);
-    if result.is_none() {
-        diag.push_error(format!("'{name}' must be a number literal"), span);
-    }
-    result
 }

--- a/internal/compiler/passes/z_order.rs
+++ b/internal/compiler/passes/z_order.rs
@@ -237,7 +237,7 @@ fn eval_const_expr(
 ) -> Option<f64> {
     let result = try_eval_const_expr(expression);
     if result.is_none() {
-        diag.push_error(format!("'{name}' must be an number literal"), span);
+        diag.push_error(format!("'{name}' must be a number literal"), span);
     }
     result
 }

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1356,42 +1356,62 @@ fn visit_internal<State>(
 
 /// One entry in the z-ordered traversal of an element's children: a plain child,
 /// or a single instance of a repeated child.
-#[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct ZSortedChild {
+struct ZSortedChild {
     /// The z value used for sorting
-    pub z: f32,
+    z: f32,
     /// Offset of the child within the parent's children (relative to children_index)
-    pub child_offset: u32,
+    child_offset: u32,
     /// The repeater instance when the child is a repeated element expanded per
-    /// instance, or `u32::MAX` to visit the whole child
-    pub instance: u32,
+    /// instance, or `None` to visit the whole child
+    instance: Option<u32>,
 }
 
-/// Sort by z, breaking ties by child_offset then instance.
-pub fn sort_z_entries(entries: &mut [ZSortedChild]) {
-    entries.sort_unstable_by(|a, b| {
-        a.z.total_cmp(&b.z)
-            .then(a.child_offset.cmp(&b.child_offset))
-            .then(a.instance.cmp(&b.instance))
-    });
+/// Visit one child of `index`'s children (an item, or a dynamic node forwarded to
+/// `visit_dynamic`), shared between the sequential and the z-sorted traversal.
+fn visit_child_at_index(
+    item_tree: &ItemTreeRc,
+    item_tree_array: &[ItemTreeNode],
+    idx: u32,
+    instance: Option<u32>,
+    order: TraversalOrder,
+    visitor: &mut vtable::VRefMut<ItemVisitorVTable>,
+    visit_dynamic: &mut dyn FnMut(
+        TraversalOrder,
+        vtable::VRefMut<ItemVisitorVTable>,
+        u32,
+        Option<u32>,
+    ) -> VisitChildrenResult,
+) -> VisitChildrenResult {
+    match &item_tree_array[idx as usize] {
+        ItemTreeNode::Item { .. } => {
+            let item = crate::items::ItemRc::new(item_tree.clone(), idx);
+            visitor.visit_item(item_tree, idx, item.borrow())
+        }
+        ItemTreeNode::DynamicTree { index, .. } => {
+            if let Some(sub_idx) =
+                visit_dynamic(order, visitor.borrow_mut(), *index, instance).aborted_index()
+            {
+                VisitChildrenResult::abort(idx, sub_idx)
+            } else {
+                VisitChildrenResult::CONTINUE
+            }
+        }
+    }
 }
 
 /// Visit the children within an array of ItemTreeNode
 ///
 /// The dynamic visitor is called for the dynamic nodes, its signature is
 /// `fn(order: TraversalOrder, visitor: vtable::VRefMut<ItemVisitorVTable>, dyn_index: u32, instance: Option<u32>)`
-/// where `instance` is a specific repeater instance to visit, or `None` for all of them.
+/// where `instance` is a specific repeater instance to visit (never set by this function,
+/// see [`visit_item_tree_z_sorted`]), or `None` for all of them.
 /// It is a `dyn` callback (capturing the component) rather than generic, so this function is
 /// not duplicated per component type.
 ///
 /// FIXME: the design of this use lots of indirection and stack frame in recursive functions
 /// Need to check if the compiler is able to optimize away some of it.
 /// Possibly we should generate code that directly call the visitor instead
-///
-/// If `sorted_children` is `Some`, the children are visited in that z-sorted order
-/// instead of the sequential order. Repeated children may be expanded to one entry
-/// per instance, so the entries can outnumber the children.
 pub fn visit_item_tree(
     item_tree: &ItemTreeRc,
     item_tree_array: &[ItemTreeNode],
@@ -1404,55 +1424,36 @@ pub fn visit_item_tree(
         u32,
         Option<u32>,
     ) -> VisitChildrenResult,
-    sorted_children: Option<&[ZSortedChild]>,
 ) -> VisitChildrenResult {
-    let mut visit_at_index = |idx: u32, instance: Option<u32>| -> VisitChildrenResult {
-        match &item_tree_array[idx as usize] {
-            ItemTreeNode::Item { .. } => {
-                let item = crate::items::ItemRc::new(item_tree.clone(), idx);
-                visitor.visit_item(item_tree, idx, item.borrow())
-            }
-            ItemTreeNode::DynamicTree { index, .. } => {
-                if let Some(sub_idx) =
-                    visit_dynamic(order, visitor.borrow_mut(), *index, instance).aborted_index()
-                {
-                    VisitChildrenResult::abort(idx, sub_idx)
-                } else {
-                    VisitChildrenResult::CONTINUE
-                }
-            }
-        }
-    };
     if index == -1 {
-        visit_at_index(0, None)
+        visit_child_at_index(
+            item_tree,
+            item_tree_array,
+            0,
+            None,
+            order,
+            &mut visitor,
+            visit_dynamic,
+        )
     } else {
         match &item_tree_array[index as usize] {
             ItemTreeNode::Item { children_index, children_count, .. } => {
-                if let Some(sorted) = sorted_children {
-                    for i in 0..sorted.len() {
-                        let entry = &sorted[match order {
-                            TraversalOrder::BackToFront => i,
-                            TraversalOrder::FrontToBack => sorted.len() - 1 - i,
-                        }];
-                        let instance = (entry.instance != u32::MAX).then_some(entry.instance);
-                        let maybe_abort_index =
-                            visit_at_index(*children_index + entry.child_offset, instance);
-                        if maybe_abort_index.has_aborted() {
-                            return maybe_abort_index;
-                        }
-                    }
-                } else {
-                    for c in 0..*children_count {
-                        let idx = match order {
-                            TraversalOrder::BackToFront => *children_index + c,
-                            TraversalOrder::FrontToBack => {
-                                *children_index + *children_count - c - 1
-                            }
-                        };
-                        let maybe_abort_index = visit_at_index(idx, None);
-                        if maybe_abort_index.has_aborted() {
-                            return maybe_abort_index;
-                        }
+                for c in 0..*children_count {
+                    let idx = match order {
+                        TraversalOrder::BackToFront => *children_index + c,
+                        TraversalOrder::FrontToBack => *children_index + *children_count - c - 1,
+                    };
+                    let maybe_abort_index = visit_child_at_index(
+                        item_tree,
+                        item_tree_array,
+                        idx,
+                        None,
+                        order,
+                        &mut visitor,
+                        visit_dynamic,
+                    );
+                    if maybe_abort_index.has_aborted() {
+                        return maybe_abort_index;
                     }
                 }
             }
@@ -1460,6 +1461,69 @@ pub fn visit_item_tree(
         };
         VisitChildrenResult::CONTINUE
     }
+}
+
+/// Visit the children of the node at `index` (which must be an `ItemTreeNode::Item` whose
+/// children have dynamic z-ordering) sorted by their z value.
+///
+/// `collect_z` is invoked once with a `push(child_offset, instance, z)` sink and must push
+/// one entry for every child: either a single entry with `instance == None`, which visits
+/// the whole child (including a repeated child as one block), or one entry per instance of
+/// a repeated child that is expanded and sorted individually (`instance == Some(i)`), so
+/// the entries can outnumber the children. `collect_z` must be side-effect free: it runs on
+/// every children traversal, and property reads in it are what registers the dependencies
+/// that re-trigger rendering when a z value changes.
+///
+/// The entries are sorted by z, ties broken by declaration order (`child_offset`) then
+/// instance, and visited in that order — reversed for `FrontToBack`. Entries with a
+/// specific instance are forwarded to `visit_dynamic` with `instance == Some(i)`.
+pub fn visit_item_tree_z_sorted(
+    item_tree: &ItemTreeRc,
+    item_tree_array: &[ItemTreeNode],
+    index: isize,
+    order: TraversalOrder,
+    mut visitor: vtable::VRefMut<ItemVisitorVTable>,
+    visit_dynamic: &mut dyn FnMut(
+        TraversalOrder,
+        vtable::VRefMut<ItemVisitorVTable>,
+        u32,
+        Option<u32>,
+    ) -> VisitChildrenResult,
+    collect_z: &mut dyn FnMut(&mut dyn FnMut(u32, Option<u32>, f32)),
+) -> VisitChildrenResult {
+    let ItemTreeNode::Item { children_index, children_count, .. } =
+        &item_tree_array[index as usize]
+    else {
+        panic!("should not be called with dynamic items")
+    };
+    let mut entries = alloc::vec::Vec::with_capacity(*children_count as usize);
+    collect_z(&mut |child_offset, instance, z| {
+        entries.push(ZSortedChild { z, child_offset, instance })
+    });
+    entries.sort_unstable_by(|a: &ZSortedChild, b: &ZSortedChild| {
+        a.z.total_cmp(&b.z)
+            .then(a.child_offset.cmp(&b.child_offset))
+            .then(a.instance.cmp(&b.instance))
+    });
+    for i in 0..entries.len() {
+        let entry = &entries[match order {
+            TraversalOrder::BackToFront => i,
+            TraversalOrder::FrontToBack => entries.len() - 1 - i,
+        }];
+        let maybe_abort_index = visit_child_at_index(
+            item_tree,
+            item_tree_array,
+            *children_index + entry.child_offset,
+            entry.instance,
+            order,
+            &mut visitor,
+            visit_dynamic,
+        );
+        if maybe_abort_index.has_aborted() {
+            return maybe_abort_index;
+        }
+    }
+    VisitChildrenResult::CONTINUE
 }
 
 #[cfg(feature = "ffi")]
@@ -1527,12 +1591,23 @@ pub(crate) mod ffi {
             &mut |order, visitor, dyn_index, instance: Option<u32>| {
                 visit_dynamic(base, order, visitor, dyn_index, instance.unwrap_or(u32::MAX))
             },
-            None,
         )
     }
 
+    /// Expose `crate::item_tree::visit_item_tree_z_sorted` to C++.
+    ///
+    /// `collect_z` receives the component `base`, an opaque `push_ctx`, and a `push`
+    /// function; it must call `push(push_ctx, child_offset, instance, z)` once per entry,
+    /// with `instance == u32::MAX` for entries that visit the whole child. See
+    /// [`crate::item_tree::visit_item_tree_z_sorted`] for the contract.
+    ///
+    /// Safety: Assume a correct implementation of the item_tree array, and of the
+    /// `visit_dynamic` and `collect_z` callbacks: both must be valid function pointers,
+    /// `collect_z` must forward the given `push_ctx` unchanged to `push` and only call
+    /// `push` for the duration of the `collect_z` call, and it must only push
+    /// `child_offset` values that are within the children of the node at `index`.
     #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_visit_item_tree_with_sorted_children(
+    pub unsafe extern "C" fn slint_visit_item_tree_z_sorted(
         item_tree: &ItemTreeRc,
         item_tree_array: Slice<ItemTreeNode>,
         index: isize,
@@ -1545,10 +1620,14 @@ pub(crate) mod ffi {
             dyn_index: u32,
             instance: u32,
         ) -> VisitChildrenResult,
-        sorted_children: Slice<crate::item_tree::ZSortedChild>,
+        collect_z: extern "C" fn(
+            base: *const c_void,
+            push_ctx: *mut c_void,
+            push: extern "C" fn(push_ctx: *mut c_void, child_offset: u32, instance: u32, z: f32),
+        ),
     ) -> VisitChildrenResult {
         let base = VRc::as_pin_ref(item_tree).get_ref() as *const vtable::Dyn as *const c_void;
-        crate::item_tree::visit_item_tree(
+        crate::item_tree::visit_item_tree_z_sorted(
             item_tree,
             item_tree_array.as_slice(),
             index,
@@ -1557,18 +1636,21 @@ pub(crate) mod ffi {
             &mut |order, visitor, dyn_index, instance: Option<u32>| {
                 visit_dynamic(base, order, visitor, dyn_index, instance.unwrap_or(u32::MAX))
             },
-            Some(sorted_children.as_slice()),
+            &mut |push| {
+                extern "C" fn push_trampoline(
+                    push_ctx: *mut c_void,
+                    child_offset: u32,
+                    instance: u32,
+                    z: f32,
+                ) {
+                    let push =
+                        unsafe { &mut **(push_ctx as *mut &mut dyn FnMut(u32, Option<u32>, f32)) };
+                    push(child_offset, (instance != u32::MAX).then_some(instance), z);
+                }
+                let mut push_ctx: &mut dyn FnMut(u32, Option<u32>, f32) = push;
+                collect_z(base, core::ptr::addr_of_mut!(push_ctx) as *mut c_void, push_trampoline);
+            },
         )
-    }
-
-    /// Safety: `entries` must point to a buffer of `len` elements
-    #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_sort_z_entries(
-        entries: *mut crate::item_tree::ZSortedChild,
-        len: usize,
-    ) {
-        let entries = unsafe { core::slice::from_raw_parts_mut(entries, len) };
-        crate::item_tree::sort_z_entries(entries);
     }
 }
 

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1362,8 +1362,9 @@ struct ZSortedChild {
     z: f32,
     /// Offset of the child within the parent's children (relative to children_index)
     child_offset: u32,
-    /// The repeater instance when the child is a repeated element expanded per
-    /// instance, or `None` to visit the whole child
+    /// The repeater instance (a model row index, as accepted by the `get_subtree`
+    /// vtable entry) when the child is a repeated element expanded per instance,
+    /// or `None` to visit the whole child
     instance: Option<u32>,
 }
 
@@ -1373,14 +1374,12 @@ fn visit_child_at_index(
     item_tree: &ItemTreeRc,
     item_tree_array: &[ItemTreeNode],
     idx: u32,
-    instance: Option<u32>,
     order: TraversalOrder,
     visitor: &mut vtable::VRefMut<ItemVisitorVTable>,
     visit_dynamic: &mut dyn FnMut(
         TraversalOrder,
         vtable::VRefMut<ItemVisitorVTable>,
         u32,
-        Option<u32>,
     ) -> VisitChildrenResult,
 ) -> VisitChildrenResult {
     match &item_tree_array[idx as usize] {
@@ -1390,7 +1389,7 @@ fn visit_child_at_index(
         }
         ItemTreeNode::DynamicTree { index, .. } => {
             if let Some(sub_idx) =
-                visit_dynamic(order, visitor.borrow_mut(), *index, instance).aborted_index()
+                visit_dynamic(order, visitor.borrow_mut(), *index).aborted_index()
             {
                 VisitChildrenResult::abort(idx, sub_idx)
             } else {
@@ -1403,9 +1402,7 @@ fn visit_child_at_index(
 /// Visit the children within an array of ItemTreeNode
 ///
 /// The dynamic visitor is called for the dynamic nodes, its signature is
-/// `fn(order: TraversalOrder, visitor: vtable::VRefMut<ItemVisitorVTable>, dyn_index: u32, instance: Option<u32>)`
-/// where `instance` is a specific repeater instance to visit (never set by this function,
-/// see [`visit_item_tree_z_sorted`]), or `None` for all of them.
+/// `fn(order: TraversalOrder, visitor: vtable::VRefMut<ItemVisitorVTable>, dyn_index: u32)`.
 /// It is a `dyn` callback (capturing the component) rather than generic, so this function is
 /// not duplicated per component type.
 ///
@@ -1422,19 +1419,10 @@ pub fn visit_item_tree(
         TraversalOrder,
         vtable::VRefMut<ItemVisitorVTable>,
         u32,
-        Option<u32>,
     ) -> VisitChildrenResult,
 ) -> VisitChildrenResult {
     if index == -1 {
-        visit_child_at_index(
-            item_tree,
-            item_tree_array,
-            0,
-            None,
-            order,
-            &mut visitor,
-            visit_dynamic,
-        )
+        visit_child_at_index(item_tree, item_tree_array, 0, order, &mut visitor, visit_dynamic)
     } else {
         match &item_tree_array[index as usize] {
             ItemTreeNode::Item { children_index, children_count, .. } => {
@@ -1447,7 +1435,6 @@ pub fn visit_item_tree(
                         item_tree,
                         item_tree_array,
                         idx,
-                        None,
                         order,
                         &mut visitor,
                         visit_dynamic,
@@ -1475,8 +1462,10 @@ pub fn visit_item_tree(
 /// that re-trigger rendering when a z value changes.
 ///
 /// The entries are sorted by z, ties broken by declaration order (`child_offset`) then
-/// instance, and visited in that order — reversed for `FrontToBack`. Entries with a
-/// specific instance are forwarded to `visit_dynamic` with `instance == Some(i)`.
+/// instance, and visited in that order — reversed for `FrontToBack`. An entry with a
+/// specific instance is visited directly through the `get_subtree` vtable entry of
+/// `item_tree` (so the instance index is a model row index, as used by `get_subtree`
+/// and `get_subtree_range`), without going through `visit_dynamic`.
 pub fn visit_item_tree_z_sorted(
     item_tree: &ItemTreeRc,
     item_tree_array: &[ItemTreeNode],
@@ -1487,7 +1476,6 @@ pub fn visit_item_tree_z_sorted(
         TraversalOrder,
         vtable::VRefMut<ItemVisitorVTable>,
         u32,
-        Option<u32>,
     ) -> VisitChildrenResult,
     collect_z: &mut dyn FnMut(&mut dyn FnMut(u32, Option<u32>, f32)),
 ) -> VisitChildrenResult {
@@ -1510,15 +1498,39 @@ pub fn visit_item_tree_z_sorted(
             TraversalOrder::BackToFront => i,
             TraversalOrder::FrontToBack => entries.len() - 1 - i,
         }];
-        let maybe_abort_index = visit_child_at_index(
-            item_tree,
-            item_tree_array,
-            *children_index + entry.child_offset,
-            entry.instance,
-            order,
-            &mut visitor,
-            visit_dynamic,
-        );
+        let idx = *children_index + entry.child_offset;
+        let maybe_abort_index = match (&item_tree_array[idx as usize], entry.instance) {
+            (ItemTreeNode::DynamicTree { index: dyn_index, .. }, Some(instance)) => {
+                // A single expanded instance: reach it through the vtable instead of the
+                // component's dynamic-visit dispatch. An instance that disappeared since
+                // `collect_z` ran is skipped.
+                let mut instance_tree: vtable::VWeak<ItemTreeVTable, Dyn> = Default::default();
+                VRc::borrow_pin(item_tree).as_ref().get_subtree(
+                    *dyn_index,
+                    instance as usize,
+                    &mut instance_tree,
+                );
+                match instance_tree.upgrade() {
+                    Some(t)
+                        if VRc::borrow_pin(&t)
+                            .as_ref()
+                            .visit_children_item(-1, order, visitor.borrow_mut())
+                            .has_aborted() =>
+                    {
+                        VisitChildrenResult::abort(idx, instance as usize)
+                    }
+                    _ => VisitChildrenResult::CONTINUE,
+                }
+            }
+            _ => visit_child_at_index(
+                item_tree,
+                item_tree_array,
+                idx,
+                order,
+                &mut visitor,
+                visit_dynamic,
+            ),
+        };
         if maybe_abort_index.has_aborted() {
             return maybe_abort_index;
         }
@@ -1578,7 +1590,6 @@ pub(crate) mod ffi {
             order: TraversalOrder,
             visitor: vtable::VRefMut<ItemVisitorVTable>,
             dyn_index: u32,
-            instance: u32,
         ) -> VisitChildrenResult,
     ) -> VisitChildrenResult {
         let base = VRc::as_pin_ref(item_tree).get_ref() as *const vtable::Dyn as *const c_void;
@@ -1588,9 +1599,7 @@ pub(crate) mod ffi {
             index,
             order,
             visitor,
-            &mut |order, visitor, dyn_index, instance: Option<u32>| {
-                visit_dynamic(base, order, visitor, dyn_index, instance.unwrap_or(u32::MAX))
-            },
+            &mut |order, visitor, dyn_index| visit_dynamic(base, order, visitor, dyn_index),
         )
     }
 
@@ -1618,7 +1627,6 @@ pub(crate) mod ffi {
             order: TraversalOrder,
             visitor: vtable::VRefMut<ItemVisitorVTable>,
             dyn_index: u32,
-            instance: u32,
         ) -> VisitChildrenResult,
         collect_z: extern "C" fn(
             base: *const c_void,
@@ -1633,9 +1641,7 @@ pub(crate) mod ffi {
             index,
             order,
             visitor,
-            &mut |order, visitor, dyn_index, instance: Option<u32>| {
-                visit_dynamic(base, order, visitor, dyn_index, instance.unwrap_or(u32::MAX))
-            },
+            &mut |order, visitor, dyn_index| visit_dynamic(base, order, visitor, dyn_index),
             &mut |push| {
                 extern "C" fn push_trampoline(
                     push_ctx: *mut c_void,

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -855,49 +855,22 @@ impl<C: RepeatedItemTree + 'static> Repeater<C> {
         crate::item_tree::VisitChildrenResult::CONTINUE
     }
 
-    /// Call the visitor for the root of a single instance.
-    pub fn visit_instance(
-        self: Pin<&Self>,
-        instance: u32,
-        order: TraversalOrder,
-        mut visitor: crate::item_tree::ItemVisitorRefMut,
-    ) -> crate::item_tree::VisitChildrenResult {
-        let c = self.0.inner.borrow().instances.get(instance as usize).and_then(|c| c.1.clone());
-        if let Some(c) = c
-            && c.as_pin_ref().visit_children_item(-1, order, visitor.borrow_mut()).has_aborted()
-        {
-            return crate::item_tree::VisitChildrenResult::abort(instance, 0);
-        }
-        crate::item_tree::VisitChildrenResult::CONTINUE
-    }
-
-    /// Visit a single instance when `instance` is `Some` (coming from a z-ordered
-    /// traversal), or all the instances when it is `None`.
-    pub fn visit_maybe_instance(
-        self: Pin<&Self>,
-        instance: Option<u32>,
-        order: TraversalOrder,
-        visitor: crate::item_tree::ItemVisitorRefMut,
-    ) -> crate::item_tree::VisitChildrenResult {
-        match instance {
-            None => self.visit(order, visitor),
-            Some(instance) => self.visit_instance(instance, order, visitor),
-        }
-    }
-
-    /// Call `cb` with the index and the z value of every instance, when the repeated
-    /// element has a dynamic z binding.
+    /// Call `cb` with the model row index and the z value of every instance, when the
+    /// repeated element has a dynamic z binding. The row index is the one accepted by
+    /// [`Self::instance_at`] (and thus by the `get_subtree` vtable entry).
     /// Also registers model dependencies so the current tracking scope is notified
     /// when the model changes.
     pub fn for_each_instance_z(self: Pin<&Self>, cb: &mut dyn FnMut(u32, f32)) {
         self.track_model_changes();
         // Read the z values without holding the borrow: evaluating the z property's
         // binding can run user code
-        let instances: Vec<_> =
-            self.0.inner.borrow().instances.iter().map(|c| c.1.clone()).collect();
+        let (offset, instances): (usize, Vec<_>) = {
+            let inner = self.0.inner.borrow();
+            (inner.layout_state.offset, inner.instances.iter().map(|c| c.1.clone()).collect())
+        };
         for (i, c) in instances.iter().enumerate() {
             let z = c.as_ref().and_then(|c| c.as_pin_ref().z_order()).unwrap_or_default();
-            cb(i as u32, z);
+            cb((offset + i) as u32, z);
         }
     }
 
@@ -1023,16 +996,6 @@ impl<C: RepeatedItemTree + 'static> Conditional<C> {
         }
 
         crate::item_tree::VisitChildrenResult::CONTINUE
-    }
-
-    /// A conditional has at most one instance, so `instance` is ignored.
-    pub fn visit_maybe_instance(
-        self: Pin<&Self>,
-        _instance: Option<u32>,
-        order: TraversalOrder,
-        visitor: crate::item_tree::ItemVisitorRefMut,
-    ) -> crate::item_tree::VisitChildrenResult {
-        self.visit(order, visitor)
     }
 
     /// Call `cb` with the index and the z value of the instance if the condition is

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -78,7 +78,9 @@ impl CachedRenderingData {
 /// After rendering an item, we cache the geometry and the transform it applies to
 /// children.
 ///
-/// `sibling_index` (the item's rank among its z-ordered siblings last frame) is a `u16` stored
+/// `sibling_index` (the item's rank among all its z-ordered siblings when it was last
+/// visited; compared in `compute_dirty_regions` against the rank counted over the items
+/// that already had a cache entry, so appearing siblings don't shift it) is a `u16` stored
 /// in each variant, so it fits the enum's padding without growing the cache entry on 32- or
 /// 64-bit. It is excluded from geometry comparisons.
 #[derive(Clone)]
@@ -425,9 +427,15 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
             depth: usize,
         }
 
-        // One counter per tree depth to give each item its rank among its z-ordered siblings;
-        // a rank that changed since last frame means the stacking order changed.
-        let sibling_counters = RefCell::new(alloc::vec::Vec::<u16>::new());
+        // Two counters per tree depth to give each item its rank among its z-ordered siblings.
+        // `.0` counts every visited item and is what gets stored in the cache entry; `.1`
+        // counts only the items that already have a cache entry and is what the stored rank
+        // is compared against. New items are skipped in the comparison rank so that an
+        // appearing sibling does not shift the ranks of the existing items (their overlap
+        // with the new sibling is covered by the new item's own dirty rect), while two
+        // existing items can never trade places without at least one comparison rank
+        // changing.
+        let sibling_counters = RefCell::new(alloc::vec::Vec::<(u16, u16)>::new());
 
         impl ComputeDirtyRegionState {
             /// Adjust transform_to_screen and old_transform_to_screen to map from item coordinates
@@ -454,11 +462,11 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                     let depth = state.depth;
                     let mut counters = sibling_counters.borrow_mut();
                     if counters.len() <= depth + 1 {
-                        counters.resize(depth + 2, 0);
+                        counters.resize(depth + 2, (0, 0));
                     }
-                    counters[depth + 1] = 0; // this item's children restart at zero
-                    let idx = counters[depth];
-                    counters[depth] = idx.saturating_add(1);
+                    counters[depth + 1] = (0, 0); // this item's children restart at zero
+                    let idx = counters[depth].0;
+                    counters[depth].0 = idx.saturating_add(1);
                     idx
                 };
                 new_state.depth = state.depth + 1;
@@ -475,14 +483,23 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                     Some(PartialRenderingCachedData { data: cached_geom, tracker }) => {
                         let rendering_dirty = tracker.as_ref().is_some_and(|tr| tr.is_dirty());
 
-                        // Only repaint when the rank decreased. When two items swap it is
-                        // enough to repaint one of them since the overlap is within both, and
-                        // this way adding a sibling (which only shifts following ranks up)
-                        // never repaints them. A saturated rank (>65535 siblings) always repaints.
+                        // Repaint when the rank among the previously known siblings changed,
+                        // in either direction: two items cannot trade places in the stacking
+                        // order with both comparison ranks unchanged, and since an overlap is
+                        // within both items' rects, repainting the changed one(s) covers it.
+                        // Only a decrease is not enough: in a permutation of three or more
+                        // items a pair can flip while one member keeps its rank and the other
+                        // only rises. A saturated rank (>65535 siblings) always repaints.
+                        let comparison_sibling_index = {
+                            let mut counters = sibling_counters.borrow_mut();
+                            let idx = counters[state.depth].1;
+                            counters[state.depth].1 = idx.saturating_add(1);
+                            idx
+                        };
                         let old_sibling_index =
                             core::mem::replace(cached_geom.sibling_index(), my_sibling_index);
-                        let sibling_index_changed =
-                            my_sibling_index == u16::MAX || my_sibling_index < old_sibling_index;
+                        let sibling_index_changed = my_sibling_index == u16::MAX
+                            || comparison_sibling_index != old_sibling_index;
                         new_state.must_refresh_children |= sibling_index_changed;
 
                         let geometry_changed = !cached_geom.same_geometry(&new_geom);

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -43,18 +43,6 @@ impl RepeaterOrConditional {
         }
     }
 
-    pub fn visit_maybe_instance(
-        &self,
-        instance: Option<u32>,
-        order: i_slint_core::item_tree::TraversalOrder,
-        visitor: i_slint_core::item_tree::ItemVisitorRefMut<'_>,
-    ) -> i_slint_core::item_tree::VisitChildrenResult {
-        match self {
-            Self::Repeater(r) => Pin::as_ref(r).visit_maybe_instance(instance, order, visitor),
-            Self::Conditional(c) => Pin::as_ref(c).visit_maybe_instance(instance, order, visitor),
-        }
-    }
-
     /// Call `cb` with the index and z value of every instance, for a repeated or
     /// conditional element whose z value is dynamic.
     pub fn for_each_instance_z(&self, cb: &mut dyn FnMut(u32, f32)) {
@@ -577,7 +565,6 @@ impl Instance {
         dyn_index: u32,
         order: i_slint_core::item_tree::TraversalOrder,
         visitor: vtable::VRefMut<'_, i_slint_core::item_tree::ItemVisitorVTable>,
-        instance: Option<u32>,
     ) -> i_slint_core::item_tree::VisitChildrenResult {
         let Some((sub, rep_idx)) = self.get_ref().dynamic_at(dyn_index) else {
             return i_slint_core::item_tree::VisitChildrenResult::CONTINUE;
@@ -603,7 +590,7 @@ impl Instance {
             let _ = read_logical_length(&sub, &lv.listview_height);
             Pin::as_ref(r).track_changes_listview_callback(&props, listview_width);
         }
-        repeater.visit_maybe_instance(instance, order, visitor)
+        repeater.visit(order, visitor)
     }
 
     /// Push one `(child_offset, instance, z)` entry per child of the node at `index`

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -606,22 +606,20 @@ impl Instance {
         repeater.visit_maybe_instance(instance, order, visitor)
     }
 
-    /// The z-sorted children of the node at `index`, or `None` if they aren't z-ordered.
-    /// Repeated children are expanded to one entry per instance.
-    pub fn compute_z_sorted_children(
+    /// Push one `(child_offset, instance, z)` entry per child of the node at `index`
+    /// (whose children must be z-ordered, see `z_sort_table`), expanding repeated
+    /// children with per-instance z to one entry per instance. This is the `collect_z`
+    /// callback for [`i_slint_core::item_tree::visit_item_tree_z_sorted`].
+    pub fn collect_z_sorted_children(
         self: Pin<&Self>,
         index: isize,
-    ) -> Option<Vec<i_slint_core::item_tree::ZSortedChild>> {
-        use i_slint_core::item_tree::ZSortedChild;
-        if index < 0 {
-            return None;
-        }
-        let sources = self.z_sort_table.get(index as usize)?.as_ref()?;
+        push: &mut dyn FnMut(u32, Option<u32>, f32),
+    ) {
+        let Some(Some(sources)) = self.z_sort_table.get(index as usize) else { return };
         let ItemTreeNode::Item { children_index, .. } = self.tree_nodes[index as usize] else {
-            return None;
+            return;
         };
         let mut ctx = crate::eval::EvalContext::new(self.root_sub_component.clone());
-        let mut entries: Vec<ZSortedChild> = Vec::with_capacity(sources.len());
         for (k, source) in sources.iter().enumerate() {
             let child_offset = k as u32;
             match source {
@@ -629,7 +627,7 @@ impl Instance {
                     let z: f64 = crate::eval::eval_expression(&mut ctx, &e.borrow())
                         .try_into()
                         .unwrap_or(0.0);
-                    entries.push(ZSortedChild { z: z as f32, child_offset, instance: u32::MAX });
+                    push(child_offset, None, z as f32);
                 }
                 llr::ZSource::RepeaterInstances => {
                     // The child is a `DynamicTree` node; its `dynamic_table` entry holds the repeater.
@@ -637,14 +635,12 @@ impl Instance {
                         self.get_ref().dynamic_at(children_index + child_offset)
                     {
                         sub.repeaters[rep_idx].for_each_instance_z(&mut |instance, z| {
-                            entries.push(ZSortedChild { z, child_offset, instance })
+                            push(child_offset, Some(instance), z)
                         });
                     }
                 }
             }
         }
-        i_slint_core::item_tree::sort_z_entries(&mut entries);
-        Some(entries)
     }
 
     /// Build an instance for a public component.

--- a/internal/interpreter/item_tree_vtable.rs
+++ b/internal/interpreter/item_tree_vtable.rs
@@ -64,18 +64,30 @@ impl i_slint_core::item_tree::ItemTree for Instance {
     ) -> VisitChildrenResult {
         let this = self.get_ref();
         let weak = this.self_weak.get().unwrap().clone();
-        let sorted = self.compute_z_sorted_children(index);
-        i_slint_core::item_tree::visit_item_tree(
-            &vtable::VRc::into_dyn(weak.upgrade().unwrap()),
-            &this.tree_nodes[..],
-            index,
-            order,
-            visitor,
-            &mut |order, visitor, dyn_index, instance| {
-                self.visit_dynamic_children(dyn_index, order, visitor, instance)
-            },
-            sorted.as_deref(),
-        )
+        if index >= 0 && this.z_sort_table.get(index as usize).is_some_and(|e| e.is_some()) {
+            i_slint_core::item_tree::visit_item_tree_z_sorted(
+                &vtable::VRc::into_dyn(weak.upgrade().unwrap()),
+                &this.tree_nodes[..],
+                index,
+                order,
+                visitor,
+                &mut |order, visitor, dyn_index, instance| {
+                    self.visit_dynamic_children(dyn_index, order, visitor, instance)
+                },
+                &mut |push| self.collect_z_sorted_children(index, push),
+            )
+        } else {
+            i_slint_core::item_tree::visit_item_tree(
+                &vtable::VRc::into_dyn(weak.upgrade().unwrap()),
+                &this.tree_nodes[..],
+                index,
+                order,
+                visitor,
+                &mut |order, visitor, dyn_index, instance| {
+                    self.visit_dynamic_children(dyn_index, order, visitor, instance)
+                },
+            )
+        }
     }
 
     fn get_item_ref(self: Pin<&Self>, index: u32) -> Pin<VRef<'_, ItemVTable>> {

--- a/internal/interpreter/item_tree_vtable.rs
+++ b/internal/interpreter/item_tree_vtable.rs
@@ -71,8 +71,8 @@ impl i_slint_core::item_tree::ItemTree for Instance {
                 index,
                 order,
                 visitor,
-                &mut |order, visitor, dyn_index, instance| {
-                    self.visit_dynamic_children(dyn_index, order, visitor, instance)
+                &mut |order, visitor, dyn_index| {
+                    self.visit_dynamic_children(dyn_index, order, visitor)
                 },
                 &mut |push| self.collect_z_sorted_children(index, push),
             )
@@ -83,8 +83,8 @@ impl i_slint_core::item_tree::ItemTree for Instance {
                 index,
                 order,
                 visitor,
-                &mut |order, visitor, dyn_index, instance| {
-                    self.visit_dynamic_children(dyn_index, order, visitor, instance)
+                &mut |order, visitor, dyn_index| {
+                    self.visit_dynamic_children(dyn_index, order, visitor)
                 },
             )
         }


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
