### PR TITLE
compiler: Fix same-named structs and enums colliding in generated code

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -1025,7 +1025,7 @@ pub fn generate(
         generate_public_component(&mut file, &conditional_includes, p, &llr);
     }
 
-    generate_type_aliases(&mut file, doc);
+    generate_type_aliases(&mut file, &llr);
 
     if conditional_includes.iostream.get() {
         file.includes.push("<iostream>".into());
@@ -6184,30 +6184,10 @@ fn return_compile_expression(
     }
 }
 
-pub fn generate_type_aliases(file: &mut File, doc: &Document) {
-    let type_aliases = doc
-        .exports
-        .iter()
-        .filter_map(|export| match &export.1 {
-            Either::Left(component) if !component.is_global() => {
-                Some((&export.0.name, component.id.clone()))
-            }
-            Either::Right(ty) => match &ty {
-                Type::Struct(s) if s.node().is_some() => {
-                    Some((&export.0.name, s.name.cpp_type().unwrap()))
-                }
-                Type::Enumeration(en) => Some((&export.0.name, en.name.clone())),
-                _ => None,
-            },
-            _ => None,
-        })
-        .filter(|(export_name, type_name)| *export_name != type_name)
-        .map(|(export_name, type_name)| {
-            Declaration::TypeAlias(TypeAlias {
-                old_name: ident(&type_name),
-                new_name: ident(export_name),
-            })
-        });
+pub fn generate_type_aliases(file: &mut File, unit: &llr::CompilationUnit) {
+    let type_aliases = unit.named_exports.iter().map(|(original, alias)| {
+        Declaration::TypeAlias(TypeAlias { old_name: ident(original), new_name: ident(alias) })
+    });
 
     file.declarations.extend(type_aliases);
 }

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -433,12 +433,18 @@ pub mod cpp_ast {
     pub struct TypeAlias {
         pub new_name: SmolStr,
         pub old_name: SmolStr,
+        /// When set, the alias is marked `[[deprecated]]` with this message.
+        pub deprecated: Option<String>,
     }
 
     impl Display for TypeAlias {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             indent(f)?;
-            writeln!(f, "using {} = {};", self.new_name, self.old_name)
+            let deprecated = match &self.deprecated {
+                Some(message) => format!("[[deprecated(\"{}\")]] ", escape_string(message)),
+                None => String::new(),
+            };
+            writeln!(f, "using {} {deprecated}= {};", self.new_name, self.old_name)
         }
     }
 
@@ -924,7 +930,11 @@ pub fn generate(
         };
 
         file.definitions.extend(glob.aliases.iter().map(|name| {
-            Declaration::TypeAlias(TypeAlias { old_name: ident(&glob.name), new_name: ident(name) })
+            Declaration::TypeAlias(TypeAlias {
+                old_name: ident(&glob.name),
+                new_name: ident(name),
+                deprecated: None,
+            })
         }));
 
         clone_constructor_global_inits.push(format!("{name}(source.{name})"));
@@ -6185,11 +6195,16 @@ fn return_compile_expression(
 }
 
 pub fn generate_type_aliases(file: &mut File, unit: &llr::CompilationUnit) {
-    let type_aliases = unit.named_exports.iter().map(|(original, alias)| {
-        Declaration::TypeAlias(TypeAlias { old_name: ident(original), new_name: ident(alias) })
-    });
-
-    file.declarations.extend(type_aliases);
+    // C++ defines every type in the namespace, so only the entries that rename a type
+    // (an export alias, or a deprecated pre-rename name) need a `using` declaration.
+    let aliases = unit.type_exports.iter().filter(|e| e.is_alias());
+    file.declarations.extend(aliases.map(|e| {
+        Declaration::TypeAlias(TypeAlias {
+            new_name: ident(&e.exported_name),
+            old_name: ident(&e.internal_name),
+            deprecated: e.deprecation_note(),
+        })
+    }));
 }
 
 #[cfg(feature = "bundle-translations")]

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -49,7 +49,7 @@ pub fn generate(
         };
     }
 
-    super::cpp::generate_type_aliases(&mut file, doc);
+    super::cpp::generate_type_aliases(&mut file, &llr);
 
     let cpp_files = file.split_off_cpp_files(config.header_include, config.cpp_files.len());
     for (cpp_file_name, cpp_file) in config.cpp_files.iter().zip(cpp_files) {

--- a/internal/compiler/generator/cpp_live_preview.rs
+++ b/internal/compiler/generator/cpp_live_preview.rs
@@ -44,6 +44,7 @@ pub fn generate(
                 Declaration::TypeAlias(TypeAlias {
                     old_name: ident(&glob.name),
                     new_name: ident(name),
+                    deprecated: None,
                 })
             }));
         };

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -369,6 +369,14 @@ pub fn generate_py_module(
         }
     }
 
