### PR TITLE
interpreter: Remove unused once_cell dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7499,7 +7499,6 @@ dependencies = [
  "i-slint-core-macros",
  "itertools 0.15.0",
  "lyon_path",
- "once_cell",
  "raw-window-handle",
  "serde_json",
  "smol_str 0.3.2",

--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -149,7 +149,6 @@ vtable = { workspace = true }
 
 derive_more = { workspace = true, features = ["std", "error"] }
 lyon_path = { workspace = true }
-once_cell = "1.5"
 serde_json = { workspace = true, optional = true }
 document-features = { version = "0.2.0", optional = true }
 spin_on = { workspace = true, optional = true }

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -5213,7 +5213,6 @@ dependencies = [
  "i-slint-core-macros",
  "itertools 0.15.0",
  "lyon_path",
- "once_cell",
  "smol_str 0.3.6",
  "spin_on",
  "typed-index-collections",


### PR DESCRIPTION
## Summary

- Remove the unused direct once_cell dependency from slint-interpreter.
- Stop slint-interpreter from enabling the once_cell default feature.
- Keep the transitively required once_cell features unchanged.

## Dependency Graph

| Metric | Before | After |
| --- | ---: | ---: |
| Direct normal dependencies | 21 | 20 |
| Resolved normal-graph packages | 185 | 185 |
| once_cell/default | enabled | disabled |

The package count is unchanged because i-slint-core and the font stack still require once_cell transitively.

## Testing

- cargo check -p slint-interpreter --no-default-features --features compat-1-2
- cargo test -p slint-interpreter --features internal,internal-highlight
- git diff --check