### PR TITLE
editor: Streamline cargo features

### DIFF
--- a/.github/workflows/visual_editor_windows_msix.yaml
+++ b/.github/workflows/visual_editor_windows_msix.yaml
@@ -75,9 +75,7 @@ jobs:
           cargo +stable build `
             --manifest-path tools/editor/Cargo.toml `
             --target ${{ matrix.target }} `
-            --profile package-release `
-            --no-default-features `
-            --features backend-winit,renderer-skia
+            --profile package-release
 
       # Only the executable differs per architecture. The packaging job builds
       # the layouts around it, so the assets are not shipped back and forth.

--- a/scripts/local_sparkle_update_test.sh
+++ b/scripts/local_sparkle_update_test.sh
@@ -15,7 +15,6 @@ ACCOUNT="slint-visual-editor-local-test"
 BUNDLE_IDENTIFIER="dev.slint.visual-editor.sparkle-test"
 ICON_SOURCE="$ROOT_DIR/tools/editor/packaging/macos/AppIcon.icon"
 RUST_TARGET="aarch64-apple-darwin"
-CARGO_FEATURES="backend-winit,renderer-skia"
 HOST="127.0.0.1"
 PORT="8765"
 WORK_DIR="/private/tmp/slint-sparkle-local-test"
@@ -166,9 +165,7 @@ build_editor_app() {
     cargo build \
             --release \
             --target "$RUST_TARGET" \
-            -p slint-editor \
-            --no-default-features \
-            --features "$CARGO_FEATURES"
+            -p slint-editor
 
     [ -x "$executable" ] || die "built executable missing: $executable"
 

--- a/tools/editor/Cargo.toml
+++ b/tools/editor/Cargo.toml
@@ -20,33 +20,15 @@ name = "slint-editor"
 path = "main.rs"
 
 [features]
-backend-qt = ["slint/backend-qt", "preview-builtin"]
-backend-winit = ["slint/backend-winit", "preview-builtin"]
-backend-winit-x11 = ["slint/backend-winit-x11", "preview-builtin"]
-backend-winit-wayland = ["slint/backend-winit-wayland", "preview-builtin"]
-backend-linuxkms = ["slint/backend-linuxkms", "preview-builtin"]
-backend-linuxkms-noseat = ["slint/backend-linuxkms-noseat", "preview-builtin"]
-backend-default = ["slint/backend-default", "preview-builtin"]
-
-renderer-femtovg = ["slint/renderer-femtovg", "preview-builtin"]
-renderer-skia = ["slint/renderer-skia", "preview-builtin"]
-renderer-skia-opengl = ["slint/renderer-skia-opengl", "preview-builtin"]
-renderer-skia-vulkan = ["slint/renderer-skia-vulkan", "preview-builtin"]
-renderer-software = ["slint/renderer-software", "preview-builtin"]
-
-preview-engine = ["i-slint-editor-preview/preview-engine"]
-preview-builtin = ["preview-engine", "i-slint-editor-preview/preview-builtin"]
-preview-external = ["preview-engine", "i-slint-editor-preview/preview-external"]
-preview-remote = ["preview-builtin", "dep:mdns-sd"]
-
-default = ["backend-default", "renderer-femtovg", "renderer-software"]
+## Discover preview targets on the local network.
+preview-remote = ["dep:mdns-sd"]
 
 [dependencies]
 i-slint-backend-selector = { workspace = true }
 i-slint-common = { workspace = true }
 i-slint-compiler = { workspace = true, features = ["display-diagnostics"] }
 i-slint-core = { workspace = true, features = ["std"] }
-i-slint-editor-preview = { workspace = true }
+i-slint-editor-preview = { workspace = true, features = ["preview-engine", "preview-builtin"] }
 i-slint-live-preview = { workspace = true, features = ["protocol", "file-watcher"] }
 
 by_address = { workspace = true }
@@ -58,7 +40,7 @@ lsp-types = { workspace = true }
 nucleo-matcher = "0.3.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
-slint = { workspace = true, features = ["compat-1-2", "unstable-winit-030", "raw-window-handle-06"] }
+slint = { workspace = true, features = ["compat-1-2", "backend-winit", "renderer-skia", "unstable-winit-030", "raw-window-handle-06"] }
 slint-interpreter = { workspace = true, features = ["compat-1-2", "internal", "internal-highlight", "internal-json", "image-default-formats"] }
 smol_str = { workspace = true }
 tokio = { version = "1.50.0", features = ["macros", "net", "rt", "sync", "time"] }

--- a/tools/editor/dev.slint.VisualEditor.yml
+++ b/tools/editor/dev.slint.VisualEditor.yml
@@ -74,8 +74,7 @@ modules:
     build-commands:
       - cargo --offline fetch --manifest-path Cargo.toml
       - cargo build --manifest-path tools/editor/Cargo.toml
-        --profile package-release --offline --no-default-features
-        --features backend-winit,renderer-skia
+        --profile package-release --offline
       - install -Dm0755 target/package-release/slint-editor ${FLATPAK_DEST}/bin/slint-visual-editor
       - install -Dm0644 tools/editor/packaging/linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       # The icon references the shared logo and tile backdrop, and librsvg only

--- a/tools/editor/macos-project.yml
+++ b/tools/editor/macos-project.yml
@@ -62,8 +62,6 @@ targets:
               ../../scripts/build_macos_app_with_cargo.bash \
               --profile package-release \
               --bin slint-editor \
-              --no-default-features \
-              --features backend-winit,renderer-skia \
               ${MACOS_CARGO_TIMINGS:+--timings}
         outputFiles:
           - $(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)

--- a/tools/editor/preview/properties.rs
+++ b/tools/editor/preview/properties.rs
@@ -793,7 +793,6 @@ pub fn set_binding_impl(
     }
 }
 
-#[cfg(any(feature = "preview-external", feature = "preview-engine"))]
 pub fn set_bindings(
     uri: Url,
     version: SourceFileVersion,
@@ -813,7 +812,6 @@ pub fn set_bindings(
     )
 }
 
-#[cfg(any(feature = "preview-external", feature = "preview-engine"))]
 fn element_at_source_code_position(
     document_cache: &i_slint_editor_preview::DocumentCache,
     position: &i_slint_editor_preview::editing::VersionedPosition,
@@ -839,7 +837,6 @@ fn element_at_source_code_position(
     })?)
 }
 
-#[cfg(any(feature = "preview-external", feature = "preview-engine"))]
 pub fn update_element_properties(
     document_cache: &i_slint_editor_preview::DocumentCache,
     position: i_slint_editor_preview::editing::VersionedPosition,

--- a/tools/editor/ui/AGENTS.md
+++ b/tools/editor/ui/AGENTS.md
@@ -13,8 +13,6 @@ Run the app with Skia against the simple local fixture:
 SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 \
 SLINT_BACKEND=winit-skia \
 cargo run -p slint-editor \
-  --no-default-features \
-  --features backend-winit,renderer-skia \
   -- tools/editor/ui/visual-editor/example/simple_preview.slint
 ```
 
