### PR TITLE
Rename `Platform.is-app` to `Platform.uses-mock-data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@ All notable changes to this project are documented in this file.
  - Added the `max-lines` property to `Text` and `StyledText` to limit the number of rendered lines.
  - Added the `line-height-factor` property to `Text`, `TextInput`, and `StyledText`, scaling the font's
    natural line height.
- - Added `Platform.is-app`: a constant that is `false` when the file is shown in a preview or viewer,
-   useful for placeholder preview data. (#12834)
+ - Added `Platform.uses-mock-data`: a constant that is `true` when the file is shown in a preview or
+   viewer, useful for placeholder preview data. (#12834)
  - `Flickable`: Added the `mouse-drag-pan-enabled` property; panning by touch is always possible. (#4352)
  - Renamed the `viewport-x`/`viewport-y`/`viewport-width`/`viewport-height` properties of `Flickable` to
    `content-x`/`content-y`/`content-width`/`content-height`. The old names remain as deprecated aliases. (#1443)

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2995,9 +2995,9 @@ export global Platform {
     /// When Slint is ported to new operating systems in the future, new enum values will be added.
     /// :::
     out property <OperatingSystemType> os;
-    /// `true` when the user interface is driven by a host application — your business logic written
-    /// in Rust, C++, JavaScript or Python — and `false` when the `.slint` file is being interpreted on
-    /// its own, with nothing behind it, such as when previewed with `slint-viewer` or the editor's preview.
+    /// `true` when the `.slint` file is being interpreted on its own, with nothing behind it, such as
+    /// when previewed with `slint-viewer` or the editor's preview, and `false` when the user interface
+    /// is driven by a host application: your business logic written in Rust, C++, JavaScript or Python.
     ///
     /// Use it to provide placeholder data and preview-only decorations that are removed from your
     /// compiled application. This property is a compile-time constant, so branches that depend on it
@@ -3014,7 +3014,7 @@ export global Platform {
     // export component Example inherits Window {
     //     width: 150px;
     //     height: 150px;
-    //     in property<[Data]> data: Platform.is-app ? [] : [
+    //     in property<[Data]> data: Platform.uses-mock-data ? [
     //                 { text: "Blue", color: #0000ff, bg: #eeeeee},
     //                 { text: "Red", color: #ff0000, bg: #eeeeee},
     //                 { text: "Green", color: #00ff00, bg: #eeeeee},
@@ -3023,7 +3023,7 @@ export global Platform {
     //                 { text: "White", color: #ffffff, bg: #222222 },
     //                 { text: "Magenta", color: #ff00ff, bg: #eeeeee },
     //                 { text: "Cyan", color: #00ffff, bg: #222222 },
-    //             ];
+    //             ] : [];
     //
     //     VerticalBox {
     //         ListView {
@@ -3041,7 +3041,7 @@ export global Platform {
     //     }
     // }
     // ```
-    out property <bool> is-app;
+    out property <bool> uses-mock-data;
     /// The name of the currently selected <Link type="StyleWidgets" label="widget style"/>. Some widget
     /// styles have dark and light variant suffixes, such as `fluent-light`. This property contains the
     /// style name without the suffix. Use <Link type="Palette" label="Palette"/>'s `color-scheme` to

--- a/internal/compiler/passes/lower_platform.rs
+++ b/internal/compiler/passes/lower_platform.rs
@@ -32,8 +32,8 @@ pub fn lower_platform(component: &Rc<Component>, type_loader: &mut crate::typelo
                         arguments: Vec::new(),
                         source_location: None,
                     }
-                } else if nr.name() == "is-app" {
-                    *e = Expression::BoolLiteral(!type_loader.compiler_config.is_preview);
+                } else if nr.name() == "uses-mock-data" {
+                    *e = Expression::BoolLiteral(type_loader.compiler_config.is_preview);
                 }
             }
             Expression::FunctionCall { function, .. }

--- a/internal/compiler/tests/platform_uses_mock_data.rs
+++ b/internal/compiler/tests/platform_uses_mock_data.rs
@@ -1,9 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! `Platform.is-app` must be constant-folded at compile time: `false` only when
+//! `Platform.uses-mock-data` must be constant-folded at compile time: `true` only when
 //! `CompilerConfiguration::is_preview` is set (as `slint-viewer` and the LSP/editor preview
-//! do), `true` otherwise — including plain `OutputFormat::Interpreter` compiles such as the
+//! do), `false` otherwise, including plain `OutputFormat::Interpreter` compiles such as the
 //! ones the Node.js and Python APIs perform when dynamically loading a `.slint` file, which
 //! have no other way to distinguish themselves from a preview tool.
 
