### PR TITLE
docs: use dashes for struct field names

### DIFF
--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -337,7 +337,7 @@ pub fn extract_builtin_structs(
 
                 let mut fields = Vec::new();
                 $(
-                    let key = stringify!($field).to_string();
+                    let key = stringify!($field).replace('_', "-");
                     let type_name = map_type!($field_type).to_string();
                     let mut f_description = String::new();
                     $(


### PR DESCRIPTION
The builtin-struct pages showed the Rust snake_case field identifiers, like touch_finger_id, but in Slint the fields are written with dashes.