@@ -25,9 +23,8 @@ Important:
 - Use Skia. Do not silently switch to the software renderer. If Skia needs a
   first-time `skia-bindings` download, ask for network approval and keep using
   Skia.
-- Use `-p slint-editor --no-default-features`. Dropping
-  `--no-default-features` can pull Qt on macOS and fail in sandboxes when
-  `ccache` writes under `~/Library/Caches/ccache`.
+- The backend and renderer are fixed to winit and Skia in
+  `tools/editor/Cargo.toml`, so no `--features` flags are needed.
 - `SLINT_ENABLE_EXPERIMENTAL_FEATURES=1` is required because the visual editor
   uses internal/experimental types such as `component-factory`.
 - Use `tools/editor/ui/visual-editor/example/simple_preview.slint` when it exists.
@@ -47,8 +44,7 @@ SLINT_EMIT_DEBUG_INFO=1 \
 SLINT_MCP_PORT=9315 \
 SLINT_BACKEND=winit-skia \
 cargo run -p slint-editor \
-  --no-default-features \
-  --features backend-winit,renderer-skia,slint/mcp \
+  --features slint/mcp \
   -- tools/editor/ui/visual-editor/example/simple_preview.slint
 ```
 
@@ -80,8 +76,7 @@ SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 \
 SLINT_LIVE_PREVIEW=1 \
 SLINT_BACKEND=winit-skia \
 cargo run --release -p slint-editor \
-  --no-default-features \
-  --features backend-winit,renderer-skia,slint/live-preview \
+  --features slint/live-preview \
   -- tools/editor/ui/visual-editor/example/Main.slint
 ```
 


### PR DESCRIPTION
Let the default build match the way we build binary packages, so that there are less surprises.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