@@ -13,10 +13,10 @@ use i_slint_compiler::generator::OutputFormat;
 use i_slint_compiler::parser::parse;
 use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
 
-fn is_app_folds_to(config: CompilerConfiguration, expected: bool) {
+fn uses_mock_data_folds_to(config: CompilerConfiguration, expected: bool) {
     let source = r#"
         component TestCase {
-            out property <bool> test: Platform.is-app;
+            out property <bool> test: Platform.uses-mock-data;
         }
     "#;
     let mut diagnostics = BuildDiagnostics::default();
@@ -31,26 +31,26 @@ fn is_app_folds_to(config: CompilerConfiguration, expected: bool) {
     let folded = binding.expression.ignore_debug_hooks();
     assert!(
         matches!(folded, Expression::BoolLiteral(b) if *b == expected),
-        "Platform.is-app did not fold to a BoolLiteral({expected}), got {folded:?}"
+        "Platform.uses-mock-data did not fold to a BoolLiteral({expected}), got {folded:?}"
     );
 }
 
 #[test]
-fn is_app_true_for_plain_interpreter() {
+fn uses_mock_data_false_for_plain_interpreter() {
     // No other signal distinguishes this from Node.js/Python dynamically loading a .slint
-    // file as part of a real application, so it must default to `true`.
-    is_app_folds_to(CompilerConfiguration::new(OutputFormat::Interpreter), true);
+    // file as part of a real application, so it must default to `false`.
+    uses_mock_data_folds_to(CompilerConfiguration::new(OutputFormat::Interpreter), false);
 }
 
 #[test]
-fn is_app_false_when_marked_preview() {
+fn uses_mock_data_true_when_marked_preview() {
     // What slint-viewer and the LSP/editor preview explicitly opt into.
     let mut config = CompilerConfiguration::new(OutputFormat::Interpreter);
     config.is_preview = true;
-    is_app_folds_to(config, false);
+    uses_mock_data_folds_to(config, true);
 }
 
 #[test]
-fn is_app_true_for_llr() {
-    is_app_folds_to(CompilerConfiguration::new(OutputFormat::Llr), true);
+fn uses_mock_data_false_for_llr() {
+    uses_mock_data_folds_to(CompilerConfiguration::new(OutputFormat::Llr), false);
 }

--- a/tests/backends/tests/cases/mod.rs
+++ b/tests/backends/tests/cases/mod.rs
@@ -4,7 +4,7 @@
 pub mod context_menu;
 pub mod harness;
 pub mod menubar;
-pub mod platform_is_app;
+pub mod platform_uses_mock_data;
 pub mod text_input_password;
 use std::sync::{
     Arc,

--- a/tests/backends/tests/cases/platform_uses_mock_data.rs
+++ b/tests/backends/tests/cases/platform_uses_mock_data.rs
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 #[satchel::test]
-fn platform_is_app() {
+fn platform_uses_mock_data() {
     slint::slint! {
         export component MainWindow inherits Window {
-            out property <bool> is_app: Platform.is-app;
+            out property <bool> uses_mock_data: Platform.uses-mock-data;
         }
     }
 
     let app = MainWindow::new().unwrap();
-    assert_eq!(app.get_is_app(), true, "Platform.is-app must be true for a real compiled application");
+    assert_eq!(
+        app.get_uses_mock_data(),
+        false,
+        "Platform.uses-mock-data must be false for a real compiled application"
+    );
 }

--- a/tests/cases/globals/platform_uses_mock_data.slint
+++ b/tests/cases/globals/platform_uses_mock_data.slint
@@ -8,9 +8,9 @@ struct Data {
 }
 
 export component TestCase inherits Window {
-    out property <bool> test: Platform.is-app;
+    out property <bool> test: !Platform.uses-mock-data;
 
-    out property<[Data]> data: Platform.is-app ? [] : [
+    out property<[Data]> data: Platform.uses-mock-data ? [
                 { text: "Blue", color: #0000ff, bg: #eeeeee},
                 { text: "Red", color: #ff0000, bg: #eeeeee},
                 { text: "Green", color: #00ff00, bg: #eeeeee},
@@ -19,7 +19,7 @@ export component TestCase inherits Window {
                 { text: "White", color: #ffffff, bg: #222222 },
                 { text: "Magenta", color: #ff00ff, bg: #eeeeee },
                 { text: "Cyan", color: #00ffff, bg: #222222 },
-            ];
+            ] : [];
 }
 
 /*


### PR DESCRIPTION
The new name says what the property is for. The value is inverted: it's now `true` when the `.slint` file is previewed or viewed on its own, and `false` when a real application drives it.

Renamed as agreed in the API review.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
