### PR TITLE
Disable unused default features of postcard, tracing, mdns-sd, float-cmp and js-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,9 +2319,6 @@ name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "flume"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,15 +584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,7 +2093,7 @@ dependencies = [
  "esp-config",
  "esp-metadata-generated",
  "esp-println",
- "heapless 0.9.3",
+ "heapless",
  "riscv",
  "xtensa-lx",
 ]
@@ -2338,8 +2329,6 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "futures-core",
- "futures-sink",
  "spin",
 ]
 
@@ -2981,15 +2970,6 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -3034,25 +3014,11 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32 0.2.1",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
- "hash32 0.3.1",
+ "hash32",
  "stable_deref_trait",
 ]
 
@@ -4684,7 +4650,6 @@ dependencies = [
  "fastrand",
  "flume",
  "if-addrs",
- "log",
  "mio",
  "socket-pktinfo",
  "socket2",
@@ -6027,7 +5992,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless 0.7.17",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 itertools = { version = "0.15" }
 log = { version = "0.4.17" }
 notify = { version = "8.0.0", default-features = false, features = ["macos_kqueue"] }
-tracing = { version = "0.1" }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-log = { version = "0.2" }
 # `svgz` was unconditional until resvg 0.48 gated it behind a feature. Slint accepts

--- a/api/wasm-interpreter/Cargo.toml
+++ b/api/wasm-interpreter/Cargo.toml
@@ -25,7 +25,7 @@ send_wrapper = { workspace = true }
 vtable = { workspace = true }
 
 console_error_panic_hook = { version = "0.1.6", optional = true }
-js-sys = "0.3.44"
+js-sys = { version = "0.3.44", default-features = false, features = ["std"] }
 wasm-bindgen-futures = { version = "0.4.18" }
 wasm-bindgen = { version = "0.2.66" }
 web-sys = { workspace = true, features = ["Request", "RequestInit", "RequestMode", "Response", "Window"] }

--- a/internal/core/Cargo.toml
+++ b/internal/core/Cargo.toml
@@ -173,7 +173,7 @@ async-channel = { version = "2", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.0", optional = true }
 wasm-bindgen = { version = "0.2" }
-js-sys = { version = "0.3" }
+js-sys = { version = "0.3", default-features = false, features = ["std"] }
 clru = { workspace = true }
 web-sys = { workspace = true, features = ["HtmlImageElement", "Navigator", "Blob", "BlobPropertyBag", "Url", "DomParser", "SupportedType", "Document", "Element"] }
 

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -32,13 +32,13 @@ dashmap = { version = "6.1.0", optional = true }
 tokio-tungstenite = { version = "0.30.0", optional = true }
 tokio = { version = "1.48.0", features = ["rt", "net", "sync", "macros", "time"], optional = true }
 futures-util = { version = "0.3.31", features = ["sink"], optional = true }
-postcard = { version = "1.1.3", features = ["alloc"], optional = true }
+postcard = { version = "1.1.3", default-features = false, features = ["alloc"], optional = true }
 base64 = { version = "0.23", optional = true }
 hostname = { version = "0.4.1", optional = true }
 anyhow = { version = "1.0.100", optional = true }
 
 [target.'cfg(not(any(target_vendor = "apple", target_arch = "wasm32")))'.dependencies]
-mdns-sd = { version = "0.20.0", default-features = false, features = ["async"], optional = true }
+mdns-sd = { version = "0.20.0", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 getifs = { version = "0.6.1", optional = true }

--- a/tools/editor/Cargo.toml
+++ b/tools/editor/Cargo.toml
@@ -63,7 +63,7 @@ objc2 = "0.6"
 raw-window-handle = "0.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-mdns-sd = { version = "0.20.0", optional = true }
+mdns-sd = { version = "0.20.0", default-features = false, optional = true }
 rfd = "0.17.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/tools/figma_import/Cargo.toml
+++ b/tools/figma_import/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-float-cmp = "0.10.0"
+float-cmp = { version = "0.10.0", default-features = false }
 clap = { workspace = true }
 # Use the ring rustls provider instead of the default aws-lc-rs, whose C build
 # takes over 10 minutes on Windows.

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -136,7 +136,7 @@ icu_properties = { version = "2.2.0", features = ["compiled_data"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.5"
-js-sys = { version = "0.3.57" }
+js-sys = { version = "0.3.57", default-features = false, features = ["std"] }
 web-sys = { workspace = true, features = ["Navigator", "Clipboard", "UrlSearchParams", "Location"] }
 send_wrapper = { workspace = true }
 serde-wasm-bindgen = "0.6.0"

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -112,7 +112,7 @@ slint-interpreter = { workspace = true, features = ["compat-1-2", "internal", "i
 nucleo-matcher = "0.3.1"
 futures-util = "0.3.32"
 tokio-tungstenite-wasm = "0.8.2"
-postcard = { version = "1.1.3", features = ["alloc"] }
+postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 
 [target.'cfg(not(any(target_os = "openbsd", target_os = "windows", target_arch = "wasm32", all(target_arch = "aarch64", target_os = "linux"))))'.dependencies]
 tikv-jemallocator = { workspace = true }
@@ -129,7 +129,7 @@ crossbeam-channel = "0.5"                                                       
 lsp-server = "0.10"
 tokio = { version = "1.50.0", features = ["rt", "sync", "time", "macros", "io-std", "io-util", "net", "fs", "process"] }
 dashmap = "6.1.0"
-mdns-sd = "0.20.0"
+mdns-sd = { version = "0.20.0", default-features = false }
 # Unicode XID property lookup used by the host-language accessor scanner to
 # tokenize identifiers in Rust/C++ source rather than scanning byte-by-byte.
 icu_properties = { version = "2.2.0", features = ["compiled_data"] }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -106,7 +106,7 @@ tempfile = "3"
 #
 # That's why we chose zeroconf for Apple platforms and mdns-sd for the other platforms.
 [target.'cfg(not(any(target_vendor = "apple", target_arch = "wasm32")))'.dependencies]
-mdns-sd = { version = "0.20.0", default-features = false, features = ["async"], optional = true }
+mdns-sd = { version = "0.20.0", default-features = false, optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 zeroconf = { version = "0.18", optional = true }


### PR DESCRIPTION
Continuation of the dependency feature audit (#13012, #13016 were earlier instalments). Three independent commits, each disabling default features whose code we never call.

| Commit | Change | Effect |
| --- | --- | --- |
| 1 | `postcard`, `tracing`, `mdns-sd` | `slint-lsp` 352 → 348 crates |
| 2 | `float-cmp` in `figma_import` | 136 → 135 crates |
| 3 | `js-sys/unsafe-eval` | no dependency change; CSP hygiene |

**postcard** — the default `heapless-cas` pulls heapless 0.7, hash32, byteorder and atomic-polyfill. Both consumers only use the alloc API (`to_allocvec` / `from_bytes`). This also collapses a duplicate heapless version, since esp-hal is on 0.9.

**tracing** — the default `attributes` pulls the `tracing-attributes` proc macro; there is no `#[instrument]` anywhere in the tree.

**mdns-sd** — the default `async` enables flume's async receiver, but the service receivers are consumed synchronously via `try_recv` and there is no `recv_async` call. The viewer and live preview already declared `default-features = false`; the LSP and the editor did not, so the feature was on for everyone through unification regardless. All four edges now read the same way. The `logging` default goes with it, matching what the viewer and live preview already did — say the word if you'd rather keep mdns-sd's log output on the tool edges.

**float-cmp** — the default `ratio` feature is for `ApproxEqRatio`, which we don't use; the one call site compares against an epsilon/ULPs margin. Drops num-traits.

**js-sys** — `unsafe-eval` gates the `eval()` and `Function::new_*` bindings, neither of which we call. Shipping them makes the generated glue incompatible with a CSP that forbids `unsafe-eval`. No crates behind this one; it's a bare cfg flag.

### Verification

- `cargo check` with `remote` / `preview-remote` enabled on all four mdns-sd consumers — that feature gating is where a bad `async` removal would hide.
- `cargo test -p i-slint-live-preview --features remote` — 11 passed.
- `wasm32-unknown-unknown` checks for `i-slint-core`, `slint-wasm-interpreter` and the `slint-lsp` lib. (The `slint-lsp` *bin* target fails on wasm with E0601 both before and after this branch — pre-existing, that target isn't meant for wasm.)

### Not included

`tokio-tungstenite`'s `connect` default is genuinely only used in a test, but dropping it removes no crates — `connect = ["stream", "tokio/net", "handshake"]` and `tokio/net` is already enabled by the live preview's own tokio edge. Didn't seem worth a `[dev-dependencies]` section for zero gain.
