### PR TITLE
python: generate the API from the LLR instead of the type loader

### DIFF
--- a/api/python/slint/interpreter.rs
+++ b/api/python/slint/interpreter.rs
@@ -212,36 +212,31 @@ impl CompilationResult {
 
     #[getter]
     fn named_exports(&self) -> Vec<(String, String)> {
-        self.result.named_exports(i_slint_core::InternalToken {}).cloned().collect::<Vec<_>>()
+        let Some(unit) = self.result.compilation_unit(i_slint_core::InternalToken {}) else {
+            return Vec::new();
+        };
+        unit.type_exports
+            .iter()
+            .filter(|e| e.is_alias())
+            .map(|e| (e.internal_name.to_string(), e.exported_name.to_string()))
+            .collect()
     }
 
     #[getter]
     fn generated_api(&self) -> PyResult<PyGeneratedAPI> {
-        let type_loader = self
+        let Some(unit) = self.result.compilation_unit(i_slint_core::InternalToken {}) else {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "Cannot generated API for empty slint file",
+            ));
+        };
+        let structs_and_enums = self
             .result
-            .components()
-            .next()
-            .ok_or_else(|| {
-                pyo3::exceptions::PyRuntimeError::new_err(
-                    "Cannot generated API for empty slint file",
-                )
-            })?
-            .type_loader();
-        let doc = type_loader.get_document(&self.path).ok_or_else(|| {
-            pyo3::exceptions::PyRuntimeError::new_err(
-                "Failed to load document from cache for API generation",
-            )
-        })?;
-        i_slint_compiler::generator::python::generate_py_module(
-            doc,
-            &i_slint_compiler::CompilerConfiguration::new(
-                i_slint_compiler::generator::OutputFormat::Python,
-            ),
-        )
-        .map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!("Error generating pymodule: {}", e))
-        })
-        .map(|module| PyGeneratedAPI { path: self.path.clone(), module })
+            .structs_and_enums(i_slint_core::InternalToken {})
+            .cloned()
+            .collect::<Vec<_>>();
+        let module =
+            i_slint_compiler::generator::python::generate_py_module(unit, &structs_and_enums);
+        Ok(PyGeneratedAPI { path: self.path.clone(), module })
     }
 }
 

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -334,64 +334,34 @@ impl PyModule {
     }
 }
 
