### PR TITLE
Fix box layout rows sized too short for word-wrapped Text

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -473,6 +473,7 @@ use crate::langtype::{
 };
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
+use crate::llr::lower_layout_expression::{MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL};
 use crate::llr::{
     self, EvaluationContext as llr_EvaluationContext, EvaluationScope, ParentScope,
     TypeResolutionContext as _,
@@ -2986,6 +2987,53 @@ fn generate_layout_item_info_decl(
     })
 }
 
+/// Generates the `layout_item_info_at_cross_width` / `_at_cross_height` member
+/// functions for a repeated component struct. A box layout calls these with
+/// the cross size it lays the instance out at, so a height-for-width (resp.
+/// width-for-height) instance measures like an equivalent static cell.
+/// Mirrors the flexbox `flexbox_layout_item_info_at_cross_*` pair; like there,
+/// both members are always emitted, with a delegating body (the equivalent of
+/// the Rust trait default) when the instance has no cross-size-dependent info.
+fn generate_layout_item_info_at_cross_decls(
+    root_sc: &llr::SubComponent,
+    ctx: &EvaluationContext,
+) -> Vec<Declaration> {
+    let is_flexbox_cell = root_sc.flexbox_layout_item_info_for_repeated.is_some();
+    let decl = |expr: Option<&llr::MutExpression>, fn_name: &str, param: &str, o: &str| {
+        let body = match expr {
+            Some(e) if !is_flexbox_cell => {
+                let info = compile_expression(&e.borrow(), ctx);
+                format!("[[maybe_unused]] auto self = this; return {{ ({info}), {{}} }};")
+            }
+            _ => format!(
+                "return layout_item_info(slint::cbindgen_private::Orientation::{o}, std::nullopt);"
+            ),
+        };
+        Declaration::Function(Function {
+            name: fn_name.into(),
+            signature: format!(
+                "([[maybe_unused]] float {param}) const -> slint::cbindgen_private::LayoutItemInfo"
+            ),
+            statements: Some(vec![body]),
+            ..Function::default()
+        })
+    };
+    vec![
+        decl(
+            root_sc.layout_info_v_at_cross_width_for_repeated.as_ref(),
+            "layout_item_info_at_cross_width",
+            "flex_cross_width",
+            "Vertical",
+        ),
+        decl(
+            root_sc.layout_info_h_at_cross_height_for_repeated.as_ref(),
+            "layout_item_info_at_cross_height",
+            "flex_cross_height",
+            "Horizontal",
+        ),
+    ]
+}
+
 fn generate_flexbox_layout_item_info_decl(
     root_sc: &llr::SubComponent,
     ctx: &EvaluationContext,
@@ -3308,6 +3356,9 @@ fn generate_repeated_component(
             Access::Public, // Because Repeater accesses it
             generate_layout_item_info_decl(root_sc, &ctx),
         ));
+        for decl in generate_layout_item_info_at_cross_decls(root_sc, &ctx) {
+            repeater_struct.members.push((Access::Public, decl));
+        }
         for decl in generate_flexbox_layout_item_info_decl(root_sc, &ctx) {
             repeater_struct.members.push((Access::Public, decl));
         }
@@ -4660,6 +4711,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             repeater_steps_var_name,
             elements,
             orientation,
+            repeated_cross_size,
             sub_expression,
         } => generate_with_layout_item_info(
             cells_variable,
@@ -4667,6 +4719,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             repeater_steps_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
             *orientation,
+            repeated_cross_size.as_deref(),
             sub_expression,
             ctx,
         ),
@@ -4702,6 +4755,65 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
             format!(
                 "slint::private_api::flexbox_layout_info_cross_axis_with_measure({}, {lambda})",
                 a.join(",")
+            )
+        }
+        Expression::BoxLayoutInfoOrthoWithMeasure {
+            solve_data,
+            padding_ortho,
+            orientation,
+            measure_cells,
+        } => {
+            let data = compile_expression(solve_data, ctx);
+            let padding = compile_expression(padding_ortho, ctx);
+            let (known_size_local, at_cross_fn) = match orientation {
+                Orientation::Vertical => (MEASURE_KNOWN_W_LOCAL, "layout_item_info_at_cross_width"),
+                Orientation::Horizontal => {
+                    (MEASURE_KNOWN_H_LOCAL, "layout_item_info_at_cross_height")
+                }
+            };
+            let min_cell_count = measure_cells.len();
+            let mut steps = String::new();
+            for cell in measure_cells {
+                match cell {
+                    llr::BoxMeasureCell::Static { info } => {
+                        let info = compile_expression(info, ctx);
+                        write!(
+                            steps,
+                            "{{
+                                [[maybe_unused]] float {known_size_local} = box_ortho_solved[cursor * 2 + 1];
+                                measure_cells_vector.push_back({{ ({info}), {{}} }});
+                                ++cursor;
+                            }}"
+                        )
+                        .unwrap();
+                    }
+                    llr::BoxMeasureCell::Repeated(repeater) => {
+                        let rep_idx = usize::from(repeater.repeater_index);
+                        write!(
+                            steps,
+                            "for (std::size_t i = 0; i < self->repeater_{rep_idx}.len(); ++i) {{
+                                if (auto *sub_comp = self->repeater_{rep_idx}.typed_instance_at(i)) {{
+                                    measure_cells_vector.push_back(sub_comp->{at_cross_fn}(box_ortho_solved[cursor * 2 + 1]));
+                                }} else {{
+                                    measure_cells_vector.push_back({{}});
+                                }}
+                                ++cursor;
+                            }}"
+                        )
+                        .unwrap();
+                    }
+                }
+            }
+            format!(
+                "[&]{{
+                    auto box_ortho_solved = slint::private_api::solve_box_layout({data}, slint::private_api::make_slice<int>(nullptr, 0));
+                    std::vector<slint::cbindgen_private::LayoutItemInfo> measure_cells_vector;
+                    measure_cells_vector.reserve({min_cell_count});
+                    std::size_t cursor = 0;
+                    {steps}
+                    (void)cursor;
+                    return slint::private_api::box_layout_info_ortho(slint::private_api::make_slice(std::span(measure_cells_vector)), {padding});
+                }}()"
             )
         }
         Expression::WithGridInputData {
@@ -5564,11 +5676,19 @@ fn generate_with_layout_item_info(
     repeater_steps_var_name: Option<&str>,
     elements: &[Either<llr::Expression, llr::LayoutRepeatedElement>],
     orientation: Orientation,
+    repeated_cross_size: Option<&llr::Expression>,
     sub_expression: &llr::Expression,
     ctx: &llr_EvaluationContext<CppGeneratorContext>,
 ) -> String {
     let repeated_indices_var_name = repeated_indices_var_name.map(ident);
     let repeater_steps_var_name = repeater_steps_var_name.map(ident);
+    // Cross-axis size forwarded to repeated cells on a box layout's main-axis
+    // pass, so a height-for-width (resp. width-for-height) instance measures
+    // at the size it is laid out at, like a static cell. Evaluated once, not
+    // per instance.
+    let cross_size_init = repeated_cross_size.map_or(String::new(), |e| {
+        format!("const float box_cross_size = static_cast<float>({});", compile_expression(e, ctx))
+    });
     let mut push_code =
         "std::vector<slint::cbindgen_private::LayoutItemInfo> cells_vector;".to_owned();
     let mut repeater_idx = 0usize;
@@ -5609,6 +5729,9 @@ fn generate_with_layout_item_info(
                     repeater_idx,
                     "max_total",
                     |repeater_id, static_count, inner_ensure, rs_init| {
+                        // Only box layouts set a cross size, and their repeaters
+                        // never have row templates.
+                        debug_assert!(repeated_cross_size.is_none());
                         // for_each only visits instantiated slots; pad the cells up to len()
                         // afterwards so the cell count matches the repeater length recorded in
                         // the repeater_indices array (not-yet-instantiated rows get placeholders).
@@ -5635,15 +5758,31 @@ fn generate_with_layout_item_info(
                             rs_init
                         } else if step == 1 && is_column_repeater {
                             // Column-repeater: each sub-component IS a cell; nullopt returns its own layout_info
+                            let item_info = match (repeated_cross_size, orientation) {
+                                (Some(_), Orientation::Vertical) => {
+                                    "sub_comp->layout_item_info_at_cross_width(box_cross_size)"
+                                        .to_owned()
+                                }
+                                (Some(_), Orientation::Horizontal) => {
+                                    "sub_comp->layout_item_info_at_cross_height(box_cross_size)"
+                                        .to_owned()
+                                }
+                                (None, _) => format!(
+                                    "sub_comp->layout_item_info({o}, std::nullopt)",
+                                    o = to_cpp_orientation(orientation),
+                                ),
+                            };
                             format!(
                                 "{rs_init}{{
                                     auto start_offset = cells_vector.size();
-                                    self->{repeater_id}.for_each([&](const auto &sub_comp){{ cells_vector.push_back(sub_comp->layout_item_info({o}, std::nullopt)); }});
+                                    self->{repeater_id}.for_each([&](const auto &sub_comp){{ cells_vector.push_back({item_info}); }});
                                     cells_vector.resize(start_offset + self->{repeater_id}.len());
                                 }}",
-                                o = to_cpp_orientation(orientation),
                             )
                         } else {
+                            // Multi-step repeaters only exist in grids, which
+                            // never set a cross size.
+                            debug_assert!(repeated_cross_size.is_none());
                             format!(
                                 "{rs_init}{{
                                     auto start_offset = cells_vector.size();
@@ -5682,7 +5821,7 @@ fn generate_with_layout_item_info(
         format!("std::array<int, {}> {rs}_array;", repeater_idx)
     });
     format!(
-        "[&]{{ {ri} {rs} {push_code} slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{} = slint::private_api::make_slice(std::span(cells_vector)); return {}; }}()",
+        "[&]{{ {ri} {rs} {cross_size_init} {push_code} slint::cbindgen_private::Slice<slint::cbindgen_private::LayoutItemInfo>{} = slint::private_api::make_slice(std::span(cells_vector)); return {}; }}()",
         ident(cells_variable),
         compile_expression(sub_expression, ctx)
     )
@@ -5800,19 +5939,19 @@ fn generate_flexbox_measure_lambda(
             if (known_w && known_h)\n\
                 return {{ w, h }};\n\
             if (known_w) {{ // measure the height at the width w\n\
-                [[maybe_unused]] float measure_known_w = w;\n\
+                [[maybe_unused]] float {MEASURE_KNOWN_W_LOCAL} = w;\n\
                 {v_body}\
                 return {{ w, h }};\n\
             }}\n\
             if (known_h) {{ // measure the width at the height h\n\
-                [[maybe_unused]] float measure_known_h = h;\n\
+                [[maybe_unused]] float {MEASURE_KNOWN_H_LOCAL} = h;\n\
                 {h_body}\
                 return {{ w, h }};\n\
             }}\n\
             // Content-size probe: measure the free axis at the default size, so\n\
             // the returned pair is self-consistent.\n\
-            [[maybe_unused]] float measure_known_w = w;\n\
-            [[maybe_unused]] float measure_known_h = h;\n\
+            [[maybe_unused]] float {MEASURE_KNOWN_W_LOCAL} = w;\n\
+            [[maybe_unused]] float {MEASURE_KNOWN_H_LOCAL} = h;\n\
             {probe_body}\
             return {{ w, h }};\n\
          }}"

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -18,6 +18,7 @@ use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp, OperatorCla
 use crate::langtype::{DeclNode, Enumeration, EnumerationValue, Struct, StructName, Type};
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
+use crate::llr::lower_layout_expression::{MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL};
 use crate::llr::{
     self, ArrayOutput, EvaluationContext as llr_EvaluationContext, EvaluationScope, Expression,
     ParentScope, TypeResolutionContext as _,
@@ -2961,9 +2962,44 @@ fn generate_repeated_component(
                     }
                 }
             });
