### PR TITLE
Make cross-axis-self-alignment experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,6 @@ All notable changes to this project are documented in this file.
 
  - Added the `FlexboxLayout` element, which arranges its children in rows or columns and wraps them
    to the next line when they don't fit.
- - Added the per-item `cross-axis-self-alignment` property: the children of a `FlexboxLayout`,
-   `HorizontalLayout`, or `VerticalLayout` can override the container's `cross-axis-alignment`.
  - Struct fields can now declare a default value: `struct Player { name: string = "unknown" }`.
  - Added `push`, `remove`, and `insert` functions on arrays and models, with matching `Model` API
    additions in every language binding. (#9457)

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -322,6 +322,10 @@ export default defineConfig({
                                                   label: "Shadowable Members",
                                                   slug: "guide/experimental/shadowable",
                                               },
+                                              {
+                                                  label: "Cross-Axis Self-Alignment",
+                                                  slug: "guide/experimental/cross-axis-self-alignment",
+                                              },
                                           ],
                                       },
                                   ]

--- a/docs/astro/src/content/docs/guide/experimental/cross-axis-self-alignment.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/cross-axis-self-alignment.mdx
@@ -1,0 +1,25 @@
+---
+title: Cross-Axis Self-Alignment
+description: Experimental per-cell cross-axis-self-alignment property for layout children.
+---
+
+The children of a `FlexboxLayout`, `HorizontalLayout`, or `VerticalLayout` can set
+`cross-axis-self-alignment` to override the container's `cross-axis-alignment` individually.
+CSS Flexbox calls this "align-self".
+
+The property has the type `CrossAxisSelfAlignment`, with the values `auto` (the default),
+`stretch`, `start`, `end`, and `center`. The default value `auto` uses the container's
+`cross-axis-alignment`.
+
+> **Note**: this property is experimental and subject to change.
+> `CrossAxisSelfAlignment` duplicates the `CrossAxisAlignment` enum plus an `auto` value.
+> Once the language has optional types, the property should become an optional
+> `CrossAxisAlignment` instead, and the extra enum should disappear.
+
+```slint no-test
+HorizontalLayout {
+    cross-axis-alignment: start;
+    Rectangle { }
+    Rectangle { cross-axis-self-alignment: stretch; }
+}
+```

--- a/docs/astro/src/content/docs/reference/layouts/overview.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/overview.mdx
@@ -20,12 +20,6 @@ See <Link type="GridLayout" />.
 See <Link type="GridLayout" />.
 </SlintProperty>
 
