### PR TITLE
compiler: map image-default-formats to image?/default-formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,6 @@ dependencies = [
  "miniz_oxide",
  "num-complex",
  "pulp",
- "rayon-core",
  "smallvec",
  "zune-inflate",
 ]
@@ -3919,7 +3918,6 @@ dependencies = [
  "png",
  "qoi",
  "ravif",
- "rayon",
  "rgb",
  "tiff",
  "zune-core",
@@ -4675,7 +4673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
- "rayon",
 ]
 
 [[package]]
@@ -6479,7 +6476,6 @@ dependencies = [
  "loop9",
  "quick-error",
  "rav1e",
- "rayon",
  "rgb",
 ]
 

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -1625,7 +1625,6 @@ dependencies = [
  "miniz_oxide",
  "num-complex",
  "pulp",
- "rayon-core",
  "smallvec",
  "zune-inflate",
 ]
@@ -2871,7 +2870,6 @@ dependencies = [
  "png",
  "qoi",
  "ravif",
- "rayon",
  "rgb",
  "tiff",
  "zune-core",
@@ -3435,7 +3433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
- "rayon",
 ]
 
 [[package]]
@@ -4738,7 +4735,6 @@ dependencies = [
  "loop9",
  "quick-error",
  "rav1e",
- "rayon",
  "rgb",
 ]
 

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -47,7 +47,7 @@ renderer-software = [
 # Enable `image`'s default feature set (additional codecs). This is enabled by
 # default by `slint-build` and the `slint-compiler` binary for compatibility, but
 # can be opted out from to keep builds minimal.
-image-default-formats = ["image?/default"]
+image-default-formats = ["image?/default-formats"]
 # Enable support to embed the fonts as signed distance fields
 sdf-fonts = ["renderer-software", "dep:fdsm", "dep:fdsm-ttf-parser", "dep:nalgebra", "dep:rayon"]
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -1655,7 +1655,6 @@ dependencies = [
  "miniz_oxide",
  "num-complex",
  "pulp",
- "rayon-core",
  "smallvec",
  "zune-inflate",
 ]
@@ -2823,7 +2822,6 @@ dependencies = [
  "png",
  "qoi",
  "ravif",
- "rayon",
  "rgb",
  "tiff",
  "zune-core",
@@ -3395,7 +3393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
- "rayon",
 ]
 
 [[package]]
@@ -4616,7 +4613,6 @@ dependencies = [
  "loop9",
  "quick-error",
  "rav1e",
- "rayon",
  "rgb",
 ]
 


### PR DESCRIPTION
Change `i-slint-compiler`'s `image-default-formats` feature mapping from `image?/default` to `image?/default-formats`.

This aligns `i-slint-compiler` with `i-slint-core` (which already maps to `image?/default-formats`) and prevents `image` from pulling in `rayon` during build-time image decoding while maintaining support for all default image formats.

Fixes #13018