### PR TITLE
editor: Add canvas manipulation UI tests

### DIFF
--- a/.github/ci_path_filters.yaml
+++ b/.github/ci_path_filters.yaml
@@ -61,12 +61,14 @@ slint:
  - 'internal/**'
  - 'tests/screenshots/**'
  - 'tools/compiler/**'
- - 'tools/editor/**'
  - 'tools/figma_import/**'
  - 'tools/lsp/**'
  - 'tools/tr-extractor/**'
  - 'tools/viewer/**'
  - 'xtask/**'
+
+visual_editor:
+ - 'tools/editor/**'
 
 # Qt backend and widget definitions — gates the Qt test step in build_and_test
 qt:
@@ -205,3 +207,4 @@ rust_files:
  - '**/*.rs'
  - '**/Cargo.toml'
  - '.clippy.toml'
+ - '!tools/editor/**'

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -41,6 +41,7 @@ jobs:
               id: filter
               with:
                   filters: .github/ci_path_filters.yaml
+                  predicate-quantifier: some-with-excludes
 
     format_fix:
         runs-on: ubuntu-latest
@@ -93,6 +94,7 @@ jobs:
             CLOUDFLARE_API_TOKEN_2: ${{ secrets.CLOUDFLARE_API_TOKEN_2 }}
             CLOUDFLARE_ACCOUNT_ID_2: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_2 }}
             READ_WRITE_PRIVATE_KEY: ${{ secrets.READ_WRITE_PRIVATE_KEY }}
+            SLINT_TESTING_TOKEN: ${{ secrets.SLINT_TESTING_TOKEN }}
 
     done:
         # Note: We use `needs` + `if: always()` here to ensure the "done"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ on:
           required: true
         READ_WRITE_PRIVATE_KEY:
           required: true
+        SLINT_TESTING_TOKEN:
+          required: true
 
 env:
     MACOSX_DEPLOYMENT_TARGET: "11.0"
@@ -77,6 +79,46 @@ jobs:
             test_rust_driver: ${{ !startsWith(matrix.os, 'macos') || inputs.full || contains(fromJSON(inputs.changes), 'api_rs') || contains(fromJSON(inputs.changes), 'tests') || contains(fromJSON(inputs.changes), 'qt') }}
             build_examples: ${{ inputs.full || contains(fromJSON(inputs.changes), 'integration') || contains(fromJSON(inputs.changes), 'examples') }}
             save_if: ${{ github.ref == 'refs/heads/master' }}
