### PR TITLE
slint-viewer: show the file name in the window title

### DIFF
--- a/api/cpp/include/slint.h
+++ b/api/cpp/include/slint.h
@@ -432,6 +432,13 @@ inline SharedString decimal_separator()
     return out;
 }
 
+inline SharedString default_window_title()
+{
+    SharedString out;
+    cbindgen_private::slint_default_window_title(&out);
+    return out;
+}
+
 inline StyledText parse_markdown(const SharedString &format_string,
                                  cbindgen_private::Slice<StyledText> args)
 {

--- a/api/rs/slint/private_unstable_api.rs
+++ b/api/rs/slint/private_unstable_api.rs
@@ -214,7 +214,7 @@ pub mod re_exports {
     };
     pub use i_slint_core::window::{
         InputMethodRequest, WindowAdapter, WindowAdapterRc, WindowInner, WindowKind, accent_color,
-        context_for_root,
+        context_for_root, default_window_title,
     };
     pub use i_slint_core::{
         Color, Coord, SharedString, SharedVector, format, string::ToSharedString,

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -792,7 +792,8 @@ impl WinitWindowAdapter {
     pub(crate) fn window_attributes() -> Result<WindowAttributes, PlatformError> {
         let mut attrs = WindowAttributes::default().with_transparent(true).with_visible(false);
 
-        attrs = attrs.with_title("Slint Window".to_string());
+        // Only until the component's own title reaches the window
+        attrs = attrs.with_title(i_slint_core::window::application_name().to_string());
 
         #[cfg(target_arch = "wasm32")]
         {

--- a/internal/compiler/builtin_elements.rs
+++ b/internal/compiler/builtin_elements.rs
@@ -180,14 +180,14 @@ macro_rules! members {
         }
         members!($l $e $($rest)*);
     };
-    // property computed per element by a BuiltinFunction that takes the element
+    // property computed by a BuiltinFunction, per element or per process
     ($l:ident $e:ident $(#![doc = $s:literal])* $(#[doc = $d:literal])* $(@$mod:ident)*
         $vis:ident property < $($ty:tt)-+ > $($name:tt)-+ { BuiltinFunction . $bf:ident } $($rest:tt)*) => {
         $e.section(docs!($($s)*));
         {
             let mut info = BuiltinPropertyInfo::new($l.ty(stringify!($($ty)-+)));
             info.property_visibility = visibility!($vis);
-            info.default_value = BuiltinPropertyDefault::ElementFunction(BuiltinFunction::$bf);
+            info.default_value = computed_default(BuiltinFunction::$bf);
             $e.add(stringify!($($name)-+), info, &[$(stringify!($mod)),*], docs!($($d)*));
         }
         members!($l $e $($rest)*);
@@ -216,6 +216,17 @@ macro_rules! members {
         $l.children(&mut $e, &[$(stringify!($child)),+]);
         members!($l $e $($rest)*);
     };
+}
+
+/// The default of a property a `BuiltinFunction` computes.
+/// A function that takes the element computes a value per element, one that takes nothing
+/// answers for the whole process.
+fn computed_default(function: BuiltinFunction) -> BuiltinPropertyDefault {
+    if function.ty().args.is_empty() {
+        BuiltinPropertyDefault::RuntimeValue(function)
+    } else {
+        BuiltinPropertyDefault::ElementFunction(function)
+    }
 }
 
 /// A native item or builtin element being built.
@@ -2127,7 +2138,8 @@ fn build(l: &mut Loader) {
         /// \default 0
         in property <length> resize-border-width;
         /// The window title that is shown in the title bar.
-        in property <string> title: "Slint Window";
+        /// \default the name of the running program
+        in property <string> title { BuiltinFunction.DefaultWindowTitle }
         /// Some devices, such as mobile phones, allow programs to overlap the system UI. A few examples for this are the notch on iPhones, the window buttons on macOS on windows that extend their content over the titlebar and the system bar on Android. This property exposes the amount of space at the edges of the window that can be drawn to but where no interactive elements should be placed. On most devices, this is 0 for all sides.
         out property <Edges> safe-area-insets;
         /// On mobile devices, virtual keyboards (aka software keyboards or onscreen keyboards) are displayed on top of the application. When such a keyboard is shown, this property denotes the position of the top left boundary of the rectangle covered by it in window coordinates.

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -146,6 +146,9 @@ pub enum BuiltinFunction {
     /// because `parse_interpolated` takes `StyledText` arguments.
     ColorToStyledText,
     DecimalSeparator,
+    /// The window title when the application doesn't set one, see
+    /// `i_slint_core::window::default_window_title`
+    DefaultWindowTitle,
     PathPointAt,
     PathAngleAt,
 }
@@ -231,6 +234,7 @@ declare_builtin_function_types!(
     ATan: (Type::Float32) -> Type::Angle,
     ATan2: (Type::Float32, Type::Float32) -> Type::Angle,
     DecimalSeparator: () -> Type::String,
+    DefaultWindowTitle: () -> Type::String,
     Log: (Type::Float32, Type::Float32) -> Type::Float32,
     Ln: (Type::Float32) -> Type::Float32,
     Pow: (Type::Float32, Type::Float32) -> Type::Float32,
@@ -374,6 +378,7 @@ impl BuiltinFunction {
             BuiltinFunction::ValidDate => false,
             BuiltinFunction::ParseDate => false,
             BuiltinFunction::DecimalSeparator => false,
+            BuiltinFunction::DefaultWindowTitle => false,
             // Even if it is not pure, we optimize it away anyway
             BuiltinFunction::Debug => true,
             BuiltinFunction::Mod
@@ -480,6 +485,7 @@ impl BuiltinFunction {
             BuiltinFunction::ValidDate => true,
             BuiltinFunction::ParseDate => true,
             BuiltinFunction::DecimalSeparator => true,
+            BuiltinFunction::DefaultWindowTitle => true,
             // Even if it has technically side effect, we still consider it as pure for our purpose
             BuiltinFunction::Debug => true,
             BuiltinFunction::Mod

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5055,6 +5055,9 @@ fn compile_builtin_function_call(
             format!("slint::private_api::debug({});", a.join(","))
         }
         BuiltinFunction::DecimalSeparator => "slint::private_api::decimal_separator()".into(),
+        BuiltinFunction::DefaultWindowTitle => {
+            "slint::private_api::default_window_title()".into()
+        }
         BuiltinFunction::Mod => {
             ctx.generator_state.conditional_includes.cmath.set(true);
             format!("([](float a, float b) {{ auto r = std::fmod(a, b); return r >= 0 ? r : r + std::abs(b); }})({},{})", a.next().unwrap(), a.next().unwrap())

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -5034,6 +5034,7 @@ fn compile_builtin_function_call(
             quote!(sp::animation_tick())
         }
         BuiltinFunction::Debug => quote!(slint::private_unstable_api::debug(#(#a)*)),
+        BuiltinFunction::DefaultWindowTitle => quote!(sp::default_window_title()),
         BuiltinFunction::DecimalSeparator => {
             let window_adapter_tokens = access_window_adapter_field(ctx);
             quote!(sp::SharedString::from(

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -366,23 +366,40 @@ pub enum BuiltinPropertyDefault {
     Expr(ConstantExpression),
     /// The property is computed per element by this function, which takes the element.
     ElementFunction(BuiltinFunction),
+    /// A value only the runtime knows, which this function returns. It takes no argument, so
+    /// unlike [`Self::ElementFunction`] the property still belongs to the native item.
+    RuntimeValue(BuiltinFunction),
     /// The property is actually not a property but a builtin function
     BuiltinFunction(BuiltinFunction),
 }
 
 impl BuiltinPropertyDefault {
-    pub fn expr(&self, elem: &crate::object_tree::ElementRc) -> Option<Expression> {
+    /// The default of a property that doesn't need an element to express, for the callers that
+    /// have no `ElementRc` at hand.
+    pub fn expr_without_element(&self) -> Option<Expression> {
         match self {
             BuiltinPropertyDefault::None => None,
             BuiltinPropertyDefault::Expr(constant) => Some(constant.to_expression()),
+            BuiltinPropertyDefault::RuntimeValue(function) => Some(Expression::FunctionCall {
+                function: function.clone().into(),
+                arguments: Vec::new(),
+                source_location: None,
+            }),
+            // Neither is a default this caller can express: ElementFunction needs the element,
+            // and a function is not a property in the first place
+            BuiltinPropertyDefault::ElementFunction(..)
+            | BuiltinPropertyDefault::BuiltinFunction(..) => None,
+        }
+    }
+
+    pub fn expr(&self, elem: &crate::object_tree::ElementRc) -> Option<Expression> {
+        match self {
             BuiltinPropertyDefault::ElementFunction(function) => Some(Expression::FunctionCall {
                 function: function.clone().into(),
                 arguments: vec![Expression::ElementReference(Rc::downgrade(elem))],
                 source_location: None,
             }),
-            BuiltinPropertyDefault::BuiltinFunction(..) => {
-                unreachable!("can't get an expression for functions")
-            }
+            other => other.expr_without_element(),
         }
     }
 }

--- a/internal/compiler/llr/optim_passes/inline_expressions.rs
+++ b/internal/compiler/llr/optim_passes/inline_expressions.rs
@@ -104,6 +104,7 @@ fn builtin_function_cost(function: &BuiltinFunction) -> isize {
         BuiltinFunction::GetWindowDefaultFontSize => PROPERTY_ACCESS_COST,
         BuiltinFunction::AnimationTick => PROPERTY_ACCESS_COST,
         BuiltinFunction::DecimalSeparator => PROPERTY_ACCESS_COST,
+        BuiltinFunction::DefaultWindowTitle => PROPERTY_ACCESS_COST,
         BuiltinFunction::Debug => isize::MAX,
         BuiltinFunction::Mod => 10,
         BuiltinFunction::Round => 10,

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -10,8 +10,7 @@
 use crate::diagnostics::{BuildDiagnostics, SourceLocation, Spanned};
 use crate::expression_tree::{self, BindingExpression, Callable, Expression, Unit};
 use crate::langtype::{
-    BuiltinElement, BuiltinPropertyDefault, Enumeration, EnumerationValue, Function, NativeClass,
-    Struct, StructName, Type,
+    BuiltinElement, Enumeration, EnumerationValue, Function, NativeClass, Struct, StructName, Type,
 };
 use crate::langtype::{ElementType, PropertyLookupMode, PropertyLookupResult};
 use crate::layout::{LayoutConstraints, Orientation};
@@ -3774,9 +3773,15 @@ pub(crate) fn apply_default_type_properties(element: &mut Element) {
     // Apply default property values on top:
     if let ElementType::Builtin(builtin_base) = &element.base_type {
         for (prop, info) in &builtin_base.properties {
-            if let BuiltinPropertyDefault::Expr(expr) = &info.default_value {
+            // A property the element declares under the same name is a different property.
+            // `ensure_window` gets here with an element that declared its members before it
+            // became a window.
+            if element.property_declarations.contains_key(prop) {
+                continue;
+            }
+            if let Some(expr) = info.default_value.expr_without_element() {
                 element.bindings.0.entry(prop.clone()).or_insert_with(|| {
-                    let mut binding = BindingExpression::from(expr.to_expression());
+                    let mut binding = BindingExpression::from(expr);
                     binding.priority = i32::MAX;
                     RefCell::new(binding)
                 });

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -150,6 +150,10 @@ pub fn ensure_window(
             to: Type::Brush,
         }
     });
+
+    // The element only became a window here, so it missed the defaults that `Element::from_node`
+    // gives a window the source writes, such as the title
+    crate::object_tree::apply_default_type_properties(&mut component.root_element.borrow_mut());
 }
 
 pub fn inherits_window(component: &Rc<Component>) -> bool {

--- a/internal/compiler/tests/default_window_title.rs
+++ b/internal/compiler/tests/default_window_title.rs
@@ -1,0 +1,142 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! A window the source leaves untitled falls back to the `DefaultWindowTitle` builtin, which the
+//! runtime answers with the name of the running program.
+//! A title the source decides is left alone, an empty one included.
+
+use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::expression_tree::{BuiltinFunction, Callable, Expression};
+use i_slint_compiler::generator::OutputFormat;
+use i_slint_compiler::parser::parse;
+use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
+
+/// Whether the root element's `title` is still the `builtins.slint` fallback.
+fn title_falls_back_to_default(source: &str) -> bool {
+    let mut diagnostics = BuildDiagnostics::default();
+    let syntax_node = parse(source.into(), None, &mut diagnostics);
+    let compiler_config = CompilerConfiguration::new(OutputFormat::Interpreter);
+    let (doc, diagnostics, _) =
+        spin_on::spin_on(compile_syntax_node(syntax_node, diagnostics, compiler_config));
+    assert!(!diagnostics.has_errors(), "{:?}", diagnostics.to_string_vec());
+    let root = doc.last_exported_component().unwrap().root_element.clone();
+    let root = root.borrow();
+    root.binding_cell_including_synthetic("title").is_some_and(|binding| {
+        matches!(binding.borrow().value_expression(),
+            Expression::FunctionCall { function: Callable::Builtin(f), .. }
+                if *f == BuiltinFunction::DefaultWindowTitle)
+    })
+}
+
+#[test]
+fn an_untitled_window_falls_back() {
+    assert!(title_falls_back_to_default(r#"export component T inherits Window { }"#));
+}
+
+#[test]
+fn a_root_that_is_not_a_window_falls_back() {
+    // ensure_window wraps it in a Window, which is untitled too
+    assert!(title_falls_back_to_default(r#"export component T inherits Rectangle { }"#));
+}
+
+#[test]
+fn a_title_from_the_source_wins() {
+    assert!(!title_falls_back_to_default(r#"export component T inherits Window { title: "hi"; }"#));
+    // An empty title is a choice too, not an absence
+    assert!(!title_falls_back_to_default(r#"export component T inherits Window { title: ""; }"#));
+    assert!(!title_falls_back_to_default(
+        r#"export component T inherits Window {
+               in-out property <string> n: "x";
+               title: "Editing " + root.n;
+           }"#
+    ));
+}
+
+#[test]
+fn a_title_from_a_base_component_wins() {
+    assert!(!title_falls_back_to_default(
+        r#"component Base inherits Window { title: "from the base"; }
+           export component T inherits Base { }"#
+    ));
+}
+
+#[test]
+fn a_two_way_binding_wins() {
+    // The alias survives the fallback, so the application still drives the title through `n`
+    assert!(!title_falls_back_to_default(
+        r#"export component T inherits Window {
+               in-out property <string> n: "x";
+               title <=> root.n;
+           }"#
+    ));
+}
+
+#[test]
+fn a_system_tray_icon_root_is_left_alone() {
+    // Its `title` is the tooltip-ish name of the tray icon, and has no default of its own
+    assert!(!title_falls_back_to_default(
+        r#"export component T inherits SystemTrayIcon {
+               icon: @image-url("");
+           }"#
+    ));
+}
+
+#[test]
+fn a_dialog_root_falls_back() {
+    assert!(title_falls_back_to_default(
+        r#"export component T inherits Dialog { Text { text: "hi"; } }"#
+    ));
+}
+
+/// The whole `title` binding, as a debug string.
+fn title_binding(source: &str) -> String {
+    let mut diagnostics = BuildDiagnostics::default();
+    let syntax_node = parse(source.into(), None, &mut diagnostics);
+    let compiler_config = CompilerConfiguration::new(OutputFormat::Interpreter);
+    let (doc, diagnostics, _) =
+        spin_on::spin_on(compile_syntax_node(syntax_node, diagnostics, compiler_config));
+    assert!(!diagnostics.has_errors(), "{:?}", diagnostics.to_string_vec());
+    let root = doc.last_exported_component().unwrap().root_element.clone();
+    let root = root.borrow();
+    format!("{:?}", root.binding_cell_including_synthetic("title").unwrap().borrow().expression)
+}
+
+#[test]
+fn a_state_that_sets_the_title_keeps_the_fallback_for_its_else_branch() {
+    // lower_states turns the state into `active ? "state" : <whatever title was bound to>`
+    let binding = title_binding(
+        r#"export component T inherits Window {
+               in-out property <bool> b;
+               states [ s when root.b: { title: "state"; } ]
+           }"#,
+    );
+    assert!(binding.contains("state"), "{binding}");
+    assert!(binding.contains("DefaultWindowTitle"), "{binding}");
+}
+
+#[test]
+fn a_state_in_a_base_component_keeps_the_fallback_too() {
+    // The fallback lands on the base, whose root is the one inheriting the builtin
+    let binding = title_binding(
+        r#"component Base inherits Window {
+               in-out property <bool> b;
+               states [ s when root.b: { title: "state"; } ]
+               TouchArea { clicked => { root.b = !root.b; } }
+           }
+           export component T inherits Base { }"#,
+    );
+    assert!(binding.contains("state"), "{binding}");
+    assert!(binding.contains("DefaultWindowTitle"), "{binding}");
+}
+
+#[test]
+fn a_title_the_root_declares_itself_is_a_different_property() {
+    // `ensure_window` makes this root a window, but the string it declared is its own property
+    // and keeps the empty default of its type
+    assert!(!title_falls_back_to_default(
+        r#"export component T inherits Rectangle {
+               in-out property <string> title;
+               Text { text: root.title; }
+           }"#
+    ));
+}

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -585,6 +585,61 @@ pub(crate) struct MouseDispatchResult {
     pub accepted: bool,
 }
 
+/// The program a path names, without its directory or the Windows `.exe` suffix.
+/// `None` for a path that names no file, or an empty name.
+#[cfg(feature = "std")]
+fn program_name(path: &std::path::Path) -> Option<SharedString> {
+    // A Windows program is called "foo", not "foo.exe"
+    let is_exe = path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
+    let name = if is_exe { path.file_stem()? } else { path.file_name()? };
+    let name = name.to_string_lossy();
+    (!name.is_empty()).then(|| name.as_ref().into())
+}
+
+/// The name of the running program, used as the window title when the application doesn't set one.
+///
+/// It comes from argument zero, which is also what winit derives the X11 `WM_CLASS` from, so the
+/// two agree even when the program is started through a symlink.
+/// Empty where the platform names the program neither way, such as on the web.
+pub fn application_name() -> SharedString {
+    #[cfg(feature = "std")]
+    {
+        static NAME: std::sync::LazyLock<SharedString> = std::sync::LazyLock::new(|| {
+            std::env::args_os()
+                .next()
+                .and_then(|arg| program_name(std::path::Path::new(&arg)))
+                .or_else(|| std::env::current_exe().ok().as_deref().and_then(program_name))
+                .unwrap_or_default()
+        });
+        NAME.clone()
+    }
+    #[cfg(not(feature = "std"))]
+    SharedString::default()
+}
+
+crate::thread_local! {
+    static DEFAULT_WINDOW_TITLE: core::cell::RefCell<Option<SharedString>> = Default::default();
+}
+
+/// Override what [`default_window_title`] returns, for this thread.
+///
+/// A tool that hosts someone else's component, like the Slint viewer, says here what its windows
+/// are called.
+/// A window reads the title when it first applies its properties, so this only reaches windows
+/// that have yet to be shown.
+pub fn set_default_window_title(title: SharedString) {
+    DEFAULT_WINDOW_TITLE.with(|slot| slot.replace(Some(title)));
+}
+
+/// The title a window shows when the application doesn't set one: [`set_default_window_title`]
+/// if a host called it on this thread, otherwise the application name.
+///
+/// This is what the compiler binds `Window.title` to, through
+/// `BuiltinFunction::DefaultWindowTitle`.
+pub fn default_window_title() -> SharedString {
+    DEFAULT_WINDOW_TITLE.with(|slot| slot.borrow().clone()).unwrap_or_else(application_name)
+}
+
 /// Inner datastructure for the [`crate::api::Window`]
 pub struct WindowInner {
     window_adapter_weak: Weak<dyn WindowAdapter>,
@@ -2540,6 +2595,12 @@ pub mod ffi {
     #[repr(C)]
     pub struct WindowAdapterRcOpaque(*const c_void, *const c_void);
 
+    /// The title a window shows when the application doesn't set one
+    #[unsafe(no_mangle)]
+    pub extern "C" fn slint_default_window_title(out: &mut SharedString) {
+        *out = super::default_window_title();
+    }
+
     /// Releases the reference to the windowrc held by handle.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_drop(handle: *mut WindowAdapterRcOpaque) {
@@ -3241,5 +3302,40 @@ pub mod ffi_window {
         } else {
             null_mut()
         }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    fn name_of(path: &str) -> Option<SharedString> {
+        program_name(std::path::Path::new(path))
+    }
+
+    #[test]
+    fn a_program_name_is_the_bare_file_name() {
+        assert_eq!(name_of("/usr/bin/gallery").as_deref(), Some("gallery"));
+        assert_eq!(name_of("gallery").as_deref(), Some("gallery"));
+        assert_eq!(name_of("./gallery").as_deref(), Some("gallery"));
+        assert_eq!(name_of("/opt/my-tool.v2").as_deref(), Some("my-tool.v2"));
+        // Windows spells the suffix either way, and its file names don't care
+        assert_eq!(name_of("gallery.exe").as_deref(), Some("gallery"));
+        assert_eq!(name_of("GALLERY.EXE").as_deref(), Some("GALLERY"));
+        // A leading dot makes it the whole name, not a suffix
+        assert_eq!(name_of(".exe").as_deref(), Some(".exe"));
+        assert_eq!(name_of(""), None);
+        assert_eq!(name_of("/"), None);
+        assert_eq!(name_of("some/dir/").as_deref(), Some("dir"));
+    }
+
+    #[test]
+    fn a_host_overrides_the_default_title() {
+        // The test binary is the running program, so the name is never empty here
+        assert!(!default_window_title().is_empty());
+        set_default_window_title("Some Viewer".into());
+        assert_eq!(default_window_title(), "Some Viewer");
+        DEFAULT_WINDOW_TITLE.with(|slot| slot.replace(None));
+        assert_eq!(default_window_title(), application_name());
     }
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1955,6 +1955,9 @@ fn call_builtin_function(
             let n = to_num(ctx, &arguments[0]);
             Value::String(i_slint_core::string::shared_string_from_number_unlocalized(n))
         }
+        BuiltinFunction::DefaultWindowTitle => {
+            Value::String(i_slint_core::window::default_window_title())
+        }
         BuiltinFunction::DecimalSeparator => Value::String(
             find_window_adapter(ctx)
                 .map(|adapter| {

--- a/tools/viewer/main.rs
+++ b/tools/viewer/main.rs
@@ -268,13 +268,14 @@ fn main() -> Result<()> {
 
         reject_non_window_component(&live.borrow().instance().definition());
 
-        setup_instance(live.borrow().instance(), &args.on, args.load_data.as_deref())?;
+        setup_instance(live.borrow().instance(), &args.on, args.load_data.as_deref(), args.path())?;
 
         {
             let on = args.on.clone();
             let load_data_path = args.load_data.clone();
+            let source_path = args.path().to_path_buf();
             live.borrow_mut().set_post_reload_hook(move |instance| {
-                let _ = setup_instance(instance, &on, load_data_path.as_deref());
+                let _ = setup_instance(instance, &on, load_data_path.as_deref(), &source_path);
             });
         }
 
@@ -301,7 +302,7 @@ fn main() -> Result<()> {
         install_log_message_handler()?;
 
         let component = c.create()?;
-        setup_instance(&component, &args.on, args.load_data.as_deref())?;
+        setup_instance(&component, &args.on, args.load_data.as_deref(), args.path())?;
 
         component.run()?;
 
@@ -367,13 +368,33 @@ fn setup_instance(
     instance: &ComponentInstance,
     callbacks: &[String],
     load_data_path: Option<&Path>,
+    source_path: &Path,
 ) -> Result<()> {
+    name_the_window(instance, source_path);
     init_dialog(instance);
     if let Some(data_path) = load_data_path {
         load_data(instance, data_path)?;
     }
     install_callbacks(instance, callbacks);
     Ok(())
+}
+
+/// Name the window after the component and the source file, so several viewer windows can be
+/// told apart.
+///
+/// This only sets the fallback the compiler binds an unset `title` to.
+/// A component that declares its own title keeps it, an empty one included.
+fn name_the_window(instance: &ComponentInstance, source_path: &Path) {
+    let definition = instance.definition();
+    let mut parts = vec![definition.name().to_string()];
+    // Reading from stdin, there is no file name to show
+    if source_path != Path::new("-")
+        && let Some(file_name) = source_path.file_name()
+    {
+        parts.push(file_name.to_string_lossy().into_owned());
+    }
+    parts.push("Slint Viewer".into());
+    i_slint_core::window::set_default_window_title(parts.join(" - ").into());
 }
 
 /// Init dialog if `instance` is a Dialog

--- a/tools/viewer/screenshot.rs
+++ b/tools/viewer/screenshot.rs
@@ -68,7 +68,7 @@ pub fn take_screenshot(args: &Cli) -> Result<()> {
     reject_non_window_component(&c);
 
     let component = c.create()?;
-    setup_instance(&component, &args.on, args.load_data.as_deref())?;
+    setup_instance(&component, &args.on, args.load_data.as_deref(), args.path())?;
 
     component.show()?;
 


### PR DESCRIPTION
slint-viewer: show the file name in the window title

When the viewed component does not declare Window.title, show
"foo.slint - Slint Viewer" instead of just "Slint Window", so multiple
viewer windows can be told apart. A declared title is left alone even
when it evaluates to empty at startup, since overwriting it would drop
its binding. Re-applied on --auto-reload since a reload creates a new
instance.

---

builds upon this other commit:

---

Window: leave the title empty by default, fall back at runtime

The builtin default title: "Slint Window" was indistinguishable from an
app setting that title, so tools like the viewer could not tell whether
the app chose a title. Leave the property empty by default and let
WindowProperties::title() (used by the winit and Qt backends and custom
platforms) fall back to "Slint Window", so the visible caption is
unchanged.
