### PR TITLE
Visual Editor: Fix repeated frame instantiation

### DIFF
--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -282,8 +282,9 @@ fn collect_row_instances(
     sub: &Pin<Rc<SubComponentInstance>>,
     out: &mut Vec<VRc<ItemTreeVTable, Instance>>,
 ) {
-    for rep in sub.repeaters.iter() {
-        for row in rep.instances_vec() {
+    for repeater in sub.repeaters.iter() {
+        repeater.track_instance_changes();
+        for row in repeater.instances_vec() {
             collect_instances(&row, out);
         }
     }

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -1604,10 +1604,12 @@ fn move_selected_element(x: f32, y: f32, mouse_x: f32, mouse_y: f32) {
         position,
         mouse_position,
     ) {
-        element_selection::select_element_at_source_code_position(
-            drop_data.path,
-            drop_data.selection_offset,
-            None,
+        element_selection::restore_selection(
+            ElementSelection {
+                path: drop_data.path,
+                offset: drop_data.selection_offset,
+                instance_index: selected.instance_index,
+            },
             SelectionNotification::AfterUpdate,
         );
 
@@ -1944,18 +1946,13 @@ async fn reload_timer_function() {
         };
     }
 
-    if let Some(se) = selected {
-        element_selection::select_element_at_source_code_position(
-            se.path.clone(),
-            se.offset,
-            None,
-            SelectionNotification::Never,
-        );
+    if let Some(selection) = selected {
+        element_selection::restore_selection(selection.clone(), SelectionNotification::Never);
 
         if notify_editor
             && let Some(component_instance) = component_instance()
             && let Some((element, debug_index)) = component_instance
-                .element_node_at_source_code_position(&se.path, se.offset.into())
+                .element_node_at_source_code_position(&selection.path, selection.offset.into())
                 .first()
         {
             let Some(element_node) = ElementRcNode::new(element.clone(), *debug_index) else {
@@ -1964,7 +1961,10 @@ async fn reload_timer_function() {
             let format = PREVIEW_STATE.with_borrow(|ps| ps.format());
             let (path, pos) = element_node.with_element_node(|node| {
                 let sf = &node.source_file;
-                (sf.path().to_owned(), util::text_size_to_lsp_position(sf, se.offset, format))
+                (
+                    sf.path().to_owned(),
+                    util::text_size_to_lsp_position(sf, selection.offset, format),
+                )
             });
             let lsp = PREVIEW_STATE.with_borrow(|ps| ps.to_lsp.borrow().clone().unwrap());
             lsp.ask_editor_to_show_document(

--- a/tools/editor/preview/element_selection.rs
+++ b/tools/editor/preview/element_selection.rs
@@ -133,6 +133,23 @@ fn select_element_at_source_code_position_impl(
     );
 }
 
+pub fn restore_selection(
+    mut selection: ElementSelection,
+    editor_notification: SelectionNotification,
+) {
+    let Some(component_instance) = super::component_instance() else {
+        return;
+    };
+    if component_instance
+        .component_positions(&selection.path, selection.offset.into())
+        .get(selection.instance_index)
+        .is_none()
+    {
+        selection.instance_index = 0;
+    }
+    super::set_selected_element(Some(selection), editor_notification);
+}
+
 struct HighlightPositionsModel {
     rows: VecModel<ui::SelectionRectangle>,
     change_tracker: ChangeTracker,

--- a/tools/editor/preview/element_selection.rs
+++ b/tools/editor/preview/element_selection.rs
@@ -1,13 +1,17 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{path::PathBuf, rc::Rc};
+use std::{
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 use i_slint_compiler::{
     object_tree::ElementRc,
     parser::{SyntaxKind, TextSize},
 };
-use i_slint_core::lengths::LogicalPoint;
+use i_slint_core::{lengths::LogicalPoint, properties::ChangeTracker};
+use slint::{Model, ModelTracker, VecModel};
 use slint_interpreter::{ComponentHandle, ComponentInstance, highlight::HighlightedRect};
 
 use crate::preview::{self, SelectionNotification, ext::ElementRcNodeExt, ui};
@@ -129,6 +133,84 @@ fn select_element_at_source_code_position_impl(
     );
 }
 
+struct HighlightPositionsModel {
+    rows: VecModel<ui::SelectionRectangle>,
+    change_tracker: ChangeTracker,
+}
+
+impl HighlightPositionsModel {
+    fn new(component_instance: ComponentInstance, path: PathBuf, offset: u32) -> Rc<Self> {
+        let model = Rc::new(Self { rows: Default::default(), change_tracker: Default::default() });
+        let model_weak = Rc::downgrade(&model);
+        let component_instance = component_instance.as_weak();
+        model.change_tracker.init_delayed(
+            (model_weak, component_instance, path, offset),
+            |(_, component_instance, path, offset)| {
+                component_instance
+                    .upgrade()
+                    .map(|component_instance| {
+                        selection_rectangles(&component_instance, path, *offset)
+                    })
+                    .unwrap_or_default()
+            },
+            |(model_weak, _, _, _), positions| {
+                if let Some(model) = model_weak.upgrade() {
+                    model.update(positions);
+                }
+            },
+        );
+        model
+    }
+
+    fn update(&self, positions: &[ui::SelectionRectangle]) {
+        if self.rows.row_count() != positions.len() {
+            self.rows.set_vec(positions.to_vec());
+            return;
+        }
+
+        for (row, position) in positions.iter().enumerate() {
+            if self.rows.row_data(row).as_ref() == Some(position) {
+                continue;
+            }
+            self.rows.set_row_data(row, position.clone());
+        }
+    }
+}
+
+impl Model for HighlightPositionsModel {
+    type Data = ui::SelectionRectangle;
+
+    fn row_count(&self) -> usize {
+        self.rows.row_count()
+    }
+
+    fn row_data(&self, row: usize) -> Option<Self::Data> {
+        self.rows.row_data(row)
+    }
+
+    fn model_tracker(&self) -> &dyn ModelTracker {
+        self.rows.model_tracker()
+    }
+}
+
+fn selection_rectangles(
+    component_instance: &ComponentInstance,
+    path: &Path,
+    offset: u32,
+) -> Vec<ui::SelectionRectangle> {
+    component_instance
+        .component_positions(path, offset)
+        .iter()
+        .map(|geometry| ui::SelectionRectangle {
+            width: geometry.rect.size.width,
+            height: geometry.rect.size.height,
+            x: geometry.rect.origin.x,
+            y: geometry.rect.origin.y,
+            angle: geometry.angle,
+        })
+        .collect()
+}
+
 pub fn highlight_positions(
     source_uri: slint::SharedString,
     offset: i32,
@@ -143,16 +225,7 @@ pub fn highlight_positions(
     else {
         return Default::default();
     };
-    let offset = TextSize::new(offset as u32);
-    let positions = component_instance.component_positions(&path, offset.into());
-    let model = slint::VecModel::from_iter(positions.iter().map(|g| ui::SelectionRectangle {
-        width: g.rect.size.width,
-        height: g.rect.size.height,
-        x: g.rect.origin.x,
-        y: g.rect.origin.y,
-        angle: g.angle,
-    }));
-    slint::ModelRc::new(model)
+    HighlightPositionsModel::new(component_instance, path, offset as u32).into()
 }
 
 fn select_element_node(

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -6,11 +6,14 @@ import { EditorMetrics, StudioTheme } from "common.slint";
 import { MoveResizeFrame } from "move-resize-frame.slint";
 
 export component BorderRadiusFrame inherits MoveResizeFrame {
+    in property <bool> enable-border-radius-edits: true;
     in property <length> top-left-radius;
     in property <length> top-right-radius;
     in property <length> bottom-right-radius;
     in property <length> bottom-left-radius;
     callback radius-changed(CanvasCorner, length, bool);
+
+    private property <[CanvasCorner]> name;
 
     width: 240px;
     height: 96px;
@@ -56,7 +59,11 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
             ? EditorMetrics.radius-handle-inset + radius
             : root.height - EditorMetrics.radius-handle-inset - radius;
 
-        visible: root.active && !root.move-pressed && !root.rotating && (root.frame-hover || root.radius-handle-active);
+        visible: root.enable-border-radius-edits
+            && root.active
+            && !root.move-pressed
+            && !root.rotating
+            && (root.frame-hover || root.radius-handle-active);
         x: handle-center-x - EditorMetrics.radius-handle-size / 2;
         y: handle-center-y - EditorMetrics.radius-handle-size / 2;
         width: EditorMetrics.radius-handle-size;
@@ -66,7 +73,7 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
         border-width: 1px;
         border-color: StudioTheme.accent-strong;
 
-        touch := TouchArea {
+        if root.enable-border-radius-edits: TouchArea {
             mouse-cursor: pointer;
             private property <bool> event-shift-pressed: false;
 

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -219,9 +219,8 @@ export component EditorCanvas inherits Rectangle {
         // MoveResizeFrame is recreated on every change, which means we lose all
         // local state like the drag position, and the interaction becomes jumpy and unusable.
         // To work around this, we only render a single MoveResizeFrame for the first selection rectangle.
-        if root.selections.length > 0 && Api.current-element.type-name != "Rectangle": MoveResizeFrame {
-            property <int> idx: 0;
-            property <SelectionRectangle> s: root.selections[0];
+        for selection[idx] in root.selections : MoveResizeFrame {
+            property <SelectionRectangle> s: selection;
             property <bool> primary: idx == Api.selection.highlight-index;
             // During a drag the frame follows the pointer locally (no disk write).
             // When idle it tracks the backend geometry from selections[].
@@ -326,128 +325,6 @@ export component EditorCanvas inherits Rectangle {
                     root.selection-rotation-active = false;
                 }
                 root.selection-drag-active = false;
-            }
-        }
-
-        if root.selections.length > 0 && Api.current-element.type-name == "Rectangle": BorderRadiusFrame {
-            property <int> idx: 0;
-            property <SelectionRectangle> s: root.selections[0];
-            property <bool> primary: idx == Api.selection.highlight-index;
-            // During a drag the frame follows the pointer locally (no disk write).
-            // When idle it tracks the backend geometry from selections[].
-            x: root.selection-drag-active && primary
-                ? root.selection-drag-position.x
-                : s.x + EditorMetrics.phone-outer-padding;
-            y: root.selection-drag-active && primary
-                ? root.selection-drag-position.y
-                : s.y + EditorMetrics.phone-outer-padding;
-            width: root.selection-drag-active && primary ? root.selection-drag-size.width : s.width;
-            height: root.selection-drag-active && primary ? root.selection-drag-size.height : s.height;
-            rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
-            active: true;
-            show-rotation-handles: primary;
-            top-left-radius: root.current-corner-radius("border-top-left-radius");
-            top-right-radius: root.current-corner-radius("border-top-right-radius");
-            bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");
-            bottom-left-radius: root.current-corner-radius("border-bottom-left-radius");
-            // Only allow move/resize for elements that have geometry outside a layout, and only
-            // when the element is not rotated (we don't support rotating + repositioning at once).
-            resizable: primary && Api.selection.is-resizable && s.angle == 0deg;
-            moveable: primary && Api.selection.is-moveable && s.angle == 0deg;
-
-            rotated-to(rotation) => {
-                root.selection-rotation-active = true;
-                root.selection-rotation = rotation;
-                Api.override-selected-element-rotation(rotation);
-            }
-            interaction-started => {
-                root.selection-rotation-active = false;
-            }
-            changed rotation-tooltip-visible => {
-                root.rotation-tooltip-visible = self.rotation-tooltip-visible;
-            }
-            changed rotation-tooltip-position => {
-                root.rotation-tooltip-position = self.rotation-tooltip-position;
-            }
-            changed rotation-tooltip-value => {
-                root.rotation-tooltip-value = self.rotation-tooltip-value;
-            }
-
-            radius-changed(corner, radius, single-corner) => {
-                Api.override-selected-element-border-radius(corner, radius, single-corner);
-            }
-
-            resized-to(corner, position, size) => {
-                root.selection-drag-active = true;
-                root.selection-move-active = false;
-                root.selection-drag-position = position;
-                root.selection-drag-size = size;
-                // Push live geometry (content space) so the previewed element follows the
-                // drag via debug-hook overrides, without writing to disk.
-                Api.override-selected-element-geometry(
-                    position.x - EditorMetrics.phone-outer-padding,
-                    position.y - EditorMetrics.phone-outer-padding,
-                    size.width,
-                    size.height,
-                );
-            }
-            moved-to(position) => {
-                let content-position = {
-                    x: position.x - EditorMetrics.phone-outer-padding,
-                    y: position.y - EditorMetrics.phone-outer-padding,
-                };
-                let content-pointer = {
-                    x: self.move-pointer-position.x - EditorMetrics.phone-outer-padding,
-                    y: self.move-pointer-position.y - EditorMetrics.phone-outer-padding,
-                };
-                if !Api.selected-element-can-move-to(
-                    content-position.x,
-                    content-position.y,
-                    content-pointer.x,
-                    content-pointer.y,
-                ) {
-                    return;
-                }
-                root.selection-drag-active = true;
-                root.selection-move-active = true;
-                root.selection-drag-position = position;
-                root.selection-drag-size = { width: s.width, height: s.height };
-                root.selection-move-pointer = self.move-pointer-position;
-                Api.override-selected-element-geometry(
-                    content-position.x,
-                    content-position.y,
-                    s.width,
-                    s.height,
-                );
-            }
-            interaction-ended => {
-                if root.selection-move-active {
-                    Api.selected-element-move(
-                        root.selection-drag-position.x - EditorMetrics.phone-outer-padding,
-                        root.selection-drag-position.y - EditorMetrics.phone-outer-padding,
-                        root.selection-move-pointer.x - EditorMetrics.phone-outer-padding,
-                        root.selection-move-pointer.y - EditorMetrics.phone-outer-padding,
-                    );
-                    root.selection-move-active = false;
-                } else if root.selection-drag-active {
-                    // Convert from phone (frame-parent) space back to content space
-                    // by subtracting the 1px phone-outer-padding, then commit once.
-                    Api.selected-element-resize(
-                        root.selection-drag-position.x - EditorMetrics.phone-outer-padding,
-                        root.selection-drag-position.y - EditorMetrics.phone-outer-padding,
-                        root.selection-drag-size.width,
-                        root.selection-drag-size.height,
-                    );
-                }
-                if root.selection-rotation-active {
-                    Api.selected-element-rotate(root.selection-rotation);
-                    root.selection-rotation-active = false;
-                }
-                root.selection-drag-active = false;
-                if self.radius-tooltip-visible {
-                    Api.persist-selected-element-border-radius();
-                    root.selection-radius-active = false;
-                }
             }
         }
 

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -65,7 +65,6 @@ export component EditorCanvas inherits Rectangle {
     private property <Size> selection-drag-size;
     private property <bool> selection-move-active: false;
     private property <Point> selection-move-pointer;
-    private property <bool> selection-radius-active: false;
     private property <bool> selection-rotation-active: false;
     private property <angle> selection-rotation;
 
@@ -213,13 +212,7 @@ export component EditorCanvas inherits Rectangle {
         // Selection frame(s) for the currently selected element. Rendered after
         // selection-area so the active frame intercepts clicks on the selected element.
         // Note: This sits outside of the PhoneChrome so it doesn't get clipped.
-        //
-        // TODO: Ugly hack! The root.selections model currently is constantly
-        // recreated, which means if we do an actual `for` loop over it, the
-        // MoveResizeFrame is recreated on every change, which means we lose all
-        // local state like the drag position, and the interaction becomes jumpy and unusable.
-        // To work around this, we only render a single MoveResizeFrame for the first selection rectangle.
-        for selection[idx] in root.selections : MoveResizeFrame {
+        for selection[idx] in root.selections : BorderRadiusFrame {
             property <SelectionRectangle> s: selection;
             property <bool> primary: idx == Api.selection.highlight-index;
             // During a drag the frame follows the pointer locally (no disk write).
@@ -235,6 +228,11 @@ export component EditorCanvas inherits Rectangle {
             rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
             active: true;
             show-rotation-handles: primary;
+            enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
+            top-left-radius: root.current-corner-radius("border-top-left-radius");
+            top-right-radius: root.current-corner-radius("border-top-right-radius");
+            bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");
+            bottom-left-radius: root.current-corner-radius("border-bottom-left-radius");
             // Only allow move/resize for elements that have geometry outside a layout, and only
             // when the element is not rotated (we don't support rotating + repositioning at once).
             resizable: primary && Api.selection.is-resizable && s.angle == 0deg;
@@ -256,6 +254,9 @@ export component EditorCanvas inherits Rectangle {
             }
             changed rotation-tooltip-value => {
                 root.rotation-tooltip-value = self.rotation-tooltip-value;
+            }
+            radius-changed(corner, radius, single-corner) => {
+                Api.override-selected-element-border-radius(corner, radius, single-corner);
             }
 
             resized-to(corner, position, size) => {
@@ -325,6 +326,9 @@ export component EditorCanvas inherits Rectangle {
                     root.selection-rotation-active = false;
                 }
                 root.selection-drag-active = false;
+                if self.radius-tooltip-visible {
+                    Api.persist-selected-element-border-radius();
+                }
             }
         }
 


### PR DESCRIPTION
- **Visual Editor: Persistent Api.highlight-positions model**
- **Preserve selection index when restoring selection**
- **Re-enable BorderRadiusFrame for Rectangles**

@NigelBreslaw This only fixes the instantiation, but the UI for visualization/behavior of repeated frames is not ideal yet.
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