+        // A box layout calls these with the cross size it lays the instance
+        // out at, so a height-for-width (resp. width-for-height) instance
+        // measures like an equivalent static cell. Mirrors the flexbox
+        // `flexbox_layout_item_info_at_cross_*` pair; the trait default (the
+        // plain `layout_item_info`) covers the other repeated components.
+        let layout_item_info_at_cross_fn =
+            |expr: Option<&llr::MutExpression>, fn_name: &str, param: &str| {
+                expr.filter(|_| root_sc.flexbox_layout_item_info_for_repeated.is_none()).map(|e| {
+                let info = compile_expression(&e.borrow(), &ctx);
+                let fn_name = ident(fn_name);
+                let param = ident(param);
+                quote! {
+                    fn #fn_name(
+                        self: ::core::pin::Pin<&Self>,
+                        #param: f32,
+                    ) -> sp::LayoutItemInfo {
+                        #[allow(unused)]
+                        let _self = self.as_ref();
+                        sp::LayoutItemInfo { constraint: #info, ..::core::default::Default::default() }
+                    }
+                }
+            })
+            };
+        let layout_item_info_at_cross_width_fn = layout_item_info_at_cross_fn(
+            root_sc.layout_info_v_at_cross_width_for_repeated.as_ref(),
+            "layout_item_info_at_cross_width",
+            "flex_cross_width",
+        );
+        let layout_item_info_at_cross_height_fn = layout_item_info_at_cross_fn(
+            root_sc.layout_info_h_at_cross_height_for_repeated.as_ref(),
+            "layout_item_info_at_cross_height",
+            "flex_cross_height",
+        );
         quote! {
             #layout_item_info_fn
             #flexbox_layout_item_info_fn
+            #layout_item_info_at_cross_width_fn
+            #layout_item_info_at_cross_height_fn
             #grid_layout_input_data_fn
         }
     };
@@ -3604,6 +3640,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             repeater_steps_var_name,
             elements,
             orientation,
+            repeated_cross_size,
             sub_expression,
         } => generate_with_layout_item_info(
             cells_variable,
@@ -3611,6 +3648,7 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             repeater_steps_var_name.as_ref().map(SmolStr::as_str),
             elements.as_ref(),
             *orientation,
+            repeated_cross_size.as_deref(),
             sub_expression,
             ctx,
         ),
