### PR TITLE
Document that FlexboxLayout is for wrapping

### DIFF
--- a/ai-plugins/skills/slint/reference/language-and-layout.md
+++ b/ai-plugins/skills/slint/reference/language-and-layout.md
@@ -28,6 +28,8 @@ Below are the rules agents most often get wrong.
 
 - Use layouts (`VerticalLayout`, `HorizontalLayout`, `GridLayout`, or the
   padded `*Box` widgets); reserve `x`/`y` for overlays and custom drawing.
+- `FlexboxLayout` is for *wrapping* (`flex-wrap` defaults to `wrap`, unlike
+  CSS); without wrapping, prefer `HorizontalLayout`/`VerticalLayout`.
 - `padding`/`spacing` only work on layout elements. To inset a `Text`, wrap
   it: `HorizontalLayout { padding-left: 6px; Text {…} }`.
 - Fill vs. preferred size: containers and graphics elements (`Rectangle`,

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2234,7 +2234,7 @@ export component HorizontalLayout {
 ///
 /// In row direction, items are placed from left to right. When the available width is exceeded, items automatically wrap to the next row. In column direction, items are placed from top to bottom and wrap to the next column when the available height is exceeded.
 ///
-/// \footer
+\footer
 /// ## Cell elements
 /// Cell elements inside a `FlexboxLayout` obtain the following new properties:
 ///
@@ -2257,16 +2257,6 @@ export component HorizontalLayout {
 /// ```
 /// </SlintProperty>
 ///
-/// The other CSS flexbox properties map as follows:
-///
-/// | CSS           | Slint                                                          |
-/// | ------------- | -------------------------------------------------------------- |
-/// | `flex-wrap`   | `flex-wrap`, but the default differs: CSS defaults to `nowrap`, Slint to `wrap`. For a non-wrapping row or column, prefer `HorizontalLayout` / `VerticalLayout` |
-/// | `flex-grow`   | `alignment: stretch` on the container, weighted per item by `horizontal-stretch` / `vertical-stretch`; `max-width` / `max-height` caps growing (space a capped item cannot take stays free) |
-/// | `flex-shrink` | nothing to opt into: every item shrinks, in proportion to its preferred size; `min-width` / `min-height` refuses shrinking |
-/// | `flex-basis`  | `preferred-width` (row) / `preferred-height` (column)          |
-/// | `align-self`  | `cross-axis-self-alignment`                                    |
-///
 /// ## Layout Behavior
 ///
 /// The layouting algorithm for FlexboxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>
@@ -2274,6 +2264,32 @@ export component HorizontalLayout {
 /// You can learn more about the CSS Flexbox specification from
 /// - <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts">the Mozilla developer website</a>
 /// - <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">A Complete Guide To Flexbox by CSS Tricks</a>. This is detailed guide with illustrations and comprehensive written explanation of the different Flexbox properties and how they work.
+///
+/// ## CSS Mapping
+///
+/// The container properties map to CSS Flexbox as follows:
+///
+/// | CSS               | Slint                                                     |
+/// | ----------------- | --------------------------------------------------------- |
+/// | `flex-direction`  | `flex-direction`                                          |
+/// | `flex-wrap`       | `flex-wrap`, but the default differs: CSS defaults to `nowrap`, Slint to `wrap`. For a non-wrapping row or column, prefer <Link type="HorizontalLayout" /> / <Link type="VerticalLayout" /> |
+/// | `justify-content` | `alignment`                                               |
+/// | `align-items`     | `cross-axis-alignment`                                    |
+/// | `align-content`   | `cross-axis-line-alignment`                               |
+/// | `gap`             | `spacing`                                                 |
+/// | `column-gap`      | `spacing-horizontal`                                      |
+/// | `row-gap`         | `spacing-vertical`                                        |
+/// | `padding`         | `padding`, `padding-left` / `-right` / `-top` / `-bottom` |
+///
+/// The CSS per-item flexbox properties are expressed with the properties the
+/// other layouts already use:
+///
+/// | CSS           | Slint                                                          |
+/// | ------------- | -------------------------------------------------------------- |
+/// | `flex-grow`   | `alignment: stretch` on the container, weighted per item by `horizontal-stretch` / `vertical-stretch`; `max-width` / `max-height` caps growing (space a capped item cannot take stays free) |
+/// | `flex-shrink` | nothing to opt into: every item shrinks, in proportion to its preferred size; `min-width` / `min-height` refuses shrinking |
+/// | `flex-basis`  | `preferred-width` (row) / `preferred-height` (column)          |
+/// | `align-self`  | `cross-axis-self-alignment`                                    |
 /// \group:layouts
 export component FlexboxLayout {
     //! ## Spacing Properties
@@ -2323,7 +2339,7 @@ export component FlexboxLayout {
     /// The default value is `stretch`.
     in property <CrossAxisLineAlignment> cross-axis-line-alignment;
     /// Set the alignment of individual items along the cross axis within each flex line.
-    /// The default value is `stretch`.
+    /// CSS Flexbox calls this "align-items". The default value is `stretch`.
     in property <CrossAxisAlignment> cross-axis-alignment;
     /// Controls whether flex items wrap onto multiple lines when they don't fit in the container.
     /// The default value is `wrap`, unlike CSS where it is `nowrap`.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2257,14 +2257,6 @@ export component HorizontalLayout {
 /// ```
 /// </SlintProperty>
 ///
-/// ## Layout Behavior
-///
-/// The layouting algorithm for FlexboxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>
-///
-/// You can learn more about the CSS Flexbox specification from
-/// - <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts">the Mozilla developer website</a>
-/// - <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">A Complete Guide To Flexbox by CSS Tricks</a>. This is detailed guide with illustrations and comprehensive written explanation of the different Flexbox properties and how they work.
-///
 /// ## CSS Mapping
 ///
 /// The container properties map to CSS Flexbox as follows:
@@ -2272,7 +2264,7 @@ export component HorizontalLayout {
 /// | CSS               | Slint                                                     |
 /// | ----------------- | --------------------------------------------------------- |
 /// | `flex-direction`  | `flex-direction`                                          |
-/// | `flex-wrap`       | `flex-wrap`, but the default differs: CSS defaults to `nowrap`, Slint to `wrap`. For a non-wrapping row or column, prefer <Link type="HorizontalLayout" /> / <Link type="VerticalLayout" /> |
+/// | `flex-wrap`       | `flex-wrap`, but the default is `wrap` (CSS: `nowrap`)    |
 /// | `justify-content` | `alignment`                                               |
 /// | `align-items`     | `cross-axis-alignment`                                    |
 /// | `align-content`   | `cross-axis-line-alignment`                               |
@@ -2290,6 +2282,15 @@ export component HorizontalLayout {
 /// | `flex-shrink` | nothing to opt into: every item shrinks, in proportion to its preferred size; `min-width` / `min-height` refuses shrinking |
 /// | `flex-basis`  | `preferred-width` (row) / `preferred-height` (column)          |
 /// | `align-self`  | `cross-axis-self-alignment`                                    |
+///
+/// ## Layout Behavior
+///
+/// The layouting algorithm for FlexboxLayout is entirely implemented by <a href="https://github.com/DioxusLabs/taffy">taffy</a>
+///
+/// You can learn more about the CSS Flexbox specification from
+/// - <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Flexible_box_layout/Basic_concepts">the Mozilla developer website</a>
+/// - <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">A Complete Guide To Flexbox by CSS Tricks</a>. This is detailed guide with illustrations and comprehensive written explanation of the different Flexbox properties and how they work.
+///
 /// \group:layouts
 export component FlexboxLayout {
     //! ## Spacing Properties

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2234,7 +2234,7 @@ export component HorizontalLayout {
 ///
 /// In row direction, items are placed from left to right. When the available width is exceeded, items automatically wrap to the next row. In column direction, items are placed from top to bottom and wrap to the next column when the available height is exceeded.
 ///
-\footer
+/// \footer
 /// ## Cell elements
 /// Cell elements inside a `FlexboxLayout` obtain the following new properties:
 ///

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2182,7 +2182,15 @@ export component HorizontalLayout {
     in property <CrossAxisAlignment> cross-axis-alignment;
 }
 
-/// `FlexboxLayout` is a flexible box layout that arranges its children in rows or columns with automatic wrapping. It implements a CSS Flexbox-like layout model suitable for creating flexible, responsive UIs.
+/// `FlexboxLayout` is a flexible box layout that arranges its children in rows or columns with automatic wrapping.
+/// It implements a CSS Flexbox-like layout model suitable for creating flexible, responsive UIs.
+///
+/// Use `FlexboxLayout` when the items should wrap: items that don't fit continue on the next line.
+/// That's why `flex-wrap` defaults to `wrap`, unlike CSS.
+/// For a single row or column, use the simpler and faster
+/// <Link type="HorizontalLayout" /> or <Link type="VerticalLayout" /> instead,
+/// unless you need a `flex-direction` that changes at runtime,
+/// or the reversed directions (`row-reverse` / `column-reverse`).
 ///
 ///
 /// ```slint playground imageAlt="flexboxlayout example with row direction" width="300" height="150"
@@ -2249,11 +2257,11 @@ export component HorizontalLayout {
 /// ```
 /// </SlintProperty>
 ///
-/// The other CSS per-item flexbox properties are expressed with the properties the
-/// other layouts already use:
+/// The other CSS flexbox properties map as follows:
 ///
 /// | CSS           | Slint                                                          |
 /// | ------------- | -------------------------------------------------------------- |
+/// | `flex-wrap`   | `flex-wrap`, but the default differs: CSS defaults to `nowrap`, Slint to `wrap`. For a non-wrapping row or column, prefer `HorizontalLayout` / `VerticalLayout` |
 /// | `flex-grow`   | `alignment: stretch` on the container, weighted per item by `horizontal-stretch` / `vertical-stretch`; `max-width` / `max-height` caps growing (space a capped item cannot take stays free) |
 /// | `flex-shrink` | nothing to opt into: every item shrinks, in proportion to its preferred size; `min-width` / `min-height` refuses shrinking |
 /// | `flex-basis`  | `preferred-width` (row) / `preferred-height` (column)          |
@@ -2318,7 +2326,7 @@ export component FlexboxLayout {
     /// The default value is `stretch`.
     in property <CrossAxisAlignment> cross-axis-alignment;
     /// Controls whether flex items wrap onto multiple lines when they don't fit in the container.
-    /// The default value is `wrap`.
+    /// The default value is `wrap`, unlike CSS where it is `nowrap`.
     in property <FlexboxLayoutWrap> flex-wrap;
 }
 


### PR DESCRIPTION
flex-wrap defaults to wrap, unlike CSS where it is nowrap, and users coming from CSS expect the CSS behavior. Point them to the simpler and faster HorizontalLayout and VerticalLayout when they don't need wrapping, in the element documentation, the CSS mapping table, and the skill.