+
+    visual_editor:
+        if: ${{ contains(fromJSON(inputs.changes), 'visual_editor') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        name: Visual Editor
+        runs-on: macos-14
+        timeout-minutes: 120
+        env:
+            RUSTFLAGS: -D warnings
+            SLINT_EMIT_DEBUG_INFO: '1'
+        steps:
+            - uses: actions/checkout@v7
+            - uses: ./.github/actions/install-skia-dependencies
+            - uses: ./.github/actions/setup-rust
+              with:
+                  components: clippy
+                  key: x-visual-editor-v1
+                  save_if: ${{ github.ref == 'refs/heads/master' }}
+            - uses: actions/setup-python@v7
+              with:
+                  python-version: '3.11'
+            - uses: astral-sh/setup-uv@v7
+            - name: Install UI test dependencies
+              working-directory: tools/editor/ui-tests
+              env:
+                  UV_INDEX: slint-private=https://testing.slint.dev/simple/
+                  UV_INDEX_SLINT_PRIVATE_USERNAME: __token__
+                  UV_INDEX_SLINT_PRIVATE_PASSWORD: ${{ secrets.SLINT_TESTING_TOKEN }}
+              run: uv sync --locked
+            - name: Lint the visual editor
+              run: cargo clippy --locked -p slint-editor --all-targets --all-features --features slint/mcp -- -D warnings
+            - name: Test the visual editor
+              run: cargo test --locked -p slint-editor --all-features --features slint/mcp
+            - name: Build the visual editor UI test binary
+              run: cargo build --locked -p slint-editor --all-features --features slint/mcp
+            - name: Run visual editor UI tests
+              working-directory: tools/editor/ui-tests
+              env:
+                  SLINT_BACKEND: headless-skia
+                  SLINT_EDITOR_BINARY: ${{ github.workspace }}/target/debug/slint-editor
+              run: ./run-tests.sh
 
     # For changes to Slint internals, do a quick test on Linux for Node.js only.
     node_test_linux:

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ uv.lock
 !api/python/slint/uv.lock
 !api/python/briefcase/uv.lock
 !docs/python/uv.lock
+!tools/editor/ui-tests/uv.lock
 .python-version
 
 MODULE.bazel.lock

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -55,12 +55,15 @@ wait_for = [
 ]
 
 ["fix:python:format"]
-description = "Run ruff format"
+description = "Run Ruff fixes and formatting"
 # Run via uv as the ruff installation via mise is unreliable in the CI.
 # It keeps failing to find ruff, despite saying that it was installed.
 # --project picks up the ruff pinned in api/python/slint's dev group so this
 # matches the version CI lints with, while still formatting from the repo root.
-run = "uv run --project api/python/slint --only-group dev ruff format"
+run = """
+uv run --project api/python/slint --only-group dev ruff check --fix tools/editor/ui-tests
+uv run --project api/python/slint --only-group dev ruff format
+"""
 
 ["fix:rust:format"]
 description = "Run cargo fmt --all"
@@ -114,6 +117,11 @@ run = "pnpm run lint:fix"
 depends = ["prepare:pnpm-install"]
 
 ### Lints
+
+["lint:spell"]
+description = "Run cspell"
+run = "pnpm spellcheck"
+depends = ["prepare:pnpm-install"]
 
 ["lint:ts:typecheck"]
 description = "Run pnpm format:fix"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -41,6 +41,12 @@ SPDX-FileCopyrightText = "Copyright © 2026 GitHub Inc."
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
+path = ["tools/editor/ui-tests/fixtures/editor-project/assets/checker.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Copyright © SixtyFPS GmbH <info@slint.dev>"
+SPDX-License-Identifier = "GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0"
+
+[[annotations]]
 path = [
   "**/.eslintrc.yml",
   "**/.gitignore",

--- a/cspell.json
+++ b/cspell.json
@@ -378,6 +378,17 @@
   ],
   "overrides": [
     {
+      "filename": "tools/editor/ui-tests/**",
+      "words": [
+        "backslashreplace",
+        "lineterm",
+        "testpaths",
+        "tofile",
+        "worksteal",
+        "xdist"
+      ]
+    },
+    {
       "filename": "demos/printerdemo/lang/fr/**",
       "language": "en,fr",
             "dictionaries": [

--- a/tools/editor/Cargo.toml
+++ b/tools/editor/Cargo.toml
@@ -22,6 +22,8 @@ path = "main.rs"
 [features]
 ## Discover preview targets on the local network.
 preview-remote = ["dep:mdns-sd"]
+## Enable the out-of-process system-testing transport.
+system-testing = ["slint/system-testing"]
 
 [dependencies]
 i-slint-backend-selector = { workspace = true }

--- a/tools/editor/ui-tests/.gitignore
+++ b/tools/editor/ui-tests/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+.pytest_cache/
+__pycache__/
+*.py[cod]

--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -1,0 +1,75 @@
+# Visual Editor UI Tests
+
+These tests use the private Python `slint-testing` package to run the visual editor and control it out of process.
+
+The suite covers 67 canvas manipulation behaviors as independent pytest cases.
+Of these, 36 run and 31 remain skipped until their Rust editor fixes land.
+
+Each behavior starts from a fresh source fixture and editor process.
+This prevents one failed interaction from affecting later behavior checks.
+
+## Set Up the Environment
+
+Set `SLINT_TESTING_TOKEN` to the access token from your Slint license.
+Then install the test dependencies without storing the token in this repository or `uv.lock`:
+
+```sh
+cd tools/editor/ui-tests
+UV_INDEX="slint-private=https://testing.slint.dev/simple/" \
+UV_INDEX_SLINT_PRIVATE_USERNAME=__token__ \
+UV_INDEX_SLINT_PRIVATE_PASSWORD="$SLINT_TESTING_TOKEN" \
+uv sync --locked
+```
+
+## Build and Run
+
+Build the editor with debug information, the system-testing transport, and the
+feature that provides the headless Skia backend:
+
+```sh
+SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 \
+SLINT_EMIT_DEBUG_INFO=1 \
+cargo build -p slint-editor \
+    --features system-testing,slint/mcp
+```
+
+Run the tests:
+
+```sh
+cd tools/editor/ui-tests
+./run-tests.sh
+```
+
+The runner uses up to four workers and lets pytest report the result and total duration.
+The tests use the headless Skia backend by default, so editor windows do not appear locally or in CI.
+
+## Watch the Tests on a Desktop
+
+Run the suite with native windows to see each interaction:
+
+```sh
+./run-tests.sh --visible
+```
+
+Visible mode uses the `winit-skia` backend and runs serially so test windows don't overlap.
+Pass a normal pytest selection after `--visible` to watch specific cases:
+
+```sh
+./run-tests.sh --visible \
+    tests/test_canvas.py::test_rotation_crosses_zero_with_exact_source
+```
+
+Set `SLINT_EDITOR_BINARY` to test a different editor binary.
+
+## Rust-Dependent Cases
+
+The suite retains skipped cases for behavior that needs changes in the Rust
+preview implementation:
+
+- resizing elements that have their own rotation
+- moving rotated elements, including a rotated child under rotated ancestors
+- persisting moves of selected Rectangle previews
+- moving selected Text elements beyond the artboard bounds
+- canceling transient preview overrides when the pointer exits
+
+Remove a skip when its Rust implementation lands.

--- a/tools/editor/ui-tests/fixtures/editor-project/BoundsCases.slint
+++ b/tools/editor/ui-tests/fixtures/editor-project/BoundsCases.slint
@@ -1,0 +1,34 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component BoundsCases inherits Window {
+    width: 388px;
+    height: 718px;
+    background: #f8fafc;
+
+    bounds-rectangle := Rectangle {
+        x: 96px;
+        y: 80px;
+        width: 120px;
+        height: 96px;
+        background: #2563eb;
+    }
+
+    bounds-text := Text {
+        x: 104px;
+        y: 260px;
+        width: 140px;
+        height: 48px;
+        text: "Bounds text";
+        color: #111827;
+    }
+
+    bounds-image := Image {
+        x: 128px;
+        y: 480px;
+        width: 128px;
+        height: 96px;
+        source: @image-url("assets/checker.svg");
+        image-fit: contain;
+    }
+}

--- a/tools/editor/ui-tests/fixtures/editor-project/CanvasCases.slint
+++ b/tools/editor/ui-tests/fixtures/editor-project/CanvasCases.slint
@@ -1,0 +1,31 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component CanvasCases inherits Window {
+    width: 640px;
+    height: 480px;
+    background: #f8fafc;
+
+    prohibited-layout := HorizontalLayout {
+        x: 32px;
+        y: 32px;
+        width: 240px;
+        height: 96px;
+
+        layout-rectangle := Rectangle {
+            background: #f97316;
+        }
+    }
+
+    HorizontalLayout {
+        x: 320px;
+        y: 48px;
+        width: 160px;
+        height: 96px;
+
+        rotated-rectangle := Rectangle {
+            background: #8b5cf6;
+            transform-rotation: 10deg;
+        }
+    }
+}

--- a/tools/editor/ui-tests/fixtures/editor-project/Main.slint
+++ b/tools/editor/ui-tests/fixtures/editor-project/Main.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { NestedCard } from "components/Nested.slint";
+
+export component Main inherits Window {
+    width: 640px;
+    height: 480px;
+    background: #f8fafc;
+
+    root-rectangle := Rectangle {
+        x: 40px;
+        y: 40px;
+        width: 180px;
+        height: 120px;
+        background: #2563eb;
+        border-radius: 12px;
+    }
+
+    root-text := Text {
+        x: 180px;
+        y: 56px;
+        width: 180px;
+        height: 48px;
+        text: "Fixture text";
+        color: #111827;
+        font-size: 20px;
+    }
+
+    root-image := Image {
+        x: 230px;
+        y: 132px;
+        width: 128px;
+        height: 96px;
+        source: @image-url("assets/checker.svg");
+        image-fit: contain;
+    }
+
+    NestedCard {
+        x: 40px;
+        y: 216px;
+    }
+}

--- a/tools/editor/ui-tests/fixtures/editor-project/RotatedCanvasCases.slint
+++ b/tools/editor/ui-tests/fixtures/editor-project/RotatedCanvasCases.slint
@@ -1,0 +1,65 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component RotatedCanvasCases inherits Window {
+    width: 640px;
+    height: 480px;
+    background: #f8fafc;
+
+    rotated-free-rectangle := Rectangle {
+        x: 64px;
+        y: 56px;
+        width: 140px;
+        height: 96px;
+        background: #2563eb;
+        transform-rotation: 30deg;
+    }
+
+    rotated-free-text := Text {
+        x: 160px;
+        y: 64px;
+        width: 180px;
+        height: 56px;
+        text: "Rotated text";
+        color: #111827;
+        transform-rotation: 30deg;
+    }
+
+    rotated-free-image := Image {
+        x: 200px;
+        y: 208px;
+        width: 144px;
+        height: 96px;
+        source: @image-url("assets/checker.svg");
+        image-fit: contain;
+        transform-rotation: 30deg;
+    }
+
+    nested-outer := Rectangle {
+        x: 360px;
+        y: 80px;
+        width: 220px;
+        height: 260px;
+        background: #e2e8f0;
+        transform-rotation: 30deg;
+
+        nested-middle := Rectangle {
+            x: 30px;
+            y: 40px;
+            width: 160px;
+            height: 180px;
+            background: #cbd5e1;
+            transform-rotation: 60deg;
+
+            nested-rotated-text := Text {
+                x: 44px;
+                y: 52px;
+                width: 100px;
+                height: 40px;
+                text: "Nested rotation";
+                color: #0f172a;
+                transform-rotation: -20deg;
+            }
+        }
+    }
+}

--- a/tools/editor/ui-tests/fixtures/editor-project/assets/checker.svg
+++ b/tools/editor/ui-tests/fixtures/editor-project/assets/checker.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="32" viewBox="0 0 64 32">
+  <rect width="64" height="32" fill="#ef4444"/>
+  <rect width="12" height="32" fill="#22c55e"/>
+  <rect x="48" width="16" height="12" fill="#3b82f6"/>
+  <circle cx="42" cy="23" r="6" fill="#f59e0b"/>
+</svg>

--- a/tools/editor/ui-tests/fixtures/editor-project/components/Nested.slint
+++ b/tools/editor/ui-tests/fixtures/editor-project/components/Nested.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component NestedCard inherits Rectangle {
+    width: 360px;
+    height: 160px;
+    background: #e2e8f0;
+
+    nested-text := Text {
+        x: 24px;
+        y: 24px;
+        text: "Imported component";
+        color: #334155;
+    }
+}

--- a/tools/editor/ui-tests/pyproject.toml
+++ b/tools/editor/ui-tests/pyproject.toml
@@ -1,0 +1,17 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+[project]
+name = "slint-editor-ui-tests"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["pytest>=9,<10", "pytest-xdist>=3.8,<4", "slint-testing==0.3"]
+
+[tool.uv]
+package = false
+
+[tool.uv.sources]
+slint-testing = { index = "slint-private" }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tools/editor/ui-tests/run-tests.sh
+++ b/tools/editor/ui-tests/run-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+# cspell:ignore getconf NPROCESSORS ONLN worksteal
+
+set -eu
+
+if [ "${1:-}" = "--visible" ]; then
+    shift
+    export SLINT_EDITOR_UI_TEST_BACKEND=winit-skia
+else
+    worker_count=$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '1\n')
+    if [ "$worker_count" -gt 4 ]; then
+        worker_count=4
+    fi
+    set -- -n "$worker_count" --dist=worksteal "$@"
+fi
+
+UV_CACHE_DIR="${UV_CACHE_DIR:-/private/tmp/slint-editor-ui-uv-cache}" \
+uv run --no-sync pytest -ra "$@"

--- a/tools/editor/ui-tests/tests/canvas_interactions.py
+++ b/tools/editor/ui-tests/tests/canvas_interactions.py
@@ -1,0 +1,321 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import math
+
+import slint_testing
+from slint_testing import keys
+from source_oracle import SourceSnapshot
+from ui_driver import elements_with_label, wait_until, window_element_with_label
+
+Frame = tuple[float, float, float, float]
+
+
+def center(element: slint_testing.Element) -> slint_testing.LogicalPosition:
+    position = element.absolute_position
+    size = element.size
+    return slint_testing.LogicalPosition(
+        x=position.x + size.width / 2,
+        y=position.y + size.height / 2,
+    )
+
+
+def position_distance(
+    left: slint_testing.LogicalPosition, right: slint_testing.LogicalPosition
+) -> float:
+    return math.hypot(left.x - right.x, left.y - right.y)
+
+
+def selection_frame(window: slint_testing.Window, kind: str) -> Frame:
+    selected = window_element_with_label(
+        window, f"Selected {kind}", slint_testing.AccessibleRole.Region
+    )
+    position = selected.absolute_position
+    size = selected.size
+    return (position.x, position.y, size.width, size.height)
+
+
+def same_state(left: Frame, right: Frame) -> bool:
+    return all(abs(a - b) < 0.01 for a, b in zip(left, right))
+
+
+def manual_drag(
+    window: slint_testing.Window,
+    handle: slint_testing.Element,
+    dx: float,
+    dy: float,
+    snapshot: SourceSnapshot,
+    shift: bool = False,
+    require_multiple_transient_states: bool = True,
+    fixed_handle_label: str | None = None,
+) -> slint_testing.LogicalPosition | None:
+    start = center(handle)
+    end = slint_testing.LogicalPosition(x=start.x + dx, y=start.y + dy)
+    button = slint_testing.PointerEventButton.Left
+    kind = handle.accessible_label.split(" ", 1)[0]
+    initial_frame = selection_frame(window, kind)
+    fixed_handle_center = (
+        center(window_element_with_label(window, fixed_handle_label))
+        if fixed_handle_label is not None
+        else None
+    )
+
+    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+    if shift:
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+
+    transient_states = []
+    for step in range(1, 4):
+        fraction = step / 3
+        position = slint_testing.LogicalPosition(
+            x=start.x + dx * fraction,
+            y=start.y + dy * fraction,
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(position))
+        transient_states.append(selection_frame(window, kind))
+
+    assert transient_states[-1] != initial_frame
+    if require_multiple_transient_states:
+        assert len(set(transient_states)) >= 2
+    if fixed_handle_center is not None:
+        assert fixed_handle_label is not None
+        assert (
+            position_distance(
+                center(window_element_with_label(window, handle.accessible_label)), end
+            )
+            < 1.5
+        )
+        assert (
+            position_distance(
+                center(window_element_with_label(window, fixed_handle_label)),
+                fixed_handle_center,
+            )
+            < 1.5
+        )
+
+    snapshot.assert_unchanged_now()
+    window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+    if shift:
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+    return fixed_handle_center
+
+
+def _rotation_tooltip_value(window: slint_testing.Window) -> int:
+    tooltip = window_element_with_label(
+        window, "Rotation angle", slint_testing.AccessibleRole.Text
+    )
+    return int(tooltip.accessible_value)
+
+
+def manual_rotation_drag(
+    window: slint_testing.Window,
+    handle: slint_testing.Element,
+    dx: float,
+    dy: float,
+    snapshot: SourceSnapshot,
+    *,
+    crosses_zero: bool = False,
+) -> None:
+    start = center(handle)
+    end = slint_testing.LogicalPosition(x=start.x + dx, y=start.y + dy)
+    button = slint_testing.PointerEventButton.Left
+    initial_frame = selection_frame(window, "Text")
+    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+    window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+    angles = [_rotation_tooltip_value(window)]
+    frames = []
+    for step in range(1, 4):
+        fraction = step / 3
+        position = slint_testing.LogicalPosition(
+            x=start.x + dx * fraction,
+            y=start.y + dy * fraction,
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(position))
+        angles.append(_rotation_tooltip_value(window))
+        frames.append(selection_frame(window, "Text"))
+    snapshot.assert_unchanged_now()
+
+    assert all(0 <= angle < 360 for angle in angles)
+    assert angles[-1] == 15 or crosses_zero
+    assert frames[-1] != initial_frame
+    if crosses_zero:
+        assert any(angle >= 345 for angle in angles)
+        assert any(angle <= 15 for angle in angles)
+    window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+    window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
+def rotation_delta(
+    window: slint_testing.Window,
+    handle: slint_testing.Element,
+    degrees: float,
+) -> tuple[float, float]:
+    x, y, width, height = selection_frame(window, "Text")
+    frame_center = slint_testing.LogicalPosition(
+        x=x + width / 2,
+        y=y + height / 2,
+    )
+    start = center(handle)
+    radians = math.radians(degrees)
+    cosine = math.cos(radians)
+    sine = math.sin(radians)
+    relative_x = start.x - frame_center.x
+    relative_y = start.y - frame_center.y
+    target_x = frame_center.x + relative_x * cosine - relative_y * sine
+    target_y = frame_center.y + relative_x * sine + relative_y * cosine
+    return target_x - start.x, target_y - start.y
+
+
+def cancel_pointer_interaction(
+    window: slint_testing.Window,
+    handle: slint_testing.Element,
+    dx: float,
+    dy: float,
+    snapshot: SourceSnapshot,
+    kind: str,
+) -> None:
+    start = center(handle)
+    target = slint_testing.LogicalPosition(x=start.x + dx, y=start.y + dy)
+    frame_kind = "Rectangle" if kind == "Rectangle-radius" else kind
+    initial_frame = selection_frame(window, frame_kind)
+    button = slint_testing.PointerEventButton.Left
+    readout_label = {
+        "Rectangle-radius": "Radius value",
+        "Text": "Rotation angle",
+    }.get(kind)
+
+    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+    if kind == "Text":
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+    initial_readout = (
+        float(
+            window_element_with_label(
+                window, readout_label, slint_testing.AccessibleRole.Text
+            ).accessible_value
+        )
+        if readout_label is not None
+        else None
+    )
+    window.dispatch_event(slint_testing.PointerMoveEvent(target))
+
+    if readout_label is None:
+        wait_until(
+            lambda: (
+                frame
+                if (frame := selection_frame(window, frame_kind)) != initial_frame
+                else None
+            )
+        )
+    else:
+        wait_until(
+            lambda: (
+                value
+                if (
+                    value := float(
+                        window_element_with_label(
+                            window, readout_label, slint_testing.AccessibleRole.Text
+                        ).accessible_value
+                    )
+                )
+                != initial_readout
+                else None
+            )
+        )
+    snapshot.assert_unchanged_now()
+
+    window.dispatch_event(slint_testing.PointerExitedEvent())
+    window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+    if kind == "Text":
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+    wait_until(
+        lambda: (
+            True
+            if same_state(selection_frame(window, frame_kind), initial_frame)
+            else None
+        )
+    )
+    assert not elements_with_label(window.root_element, "Rotation angle")
+    assert not elements_with_label(window.root_element, "Radius value")
+    snapshot.assert_unchanged()
+
+
+def live_modifier_resize(
+    window: slint_testing.Window,
+    snapshot: SourceSnapshot,
+    *,
+    press_shift_during_drag: bool,
+) -> None:
+    handle = window_element_with_label(window, "Rectangle resize bottom-right")
+    start = center(handle)
+    end = slint_testing.LogicalPosition(x=start.x + 20, y=start.y + 16)
+    button = slint_testing.PointerEventButton.Left
+    if not press_shift_during_drag:
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+    window.dispatch_event(slint_testing.PointerMoveEvent(end))
+    before_modifier = selection_frame(window, "Rectangle")
+    snapshot.assert_unchanged_now()
+
+    modifier_event = (
+        slint_testing.KeyPressedEvent(text=keys.Shift)
+        if press_shift_during_drag
+        else slint_testing.KeyReleasedEvent(text=keys.Shift)
+    )
+    window.dispatch_event(modifier_event)
+    after_modifier = wait_until(
+        lambda: (
+            frame
+            if (frame := selection_frame(window, "Rectangle")) != before_modifier
+            else None
+        )
+    )
+    if press_shift_during_drag:
+        assert after_modifier[2] == after_modifier[3]
+    else:
+        assert after_modifier[2] != after_modifier[3]
+    snapshot.assert_unchanged_now()
+
+    window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+    if press_shift_during_drag:
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
+def manual_radius_drag(
+    window: slint_testing.Window,
+    handle: slint_testing.Element,
+    dx: float,
+    dy: float,
+    snapshot: SourceSnapshot,
+    *,
+    shift: bool = False,
+) -> None:
+    start = center(handle)
+    target = slint_testing.LogicalPosition(x=start.x + dx, y=start.y + dy)
+    button = slint_testing.PointerEventButton.Left
+    if shift:
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+    initial_value = float(
+        window_element_with_label(
+            window, "Radius value", slint_testing.AccessibleRole.Text
+        ).accessible_value
+    )
+    window.dispatch_event(slint_testing.PointerMoveEvent(target))
+    wait_until(
+        lambda: (
+            value
+            if (
+                value := float(
+                    window_element_with_label(
+                        window, "Radius value", slint_testing.AccessibleRole.Text
+                    ).accessible_value
+                )
+            )
+            != initial_value
+            else None
+        )
+    )
+    snapshot.assert_unchanged_now()
+    window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+    if shift:
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))

--- a/tools/editor/ui-tests/tests/conftest.py
+++ b/tools/editor/ui-tests/tests/conftest.py
@@ -1,0 +1,43 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+UI_TEST_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = UI_TEST_ROOT.parents[2]
+FIXTURE_PROJECT = UI_TEST_ROOT / "fixtures" / "editor-project"
+DEFAULT_EDITOR_BINARY = REPOSITORY_ROOT / "target" / "debug" / "slint-editor"
+
+
+@pytest.fixture
+def editor_binary() -> Path:
+    binary = Path(os.environ.get("SLINT_EDITOR_BINARY", DEFAULT_EDITOR_BINARY))
+    assert binary.is_file(), f"Editor binary not found at {binary}"
+    return binary
+
+
+@pytest.fixture
+def editor_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.pop("SLINT_SCALE_FACTOR", None)
+    environment.update(
+        {
+            "SLINT_BACKEND": environment.get(
+                "SLINT_EDITOR_UI_TEST_BACKEND", "headless-skia"
+            ),
+            "SLINT_EMIT_DEBUG_INFO": "1",
+            "SLINT_ENABLE_EXPERIMENTAL_FEATURES": "1",
+        }
+    )
+    return environment
+
+
+@pytest.fixture
+def fixture_project(tmp_path: Path) -> Path:
+    destination = tmp_path / "editor-project"
+    shutil.copytree(FIXTURE_PROJECT, destination)
+    return destination

--- a/tools/editor/ui-tests/tests/source_oracle.py
+++ b/tools/editor/ui-tests/tests/source_oracle.py
@@ -1,0 +1,81 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import time
+from dataclasses import dataclass
+from difflib import unified_diff
+from pathlib import Path
+
+
+def slint_sources(project: Path) -> dict[Path, bytes]:
+    return {
+        path.relative_to(project): path.read_bytes()
+        for path in sorted(project.rglob("*.slint"))
+    }
+
+
+def exact_source_mismatch(
+    current: dict[Path, bytes], expected: dict[Path, bytes]
+) -> str:
+    differences = []
+    for path in sorted(current.keys() | expected.keys()):
+        actual = current.get(path, b"").decode(errors="backslashreplace").splitlines()
+        wanted = expected.get(path, b"").decode(errors="backslashreplace").splitlines()
+        if actual == wanted:
+            continue
+        differences.extend(
+            unified_diff(
+                wanted,
+                actual,
+                fromfile=f"expected/{path}",
+                tofile=f"actual/{path}",
+                lineterm="",
+            )
+        )
+    return "exact .slint source mismatch:\n" + "\n".join(differences)
+
+
+@dataclass(frozen=True)
+class SourceSnapshot:
+    project: Path
+    sources: dict[Path, bytes]
+
+    @classmethod
+    def capture(cls, project: Path) -> "SourceSnapshot":
+        return cls(project=project, sources=slint_sources(project))
+
+    def assert_unchanged_now(self) -> None:
+        current = slint_sources(self.project)
+        assert current == self.sources, exact_source_mismatch(current, self.sources)
+
+    def assert_unchanged(
+        self, quiescence: float = 0.25, poll_interval: float = 0.02
+    ) -> None:
+        deadline = time.monotonic() + quiescence
+        while True:
+            self.assert_unchanged_now()
+            if time.monotonic() >= deadline:
+                return
+            time.sleep(poll_interval)
+
+    def wait_for_exact(
+        self,
+        expected: bytes,
+        relative_path: Path | str = "Main.slint",
+        timeout: float = 5,
+        poll_interval: float = 0.02,
+    ) -> None:
+        relative_path = Path(relative_path)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            current = slint_sources(self.project)
+            expected_sources = self.sources | {relative_path: expected}
+            if current == expected_sources:
+                return
+            time.sleep(poll_interval)
+
+        current = slint_sources(self.project)
+        expected_sources = self.sources | {relative_path: expected}
+        assert current == expected_sources, exact_source_mismatch(
+            current, expected_sources
+        )

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -1,0 +1,865 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import math
+from pathlib import Path
+
+import pytest
+import slint_testing
+from canvas_interactions import (
+    cancel_pointer_interaction,
+    center,
+    live_modifier_resize,
+    manual_drag,
+    manual_radius_drag,
+    manual_rotation_drag,
+    position_distance,
+    rotation_delta,
+    same_state,
+    selection_frame,
+)
+from source_oracle import SourceSnapshot
+from ui_driver import (
+    first_window,
+    launch_editor,
+    select_fixture_element,
+    select_outline_row,
+    window_element_with_label,
+)
+
+CORNERS = ["top-left", "top-right", "bottom-right", "bottom-left"]
+OPPOSITE_CORNERS = {
+    "top-left": "bottom-right",
+    "top-right": "bottom-left",
+    "bottom-right": "top-left",
+    "bottom-left": "top-right",
+}
+CORNER_DELTAS: dict[str, tuple[int, int]] = {
+    "top-left": (-20, -16),
+    "top-right": (20, -16),
+    "bottom-right": (20, 16),
+    "bottom-left": (-20, 16),
+}
+RADIUS_DELTAS: dict[str, tuple[int, int]] = {
+    "top-left": (4, 4),
+    "top-right": (-4, 4),
+    "bottom-right": (-4, -4),
+    "bottom-left": (4, -4),
+}
+MOVE_KINDS = ("Rectangle", "Text", "Image")
+ROTATED_KINDS = ("Rectangle", "Text", "Image")
+BOUNDARY_KINDS = ("Rectangle", "Text", "Image")
+BOUNDARY_MOVE_DIRECTIONS = ("top-left", "bottom-right")
+OUTSIDE_ARTBOARD_DISTANCE = 32
+BOUNDS_WIDTH = 388
+BOUNDS_HEIGHT = 718
+THRESHOLD_LABELS = (
+    "Rectangle move handle",
+    "Rectangle resize bottom-right",
+    "Rectangle rotate top-left",
+    "Rectangle radius top-left",
+)
+DISABLED_IDS = ("layout-rectangle", "rotated-rectangle")
+RUST_FIX_REQUIRED = pytest.mark.skip(
+    reason="Requires a Rust visual editor behavior fix"
+)
+
+
+def replace_once(source: bytes, old: bytes, new: bytes) -> bytes:
+    assert source.count(old) == 1
+    return source.replace(old, new, 1)
+
+
+def rotated_resize_values(
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    corner: str,
+    dx: float,
+    dy: float,
+    angle_degrees: float = 30,
+) -> tuple[int, int, int, int]:
+    angle = math.radians(angle_degrees)
+    cosine = math.cos(angle)
+    sine = math.sin(angle)
+    local_dx = dx * cosine + dy * sine
+    local_dy = -dx * sine + dy * cosine
+    new_width = width - local_dx if corner.endswith("left") else width + local_dx
+    new_height = height - local_dy if corner.startswith("top") else height + local_dy
+
+    fixed_left = not corner.endswith("left")
+    fixed_top = not corner.startswith("top")
+    old_fixed_x = 0 if fixed_left else width
+    old_fixed_y = 0 if fixed_top else height
+    old_center_x = width / 2
+    old_center_y = height / 2
+    fixed_parent_x = (
+        x
+        + old_center_x
+        + (old_fixed_x - old_center_x) * cosine
+        - (old_fixed_y - old_center_y) * sine
+    )
+    fixed_parent_y = (
+        y
+        + old_center_y
+        + (old_fixed_x - old_center_x) * sine
+        + (old_fixed_y - old_center_y) * cosine
+    )
+    new_fixed_x = 0 if fixed_left else new_width
+    new_fixed_y = 0 if fixed_top else new_height
+    new_center_x = new_width / 2
+    new_center_y = new_height / 2
+    fixed_delta_x = (new_fixed_x - new_center_x) * cosine - (
+        new_fixed_y - new_center_y
+    ) * sine
+    fixed_delta_y = (new_fixed_x - new_center_x) * sine + (
+        new_fixed_y - new_center_y
+    ) * cosine
+    new_x = fixed_parent_x - fixed_delta_x - new_center_x
+    new_y = fixed_parent_y - fixed_delta_y - new_center_y
+    return (round(new_x), round(new_y), round(new_width), round(new_height))
+
+
+def geometry_source(values: tuple[int, int, int, int]) -> bytes:
+    x, y, width, height = values
+    return (
+        f"        x: {x}px;\n"
+        f"        y: {y}px;\n"
+        f"        width: {width}px;\n"
+        f"        height: {height}px;"
+    ).encode()
+
+
+def outside_move_values(
+    geometry: tuple[int, int, int, int], direction: str
+) -> tuple[int, int, int, int]:
+    _, _, width, height = geometry
+    if direction == "top-left":
+        return (
+            -OUTSIDE_ARTBOARD_DISTANCE,
+            -OUTSIDE_ARTBOARD_DISTANCE,
+            width,
+            height,
+        )
+    return (
+        BOUNDS_WIDTH + OUTSIDE_ARTBOARD_DISTANCE - width,
+        BOUNDS_HEIGHT + OUTSIDE_ARTBOARD_DISTANCE - height,
+        width,
+        height,
+    )
+
+
+def outside_resize_values(
+    geometry: tuple[int, int, int, int], corner: str
+) -> tuple[int, int, int, int]:
+    x, y, width, height = geometry
+    if corner == "top-left":
+        return (
+            -OUTSIDE_ARTBOARD_DISTANCE,
+            -OUTSIDE_ARTBOARD_DISTANCE,
+            x + width + OUTSIDE_ARTBOARD_DISTANCE,
+            y + height + OUTSIDE_ARTBOARD_DISTANCE,
+        )
+    if corner == "top-right":
+        return (
+            x,
+            -OUTSIDE_ARTBOARD_DISTANCE,
+            BOUNDS_WIDTH + OUTSIDE_ARTBOARD_DISTANCE - x,
+            y + height + OUTSIDE_ARTBOARD_DISTANCE,
+        )
+    if corner == "bottom-right":
+        return (
+            x,
+            y,
+            BOUNDS_WIDTH + OUTSIDE_ARTBOARD_DISTANCE - x,
+            BOUNDS_HEIGHT + OUTSIDE_ARTBOARD_DISTANCE - y,
+        )
+    return (
+        -OUTSIDE_ARTBOARD_DISTANCE,
+        y,
+        x + width + OUTSIDE_ARTBOARD_DISTANCE,
+        BOUNDS_HEIGHT + OUTSIDE_ARTBOARD_DISTANCE - y,
+    )
+
+
+def radius_handle(window: slint_testing.Window, corner: str) -> slint_testing.Element:
+    selection = window_element_with_label(
+        window, "Selected Rectangle", slint_testing.AccessibleRole.Region
+    )
+    # A live reload can replace the frame while the pointer remains at the same logical
+    # position. Move away first so the real frame receives a fresh hover transition.
+    window.dispatch_event(
+        slint_testing.PointerMoveEvent(slint_testing.LogicalPosition(x=1, y=1))
+    )
+    window.dispatch_event(slint_testing.PointerMoveEvent(center(selection)))
+    return window_element_with_label(window, f"Rectangle radius {corner}")
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [pytest.param("Rectangle", marks=RUST_FIX_REQUIRED), "Text", "Image"],
+)
+def test_move_element_writes_exact_source_on_release(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    positions = {
+        "Rectangle": (
+            b"        x: 40px;\n        y: 40px;",
+            b"        x: 60px;\n        y: 56px;",
+        ),
+        "Text": (
+            b"        x: 180px;\n        y: 56px;",
+            b"        x: 200px;\n        y: 72px;",
+        ),
+        "Image": (
+            b"        x: 230px;\n        y: 132px;",
+            b"        x: 250px;\n        y: 148px;",
+        ),
+    }
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        snapshot = SourceSnapshot.capture(fixture_project)
+        select_fixture_element(window, kind)
+        manual_drag(
+            window,
+            window_element_with_label(window, f"{kind} move handle"),
+            20,
+            16,
+            snapshot,
+        )
+        expected = replace_once(baseline, *positions[kind])
+        snapshot.wait_for_exact(expected)
+
+
+@RUST_FIX_REQUIRED
+@pytest.mark.parametrize("kind", MOVE_KINDS)
+def test_move_rotated_element_writes_exact_source_on_release(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+) -> None:
+    source_file = fixture_project / "RotatedCanvasCases.slint"
+    baseline = source_file.read_bytes()
+    positions = {
+        "Rectangle": (
+            b"        x: 64px;\n        y: 56px;",
+            b"        x: 84px;\n        y: 72px;",
+        ),
+        "Text": (
+            b"        x: 160px;\n        y: 64px;",
+            b"        x: 180px;\n        y: 80px;",
+        ),
+        "Image": (
+            b"        x: 200px;\n        y: 208px;",
+            b"        x: 220px;\n        y: 224px;",
+        ),
+    }
+
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        snapshot = SourceSnapshot.capture(fixture_project)
+        select_outline_row(window, f"rotated-free-{kind.lower()}")
+        manual_drag(
+            window,
+            window_element_with_label(window, f"{kind} move handle"),
+            20,
+            16,
+            snapshot,
+        )
+        expected = replace_once(baseline, *positions[kind])
+        snapshot.wait_for_exact(expected, "RotatedCanvasCases.slint")
+
+
+@RUST_FIX_REQUIRED
+def test_nested_rotated_element_move_writes_exact_local_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "RotatedCanvasCases.slint"
+    baseline = source_file.read_bytes()
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        snapshot = SourceSnapshot.capture(fixture_project)
+        select_outline_row(window, "nested-rotated-text")
+        manual_drag(
+            window,
+            window_element_with_label(window, "Text move handle"),
+            20,
+            16,
+            snapshot,
+        )
+        expected = replace_once(
+            baseline,
+            b"                x: 44px;\n                y: 52px;",
+            b"                x: 60px;\n                y: 32px;",
+        )
+        snapshot.wait_for_exact(expected, "RotatedCanvasCases.slint")
+
+
+@pytest.mark.parametrize("corner", CORNERS)
+def test_each_resize_handle_writes_exact_source_on_release(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    corner: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    original = b"        x: 40px;\n        y: 40px;\n        width: 180px;\n        height: 120px;"
+    geometries = {
+        "top-left": b"        x: 20px;\n        y: 24px;\n        width: 200px;\n        height: 136px;",
+        "top-right": b"        x: 40px;\n        y: 24px;\n        width: 200px;\n        height: 136px;",
+        "bottom-right": b"        x: 40px;\n        y: 40px;\n        width: 200px;\n        height: 136px;",
+        "bottom-left": b"        x: 20px;\n        y: 40px;\n        width: 200px;\n        height: 136px;",
+    }
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        manual_drag(
+            window,
+            window_element_with_label(window, f"Rectangle resize {corner}"),
+            *CORNER_DELTAS[corner],
+            snapshot,
+        )
+        expected = replace_once(baseline, original, geometries[corner])
+        snapshot.wait_for_exact(expected)
+
+
+def test_shift_resize_is_proportional(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        manual_drag(
+            window,
+            window_element_with_label(window, "Rectangle resize bottom-right"),
+            20,
+            16,
+            snapshot,
+            shift=True,
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                baseline,
+                b"        width: 180px;\n        height: 120px;",
+                b"        width: 200px;\n        height: 200px;",
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "press_shift_during_drag",
+    [pytest.param(True, id="press-shift"), pytest.param(False, id="release-shift")],
+)
+def test_resize_modifier_changes_during_drag(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    press_shift_during_drag: bool,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        live_modifier_resize(
+            window,
+            snapshot,
+            press_shift_during_drag=press_shift_during_drag,
+        )
+        geometry = (
+            b"        width: 200px;\n        height: 200px;"
+            if press_shift_during_drag
+            else b"        width: 200px;\n        height: 136px;"
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                baseline,
+                b"        width: 180px;\n        height: 120px;",
+                geometry,
+            ),
+        )
+
+
+@RUST_FIX_REQUIRED
+@pytest.mark.parametrize("kind", ROTATED_KINDS)
+@pytest.mark.parametrize("corner", CORNERS)
+def test_rotated_element_resize_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+    corner: str,
+) -> None:
+    source_file = fixture_project / "RotatedCanvasCases.slint"
+    baseline = source_file.read_bytes()
+    geometries = {
+        "Rectangle": (64, 56, 140, 96),
+        "Text": (160, 64, 180, 56),
+        "Image": (200, 208, 144, 96),
+    }
+    element_id = f"rotated-free-{kind.lower()}"
+
+    x, y, width, height = geometries[kind]
+    original = (
+        f"        x: {x}px;\n"
+        f"        y: {y}px;\n"
+        f"        width: {width}px;\n"
+        f"        height: {height}px;"
+    ).encode()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        snapshot = SourceSnapshot.capture(fixture_project)
+        select_outline_row(window, element_id)
+        opposite_label = f"{kind} resize {OPPOSITE_CORNERS[corner]}"
+        fixed_handle_center = manual_drag(
+            window,
+            window_element_with_label(window, f"{kind} resize {corner}"),
+            *CORNER_DELTAS[corner],
+            snapshot,
+            fixed_handle_label=opposite_label,
+        )
+        assert fixed_handle_center is not None
+        new_x, new_y, new_width, new_height = rotated_resize_values(
+            x,
+            y,
+            width,
+            height,
+            corner,
+            *CORNER_DELTAS[corner],
+        )
+        changed = (
+            f"        x: {new_x}px;\n"
+            f"        y: {new_y}px;\n"
+            f"        width: {new_width}px;\n"
+            f"        height: {new_height}px;"
+        ).encode()
+        snapshot.wait_for_exact(
+            replace_once(baseline, original, changed),
+            "RotatedCanvasCases.slint",
+        )
+        assert (
+            position_distance(
+                center(window_element_with_label(window, opposite_label)),
+                fixed_handle_center,
+            )
+            < 1.5
+        )
+
+
+def run_canvas_boundary_case(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+    operation: str,
+    target: str,
+) -> None:
+    source_file = fixture_project / "BoundsCases.slint"
+    baseline = source_file.read_bytes()
+    geometries = {
+        "Rectangle": (96, 80, 120, 96),
+        "Text": (104, 260, 140, 48),
+        "Image": (128, 480, 128, 96),
+    }
+    element_id = f"bounds-{kind.lower()}"
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_outline_row(window, element_id)
+        baseline_frame = selection_frame(window, kind)
+
+        geometry = geometries[kind]
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
+        left = artboard.absolute_position.x
+        top = artboard.absolute_position.y
+        right = left + artboard.size.width
+        bottom = top + artboard.size.height
+        if operation == "move":
+            label = f"{kind} move handle"
+            desired_position = (
+                (
+                    left - OUTSIDE_ARTBOARD_DISTANCE,
+                    top - OUTSIDE_ARTBOARD_DISTANCE,
+                )
+                if target == "top-left"
+                else (
+                    right + OUTSIDE_ARTBOARD_DISTANCE - baseline_frame[2],
+                    bottom + OUTSIDE_ARTBOARD_DISTANCE - baseline_frame[3],
+                )
+            )
+            delta = (
+                desired_position[0] - baseline_frame[0],
+                desired_position[1] - baseline_frame[1],
+            )
+            expected_geometry = outside_move_values(geometry, target)
+        else:
+            label = f"{kind} resize {target}"
+            handle = window_element_with_label(window, label)
+            start = center(handle)
+            target_position = {
+                "top-left": (
+                    left - OUTSIDE_ARTBOARD_DISTANCE,
+                    top - OUTSIDE_ARTBOARD_DISTANCE,
+                ),
+                "top-right": (
+                    right + OUTSIDE_ARTBOARD_DISTANCE,
+                    top - OUTSIDE_ARTBOARD_DISTANCE,
+                ),
+                "bottom-right": (
+                    right + OUTSIDE_ARTBOARD_DISTANCE,
+                    bottom + OUTSIDE_ARTBOARD_DISTANCE,
+                ),
+                "bottom-left": (
+                    left - OUTSIDE_ARTBOARD_DISTANCE,
+                    bottom + OUTSIDE_ARTBOARD_DISTANCE,
+                ),
+            }[target]
+            delta = (
+                target_position[0] - start.x,
+                target_position[1] - start.y,
+            )
+            expected_geometry = outside_resize_values(geometry, target)
+
+        snapshot = SourceSnapshot.capture(fixture_project)
+        manual_drag(
+            window,
+            window_element_with_label(window, label),
+            *delta,
+            snapshot,
+            require_multiple_transient_states=False,
+        )
+        expected = replace_once(
+            baseline,
+            geometry_source(geometry),
+            geometry_source(expected_geometry),
+        )
+        snapshot.wait_for_exact(expected, "BoundsCases.slint")
+
+
+@pytest.mark.parametrize(
+    ("kind", "direction"),
+    [
+        pytest.param(
+            kind,
+            direction,
+            marks=RUST_FIX_REQUIRED if kind == "Text" else (),
+            id=f"{kind}-{direction}",
+        )
+        for kind in BOUNDARY_KINDS
+        for direction in BOUNDARY_MOVE_DIRECTIONS
+    ],
+)
+def test_artboard_allows_moved_element_outside(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+    direction: str,
+) -> None:
+    run_canvas_boundary_case(
+        editor_binary,
+        editor_environment,
+        fixture_project,
+        kind,
+        "move",
+        direction,
+    )
+
+
+@pytest.mark.parametrize("kind", BOUNDARY_KINDS)
+@pytest.mark.parametrize("corner", CORNERS)
+def test_artboard_allows_resized_element_outside(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+    corner: str,
+) -> None:
+    run_canvas_boundary_case(
+        editor_binary,
+        editor_environment,
+        fixture_project,
+        kind,
+        "resize",
+        corner,
+    )
+
+
+@pytest.mark.parametrize("corner", CORNERS)
+def test_each_rotation_zone_writes_exact_source_on_release(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    corner: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    original = b'        text: "Fixture text";'
+    rotated = original + b"\n        transform-rotation: 15deg;"
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Text")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        handle = window_element_with_label(window, f"Text rotate {corner}")
+        manual_rotation_drag(
+            window,
+            handle,
+            *rotation_delta(window, handle, 15),
+            snapshot,
+        )
+        expected = replace_once(baseline, original, rotated)
+        snapshot.wait_for_exact(expected)
+
+
+def test_rotation_crosses_zero_with_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    original = b'        text: "Fixture text";'
+    crossing_baseline = replace_once(
+        baseline, original, original + b"\n        transform-rotation: 350deg;"
+    )
+    source_file.write_bytes(crossing_baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Text")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        manual_rotation_drag(
+            window,
+            window_element_with_label(window, "Text rotate top-left"),
+            20,
+            -20,
+            snapshot,
+            crosses_zero=True,
+        )
+        snapshot.wait_for_exact(
+            crossing_baseline.replace(
+                b"        transform-rotation: 350deg;",
+                b"        transform-rotation: 0deg;",
+                1,
+            ),
+        )
+
+
+def radius_source(baseline: bytes, radii: dict[str, int]) -> bytes:
+    original = b"        border-radius: 12px;"
+    properties = {"border-radius": 12}
+    properties.update(
+        {f"border-{corner}-radius": radius for corner, radius in radii.items()}
+    )
+    changed = "\n".join(
+        f"        {name}: {value}px;" for name, value in sorted(properties.items())
+    ).encode()
+    return replace_once(baseline, original, changed)
+
+
+@RUST_FIX_REQUIRED
+@pytest.mark.parametrize(
+    ("single", "corner"),
+    [
+        pytest.param(single, corner, id=f"{single}-{corner}")
+        for single in (False, True)
+        for corner in CORNERS
+    ],
+)
+def test_each_radius_handle_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    single: bool,
+    corner: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    radii = {corner: 16} if single else {name: 16 for name in CORNERS}
+    expected = radius_source(baseline, radii)
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        manual_radius_drag(
+            window,
+            radius_handle(window, corner),
+            *RADIUS_DELTAS[corner],
+            snapshot,
+            shift=single,
+        )
+        snapshot.wait_for_exact(expected)
+
+
+@RUST_FIX_REQUIRED
+def test_radius_is_clamped_to_half_the_shortest_side(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    expected = radius_source(baseline, {name: 60 for name in CORNERS})
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        manual_radius_drag(
+            window,
+            radius_handle(window, "top-left"),
+            100,
+            100,
+            snapshot,
+        )
+        snapshot.wait_for_exact(expected)
+
+
+@RUST_FIX_REQUIRED
+@pytest.mark.parametrize(
+    ("kind", "label", "delta"),
+    [
+        pytest.param(
+            "Rectangle", "Rectangle resize bottom-right", (20, 16), id="resize"
+        ),
+        pytest.param("Text", "Text rotate top-left", (20, -20), id="rotation"),
+        pytest.param(
+            "Rectangle-radius", "Rectangle radius top-left", (4, 4), id="radius"
+        ),
+    ],
+)
+def test_pointer_exit_cancels_interaction_and_allows_recovery(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+    label: str,
+    delta: tuple[int, int],
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Text" if kind == "Text" else "Rectangle")
+        handle = (
+            radius_handle(window, "top-left")
+            if kind == "Rectangle-radius"
+            else window_element_with_label(window, label)
+        )
+        snapshot = SourceSnapshot.capture(fixture_project)
+        cancel_pointer_interaction(window, handle, *delta, snapshot, kind)
+        if kind == "Rectangle":
+            manual_drag(
+                window,
+                window_element_with_label(window, label),
+                *delta,
+                snapshot,
+            )
+            expected = replace_once(
+                baseline,
+                b"        width: 180px;\n        height: 120px;",
+                b"        width: 200px;\n        height: 136px;",
+            )
+        elif kind == "Text":
+            manual_rotation_drag(
+                window,
+                window_element_with_label(window, label),
+                *delta,
+                snapshot,
+            )
+            expected = replace_once(
+                baseline,
+                b'        text: "Fixture text";',
+                b'        text: "Fixture text";\n        transform-rotation: 15deg;',
+            )
+        else:
+            manual_radius_drag(
+                window,
+                radius_handle(window, "top-left"),
+                *delta,
+                snapshot,
+            )
+            expected = radius_source(baseline, {corner: 16 for corner in CORNERS})
+        snapshot.wait_for_exact(expected)
+
+
+@pytest.mark.parametrize("label", THRESHOLD_LABELS)
+def test_handle_click_below_drag_threshold_does_not_edit_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    label: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        snapshot = SourceSnapshot.capture(fixture_project)
+        handle = (
+            radius_handle(window, "top-left")
+            if label == "Rectangle radius top-left"
+            else window_element_with_label(window, label)
+        )
+        before = selection_frame(window, "Rectangle")
+        start = center(handle)
+        end = slint_testing.LogicalPosition(x=start.x + 1, y=start.y + 1)
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+        assert same_state(selection_frame(window, "Rectangle"), before)
+        snapshot.assert_unchanged()
+
+
+@pytest.mark.parametrize("element_id", DISABLED_IDS)
+def test_disabled_manipulation_does_not_edit_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    element_id: str,
+) -> None:
+    source_file = fixture_project / "CanvasCases.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        snapshot = SourceSnapshot.capture(fixture_project)
+        select_outline_row(window, element_id)
+        window_element_with_label(window, "Selected Rectangle")
+        handle = window_element_with_label(window, "Rectangle resize bottom-right")
+        assert not handle.accessible_enabled
+        target = center(handle)
+        window.drag_and_drop(
+            target,
+            slint_testing.LogicalPosition(x=target.x + 20, y=target.y + 16),
+        )
+        snapshot.assert_unchanged()

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -1,0 +1,116 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import contextlib
+import time
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import TypeVar
+
+import slint_testing
+
+T = TypeVar("T")
+
+
+def wait_until(probe: Callable[[], T | None], timeout: float = 5) -> T:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = probe()
+        if result is not None:
+            return result
+        time.sleep(0.02)
+    result = probe()
+    assert result is not None
+    return result
+
+
+def first_window(
+    application: slint_testing.Application,
+) -> slint_testing.Window:
+    window = application.first_window
+    assert window is not None
+    return window
+
+
+def elements_with_label(
+    root: slint_testing.Element,
+    label: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> list[slint_testing.Element]:
+    query = root.query_descendants()
+    if role is not None:
+        query = query.match_accessible_role(role)
+    return [
+        element for element in query.find_all() if element.accessible_label == label
+    ]
+
+
+def element_with_label(
+    root: slint_testing.Element,
+    label: str,
+    role: slint_testing.AccessibleRole | None = None,
+    timeout: float = 5,
+) -> slint_testing.Element:
+    matches: list[slint_testing.Element] = []
+
+    def unique_match() -> slint_testing.Element | None:
+        nonlocal matches
+        matches = elements_with_label(root, label, role)
+        return matches[0] if len(matches) == 1 else None
+
+    try:
+        return wait_until(unique_match, timeout=timeout)
+    except AssertionError as error:
+        raise AssertionError(
+            f"expected exactly one element labeled {label!r}, found {len(matches)}"
+        ) from error
+
+
+def window_element_with_label(
+    window: slint_testing.Window,
+    label: str,
+    role: slint_testing.AccessibleRole | None = None,
+    timeout: float = 5,
+) -> slint_testing.Element:
+    return element_with_label(window.root_element, label, role, timeout)
+
+
+ELEMENT_ROWS = {
+    "Rectangle": "root-rectangle",
+    "Text": "root-text",
+    "Image": "root-image",
+}
+
+
+def select_outline_row(
+    window: slint_testing.Window, row_label: str
+) -> slint_testing.Element:
+    row = window_element_with_label(
+        window, row_label, slint_testing.AccessibleRole.ListItem
+    )
+    row.invoke_accessible_default_action()
+    return wait_until(lambda: row if row.accessible_item_selected else None)
+
+
+def select_fixture_element(window: slint_testing.Window, element_type: str) -> None:
+    select_outline_row(window, ELEMENT_ROWS[element_type])
+    window_element_with_label(
+        window,
+        f"Selected {element_type}",
+        slint_testing.AccessibleRole.Region,
+    )
+
+
+@contextlib.contextmanager
+def launch_editor(
+    binary: Path,
+    environment: dict[str, str],
+    file: Path | None = None,
+) -> Iterator[slint_testing.Application]:
+    arguments = [str(binary)]
+    if file is not None:
+        arguments.append(str(file))
+    with slint_testing.Application(
+        arguments, env=environment, launch_timeout=20
+    ) as application:
+        yield application

--- a/tools/editor/ui-tests/uv.lock
+++ b/tools/editor/ui-tests/uv.lock
@@ -1,0 +1,129 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "slint-editor-ui-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-xdist" },
+    { name = "slint-testing" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", specifier = ">=9,<10" },
+    { name = "pytest-xdist", specifier = ">=3.8,<4" },
+    { name = "slint-testing", specifier = "==0.3", index = "https://testing.slint.dev/simple/" },
+]
+
+[[package]]
+name = "slint-testing"
+version = "0.3"
+source = { registry = "https://testing.slint.dev/simple/" }
+dependencies = [
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://testing.slint.dev/simple/slint-testing/slint_testing-0.3-py3-none-any.whl", hash = "sha256:91c05d4f3faf528df26beb197cce668c7a61e97ac00b46eb0cc09666dbdcfe9f" },
+]

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -78,6 +78,7 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
             accessible-role: AccessibleRole.button;
             accessible-label: root.accessible-prefix + " radius " + root.corner-name(corner);
             private property <bool> event-shift-pressed: false;
+            private property <Point> press-position: { x: 0px, y: 0px };
 
             pointer-event(event) => {
                 self.event-shift-pressed = event.modifiers.shift;
@@ -90,6 +91,7 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
             changed pressed => {
                 root.radius-handle-active = self.has-hover || self.pressed;
                 if self.pressed {
+                    self.press-position = { x: self.mouse-x, y: self.mouse-y };
                     let pointer-x = parent.x + self.mouse-x;
                     let pointer-y = parent.y + self.mouse-y;
                     root.selected();
@@ -104,6 +106,14 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
             }
 
             moved => {
+                if !self.pressed {
+                    return;
+                }
+                let moved-far-enough = (self.mouse-x - self.press-position.x).abs() >= 2px
+                    || (self.mouse-y - self.press-position.y).abs() >= 2px;
+                if !moved-far-enough {
+                    return;
+                }
                 let pointer-x = parent.x + self.mouse-x;
                 let pointer-y = parent.y + self.mouse-y;
                 let radius = root.radius-from-handle(corner, pointer-x, pointer-y);

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -75,6 +75,8 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
 
         if root.enable-border-radius-edits: TouchArea {
             mouse-cursor: pointer;
+            accessible-role: AccessibleRole.button;
+            accessible-label: root.accessible-prefix + " radius " + root.corner-name(corner);
             private property <bool> event-shift-pressed: false;
 
             pointer-event(event) => {

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -21,6 +21,8 @@ component PhoneChrome inherits Rectangle {
         y: EditorMetrics.phone-outer-padding;
         width: parent.width - (2 * EditorMetrics.phone-outer-padding);
         height: parent.height - (2 * EditorMetrics.phone-outer-padding);
+        accessible-role: AccessibleRole.region;
+        accessible-label: "Artboard";
 
         @children
     }
@@ -226,6 +228,7 @@ export component EditorCanvas inherits Rectangle {
             width: root.selection-drag-active && primary ? root.selection-drag-size.width : s.width;
             height: root.selection-drag-active && primary ? root.selection-drag-size.height : s.height;
             rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
+            accessible-prefix: Api.current-element.type-name;
             active: true;
             show-rotation-handles: primary;
             enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
@@ -237,6 +240,8 @@ export component EditorCanvas inherits Rectangle {
             // when the element is not rotated (we don't support rotating + repositioning at once).
             resizable: primary && Api.selection.is-resizable && s.angle == 0deg;
             moveable: primary && Api.selection.is-moveable && s.angle == 0deg;
+            accessible-role: AccessibleRole.region;
+            accessible-label: "Selected " + Api.current-element.type-name;
 
             rotated-to(rotation) => {
                 root.selection-rotation-active = true;
@@ -395,6 +400,9 @@ export component EditorCanvas inherits Rectangle {
             drop-shadow-blur: 12px;
             drop-shadow-offset-y: 4px;
             drop-shadow-color: #33415535;
+            accessible-role: AccessibleRole.text;
+            accessible-label: "Radius value";
+            accessible-value: (root.radius-tooltip-value / 1px).to-fixed(0);
 
             radius-tip := Text {
                 text: "Radius \{(root.radius-tooltip-value / 1px).to-fixed(0)}";
@@ -402,6 +410,7 @@ export component EditorCanvas inherits Rectangle {
                 font-size: 12px;
                 horizontal-alignment: center;
                 vertical-alignment: center;
+                accessible-role: none;
             }
         }
 
@@ -490,6 +499,7 @@ export component EditorCanvas inherits Rectangle {
         }
 
         if root.rotation-tooltip-visible: Rectangle {
+            property <int> display-angle: (root.normalized-angle(root.rotation-tooltip-value) / 1deg).round();
             x: root.rotation-tooltip-position.x - self.width - 12px;
             y: root.rotation-tooltip-position.y - self.height - 12px;
             width: rotation-tip.width + 14px;
@@ -499,13 +509,17 @@ export component EditorCanvas inherits Rectangle {
             drop-shadow-blur: 12px;
             drop-shadow-offset-y: 4px;
             drop-shadow-color: #33415535;
+            accessible-role: AccessibleRole.text;
+            accessible-label: "Rotation angle";
+            accessible-value: "\{self.display-angle}";
 
             rotation-tip := Text {
-                text: "Rotation \{(root.normalized-angle(root.rotation-tooltip-value) / 1deg).round()}°";
+                text: "Rotation \{parent.display-angle}°";
                 color: white;
                 font-size: 12px;
                 horizontal-alignment: center;
                 vertical-alignment: center;
+                accessible-role: none;
             }
         }
     }

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -230,6 +230,7 @@ export component EditorCanvas inherits Rectangle {
             rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
             accessible-prefix: Api.current-element.type-name;
             active: true;
+            shift-pressed: root.shift-pressed;
             show-rotation-handles: primary;
             enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
             top-left-radius: root.current-corner-radius("border-top-left-radius");
@@ -259,6 +260,18 @@ export component EditorCanvas inherits Rectangle {
             }
             changed rotation-tooltip-value => {
                 root.rotation-tooltip-value = self.rotation-tooltip-value;
+            }
+            changed radius-tooltip-visible => {
+                root.radius-tooltip-visible = self.radius-tooltip-visible;
+            }
+            changed radius-tooltip-position => {
+                root.radius-tooltip-position = {
+                    x: self.x + self.radius-tooltip-position.x,
+                    y: self.y + self.radius-tooltip-position.y,
+                };
+            }
+            changed radius-tooltip-value => {
+                root.radius-tooltip-value = self.radius-tooltip-value;
             }
             radius-changed(corner, radius, single-corner) => {
                 Api.override-selected-element-border-radius(corner, radius, single-corner);
@@ -390,7 +403,7 @@ export component EditorCanvas inherits Rectangle {
             }
         }
 
-        if root.placed-kind == PrototypeComponentKind.rectangle && root.radius-tooltip-visible: Rectangle {
+        if root.radius-tooltip-visible: Rectangle {
             x: root.radius-tooltip-position.x - self.width - 12px;
             y: root.radius-tooltip-position.y - self.height - 12px;
             width: radius-tip.width + 14px;

--- a/tools/editor/ui/components/editor-tree-view.slint
+++ b/tools/editor/ui/components/editor-tree-view.slint
@@ -46,6 +46,15 @@ component EditorTreeRow {
 
     vertical-stretch: 0;
     horizontal-stretch: 1;
+    accessible-role: AccessibleRole.list-item;
+    accessible-label: root.row-label;
+    accessible-description: "Hierarchy level \{root.level-safe}";
+    accessible-item-selectable: true;
+    accessible-item-selected: root.current;
+    accessible-action-default => {
+        row-focus.focus();
+        root.select();
+    }
 
     changed row-has-hover => {
         root.row-hover-changed(root.row-index, root.row-has-hover);
@@ -206,6 +215,7 @@ component EditorTreeRow {
                         height: parent.height;
                         mouse-cursor: pointer;
                         clicked => {
+                            row-focus.focus();
                             root.select();
                         }
                     }

--- a/tools/editor/ui/components/move-resize-frame.slint
+++ b/tools/editor/ui/components/move-resize-frame.slint
@@ -6,6 +6,7 @@ import { CanvasCorner } from "../api.slint";
 import { EditorMetrics, StudioTheme } from "common.slint";
 
 export component MoveResizeFrame inherits Rectangle {
+    in property <string> accessible-prefix: "Selection";
     in property <bool> active;
     in property <bool> shift-pressed: false;
     in property <angle> rotation: 0deg;
@@ -43,6 +44,19 @@ export component MoveResizeFrame inherits Rectangle {
 
     public pure function corner-on-top(corner: CanvasCorner) -> bool {
         return corner == CanvasCorner.top-left || corner == CanvasCorner.top-right;
+    }
+
+    public pure function corner-name(corner: CanvasCorner) -> string {
+        if corner == CanvasCorner.top-left {
+            return "top-left";
+        }
+        if corner == CanvasCorner.top-right {
+            return "top-right";
+        }
+        if corner == CanvasCorner.bottom-right {
+            return "bottom-right";
+        }
+        return "bottom-left";
     }
 
     pure function corner-resize-cursor-is-forward-diagonal(corner: CanvasCorner) -> bool {
@@ -231,6 +245,9 @@ export component MoveResizeFrame inherits Rectangle {
             width: root.width;
             height: root.height;
             mouse-cursor: move;
+            accessible-role: AccessibleRole.button;
+            accessible-label: root.accessible-prefix + " move handle";
+            accessible-enabled: root.moveable;
             private property <Point> move-start-position: { x: 0px, y: 0px };
             private property <Point> move-start-pointer: { x: 0px, y: 0px };
 
@@ -316,6 +333,9 @@ export component MoveResizeFrame inherits Rectangle {
 
                 TouchArea {
                     mouse-cursor: root.rotation-cursor-is-forward-diagonal(corner) ? nwse-resize : nesw-resize;
+                    accessible-role: AccessibleRole.button;
+                    accessible-label: root.accessible-prefix + " rotate " + root.corner-name(corner);
+                    accessible-enabled: root.show-rotation-handles;
                     private property <bool> event-shift-pressed: false;
                     private property <angle> start-rotation;
                     private property <angle> start-pointer-angle;
@@ -381,6 +401,9 @@ export component MoveResizeFrame inherits Rectangle {
                     TouchArea {
                         enabled: root.resizable;
                         mouse-cursor: root.corner-resize-cursor-is-forward-diagonal(corner) ? nwse-resize : nesw-resize;
+                        accessible-role: AccessibleRole.button;
+                        accessible-label: root.accessible-prefix + " resize " + root.corner-name(corner);
+                        accessible-enabled: root.resizable;
                         private property <bool> event-shift-pressed: false;
 
                         pointer-event(event) => {

--- a/tools/editor/ui/components/move-resize-frame.slint
+++ b/tools/editor/ui/components/move-resize-frame.slint
@@ -21,6 +21,7 @@ export component MoveResizeFrame inherits Rectangle {
     out property <angle> rotation-tooltip-value: 0deg;
     private property <length> drag-threshold: 2px;
     private property <bool> resize-pressed: false;
+    private property <bool> resize-dragging: false;
     private property <bool> resize-shift-pressed: false;
     private property <CanvasCorner> resize-corner: CanvasCorner.top-left;
     private property <Size> resize-start-size: { width: 0px, height: 0px };
@@ -229,7 +230,7 @@ export component MoveResizeFrame inherits Rectangle {
     }
 
     changed shift-pressed => {
-        if root.resize-pressed {
+        if root.resize-pressed && root.resize-dragging {
             root.resize-shift-pressed = root.shift-pressed;
             root.emit-resize-target();
         }
@@ -339,6 +340,7 @@ export component MoveResizeFrame inherits Rectangle {
                     private property <bool> event-shift-pressed: false;
                     private property <angle> start-rotation;
                     private property <angle> start-pointer-angle;
+                    private property <Point> press-position: { x: 0px, y: 0px };
 
                     pointer-event(event) => {
                         self.event-shift-pressed = event.modifiers.shift;
@@ -346,6 +348,7 @@ export component MoveResizeFrame inherits Rectangle {
 
                     changed pressed => {
                         if self.pressed {
+                            self.press-position = { x: self.mouse-x, y: self.mouse-y };
                             let local-point = root.child-local-point(
                                 { x: parent.x, y: parent.y },
                                 { x: self.mouse-x, y: self.mouse-y },
@@ -366,6 +369,14 @@ export component MoveResizeFrame inherits Rectangle {
                     }
 
                     moved => {
+                        if !self.pressed {
+                            return;
+                        }
+                        let moved-far-enough = (self.mouse-x - self.press-position.x).abs() >= root.drag-threshold
+                            || (self.mouse-y - self.press-position.y).abs() >= root.drag-threshold;
+                        if !moved-far-enough {
+                            return;
+                        }
                         let local-point = root.child-local-point(
                             { x: parent.x, y: parent.y },
                             { x: self.mouse-x, y: self.mouse-y },
@@ -408,7 +419,7 @@ export component MoveResizeFrame inherits Rectangle {
 
                         pointer-event(event) => {
                             self.event-shift-pressed = event.modifiers.shift;
-                            if root.resize-pressed {
+                            if root.resize-pressed && root.resize-dragging {
                                 root.resize-shift-pressed = event.modifiers.shift;
                                 root.emit-resize-target();
                             }
@@ -422,9 +433,9 @@ export component MoveResizeFrame inherits Rectangle {
                                 ));
 
                                 root.selected();
-                                root.interaction-started();
                                 root.resize-corner = corner;
                                 root.resize-pressed = true;
+                                root.resize-dragging = false;
                                 root.resize-shift-pressed = root.shift-pressed || self.event-shift-pressed;
                                 root.resize-start-size = { width: root.width, height: root.height };
                                 root.resize-start-rotation = root.rotation;
@@ -436,21 +447,39 @@ export component MoveResizeFrame inherits Rectangle {
                                     root.resize-start-rotation,
                                 );
                                 root.store-free-resize-target(pointer);
-                                root.emit-resize-target();
                             } else {
-                                if root.resize-pressed {
+                                if root.resize-pressed && root.resize-dragging {
                                     root.interaction-ended();
                                 }
                                 root.resize-pressed = false;
+                                root.resize-dragging = false;
                                 root.resize-shift-pressed = false;
                             }
                         }
 
                         moved => {
-                            root.store-free-resize-target(root.local-point-to-parent(root.child-local-point(
+                            if !root.resize-pressed {
+                                return;
+                            }
+                            let pointer = root.local-point-to-parent(root.child-local-point(
                                 { x: parent.x, y: parent.y },
                                 { x: self.mouse-x, y: self.mouse-y },
-                            )));
+                            ));
+                            let delta = {
+                                x: pointer.x - root.resize-start-pointer.x,
+                                y: pointer.y - root.resize-start-pointer.y,
+                            };
+                            let moved-far-enough = delta.x.abs() >= root.drag-threshold
+                                || delta.y.abs() >= root.drag-threshold;
+                            if !root.resize-dragging && moved-far-enough {
+                                root.resize-shift-pressed = root.shift-pressed || self.event-shift-pressed;
+                                root.resize-dragging = true;
+                                root.interaction-started();
+                            }
+                            if !root.resize-dragging {
+                                return;
+                            }
+                            root.store-free-resize-target(pointer);
                             root.emit-resize-target();
                         }
                     }


### PR DESCRIPTION
Add accessibility semantics for the editor canvas manipulation controls and cover the production interactions through slint-testing.

The UI suite exercises moving, resizing, rotation, corner radii, drag thresholds, modifier changes, and cancellation. Each behavior starts from a fresh source fixture and editor process, and known Rust limitations use strict expected failures.

Pin slint-testing 0.3 and commit the uv lockfile so the private test-framework dependency is reproducible.

Tests:
- Serial: 13 passed, 18 xfailed, 45 subtests passed
- Parallel: 13 passed, 18 xfailed, 45 subtests passed