### PR TITLE
wasm: halve the binary size and fix japanese gallery 

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -777,10 +777,9 @@ pub mod fontique_011 {
     /// }
     /// ```
     pub fn shared_collection() -> fontique::Collection {
-        i_slint_core::with_global_context(
-            || panic!("slint platform not initialized"),
-            |ctx| ctx.font_context().borrow().collection.clone(),
-        )
+        i_slint_backend_selector::with_global_context(|ctx| {
+            ctx.font_context().borrow().collection.clone()
+        })
         .unwrap()
     }
 }

--- a/api/rs/slint/tests/fontique_shared_collection.rs
+++ b/api/rs/slint/tests/fontique_shared_collection.rs
@@ -1,0 +1,46 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore donotexist
+
+#![cfg(feature = "unstable-fontique-011")]
+
+use slint::fontique_011::fontique;
+
+// The wasm gallery downloads a CJK font and registers it as a fallback before the first
+// component is created, so `shared_collection()` must work without an initialized
+// platform.
+#[test]
+fn register_fonts_before_platform_init() {
+    // shared_collection creates the default backend on demand; pick the testing
+    // backend so this also works without a display.
+    unsafe { std::env::set_var("SLINT_BACKEND", "testing") };
+
+    let font_data = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../internal/common/sharedfontique/Inter-VariableFont.ttf"
+    ))
+    .unwrap();
+
+    let blob = fontique::Blob::new(std::sync::Arc::new(font_data));
+    let mut collection = slint::fontique_011::shared_collection();
+    let fonts = collection.register_fonts(blob, None);
+
+    let (family_id, font_infos) = fonts.first().expect("no font was registered");
+    assert!(!font_infos.is_empty());
+    assert_eq!(collection.family_name(*family_id), Some("Inter"));
+
+    let script = fontique::Script::from_str_unchecked("Hani");
+    collection
+        .append_fallbacks(fontique::FallbackKey::new(script, None), fonts.iter().map(|x| x.0));
+    assert!(
+        collection
+            .fallback_families(fontique::FallbackKey::new(script, None))
+            .any(|id| id == *family_id),
+        "the registered font is not in the fallback chain"
+    );
+
+    // Data that isn't a font must not register anything.
+    let invalid = fontique::Blob::new(std::sync::Arc::new(b"donotexist.ttf".to_vec()));
+    assert!(collection.register_fonts(invalid, None).is_empty());
+}

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -131,7 +131,6 @@ unicode-linebreak = { version = "0.1.5", optional = true }
 unicode-script = { version = "0.5.7", optional = true }
 icu_normalizer = { workspace = true, optional = true }
 sys-locale = { version = "0.3.2", optional = true, features = ["js"] }
-parley = { version = "0.11.1", optional = true, features = ["complex-scripts"] }
 accesskit = { version = "0.24", optional = true }
 
 image = { workspace = true, optional = true, default-features = false }
@@ -170,7 +169,13 @@ windows = { workspace = true, features = ["Win32_Foundation", "Win32_Graphics_Gd
 ksni = { version = "0.3.3", optional = true, default-features = false }
 async-channel = { version = "2", optional = true }
 
+# The complex-scripts line-breaking dictionaries cost several MB, so leave them out of
+# wasm binaries.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+parley = { version = "0.11.1", optional = true, features = ["complex-scripts"] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+parley = { version = "0.11.1", optional = true }
 web-time = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2" }
 js-sys = { version = "0.3" }


### PR DESCRIPTION
The printerdemo wasm goes from 8.6 MB (4.5 MB gzipped) to 4.3 MB (1.8 MB gzipped). All wasm builds, including SlintPad, benefit.

- Don't include parley's complex-scripts line-breaking dictionaries on wasm (3.8 MB). They only improve line breaking for CJK, Thai, Khmer, Lao, and Burmese. Apps that ship their own font for those scripts now get rule-based line breaking instead. That's fine for CJK, and the built-in fallback font has no glyphs for those scripts anyway.
- Use a Latin/Greek/Cyrillic subset of the Inter fallback font on wasm (saves 0.5 MB). Nothing that rendered before is lost.
- Fix a panic in fontique_011::shared_collection() when it's called before the platform is initialized. This broke the gallery demo's runtime CJK font loading since 1.16.0 (regression from #10800). Verified: the gallery renders in Japanese again with the downloaded Noto font. Comes with a test.


  