+    // A type exported only under a different name is renamed to that name; keep the original
+    // name available as an alias so code that still imports it keeps working. The name belongs
+    // to whichever of the two type kinds actually declares it; the other map entry is never read.
+    for (old_name, new_name) in &doc.used_types.borrow().deprecated_type_aliases {
+        struct_aliases.entry(new_name.clone()).or_default().push(old_name.clone());
+        enum_aliases.entry(new_name.clone()).or_default().push(old_name.clone());
+    }
+
     for ty in &doc.used_types.borrow().structs_and_enums {
         match ty {
             Type::Struct(s) => module.structs_and_enums.extend(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -212,8 +212,7 @@ pub fn generate(
         return Ok(Default::default());
     }
 
-    let (structs_and_enums_ids, inner_module) =
-        generate_types(&doc.used_types.borrow().structs_and_enums, &llr);
+    let inner_module = generate_types(&doc.used_types.borrow().structs_and_enums, &llr);
 
     let sub_compos = llr
         .used_sub_components
@@ -248,13 +247,14 @@ pub fn generate(
     let compo_ids = llr.public_components.iter().map(|c| ident(&c.name));
 
     let resource_symbols = generate_resources(doc);
-    let named_exports = generate_named_exports(&llr.named_exports);
     // The inner module was meant to be internal private, but projects have been reaching into it
     // so we can't change the name of this module
     let generated_mod = doc
         .last_exported_component()
         .map(|c| format_ident!("slint_generated{}", ident(&c.id)))
         .unwrap_or_else(|| format_ident!("slint_generated"));
+
+    let (type_reexports, deprecated_type_exports) = type_exports(&llr, &generated_mod);
 
     #[cfg(not(feature = "bundle-translations"))]
     let translations = quote!();
@@ -276,7 +276,8 @@ pub fn generate(
             #translations
         }
         #[allow(unused_imports)]
-        pub use #generated_mod::{#(#compo_ids,)* #(#structs_and_enums_ids,)* #(#globals_ids,)* #(#named_exports,)* #(#global_exports,)*};
+        pub use #generated_mod::{#(#compo_ids,)* #(#type_reexports,)* #(#globals_ids,)* #(#global_exports,)*};
+        #(#deprecated_type_exports)*
         #[allow(unused_imports)]
         pub use slint::{ComponentHandle as _, Global as _, ModelExt as _};
     })
@@ -285,7 +286,7 @@ pub fn generate(
 pub(super) fn generate_module_header() -> TokenStream {
     quote! {
         #![allow(non_snake_case, non_camel_case_types)]
-        #![allow(unused_braces, unused_parens)]
+        #![allow(unused_braces, unused_parens, dead_code)]
         #![allow(clippy::all, clippy::pedantic, clippy::nursery)]
         #![allow(unknown_lints, if_let_rescope, tail_expr_drop_order)] // We don't have fancy Drop
 
@@ -295,24 +296,18 @@ pub(super) fn generate_module_header() -> TokenStream {
     }
 }
 
-/// Generate the struct and enums. Return a vector of names to import and a token stream with the inner module
-pub fn generate_types(
-    used_types: &[Type],
-    unit: &llr::CompilationUnit,
-) -> (Vec<Ident>, TokenStream) {
-    let (structs_and_enums_ids, structs_and_enum_def): (Vec<_>, Vec<_>) = used_types
-        .iter()
-        .filter_map(|ty| match ty {
-            Type::Struct(s) => match s.as_ref() {
-                the_struct @ Struct { name: StructName::User { name, .. }, .. } => {
-                    Some((ident(name), generate_struct(the_struct, unit)))
-                }
-                _ => None,
-            },
-            Type::Enumeration(en) => Some((ident(&en.name), generate_enum(en))),
+/// Generate the definitions of the structs and enums, as the inner module's token stream.
+pub fn generate_types(used_types: &[Type], unit: &llr::CompilationUnit) -> TokenStream {
+    let structs_and_enum_def = used_types.iter().filter_map(|ty| match ty {
+        Type::Struct(s) => match s.as_ref() {
+            the_struct @ Struct { name: StructName::User { .. }, .. } => {
+                Some(generate_struct(the_struct, unit))
+            }
             _ => None,
-        })
-        .unzip();
+        },
+        Type::Enumeration(en) => Some(generate_enum(en)),
+        _ => None,
+    });
 
     let version_check = format_ident!(
         "VersionCheck_{}_{}_{}",
@@ -321,12 +316,39 @@ pub fn generate_types(
         env!("CARGO_PKG_VERSION_PATCH"),
     );
 
-    let inner_module = quote! {
+    quote! {
         #(#structs_and_enum_def)*
         const _THE_SAME_VERSION_MUST_BE_USED_FOR_THE_COMPILER_AND_THE_RUNTIME : slint::#version_check = slint::#version_check;
-    };
+    }
+}
 
-    (structs_and_enums_ids, inner_module)
+/// Render the re-exports of [`llr::CompilationUnit::type_exports`]: `pub use` for a type
+/// exposed under a name, and a deprecated `pub type` alias for one kept only for backward
+/// compatibility. Returns the `pub use` items (spliced into the module's use list) and the
+/// deprecated aliases (emitted as standalone items).
+pub(super) fn type_exports(
+    unit: &llr::CompilationUnit,
+    generated_mod: &Ident,
+) -> (Vec<TokenStream>, Vec<TokenStream>) {
+    let mut reexports = Vec::new();
+    let mut deprecated_type_exports = Vec::new();
+    for e in &unit.type_exports {
+        let exported = ident(&e.exported_name);
+        let internal = ident(&e.internal_name);
+        if let Some(note) = e.deprecation_note() {
+            // A `#[deprecated] pub use` does not warn on use, but a deprecated type alias does.
+            deprecated_type_exports.push(quote! {
+                #[deprecated(note = #note)]
+                #[allow(dead_code)]
+                pub type #exported = #generated_mod::#internal;
+            });
+        } else if e.is_alias() {
+            reexports.push(quote!(#internal as #exported));
+        } else {
+            reexports.push(quote!(#exported));
+        }
+    }
+    (reexports, deprecated_type_exports)
 }
 
 fn generate_public_component(
@@ -6181,17 +6203,6 @@ fn generate_resources(doc: &Document) -> Vec<TokenStream> {
             }
         })
         .collect()
-}
-
-pub fn generate_named_exports(named_exports: &[(SmolStr, SmolStr)]) -> Vec<TokenStream> {
-    named_exports
-        .iter()
-        .map(|(original, alias)| {
-            let original = ident(original);
-            let alias = ident(alias);
-            quote!(#original as #alias)
-        })
-        .collect::<Vec<_>>()
 }
 
 fn remove_parenthesis(

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -248,7 +248,7 @@ pub fn generate(
     let compo_ids = llr.public_components.iter().map(|c| ident(&c.name));
 
     let resource_symbols = generate_resources(doc);
-    let named_exports = generate_named_exports(&doc.exports);
+    let named_exports = generate_named_exports(&llr.named_exports);
     // The inner module was meant to be internal private, but projects have been reaching into it
     // so we can't change the name of this module
     let generated_mod = doc
@@ -6183,44 +6183,13 @@ fn generate_resources(doc: &Document) -> Vec<TokenStream> {
         .collect()
 }
 
-pub fn generate_named_exports(exports: &crate::object_tree::Exports) -> Vec<TokenStream> {
-    exports
+pub fn generate_named_exports(named_exports: &[(SmolStr, SmolStr)]) -> Vec<TokenStream> {
+    named_exports
         .iter()
-        .filter_map(|export| match &export.1 {
-            Either::Left(component) if !component.is_global() => {
-                if export.0.name != component.id {
-                    Some((
-                        &export.0.name,
-                        proc_macro2::TokenTree::from(ident(&component.id)).into(),
-                    ))
-                } else {
-                    None
-                }
-            }
-            Either::Right(ty) => match &ty {
-                Type::Struct(s) if s.node().is_some() => {
-                    if let StructName::User { name, .. } = &s.name
-                        && *name == export.0.name
-                    {
-                        None
-                    } else {
-                        Some((&export.0.name, struct_name_to_tokens(&s.name).unwrap()))
-                    }
-                }
-                Type::Enumeration(en) => {
-                    if export.0.name != en.name {
-                        Some((&export.0.name, proc_macro2::TokenTree::from(ident(&en.name)).into()))
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            },
-            _ => None,
-        })
-        .map(|(export_name, type_id)| {
-            let export_id = ident(export_name);
-            quote!(#type_id as #export_id)
+        .map(|(original, alias)| {
+            let original = ident(original);
+            let alias = ident(alias);
+            quote!(#original as #alias)
         })
         .collect::<Vec<_>>()
 }

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -26,7 +26,7 @@ pub fn generate(
         return Ok(Default::default());
     }
 
-    let (structs_and_enums_ids, inner_module) =
+    let inner_module =
         super::rust::generate_types(&doc.used_types.borrow().structs_and_enums, &llr);
 
     let main_file = doc
@@ -53,13 +53,14 @@ pub fn generate(
     });
     let compo_ids = llr.public_components.iter().map(|c| ident(&c.name));
 
-    let named_exports = super::rust::generate_named_exports(&llr.named_exports);
     // The inner module was meant to be internal private, but projects have been reaching into it
     // so we can't change the name of this module
     let generated_mod = doc
         .last_exported_component()
         .map(|c| format_ident!("slint_generated{}", ident(&c.id)))
         .unwrap_or_else(|| format_ident!("slint_generated"));
+
+    let (type_reexports, deprecated_type_exports) = super::rust::type_exports(&llr, &generated_mod);
 
     Ok(quote! {
         mod #generated_mod {
@@ -69,8 +70,9 @@ pub fn generate(
             #(#public_components)*
             #type_value_conversions
         }
+        #(#deprecated_type_exports)*
         #[allow(unused_imports)]
-        pub use #generated_mod::{#(#compo_ids,)* #(#structs_and_enums_ids,)* #(#globals_ids,)* #(#named_exports,)*};
+        pub use #generated_mod::{#(#compo_ids,)* #(#type_reexports,)* #(#globals_ids,)*};
         #[allow(unused_imports)]
         pub use slint::{ComponentHandle as _, Global as _, ModelExt as _};
     })

--- a/internal/compiler/generator/rust_live_preview.rs
+++ b/internal/compiler/generator/rust_live_preview.rs
@@ -53,7 +53,7 @@ pub fn generate(
     });
     let compo_ids = llr.public_components.iter().map(|c| ident(&c.name));
 
-    let named_exports = super::rust::generate_named_exports(&doc.exports);
+    let named_exports = super::rust::generate_named_exports(&llr.named_exports);
     // The inner module was meant to be internal private, but projects have been reaching into it
     // so we can't change the name of this module
     let generated_mod = doc

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -1311,6 +1311,32 @@ impl Display for Struct {
     }
 }
 
+/// Call `visitor` for every user-declared (non-builtin) struct or enum reachable from `ty`,
+/// recursing through struct fields, arrays, and callback/function signatures.
+pub(crate) fn visit_declared_types(ty: &Type, visitor: &mut impl FnMut(&SmolStr, &Type)) {
+    match ty {
+        Type::Struct(s) => {
+            if s.node().is_some()
+                && let StructName::User { name, .. } = &s.name
+            {
+                visitor(name, ty);
+            }
+            for sub_ty in s.fields.values() {
+                visit_declared_types(sub_ty, visitor);
+            }
+        }
+        Type::Array(x) => visit_declared_types(x, visitor),
+        Type::Function(function) | Type::Callback(function) => {
+            visit_declared_types(&function.return_type, visitor);
+            for a in &function.args {
+                visit_declared_types(a, visitor);
+            }
+        }
+        Type::Enumeration(en) if en.node.is_some() => visitor(&en.name, ty),
+        _ => {}
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Enumeration {
     pub name: SmolStr,

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -697,6 +697,10 @@ pub struct CompilationUnit {
     pub globals: TiVec<GlobalIdx, GlobalComponent>,
     pub popup_menu: Option<PopupMenu>,
     pub has_debug_info: bool,
+    /// The `(original, alias)` pairs for renamed `export { Original as Alias }`
+    /// declarations of components, structs and enums. The generators emit a
+    /// type alias for each. (Global aliases are on [`GlobalComponent::aliases`].)
+    pub named_exports: Vec<(SmolStr, SmolStr)>,
     #[cfg(feature = "bundle-translations")]
     pub translations: Option<crate::translations::Translations>,
 }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -687,6 +687,47 @@ pub struct PublicComponent {
     pub top_level_type: TopLevelComponentType,
 }
 
+/// One name the generated module exposes for a declared type (or a component alias):
+/// its own name, a renamed export, or a name kept only for backward compatibility.
+#[derive(Debug)]
+pub struct TypeExport {
+    /// The name users write.
+    pub exported_name: SmolStr,
+    /// The generated declaration it points at. Equal to `exported_name` for a type
+    /// re-exported under its own name.
+    pub internal_name: SmolStr,
+    /// When set, `exported_name` warns on use: the type is not part of the public API,
+    /// or was renamed on export.
+    pub deprecated: bool,
+}
+
+impl TypeExport {
+    /// True when the type is exposed under a name other than its own — a renamed export,
+    /// or the pre-rename name kept for compatibility. False for a type re-exported under
+    /// its own name.
+    pub fn is_alias(&self) -> bool {
+        self.exported_name != self.internal_name
+    }
+
+    /// The message shown when `exported_name` is used, or `None` when it is not deprecated.
+    /// Shared by the generators so the wording stays identical across languages.
+    pub fn deprecation_note(&self) -> Option<String> {
+        self.deprecated.then(|| {
+            if self.is_alias() {
+                format!(
+                    "`{0}` was renamed to `{1}` on export. Use `{1}`.",
+                    self.exported_name, self.internal_name
+                )
+            } else {
+                format!(
+                    "`{}` is not part of the public API. Re-export it from your main .slint file to make it public.",
+                    self.exported_name
+                )
+            }
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct CompilationUnit {
     pub public_components: Vec<PublicComponent>,
@@ -697,10 +738,11 @@ pub struct CompilationUnit {
     pub globals: TiVec<GlobalIdx, GlobalComponent>,
     pub popup_menu: Option<PopupMenu>,
     pub has_debug_info: bool,
-    /// The `(original, alias)` pairs for renamed `export { Original as Alias }`
-    /// declarations of components, structs and enums. The generators emit a
-    /// type alias for each. (Global aliases are on [`GlobalComponent::aliases`].)
-    pub named_exports: Vec<(SmolStr, SmolStr)>,
+    /// Every name the generated module re-exports for a declared type, plus the
+    /// renamed `export { Original as Alias }` aliases of components. Types renamed to
+    /// resolve a same-name collision are absent: they were never public. (Global
+    /// aliases are on [`GlobalComponent::aliases`].)
+    pub type_exports: Vec<TypeExport>,
     #[cfg(feature = "bundle-translations")]
     pub translations: Option<crate::translations::Translations>,
 }

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -106,6 +106,7 @@ pub fn lower_to_item_tree(
             .collect(),
         has_debug_info: compiler_config.debug_info,
         popup_menu,
+        named_exports: document.exports.named_type_aliases(),
         #[cfg(feature = "bundle-translations")]
         translations: state.translation_builder.map(|x| x.result()),
     };

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use by_address::ByAddress;
+use itertools::Either;
 use std::sync::Arc;
 
 use super::lower_expression::{ExpressionLoweringCtx, ExpressionLoweringCtxInner};
@@ -15,6 +16,70 @@ use smol_str::{SmolStr, format_smolstr};
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use typed_index_collections::TiVec;
+
+/// The types the generated module re-exports: every declared struct/enum under its own
+/// name (deprecated when not reachable from the public API), the renamed export aliases,
+/// and the deprecated pre-rename names. Collision-renamed types are omitted — they were
+/// never public.
+fn type_exports(document: &object_tree::Document) -> Vec<TypeExport> {
+    let used_types = document.used_types.borrow();
+    let public = public_facing_type_names(document);
+    let mut list = Vec::new();
+    for ty in &used_types.structs_and_enums {
+        let name = match ty {
+            Type::Struct(s) => match &s.name {
+                StructName::User { name, .. } => Some(name.clone()),
+                _ => None,
+            },
+            Type::Enumeration(en) => Some(en.name.clone()),
+            _ => None,
+        };
+        let Some(name) = name else { continue };
+        if used_types.collision_renamed_names.contains(&name) {
+            continue;
+        }
+        let deprecated = !public.contains(&name);
+        list.push(TypeExport { exported_name: name.clone(), internal_name: name, deprecated });
+    }
+    for (internal_name, exported_name) in document.exports.named_type_aliases() {
+        list.push(TypeExport { exported_name, internal_name, deprecated: false });
+    }
+    for (old_name, new_name) in &used_types.deprecated_type_aliases {
+        list.push(TypeExport {
+            exported_name: old_name.clone(),
+            internal_name: new_name.clone(),
+            deprecated: true,
+        });
+    }
+    list
+}
+
+/// The names of the structs and enums reachable from the public API: explicitly exported,
+/// or used on a public member of an exported component. A type used only privately is not
+/// part of the public namespace.
+fn public_facing_type_names(
+    document: &object_tree::Document,
+) -> std::collections::HashSet<SmolStr> {
+    let mut public = std::collections::HashSet::new();
+    let mut collect = |ty: &Type| {
+        crate::langtype::visit_declared_types(ty, &mut |name, _| {
+            public.insert(name.clone());
+        })
+    };
+    for (_, export) in document.exports.iter() {
+        match export {
+            Either::Right(ty) => collect(ty),
+            Either::Left(component) => {
+                for pd in component.root_element.borrow().property_declarations.values() {
+                    if pd.visibility != object_tree::PropertyVisibility::Private {
+                        collect(&pd.property_type);
+                    }
+                }
+            }
+        }
+    }
+    public
+}
 
 pub fn lower_to_item_tree(
     document: &crate::object_tree::Document,
@@ -106,7 +171,7 @@ pub fn lower_to_item_tree(
             .collect(),
         has_debug_info: compiler_config.debug_info,
         popup_menu,
-        named_exports: document.exports.named_type_aliases(),
+        type_exports: type_exports(document),
         #[cfg(feature = "bundle-translations")]
         translations: state.translation_builder.map(|x| x.result()),
     };

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -242,6 +242,7 @@ mod visitor {
             globals,
             popup_menu,
             has_debug_info: _,
+            named_exports: _,
             #[cfg(feature = "bundle-translations")]
                 translations: _,
         }: &mut crate::llr::CompilationUnit,

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -242,7 +242,7 @@ mod visitor {
             globals,
             popup_menu,
             has_debug_info: _,
-            named_exports: _,
+            type_exports: _,
             #[cfg(feature = "bundle-translations")]
                 translations: _,
         }: &mut crate::llr::CompilationUnit,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -447,6 +447,12 @@ pub struct UsedSubTypes {
     /// All global components that originates from an
     /// external library
     pub library_global_imports: Vec<(SmolStr, LibraryInfo)>,
+    /// `(old_name, new_name)` for types renamed to their export name. The generators emit a
+    /// deprecated alias under `old_name` so code that used it keeps compiling.
+    pub deprecated_type_aliases: Vec<(SmolStr, SmolStr)>,
+    /// The fresh names given to types that collided with another declaration. These names were
+    /// never part of the public API, so the generators must not re-export them (deprecated or not).
+    pub collision_renamed_names: std::collections::BTreeSet<SmolStr>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -4757,6 +4757,32 @@ impl Exports {
             .map(|index| self.components_or_types[index].1.clone())
     }
 
+    /// The `(original, alias)` pairs for renamed `export { Original as Alias }`
+    /// of components (non-global), structs and enums — the aliases the
+    /// generators attach to the generated type. Global aliases are handled
+    /// separately, through `GlobalComponent::aliases`.
+    pub fn named_type_aliases(&self) -> Vec<(SmolStr, SmolStr)> {
+        self.iter()
+            .filter_map(|(exported, item)| match item {
+                Either::Left(component) if !component.is_global() => {
+                    Some((component.id.clone(), exported.name.clone()))
+                }
+                Either::Right(ty) => match ty {
+                    Type::Struct(s) if s.node().is_some() => match &s.name {
+                        StructName::User { name, .. } => {
+                            Some((name.clone(), exported.name.clone()))
+                        }
+                        _ => None,
+                    },
+                    Type::Enumeration(en) => Some((en.name.clone(), exported.name.clone())),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .filter(|(original, alias)| original != alias)
+            .collect()
+    }
+
     pub fn retain(
         &mut self,
         func: impl FnMut(&mut (ExportedName, Either<Rc<Component>, Type>)) -> bool,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -57,6 +57,7 @@ mod remove_unused_properties;
 mod repeater_component;
 pub mod resolve_native_classes;
 pub mod resolving;
+mod unique_declared_type_names;
 mod unique_id;
 mod visible;
 mod windows;
@@ -287,6 +288,7 @@ pub async fn run_passes(
 
     // collect globals once more: After optimizations we might have less globals
     collect_globals::collect_globals(doc, diag);
+    unique_declared_type_names::assign_unique_declared_type_names(doc);
     collect_structs_and_enums::collect_structs_and_enums(doc);
 
     doc.visit_all_used_components(|component| {

--- a/internal/compiler/passes/collect_structs_and_enums.rs
+++ b/internal/compiler/passes/collect_structs_and_enums.rs
@@ -42,7 +42,7 @@ pub fn collect_structs_and_enums(doc: &Document) {
 }
 
 fn maybe_collect_struct(ty: &Type, hash: &mut BTreeMap<SmolStr, Type>) {
-    visit_declared_type(ty, &mut |name, sub_ty| {
+    crate::langtype::visit_declared_types(ty, &mut |name, sub_ty| {
         hash.entry(name.clone()).or_insert_with(|| sub_ty.clone());
     });
 }
@@ -78,33 +78,10 @@ fn sort_types(
         && let StructName::User { .. } = &s.name
     {
         for sub_ty in s.fields.values() {
-            visit_declared_type(sub_ty, &mut |name, _| sort_types(hash, name, visitor));
+            crate::langtype::visit_declared_types(sub_ty, &mut |name, _| {
+                sort_types(hash, name, visitor)
+            });
         }
     }
     visitor(key, &ty)
-}
-
-/// Will call the `visitor` for every named struct or enum that is not builtin
-fn visit_declared_type(ty: &Type, visitor: &mut impl FnMut(&SmolStr, &Type)) {
-    match ty {
-        Type::Struct(s) => {
-            if s.node().is_some()
-                && let StructName::User { name, .. } = &s.name
-            {
-                visitor(name, ty);
-            }
-            for sub_ty in s.fields.values() {
-                visit_declared_type(sub_ty, visitor);
-            }
-        }
-        Type::Array(x) => visit_declared_type(x, visitor),
-        Type::Function(function) | Type::Callback(function) => {
-            visit_declared_type(&function.return_type, visitor);
-            for a in &function.args {
-                visit_declared_type(a, visitor);
-            }
-        }
-        Type::Enumeration(en) if en.node.is_some() => visitor(&en.name, ty),
-        _ => {}
-    }
 }

--- a/internal/compiler/passes/unique_declared_type_names.rs
+++ b/internal/compiler/passes/unique_declared_type_names.rs
@@ -1,0 +1,222 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! This pass gives a unique internal name to declared structs and enums that would otherwise
+//! share a name with a different declaration.
+//!
+//! `collect_structs_and_enums` and the code generators identify a declared type by its name.
+//! When two different files declare a `struct` or `enum` with the same name, they would collapse
+//! into one type, so a value of one silently becomes a value of the other (see #6880, #9358).
+//! Renaming the extra declarations here keeps each one distinct.
+
+use crate::expression_tree::Expression;
+use crate::langtype::{DeclNode, Struct, StructName, Type, visit_declared_types};
+use crate::object_tree::*;
+use smol_str::{SmolStr, format_smolstr};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
+
+/// Identifies a declaration by its source location, so two references to the same declared type
+/// share an identity while two same-named declarations in different places do not.
+type Identity = (SmolStr, u32, u32);
+
+fn identity(node: &DeclNode) -> Identity {
+    let range = node.text_range();
+    (node.source_file().path().to_string_lossy().into(), range.start().into(), range.end().into())
+}
+
+type Renames = HashMap<Identity, SmolStr>;
+
+pub fn assign_unique_declared_type_names(doc: &mut Document) {
+    // 1. Gather every declared struct/enum, grouped by name, and the set of all used names.
+    let by_name: RefCell<BTreeMap<SmolStr, BTreeSet<Identity>>> = RefCell::new(BTreeMap::new());
+    let all_names: RefCell<BTreeSet<SmolStr>> = RefCell::new(BTreeSet::new());
+    let record = |name: &SmolStr, ty: &Type| {
+        all_names.borrow_mut().insert(name.clone());
+        if let Some((_, id)) = declared_name_and_identity(ty) {
+            by_name.borrow_mut().entry(name.clone()).or_default().insert(id);
+        }
+    };
+    let collect = |ty: &Type| visit_declared_types(ty, &mut |name, ty| record(name, ty));
+    for (_, export) in doc.exports.iter() {
+        if let Some(ty) = export.as_ref().right() {
+            collect(ty);
+        }
+    }
+    doc.visit_all_used_components(|component| {
+        recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
+            for pd in elem.borrow().property_declarations.values() {
+                collect(&pd.property_type);
+            }
+        });
+        visit_all_expressions(component, |expr, _| {
+            expr.visit_recursive(&mut |e| collect_expression_types(e, &collect));
+        });
+    });
+
+    // 2. For each colliding name, keep one declaration with the original name (preferring an
+    //    exported one, so the public type keeps its name) and give the others a fresh unique name.
+    let exported_ids: BTreeSet<Identity> = doc
+        .exports
+        .iter()
+        .filter_map(|(_, component_or_type)| match component_or_type {
+            itertools::Either::Right(ty) => declared_name_and_identity(ty).map(|(_, id)| id),
+            _ => None,
+        })
+        .collect();
+    let mut renames = Renames::new();
+    let mut all_names = all_names.into_inner();
+    for (name, ids) in by_name.into_inner() {
+        if ids.len() <= 1 {
+            continue;
+        }
+        let ids: Vec<Identity> = ids.into_iter().collect();
+        let keep = ids.iter().position(|id| exported_ids.contains(id)).unwrap_or(0);
+        for (i, id) in ids.into_iter().enumerate() {
+            if i == keep {
+                continue;
+            }
+            let mut n = 2;
+            let new_name = loop {
+                let candidate = format_smolstr!("{name}{n}");
+                if all_names.insert(candidate.clone()) {
+                    break candidate;
+                }
+                n += 1;
+            };
+            renames.insert(id, new_name);
+        }
+    }
+
+    if renames.is_empty() {
+        return;
+    }
+
+    // 3. Rewrite every reference to a renamed declaration.
+    doc.visit_all_used_components(|component| {
+        recurse_elem_including_sub_components(component, &(), &mut |elem, _| {
+            for pd in elem.borrow_mut().property_declarations.values_mut() {
+                rename_type(&mut pd.property_type, &renames);
+            }
+        });
+        visit_all_expressions(component, |expr, _| {
+            expr.visit_recursive_mut(&mut |e| rewrite_expression_types(e, &renames));
+        });
+    });
+
+    // The exported types too, so a re-export points at the renamed type and not the one that
+    // happens to keep the original name.
+    doc.exports.retain(|(_, component_or_type)| {
+        if let itertools::Either::Right(ty) = component_or_type {
+            rename_type(ty, &renames);
+        }
+        true
+    });
+}
+
+/// The declared name and identity of a user-declared struct or enum, if `ty` is one.
+fn declared_name_and_identity(ty: &Type) -> Option<(SmolStr, Identity)> {
+    match ty {
+        Type::Enumeration(en) => en.node.as_ref().map(|node| (en.name.clone(), identity(node))),
+        Type::Struct(s) => match &s.name {
+            StructName::User { name, node, .. } => Some((name.clone(), identity(node))),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn collect_expression_types(e: &Expression, collect: &impl Fn(&Type)) {
+    match e {
+        Expression::FunctionParameterReference { ty, .. }
+        | Expression::ReadLocalVariable { ty, .. }
+        | Expression::Cast { to: ty, .. }
+        | Expression::Array { element_ty: ty, .. }
+        | Expression::MinMax { ty, .. } => collect(ty),
+        Expression::Struct { ty, .. } => collect(&Type::Struct(ty.clone())),
+        Expression::EnumerationValue(ev) => collect(&Type::Enumeration(ev.enumeration.clone())),
+        _ => {}
+    }
+}
+
+fn rewrite_expression_types(e: &mut Expression, renames: &Renames) {
+    match e {
+        Expression::FunctionParameterReference { ty, .. }
+        | Expression::ReadLocalVariable { ty, .. }
+        | Expression::Cast { to: ty, .. }
+        | Expression::Array { element_ty: ty, .. }
+        | Expression::MinMax { ty, .. } => rename_type(ty, renames),
+        Expression::Struct { ty, .. } => rename_struct(ty, renames),
+        Expression::EnumerationValue(ev) => rename_type_enum(&mut ev.enumeration, renames),
+        _ => {}
+    }
+}
+
+fn rename_type(ty: &mut Type, renames: &Renames) {
+    match ty {
+        Type::Enumeration(en) => rename_type_enum(en, renames),
+        Type::Struct(s) => rename_struct(s, renames),
+        Type::Array(inner) => {
+            let mut new_inner = (**inner).clone();
+            rename_type(&mut new_inner, renames);
+            if new_inner != **inner {
+                *inner = Arc::new(new_inner);
+            }
+        }
+        Type::Callback(function) | Type::Function(function) => {
+            let mut f = (**function).clone();
+            rename_type(&mut f.return_type, renames);
+            for arg in &mut f.args {
+                rename_type(arg, renames);
+            }
+            if f != **function {
+                *function = Arc::new(f);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn rename_type_enum(en: &mut Arc<crate::langtype::Enumeration>, renames: &Renames) {
+    let Some(new_name) = en.node.as_ref().and_then(|node| renames.get(&identity(node))) else {
+        return;
+    };
+    if &en.name != new_name {
+        let mut new_en = (**en).clone();
+        new_en.name = new_name.clone();
+        *en = Arc::new(new_en);
+    }
+}
+
+fn rename_struct(s: &mut Arc<Struct>, renames: &Renames) {
+    let mut new_fields: Option<BTreeMap<SmolStr, Type>> = None;
+    for (key, field) in &s.fields {
+        let mut new_field = field.clone();
+        rename_type(&mut new_field, renames);
+        if &new_field != field {
+            new_fields.get_or_insert_with(|| s.fields.clone()).insert(key.clone(), new_field);
+        }
+    }
+
+    let new_name = if let StructName::User { name, node, .. } = &s.name {
+        renames.get(&identity(node)).filter(|n| *n != name).cloned()
+    } else {
+        None
+    };
+
+    if new_fields.is_none() && new_name.is_none() {
+        return;
+    }
+
+    let mut new_struct = (**s).clone();
+    if let Some(fields) = new_fields {
+        new_struct.fields = fields;
+    }
+    if let Some(name) = new_name
+        && let StructName::User { name: struct_name, .. } = &mut new_struct.name
+    {
+        *struct_name = name;
+    }
+    *s = Arc::new(new_struct);
+}

--- a/internal/compiler/passes/unique_declared_type_names.rs
+++ b/internal/compiler/passes/unique_declared_type_names.rs
@@ -67,6 +67,7 @@ pub fn assign_unique_declared_type_names(doc: &mut Document) {
         .collect();
     let mut renames = Renames::new();
     let mut all_names = all_names.into_inner();
+    let mut collision_renamed_names = BTreeSet::new();
     for (name, ids) in by_name.into_inner() {
         if ids.len() <= 1 {
             continue;
@@ -85,9 +86,29 @@ pub fn assign_unique_declared_type_names(doc: &mut Document) {
                 }
                 n += 1;
             };
+            collision_renamed_names.insert(new_name.clone());
             renames.insert(id, new_name);
         }
     }
+    doc.used_types.borrow_mut().collision_renamed_names = collision_renamed_names;
+
+    // A type exported only under a different name (`export { X as Y }`, with `X` not exported on
+    // its own) is renamed to that export name, so `Y` becomes its real name and `X` is kept only
+    // as a deprecated alias.
+    let export_names: BTreeSet<SmolStr> =
+        doc.exports.iter().map(|(name, _)| name.name.clone()).collect();
+    let mut deprecated_type_aliases = Vec::new();
+    for (export_name, component_or_type) in doc.exports.iter() {
+        if let itertools::Either::Right(ty) = component_or_type
+            && let Some((type_name, id)) = declared_name_and_identity(ty)
+            && type_name != export_name.name
+            && !export_names.contains(&type_name)
+        {
+            renames.insert(id, export_name.name.clone());
+            deprecated_type_aliases.push((type_name, export_name.name.clone()));
+        }
+    }
+    doc.used_types.borrow_mut().deprecated_type_aliases = deprecated_type_aliases;
 
     if renames.is_empty() {
         return;

--- a/internal/compiler/translations.rs
+++ b/internal/compiler/translations.rs
@@ -431,6 +431,7 @@ mod plural_rule_parser {
                     has_debug_info: false,
                     translations: None,
                     popup_menu: None,
+                    named_exports: Default::default(),
                 },
                 current_scope: crate::llr::EvaluationScope::Global(0.into()),
                 generator_state: (),

--- a/internal/compiler/translations.rs
+++ b/internal/compiler/translations.rs
@@ -431,7 +431,7 @@ mod plural_rule_parser {
                     has_debug_info: false,
                     translations: None,
                     popup_menu: None,
-                    named_exports: Default::default(),
+                    type_exports: Default::default(),
                 },
                 current_scope: crate::llr::EvaluationScope::Global(0.into()),
                 generator_state: (),

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -674,6 +674,8 @@ impl Snapshotter {
             sub_components,
             library_types_imports,
             library_global_imports,
+            deprecated_type_aliases: Vec::new(),
+            collision_renamed_names: Default::default(),
         }
     }
 

--- a/internal/interpreter/component.rs
+++ b/internal/interpreter/component.rs
@@ -452,7 +452,7 @@ pub async fn build_from_source(
     #[cfg(feature = "internal")]
     let structs_and_enums = doc.used_types.borrow().structs_and_enums.clone();
     #[cfg(feature = "internal")]
-    let named_exports = doc
+    let mut named_exports = doc
         .exports
         .iter()
         .filter_map(|export| {
@@ -479,6 +479,16 @@ pub async fn build_from_source(
         .filter(|(export_name, type_name)| *export_name != *type_name)
         .map(|(export_name, type_name)| (type_name.to_string(), export_name.to_string()))
         .collect::<Vec<_>>();
+    // A type exported only under a different name is renamed to that name; keep the original
+    // name available as an alias so existing code keeps working.
+    #[cfg(feature = "internal")]
+    named_exports.extend(
+        doc.used_types
+            .borrow()
+            .deprecated_type_aliases
+            .iter()
+            .map(|(old_name, new_name)| (new_name.to_string(), old_name.to_string())),
+    );
     BuildResult {
         diagnostics: diag.into_iter().collect(),
         components,

--- a/tests/cases/exports/named_exports.slint
+++ b/tests/cases/exports/named_exports.slint
@@ -19,11 +19,19 @@ export { TestCase as NamedTestCase }
 auto handle = NamedTestCase::create();
 const TestCase &instance = *handle;
 assert(instance.get_en() == NamedEnum::Bonjour);
+NamedStruct value;
+instance.set_st(value);
 ```
 
 ```rust
 let instance = NamedTestCase::new().unwrap();
 assert_eq!(instance.get_en(), NamedEnum::Bonjour);
+instance.set_st(NamedStruct::default());
+// The old names before the `as` rename still resolve, but are deprecated.
+#[expect(deprecated)]
+let _: ExportedStruct = NamedStruct::default();
+#[expect(deprecated)]
+let _ = ExportEnum::Bonjour;
 ```
 
 */

--- a/tests/cases/types/duplicated_type_names.slint
+++ b/tests/cases/types/duplicated_type_names.slint
@@ -1,0 +1,39 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Two imported files declare an enum and a struct with the same names (SharedEnum, SharedStruct)
+// but different members. The generated code must keep them distinct, otherwise a member of one
+// resolves to the other. #6880 #9358
+// Python is ignored because include paths aren't forwarded in the generated stubs.
+//ignore: pyi
+//include_path: ../../helper_components
+import { DupUserA, SharedStruct } from "duplicated_type_name_a.slint";
+import { DupUserB } from "duplicated_type_name_b.slint";
+
+export component TestCase {
+    a := DupUserA { pick: 1; }
+    b := DupUserB { pick: 2; }
+    // A public property keeps the surviving collision type under its real name (SharedStruct).
+    out property <SharedStruct> sa: a.the-struct;
+    out property <bool> test: a.result == 21 && b.result == 32 && b.struct-ok && sa.a-value == 7;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+// The surviving collision type keeps its real name and is public.
+assert(handle->get_sa().a_value == 7);
+(void)SharedEnum::AaFirst;
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+// The surviving collision type keeps its real name and is public.
+assert_eq!(instance.get_sa().a_value, 7);
+// SharedEnum is only used on private properties, so it is deprecated in the public API.
+#[expect(deprecated)]
+let _ = SharedEnum::AaFirst;
+```
+*/

--- a/tests/cases/types/reexport_duplicated_type_name.slint
+++ b/tests/cases/types/reexport_duplicated_type_name.slint
@@ -1,0 +1,36 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A renamed re-export (RenamedEnum) of an enum whose name (ReExpEnum) collides with a local enum.
+// RenamedEnum must keep the imported variants, not resolve to the local ReExpEnum. #9094
+// Python is ignored because include paths aren't forwarded in the generated stubs.
+//ignore: pyi
+//include_path: ../../helper_components
+import { RenamedEnum } from "reexport_dup_enum.slint";
+
+export enum ReExpEnum { MainX, MainY }
+
+export component TestCase {
+    property <RenamedEnum> r: RenamedEnum.OtherC;
+    property <ReExpEnum> m: ReExpEnum.MainY;
+    out property <bool> test: (r == RenamedEnum.OtherC) && (m == ReExpEnum.MainY);
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+// The local ReExpEnum keeps its name and variants; the imported one didn't overwrite it.
+assert(ReExpEnum::MainY == ReExpEnum::MainY);
+// The imported enum collided, so it was renamed to ReExpEnum2 but kept its own variants.
+assert(ReExpEnum2::OtherC == ReExpEnum2::OtherC);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+// The local ReExpEnum keeps its name and variants.
+assert_eq!(ReExpEnum::MainY, ReExpEnum::MainY);
+// The imported enum collided, so it was renamed and, never being public, is not exposed here.
+```
+*/

--- a/tests/helper_components/duplicated_type_name_a.slint
+++ b/tests/helper_components/duplicated_type_name_a.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export enum SharedEnum { AaFirst, AaSecond }
+export struct SharedStruct { a-value: int }
+
+export component DupUserA {
+    in property <int> pick;
+    property <SharedEnum> sel: pick == 1 ? SharedEnum.AaSecond : SharedEnum.AaFirst;
+    out property <int> result: sel == SharedEnum.AaSecond ? 21 : 11;
+    out property <SharedStruct> the-struct: { a-value: 7 };
+}

--- a/tests/helper_components/duplicated_type_name_b.slint
+++ b/tests/helper_components/duplicated_type_name_b.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Same enum and struct names as duplicated_type_name_a.slint but different members: they must not collapse.
+export enum SharedEnum { BbAlpha, BbBeta, BbGamma }
+export struct SharedStruct { kind: SharedEnum, b-count: int }
+
+export component DupUserB {
+    in property <int> pick;
+    property <SharedEnum> sel: pick == 2 ? SharedEnum.BbGamma : SharedEnum.BbAlpha;
+    out property <int> result: sel == SharedEnum.BbGamma ? 32 : 12;
+    property <SharedStruct> the-struct: { kind: SharedEnum.BbGamma, b-count: 5 };
+    // Reads a renamed enum through a renamed struct field, so the field type must be rewritten too.
+    out property <bool> struct-ok: the-struct.kind == SharedEnum.BbGamma && the-struct.b-count == 5;
+}

--- a/tests/helper_components/reexport_dup_enum.slint
+++ b/tests/helper_components/reexport_dup_enum.slint
@@ -1,0 +1,5 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export enum ReExpEnum { OtherA, OtherB, OtherC }
+export { ReExpEnum as RenamedEnum }


### PR DESCRIPTION
When two `.slint` files declared a struct or enum with the same name, code
generation identified them by name and merged them into one. A value of one
type silently became the other, so you got the wrong enum variant, or a
variant that no longer existed.
  
A new compiler pass now renames the extra declarations to a unique internal
name before the types are collected, so each one stays distinct. This fixes
both the Rust and C++ generators.
  
While there, types that are only used privately, or exported under a different
name, are no longer re-exported under their real name as if they were public.
They are kept as deprecated aliases, so code that still uses the old name
keeps compiling but gets a warning pointing at the fix.
  
Fixes #6880                                                            
Fixes #9358
Fixes #9094

