### PR TITLE
Remove the unused derive_more dependency from three crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,7 +3345,6 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "derive_more",
  "futures",
  "glutin",
  "glutin-winit",
@@ -3589,7 +3588,6 @@ version = "1.18.0"
 dependencies = [
  "cfg-if",
  "const-field-offset",
- "derive_more",
  "femtovg",
  "glow 0.18.0",
  "i-slint-common",
@@ -3614,7 +3612,6 @@ dependencies = [
  "cfg_aliases",
  "clru",
  "const-field-offset",
- "derive_more",
  "glow 0.18.0",
  "glutin",
  "i-slint-common",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -1044,9 +1044,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -2421,7 +2421,6 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "derive_more",
  "futures",
  "glutin",
  "glutin-winit",
@@ -2571,7 +2570,6 @@ version = "1.18.0"
 dependencies = [
  "cfg-if",
  "const-field-offset",
- "derive_more",
  "femtovg",
  "glow",
  "i-slint-common",
@@ -2594,7 +2592,6 @@ dependencies = [
  "cfg_aliases",
  "clru",
  "const-field-offset",
- "derive_more",
  "glow",
  "glutin",
  "i-slint-common",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6025,7 +6025,6 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "derive_more",
  "futures",
  "glutin",
  "glutin-winit",
@@ -6177,7 +6176,6 @@ version = "1.18.0"
 dependencies = [
  "cfg-if",
  "const-field-offset",
- "derive_more",
  "femtovg",
  "glow 0.18.0",
  "i-slint-common",
@@ -6202,7 +6200,6 @@ dependencies = [
  "cfg_aliases",
  "clru",
  "const-field-offset",
- "derive_more",
  "glow 0.18.0",
  "glutin",
  "i-slint-common",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -71,7 +71,6 @@ i-slint-core-macros = { workspace = true, features = ["default"] }
 i-slint-common = { workspace = true, features = ["default"] }
 
 cfg-if = "1"
-derive_more = { workspace = true }
 lyon_path = { workspace = true }
 pin-weak = "1"
 scoped-tls-hkt = "0.1"

--- a/internal/renderers/femtovg/Cargo.toml
+++ b/internal/renderers/femtovg/Cargo.toml
@@ -32,7 +32,6 @@ i-slint-common = { workspace = true, features = ["default", "shared-fontique"] }
 const-field-offset = { version = "0.2", path = "../../../helper_crates/const-field-offset" }
 
 cfg-if = "1"
-derive_more = { workspace = true }
 lyon_path = { workspace = true }
 pin-weak = "1"
 femtovg = { version = "0.26", default-features = false, features = ["swash"] }

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -44,7 +44,6 @@ const-field-offset = { version = "0.2", path = "../../../helper_crates/const-fie
 vtable = { workspace = true }
 
 cfg-if = "1"
-derive_more = { workspace = true }
 lyon_path = { workspace = true }
 pin-weak = "1"
 scoped-tls-hkt = "0.1"

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -1103,9 +1103,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -2345,7 +2345,6 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "derive_more",
  "futures",
  "glutin",
  "glutin-winit",
@@ -2523,7 +2522,6 @@ version = "1.18.0"
 dependencies = [
  "cfg-if",
  "const-field-offset",
- "derive_more",
  "femtovg",
  "glow",
  "i-slint-common",
@@ -2546,7 +2544,6 @@ dependencies = [
  "cfg_aliases",
  "clru",
  "const-field-offset",
- "derive_more",
  "glow",
  "glutin",
  "i-slint-common",


### PR DESCRIPTION
`i-slint-backend-winit`, `i-slint-renderer-femtovg` and `i-slint-renderer-skia` declare `derive_more` but never reference it — no `use derive_more::...` and no derive from it, in any file, platform-gated ones included.

`derive_more` stays in the graph for the crates that do use it, so no dependency versions change and no crates leave the lockfile. This is manifest hygiene: three crates stop building a proc macro they don't need.

Verified with `cargo check --workspace`.

### Two related leads that turned out to be wrong

Same audit pass, worth recording so nobody retries them:

- **`derive_more`'s `not` feature is not dead.** It gates the `Neg` derive as well as `Not`, and `tools/figma_import/src/figmatypes.rs:102` derives `Neg`. Removing it from the shared `[workspace.dependencies]` bundle fails with `E0432: no Neg in the root`.
- **`xtask`'s `i-slint-common` and `proc-macro2` are not dead.** `cargo-machete` and a directory-scoped grep both miss them because `xtask` compiles `api/cpp/cbindgen.rs` via a `#[path]` module outside its own directory, and that file uses both. Removing them fails with `E0433`.