-### cross-axis-self-alignment
-<SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
-Overrides the container's `cross-axis-alignment` for this element.
-Valid on the children of a <Link type="HorizontalLayout" />, <Link type="VerticalLayout" />, or `FlexboxLayout`.
-</SlintProperty>
-
 ### horizontal-stretch, vertical-stretch
 <SlintProperty propName="horizontal-stretch, vertical-stretch" typeName="float" propertyVisibility="in-out">
 Specify how much relative space these elements are stretching in a layout. When 0, this means that the

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2049,15 +2049,6 @@ export component GridLayout {
 /// Places its children next to each other vertically.
 /// The size of elements can either be fixed with the `width` or `height` property, or if they aren't set
 /// they will be computed by the layout respecting the minimum and maximum sizes and the stretch factor.
-/// \footer
-/// ## Cell elements
-/// Cell elements inside a `VerticalLayout` obtain the following new property:
-///
-/// ### cross-axis-self-alignment
-/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
-/// Overrides the container's `cross-axis-alignment` for this element.
-/// The default value `auto` uses the container's `cross-axis-alignment`.
-/// </SlintProperty>
 /// \group:layouts
 export component VerticalLayout {
     //! ## Spacing Properties
@@ -2123,15 +2114,6 @@ export component VerticalLayout {
 /// Places its children next to each other horizontally.
 /// The size of elements can either be fixed with the `width` or `height` property, or if they aren't set
 /// they will be computed by the layout respecting the minimum and maximum sizes and the stretch factor.
-/// \footer
-/// ## Cell elements
-/// Cell elements inside a `HorizontalLayout` obtain the following new property:
-///
-/// ### cross-axis-self-alignment
-/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
-/// Overrides the container's `cross-axis-alignment` for this element.
-/// The default value `auto` uses the container's `cross-axis-alignment`.
-/// </SlintProperty>
 /// \group:layouts
 export component HorizontalLayout {
     //! ## Spacing Properties
@@ -2236,13 +2218,7 @@ export component HorizontalLayout {
 ///
 /// \footer
 /// ## Cell elements
-/// Cell elements inside a `FlexboxLayout` obtain the following new properties:
-///
-/// ### cross-axis-self-alignment
-/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
-/// Overrides the container's `cross-axis-alignment` for this element. CSS Flexbox calls this "align-self".
-/// The default value `auto` uses the container's `cross-axis-alignment`.
-/// </SlintProperty>
+/// Cell elements inside a `FlexboxLayout` obtain the following new property:
 ///
 /// ### layout-order
 /// <SlintProperty propName="layout-order" typeName="int" defaultValue="0">
@@ -2281,7 +2257,6 @@ export component HorizontalLayout {
 /// | `flex-grow`   | `alignment: stretch` on the container, weighted per item by `horizontal-stretch` / `vertical-stretch`; `max-width` / `max-height` caps growing (space a capped item cannot take stays free) |
 /// | `flex-shrink` | nothing to opt into: every item shrinks, in proportion to its preferred size; `min-width` / `min-height` refuses shrinking |
 /// | `flex-basis`  | `preferred-width` (row) / `preferred-height` (column)          |
-/// | `align-self`  | `cross-axis-self-alignment`                                    |
 ///
 /// ## Layout Behavior
 ///

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -502,7 +502,7 @@ fn lower_element_layout(
         None
     };
 
-    check_no_layout_properties(elem, &layout_type, parent_layout_type, diag);
+    check_no_layout_properties(elem, &layout_type, parent_layout_type, type_register, diag);
 
     match layout_type.as_ref()?.as_str() {
         "Row" => return layout_type,
@@ -2539,6 +2539,7 @@ fn check_no_layout_properties(
     item: &ElementRc,
     layout_type: &Option<SmolStr>,
     parent_layout_type: &Option<SmolStr>,
+    type_register: &TypeRegister,
     diag: &mut BuildDiagnostics,
 ) {
     let elem = item.borrow();
@@ -2551,18 +2552,21 @@ fn check_no_layout_properties(
         if prop == "layout-order" && parent_layout_type.as_deref() != Some("FlexboxLayout") {
             diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
         }
-        if prop == "cross-axis-self-alignment"
-            && !matches!(
+        if prop == "cross-axis-self-alignment" {
+            if !matches!(
                 parent_layout_type.as_deref(),
                 Some("FlexboxLayout" | "HorizontalLayout" | "VerticalLayout")
-            )
-        {
-            diag.push_error(
-                format!(
-                    "{prop} used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout"
-                ),
-                &*expr.borrow(),
-            );
+            ) {
+                diag.push_error(
+                    format!(
+                        "{prop} used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout"
+                    ),
+                    &*expr.borrow(),
+                );
+            } else {
+                // Not stable API yet: pending optional types.
+                crate::reject_experimental_feature(diag, type_register, prop, &*expr.borrow());
+            }
         }
         if parent_layout_type.as_deref() != Some("Dialog")
             && matches!(prop.as_ref(), "dialog-button-role")

--- a/internal/compiler/tests/flex_item_properties.rs
+++ b/internal/compiler/tests/flex_item_properties.rs
@@ -1,9 +1,9 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! The per-item properties of a `FlexboxLayout` (`layout-order`, `cross-axis-self-alignment`)
-//! are stable API. The syntax tests can't verify that because they always enable the
-//! experimental features, so these tests compile with them disabled.
+//! `layout-order` is stable API while `cross-axis-self-alignment` is experimental.
+//! The syntax tests can't verify that because they always enable the experimental
+//! features, so these tests compile with them disabled.
 
 use i_slint_compiler::diagnostics::{BuildDiagnostics, DiagnosticLevel};
 use i_slint_compiler::generator::OutputFormat;
@@ -52,11 +52,10 @@ fn flex_item_properties_are_stable() {
     }
 }
 
-/// `cross-axis-self-alignment` is usable in a FlexboxLayout and in the box layouts.
+/// `cross-axis-self-alignment` is experimental in every layout, pending optional types.
 #[test]
-fn cross_axis_self_alignment_is_stable() {
-    assert_eq!(in_flexbox("cross-axis-self-alignment: center"), Vec::<String>::new());
-    for layout in ["HorizontalLayout", "VerticalLayout"] {
+fn cross_axis_self_alignment_is_experimental() {
+    for layout in ["FlexboxLayout", "HorizontalLayout", "VerticalLayout"] {
         let source = format!(
             r#"
 export component TestCase inherits Window {{
@@ -66,7 +65,7 @@ export component TestCase inherits Window {{
 }}
 "#
         );
-        assert_eq!(errors(source), Vec::<String>::new());
+        assert_eq!(errors(source), ["'cross-axis-self-alignment' is an experimental feature"]);
     }
 }
 
@@ -125,17 +124,13 @@ export component TestCase inherits Window {{
     }
 }
 
-/// The `CrossAxisSelfAlignment` enum is in the stable type register:
-/// nameable as a type and as a qualified value without experimental features.
+/// The `CrossAxisSelfAlignment` enum is not in the stable type register.
 #[test]
-fn cross_axis_self_alignment_enum_is_stable() {
+fn cross_axis_self_alignment_enum_is_experimental() {
     let source = r#"
 export component TestCase inherits Window {
-    in property <CrossAxisSelfAlignment> a: CrossAxisSelfAlignment.center;
-    FlexboxLayout {
-        Rectangle { cross-axis-self-alignment: root.a; }
-    }
+    in property <CrossAxisSelfAlignment> a;
 }
 "#;
-    assert_eq!(errors(source.into()), Vec::<String>::new());
+    assert_eq!(errors(source.into()), ["Unknown type 'CrossAxisSelfAlignment'"]);
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -626,6 +626,8 @@ impl TypeRegister {
         register.elements.remove("ComponentContainer").unwrap();
         register.types.remove("component-factory").unwrap();
 
+        register.types.remove("CrossAxisSelfAlignment").unwrap();
+
         Rc::new(RefCell::new(register))
     }
 

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -541,6 +541,7 @@ fn is_reserved_prop_valid(
     prop: &str,
     element_type: &ElementType,
     parent_element_type: Option<&ElementType>,
+    enable_experimental: bool,
 ) -> bool {
     let name_of = |t: &ElementType| -> Option<SmolStr> {
         match t {
@@ -558,10 +559,11 @@ fn is_reserved_prop_valid(
         return matches!(parent_name, Some("GridLayout" | "Row"));
     }
     if prop == "cross-axis-self-alignment" {
-        return matches!(
-            parent_name,
-            Some("FlexboxLayout" | "HorizontalLayout" | "VerticalLayout")
-        );
+        return enable_experimental
+            && matches!(
+                parent_name,
+                Some("FlexboxLayout" | "HorizontalLayout" | "VerticalLayout")
+            );
     }
     if name_in(i_slint_compiler::typeregister::RESERVED_FLEXBOXLAYOUT_PROPERTIES) {
         return parent_name == Some("FlexboxLayout");
@@ -583,6 +585,7 @@ fn properties_for_changed_callbacks(
     mut node: SyntaxNode,
     document_cache: &mut DocumentCache,
 ) -> Option<Vec<CompletionItem>> {
+    let enable_experimental = document_cache.compiler_configuration().enable_experimental;
     let element = loop {
         if let Some(e) = syntax_nodes::Element::new(node.clone()) {
             break e;
@@ -619,7 +622,12 @@ fn properties_for_changed_callbacks(
             if !ty.is_property_type() {
                 return None;
             }
-            if !is_reserved_prop_valid(k, &element_type, parent_element_type.as_ref()) {
+            if !is_reserved_prop_valid(
+                k,
+                &element_type,
+                parent_element_type.as_ref(),
+                enable_experimental,
+            ) {
                 return None;
             }
             let mut c = CompletionItem::new_simple(k.into(), ty.to_string());
@@ -637,6 +645,7 @@ fn resolve_element_scope(
     document_cache: &DocumentCache,
     with_snippets: bool,
 ) -> Option<Vec<CompletionItem>> {
+    let enable_experimental = document_cache.compiler_configuration().enable_experimental;
     let apply_property_ty =
         |c: CompletionItem, ty: &Type, cb_args: Option<&[SmolStr]>| -> CompletionItem {
             if matches!(ty, Type::InferredCallback | Type::Callback { .. }) {
@@ -770,7 +779,12 @@ fn resolve_element_scope(
                     if matches!(ty, Type::Function { .. }) {
                         return None;
                     }
-                    if !is_reserved_prop_valid(k, &element_type, parent_element_type.as_ref()) {
+                    if !is_reserved_prop_valid(
+                        k,
+                        &element_type,
+                        parent_element_type.as_ref(),
+                        enable_experimental,
+                    ) {
                         return None;
                     }
                     let c = CompletionItem::new_simple(k.into(), ty.to_string());
@@ -2925,6 +2939,12 @@ export component Foo {
             results.iter().any(|completion| completion.label == "layout-order"),
             "no 'layout-order' completion"
         );
+        // cross-axis-self-alignment is experimental
+        assert!(
+            !results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
+            "'cross-axis-self-alignment' offered without experimental features"
+        );
+        let results = get_completions_experimental(source).unwrap();
         assert!(
             results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
             "no 'cross-axis-self-alignment' completion"
@@ -2945,7 +2965,13 @@ component Foo {{
 }}
 "#
             );
+            // cross-axis-self-alignment is experimental
             let results = get_completions(&source).unwrap();
+            assert!(
+                !results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
+                "'cross-axis-self-alignment' offered without experimental features in a {layout}"
+            );
+            let results = get_completions_experimental(&source).unwrap();
             assert!(
                 results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
                 "no 'cross-axis-self-alignment' completion in a {layout}"


### PR DESCRIPTION
Follow-up from the 1.18 API review: each of these has a better shape waiting on a language feature, so ship them experimental instead of freezing them in 1.18.

 - cross-axis-self-alignment: the CrossAxisSelfAlignment enum is CrossAxisAlignment plus an auto value; it should become an optional CrossAxisAlignment once the language has optional types.   