@@ -3650,6 +3688,62 @@ fn compile_expression(expr: &Expression, ctx: &EvaluationContext) -> TokenStream
             quote! { {
                 #closure
                 sp::flexbox_layout_info_cross_axis_with_measure(#(#a as _,)* Some(&mut measure))
+            } }
+        }
+
+        Expression::BoxLayoutInfoOrthoWithMeasure {
+            solve_data,
+            padding_ortho,
+            orientation,
+            measure_cells,
+        } => {
+            let data = compile_expression(solve_data, ctx);
+            let padding = compile_expression(padding_ortho, ctx);
+            let known_size_ident = match orientation {
+                Orientation::Vertical => ident(MEASURE_KNOWN_W_LOCAL),
+                Orientation::Horizontal => ident(MEASURE_KNOWN_H_LOCAL),
+            };
+            let at_cross_fn = match orientation {
+                Orientation::Vertical => quote!(layout_item_info_at_cross_width),
+                Orientation::Horizontal => quote!(layout_item_info_at_cross_height),
+            };
+            let steps = measure_cells.iter().map(|cell| match cell {
+                llr::BoxMeasureCell::Static { info } => {
+                    let info = compile_expression(info, ctx);
+                    quote!(
+                        {
+                            let #known_size_ident = box_ortho_solved.as_slice()[cursor * 2 + 1] as f32;
+                            let _ = #known_size_ident;
+                            cells_vec.push(sp::LayoutItemInfo { constraint: { #info }, ..::core::default::Default::default() });
+                            cursor += 1;
+                        }
+                    )
+                }
+                llr::BoxMeasureCell::Repeated(repeater) => {
+                    let repeater_id =
+                        format_ident!("repeater{}", usize::from(repeater.repeater_index));
+                    quote!(
+                        for i in 0.._self.#repeater_id.len() {
+                            if let Some(sub_comp) = _self.#repeater_id.instance_at(i) {
+                                cells_vec.push(sub_comp.as_pin_ref().#at_cross_fn(
+                                    box_ortho_solved.as_slice()[cursor * 2 + 1] as f32,
+                                ));
+                            } else {
+                                cells_vec.push(::core::default::Default::default());
+                            }
+                            cursor += 1;
+                        }
+                    )
+                }
+            });
+            let min_cell_count = measure_cells.len();
+            quote! { {
+                let box_ortho_solved = sp::solve_box_layout(&#data, sp::Slice::from_slice(&[]));
+                let mut cells_vec = sp::Vec::with_capacity(#min_cell_count);
+                let mut cursor = 0usize;
+                #(#steps)*
+                let _ = cursor;
+                sp::box_layout_info_ortho(sp::Slice::from_slice(&cells_vec), &#padding)
             } }
         }
 
@@ -5536,11 +5630,20 @@ fn generate_with_layout_item_info(
     repeater_steps_var_name: Option<&str>,
     elements: &[Either<Expression, llr::LayoutRepeatedElement>],
     orientation: Orientation,
+    repeated_cross_size: Option<&Expression>,
     sub_expression: &Expression,
     ctx: &EvaluationContext,
 ) -> TokenStream {
     let repeated_indices_var_name = repeated_indices_var_name.map(ident);
     let repeater_steps_var_name = repeater_steps_var_name.map(ident);
+    // Cross-axis size forwarded to repeated cells on a box layout's main-axis
+    // pass, so a height-for-width (resp. width-for-height) instance measures
+    // at the size it is laid out at, like a static cell. Evaluated once, not
+    // per instance.
+    let cross_size_init = repeated_cross_size.map(|e| {
+        let cs = compile_expression(e, ctx);
+        quote!(let box_cross_size = (#cs) as f32;)
+    });
     let mut fixed_count = 0usize;
     let mut repeated_count_code = quote!();
     let mut push_code = Vec::new();
@@ -5562,6 +5665,9 @@ fn generate_with_layout_item_info(
                     &mut repeated_count_code,
                     ctx,
                     |repeater_id, static_count, inner_ensure_and_len, rs_init| {
+                        // Only box layouts set a cross size, and their repeaters
+                        // never have row templates.
+                        debug_assert!(cross_size_init.is_none());
                         quote!(
                             {
                                 let len = _self.#repeater_id.len();
@@ -5594,16 +5700,34 @@ fn generate_with_layout_item_info(
                             quote!()
                         } else if step == 1 && is_column_repeater {
                             // Column-repeater: each sub-component IS a cell; None returns its own layout_info
+                            let item_info = match (&cross_size_init, orientation) {
+                                (Some(_), Orientation::Vertical) => quote!(
+                                    sub_comp
+                                        .as_pin_ref()
+                                        .layout_item_info_at_cross_width(box_cross_size)
+                                ),
+                                (Some(_), Orientation::Horizontal) => quote!(
+                                    sub_comp
+                                        .as_pin_ref()
+                                        .layout_item_info_at_cross_height(box_cross_size)
+                                ),
+                                (None, _) => quote!(
+                                    sub_comp.as_pin_ref().layout_item_info(#orientation, None)
+                                ),
+                            };
                             quote!(
                                 for i in 0.._self.#repeater_id.len() {
                                     if let Some(sub_comp) = _self.#repeater_id.instance_at(i) {
-                                       items_vec.push(sub_comp.as_pin_ref().layout_item_info(#orientation, None));
+                                       items_vec.push(#item_info);
                                     } else {
                                         items_vec.push(::core::default::Default::default());
                                     }
                                 }
                             )
                         } else {
+                            // Multi-step repeaters only exist in grids, which
+                            // never set a cross size.
+                            debug_assert!(cross_size_init.is_none());
                             quote!(
                                 for i in 0.._self.#repeater_id.len() {
                                     if let Some(sub_comp) = _self.#repeater_id.instance_at(i) {
@@ -5637,6 +5761,7 @@ fn generate_with_layout_item_info(
 
     quote! { {
         #ri_init_code
+        #cross_size_init
         let mut items_vec = sp::Vec::with_capacity(#fixed_count #repeated_count_code);
         #(#push_code)*
         let #cells_variable = sp::Slice::from_slice(&items_vec);
@@ -5787,8 +5912,8 @@ fn generate_flexbox_measure_closure(
     measure_cells: &[llr::FlexboxMeasureCell],
     ctx: &EvaluationContext,
 ) -> TokenStream {
-    let known_w_ident = ident("measure_known_w");
-    let known_h_ident = ident("measure_known_h");
+    let known_w_ident = ident(MEASURE_KNOWN_W_LOCAL);
+    let known_h_ident = ident(MEASURE_KNOWN_H_LOCAL);
     let has_repeater = measure_cells
         .iter()
         .any(|item| matches!(item.kind, llr::FlexboxMeasureCellKind::Repeated(_)));

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -51,6 +51,22 @@ pub enum FlexboxMeasureCellKind {
     Fixed,
 }
 
+/// One cell of a box layout's cross-axis measure pass. See
+/// [`Expression::BoxLayoutInfoOrthoWithMeasure`].
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum BoxMeasureCell {
+    /// A static cell: its cross-axis `LayoutInfo` expression. A
+    /// height-for-width (resp. width-for-height) cell reads the
+    /// `measure_known_w` (resp. `measure_known_h`) local as its cross-axis
+    /// constraint; any other cell just doesn't read it.
+    Static { info: Expression },
+    /// A repeater: its instances are only known at run time, so the generated
+    /// code queries each instance's `layout_item_info_at_cross_width` /
+    /// `_at_cross_height` at its solved main-axis size.
+    Repeated(LayoutRepeatedElement),
+}
+
 #[derive(Debug, Clone)]
 pub enum Expression {
     /// A string literal. The .0 is the content of the string, without the quotes
@@ -258,6 +274,14 @@ pub enum Expression {
         /// Either an expression of type LayoutItemInfo, or information about the repeater
         elements: Vec<Either<Expression, LayoutRepeatedElement>>,
         orientation: Orientation,
+        /// Cross-axis size of the box layout on its main-axis pass: passed to
+        /// each repeated cell's `layout_item_info_at_cross_width` /
+        /// `_at_cross_height` so a height-for-width instance wraps to the real
+        /// width instead of its preferred width. `None` on the cross-axis pass
+        /// (and for grids). Only the plain column-repeater code path forwards
+        /// it — box layout repeaters are always step-1 column repeaters (no
+        /// `row_child_templates`); the generators assert this.
+        repeated_cross_size: Option<Box<Expression>>,
         sub_expression: Box<Expression>,
     },
     /// Will call the sub_expression, with two cells variables (horizontal and vertical)
@@ -305,6 +329,23 @@ pub enum Expression {
         data: Box<Expression>,
         repeater_indices: Box<Expression>,
         measure_cells: Vec<FlexboxMeasureCell>,
+    },
+    /// Cross-axis info of a box layout at a known main-axis size: solves the
+    /// main axis at that size, then folds the cells' cross-axis infos with
+    /// `box_layout_info_ortho`, measuring each height-for-width (resp.
+    /// width-for-height) cell at its solved main size — the box layout
+    /// counterpart of [`Self::FlexboxLayoutInfoCrossAxisWithMeasure`].
+    BoxLayoutInfoOrthoWithMeasure {
+        /// The `BoxLayoutData` for the main-axis solve; its `size` is the
+        /// known cross-axis size of the info being computed.
+        solve_data: Box<Expression>,
+        /// The cross-axis `Padding` for the fold.
+        padding_ortho: Box<Expression>,
+        /// The axis of the computed info: `Vertical` for a horizontal layout's
+        /// vertical info at a known width (cells measure height at their
+        /// solved width), `Horizontal` for the mirror.
+        orientation: Orientation,
+        measure_cells: Vec<BoxMeasureCell>,
     },
     /// Calls `flexbox_layout_info_cross_axis_with_measure` with the same
     /// generated measure callback as [`Self::SolveFlexboxLayoutWithMeasure`],
@@ -505,6 +546,9 @@ impl Expression {
             Self::WithLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
             Self::WithFlexboxLayoutItemInfo { sub_expression, .. } => sub_expression.ty(ctx),
             Self::SolveFlexboxLayoutWithMeasure { .. } => Type::LayoutCache,
+            Self::BoxLayoutInfoOrthoWithMeasure { .. } => {
+                crate::typeregister::layout_info_type().into()
+            }
             Self::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => {
                 crate::typeregister::layout_info_type().into()
             }
@@ -629,8 +673,16 @@ macro_rules! visit_impl {
                     $visitor(inner_repeater_index);
                 }
             }
-            Expression::WithLayoutItemInfo { elements, sub_expression, .. } => {
+            Expression::WithLayoutItemInfo {
+                elements,
+                repeated_cross_size,
+                sub_expression,
+                ..
+            } => {
                 $visitor(sub_expression);
+                if let Some(s) = repeated_cross_size {
+                    $visitor(s);
+                }
                 elements.$iter().filter_map(|x| x.$as_ref().left()).for_each($visitor);
             }
             Expression::WithFlexboxLayoutItemInfo {
@@ -663,6 +715,20 @@ macro_rules! visit_impl {
                     {
                         $visitor(h_info);
                         $visitor(v_info);
+                    }
+                });
+            }
+            Expression::BoxLayoutInfoOrthoWithMeasure {
+                solve_data,
+                padding_ortho,
+                measure_cells,
+                ..
+            } => {
+                $visitor(solve_data);
+                $visitor(padding_ortho);
+                measure_cells.$iter().for_each(|x| {
+                    if let BoxMeasureCell::Static { info } = x {
+                        $visitor(info);
                     }
                 });
             }

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -14,7 +14,7 @@ use crate::langtype::{BuiltinStruct, EnumerationValue, Struct, Type};
 use crate::layout::{FlexboxAxisRelation, GridLayoutCell, Orientation, RowColExpr};
 use crate::llr::ArrayOutput as llr_ArrayOutput;
 use crate::llr::Expression as llr_Expression;
-use crate::llr::{FlexboxMeasureCell, FlexboxMeasureCellKind};
+use crate::llr::{BoxMeasureCell, FlexboxMeasureCell, FlexboxMeasureCellKind};
 use crate::namedreference::NamedReference;
 use crate::object_tree::ElementRc;
 
@@ -77,11 +77,41 @@ pub(super) fn compute_grid_layout_info(
             repeater_steps_var_name: Some("repeater_steps".into()),
             elements,
             orientation: o,
+            repeated_cross_size: None,
             sub_expression: Box::new(sub_expression),
         },
         None => sub_expression,
     }
 }
+
+/// Whether a repeated cell of `layout` measures the `o` axis through a
+/// parametrized layout-info function (height-for-width for Vertical,
+/// width-for-height for Horizontal). Only then does forwarding a cross-axis
+/// size to the repeated cells change anything.
+fn box_layout_has_constrained_repeated_cell(
+    layout: &crate::layout::BoxLayout,
+    o: Orientation,
+) -> bool {
+    layout.elems.iter().any(|item| {
+        item.element.borrow().repeated.is_some()
+            && match o {
+                Orientation::Vertical => {
+                    item.element.borrow().has_inherited_layout_info_v_with_constraint()
+                }
+                Orientation::Horizontal => {
+                    item.element.borrow().has_inherited_layout_info_h_with_constraint()
+                }
+            }
+    })
+}
+
+/// Name of the local that carries the known width (resp. height) a measure
+/// pass measures a cell at. The generated code binds it around each static
+/// measure cell's `LayoutInfo` expression; shared by the flexbox and box
+/// layout measure passes.
+pub const MEASURE_KNOWN_W_LOCAL: &str = "measure_known_w";
+/// See [`MEASURE_KNOWN_W_LOCAL`].
+pub const MEASURE_KNOWN_H_LOCAL: &str = "measure_known_h";
 
 pub(super) fn compute_box_layout_info(
     layout: &crate::layout::BoxLayout,
@@ -90,9 +120,21 @@ pub(super) fn compute_box_layout_info(
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
 ) -> llr_Expression {
     let (padding, spacing) = generate_layout_padding_and_spacing(&layout.geometry, o, ctx);
+    // Cross-axis info at a known main-axis size (a horizontal layout's
+    // vertical info at a known width, or the mirror): solve the main axis at
+    // that size and measure each height-for-width (resp. width-for-height)
+    // cell at its solved main size — feeding every cell the whole size would
+    // overestimate what the layout actually gives it, and so underestimate
+    // the cross size the cell needs.
+    if o != layout.orientation
+        && let Some(override_expr) = cross_axis_size_override
+        && box_layout_needs_measure(layout, o)
+    {
+        return compute_box_layout_info_ortho_with_measure(layout, ctx, override_expr, padding, o);
+    }
     let adjusted_override = cross_axis_size_override
         .map(|o_expr| subtract_padding(o_expr.clone(), &layout.geometry, o.orthogonal()));
-    let bld = box_layout_data(layout, o, ctx, adjusted_override.as_ref(), None, false);
+    let bld = box_layout_data(layout, o, ctx, adjusted_override.as_ref(), None, false, false);
     let sub_expression = if o == layout.orientation {
         llr_Expression::ExtraBuiltinFunctionCall {
             function: "box_layout_info".into(),
@@ -106,6 +148,12 @@ pub(super) fn compute_box_layout_info(
             return_ty: crate::typeregister::layout_info_type().into(),
         }
     };
+    // On the main pass with a known cross-axis size (a `layoutinfo-*-with-constraint`
+    // body), measure repeated cells at that size too, like the static cells.
+    let repeated_cross_size = adjusted_override
+        .as_ref()
+        .filter(|_| o == layout.orientation && box_layout_has_constrained_repeated_cell(layout, o))
+        .map(|e| Box::new(super::lower_expression::lower_expression(e, ctx)));
     match bld.compute_cells {
         Some((cells_variable, elements)) => llr_Expression::WithLayoutItemInfo {
             cells_variable,
@@ -113,6 +161,111 @@ pub(super) fn compute_box_layout_info(
             repeater_steps_var_name: None,
             elements,
             orientation: o,
+            repeated_cross_size,
+            sub_expression: Box::new(sub_expression),
+        },
+        None => sub_expression,
+    }
+}
+
+/// Whether any cell of the box layout is height-for-width (`o` Vertical) resp.
+/// width-for-height (`o` Horizontal), so an `o`-axis info computation at a
+/// known main-axis size needs the solve-and-measure pass.
+fn box_layout_needs_measure(layout: &crate::layout::BoxLayout, o: Orientation) -> bool {
+    layout.elems.iter().any(|li| {
+        let (h4w, w4h) = cell_measure_capability(&li.element);
+        match o {
+            Orientation::Vertical => h4w,
+            Orientation::Horizontal => w4h,
+        }
+    })
+}
+
+/// Per-element measure inputs for [`llr_Expression::BoxLayoutInfoOrthoWithMeasure`]:
+/// the cell's `o`-axis `LayoutInfo` measured at its solved main size, read from
+/// the [`MEASURE_KNOWN_W_LOCAL`] resp. [`MEASURE_KNOWN_H_LOCAL`] local (the
+/// same locals the flexbox measure cells use). A repeated element becomes a
+/// [`BoxMeasureCell::Repeated`]: its instances are only known at solve time, so
+/// the generated code queries each instance's `layout_item_info_at_cross_width`
+/// / `_at_cross_height` directly.
+fn box_measure_cells_for(
+    layout: &crate::layout::BoxLayout,
+    ctx: &mut ExpressionLoweringCtx,
+    o: Orientation,
+) -> Vec<BoxMeasureCell> {
+    layout
+        .elems
+        .iter()
+        .map(|li| {
+            let elem = &li.element;
+            if elem.borrow().repeated.is_some() {
+                let repeater_index =
+                    match ctx.mapping.element_mapping.get(&elem.clone().into()).unwrap() {
+                        LoweredElement::Repeated { repeated_index } => *repeated_index,
+                        _ => panic!("repeated box layout element not lowered as Repeated"),
+                    };
+                return BoxMeasureCell::Repeated(LayoutRepeatedElement {
+                    repeater_index,
+                    row_child_templates: None,
+                });
+            }
+            let measure_local = crate::expression_tree::Expression::ReadLocalVariable {
+                name: match o {
+                    Orientation::Vertical => MEASURE_KNOWN_W_LOCAL.into(),
+                    Orientation::Horizontal => MEASURE_KNOWN_H_LOCAL.into(),
+                },
+                ty: Type::LogicalLength,
+            };
+            let info =
+                cell_layout_info(elem, &li.constraints, ctx, o, Some(&measure_local), None, false);
+            BoxMeasureCell::Static { info }
+        })
+        .collect()
+}
+
+/// Build the [`llr_Expression::BoxLayoutInfoOrthoWithMeasure`] for the layout's
+/// `o`-axis info at the known main-axis size `cross_axis_size` (a horizontal
+/// layout's vertical info at a known width, or the mirror).
+fn compute_box_layout_info_ortho_with_measure(
+    layout: &crate::layout::BoxLayout,
+    ctx: &mut ExpressionLoweringCtx,
+    cross_axis_size: &crate::expression_tree::Expression,
+    padding_ortho: llr_Expression,
+    o: Orientation,
+) -> llr_Expression {
+    let main_o = layout.orientation;
+    let (padding_main, spacing_main) =
+        generate_layout_padding_and_spacing(&layout.geometry, main_o, ctx);
+    let bld = box_layout_data(layout, main_o, ctx, None, None, false, true);
+    let size = super::lower_expression::lower_expression(cross_axis_size, ctx);
+    let solve_data = make_struct(
+        BuiltinStruct::BoxLayoutData,
+        [
+            ("size", Type::Float32, size),
+            ("spacing", Type::Float32, spacing_main),
+            ("padding", padding_main.ty(ctx), padding_main),
+            (
+                "alignment",
+                Type::Enumeration(crate::typeregister::BUILTIN.enums.LayoutAlignment.clone()),
+                bld.alignment,
+            ),
+            ("cells", bld.cells.ty(ctx), bld.cells),
+        ],
+    );
+    let sub_expression = llr_Expression::BoxLayoutInfoOrthoWithMeasure {
+        solve_data: Box::new(solve_data),
+        padding_ortho: Box::new(padding_ortho),
+        orientation: o,
+        measure_cells: box_measure_cells_for(layout, ctx, o),
+    };
+    match bld.compute_cells {
+        Some((cells_variable, elements)) => llr_Expression::WithLayoutItemInfo {
+            cells_variable,
+            repeater_indices_var_name: None,
+            repeater_steps_var_name: None,
+            elements,
+            orientation: main_o,
+            repeated_cross_size: None,
             sub_expression: Box::new(sub_expression),
         },
         None => sub_expression,
@@ -215,6 +368,7 @@ pub(super) fn solve_grid_layout(
             repeater_steps_var_name: Some("repeater_steps".into()),
             elements,
             orientation: o,
+            repeated_cross_size: None,
             sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
                 function: "solve_grid_layout".into(),
                 arguments: vec![
@@ -259,7 +413,12 @@ pub(super) fn solve_box_layout(
     // For a horizontal layout's main (width) pass, feed each width-for-height
     // child the layout's real cross size (its content height) instead of the
     // `f32::MAX` "assume infinite height" fallback, so the width reserved for the
-    // child matches the height it will actually be given.
+    // child matches the height it will actually be given. The vertical main
+    // pass must NOT do the mirror image: embedding `self.width` into the
+    // cache would let a geometry pull inside a horizontal info chain (a cell
+    // with `width: self.height`) close a binding loop through an ancestor's
+    // cache. Height-for-width children read their own laid-out width instead
+    // (see `text_layout_info` in i-slint-core).
     let cross_override = (o == layout.orientation && o == Orientation::Horizontal)
         .then(|| layout_cross_content_size(layout))
         .flatten();
@@ -268,7 +427,17 @@ pub(super) fn solve_box_layout(
     // gets its natural single-line size instead of the compact sqrt preferred.
     let cross_clamp =
         (o != layout.orientation).then(|| layout_cross_content_size(layout)).flatten();
-    let bld = box_layout_data(layout, o, ctx, cross_override.as_ref(), cross_clamp.as_ref(), true);
+    let bld =
+        box_layout_data(layout, o, ctx, cross_override.as_ref(), cross_clamp.as_ref(), true, false);
+    // On the main pass, measure repeated height-for-width (resp. width-for-height)
+    // cells at the layout's cross content size, like the flexbox solve does: their
+    // plain layout-info is measured at their preferred size, which is not the size
+    // the layout gives them.
+    let repeated_cross_size = (o == layout.orientation)
+        .then(|| layout_cross_content_size(layout))
+        .flatten()
+        .filter(|_| box_layout_has_constrained_repeated_cell(layout, o))
+        .map(|e| Box::new(super::lower_expression::lower_expression(&e, ctx)));
     let size = layout_geometry_size(&layout.geometry.rect, o, ctx);
     let (data, function) = if o == layout.orientation {
         let data = make_struct(
@@ -316,6 +485,7 @@ pub(super) fn solve_box_layout(
             repeater_steps_var_name: None,
             elements,
             orientation: o,
+            repeated_cross_size,
             sub_expression: Box::new(llr_Expression::ExtraBuiltinFunctionCall {
                 function: function.into(),
                 arguments: vec![
@@ -527,7 +697,7 @@ fn measure_cells_for(
                 return FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Fixed, w4h_only: false };
             }
             let v_constraint = h4w.then(|| crate::expression_tree::Expression::ReadLocalVariable {
-                name: "measure_known_w".into(),
+                name: MEASURE_KNOWN_W_LOCAL.into(),
                 ty: Type::LogicalLength,
             });
             let v_info = get_flex_cell_layout_info(
@@ -538,7 +708,7 @@ fn measure_cells_for(
                 v_constraint,
             );
             let h_constraint = w4h.then(|| crate::expression_tree::Expression::ReadLocalVariable {
-                name: "measure_known_h".into(),
+                name: MEASURE_KNOWN_H_LOCAL.into(),
                 ty: Type::LogicalLength,
             });
             let h_info = get_flex_cell_layout_info(
@@ -1112,6 +1282,7 @@ fn box_layout_data(
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
     cross_clamp: Option<&crate::expression_tree::Expression>,
     for_solve: bool,
+    for_measure_solve: bool,
 ) -> BoxLayoutDataResult {
     let alignment = if let Some(expr) = &layout.geometry.alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
@@ -1152,6 +1323,7 @@ fn box_layout_data(
                         orientation,
                         cross_axis_size_override,
                         cross_clamp,
+                        for_measure_solve,
                     );
                     let align_self = cell_align_self(li, ctx);
                     make_layout_cell_data_struct(layout_info, align_self)
@@ -1182,6 +1354,7 @@ fn box_layout_data(
                     orientation,
                     cross_axis_size_override,
                     cross_clamp,
+                    for_measure_solve,
                 );
                 let align_self = cell_align_self(item, ctx);
                 elements.push(Either::Left(make_layout_cell_data_struct(layout_info, align_self)));
@@ -1195,6 +1368,11 @@ fn box_layout_data(
     }
 }
 
+/// `for_measure_solve` marks the main-axis solve inside
+/// [`compute_box_layout_info_ortho_with_measure`]: height-for-width cells are
+/// then measured at their preferred width rather than left unconstrained —
+/// the unconstrained query reads the cell's current width, which can depend
+/// on the very layout cache this solve is computed for.
 fn cell_layout_info(
     elem: &ElementRc,
     constraints: &crate::layout::LayoutConstraints,
@@ -1202,11 +1380,17 @@ fn cell_layout_info(
     orientation: Orientation,
     cross_axis_size_override: Option<&crate::expression_tree::Expression>,
     cross_clamp: Option<&crate::expression_tree::Expression>,
+    for_measure_solve: bool,
 ) -> llr_Expression {
     let constraint = match orientation {
-        Orientation::Vertical => {
-            cross_axis_size_override.filter(|_| is_height_for_width_cell(elem)).cloned()
-        }
+        Orientation::Vertical => cross_axis_size_override
+            .filter(|_| is_height_for_width_cell(elem))
+            .cloned()
+            .or_else(|| {
+                (for_measure_solve && is_height_for_width_cell(elem))
+                    .then(|| default_cross_axis_constraint(elem))
+                    .flatten()
+            }),
         Orientation::Horizontal => {
             // Cells with `layoutinfo-h-with-constraint` need a constraint
             // to dispatch via the parametrized layout-info function
@@ -1445,6 +1629,7 @@ fn grid_layout_cell_constraints(
                         orientation,
                         cross_axis_size_override,
                         None,
+                        false,
                     );
                     make_layout_cell_data_struct(layout_info, None)
                 })
@@ -1478,6 +1663,7 @@ fn grid_layout_cell_constraints(
                     orientation,
                     cross_axis_size_override,
                     None,
+                    false,
                 );
                 elements.push(Either::Left(make_layout_cell_data_struct(layout_info, None)));
             }
@@ -2041,14 +2227,21 @@ pub const FLEX_CROSS_WIDTH_LOCAL: &str = "flex_cross_width";
 
 /// Like [`get_layout_info_v_constrained_for_repeated`], but measures at the
 /// width passed in the [`FLEX_CROSS_WIDTH_LOCAL`] local instead of the
-/// element's preferred width. A column FlexboxLayout supplies its real
-/// container width here at solve time, so a repeated height-for-width instance
-/// gets the same wrapped height as an equivalent static cell. Returns `None`
-/// when the element has no constrained vertical layout-info.
+/// element's preferred width. A column FlexboxLayout (or a box layout)
+/// supplies the width it assigns the instance here at solve time, so a
+/// repeated height-for-width instance gets the same wrapped height as an
+/// equivalent static cell. Returns `None` when the element has no constrained
+/// vertical layout-info.
+///
+/// `for_flex_cell` selects [`get_flex_cell_layout_info`] (flexbox:
+/// re-reading inherited constraints unconstrained would reintroduce the
+/// height-for-width cycle); every other layout kind uses [`get_layout_info`]
+/// (inherited constraints are re-applied, like for static box cells).
 pub fn get_layout_info_v_at_cross_width_for_repeated(
     ctx: &mut ExpressionLoweringCtx,
     element: &ElementRc,
     constraints: &crate::layout::LayoutConstraints,
+    for_flex_cell: bool,
 ) -> Option<llr_Expression> {
     if !element.borrow().has_inherited_layout_info_v_with_constraint() {
         return None;
@@ -2057,13 +2250,8 @@ pub fn get_layout_info_v_at_cross_width_for_repeated(
         name: FLEX_CROSS_WIDTH_LOCAL.into(),
         ty: Type::LogicalLength,
     };
-    Some(get_flex_cell_layout_info(
-        element,
-        ctx,
-        constraints,
-        Orientation::Vertical,
-        Some(width_constraint),
-    ))
+    let get = if for_flex_cell { get_flex_cell_layout_info } else { get_layout_info };
+    Some(get(element, ctx, constraints, Orientation::Vertical, Some(width_constraint)))
 }
 
 /// Horizontal `LayoutInfo` for a repeated element, computed with an unbounded
@@ -2101,25 +2289,22 @@ pub const FLEX_CROSS_HEIGHT_LOCAL: &str = "flex_cross_height";
 
 /// Like [`get_layout_info_h_constrained_for_repeated`], but measures at the
 /// height passed in the [`FLEX_CROSS_HEIGHT_LOCAL`] local instead of leaving it
-/// unbounded. A FlexboxLayout supplies the height it assigned at solve time, so
-/// a repeated width-for-height instance gets the same width as an equivalent
-/// static cell. Returns `None` when the element has no constrained horizontal
-/// layout-info.
+/// unbounded. A FlexboxLayout (or a box layout) supplies the height it
+/// assigned at solve time, so a repeated width-for-height instance gets the
+/// same width as an equivalent static cell. Returns `None` when the element
+/// has no constrained horizontal layout-info. See
+/// [`get_layout_info_v_at_cross_width_for_repeated`] for `for_flex_cell`.
 pub fn get_layout_info_h_at_cross_height_for_repeated(
     ctx: &mut ExpressionLoweringCtx,
     element: &ElementRc,
     constraints: &crate::layout::LayoutConstraints,
+    for_flex_cell: bool,
 ) -> Option<llr_Expression> {
     element.borrow().inherited_layout_info_h_with_constraint()?;
     let height_constraint = crate::expression_tree::Expression::ReadLocalVariable {
         name: FLEX_CROSS_HEIGHT_LOCAL.into(),
         ty: Type::LogicalLength,
     };
-    Some(get_flex_cell_layout_info(
-        element,
-        ctx,
-        constraints,
-        Orientation::Horizontal,
-        Some(height_constraint),
-    ))
+    let get = if for_flex_cell { get_flex_cell_layout_info } else { get_layout_info };
+    Some(get(element, ctx, constraints, Orientation::Horizontal, Some(height_constraint)))
 }

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -729,6 +729,7 @@ fn lower_sub_component(
                 &mut ctx,
                 root_elem,
                 &component.root_constraints.borrow(),
+                true,
             )
             .map(Into::into);
         sub_component.layout_info_h_constrained_for_repeated = h_constrained.map(Into::into);
@@ -737,6 +738,7 @@ fn lower_sub_component(
                 &mut ctx,
                 root_elem,
                 &component.root_constraints.borrow(),
+                true,
             )
             .map(Into::into);
     } else if let Some(box_orientation) =
@@ -752,6 +754,29 @@ fn lower_sub_component(
                 super::Expression::PropertyReference(ctx.map_property_reference(&nr)).into(),
             ));
         }
+        // The parent box layout measures a height-for-width (resp.
+        // width-for-height) instance at the cross size it lays it out at,
+        // through `layout_item_info_at_cross_width` / `_at_cross_height` — the
+        // plain `layout_info` measures at the instance's preferred size.
+        // Generate both accessors: the main-axis pass queries the parent's
+        // orientation, the ortho measure pass queries the orthogonal one.
+        let root_elem = &component.root_element;
+        sub_component.layout_info_v_at_cross_width_for_repeated =
+            super::lower_layout_expression::get_layout_info_v_at_cross_width_for_repeated(
+                &mut ctx,
+                root_elem,
+                &component.root_constraints.borrow(),
+                false,
+            )
+            .map(Into::into);
+        sub_component.layout_info_h_at_cross_height_for_repeated =
+            super::lower_layout_expression::get_layout_info_h_at_cross_height_for_repeated(
+                &mut ctx,
+                root_elem,
+                &component.root_constraints.borrow(),
+                false,
+            )
+            .map(Into::into);
     }
 
     if let Some(grid_layout_cell) = component.root_element.borrow().grid_layout_cell.as_ref() {

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -74,6 +74,7 @@ fn expression_cost(exp: &Expression, ctx: &EvaluationContext) -> isize {
         Expression::WithLayoutItemInfo { .. } => return isize::MAX,
         Expression::WithFlexboxLayoutItemInfo { .. } => return isize::MAX,
         Expression::SolveFlexboxLayoutWithMeasure { .. } => return isize::MAX,
+        Expression::BoxLayoutInfoOrthoWithMeasure { .. } => return isize::MAX,
         Expression::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => return isize::MAX,
         Expression::WithGridInputData { .. } => return isize::MAX,
         Expression::MinMax { .. } => 10,

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -645,6 +645,7 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                 repeater_steps_var_name,
                 elements,
                 orientation,
+                repeated_cross_size,
                 sub_expression,
             } => {
                 write!(
@@ -670,10 +671,16 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                 if let Some(v) = repeater_steps_var_name {
                     write!(f, "{v} = @repeater-steps; ")?;
                 }
+                if let Some(s) = repeated_cross_size {
+                    write!(f, "@repeated-cross-size = {}; ", e(s))?;
+                }
                 write!(f, "{} }}", e(sub_expression))
             }
             Expression::WithFlexboxLayoutItemInfo { .. } => {
                 write!(f, "WithFlexboxLayoutItemInfo(TODO)",)
+            }
+            Expression::BoxLayoutInfoOrthoWithMeasure { .. } => {
+                write!(f, "BoxLayoutInfoOrthoWithMeasure(TODO)",)
             }
             Expression::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => {
                 write!(f, "FlexboxLayoutInfoCrossAxisWithMeasure(TODO)",)

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3365,6 +3365,23 @@ impl Element {
         false
     }
 
+    /// Whether [`Self::inherited_layout_info_h_with_constraint`] would return
+    /// `Some`, without cloning the `NamedReference`.
+    pub fn has_inherited_layout_info_h_with_constraint(&self) -> bool {
+        if self.layout_info_h_with_constraint.is_some() {
+            return true;
+        }
+        let mut base = self.base_type.clone();
+        while let ElementType::Component(base_comp) = base {
+            let root = base_comp.root_element.borrow();
+            if root.layout_info_h_with_constraint.is_some() {
+                return true;
+            }
+            base = root.base_type.clone();
+        }
+        false
+    }
+
     /// Mirror of [`Self::inherited_layout_info_v_with_constraint`] for the
     /// horizontal axis.
     pub fn inherited_layout_info_h_with_constraint(&self) -> Option<NamedReference> {
@@ -3395,8 +3412,8 @@ impl Element {
     pub fn layout_info_includes_own_constraints(&self, orientation: Orientation) -> bool {
         self.layout_info_prop(orientation).is_some()
             || match orientation {
-                Orientation::Vertical => self.inherited_layout_info_v_with_constraint().is_some(),
-                Orientation::Horizontal => self.inherited_layout_info_h_with_constraint().is_some(),
+                Orientation::Vertical => self.has_inherited_layout_info_v_with_constraint(),
+                Orientation::Horizontal => self.has_inherited_layout_info_h_with_constraint(),
             }
     }
 

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -198,13 +198,17 @@ pub(crate) fn synthesize_layoutinfo_h_with_constraint_on(
 }
 
 /// Same as `rewrite_layoutinfo_v_for_constraint`, but for the horizontal
-/// axis. Only `ComputeFlexboxLayoutInfo` and `PropertyReference` are
-/// rewritten — there's no width-for-height equivalent in box/grid
-/// layouts, and `ImplicitLayoutInfo(Horizontal)` on a non-component
-/// element doesn't depend on `self.height`.
+/// axis. Grids are not rewritten (no width-for-height path there), and
+/// `ImplicitLayoutInfo(Horizontal)` on a non-component element doesn't
+/// depend on `self.height` (there is no builtin width-for-height item).
 fn rewrite_layoutinfo_h_for_constraint(expr: &mut Expression, height_param: &Expression) {
     expr.visit_recursive_mut(&mut |sub| match sub {
-        Expression::ComputeFlexboxLayoutInfo {
+        Expression::ComputeBoxLayoutInfo {
+            orientation: Orientation::Horizontal,
+            cross_axis_size,
+            ..
+        }
+        | Expression::ComputeFlexboxLayoutInfo {
             orientation: Orientation::Horizontal,
             cross_axis_size,
             ..
@@ -1691,11 +1695,12 @@ fn lower_box_layout(
     // needs to know whether any cell sets `cross-axis-self-alignment`.
     let items: Vec<_> =
         layout_children.iter().map(|child| create_layout_item(child, diag)).collect();
-    // A repeated cell with `cross-axis-self-alignment` returns that value through
-    // the generated `layout_item_info`, which needs the layout's orientation to
-    // restrict it to the cross axis.
+    // A repeated cell needs the layout's orientation: `lower_to_item_tree` uses
+    // it to restrict a `cross-axis-self-alignment` to the cross axis, and to
+    // generate `layout_item_info_at_cross_width` / `_at_cross_height` for a
+    // height-for-width (resp. width-for-height) instance.
     for item in &items {
-        if item.repeater_index.is_some() && item.item.cross_axis_self_alignment.is_some() {
+        if item.repeater_index.is_some() {
             item.elem.borrow_mut().parent_box_layout_orientation = Some(orientation);
         }
     }

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -58,6 +58,29 @@ pub trait RepeatedItemTree:
         crate::layout::LayoutItemInfo::default()
     }
 
+    /// Vertical layout info measured at the given cross-axis (container) width.
+    /// A box layout calls this so a height-for-width instance wraps to the
+    /// real width. The default ignores the width (non-height-for-width cells);
+    /// the generated code overrides it for height-for-width instances.
+    fn layout_item_info_at_cross_width(
+        self: Pin<&Self>,
+        _cross_width: f32,
+    ) -> crate::layout::LayoutItemInfo {
+        self.layout_item_info(Orientation::Vertical, None)
+    }
+
+    /// Horizontal layout info measured at the given cross-axis (container)
+    /// height. A box layout calls this so a width-for-height instance
+    /// resolves to the width it really needs at that height. The default
+    /// ignores the height (non-width-for-height cells); the generated code
+    /// overrides it for width-for-height instances.
+    fn layout_item_info_at_cross_height(
+        self: Pin<&Self>,
+        _cross_height: f32,
+    ) -> crate::layout::LayoutItemInfo {
+        self.layout_item_info(Orientation::Horizontal, None)
+    }
+
     /// Returns what's needed to perform a flexbox layout if this ItemTree is in a FlexboxLayout.
     /// Includes flex-specific properties (layout-order).
     fn flexbox_layout_item_info(

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1031,9 +1031,17 @@ pub fn eval_expression(ctx: &mut EvalContext, expression: &Expression) -> Value 
             cells_variable,
             elements,
             orientation,
+            repeated_cross_size,
             sub_expression,
             ..
-        } => with_layout_item_info(ctx, cells_variable, elements, *orientation, sub_expression),
+        } => with_layout_item_info(
+            ctx,
+            cells_variable,
+            elements,
+            *orientation,
+            repeated_cross_size.as_deref(),
+            sub_expression,
+        ),
         Expression::WithFlexboxLayoutItemInfo {
             cells_h_variable,
             cells_v_variable,
@@ -1070,6 +1078,9 @@ pub fn eval_expression(ctx: &mut EvalContext, expression: &Expression) -> Value 
         Expression::FlexboxLayoutInfoCrossAxisWithMeasure { .. } => {
             crate::eval_layout::flexbox_layout_info_cross_axis_with_measure(ctx, expression)
         }
+        Expression::BoxLayoutInfoOrthoWithMeasure { .. } => {
+            crate::eval_layout::box_layout_info_ortho_with_measure(ctx, expression)
+        }
         Expression::TranslationReference { .. } => {
             // TranslationReference is only emitted when `bundle-translations`
             // is active, which the interpreter does not use. Runtime @tr()
@@ -1093,8 +1104,15 @@ fn with_layout_item_info(
     cells_variable: &str,
     elements: &[itertools::Either<Expression, i_slint_compiler::llr::LayoutRepeatedElement>],
     orientation: i_slint_compiler::layout::Orientation,
+    repeated_cross_size: Option<&Expression>,
     sub_expression: &Expression,
 ) -> Value {
+    // On a box layout's main-axis pass, re-measure each repeated cell at the
+    // layout's cross size so a height-for-width (resp. width-for-height)
+    // instance measures like an equivalent static cell. On a non-numeric
+    // value, fall back to the plain layout info rather than measuring at 0.
+    let cross_size: Option<f32> =
+        repeated_cross_size.and_then(|e| eval_expression(ctx, e).try_into().ok());
     let mut cells: Vec<Value> = Vec::with_capacity(elements.len());
     let mut repeated_indices: Vec<u32> = Vec::new();
     let mut repeater_steps: Vec<u32> = Vec::new();
@@ -1108,6 +1126,7 @@ fn with_layout_item_info(
                     repeater.repeater_index,
                     repeater.row_child_templates.as_deref(),
                     orientation,
+                    cross_size,
                     &mut cells,
                 );
                 repeated_indices.push(offset);
@@ -1142,6 +1161,7 @@ fn push_repeater_layout_items(
     repeater_idx: i_slint_compiler::llr::RepeatedElementIdx,
     row_child_templates: Option<&[i_slint_compiler::llr::RowChildTemplateInfo]>,
     orientation: i_slint_compiler::layout::Orientation,
+    cross_size: Option<f32>,
     cells: &mut Vec<Value>,
 ) -> (u32, u32) {
     use i_slint_core::model::RepeatedItemTree;
@@ -1169,18 +1189,33 @@ fn push_repeater_layout_items(
     let step = match row_child_templates {
         None => {
             // Column repeater: one cell per instance, asking the sub-component
-            // for its own layout info.
+            // for its own layout info — at the layout's cross size when the
+            // main-axis pass forwards one.
             for instance in &instances {
-                let info = RepeatedItemTree::layout_item_info(
-                    instance.as_pin_ref(),
-                    core_orientation,
-                    None,
-                );
+                let info = match (cross_size, core_orientation) {
+                    (Some(cs), i_slint_core::items::Orientation::Vertical) => {
+                        RepeatedItemTree::layout_item_info_at_cross_width(instance.as_pin_ref(), cs)
+                    }
+                    (Some(cs), i_slint_core::items::Orientation::Horizontal) => {
+                        RepeatedItemTree::layout_item_info_at_cross_height(
+                            instance.as_pin_ref(),
+                            cs,
+                        )
+                    }
+                    (None, _) => RepeatedItemTree::layout_item_info(
+                        instance.as_pin_ref(),
+                        core_orientation,
+                        None,
+                    ),
+                };
                 push_cell(cells, info);
             }
             1
         }
         Some(templates) => {
+            // Only box layouts set a cross size, and their repeaters never
+            // have row templates.
+            debug_assert!(cross_size.is_none());
             // Row repeater: the step is the maximum total child count across
             // instances (static children plus each instance's inner repeaters
             // realized via RowChildTemplateInfo::Repeated).

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -6,7 +6,13 @@
 
 use crate::Value;
 use crate::eval::{EvalContext, eval_expression};
-use i_slint_compiler::llr::{Expression, FlexboxMeasureCell, FlexboxMeasureCellKind};
+use i_slint_compiler::layout::Orientation;
+use i_slint_compiler::llr::lower_layout_expression::{
+    MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL,
+};
+use i_slint_compiler::llr::{
+    BoxMeasureCell, Expression, FlexboxMeasureCell, FlexboxMeasureCellKind,
+};
 use i_slint_core::SharedVector;
 use i_slint_core::layout::{
     BoxLayoutData, FlexboxLayoutData, FlexboxLayoutItemInfo, GridLayoutData, GridLayoutInputData,
@@ -405,9 +411,9 @@ fn measure_flexbox_cell(
     // measure the height at the width `w`
     let measure_height = |ctx: &mut EvalContext| match &cell.kind {
         FlatCellKind::Static { v_info, .. } => {
-            let prev = ctx.locals.insert("measure_known_w".into(), Value::Number(w as f64));
+            let prev = ctx.locals.insert(MEASURE_KNOWN_W_LOCAL.into(), Value::Number(w as f64));
             let info = eval_info(ctx, v_info);
-            crate::eval::restore_local(ctx, "measure_known_w", prev);
+            crate::eval::restore_local(ctx, MEASURE_KNOWN_W_LOCAL, prev);
             (w, info.preferred_bounded())
         }
         FlatCellKind::Repeated(instance) => (
@@ -423,9 +429,9 @@ fn measure_flexbox_cell(
     // measure the width at the height `h`
     let measure_width = |ctx: &mut EvalContext| match &cell.kind {
         FlatCellKind::Static { h_info, .. } => {
-            let prev = ctx.locals.insert("measure_known_h".into(), Value::Number(h as f64));
+            let prev = ctx.locals.insert(MEASURE_KNOWN_H_LOCAL.into(), Value::Number(h as f64));
             let info = eval_info(ctx, h_info);
-            crate::eval::restore_local(ctx, "measure_known_h", prev);
+            crate::eval::restore_local(ctx, MEASURE_KNOWN_H_LOCAL, prev);
             (info.preferred_bounded(), h)
         }
         FlatCellKind::Repeated(instance) => (
@@ -498,6 +504,87 @@ pub(crate) fn solve_flexbox_layout_with_measure(ctx: &mut EvalContext, expr: &Ex
         Slice::from_slice(&ri),
         Some(&mut measure),
     ))
+}
+
+/// Interpret [`Expression::BoxLayoutInfoOrthoWithMeasure`]: solve the box
+/// layout's main axis at the known cross-axis size, then fold the cells'
+/// cross-axis infos with `box_layout_info_ortho`, measuring each
+/// height-for-width (resp. width-for-height) cell at its solved main size.
+pub(crate) fn box_layout_info_ortho_with_measure(
+    ctx: &mut EvalContext,
+    expr: &Expression,
+) -> Value {
+    use i_slint_core::model::RepeatedItemTree;
+    let Expression::BoxLayoutInfoOrthoWithMeasure {
+        solve_data,
+        padding_ortho,
+        orientation,
+        measure_cells,
+    } = expr
+    else {
+        return Value::Void;
+    };
+    let known_size_local = match orientation {
+        Orientation::Vertical => MEASURE_KNOWN_W_LOCAL,
+        Orientation::Horizontal => MEASURE_KNOWN_H_LOCAL,
+    };
+    let data = eval_expression(ctx, solve_data);
+    let Value::Struct(s) = &data else { return LayoutInfo::default().into() };
+    let cells = s.get_field("cells").map(to_cells).unwrap_or_default();
+    let solved = i_slint_core::layout::solve_box_layout(
+        &BoxLayoutData {
+            size: sf32(s, "size"),
+            spacing: sf32(s, "spacing"),
+            padding: s.get_field("padding").map(to_padding).unwrap_or_default(),
+            alignment: s.get_field("alignment").map(to_enum).unwrap_or_default(),
+            cells: Slice::from_slice(&cells),
+        },
+        Slice::from_slice(&[]),
+    );
+    let solved_size = |cursor: usize| solved.as_slice().get(cursor * 2 + 1).copied().unwrap_or(0.);
+    let mut out_cells: Vec<LayoutItemInfo> = Vec::with_capacity(cells.len());
+    let mut cursor = 0usize;
+    for cell in measure_cells {
+        match cell {
+            BoxMeasureCell::Static { info } => {
+                let prev = ctx
+                    .locals
+                    .insert(known_size_local.into(), Value::Number(solved_size(cursor) as f64));
+                let constraint = eval_info(ctx, info);
+                crate::eval::restore_local(ctx, known_size_local, prev);
+                out_cells.push(LayoutItemInfo { constraint, ..Default::default() });
+                cursor += 1;
+            }
+            BoxMeasureCell::Repeated(repeater) => {
+                let Some(current) = ctx.current.as_ref() else {
+                    // Without an instance, the repeater's cell count is
+                    // unknown, so the later cells' solved sizes can't be
+                    // located either.
+                    debug_assert!(false, "measure pass evaluated without a current instance");
+                    return LayoutInfo::default().into();
+                };
+                let rep = &current.repeaters[repeater.repeater_index];
+                rep.track_instance_changes();
+                for instance in rep.instances_vec() {
+                    let info = match orientation {
+                        Orientation::Vertical => instance
+                            .as_pin_ref()
+                            .layout_item_info_at_cross_width(solved_size(cursor)),
+                        Orientation::Horizontal => instance
+                            .as_pin_ref()
+                            .layout_item_info_at_cross_height(solved_size(cursor)),
+                    };
+                    out_cells.push(info);
+                    cursor += 1;
+                }
+            }
+        }
+    }
+    i_slint_core::layout::box_layout_info_ortho(
+        Slice::from_slice(&out_cells),
+        &to_padding(&eval_expression(ctx, padding_ortho)),
+    )
+    .into()
 }
 
 /// Interpret [`Expression::FlexboxLayoutInfoCrossAxisWithMeasure`]: the

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -1128,6 +1128,26 @@ impl i_slint_core::model::RepeatedItemTree for Instance {
         i_slint_core::layout::LayoutItemInfo { constraint, cross_axis_self_alignment }
     }
 
+    fn layout_item_info_at_cross_width(
+        self: Pin<&Self>,
+        flex_cross_width: f32,
+    ) -> i_slint_core::layout::LayoutItemInfo {
+        self.box_layout_item_info_at_cross(
+            i_slint_core::items::Orientation::Vertical,
+            flex_cross_width,
+        )
+    }
+
+    fn layout_item_info_at_cross_height(
+        self: Pin<&Self>,
+        flex_cross_height: f32,
+    ) -> i_slint_core::layout::LayoutItemInfo {
+        self.box_layout_item_info_at_cross(
+            i_slint_core::items::Orientation::Horizontal,
+            flex_cross_height,
+        )
+    }
+
     fn flexbox_layout_item_info(
         self: Pin<&Self>,
         orientation: i_slint_core::items::Orientation,
@@ -1183,6 +1203,46 @@ impl i_slint_core::model::RepeatedItemTree for Instance {
 }
 
 impl Instance {
+    /// Shared body of the box-layout `layout_item_info_at_cross_width` /
+    /// `_at_cross_height` accessors: measure the instance at the cross size a
+    /// box layout lays it out at. The `cross-axis-self-alignment` only
+    /// matters on the cross-axis pass, so it stays `Auto` here.
+    /// For a flexbox cell the stored expression was built without re-applying
+    /// inherited constraints (see
+    /// `get_layout_info_v_at_cross_width_for_repeated`), so fall back to the
+    /// plain info like the generated Rust and C++ code do.
+    fn box_layout_item_info_at_cross(
+        self: Pin<&Self>,
+        orientation: i_slint_core::items::Orientation,
+        cross_size: f32,
+    ) -> i_slint_core::layout::LayoutItemInfo {
+        use i_slint_compiler::llr::lower_layout_expression::{
+            FLEX_CROSS_HEIGHT_LOCAL, FLEX_CROSS_WIDTH_LOCAL,
+        };
+        let cu = self.root_sub_component.compilation_unit.clone();
+        let sc = &cu.sub_components[self.root_sub_component.sub_component_idx];
+        let (expr, local) = match orientation {
+            i_slint_core::items::Orientation::Vertical => {
+                (sc.layout_info_v_at_cross_width_for_repeated.as_ref(), FLEX_CROSS_WIDTH_LOCAL)
+            }
+            i_slint_core::items::Orientation::Horizontal => {
+                (sc.layout_info_h_at_cross_height_for_repeated.as_ref(), FLEX_CROSS_HEIGHT_LOCAL)
+            }
+        };
+        let Some(expr) = expr.filter(|_| sc.flexbox_layout_item_info_for_repeated.is_none()) else {
+            return i_slint_core::model::RepeatedItemTree::layout_item_info(
+                self,
+                orientation,
+                None,
+            );
+        };
+        let mut ctx = crate::eval::EvalContext::new(self.root_sub_component.clone());
+        ctx.locals.insert(local.into(), crate::Value::Number(cross_size as f64));
+        let constraint =
+            crate::eval::eval_expression(&mut ctx, &expr.borrow()).try_into().unwrap_or_default();
+        i_slint_core::layout::LayoutItemInfo { constraint, ..Default::default() }
+    }
+
     /// Vertical flexbox info for a repeated instance measured at the container
     /// cross width instead of its own preferred width, so a height-for-width
     /// cell wraps to the same height as an equivalent static cell.

--- a/tests/cases/layout/flexbox_pref_probe.slint
+++ b/tests/cases/layout/flexbox_pref_probe.slint
@@ -1,0 +1,48 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Button } from "std-widgets.slint";
+export component TestCase inherits Window {
+    width: 600px;
+    height: 120px;
+    HorizontalLayout {
+        alignment: start;
+        spacing: 24px;
+        padding: 12px;
+        flex1 := FlexboxLayout {
+            flex-direction: column;
+            spacing: 8px;
+            b1 := Button { text: "Portrait"; }
+            b2 := Button { text: "Landscape"; }
+            b3 := Button { text: "Auto"; }
+        }
+        flex2 := FlexboxLayout {
+            flex-direction: row;
+            spacing: 8px;
+            Button { text: "Start"; }
+            Button { text: "Center"; }
+            Button { text: "End"; }
+        }
+    }
+    out property <length> f1_pw: flex1.preferred-width;
+    out property <length> f1_w: flex1.width;
+    out property <length> f1_h: flex1.height;
+    out property <length> b1_x: b1.x;
+    out property <length> b2_x: b2.x;
+    out property <length> b3_x: b3.x;  // if > 0, flex1 wrapped into a 2nd column
+    out property <length> b3_right: b3.x + b3.width; // actual right edge inside flex1
+    out property <length> f2_x: flex2.x;
+    out property <bool> test: true;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+eprintln!("flex1: preferred_w={} assigned_w={} assigned_h={}",
+    instance.get_f1_pw(), instance.get_f1_w(), instance.get_f1_h());
+eprintln!("flex1 buttons x: b1={} b2={} b3={} | b3_right_edge={} | flex2.x={}",
+    instance.get_b1_x(), instance.get_b2_x(), instance.get_b3_x(),
+    instance.get_b3_right(), instance.get_f2_x());
+assert!(instance.get_test());
+```
+*/

--- a/tests/cases/layout/hlayout_height_for_width_cell.slint
+++ b/tests/cases/layout/hlayout_height_for_width_cell.slint
@@ -1,0 +1,234 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A height-for-width cell directly inside a HorizontalLayout row: the row's
+// vertical info at a known width must measure the cell at the width the row
+// assigns to it — whether the cell is static or repeated.
+
+// A wrapping row flex is height-for-width: its 4 boxes of 30px sit in a single
+// 40px-tall line when wide enough, and flow onto a second line (80px tall) at
+// 70px wide. The boxes are numbered so the flow order is visible.
+component WrapRow {
+    FlexboxLayout {
+        flex-direction: row;
+        flex-wrap: wrap;
+        spacing: 0px;
+        padding: 0px;
+        cross-axis-line-alignment: start;
+        Rectangle { width: 30px; height: 40px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "1"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+        Rectangle { width: 30px; height: 40px; background: #a6cbe8; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "2"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+        Rectangle { width: 30px; height: 40px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "3"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+        Rectangle { width: 30px; height: 40px; background: #a6cbe8; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "4"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 700px;
+    // Derived from the content so the visual aids fit at any font size.
+    height: text-repeated-block.y + text-marker.y + 40px;
+
+    property <[int]> empty-model: [];
+
+    // The captions and blocks are chained off each other's actual geometry:
+    // the text heights depend on the font, so fixed positions would overlap.
+    property <length> band-y: cap-a.y + cap-a.height + 8px;
+
+    // Single-line reference for a font-independent line height.
+    ref := Text {
+        x: 640px;
+        y: 4px;
+        text: "Word";
+        color: #555555;
+    }
+
+    legend := Text {
+        x: 8px; y: 4px; width: 620px;
+        font-size: 11px; color: #555555;
+        text: "Each column is a fixed-width VerticalLayout holding one HorizontalLayout row. The row's cell is a wrapping FlexboxLayout (WrapRow) and therefore height-for-width: the flex flows the blue boxes 1-4 onto a second line at the width the row assigns. The magenta outline is the row's reported box — it must contain both flex lines (80px, not the single-line 40px).";
+        wrap: word-wrap;
+    }
+
+    // Each VerticalLayout is 70px wide, so the row assigns 70px to the WrapRow
+    // and its boxes flow onto a second 40px line: the row's height must be
+    // 80px, not the 40px it measures at its preferred (unwrapped) width.
+
+    cap-a := Text { x: 0px; y: legend.y + legend.height + 10px; font-size: 10px; color: #555555; text: "A: static"; }
+    Text { x: 100px; y: cap-a.y; font-size: 10px; color: #555555; text: "B: repeated"; }
+    Text { x: 200px; y: cap-a.y; font-size: 10px; color: #555555; text: "C: 2 repeated ×70px"; }
+    Text { x: 360px; y: cap-a.y; font-size: 10px; color: #555555; text: "D: empty rep. first"; }
+    Text { x: 480px; y: cap-a.y; font-size: 10px; color: #555555; text: "E: rep. first"; }
+
+    // A: static reference.
+    a-band := VerticalLayout {
+        x: 0; y: band-y; width: 70px;
+        alignment: start; padding: 0px; spacing: 0px;
+        static-row := HorizontalLayout {
+            WrapRow { }
+        }
+    }
+
+    // B: repeated height-for-width cell.
+    b-band := VerticalLayout {
+        x: 100px; y: band-y; width: 70px;
+        alignment: start; padding: 0px; spacing: 0px;
+        repeated-row := HorizontalLayout {
+            for x in [1]: WrapRow { }
+        }
+    }
+
+    // C: two repeated instances side by side, each solved at 70px.
+    c-band := VerticalLayout {
+        x: 200px; y: band-y; width: 140px;
+        alignment: start; padding: 0px; spacing: 0px;
+        multi-row := HorizontalLayout {
+            for x in [1, 2]: WrapRow { }
+        }
+    }
+
+    // D: an empty repeater before the static cell must not shift the solved
+    // size the cell is measured at.
+    d-band := VerticalLayout {
+        x: 360px; y: band-y; width: 70px;
+        alignment: start; padding: 0px; spacing: 0px;
+        empty-rep-row := HorizontalLayout {
+            for x in empty-model: Rectangle { width: 0px; height: 0px; }
+            WrapRow { }
+        }
+    }
+
+    // E: a repeater instance before the static cell offsets its cell index.
+    e-band := VerticalLayout {
+        x: 480px; y: band-y; width: 100px;
+        alignment: start; padding: 0px; spacing: 0px;
+        offset-row := HorizontalLayout {
+            for x in [1]: Rectangle { width: 30px; height: 5px; background: #dcdcdc; border-width: 1px; border-color: #a0a0a0; }
+            WrapRow { }
+        }
+    }
+
+    // Outlines of the rows' reported boxes (display only).
+    Rectangle { x: a-band.x + static-row.x; y: a-band.y + static-row.y; width: static-row.width; height: static-row.height;
+        border-color: #f0f; border-width: 1px; }
+    Rectangle { x: b-band.x + repeated-row.x; y: b-band.y + repeated-row.y; width: repeated-row.width; height: repeated-row.height;
+        border-color: #f0f; border-width: 1px; }
+    Rectangle { x: c-band.x + multi-row.x; y: c-band.y + multi-row.y; width: multi-row.width; height: multi-row.height;
+        border-color: #f0f; border-width: 1px; }
+    Rectangle { x: d-band.x + empty-rep-row.x; y: d-band.y + empty-rep-row.y; width: empty-rep-row.width; height: empty-rep-row.height;
+        border-color: #f0f; border-width: 1px; }
+    Rectangle { x: e-band.x + offset-row.x; y: e-band.y + offset-row.y; width: offset-row.width; height: offset-row.height;
+        border-color: #f0f; border-width: 1px; }
+
+    // F: the repeated-row-with-repeated-cell table shape of issue #12776. The
+    // repeated row is measured through the repeated-instance accessor at the
+    // VerticalLayout's content width, and its own repeated word-wrapped Text
+    // cell at the width the row's solve assigns. Unlike the flex-based
+    // WrapRow, a Text's info is measured at its preferred width unless the
+    // row forwards the solved width, so a fallback to the plain layout info
+    // yields a single-line height and the repeated row comes out shorter
+    // than the static one.
+    cap-f := Text {
+        x: 0px; y: band-y + 110px; width: 620px;
+        font-size: 11px; color: #555555;
+        text: "F: table shape of issue #12776 — static row (left) vs repeated row with repeated wrapped-text cell (right). The blue end bars must line up: a too-short repeated row pulls the right bar up into the text.";
+        wrap: word-wrap;
+    }
+    text-static-block := VerticalLayout {
+        x: 0; y: cap-f.y + cap-f.height + 8px; width: 300px;
+        height: 150px + ref.height * 15;
+        alignment: start; padding: 0px; spacing: 0px;
+        text-static-row := HorizontalLayout {
+            Rectangle { width: 90px; background: #dcdcdc; border-width: 1px; border-color: #a0a0a0;
+                Text { x: 0px; width: 100%; height: 100%; text: "90px"; font-size: 10px; color: #333333;
+                    horizontal-alignment: center; vertical-alignment: center; } }
+            VerticalLayout {
+                padding: 0px;
+                wrap-static := Text {
+                    color: #003366;
+                    text: "A long wrapped cell: the quick brown fox jumps over the lazy dog again and again, until this text clearly needs several lines at the cell's final width.";
+                    wrap: word-wrap;
+                }
+            }
+        }
+        Rectangle { height: 5px; background: #5b8db8; }
+    }
+    text-repeated-block := VerticalLayout {
+        x: 320px; y: text-static-block.y; width: 300px;
+        height: text-static-block.height;
+        alignment: start; padding: 0px; spacing: 0px;
+        for x in [1]: HorizontalLayout {
+            Rectangle { width: 90px; background: #dcdcdc; border-width: 1px; border-color: #a0a0a0;
+                Text { x: 0px; width: 100%; height: 100%; text: "90px"; font-size: 10px; color: #333333;
+                    horizontal-alignment: center; vertical-alignment: center; } }
+            for y in [1]: VerticalLayout {
+                padding: 0px;
+                Text {
+                    color: #003366;
+                    text: "A long wrapped cell: the quick brown fox jumps over the lazy dog again and again, until this text clearly needs several lines at the cell's final width.";
+                    wrap: word-wrap;
+                }
+            }
+        }
+        text-marker := Rectangle { height: 5px; background: #5b8db8; }
+    }
+    Rectangle { x: text-static-block.x + text-static-row.x; y: text-static-block.y + text-static-row.y;
+        width: text-static-row.width; height: text-static-row.height;
+        border-color: #f0f; border-width: 1px; }
+
+    // The reference cell really wrapped (80px, not 40px), otherwise the
+    // equalities below would hold trivially.
+    out property <bool> wrapped: static-row.height > 60px;
+    out property <bool> repeated-ok: abs(repeated-row.height - static-row.height) < 1px;
+    out property <bool> multi-ok: abs(multi-row.height - static-row.height) < 1px;
+    out property <bool> empty-ok: abs(empty-rep-row.height - static-row.height) < 1px;
+    out property <bool> offset-ok: abs(offset-row.height - static-row.height) < 1px;
+    // The static text row wrapped, and the repeated row (whose height is the
+    // marker position: single row, alignment start, no spacing) matches it.
+    out property <bool> text-wraps: text-static-row.height >= 2 * ref.height;
+    out property <bool> text-repeated-ok: abs(text-marker.y - text-static-row.height) < 1px;
+
+    out property <bool> test: wrapped && repeated-ok && multi-ok && empty-ok && offset-ok
+        && text-wraps && text-repeated-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_wrapped(), "reference cell did not wrap");
+assert!(instance.get_repeated_ok(), "repeated height-for-width cell not measured at its solved width");
+assert!(instance.get_multi_ok(), "second repeated height-for-width instance not measured at its solved width");
+assert!(instance.get_empty_ok(), "empty repeater shifted the static height-for-width cell index");
+assert!(instance.get_offset_ok(), "static height-for-width cell after a repeater not measured at its solved width");
+assert!(instance.get_text_wraps(), "static text row did not wrap");
+assert!(instance.get_text_repeated_ok(), "repeated wrapped-text cell not measured at its solved width");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_wrapped());
+assert(instance.get_repeated_ok());
+assert(instance.get_multi_ok());
+assert(instance.get_empty_ok());
+assert(instance.get_offset_ok());
+assert(instance.get_text_wraps());
+assert(instance.get_text_repeated_ok());
+```
+
+```js
+// The text-based properties are left out: nodejs has no test fonts.
+var instance = new slint.TestCase({});
+assert(instance.wrapped);
+assert(instance.repeated_ok);
+assert(instance.multi_ok);
+assert(instance.empty_ok);
+assert(instance.offset_ok);
+```
+*/

--- a/tests/cases/layout/vlayout_width_for_height_cell.slint
+++ b/tests/cases/layout/vlayout_width_for_height_cell.slint
@@ -1,0 +1,160 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Width-for-height cells in box layouts, the mirror of
+// hlayout_height_for_width_cell.slint: a VerticalLayout's horizontal info at a
+// known height must measure each cell at the height the layout assigns to it,
+// and a HorizontalLayout must measure its width-for-height cells at the
+// layout's own height — for static and repeated cells alike.
+
+// A wrapping column flex is width-for-height: its 4 boxes of 30px stack into a
+// single 40px-wide column when tall enough, and flow into a second column
+// (80px wide) at 70px. The boxes are numbered so the flow order is visible.
+component WrapCol {
+    FlexboxLayout {
+        flex-direction: column;
+        flex-wrap: wrap;
+        spacing: 0px;
+        padding: 0px;
+        cross-axis-line-alignment: start;
+        Rectangle { width: 40px; height: 30px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "1"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+        Rectangle { width: 40px; height: 30px; background: #a6cbe8; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "2"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+        Rectangle { width: 40px; height: 30px; background: #cce6ff; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "3"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+        Rectangle { width: 40px; height: 30px; background: #a6cbe8; border-width: 1px; border-color: #5b8db8;
+            Text { x: 0px; width: 100%; height: 100%; text: "4"; font-size: 10px; color: #003366;
+                horizontal-alignment: center; vertical-alignment: center; } }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 800px;
+    // Derived from the content so the visual aids fit at any font size.
+    height: d-band.y + d-band.height + 30px;
+
+    // The captions and bands are chained off each other's actual geometry:
+    // the text heights depend on the font, so fixed positions would overlap.
+    property <length> band-y: cap-c.y + cap-c.height + 8px;
+
+    legend := Text {
+        x: 8px; y: 4px; width: 784px;
+        font-size: 11px; color: #555555;
+        text: "Each cell is a wrapping column FlexboxLayout (WrapCol) and therefore width-for-height: the flex flows the blue boxes 1-4 into a second column at the height the box layout assigns (70px → two columns, 80px wide). The blue bar is an anchor sitting right after the measured cells, the magenta outline a reported box: both must sit at 80px per WrapCol, not the single-column 40px.";
+        wrap: word-wrap;
+    }
+
+    // A and B: a VerticalLayout of two 70px-tall WrapCol cells. Its horizontal
+    // info at the known 140px height must measure each cell at its assigned
+    // 70px height (wrapped: 80px wide), not at the whole height (40px wide).
+
+    Text { x: 0px; y: cap-c.y; width: 200px; font-size: 10px; color: #555555; text: "A: static (reference)"; }
+    Text { x: 210px; y: cap-c.y; width: 200px; font-size: 10px; color: #555555; text: "B: repeated"; }
+    cap-c := Text { x: 430px; y: legend.y + legend.height + 10px; width: 340px; font-size: 10px; color: #555555; wrap: word-wrap;
+        text: "C: HorizontalLayout solve — static (top) vs repeated (bottom): the blue bars must sit at the same x"; }
+
+    // A: static cells. (The anchor also keeps the row from being optimized
+    // into a single-cell layout without a solve.)
+    a-band := HorizontalLayout {
+        x: 0; y: band-y; width: 200px; height: 140px;
+        alignment: start; padding: 0px; spacing: 0px;
+        static-col := VerticalLayout {
+            padding: 0px; spacing: 0px;
+            WrapCol { min-height: 70px; max-height: 70px; }
+            WrapCol { min-height: 70px; max-height: 70px; }
+        }
+        Rectangle { width: 5px; background: #5b8db8; }
+    }
+
+    // B: repeated cells.
+    b-band := HorizontalLayout {
+        x: 210px; y: band-y; width: 200px; height: 140px;
+        alignment: start; padding: 0px; spacing: 0px;
+        repeated-col := VerticalLayout {
+            padding: 0px; spacing: 0px;
+            for x in [1, 2]: WrapCol { min-height: 70px; max-height: 70px; }
+        }
+        Rectangle { width: 5px; background: #5b8db8; }
+    }
+
+    // C: a HorizontalLayout's own solve measures a repeated width-for-height
+    // cell at the layout's content height, like the static reference.
+    HorizontalLayout {
+        x: 430px; y: band-y; width: 300px; height: 70px;
+        alignment: start; padding: 0px; spacing: 0px;
+        WrapCol { min-height: 70px; max-height: 70px; }
+        static-anchor := Rectangle { width: 5px; background: #5b8db8; }
+    }
+    HorizontalLayout {
+        x: 430px; y: band-y + 80px; width: 300px; height: 70px;
+        alignment: start; padding: 0px; spacing: 0px;
+        for x in [1]: WrapCol { min-height: 70px; max-height: 70px; }
+        repeated-anchor := Rectangle { width: 5px; background: #5b8db8; }
+    }
+
+    // D: the outer row queries the inner row's horizontal info at the known
+    // height (the info path rather than the solve path).
+    cap-d := Text { x: 0px; y: band-y + 165px; width: 400px; font-size: 10px; color: #555555;
+        text: "D: nested row queried on the info path — reported box around both cells"; wrap: word-wrap; }
+    d-band := HorizontalLayout {
+        x: 0; y: cap-d.y + cap-d.height + 8px; width: 400px; height: 70px;
+        alignment: start; padding: 0px; spacing: 0px;
+        inner-row := HorizontalLayout {
+            padding: 0px; spacing: 0px;
+            for x in [1, 2]: WrapCol { min-height: 70px; max-height: 70px; }
+        }
+        Rectangle { width: 5px; background: #5b8db8; }
+    }
+
+    // Outlines of the reported boxes the assertions check (display only).
+    Rectangle { x: a-band.x + static-col.x; y: a-band.y + static-col.y; width: static-col.width; height: static-col.height;
+        border-color: #f0f; border-width: 1px; }
+    Rectangle { x: b-band.x + repeated-col.x; y: b-band.y + repeated-col.y; width: repeated-col.width; height: repeated-col.height;
+        border-color: #f0f; border-width: 1px; }
+    Rectangle { x: d-band.x + inner-row.x; y: d-band.y + inner-row.y; width: inner-row.width; height: inner-row.height;
+        border-color: #f0f; border-width: 1px; }
+
+    // The reference cell really wrapped into two columns (80px, not 40px).
+    out property <bool> wrapped: static-anchor.x > 60px;
+    out property <bool> ortho-static-ok: abs(static-col.width - static-anchor.x) < 1px;
+    out property <bool> ortho-repeated-ok: abs(repeated-col.width - static-anchor.x) < 1px;
+    out property <bool> solve-repeated-ok: abs(repeated-anchor.x - static-anchor.x) < 1px;
+    out property <bool> info-nested-ok: abs(inner-row.width - 2 * static-anchor.x) < 1px;
+
+    out property <bool> test: wrapped && ortho-static-ok && ortho-repeated-ok
+        && solve-repeated-ok && info-nested-ok;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_wrapped(), "reference cell did not wrap");
+assert!(instance.get_ortho_static_ok(), "static width-for-height cell not measured at its assigned height");
+assert!(instance.get_ortho_repeated_ok(), "repeated width-for-height cell not measured at its assigned height");
+assert!(instance.get_solve_repeated_ok(), "repeated width-for-height cell not measured at the layout height in the solve");
+assert!(instance.get_info_nested_ok(), "repeated width-for-height cell not measured at the layout height in the info path");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_wrapped());
+assert(instance.get_ortho_static_ok());
+assert(instance.get_ortho_repeated_ok());
+assert(instance.get_solve_repeated_ok());
+assert(instance.get_info_nested_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.wrapped);
+assert(instance.ortho_static_ok);
+assert(instance.ortho_repeated_ok);
+assert(instance.solve_repeated_ok);
+assert(instance.info_nested_ok);
+```
+*/

--- a/tests/cases/layout/vlayout_wrapped_text_row_height.slint
+++ b/tests/cases/layout/vlayout_wrapped_text_row_height.slint
@@ -1,0 +1,255 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Issue #12776: in a VerticalLayout of HorizontalLayout rows (the table-row
+// shape), each row's height must be enough for the height its word-wrapped
+// Text needs at the width the row actually assigns to the cell — not the
+// height at whatever width the text had when the constraint was computed.
+//
+// Reading the rendered window: three table blocks, each a caption plus rows of
+// [gray 90phx label column | blue wrapped-text cell]. A too-short row makes
+// the text paint over the next row, and in the repeated blocks it pulls the
+// blue end bar up into the text.
+
+component TableRow inherits HorizontalLayout {
+    in property <string> detail;
+    spacing: 2px;
+    Rectangle {
+        width: 90phx;
+        background: #dcdcdc;
+        border-width: 1px;
+        border-color: #a0a0a0;
+        Text { x: 0px; width: 100%; height: 100%; text: "90phx"; font-size: 10px; color: #333333;
+            horizontal-alignment: center; vertical-alignment: center; }
+    }
+    Rectangle {
+        background: #cce6ff;
+        border-width: 1px;
+        border-color: #5b8db8;
+        VerticalLayout {
+            padding: 8px;
+            Text {
+                text: detail;
+                wrap: word-wrap;
+                color: #003366;
+            }
+        }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 820phx;
+    // Derived from the content so the blocks fit at any font size. Two
+    // columns: static + repeated rows on the left, the TableRow block on the
+    // right.
+    height: max(repeated-rows.y + marker.y + marker.height, component-rows.y + marker2.y + marker2.height) + 40px;
+
+    // Single-line reference for a font-independent line height.
+    ref := Text {
+        x: 300phx;
+        y: 0;
+        text: "Word";
+        color: #555555;
+    }
+
+    // The captions and blocks are chained off each other's actual geometry:
+    // the row heights depend on the font, so fixed positions would overlap.
+    cap1 := Text { x: 4phx; y: 2phx; width: 290phx; font-size: 11px; color: #555555;
+        text: "static rows (row 3: bare text, no wrapper cell)"; wrap: word-wrap; }
+    static-block := VerticalLayout {
+        x: 0;
+        y: cap1.y + cap1.height + 6px;
+        width: 400phx;
+        height: 100px + ref.height * 25;
+        alignment: start;
+        padding: 12px;
+        spacing: 2px;
+
+        row1 := HorizontalLayout {
+            spacing: 2px;
+            Rectangle {
+                width: 90phx;
+                background: #dcdcdc;
+                border-width: 1px;
+                border-color: #a0a0a0;
+                Text { x: 0px; width: 100%; height: 100%; text: "90phx"; font-size: 10px; color: #333333;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 8px;
+                    text1 := Text {
+                        text: "A long wrapped cell: the quick brown fox jumps over the lazy dog again and again and again, until this text clearly needs three or more lines at the second column's final width.";
+                        wrap: word-wrap;
+                        color: #003366;
+                    }
+                }
+            }
+        }
+        row2 := HorizontalLayout {
+            spacing: 2px;
+            Rectangle {
+                width: 90phx;
+                background: #dcdcdc;
+                border-width: 1px;
+                border-color: #a0a0a0;
+                Text { x: 0px; width: 100%; height: 100%; text: "90phx"; font-size: 10px; color: #333333;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 8px;
+                    text2 := Text {
+                        text: "Second row, shorter text.";
+                        wrap: word-wrap;
+                        color: #003366;
+                    }
+                }
+            }
+        }
+        // A wrapped Text directly in the row, without a wrapper cell.
+        row3 := HorizontalLayout {
+            spacing: 2px;
+            Rectangle {
+                width: 90phx;
+                background: #dcdcdc;
+                border-width: 1px;
+                border-color: #a0a0a0;
+                Text { x: 0px; width: 100%; height: 100%; text: "90phx"; font-size: 10px; color: #333333;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            text3 := Text {
+                text: "Third row, long enough to check that a bare wrapped text cell also gets enough height: pack my box with five dozen liquor jugs, and then a few words more.";
+                wrap: word-wrap;
+                color: #003366;
+            }
+        }
+    }
+
+    // The same table-row shape as above, but with repeated rows like in the
+    // repro of issue #12776: all rows use the same long text, so each repeated row
+    // must get the same height as the equivalent static row above it.
+    cap2 := Text { x: 4phx; y: static-block.y + row3.y + row3.height + 24px; width: 390phx; font-size: 11px; color: #555555;
+        text: "repeated rows (#12776): 3 repeated rows below the static one, all the same height — the blue end bar must sit at 4 × row height"; wrap: word-wrap; }
+    repeated-rows := VerticalLayout {
+        x: 0;
+        y: cap2.y + cap2.height + 6px;
+        width: 400phx;
+        height: 100px + ref.height * 40;
+        alignment: start;
+        padding: 12px;
+        spacing: 2px;
+
+        static-row := HorizontalLayout {
+            spacing: 2px;
+            Rectangle {
+                width: 90phx;
+                background: #dcdcdc;
+                border-width: 1px;
+                border-color: #a0a0a0;
+                Text { x: 0px; width: 100%; height: 100%; text: "90phx"; font-size: 10px; color: #333333;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 8px;
+                    static-text := Text {
+                        text: "A long wrapped cell: the quick brown fox jumps over the lazy dog again and again and again, until this text clearly needs three or more lines at the second column's final width.";
+                        wrap: word-wrap;
+                        color: #003366;
+                    }
+                }
+            }
+        }
+        for i in 3: HorizontalLayout {
+            spacing: 2px;
+            Rectangle {
+                width: 90phx;
+                background: #dcdcdc;
+                border-width: 1px;
+                border-color: #a0a0a0;
+                Text { x: 0px; width: 100%; height: 100%; text: "90phx"; font-size: 10px; color: #333333;
+                    horizontal-alignment: center; vertical-alignment: center; }
+            }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 8px;
+                    Text {
+                        text: "A long wrapped cell: the quick brown fox jumps over the lazy dog again and again and again, until this text clearly needs three or more lines at the second column's final width.";
+                        wrap: word-wrap;
+                        color: #003366;
+                    }
+                }
+            }
+        }
+        marker := Rectangle { height: 10phx; background: #5b8db8; }
+    }
+
+    // The same, with the row behind a component (a different dispatch path
+    // for the repeated instances' layout info).
+    cap3 := Text { x: 424phx; y: 2phx; width: 390phx; font-size: 11px; color: #555555;
+        text: "rows behind a component (TableRow): same, different dispatch path"; wrap: word-wrap; }
+    component-rows := VerticalLayout {
+        x: 420phx;
+        y: cap3.y + cap3.height + 6px;
+        width: 400phx;
+        height: 100px + ref.height * 40;
+        alignment: start;
+        padding: 12px;
+        spacing: 2px;
+
+        static-comp-row := TableRow {
+            detail: "A long wrapped cell: the quick brown fox jumps over the lazy dog again and again and again, until this text clearly needs three or more lines at the second column's final width.";
+        }
+        for i in 3: TableRow {
+            detail: "A long wrapped cell: the quick brown fox jumps over the lazy dog again and again and again, until this text clearly needs three or more lines at the second column's final width.";
+        }
+        marker2 := Rectangle { height: 10phx; background: #5b8db8; }
+    }
+
+    // Sanity: the wrapped texts do wrap at the cell width.
+    out property <bool> test-wraps: text1.preferred-height >= 2 * ref.height && text3.preferred-height >= 2 * ref.height;
+    // Each row must be tall enough for its wrapped text plus the cell padding.
+    out property <bool> test-row1: row1.height >= text1.preferred-height + 16px;
+    out property <bool> test-row2: row2.height >= text2.preferred-height + 16px;
+    out property <bool> test-row3: row3.height >= text3.preferred-height;
+    // The text items themselves get at least the height they need to paint.
+    out property <bool> test-texts-fit: text1.height >= text1.preferred-height && text3.height >= text3.preferred-height;
+    // Each of the 3 repeated rows must be as tall as the identical static row:
+    // marker.y == top padding + 4 rows + 4 spacings. Compare with a tolerance:
+    // the marker position accumulates the row heights one by one, which is not
+    // bit-identical to the multiplication for a fractional row height.
+    out property <bool> test-repeated-rows: abs((marker.y - static-row.y) - 4 * (static-row.height + 2px)) < 1px;
+    out property <bool> test-component-rows: abs((marker2.y - static-comp-row.y) - 4 * (static-comp-row.height + 2px)) < 1px && abs(static-comp-row.height - static-row.height) < 1px;
+
+    out property <bool> test: test-wraps && test-row1 && test-row2 && test-row3 && test-texts-fit && test-repeated-rows && test-component-rows;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
Fixes #12776: in a `VerticalLayout` of `HorizontalLayout` rows (the
table-row shape), a repeated row's height was measured at the row's
preferred width — a single line — instead of the width the layout
assigns, so wrapped cells painted over the next row.

Reuse the flexbox solution for box layouts:
- a box layout's main-axis pass measures repeated cells through new
  `layout_item_info_at_cross_width` / `_at_cross_height accessors`, backed
  by the same `layout_info_{v,h}_at_cross_*_for_repeated` expressions as
  flexbox cells; both accessors are generated, because the cross-axis
  pass below queries the axis orthogonal to the parent's orientation
- a box layout's cross-axis info at a known main-axis size solves the
  main axis at that size and measures each height-for-width (resp.
  width-for-height) cell at its solved size
  (`BoxLayoutInfoOrthoWithMeasure`), instead of feeding every cell the
  whole size

<img width="700" height="366" alt="hlayout_height_for_width_cell" src="https://github.com/user-attachments/assets/483c9345-b88b-4f4e-86dd-2fbc3d349279" />
<img width="800" height="382" alt="vlayout_width_for_height_cell" src="https://github.com/user-attachments/assets/c82292fa-1604-442b-b4d7-4f941424dd7f" />
<img width="820" height="678" alt="vlayout_wrapped_text_row_height" src="https://github.com/user-attachments/assets/22c6f034-e7ed-4939-9187-3d2989f3cde8" />


A followup PR will rename `flex_cross_*` to `cross_*` now that it's not flex specific
(kept separate to make reviewing this one easier)

Another one will take care of grid layouts...