### PR TITLE
docs: link the types in callback and function signatures

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -493,7 +493,7 @@ pub mod platform {
 #[i_slint_core_macros::slint_doc]
 /// This module contains some of the enums and structs from the Slint language.
 ///
-/// See also the list of [global structs and enums](slint:StructType)
+/// See also the list of [global structs and enums](slint:struct)
 pub mod language {
     macro_rules! export_builtin_structs {
         ($(

--- a/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
+++ b/docs/astro/src/content/docs/guide/development/drag-and-drop.mdx
@@ -8,7 +8,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 Use <Link type="DragArea" /> and <Link type="DropArea" /> to move data between parts of the UI with a drag-and-drop gesture.
 On platforms that support it, a <Link type="DropArea" /> also accepts drops from other applications.
 
-The payload is a <Link type="data_transfer" label="data-transfer" code /> value, which abstracts over the file-type transfer mechanisms supported by each platform.
+The payload is a <Link type="data-transfer" code /> value, which abstracts over the file-type transfer mechanisms supported by each platform.
 `data-transfer` values are opaque in Slint code:
 construct and read them via callbacks implemented in the host language.
 

--- a/docs/astro/src/content/docs/guide/development/translations.mdx
+++ b/docs/astro/src/content/docs/guide/development/translations.mdx
@@ -311,7 +311,7 @@ Conversions between `float` and `string` use the locale's decimal separator,
 for example the comma (`,`) in a German locale.
 See <Link type="NumberStringConversion" label="Converting Between Numbers and Strings" /> for the conversion rules.
 
-Read the currently used separator from <Link type="Platform.decimal-separator" label="Platform.decimal-separator" />.
+Read the currently used separator from <Link type="Platform.decimal-separator" />.
 It defaults to the dot (`.`).
 
 When bundling translations, the decimal separator of each language is determined at compile time

--- a/docs/astro/src/content/docs/guide/tooling/manual-setup.mdx
+++ b/docs/astro/src/content/docs/guide/tooling/manual-setup.mdx
@@ -10,13 +10,13 @@ We provide extensions or configuration files for different editors to better sup
 ### Editors
 
 - <Link type="VSCode" label="Visual Studio Code"/>
-- <Link type="Kate" label="Kate"/>
+- <Link type="Kate"/>
 - <Link type="QtCreator" label="Qt Creator"/>
-- <Link type="Helix" label="Helix"/>
+- <Link type="Helix"/>
 - <Link type="NeoVim" label="(Neo-)Vim"/>
 - <Link type="SublimeText" label="Sublime Text"/>
 - <Link type="JetBrains" label="JetBrains IDE"/>
-- <Link type="Zed" label="Zed"/>
+- <Link type="Zed"/>
 
 If your favorite editor is not in the list of supported editors, it just means we did not test it, not that it doesn't work. We do provide a language server for Slint that should work with most editor that supports the Language Server Protocol (LSP). If you do test your editor with it, we would be happy to accept a pull request that adds instructions here.
 

--- a/docs/astro/src/content/docs/reference/keyboard-input/overview.mdx
+++ b/docs/astro/src/content/docs/reference/keyboard-input/overview.mdx
@@ -14,7 +14,7 @@ encoded in a string.
 Use the [`Key` namespace](#key-namespace) to identify known named keys.
 
 See the [Key Bindings](#key-bindings) section for how to handle key bindings declaratively with
-Slint's <Link type="KeyBinding" label="KeyBinding"/> elements and the built-in <Link type="keys" label="keys" /> type, which is constructed from the `@keys` macro.
+Slint's <Link type="KeyBinding"/> elements and the built-in <Link type="keys" /> type, which is constructed from the `@keys` macro.
 
 ## KeyEvent
 

--- a/docs/astro/src/content/docs/reference/language/type-conversions.mdx
+++ b/docs/astro/src/content/docs/reference/language/type-conversions.mdx
@@ -57,7 +57,7 @@ For the other direction, convert a `string` to a number with the [`to-float()`](
 and check whether a string holds a valid number with `is-float()`.
 
 All these conversions use the decimal separator of the current locale,
-which is exposed as <Link type="Platform.decimal-separator" label="Platform.decimal-separator" /> and defaults to the dot (`.`).
+which is exposed as <Link type="Platform.decimal-separator" /> and defaults to the dot (`.`).
 For example, in a German locale the decimal separator is the comma (`,`):
 
 -   The `float` value `1.5` converts to the string `"1,5"`.

--- a/docs/astro/src/content/docs/reference/std-widgets/style.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/style.mdx
@@ -82,7 +82,7 @@ main_window.run()
 
 ## Using Style Properties In Your Own Components
 
-The global <Link type="Palette" label="Palette"/> and <Link type="StyleMetrics" label="StyleMetrics"/> properties can be accessed and will be set to the appropriate values of the current style.
+The global <Link type="Palette"/> and <Link type="StyleMetrics"/> properties can be accessed and will be set to the appropriate values of the current style.
 
 ```slint playground
 import { Palette, StyleMetrics } from "std-widgets.slint";

--- a/docs/common/src/utils/utils.ts
+++ b/docs/common/src/utils/utils.ts
@@ -47,137 +47,46 @@ export interface TypeInfo {
     defaultValue: string;
 }
 
+/** The value a property of each type holds when nothing assigns to it. */
+const defaultValues: Partial<Record<KnownType, string>> = {
+    angle: "0deg",
+    bool: "false",
+    brush: "a transparent brush",
+    callback: '""',
+    color: "a transparent color",
+    "data-transfer": "an empty data-transfer",
+    duration: "0ms",
+    easing: "linear",
+    enum: "the first enum value",
+    float: "0.0",
+    image: "the empty image",
+    int: "0",
+    keys: "@keys()",
+    length: "0px",
+    MouseCursor: "default",
+    percent: "0%",
+    "physical-length": "0phx",
+    Edges: "0px",
+    Point: "(0px, 0px)",
+    Size: "(0px, 0px)",
+    "styled-text": '""',
+    "relative-font-size": "0rem",
+    string: '""',
+    struct: "a struct with all default values",
+};
+
+// `link-data.json` keys the documentation of a type by the type's own name.
 export function getTypeInfo(typeName: KnownType): TypeInfo {
     const baseType = typeName.replace(/[\[\]]/g, "") as KnownType;
-    switch (baseType) {
-        case "angle":
-            return {
-                href: linkMap.angle.href,
-                defaultValue: "0deg",
-            };
-        case "bool":
-            return {
-                href: linkMap.bool.href,
-                defaultValue: "false",
-            };
-        case "brush":
-            return {
-                href: linkMap.brush.href,
-                defaultValue: "a transparent brush",
-            };
-        case "color":
-            return {
-                href: linkMap.color.href,
-                defaultValue: "a transparent color",
-            };
-        case "data-transfer":
-            return {
-                href: linkMap.data_transfer.href,
-                defaultValue: "an empty data-transfer",
-            };
-        case "duration":
-            return {
-                href: linkMap.duration.href,
-                defaultValue: "0ms",
-            };
-        case "easing":
-            return {
-                href: linkMap.easing.href,
-                defaultValue: "linear",
-            };
-        case "enum":
-            return {
-                href: linkMap.EnumType.href,
-                defaultValue: "the first enum value",
-            };
-        case "Edges":
-            return {
-                href: linkMap.Edges.href,
-                defaultValue: "0px",
-            };
-        case "float":
-            return {
-                href: linkMap.float.href,
-                defaultValue: "0.0",
-            };
-        case "image":
-            return {
-                href: linkMap.ImageType.href,
-                defaultValue: "the empty image",
-            };
-        case "keys":
-            return {
-                href: linkMap["keys"].href,
-                defaultValue: "@keys()",
-            };
-        case "int":
-            return {
-                href: linkMap.int.href,
-                defaultValue: "0",
-            };
-        case "length":
-            return {
-                href: linkMap.length.href,
-                defaultValue: "0px",
-            };
-        case "MouseCursor":
-            return {
-                href: linkMap.MouseCursor.href,
-                defaultValue: "default",
-            };
-        case "percent":
-            return {
-                href: linkMap.percent.href,
-                defaultValue: "0%",
-            };
-        case "physical-length":
-            return {
-                href: linkMap.physicalLength.href,
-                defaultValue: "0phx",
-            };
-        case "Point":
-            return {
-                href: linkMap.Point.href,
-                defaultValue: "(0px, 0px)",
-            };
-        case "Size":
-            return {
-                href: linkMap.Size.href,
-                defaultValue: "(0px, 0px)",
-            };
-        case "relative-font-size":
-            return {
-                href: linkMap.relativeFontSize.href,
-                defaultValue: "0rem",
-            };
-        case "string":
-            return {
-                href: linkMap.StringType.href,
-                defaultValue: '""',
-            };
-        case "styled-text":
-            return {
-                href: linkMap.styled_text.href,
-                defaultValue: '""',
-            };
-        case "callback":
-            return {
-                href: linkMap.callback.href,
-                defaultValue: '""',
-            };
-        case "struct":
-            return {
-                href: linkMap.StructType.href,
-                defaultValue: "a struct with all default values",
-            };
-        default: {
-            console.error("Unknown type: ", typeName);
-            return {
-                href: "",
-                defaultValue: "<???>",
-            };
-        }
+    const defaultValue = defaultValues[baseType];
+    if (defaultValue === undefined || !(baseType in linkMap)) {
+        console.error("Unknown type: ", typeName);
+        return {
+            href: "",
+            defaultValue: "<???>",
+        };
     }
+    return { href: linkMap[baseType].href, defaultValue };
 }
 
 export function extractLines(

--- a/docs/cpp/src/content/docs/cmake-reference/resource-embedding.mdx
+++ b/docs/cpp/src/content/docs/cmake-reference/resource-embedding.mdx
@@ -5,7 +5,7 @@ description: Embed images and fonts into the binary with the SLINT_EMBED_RESOURC
 
 import SlintRef from "../../../components/SlintRef.astro";
 
-By default, images from <SlintRef type="ImageType" label="@image-url()" /> or fonts that your Slint files reference are loaded from disk at run-time. This minimizes build times, but requires that the directory structure with the files remains stable. If you want to build a program that runs anywhere, then you can configure the Slint compiler to embed such sources into the binary.
+By default, images from <SlintRef type="image" label="@image-url()" /> or fonts that your Slint files reference are loaded from disk at run-time. This minimizes build times, but requires that the directory structure with the files remains stable. If you want to build a program that runs anywhere, then you can configure the Slint compiler to embed such sources into the binary.
 
 Set the `SLINT_EMBED_RESOURCES` target property on your CMake target to one of the following values:
 

--- a/docs/cpp/src/content/docs/types.mdx
+++ b/docs/cpp/src/content/docs/types.mdx
@@ -13,20 +13,20 @@ The follow table summarizes the entire mapping. The `.slint` types link to the S
 | <SlintRef type="int" /> | `int` | |
 | <SlintRef type="float" /> | `float` | |
 | <SlintRef type="bool" /> | `bool` | |
-| <SlintRef type="StringType" label="string" /> | [`slint::SharedString`](../api/slint/sharedstring/) | A reference-counted string type that uses UTF-8 encoding and can be easily converted to a `std::string_view` or a `const char *`. |
+| <SlintRef type="string" /> | [`slint::SharedString`](../api/slint/sharedstring/) | A reference-counted string type that uses UTF-8 encoding and can be easily converted to a `std::string_view` or a `const char *`. |
 | <SlintRef type="color" /> | [`slint::Color`](../api/slint/color/) | |
 | <SlintRef type="brush" /> | [`slint::Brush`](../api/slint/brush/) | |
-| <SlintRef type="ImageType" label="image" /> | [`slint::Image`](../api/slint/image/) | |
-| <SlintRef type="physicalLength" label="physical_length" /> | `float` | The unit are physical pixels. |
+| <SlintRef type="image" /> | [`slint::Image`](../api/slint/image/) | |
+| <SlintRef type="physical-length" /> | `float` | The unit are physical pixels. |
 | <SlintRef type="length" /> | `float` | At run-time, logical lengths are automatically translated to physical pixels using the device pixel ratio. |
 | <SlintRef type="duration" /> | `std::int64_t` | At run-time, durations are always represented as signed 64-bit integers with millisecond precision. |
 | <SlintRef type="angle" /> | `float` | The angle in degrees. |
-| <SlintRef type="relativeFontSize" label="relative-font-size" /> | `float` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
-| <SlintRef type="StructType" label="structure" code={false} /> | A `class` of the same name | The order of the data member are in the same as in the slint declaration. |
+| <SlintRef type="relative-font-size" /> | `float` | Relative font size factor that is multiplied with the `Window.default-font-size` and can be converted to a `length`. |
+| <SlintRef type="struct" label="structure" code={false} /> | A `class` of the same name | The order of the data member are in the same as in the slint declaration. |
 | anonymous object | A `std::tuple` | The fields are in alphabetical order. |
-| <SlintRef type="EnumType" label="enum" code={false} /> | An `enum class` | The values are always converted to CamelCase. The order of the values is the same as in the declaration. |
-| <SlintRef type="data_transfer" label="data-transfer" /> | [`slint::DataTransfer`](../api/slint/datatransfer/) | Data associated with a drag-drop transfer. |
-| <SlintRef type="styled_text" label="styled-text" /> | [`slint::StyledText`](../api/slint/styledtext/) | Styled text parsed from markdown or plain text. Use `StyledText::from_markdown()` or `StyledText::from_plain_text()` to create. |
+| <SlintRef type="enum" code={false} /> | An `enum class` | The values are always converted to CamelCase. The order of the values is the same as in the declaration. |
+| <SlintRef type="data-transfer" /> | [`slint::DataTransfer`](../api/slint/datatransfer/) | Data associated with a drag-drop transfer. |
+| <SlintRef type="styled-text" /> | [`slint::StyledText`](../api/slint/styledtext/) | Styled text parsed from markdown or plain text. Use `StyledText::from_markdown()` or `StyledText::from_plain_text()` to create. |
 | <SlintRef type="Point" /> | [`slint::LogicalPosition`](../api/slint/logicalposition/) | A struct with `x` and `y` fields, representing logical coordinates. |
 
 ## Structures

--- a/docs/python/src/content/docs/index.mdx
+++ b/docs/python/src/content/docs/index.mdx
@@ -193,12 +193,12 @@ Python type:
 | <SlintRef type="int" /> | `int` |
 | <SlintRef type="float" /> | `float` |
 | <SlintRef type="bool" /> | `bool` |
-| <SlintRef type="StringType" label="string" /> | `str` |
+| <SlintRef type="string" /> | `str` |
 | <SlintRef type="color" /> | <XRef to="Color" /> |
 | <SlintRef type="brush" /> | <XRef to="Brush" /> |
-| <SlintRef type="ImageType" label="image" /> | <XRef to="Image" /> |
-| <SlintRef type="styled_text" label="styled-text" /> | <XRef to="StyledText" /> |
-| <SlintRef type="data_transfer" label="data-transfer" /> | <XRef to="DataTransfer" /> |
+| <SlintRef type="image" /> | <XRef to="Image" /> |
+| <SlintRef type="styled-text" /> | <XRef to="StyledText" /> |
+| <SlintRef type="data-transfer" /> | <XRef to="DataTransfer" /> |
 | `length`, `physical-length`, `duration`, `angle`, `relative-font-size` | `float` |
 | structure | `dict` / `Struct` |
 | array | <XRef to="Model" /> |

--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -357,19 +357,30 @@ fn format_default_expr(expr: &i_slint_compiler::expression_tree::Expression) -> 
     }
 }
 
-/// Format a callback or function signature from a `Function` type.
-fn format_signature(func: &i_slint_compiler::langtype::Function) -> String {
+/// Format a callback or function signature from a `Function` type. Pass `None`
+/// for a signature rendered as code: a link doesn't survive backticks.
+fn format_signature(
+    func: &i_slint_compiler::langtype::Function,
+    links: Option<&mdx::TypeLinks>,
+) -> String {
+    let type_name = |ty: &Type| match links {
+        Some(links) => links.linked(&ty.to_string()),
+        None => ty.to_string(),
+    };
     let params: Vec<String> = func
         .arg_names
         .iter()
         .zip(func.args.iter())
         .filter(|(_, ty)| !matches!(ty, Type::ElementReference))
-        .map(|(name, ty)| if name.is_empty() { ty.to_string() } else { format!("{name}: {ty}") })
+        .map(|(name, ty)| {
+            let ty = type_name(ty);
+            if name.is_empty() { ty } else { format!("{name}: {ty}") }
+        })
         .collect();
     let ret = if matches!(func.return_type, Type::Void) {
         String::new()
     } else {
-        format!(" -> {}", func.return_type)
+        format!(" -> {}", type_name(&func.return_type))
     };
     format!("({}){ret}", params.join(", "))
 }
@@ -381,13 +392,13 @@ fn write_mdx_signature_heading(
     markdown_heading: &str,
     name: &str,
     func: &i_slint_compiler::langtype::Function,
+    links: &mdx::TypeLinks,
 ) -> std::io::Result<()> {
-    let sig = format_signature(func);
-    let title = format!("{name}{sig}");
-    if title.contains('{') || title.contains('<') {
-        writeln!(file, "{markdown_heading} `{title}`")?;
+    let sig = format_signature(func, None);
+    if sig.contains('{') || sig.contains('<') {
+        writeln!(file, "{markdown_heading} `{name}{sig}`")?;
     } else {
-        writeln!(file, "{markdown_heading} {title}")?;
+        writeln!(file, "{markdown_heading} {name}{}", format_signature(func, Some(links)))?;
     }
     Ok(())
 }
@@ -475,13 +486,22 @@ fn collect_all_text(builtin: &BuiltinElement, skip_children: bool, sc_only: bool
     text
 }
 
+/// The built-in type names an element's documentation resolves against.
+struct TypeContext<'a> {
+    /// Every built-in enum and struct, whether or not this run documents it: a
+    /// property names the kind of its type either way.
+    enums: HashSet<String>,
+    structs: HashSet<String>,
+    /// The pages this run writes, for the types it links.
+    links: &'a mdx::TypeLinks,
+}
+
 fn write_slint_property(
     file: &mut impl Write,
     name: &str,
     info: &BuiltinPropertyInfo,
     heading: &str,
-    enums: &HashSet<String>,
-    structs: &HashSet<String>,
+    types: &TypeContext,
     sc: &mut ScreenshotCounter,
 ) -> std::io::Result<()> {
     let type_name = info.ty.to_string();
@@ -497,9 +517,9 @@ fn write_slint_property(
         default_value = d;
     }
 
-    let (type_attr, is_enum, is_struct) = if enums.contains(&type_name) {
+    let (type_attr, is_enum, is_struct) = if types.enums.contains(&type_name) {
         ("enum", true, false)
-    } else if structs.contains(&type_name) {
+    } else if types.structs.contains(&type_name) {
         ("struct", false, true)
     } else {
         (type_name.as_str(), false, false)
@@ -540,8 +560,7 @@ fn write_member(
     in_properties: &mut bool,
     in_callbacks: &mut bool,
     in_functions: &mut bool,
-    enums: &HashSet<String>,
-    structs: &HashSet<String>,
+    types: &TypeContext,
     sc: &mut ScreenshotCounter,
 ) -> std::io::Result<()> {
     match &info.ty {
@@ -551,7 +570,7 @@ fn write_member(
                 writeln!(file)?;
                 *in_properties = true;
             }
-            write_slint_property(file, name, info, "###", enums, structs, sc)?;
+            write_slint_property(file, name, info, "###", types, sc)?;
         }
         Type::Callback(func) => {
             if !*in_callbacks {
@@ -559,7 +578,7 @@ fn write_member(
                 writeln!(file)?;
                 *in_callbacks = true;
             }
-            write_mdx_signature_heading(file, "###", name, func)?;
+            write_mdx_signature_heading(file, "###", name, func, types.links)?;
             if let Some(doc) = &info.docs
                 && !doc.is_empty()
             {
@@ -573,7 +592,7 @@ fn write_member(
                 writeln!(file)?;
                 *in_functions = true;
             }
-            write_mdx_signature_heading(file, "###", name, func)?;
+            write_mdx_signature_heading(file, "###", name, func, types.links)?;
             if let Some(doc) = &info.docs {
                 writeln!(file, "{}", transform_code_fences(doc, sc).trim_end())?;
             }
@@ -627,8 +646,7 @@ fn normalize_section_text(text: &str) -> String {
 fn write_members(
     file: &mut impl Write,
     builtin: &BuiltinElement,
-    enums: &HashSet<String>,
-    structs: &HashSet<String>,
+    types: &TypeContext,
     sc: &mut ScreenshotCounter,
     cfg: &Config,
 ) -> std::io::Result<()> {
@@ -681,8 +699,7 @@ fn write_members(
                     &mut in_properties,
                     &mut in_callbacks,
                     &mut in_functions,
-                    enums,
-                    structs,
+                    types,
                     sc,
                 )?;
             }
@@ -693,13 +710,11 @@ fn write_members(
 }
 
 /// Write a sub-element section. Recurse into the sub-element's own children.
-#[allow(clippy::too_many_arguments)]
 fn write_sub_element(
     file: &mut impl Write,
     child_name: &str,
     child: &BuiltinElement,
-    enums: &HashSet<String>,
-    structs: &HashSet<String>,
+    types: &TypeContext,
     seen: &mut HashSet<String>,
     sc: &mut ScreenshotCounter,
     cfg: &Config,
@@ -764,7 +779,7 @@ fn write_sub_element(
             writeln!(file)?;
         }
         for (name, info) in &props {
-            write_slint_property(file, name, info, h, enums, structs, sc)?;
+            write_slint_property(file, name, info, h, types, sc)?;
         }
     }
     if !cbs.is_empty() {
@@ -772,7 +787,7 @@ fn write_sub_element(
         writeln!(file)?;
         for (name, info) in &cbs {
             let Type::Callback(func) = &info.ty else { continue };
-            write_mdx_signature_heading(file, h, name, func)?;
+            write_mdx_signature_heading(file, h, name, func, types.links)?;
             if let Some(doc) = &info.docs
                 && !doc.is_empty()
             {
@@ -786,7 +801,7 @@ fn write_sub_element(
         writeln!(file)?;
         for (name, info) in &fns {
             let Type::Function(func) = &info.ty else { continue };
-            write_mdx_signature_heading(file, h, name, func)?;
+            write_mdx_signature_heading(file, h, name, func, types.links)?;
             if let Some(doc) = &info.docs {
                 writeln!(file, "{}", transform_code_fences(doc, sc).trim_end())?;
             }
@@ -797,7 +812,7 @@ fn write_sub_element(
     // Recurse into grandchildren.
     if !skip_children {
         for (gc_name, gc) in &child.additional_accepted_child_types {
-            write_sub_element(file, gc_name, gc, enums, structs, seen, sc, cfg)?;
+            write_sub_element(file, gc_name, gc, types, seen, sc, cfg)?;
         }
     }
 
@@ -805,7 +820,7 @@ fn write_sub_element(
 }
 
 /// Generate .mdx page files for each exported builtin element.
-pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
+pub fn generate(cfg: &Config, links: &mdx::TypeLinks) -> Result<(), Box<dyn std::error::Error>> {
     let register = i_slint_compiler::typeregister::TypeRegister::builtin_experimental(
         &i_slint_compiler::symbol_counters::SymbolCounters::shared(),
     );
@@ -813,12 +828,11 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     let generated_dir = cfg.reference_dir();
     create_dir_all(&generated_dir)?;
 
-    // Include all types for resolution, regardless of experimental or SC flag,
-    // so property types still resolve their kind even when the target page
-    // isn't generated.
-    let enum_names: HashSet<String> = mdx::extract_enum_docs(true, false).keys().cloned().collect();
-    let struct_names: HashSet<String> =
-        mdx::extract_builtin_structs(true, false).keys().cloned().collect();
+    let types = TypeContext {
+        enums: mdx::extract_enum_docs(true, false).keys().cloned().collect(),
+        structs: mdx::extract_builtin_structs(true, false).keys().cloned().collect(),
+        links,
+    };
 
     // Collect exported elements.
     let mut elements = Vec::new();
@@ -906,7 +920,7 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
             )?;
         }
         let mut extra_imports = Vec::new();
-        for sname in &struct_names {
+        for sname in &types.structs {
             if all_text.contains(&format!("<{sname} />"))
                 || all_text.contains(&format!("<{sname}/>"))
             {
@@ -916,7 +930,7 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
                 ));
             }
         }
-        for ename in &enum_names {
+        for ename in &types.enums {
             if all_text.contains(&format!("<{ename} />"))
                 || all_text.contains(&format!("<{ename}/>"))
             {
@@ -959,7 +973,7 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // Members.
-        write_members(&mut file, builtin, &enum_names, &struct_names, &mut sc, cfg)?;
+        write_members(&mut file, builtin, &types, &mut sc, cfg)?;
 
         // Sub-elements (recursive, with cycle protection).
         if !skip_children {
@@ -969,8 +983,7 @@ pub fn generate(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
                     &mut file,
                     child_name,
                     child,
-                    &enum_names,
-                    &struct_names,
+                    &types,
                     &mut seen_children,
                     &mut sc,
                     cfg,

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -33,16 +33,22 @@ pub fn generate(cfg: &Config) -> Result<Vec<String>, Box<dyn std::error::Error>>
         std::fs::remove_dir_all(&cfg.generated_dir)
             .context(format!("error clearing {:?}", cfg.generated_dir))?;
     }
-    // The struct pages link to the type pages, so both are written from the
-    // same maps: a type this run leaves out is never linked to.
+    // The struct and element pages link to the type pages, so all of them are
+    // written from the same maps: a type this run leaves out is never linked to.
     let enums = extract_enum_docs(cfg.include_experimental, cfg.sc_only);
     let structs = extract_builtin_structs(cfg.include_experimental, cfg.sc_only);
+    // The pages of this site can also link the hand-written property-types
+    // pages, unless it's the safety manual: it serves an SC-filtered copy of
+    // those, which drops the sections of the types it doesn't cover. The struct
+    // partials are inlined into both sites, so they never link them.
+    let site_links = TypeLinks::new(&enums, &structs, !cfg.sc_only);
+    let shared_links = TypeLinks::new(&enums, &structs, false);
     write_individual_enum_files(cfg, &enums)?;
-    write_individual_struct_files(cfg, &structs, &enums)?;
+    write_individual_struct_files(cfg, &structs, &shared_links)?;
     if !cfg.sc_only {
         generate_keys_docs(cfg)?;
     }
-    crate::element_docs::generate(cfg)?;
+    crate::element_docs::generate(cfg, &site_links)?;
 
     if !cfg.sc_only || !enums.is_empty() || !structs.is_empty() {
         write_builtin_structs_and_enums(cfg, &structs, &enums)?;
@@ -389,24 +395,87 @@ pub fn extract_builtin_structs(
     structs
 }
 
-/// The section documenting `type_name` on the built-in enums or structs page.
-/// The maps are the ones those pages are written from, so a type left out of
-/// this run gets no link rather than one to a missing anchor.
-/// The link is written from the site root; `remarkBaseLinks` adds the base of
-/// whichever site renders it.
-fn type_href(
-    type_name: &str,
-    enums: &std::collections::BTreeMap<String, EnumDoc>,
-    structs: &std::collections::BTreeMap<String, StructDoc>,
-) -> Option<String> {
-    let page = if enums.contains_key(type_name) && !enum_documented_elsewhere(type_name) {
-        BUILTIN_ENUMS_SLUG
-    } else if structs.contains_key(type_name) {
-        BUILTIN_STRUCTS_SLUG
-    } else {
-        return None;
+/// The documentation of the built-in types, for linking a type named in a
+/// struct field or a callback signature to the section that describes it.
+pub struct TypeLinks {
+    /// The enums and structs this run writes a section for. A type left out of
+    /// it gets no link rather than one to a missing anchor.
+    enums: std::collections::BTreeSet<String>,
+    structs: std::collections::BTreeSet<String>,
+    /// Whether the primitive types link to the hand-written property-types
+    /// pages as well.
+    primitives: bool,
+}
+
+impl TypeLinks {
+    fn new(
+        enums: &std::collections::BTreeMap<String, EnumDoc>,
+        structs: &std::collections::BTreeMap<String, StructDoc>,
+        primitives: bool,
+    ) -> Self {
+        Self {
+            enums: enums.keys().filter(|name| !enum_documented_elsewhere(name)).cloned().collect(),
+            structs: structs.keys().cloned().collect(),
+            primitives,
+        }
+    }
+
+    /// The section documenting `type_name`, or `None` for a type this run
+    /// leaves out. The link is written from the site root; `remarkBaseLinks`
+    /// adds the base of whichever site renders it.
+    fn href(&self, type_name: &str) -> Option<String> {
+        let page = if self.enums.contains(type_name) {
+            BUILTIN_ENUMS_SLUG
+        } else if self.structs.contains(type_name) {
+            BUILTIN_STRUCTS_SLUG
+        } else {
+            return self.primitives.then(|| primitive_href(type_name)).flatten();
+        };
+        Some(format!("/{page}/#{}", type_name.to_lowercase()))
+    }
+
+    /// The documentation of `value` among the values `type_name` can take, or
+    /// `None` for an enum this run leaves out.
+    fn enum_value_href(&self, type_name: &str, value: &str) -> Option<String> {
+        self.enums
+            .contains(type_name)
+            .then(|| format!("/{BUILTIN_ENUMS_SLUG}/#{}", enum_value_anchor(type_name, value)))
+    }
+
+    /// `type_name` as markdown, linked to its documentation when it has any.
+    pub fn linked(&self, type_name: &str) -> String {
+        self.href(type_name)
+            .map_or_else(|| type_name.to_string(), |href| format!("[{type_name}]({href})"))
+    }
+}
+
+/// The section documenting a primitive type, from `link-data.json`: the map
+/// the docs site resolves its own `slint:` links with, so these links follow a
+/// page that moves.
+fn primitive_href(type_name: &str) -> Option<String> {
+    static LINK_MAP: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../internal/core-macros/link-data.json"
+        )))
+        .expect("failed to parse link-data.json")
+    });
+    // The map keys some of the types under a name of its own.
+    let key = match type_name {
+        "angle" | "bool" | "brush" | "color" | "duration" | "easing" | "float" | "int" | "keys"
+        | "length" | "percent" | "BuiltInMouseCursor" | "MouseCursor" => type_name,
+        "data-transfer" => "data_transfer",
+        "image" => "ImageType",
+        "physical-length" => "physicalLength",
+        "relative-font-size" => "relativeFontSize",
+        "string" => "StringType",
+        "styled-text" => "styled_text",
+        _ => return None,
     };
-    Some(format!("/{page}/#{}", type_name.to_lowercase()))
+    let href = LINK_MAP[key]["href"]
+        .as_str()
+        .unwrap_or_else(|| panic!("link-data.json has no href for {key}"));
+    Some(format!("/{href}"))
 }
 
 /// The id of one value on the page documenting `enum_name`.
@@ -428,25 +497,17 @@ fn declared_default(tokens: &str) -> String {
 
 /// The list entry documenting one field of a struct, with the field's type
 /// linked to its own documentation when it has any.
-fn struct_field_line(
-    field: &StructFieldDoc,
-    enums: &std::collections::BTreeMap<String, EnumDoc>,
-    structs: &std::collections::BTreeMap<String, StructDoc>,
-) -> String {
+fn struct_field_line(field: &StructFieldDoc, links: &TypeLinks) -> String {
     let name = &field.type_name;
-    let type_name = type_href(name, enums, structs)
-        .map_or_else(|| format!("_{name}_"), |href| format!("[_{name}_]({href})"));
+    let type_name =
+        links.href(name).map_or_else(|| format!("_{name}_"), |href| format!("[_{name}_]({href})"));
     let default_value = field.default_value.as_ref().map_or_else(String::new, |value| {
         // An enum value links to its own documentation, next to the values it could
-        // take instead; `type_href` decides whether the enum is documented there.
-        let documented = enums.contains_key(name) && type_href(name, enums, structs).is_some();
-        match documented {
-            true => format!(
-                " Defaults to [`{value}`](/{BUILTIN_ENUMS_SLUG}/#{}).",
-                enum_value_anchor(name, value)
-            ),
-            false => format!(" Defaults to `{value}`."),
-        }
+        // take instead.
+        links.enum_value_href(name, value).map_or_else(
+            || format!(" Defaults to `{value}`."),
+            |href| format!(" Defaults to [`{value}`]({href})."),
+        )
     });
     format!("- **`{}`** ({}): {}{}", field.key, type_name, field.description, default_value)
 }
@@ -454,7 +515,7 @@ fn struct_field_line(
 fn write_individual_struct_files(
     cfg: &Config,
     structs: &std::collections::BTreeMap<String, StructDoc>,
-    enums: &std::collections::BTreeMap<String, EnumDoc>,
+    links: &TypeLinks,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let structs_dir = cfg.reference_dir().join("structs");
     create_dir_all(&structs_dir).context(format!(
@@ -484,7 +545,7 @@ description: {0} content
         )?;
 
         for f in &v.fields {
-            writeln!(file, "{}", struct_field_line(f, enums, structs))?;
+            writeln!(file, "{}", struct_field_line(f, links))?;
         }
 
         file.flush()?;
@@ -553,17 +614,14 @@ fn test_is_generated_dir() {
 }
 
 #[test]
-fn test_type_href() {
-    let enum_doc = || EnumDoc { description: String::new(), values: vec![] };
-    let enums = std::collections::BTreeMap::from([
-        ("CapitalizationMode".to_string(), enum_doc()),
-        ("BuiltInMouseCursor".to_string(), enum_doc()),
-    ]);
-    let structs = std::collections::BTreeMap::from([(
-        "KeyboardModifiers".to_string(),
-        StructDoc { description: String::new(), fields: vec![] },
-    )]);
-    let href = |type_name| type_href(type_name, &enums, &structs);
+fn test_type_links() {
+    let make_links = |primitives| TypeLinks {
+        enums: ["CapitalizationMode".to_string()].into(),
+        structs: ["KeyboardModifiers".to_string()].into(),
+        primitives,
+    };
+    let links = make_links(true);
+    let href = |type_name| links.href(type_name);
 
     assert_eq!(
         href("CapitalizationMode").as_deref(),
@@ -573,9 +631,31 @@ fn test_type_href() {
         href("KeyboardModifiers").as_deref(),
         Some("/reference/property-types/builtin-structs/#keyboardmodifiers")
     );
-    // A type without a section of its own, and one documented elsewhere.
-    assert_eq!(href("int"), None);
-    assert_eq!(href("BuiltInMouseCursor"), None);
+    // The primitive types are documented on the hand-written pages, the mouse
+    // cursor shapes among them.
+    assert_eq!(href("int").as_deref(), Some("/reference/property-types/numeric-types/#int"));
+    assert_eq!(href("string").as_deref(), Some("/reference/property-types/strings/#string"));
+    assert_eq!(
+        href("BuiltInMouseCursor").as_deref(),
+        Some("/reference/property-types/other-types/#mousecursor")
+    );
+    // A type with no documentation of its own.
+    assert_eq!(href("element ref"), None);
+
+    // Content shared with the safety manual links the generated pages only.
+    let shared_links = make_links(false);
+    assert_eq!(shared_links.href("int"), None);
+    assert_eq!(
+        shared_links.href("CapitalizationMode").as_deref(),
+        Some("/reference/property-types/builtin-enums/#capitalizationmode")
+    );
+
+    assert_eq!(
+        links.linked("KeyEvent"),
+        "KeyEvent",
+        "a type this run doesn't document is written plain"
+    );
+    assert_eq!(links.linked("int"), "[int](/reference/property-types/numeric-types/#int)");
 
     let field = StructFieldDoc {
         key: "field".to_string(),
@@ -584,7 +664,7 @@ fn test_type_href() {
         default_value: None,
     };
     assert_eq!(
-        struct_field_line(&field, &enums, &structs),
+        struct_field_line(&field, &links),
         "- **`field`** ([_CapitalizationMode_](/reference/property-types/builtin-enums/#capitalizationmode)): The docs"
     );
     // A declared default value is documented after the description.
@@ -595,9 +675,9 @@ fn test_type_href() {
         default_value: Some(declared_default("(CapitalizationMode::Sentences)")),
     };
     assert_eq!(
-        struct_field_line(&with_default, &enums, &structs),
+        struct_field_line(&with_default, &links),
         "- **`field`** ([_CapitalizationMode_](/reference/property-types/builtin-enums/#capitalizationmode)): The docs Defaults to [`sentences`](/reference/property-types/builtin-enums/#capitalizationmode-sentences)."
     );
-    let field = StructFieldDoc { type_name: "int".to_string(), ..field };
-    assert_eq!(struct_field_line(&field, &enums, &structs), "- **`field`** (_int_): The docs");
+    let field = StructFieldDoc { type_name: "element ref".to_string(), ..field };
+    assert_eq!(struct_field_line(&field, &links), "- **`field`** (_element ref_): The docs");
 }

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cspell:ignore capitalizationmode keyboardmodifiers
+// cspell:ignore capitalizationmode keyboardmodifiers keyevent
 
 use crate::Config;
 use anyhow::Context;
@@ -423,6 +423,10 @@ impl TypeLinks {
     /// The section documenting `type_name`, or `None` for a type this run
     /// leaves out. The link is written from the site root; `remarkBaseLinks`
     /// adds the base of whichever site renders it.
+    ///
+    /// The generated pages come first: `link-data.json` keys pages of every
+    /// kind, and some of them under the name of a type it documents elsewhere
+    /// (`KeyEvent` points at the keyboard input overview).
     fn href(&self, type_name: &str) -> Option<String> {
         let page = if self.enums.contains(type_name) {
             BUILTIN_ENUMS_SLUG
@@ -451,7 +455,7 @@ impl TypeLinks {
 
 /// The section documenting a primitive type, from `link-data.json`: the map
 /// the docs site resolves its own `slint:` links with, so these links follow a
-/// page that moves.
+/// page that moves. It keys the types by their name in `.slint`.
 fn primitive_href(type_name: &str) -> Option<String> {
     static LINK_MAP: std::sync::LazyLock<serde_json::Value> = std::sync::LazyLock::new(|| {
         serde_json::from_str(include_str!(concat!(
@@ -460,21 +464,9 @@ fn primitive_href(type_name: &str) -> Option<String> {
         )))
         .expect("failed to parse link-data.json")
     });
-    // The map keys some of the types under a name of its own.
-    let key = match type_name {
-        "angle" | "bool" | "brush" | "color" | "duration" | "easing" | "float" | "int" | "keys"
-        | "length" | "percent" | "BuiltInMouseCursor" | "MouseCursor" => type_name,
-        "data-transfer" => "data_transfer",
-        "image" => "ImageType",
-        "physical-length" => "physicalLength",
-        "relative-font-size" => "relativeFontSize",
-        "string" => "StringType",
-        "styled-text" => "styled_text",
-        _ => return None,
-    };
-    let href = LINK_MAP[key]["href"]
+    let href = LINK_MAP.get(type_name)?["href"]
         .as_str()
-        .unwrap_or_else(|| panic!("link-data.json has no href for {key}"));
+        .unwrap_or_else(|| panic!("link-data.json has no href for {type_name}"));
     Some(format!("/{href}"))
 }
 
@@ -617,7 +609,7 @@ fn test_is_generated_dir() {
 fn test_type_links() {
     let make_links = |primitives| TypeLinks {
         enums: ["CapitalizationMode".to_string()].into(),
-        structs: ["KeyboardModifiers".to_string()].into(),
+        structs: ["KeyboardModifiers".to_string(), "KeyEvent".to_string()].into(),
         primitives,
     };
     let links = make_links(true);
@@ -634,13 +626,28 @@ fn test_type_links() {
     // The primitive types are documented on the hand-written pages, the mouse
     // cursor shapes among them.
     assert_eq!(href("int").as_deref(), Some("/reference/property-types/numeric-types/#int"));
-    assert_eq!(href("string").as_deref(), Some("/reference/property-types/strings/#string"));
     assert_eq!(
         href("BuiltInMouseCursor").as_deref(),
         Some("/reference/property-types/other-types/#mousecursor")
     );
-    // A type with no documentation of its own.
-    assert_eq!(href("element ref"), None);
+    // A key spelled otherwise than the type would drop the link, unnoticed.
+    for type_name in [
+        "data-transfer",
+        "enum",
+        "image",
+        "physical-length",
+        "relative-font-size",
+        "string",
+        "struct",
+        "styled-text",
+    ] {
+        assert!(href(type_name).is_some(), "link-data.json has no entry for {type_name}");
+    }
+    // The generated section wins over the map's own `KeyEvent` entry.
+    assert_eq!(
+        href("KeyEvent").as_deref(),
+        Some("/reference/property-types/builtin-structs/#keyevent")
+    );
 
     // Content shared with the safety manual links the generated pages only.
     let shared_links = make_links(false);
@@ -651,9 +658,9 @@ fn test_type_links() {
     );
 
     assert_eq!(
-        links.linked("KeyEvent"),
-        "KeyEvent",
-        "a type this run doesn't document is written plain"
+        links.linked("element ref"),
+        "element ref",
+        "a type with no documentation of its own is written plain"
     );
     assert_eq!(links.linked("int"), "[int](/reference/property-types/numeric-types/#int)");
 

--- a/internal/core-macros/link-data.json
+++ b/internal/core-macros/link-data.json
@@ -35,7 +35,7 @@
     "DragAndDrop": {
         "href": "guide/development/drag-and-drop/"
     },
-    "data_transfer": {
+    "data-transfer": {
         "href": "reference/property-types/other-types/#data-transfer"
     },
     "DragAction": {
@@ -68,7 +68,7 @@
     "Edges": {
         "href": "reference/property-types/builtin-structs/#edges"
     },
-    "EnumType": {
+    "enum": {
         "href": "reference/property-types/builtin-enums/"
     },
     "EventResult": {
@@ -110,7 +110,7 @@
     "Image": {
         "href": "reference/elements/image/"
     },
-    "ImageType": {
+    "image": {
         "href": "reference/property-types/images/#image"
     },
     "int": {
@@ -176,7 +176,7 @@
     "percent": {
         "href": "reference/property-types/numeric-types/#percent"
     },
-    "physicalLength": {
+    "physical-length": {
         "href": "reference/property-types/numeric-types/#physical-length"
     },
     "PopupWindow": {
@@ -194,7 +194,7 @@
     "Rectangle": {
         "href": "reference/elements/rectangle/"
     },
-    "relativeFontSize": {
+    "relative-font-size": {
         "href": "reference/property-types/numeric-types/#relative-font-size"
     },
     "Size": {
@@ -215,7 +215,7 @@
     "SystemTrayIcon": {
         "href": "reference/window/systemtrayicon/"
     },
-    "styled_text": {
+    "styled-text": {
         "href": "reference/property-types/strings/#styled-text"
     },
     "callback": {
@@ -227,10 +227,10 @@
     "StandardButton": {
         "href": "reference/std-widgets/basic-widgets/standardbutton/"
     },
-    "StringType": {
+    "string": {
         "href": "reference/property-types/strings/#string"
     },
-    "StructType": {
+    "struct": {
         "href": "reference/property-types/builtin-structs/"
     },
     "StyleWidgets": {


### PR DESCRIPTION
The signature in a callback or function heading named its types in plain text, so a reader wondering what an `EventResult` is had to go looking for it. Link each parameter and return type to its own documentation: the built-in enums and structs pages this run writes, and for the primitive types the property-types reference, resolved through the link map the site uses for its own links.

The heading keeps the id it had, since that comes from its text and the text of a link counts.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