-pub fn generate_py_module(
-    doc: &Document,
-    compiler_config: &CompilerConfiguration,
-) -> std::io::Result<PyModule> {
+/// Build the Python API description from the lowered LLR plus the source-level
+/// `structs_and_enums`, which the LLR does not carry. Both are available without
+/// the object-tree `Document`, so the interpreter can generate the API from a
+/// `CompilationResult` alone.
+pub fn generate_py_module(unit: &llr::CompilationUnit, structs_and_enums: &[Type]) -> PyModule {
     let mut module = PyModule::default();
 
-    let mut compo_aliases: HashMap<SmolStr, Vec<SmolStr>> = Default::default();
-    let mut struct_aliases: HashMap<SmolStr, Vec<SmolStr>> = Default::default();
-    let mut enum_aliases: HashMap<SmolStr, Vec<SmolStr>> = Default::default();
-
-    for export in doc.exports.iter() {
-        match &export.1 {
-            Either::Left(component) if !component.is_global() && export.0.name != component.id => {
-                compo_aliases.entry(component.id.clone()).or_default().push(export.0.name.clone());
-            }
-            Either::Right(ty) => match &ty {
-                Type::Struct(s) if s.node().is_some() => {
-                    if let StructName::User { name: orig_name, .. } = &s.name
-                        && export.0.name != *orig_name
-                    {
-                        struct_aliases
-                            .entry(orig_name.clone())
-                            .or_default()
-                            .push(export.0.name.clone());
-                    }
-                }
-                Type::Enumeration(en) if export.0.name != en.name => {
-                    enum_aliases.entry(en.name.clone()).or_default().push(export.0.name.clone());
-                }
-                _ => {}
-            },
-            _ => {}
-        }
+    let mut aliases: HashMap<&str, Vec<SmolStr>> = Default::default();
+    for export in unit.type_exports.iter().filter(|e| e.is_alias()) {
+        aliases.entry(export.internal_name.as_str()).or_default().push(export.exported_name.clone());
     }
+    let aliases_of = |name: &str| aliases.get(name).cloned().unwrap_or_default();
 
-    // A type exported only under a different name is renamed to that name; keep the original
-    // name available as an alias so code that still imports it keeps working. The name belongs
-    // to whichever of the two type kinds actually declares it; the other map entry is never read.
-    for (old_name, new_name) in &doc.used_types.borrow().deprecated_type_aliases {
-        struct_aliases.entry(new_name.clone()).or_default().push(old_name.clone());
-        enum_aliases.entry(new_name.clone()).or_default().push(old_name.clone());
-    }
-
-    for ty in &doc.used_types.borrow().structs_and_enums {
+    for ty in structs_and_enums {
         match ty {
             Type::Struct(s) => module.structs_and_enums.extend(
                 PyStruct::try_from(s).ok().and_then(|mut pystruct| {
                     let StructName::User { name, .. } = &s.name else {
                         return None;
                     };
-                    pystruct.aliases = struct_aliases.remove(name).unwrap_or_default();
+                    pystruct.aliases = aliases_of(name);
                     Some(PyStructOrEnum::Struct(pystruct))
                 }),
             ),
             Type::Enumeration(en) => {
                 module.structs_and_enums.push({
                     let mut pyenum = PyEnum::from(en);
-                    pyenum.aliases = enum_aliases.remove(&en.name).unwrap_or_default();
+                    pyenum.aliases = aliases_of(&en.name);
                     PyStructOrEnum::Enum(pyenum)
                 });
             }
@@ -399,18 +369,19 @@ pub fn generate_py_module(
         }
     }
 
-    let llr = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
-
-    let globals = llr.globals.iter().filter(|glob| glob.exported && glob.must_generate());
-
-    module.globals.extend(globals.clone().map(PyComponent::from));
-    module.components.extend(llr.public_components.iter().map(|llr_compo| {
+    module.globals.extend(
+        unit.globals
+            .iter()
+            .filter(|glob| glob.exported && glob.must_generate())
+            .map(PyComponent::from),
+    );
+    module.components.extend(unit.public_components.iter().map(|llr_compo| {
         let mut pycompo = PyComponent::from(llr_compo);
-        pycompo.aliases = compo_aliases.remove(&llr_compo.name).unwrap_or_default();
+        pycompo.aliases = aliases_of(&llr_compo.name);
         pycompo
     }));
 
-    Ok(module)
+    module
 }
 
 /// This module contains some data structures that helps represent a Python file.
@@ -581,7 +552,7 @@ use crate::langtype::{StructName, Type};
 use crate::CompilerConfiguration;
 use crate::llr;
 use crate::object_tree::Document;
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use python_ast::*;
 
 /// Returns the text of the Python code produced by the given root component
@@ -594,7 +565,8 @@ pub fn generate(
     file.imports.push(SmolStr::new_static("slint"));
     file.imports.push(SmolStr::new_static("typing"));
 
-    let pymodule = generate_py_module(doc, compiler_config)?;
+    let unit = llr::lower_to_item_tree::lower_to_item_tree(doc, compiler_config);
+    let pymodule = generate_py_module(&unit, &doc.used_types.borrow().structs_and_enums);
 
     if pymodule.structs_and_enums.iter().any(|se| matches!(se, PyStructOrEnum::Enum(_))) {
         file.imports.push(SmolStr::new_static("enum"));

--- a/internal/compiler/generator/python.rs
+++ b/internal/compiler/generator/python.rs
@@ -343,7 +343,10 @@ pub fn generate_py_module(unit: &llr::CompilationUnit, structs_and_enums: &[Type
 
     let mut aliases: HashMap<&str, Vec<SmolStr>> = Default::default();
     for export in unit.type_exports.iter().filter(|e| e.is_alias()) {
-        aliases.entry(export.internal_name.as_str()).or_default().push(export.exported_name.clone());
+        aliases
+            .entry(export.internal_name.as_str())
+            .or_default()
+            .push(export.exported_name.clone());
     }
     let aliases_of = |name: &str| aliases.get(name).cloned().unwrap_or_default();
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1015,8 +1015,6 @@ impl Compiler {
                     watch_paths: vec![i_slint_compiler::pathutils::clean_path(path)],
                     #[cfg(feature = "internal")]
                     structs_and_enums: Vec::new(),
-                    #[cfg(feature = "internal")]
-                    named_exports: Vec::new(),
                 };
             }
         };
@@ -1059,8 +1057,6 @@ async fn build_compilation_result(
         watch_paths: result.watch_paths,
         #[cfg(feature = "internal")]
         structs_and_enums: result.structs_and_enums,
-        #[cfg(feature = "internal")]
-        named_exports: result.named_exports,
     }
 }
 
@@ -1078,9 +1074,6 @@ pub struct CompilationResult {
     pub(crate) watch_paths: Vec<PathBuf>,
     #[cfg(feature = "internal")]
     pub(crate) structs_and_enums: Vec<LangType>,
-    /// For `export { Foo as Bar }` this vec contains tuples of (`Foo`, `Bar`)
-    #[cfg(feature = "internal")]
-    pub(crate) named_exports: Vec<(String, String)>,
 }
 
 impl core::fmt::Debug for CompilationResult {
@@ -1150,14 +1143,14 @@ impl CompilationResult {
     }
 
     /// This is an internal function without API stability guarantees.
-    /// Returns the list of named export aliases as tuples (`export { Foo as Bar}` is (`Foo`, `Bar` tuple)).
+    /// The lowered compilation unit, or `None` when the compilation failed.
     #[doc(hidden)]
     #[cfg(feature = "internal")]
-    pub fn named_exports(
+    pub fn compilation_unit(
         &self,
         _: i_slint_core::InternalToken,
-    ) -> impl Iterator<Item = &(String, String)> {
-        self.named_exports.iter()
+    ) -> Option<&i_slint_compiler::llr::CompilationUnit> {
+        self.components.values().next().map(|d| &*d.inner.compilation_unit)
     }
 }
 

--- a/internal/interpreter/component.rs
+++ b/internal/interpreter/component.rs
@@ -347,9 +347,6 @@ pub struct BuildResult {
     pub watch_paths: Vec<std::path::PathBuf>,
     #[cfg(feature = "internal")]
     pub structs_and_enums: Vec<LangType>,
-    /// For `export { Foo as Bar }` this vec contains tuples of (`Foo`, `Bar`)
-    #[cfg(feature = "internal")]
-    pub named_exports: Vec<(String, String)>,
 }
 
 /// Compile a `.slint` source string.
@@ -416,8 +413,6 @@ pub async fn build_from_source(
         watch_paths: Vec::new(),
         #[cfg(feature = "internal")]
         structs_and_enums: Vec::new(),
-        #[cfg(feature = "internal")]
-        named_exports: Vec::new(),
     };
     if diag.has_errors() {
         return BuildResult {
@@ -451,44 +446,6 @@ pub async fn build_from_source(
     }
     #[cfg(feature = "internal")]
     let structs_and_enums = doc.used_types.borrow().structs_and_enums.clone();
-    #[cfg(feature = "internal")]
-    let mut named_exports = doc
-        .exports
-        .iter()
-        .filter_map(|export| {
-            use i_slint_compiler::langtype::{StructName, Type};
-            use itertools::Either;
-            match &export.1 {
-                Either::Left(component) if !component.is_global() => {
-                    Some((&export.0.name, &component.id))
-                }
-                Either::Right(ty) => match &ty {
-                    Type::Struct(s) if s.node().is_some() => {
-                        if let StructName::User { name, .. } = &s.name {
-                            Some((&export.0.name, name))
-                        } else {
-                            None
-                        }
-                    }
-                    Type::Enumeration(en) => Some((&export.0.name, &en.name)),
-                    _ => None,
-                },
-                _ => None,
-            }
-        })
-        .filter(|(export_name, type_name)| *export_name != *type_name)
-        .map(|(export_name, type_name)| (type_name.to_string(), export_name.to_string()))
-        .collect::<Vec<_>>();
-    // A type exported only under a different name is renamed to that name; keep the original
-    // name available as an alias so existing code keeps working.
-    #[cfg(feature = "internal")]
-    named_exports.extend(
-        doc.used_types
-            .borrow()
-            .deprecated_type_aliases
-            .iter()
-            .map(|(old_name, new_name)| (new_name.to_string(), old_name.to_string())),
-    );
     BuildResult {
         diagnostics: diag.into_iter().collect(),
         components,
@@ -496,7 +453,5 @@ pub async fn build_from_source(
         watch_paths,
         #[cfg(feature = "internal")]
         structs_and_enums,
-        #[cfg(feature = "internal")]
-        named_exports,
     }
 }


### PR DESCRIPTION
The Python generated_api regenerates the typed API to check the AOT stubs. Its generator (generate_py_module) already re-lowered the object tree to LLR and only pulled the structs/enums and export aliases from the Document -- the former are on CompilationResult, the latter now on the CompilationUnit. Drive it from the compilation unit plus the structs/enums list, so Python reads the API off the LLR and no longer re-lowers or needs the type loader. This also drops the tooling-only named_exports from BuildResult and CompilationResult.
