### PR TITLE
Add a custom-titlebar example 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ These examples demonstrate the main features of Slint and how to use them in dif
 | [7GUIs![7 GUI's demo image](https://user-images.githubusercontent.com/22800467/169002497-5b90e63b-5717-4290-8ac7-c618d9e2a4f1.png "7 GUI's demo image")](./7guis/) | Our implementations of the ["7GUIs"](https://7guis.github.io/7guis/) Tasks. <br/> [Project...](./7guis/) |  |
 | [Slint & Bevy![Bevy demo image](https://github.com/user-attachments/assets/69785864-b6ae-40e1-8f62-4f70677d930e "Bevy demo image")](./bevy/slint-hosts-bevy/) | A demo that shows how to embed [Bevy](https://bevyengine.org) into Slint <br/> [Project...](./bevy/slint-hosts-bevy) |  |
 | [Bevy & Slint![Bevy demo image](https://github.com/user-attachments/assets/47671596-36df-4b3b-b316-a5e1c9475050 "Bevy demo image")](./bevy/bevy-hosts-slint/) | A demo that shows how to embed Slint into [Bevy](https://bevyengine.org) <br/> [Project...](./bevy/bevy-hosts-slint) |  |
+| [Custom Title Bar![Custom title bar demo image](https://github.com/user-attachments/assets/eaaf24d4-892e-49b0-aef7-6271df05f7d4 "Custom title bar demo image")](./custom-titlebar/) | A frameless window with a custom title bar: move, resize, minimize, maximize, and close. <br/> [Project...](./custom-titlebar) |  |
 
 ### Additional Examples
 

--- a/examples/custom-titlebar/README.md
+++ b/examples/custom-titlebar/README.md
@@ -1,0 +1,23 @@
+# Custom Title Bar
+
+A frameless window (`no-frame: true`) with rounded corners and a fully custom title bar,
+all built from ordinary Slint elements: drag the bar to move the window (`WindowMoveArea`), drag the window
+edges to resize it (`resize-border-width`), double-click the bar to maximize, and use the minimize / maximize /
+close buttons.
+
+The window background is transparent so the rounded corners show through, and the corners square off while the
+window is maximized, like native decorations do.
+
+![Screenshot of the custom title bar example](https://github.com/user-attachments/assets/eaaf24d4-892e-49b0-aef7-6271df05f7d4 "Custom Title Bar")
+
+Run it natively to see the real window behavior:
+
+```sh
+cargo run -p slint-viewer -- examples/custom-titlebar/custom-titlebar.slint
+```
+
+Moving the window requires a backend and platform with support for it (winit on Windows, macOS, X11, and Wayland;
+Qt), and `resize-border-width` is winit-only for now. In the browser preview the window-management features do
+nothing.
+
+[Online code editor](https://slint.dev/snapshots/master/editor/index.html?load_url=https://raw.githubusercontent.com/slint-ui/slint/master/examples/custom-titlebar/custom-titlebar.slint)

--- a/examples/custom-titlebar/custom-titlebar.slint
+++ b/examples/custom-titlebar/custom-titlebar.slint
@@ -1,0 +1,153 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+import { Palette } from "std-widgets.slint";
+
+component TitleBarButton inherits Rectangle {
+    /// The button's icon as SVG path commands in a 10x10 view box.
+    in property <string> icon-commands;
+    in property <color> hover-background: #ffffff26;
+    in property <string> label;
+    callback clicked;
+
+    width: 44px;
+    background: touch.has-hover ? root.hover-background : transparent;
+    animate background { duration: 150ms; }
+
+    accessible-role: button;
+    accessible-label: root.label;
+    accessible-action-default => { root.clicked(); }
+
+    touch := TouchArea {
+        clicked => {
+            root.clicked();
+        }
+    }
+
+    Path {
+        commands: root.icon-commands;
+        stroke: white;
+        stroke-width: 1px;
+        viewbox-width: 10;
+        viewbox-height: 10;
+        width: 10px;
+        height: 10px;
+    }
+}
+
+export component MainWindow inherits Window {
+    title: "Custom title bar";
+    no-frame: true;
+    background: transparent;
+    preferred-width: 520px;
+    preferred-height: 380px;
+    min-width: 320px;
+    min-height: 200px;
+
+    // Squared off when maximized, like native window decorations.
+    property <length> corner-radius: root.maximized ? 0px : 12px;
+
+    resize-border-width: root.maximized ? 0px : 6px;
+
+    Rectangle {
+        background: Palette.background;
+        border-radius: root.corner-radius;
+        border-width: 1phx;
+        border-color: Palette.border;
+
+        VerticalLayout {
+            Rectangle {
+                height: 40px;
+                background: @linear-gradient(180deg, #37373c 0%, #2a2a2e 100%);
+                border-top-left-radius: root.corner-radius;
+                border-top-right-radius: root.corner-radius;
+                // Keep the hover highlights inside the rounded corners.
+                clip: true;
+
+                accessible-role: window-title-bar;
+                accessible-label: root.title;
+
+                WindowMoveArea {
+                    // Before the buttons so they stay on top.
+                    TouchArea {
+                        double-clicked => {
+                            root.maximized = !root.maximized;
+                        }
+                    }
+
+                    HorizontalLayout {
+                        padding-left: 14px;
+                        spacing: 10px;
+
+                        Image {
+                            source: @image-url("../../logo/slint-logo-small-dark.svg");
+                            width: 16px;
+                            height: 16px;
+                            cross-axis-self-alignment: center;
+                        }
+
+                        Text {
+                            text: root.title;
+                            color: white;
+                            vertical-alignment: center;
+                        }
+
+                        // Spacer pushing the buttons to the right.
+                        Rectangle { }
+
+                        // Half-pixel coordinates keep the 1px strokes crisp.
+                        TitleBarButton {
+                            label: "Minimize";
+                            icon-commands: "M 0.5 5.5 L 9.5 5.5";
+                            clicked => {
+                                root.minimized = true;
+                            }
+                        }
+
+                        TitleBarButton {
+                            label: root.maximized ? "Restore" : "Maximize";
+                            icon-commands: root.maximized
+                                ? "M 0.5 3.5 L 6.5 3.5 L 6.5 9.5 L 0.5 9.5 Z M 2.5 3.5 L 2.5 0.5 L 9.5 0.5 L 9.5 7.5 L 6.5 7.5"
+                                : "M 0.5 0.5 L 9.5 0.5 L 9.5 9.5 L 0.5 9.5 Z";
+                            clicked => {
+                                root.maximized = !root.maximized;
+                            }
+                        }
+
+                        TitleBarButton {
+                            label: "Close";
+                            hover-background: #e81123;
+                            icon-commands: "M 0.5 0.5 L 9.5 9.5 M 9.5 0.5 L 0.5 9.5";
+                            clicked => {
+                                root.close();
+                            }
+                        }
+                    }
+                }
+            }
+
+            VerticalLayout {
+                padding: 32px;
+                spacing: 12px;
+
+                Rectangle { }
+
+                Text {
+                    text: "This window has no native frame";
+                    font-size: 1.3rem;
+                    font-weight: 600;
+                    horizontal-alignment: center;
+                }
+
+                Text {
+                    text: "The title bar and rounded corners above are ordinary Slint UI. Drag the title bar to move the window, drag the edges to resize it, and double-click the title bar to maximize.";
+                    color: Palette.foreground.transparentize(0.4);
+                    wrap: word-wrap;
+                    horizontal-alignment: center;
+                }
+
+                Rectangle { }
+            }
+        }
+    }
+}

--- a/internal/backends/qt/qt_accessible.rs
+++ b/internal/backends/qt/qt_accessible.rs
@@ -338,6 +338,7 @@ cpp! {{
                     i_slint_core::items::AccessibleRole::Image => QAccessible_Role_Graphic,
                     i_slint_core::items::AccessibleRole::RadioButton => QAccessible_Role_RadioButton,
                     i_slint_core::items::AccessibleRole::RadioGroup => QAccessible_Role_Grouping,
+                    i_slint_core::items::AccessibleRole::WindowTitleBar => QAccessible_Role_TitleBar,
                     i_slint_core::items::AccessibleRole::Banner => QAccessible_Role_Section,
                     i_slint_core::items::AccessibleRole::Complementary => QAccessible_Role_ComplementaryContent,
                     i_slint_core::items::AccessibleRole::ContentInfo => QAccessible_Role_Footer,

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -687,6 +687,9 @@ pub(crate) fn convert_to_proto_accessible_role(
         i_slint_core::items::AccessibleRole::Image => proto::AccessibleRole::Image,
         i_slint_core::items::AccessibleRole::RadioButton => proto::AccessibleRole::RadioButton,
         i_slint_core::items::AccessibleRole::RadioGroup => proto::AccessibleRole::RadioGroup,
+        i_slint_core::items::AccessibleRole::WindowTitleBar => {
+            proto::AccessibleRole::WindowTitleBar
+        }
         i_slint_core::items::AccessibleRole::Banner => proto::AccessibleRole::Banner,
         i_slint_core::items::AccessibleRole::Complementary => proto::AccessibleRole::Complementary,
         i_slint_core::items::AccessibleRole::ContentInfo => proto::AccessibleRole::ContentInfo,
@@ -737,6 +740,9 @@ pub(crate) fn convert_from_proto_accessible_role(
         proto::AccessibleRole::Image => i_slint_core::items::AccessibleRole::Image,
         proto::AccessibleRole::RadioButton => i_slint_core::items::AccessibleRole::RadioButton,
         proto::AccessibleRole::RadioGroup => i_slint_core::items::AccessibleRole::RadioGroup,
+        proto::AccessibleRole::WindowTitleBar => {
+            i_slint_core::items::AccessibleRole::WindowTitleBar
+        }
         proto::AccessibleRole::Banner => i_slint_core::items::AccessibleRole::Banner,
         proto::AccessibleRole::Complementary => i_slint_core::items::AccessibleRole::Complementary,
         proto::AccessibleRole::ContentInfo => i_slint_core::items::AccessibleRole::ContentInfo,

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -158,6 +158,7 @@ enum AccessibleRole {
     Navigation = 26;
     Region = 27;
     Search = 28;
+    WindowTitleBar = 29;
 }
 
 enum RecordedEventResult {

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -731,6 +731,7 @@ impl NodeCollection {
                     i_slint_core::items::AccessibleRole::Image => Role::Image,
                     i_slint_core::items::AccessibleRole::RadioButton => Role::RadioButton,
                     i_slint_core::items::AccessibleRole::RadioGroup => Role::RadioGroup,
+                    i_slint_core::items::AccessibleRole::WindowTitleBar => Role::TitleBar,
                     i_slint_core::items::AccessibleRole::Banner => Role::Banner,
                     i_slint_core::items::AccessibleRole::Complementary => Role::Complementary,
                     i_slint_core::items::AccessibleRole::ContentInfo => Role::ContentInfo,

--- a/internal/backends/winit/drag_resize_window.rs
+++ b/internal/backends/winit/drag_resize_window.rs
@@ -2,15 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 // cSpell: ignore xdir ydir
+use i_slint_core::lengths::LogicalLength;
 use winit::window::{CursorIcon, ResizeDirection};
 
 pub fn handle_cursor_move_for_resize(
     window: &winit::window::Window,
     position: winit::dpi::PhysicalPosition<f64>,
     current_direction: Option<ResizeDirection>,
-    border_size: f64,
+    border_width: LogicalLength,
 ) -> Option<ResizeDirection> {
     if !window.is_decorated() && window.is_resizable() {
+        let border_size = f64::from(border_width.get()) * window.scale_factor();
         let location = get_resize_direction(window.inner_size(), position, border_size);
 
         if current_direction != location {

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1387,7 +1387,7 @@ impl WinitWindowAdapter {
                     self.current_resize_direction.get(),
                     runtime_window
                         .window_item()
-                        .map_or(0_f64, |w| w.as_pin_ref().resize_border_width().get().into()),
+                        .map_or(Default::default(), |w| w.as_pin_ref().resize_border_width()),
                 ));
                 let position = position.to_logical(runtime_window.scale_factor() as f64);
                 let cursor_pos = euclid::point2(position.x, position.y);

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -519,6 +519,9 @@ macro_rules! for_each_enums {
                 RadioButton,
                 /// The element is a container grouping related `RadioButton`s.
                 RadioGroup,
+                /// The element is a window title bar, typically containing the window title and controls
+                /// such as minimize, maximize, and close.
+                WindowTitleBar,
                 // Landmark roles
                 /// Landmark: the header area of the application, typically containing a logo, title, or global navigation.
                 Banner,

--- a/tests/driver/interpreter/build.rs
+++ b/tests/driver/interpreter/build.rs
@@ -24,6 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ("example_bash_sysinfo", "examples/bash/sysinfo.slint"),
         ("example_carousel", "examples/carousel/ui/carousel_demo.slint"),
         ("example_iot_dashboard", "examples/iot-dashboard/main.slint"),
+        ("example_custom_titlebar", "examples/custom-titlebar/custom-titlebar.slint"),
         ("example_dial", "examples/dial/dial.slint"),
         ("example_sprite_sheet", "examples/sprite-sheet/demo.slint"),
         ("example_fancy_switches", "examples/fancy-switches/demo.slint"),


### PR DESCRIPTION
A frameless window with a custom title bar demonstrating the new
WindowMoveArea element together with resize-border-width, maximized,
minimized, and close().


<img width="837" height="635" alt="image" src="https://github.com/user-attachments/assets/344b3127-0e45-4e04-9695-6af40e351a62" />

---

Also contains a winit fix for the resizing border.