### PR TITLE
FlexboxLayout: use LayoutAlignment for cross-axis-line-alignment

### DIFF
--- a/examples/layouts/flexbox-interactive.slint
+++ b/examples/layouts/flexbox-interactive.slint
@@ -67,14 +67,14 @@ export component MainWindow inherits Window {
         "Space Around",
         "Space Evenly"
     ];
-    property <[CrossAxisLineAlignment]> cross_axis_line_alignment_values: [
-        CrossAxisLineAlignment.stretch,
-        CrossAxisLineAlignment.start,
-        CrossAxisLineAlignment.end,
-        CrossAxisLineAlignment.center,
-        CrossAxisLineAlignment.space-between,
-        CrossAxisLineAlignment.space-around,
-        CrossAxisLineAlignment.space-evenly
+    property <[LayoutAlignment]> cross_axis_line_alignment_values: [
+        LayoutAlignment.stretch,
+        LayoutAlignment.start,
+        LayoutAlignment.end,
+        LayoutAlignment.center,
+        LayoutAlignment.space-between,
+        LayoutAlignment.space-around,
+        LayoutAlignment.space-evenly
     ];
     property <[string]> cross_axis_alignment_options: ["Stretch", "Start", "End", "Center"];
     property <[CrossAxisAlignment]> cross_axis_alignment_values: [

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -398,26 +398,6 @@ macro_rules! for_each_enums {
                 ColumnReverse,
             }
 
-            /// Controls the distribution of flex lines along the cross axis in a flex container.
-            /// Used as the `cross-axis-line-alignment` property of `FlexboxLayout`.
-            #[non_exhaustive]
-            enum CrossAxisLineAlignment {
-                /// Lines are stretched to fill the container along the cross axis.
-                Stretch,
-                /// Lines are placed at the start of the cross axis.
-                Start,
-                /// Lines are placed at the end of the cross axis.
-                End,
-                /// Lines are centered along the cross axis.
-                Center,
-                /// Equal gaps between lines, no gap at the edges.
-                SpaceBetween,
-                /// Equal gaps around each line (half-size at edges).
-                SpaceAround,
-                /// Equal gaps between lines and at the edges.
-                SpaceEvenly,
-            }
-
             /// Controls the alignment of individual items along the cross axis of a layout.
             /// Used as the `cross-axis-alignment` property of `HorizontalLayout`, `VerticalLayout`,
             /// and `FlexboxLayout`.

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -360,11 +360,17 @@ macro_rules! for_each_enums {
 
             /// Enum representing the `alignment` property of a
             /// `HorizontalBox`, a `VerticalBox`,
-            /// a `HorizontalLayout`, or `VerticalLayout`.
+            /// a `HorizontalLayout`, a `VerticalLayout`, or a `FlexboxLayout`,
+            /// and the `cross-axis-line-alignment` property of a `FlexboxLayout`.
+            ///
+            /// For `cross-axis-line-alignment`, the values below apply to the flex lines
+            /// instead of the elements.
             #[non_exhaustive]
             enum LayoutAlignment {
-                /// Use the minimum size of all elements in a layout, distribute remaining space
-                /// based on `*-stretch` among all elements.
+                /// For `alignment`: use the minimum size of all elements in a layout, distribute
+                /// remaining space based on `*-stretch` among all elements.
+                /// For `cross-axis-line-alignment`: the flex lines have no stretch factor and
+                /// share the remaining space equally.
                 Stretch,
                 /// Use the preferred size for all elements, distribute remaining space evenly before the
                 /// first and after the last element.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2313,7 +2313,7 @@ export component FlexboxLayout {
     /// Set the distribution of flex lines along the cross axis. CSS Flexbox calls this "align-content";
     /// the name here pairs with `cross-axis-alignment`, which aligns the items within one line.
     /// The default value is `stretch`.
-    in property <CrossAxisLineAlignment> cross-axis-line-alignment;
+    in property <LayoutAlignment> cross-axis-line-alignment;
     /// Set the alignment of individual items along the cross axis within each flex line.
     /// The default value is `stretch`.
     in property <CrossAxisAlignment> cross-axis-alignment;

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -388,9 +388,7 @@ pub(super) fn solve_flexbox_layout(
             ),
             (
                 "cross_axis_line_alignment",
-                Type::Enumeration(
-                    crate::typeregister::BUILTIN.enums.CrossAxisLineAlignment.clone(),
-                ),
+                Type::Enumeration(crate::typeregister::BUILTIN.enums.LayoutAlignment.clone()),
                 fld.cross_axis_line_alignment,
             ),
             (
@@ -824,7 +822,7 @@ fn flexbox_layout_data(
     let cross_axis_line_alignment = if let Some(expr) = &layout.cross_axis_line_alignment {
         llr_Expression::PropertyReference(ctx.map_property_reference(expr))
     } else {
-        let e = crate::typeregister::BUILTIN.enums.CrossAxisLineAlignment.clone();
+        let e = crate::typeregister::BUILTIN.enums.LayoutAlignment.clone();
         llr_Expression::EnumerationValue(EnumerationValue {
             value: e.default_value,
             enumeration: e,

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -16,6 +16,6 @@ export component X inherits Rectangle {
 //      >        <error{Use spacing-horizontal instead of column-gap}
         justify-content: center;
 //      >             <error{Use alignment instead of justify-content}
-//                       >    <^error{Unknown unqualified identifier 'center'. Did you mean 'CrossAxisAlignment.center', 'CrossAxisLineAlignment.center', 'CrossAxisSelfAlignment.center', 'ImageHorizontalAlignment.center', 'ImageVerticalAlignment.center', 'LayoutAlignment.center', 'TextHorizontalAlignment.center', 'TextStrokeStyle.center' or 'TextVerticalAlignment.center'?}
+//                       >    <^error{Unknown unqualified identifier 'center'. Did you mean 'CrossAxisAlignment.center', 'CrossAxisSelfAlignment.center', 'ImageHorizontalAlignment.center', 'ImageVerticalAlignment.center', 'LayoutAlignment.center', 'TextHorizontalAlignment.center', 'TextStrokeStyle.center' or 'TextVerticalAlignment.center'?}
     }
 }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1396,6 +1396,20 @@ mod flexbox_taffy {
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
     use taffy::prelude::*;
 
+    /// Start/End map to FlexStart/FlexEnd to respect the flex direction (including reverse);
+    /// AlignContent::Start/End would ignore the direction and always use the writing mode.
+    fn to_align_content(alignment: LayoutAlignment) -> AlignContent {
+        match alignment {
+            LayoutAlignment::Stretch => AlignContent::Stretch,
+            LayoutAlignment::Start => AlignContent::FlexStart,
+            LayoutAlignment::End => AlignContent::FlexEnd,
+            LayoutAlignment::Center => AlignContent::Center,
+            LayoutAlignment::SpaceBetween => AlignContent::SpaceBetween,
+            LayoutAlignment::SpaceAround => AlignContent::SpaceAround,
+            LayoutAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
+        }
+    }
+
     /// Parameters for FlexboxTaffyBuilder::new
     pub struct FlexboxLayoutParams<'a> {
         pub cells_h: &'a Slice<'a, LayoutItemInfo>,
@@ -1659,32 +1673,14 @@ mod flexbox_taffy {
                             SlintFlexboxLayoutWrap::NoWrap => FlexWrap::NoWrap,
                             SlintFlexboxLayoutWrap::WrapReverse => FlexWrap::WrapReverse,
                         },
-                        justify_content: Some(match params.alignment {
-                            // Start/End map to FlexStart/FlexEnd to respect flex direction (including reverse)
-                            // AlignContent::Start/End would ignore direction and always use writing mode
-                            LayoutAlignment::Start => AlignContent::FlexStart,
-                            LayoutAlignment::End => AlignContent::FlexEnd,
-                            LayoutAlignment::Center => AlignContent::Center,
-                            LayoutAlignment::Stretch => AlignContent::Stretch,
-                            LayoutAlignment::SpaceBetween => AlignContent::SpaceBetween,
-                            LayoutAlignment::SpaceAround => AlignContent::SpaceAround,
-                            LayoutAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
-                        }),
+                        justify_content: Some(to_align_content(params.alignment)),
                         align_items: Some(match params.cross_axis_alignment {
                             CrossAxisAlignment::Stretch => AlignItems::Stretch,
                             CrossAxisAlignment::Start => AlignItems::FlexStart,
                             CrossAxisAlignment::End => AlignItems::FlexEnd,
                             CrossAxisAlignment::Center => AlignItems::Center,
                         }),
-                        align_content: Some(match params.cross_axis_line_alignment {
-                            LayoutAlignment::Stretch => AlignContent::Stretch,
-                            LayoutAlignment::Start => AlignContent::FlexStart,
-                            LayoutAlignment::End => AlignContent::FlexEnd,
-                            LayoutAlignment::Center => AlignContent::Center,
-                            LayoutAlignment::SpaceBetween => AlignContent::SpaceBetween,
-                            LayoutAlignment::SpaceAround => AlignContent::SpaceAround,
-                            LayoutAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
-                        }),
+                        align_content: Some(to_align_content(params.cross_axis_line_alignment)),
                         gap: Size {
                             width: LengthPercentage::length(params.spacing_h as _),
                             height: LengthPercentage::length(params.spacing_v as _),

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,7 +6,7 @@
 // cspell:ignore coord
 
 use crate::items::{
-    CrossAxisAlignment, CrossAxisLineAlignment, CrossAxisSelfAlignment, DialogButtonRole,
+    CrossAxisAlignment, CrossAxisSelfAlignment, DialogButtonRole,
     FlexboxLayoutDirection, FlexboxLayoutWrap, LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
@@ -1151,7 +1151,7 @@ pub struct FlexboxLayoutData<'a> {
     pub padding_v: Padding,
     pub alignment: LayoutAlignment,
     pub direction: FlexboxLayoutDirection,
-    pub cross_axis_line_alignment: CrossAxisLineAlignment,
+    pub cross_axis_line_alignment: LayoutAlignment,
     pub cross_axis_alignment: CrossAxisAlignment,
     pub flex_wrap: FlexboxLayoutWrap,
     /// Horizontal constraints (width) for each cell
@@ -1388,7 +1388,7 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, CrossAxisAlignment, CrossAxisLineAlignment, CrossAxisSelfAlignment, FlexItemProps,
+        Coord, CrossAxisAlignment, CrossAxisSelfAlignment, FlexItemProps,
         FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment, LayoutInfo, LayoutItemInfo,
         Padding, Slice,
     };
@@ -1406,7 +1406,7 @@ mod flexbox_taffy {
         pub padding_h: &'a Padding,
         pub padding_v: &'a Padding,
         pub alignment: LayoutAlignment,
-        pub cross_axis_line_alignment: CrossAxisLineAlignment,
+        pub cross_axis_line_alignment: LayoutAlignment,
         pub cross_axis_alignment: CrossAxisAlignment,
         pub flex_wrap: SlintFlexboxLayoutWrap,
         pub flex_direction: TaffyFlexDirection,
@@ -1677,13 +1677,13 @@ mod flexbox_taffy {
                             CrossAxisAlignment::Center => AlignItems::Center,
                         }),
                         align_content: Some(match params.cross_axis_line_alignment {
-                            CrossAxisLineAlignment::Stretch => AlignContent::Stretch,
-                            CrossAxisLineAlignment::Start => AlignContent::FlexStart,
-                            CrossAxisLineAlignment::End => AlignContent::FlexEnd,
-                            CrossAxisLineAlignment::Center => AlignContent::Center,
-                            CrossAxisLineAlignment::SpaceBetween => AlignContent::SpaceBetween,
-                            CrossAxisLineAlignment::SpaceAround => AlignContent::SpaceAround,
-                            CrossAxisLineAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
+                            LayoutAlignment::Stretch => AlignContent::Stretch,
+                            LayoutAlignment::Start => AlignContent::FlexStart,
+                            LayoutAlignment::End => AlignContent::FlexEnd,
+                            LayoutAlignment::Center => AlignContent::Center,
+                            LayoutAlignment::SpaceBetween => AlignContent::SpaceBetween,
+                            LayoutAlignment::SpaceAround => AlignContent::SpaceAround,
+                            LayoutAlignment::SpaceEvenly => AlignContent::SpaceEvenly,
                         }),
                         gap: Size {
                             width: LengthPercentage::length(params.spacing_h as _),
@@ -2233,7 +2233,7 @@ pub fn flexbox_layout_info_cross_axis_with_measure(
         padding_h,
         padding_v,
         alignment,
-        cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
+        cross_axis_line_alignment: LayoutAlignment::Stretch,
         cross_axis_alignment: CrossAxisAlignment::Stretch,
         flex_wrap,
         flex_direction: taffy_direction,
@@ -3187,7 +3187,7 @@ mod tests {
                     // Stretch: the strongest growing mode, to show the stretch
                     // factors cancel out of the max-content size.
                     alignment: LayoutAlignment::Stretch,
-                    cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
+                    cross_axis_line_alignment: LayoutAlignment::Stretch,
                     cross_axis_alignment: CrossAxisAlignment::Stretch,
                     flex_wrap: FlexboxLayoutWrap::NoWrap,
                     flex_direction: flexbox_taffy::TaffyFlexDirection::Row,
@@ -3261,7 +3261,7 @@ mod tests {
                     padding_h: &pad,
                     padding_v: &pad,
                     alignment: LayoutAlignment::Stretch,
-                    cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
+                    cross_axis_line_alignment: LayoutAlignment::Stretch,
                     cross_axis_alignment: CrossAxisAlignment::Stretch,
                     flex_wrap: FlexboxLayoutWrap::NoWrap,
                     flex_direction: flexbox_taffy::TaffyFlexDirection::Column,
@@ -3329,7 +3329,7 @@ mod tests {
                     padding_h: &pad,
                     padding_v: &pad,
                     alignment,
-                    cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
+                    cross_axis_line_alignment: LayoutAlignment::Stretch,
                     cross_axis_alignment: CrossAxisAlignment::Stretch,
                     flex_wrap: FlexboxLayoutWrap::Wrap,
                     flex_direction: flexbox_taffy::TaffyFlexDirection::Row,
@@ -3413,7 +3413,7 @@ mod tests {
                 padding_h: &pad,
                 padding_v: &pad,
                 alignment: LayoutAlignment::Start,
-                cross_axis_line_alignment: CrossAxisLineAlignment::Stretch,
+                cross_axis_line_alignment: LayoutAlignment::Stretch,
                 cross_axis_alignment: CrossAxisAlignment::Stretch,
                 flex_wrap: FlexboxLayoutWrap::NoWrap,
                 flex_direction: flexbox_taffy::TaffyFlexDirection::Row,

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,8 +6,8 @@
 // cspell:ignore coord
 
 use crate::items::{
-    CrossAxisAlignment, CrossAxisSelfAlignment, DialogButtonRole,
-    FlexboxLayoutDirection, FlexboxLayoutWrap, LayoutAlignment,
+    CrossAxisAlignment, CrossAxisSelfAlignment, DialogButtonRole, FlexboxLayoutDirection,
+    FlexboxLayoutWrap, LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
 use alloc::format;


### PR DESCRIPTION
LayoutAlignment has the same variants, so the separate CrossAxisLineAlignment enum is not needed.

As discussed in the API review.
