### PR TITLE
LSP: resolve bare enum/color literals by their expected type

### DIFF
--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -14,7 +14,7 @@ use crate::expression_tree::{
 use crate::langtype::{ElementType, Enumeration, EnumerationValue, PropertyLookupMode, Type};
 use crate::namedreference::NamedReference;
 use crate::object_tree::{ElementRc, PropertyVisibility};
-use crate::parser::NodeOrToken;
+use crate::parser::{NodeOrToken, TextRange, TextSize};
 use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
 use smol_str::{SmolStr, format_smolstr};
@@ -61,6 +61,10 @@ pub struct LookupCtx<'a> {
 
     /// A stack of local variable scopes
     pub local_variables: Vec<Vec<(SmolStr, Type)>>,
+
+    /// LSP probe: while resolving, the `Type` is set to the `expected_type` at the innermost
+    /// node containing the offset. `None` during normal compilation.
+    pub expected_type_probe: Option<(TextSize, Type)>,
 }
 
 impl<'a> LookupCtx<'a> {
@@ -82,6 +86,7 @@ impl<'a> LookupCtx<'a> {
             type_loader: None,
             current_token: None,
             local_variables: Default::default(),
+            expected_type_probe: None,
         }
     }
 
@@ -96,6 +101,16 @@ impl<'a> LookupCtx<'a> {
     /// or the builtin widget library, which may use them.
     fn experimental_lookup_enabled(&self) -> bool {
         self.diag.enable_experimental || self.type_register.expose_internal_types
+    }
+
+    /// Record `ty` on the probe when its offset is in `range` — for a slot with no expression
+    /// node (the empty element/argument left by a trailing comma).
+    pub fn record_expected_type_probe(&mut self, range: TextRange, ty: &Type) {
+        if let Some((offset, slot)) = &mut self.expected_type_probe
+            && range.contains_inclusive(*offset)
+        {
+            *slot = ty.clone();
+        }
     }
 
     /// Run `f` with `expected_type` temporarily set to `ty`, restoring it afterwards.

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -103,6 +103,21 @@ impl<'a> LookupCtx<'a> {
         self.diag.enable_experimental || self.type_register.expose_internal_types
     }
 
+    /// Arm the LSP probe at `offset`, seeded with the current `expected_type` as fallback.
+    pub fn set_expected_type_probe(&mut self, offset: TextSize) {
+        self.expected_type_probe = Some((offset, self.expected_type.clone()));
+    }
+
+    /// The armed probe's offset, or `None` during normal compilation.
+    pub fn expected_type_probe_offset(&self) -> Option<TextSize> {
+        self.expected_type_probe.as_ref().map(|(offset, _)| *offset)
+    }
+
+    /// Disarm the probe and return the type recorded at its offset.
+    pub fn take_expected_type_probe(&mut self) -> Option<Type> {
+        self.expected_type_probe.take().map(|(_, ty)| ty)
+    }
+
     /// Record `ty` on the probe when its offset is in `range` — for a slot with no expression
     /// node (the empty element/argument left by a trailing comma).
     pub fn record_expected_type_probe(&mut self, range: TextRange, ty: &Type) {

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -18,7 +18,7 @@ use crate::langtype::{
 use crate::lookup::{LookupCtx, LookupObject, LookupResult, LookupResultCallable};
 use crate::object_tree::*;
 use crate::parser::{
-    NodeOrToken, SyntaxKind, SyntaxNode, TextRange, TextSize, identifier_text, syntax_nodes,
+    NodeOrToken, SyntaxKind, SyntaxNode, TextRange, identifier_text, syntax_nodes,
 };
 use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
@@ -397,16 +397,10 @@ enum LookupPhase {
     ResolvingTwoWayBindings,
 }
 
-/// Whether the probe `offset` is in `node`, counting the leading whitespace the parser strips
-/// before opening the node — so a cursor in the gap of `x ==  ` maps to the empty rhs slot.
-fn probe_offset_in_node(node: &SyntaxNode, offset: TextSize) -> bool {
+/// The range of `node`, extended to cover any blank space before it so a cursor there
+/// (like the empty rhs of `x ==  `) still resolves to this node.
+fn probe_range(node: &SyntaxNode) -> TextRange {
     let range = node.text_range();
-    if range.start() <= offset && offset <= range.end() {
-        return true;
-    }
-    if offset >= range.start() {
-        return false;
-    }
     let mut start = range.start();
     let mut prev = node.node.prev_sibling_or_token();
     while let Some(rowan::NodeOrToken::Token(t)) = &prev {
@@ -416,7 +410,7 @@ fn probe_offset_in_node(node: &SyntaxNode, offset: TextSize) -> bool {
         start = t.text_range().start();
         prev = t.prev_sibling_or_token();
     }
-    start <= offset
+    TextRange::new(start, range.end())
 }
 
 impl Expression {
@@ -617,10 +611,9 @@ impl Expression {
 
     pub fn from_expression_node(node: syntax_nodes::Expression, ctx: &mut LookupCtx) -> Self {
         // LSP probe: the innermost node containing the offset wins (depth-first descent).
-        if let Some((offset, slot)) = &mut ctx.expected_type_probe
-            && probe_offset_in_node(&node, *offset)
-        {
-            *slot = ctx.expected_type.clone();
+        if ctx.expected_type_probe.is_some() {
+            let ty = ctx.expected_type.clone();
+            ctx.record_expected_type_probe(probe_range(&node), &ty);
         }
 
         // This function recurses for nested expressions. Dispatch with early returns
@@ -1803,7 +1796,7 @@ impl Expression {
         let arg_nodes = sub_expr.collect::<Vec<_>>();
         let convert_args = |ctx: &mut LookupCtx, expected: &[Type]| {
             // Empty trailing-comma argument has no node: record its parameter type for the probe.
-            if let Some((offset, _)) = ctx.expected_type_probe {
+            if let Some(offset) = ctx.expected_type_probe_offset() {
                 let idx = arg_nodes.iter().take_while(|n| n.text_range().end() <= offset).count();
                 if let Some(ty) = expected.get(idx).cloned() {
                     ctx.record_expected_type_probe(args_range, &ty);

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -17,7 +17,9 @@ use crate::langtype::{
 };
 use crate::lookup::{LookupCtx, LookupObject, LookupResult, LookupResultCallable};
 use crate::object_tree::*;
-use crate::parser::{NodeOrToken, SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
+use crate::parser::{
+    NodeOrToken, SyntaxKind, SyntaxNode, TextRange, TextSize, identifier_text, syntax_nodes,
+};
 use crate::symbol_counters::SymbolCounters;
 use crate::typeregister::TypeRegister;
 use core::num::IntErrorKind;
@@ -57,6 +59,7 @@ fn resolve_expression(
             type_loader: Some(type_loader),
             current_token: None,
             local_variables: Vec::new(),
+            expected_type_probe: None,
         };
         lookup_ctx.expected_type = lookup_ctx.return_type().clone();
 
@@ -394,6 +397,28 @@ enum LookupPhase {
     ResolvingTwoWayBindings,
 }
 
+/// Whether the probe `offset` is in `node`, counting the leading whitespace the parser strips
+/// before opening the node — so a cursor in the gap of `x ==  ` maps to the empty rhs slot.
+fn probe_offset_in_node(node: &SyntaxNode, offset: TextSize) -> bool {
+    let range = node.text_range();
+    if range.start() <= offset && offset <= range.end() {
+        return true;
+    }
+    if offset >= range.start() {
+        return false;
+    }
+    let mut start = range.start();
+    let mut prev = node.node.prev_sibling_or_token();
+    while let Some(rowan::NodeOrToken::Token(t)) = &prev {
+        if !matches!(t.kind(), SyntaxKind::Whitespace | SyntaxKind::Comment) {
+            break;
+        }
+        start = t.text_range().start();
+        prev = t.prev_sibling_or_token();
+    }
+    start <= offset
+}
+
 impl Expression {
     pub fn from_binding_expression_node(node: SyntaxNode, ctx: &mut LookupCtx) -> Self {
         debug_assert_eq!(node.kind(), SyntaxKind::BindingExpression);
@@ -591,6 +616,13 @@ impl Expression {
     }
 
     pub fn from_expression_node(node: syntax_nodes::Expression, ctx: &mut LookupCtx) -> Self {
+        // LSP probe: the innermost node containing the offset wins (depth-first descent).
+        if let Some((offset, slot)) = &mut ctx.expected_type_probe
+            && probe_offset_in_node(&node, *offset)
+        {
+            *slot = ctx.expected_type.clone();
+        }
+
         // This function recurses for nested expressions. Dispatch with early returns
         // instead of a `find_map` closure: in unoptimized builds, every arm of a match
         // producing a value gets its own stack slot for the resulting `Expression`,
@@ -1723,6 +1755,8 @@ impl Expression {
         let mut sub_expr = node.Expression();
 
         let func_expr = sub_expr.next().unwrap();
+        // The argument list `(...)`, for placing the probe on an empty argument slot.
+        let args_range = TextRange::new(func_expr.text_range().end(), node.text_range().end());
 
         let (function, source_location) = if let Some(qn) = func_expr.QualifiedName() {
             let sl = qn.last_token().unwrap().to_source_location();
@@ -1768,6 +1802,13 @@ impl Expression {
         // literals resolve against the parameter type at their exact argument position.
         let arg_nodes = sub_expr.collect::<Vec<_>>();
         let convert_args = |ctx: &mut LookupCtx, expected: &[Type]| {
+            // Empty trailing-comma argument has no node: record its parameter type for the probe.
+            if let Some((offset, _)) = ctx.expected_type_probe {
+                let idx = arg_nodes.iter().take_while(|n| n.text_range().end() <= offset).count();
+                if let Some(ty) = expected.get(idx).cloned() {
+                    ctx.record_expected_type_probe(args_range, &ty);
+                }
+            }
             arg_nodes
                 .iter()
                 .enumerate()
@@ -2183,6 +2224,8 @@ impl Expression {
             Type::Array(el) => (**el).clone(),
             _ => Type::Invalid,
         };
+        // Empty trailing-comma element has no node: record the element type for the probe.
+        ctx.record_expected_type_probe(node.text_range(), &element_expected);
         let mut values: Vec<Expression> = node
             .Expression()
             .map(|e| {
@@ -2939,6 +2982,7 @@ fn resolve_two_way_bindings_for_element(
                 type_loader: None,
                 current_token: Some(node.clone().into()),
                 local_variables: Vec::new(),
+                expected_type_probe: None,
             };
 
             // Only the alias-only case stores the two-way binding in the expression slot;

--- a/internal/editor-preview/util.rs
+++ b/internal/editor-preview/util.rs
@@ -322,9 +322,9 @@ pub fn with_lookup_ctx<R>(
                 None => return Some(f(&mut lookup_context)),
             }
         }
-        lookup_context.expected_type_probe = Some((offset, lookup_context.expected_type.clone()));
+        lookup_context.set_expected_type_probe(offset);
         Expression::from_expression_node(expr, &mut lookup_context);
-        if let Some((_, ty)) = lookup_context.expected_type_probe.take() {
+        if let Some(ty) = lookup_context.take_expected_type_probe() {
             lookup_context.expected_type = ty;
         }
     }

--- a/internal/editor-preview/util.rs
+++ b/internal/editor-preview/util.rs
@@ -171,16 +171,13 @@ pub fn lookup_current_element_type(mut node: SyntaxNode, tr: &TypeRegister) -> O
 }
 
 #[derive(Debug)]
-pub struct ExpressionContextInfo {
+struct ExpressionContextInfo {
     element: syntax_nodes::Element,
     property_name: SmolStr,
     is_animate: bool,
-}
-
-impl ExpressionContextInfo {
-    pub fn new(element: syntax_nodes::Element, property_name: SmolStr, is_animate: bool) -> Self {
-        ExpressionContextInfo { element, property_name, is_animate }
-    }
+    /// Expression to resolve for the probe, with its parent (used only to special-case a typed
+    /// `let`). `None` when the cursor isn't in a resolvable expression.
+    binding_expr: Option<(SyntaxNode, SyntaxNode)>,
 }
 
 /// Run the function with the LookupCtx associated with the token
@@ -190,17 +187,8 @@ pub fn with_lookup_ctx<R>(
     to_offset: Option<TextSize>,
     f: impl FnOnce(&mut LookupCtx) -> R,
 ) -> Option<R> {
-    let expr_context_info = lookup_expression_context(node)?;
-    with_property_lookup_ctx::<R>(document_cache, &expr_context_info, to_offset, f)
-}
-
-/// Run the function with the LookupCtx associated with the token
-pub fn with_property_lookup_ctx<R>(
-    document_cache: &crate::DocumentCache,
-    expr_context_info: &ExpressionContextInfo,
-    to_offset: Option<TextSize>,
-    f: impl FnOnce(&mut LookupCtx) -> R,
-) -> Option<R> {
+    let offset = to_offset.unwrap_or_else(|| node.text_range().start());
+    let expr_context_info = lookup_expression_context(node, offset)?;
     let (element, prop_name, is_animate) = (
         &expr_context_info.element,
         expr_context_info.property_name.as_str(),
@@ -316,6 +304,31 @@ pub fn with_property_lookup_ctx<R>(
         add_codeblock_local_variables(&cb, to_offset, &mut lookup_context);
     }
 
+    // Narrow `expected_type` to the type expected at the cursor (comparison rhs, call argument,
+    // struct field, ...) by resolving the binding expression with the probe set.
+    if let Some((expr, boundary)) = &expr_context_info.binding_expr
+        && let Some(expr) = syntax_nodes::Expression::new(expr.clone())
+    {
+        if boundary.kind() == SyntaxKind::LetStatement {
+            // A `let` with a declared type constrains its value; an untyped one doesn't.
+            match boundary.child_node(SyntaxKind::Type) {
+                Some(t) => {
+                    lookup_context.expected_type = type_from_node(
+                        t.into(),
+                        &mut Default::default(),
+                        lookup_context.type_register,
+                    )
+                }
+                None => return Some(f(&mut lookup_context)),
+            }
+        }
+        lookup_context.expected_type_probe = Some((offset, lookup_context.expected_type.clone()));
+        Expression::from_expression_node(expr, &mut lookup_context);
+        if let Some((_, ty)) = lookup_context.expected_type_probe.take() {
+            lookup_context.expected_type = ty;
+        }
+    }
+
     Some(f(&mut lookup_context))
 }
 
@@ -357,9 +370,13 @@ fn add_codeblock_local_variables(
     })
 }
 
-/// Return the element and property name in which we are
-fn lookup_expression_context(mut n: SyntaxNode) -> Option<ExpressionContextInfo> {
+/// The element and property name we are in, plus (from the same walk) the expression to probe.
+fn lookup_expression_context(mut n: SyntaxNode, offset: TextSize) -> Option<ExpressionContextInfo> {
+    let mut binding_expr = None;
     let (element, prop_name, is_animate) = loop {
+        if binding_expr.is_none() {
+            binding_expr = probe_expression(&n, offset);
+        }
         if let Some(decl) = syntax_nodes::PropertyDeclaration::new(n.clone()) {
             let prop_name = i_slint_compiler::parser::identifier_text(&decl.DeclaredIdentifier())?;
             let element = syntax_nodes::Element::new(n.parent()?)?;
@@ -380,7 +397,12 @@ fn lookup_expression_context(mut n: SyntaxNode) -> Option<ExpressionContextInfo>
                         i_slint_compiler::parser::identifier_text(&n).unwrap_or_default();
                     loop {
                         if let Some(element) = syntax_nodes::Element::new(parent.clone()) {
-                            return Some(ExpressionContextInfo::new(element, prop_name, false));
+                            return Some(ExpressionContextInfo {
+                                element,
+                                property_name: prop_name,
+                                is_animate: false,
+                                binding_expr,
+                            });
                         }
                         parent = parent.parent()?;
                     }
@@ -405,7 +427,37 @@ fn lookup_expression_context(mut n: SyntaxNode) -> Option<ExpressionContextInfo>
             _ => n = n.parent()?,
         }
     };
-    Some(ExpressionContextInfo::new(element, prop_name, is_animate))
+    Some(ExpressionContextInfo { element, property_name: prop_name, is_animate, binding_expr })
+}
+
+/// If `n` is a binding / code-block container, the expression holding `offset` to probe, with
+/// its parent (to special-case `let`).
+fn probe_expression(n: &SyntaxNode, offset: TextSize) -> Option<(SyntaxNode, SyntaxNode)> {
+    let container = match n.kind() {
+        SyntaxKind::BindingExpression
+        | SyntaxKind::TwoWayBinding
+        | SyntaxKind::CodeBlock
+        | SyntaxKind::ReturnStatement
+        | SyntaxKind::LetStatement => n.clone(),
+        SyntaxKind::Binding => n.child_node(SyntaxKind::BindingExpression)?,
+        SyntaxKind::CallbackConnection
+        | SyntaxKind::PropertyChangedCallback
+        | SyntaxKind::Function => n.child_node(SyntaxKind::CodeBlock)?,
+        _ => return None,
+    };
+    if container.kind() == SyntaxKind::CodeBlock {
+        let stmt = container.children().find(|c| {
+            matches!(
+                c.kind(),
+                SyntaxKind::Expression | SyntaxKind::ReturnStatement | SyntaxKind::LetStatement
+            ) && c.text_range().contains_inclusive(offset)
+        })?;
+        return match stmt.kind() {
+            SyntaxKind::Expression => Some((stmt, container)),
+            _ => Some((stmt.child_node(SyntaxKind::Expression)?, stmt)),
+        };
+    }
+    Some((container.child_node(SyntaxKind::Expression)?, container))
 }
 
 #[cfg(test)]

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -289,6 +289,15 @@ pub(crate) fn completion_at(
         })?;
     } else if node.kind() == SyntaxKind::AtKeys {
         return with_lookup_ctx(document_cache, node, Some(offset), at_keys_completions);
+    } else if let Some(member) = syntax_nodes::ObjectMember::new(node.clone()) {
+        // Completing an object-literal field value (the value expression is still empty).
+        if let Some(colon) = member.child_token(SyntaxKind::Colon)
+            && offset >= colon.text_range().end()
+        {
+            return with_lookup_ctx(document_cache, node, Some(offset), |ctx| {
+                resolve_expression_scope(ctx, document_cache, snippet_support)
+            })?;
+        }
     } else if let Some(q) = syntax_nodes::QualifiedName::new(node.clone()) {
         match q.parent()?.kind() {
             SyntaxKind::Element => {
@@ -2010,6 +2019,88 @@ mod tests {
         res.iter().find(|ci| ci.label == "beta-gamma").unwrap();
         res.iter().find(|ci| ci.label == "red").unwrap();
         assert!(!res.iter().any(|ci| ci.label == "width"));
+    }
+
+    #[test]
+    fn expected_type_comparison_rhs() {
+        // A bare enum value / color resolves against the type of the comparison's left-hand
+        // side, so completion offers the matching values after `==`.
+        let source = r#"
+            enum Direction { up, down, forward }
+            component Foo {
+                in property <Direction> dir;
+                in property <color> col;
+                out property <bool> b1: dir == 🔺;
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "up").unwrap();
+        res.iter().find(|ci| ci.label == "down").unwrap();
+        res.iter().find(|ci| ci.label == "forward").unwrap();
+        // The left-hand side is an enum, so colors must not be offered here.
+        assert!(!res.iter().any(|ci| ci.label == "red"));
+
+        let source = r#"
+            component Foo {
+                in property <color> fg;
+                out property <bool> b1: fg != 🔺;
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "red").unwrap();
+        res.iter().find(|ci| ci.label == "blue").unwrap();
+    }
+
+    #[test]
+    fn expected_type_call_argument() {
+        // A bare enum value resolves against the parameter type at its argument position.
+        let source = r#"
+            enum Direction { up, down, forward }
+            component Foo {
+                callback cb(int, Direction);
+                callback trigger;
+                trigger => { cb(1, 🔺) }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "up").unwrap();
+        res.iter().find(|ci| ci.label == "forward").unwrap();
+
+        // First argument is an int, so the enum values must not leak into that position.
+        let source = r#"
+            enum Direction { up, down, forward }
+            component Foo {
+                callback cb(int, Direction);
+                callback trigger;
+                trigger => { cb(🔺, up) }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        assert!(!res.iter().any(|ci| ci.label == "up"));
+    }
+
+    #[test]
+    fn expected_type_struct_field_and_array() {
+        // Struct-literal field values and array elements resolve against the field/element type.
+        let source = r#"
+            enum Direction { up, down, forward }
+            struct S { dir: Direction, count: int }
+            component Foo {
+                in property <S> s: { dir: 🔺 };
+            }
+        "#;
+        let res = get_completions(source).unwrap_or_default();
+        res.iter().find(|ci| ci.label == "up").unwrap();
+        res.iter().find(|ci| ci.label == "forward").unwrap();
+
+        let source = r#"
+            component Foo {
+                in property <[color]> cols: [red, 🔺];
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        res.iter().find(|ci| ci.label == "blue").unwrap();
+        res.iter().find(|ci| ci.label == "green").unwrap();
     }
 
     #[test]

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -313,3 +313,37 @@ fn test_goto_definition_multi_files() {
     assert_eq!(link.target_uri, url1);
     assert_eq!(link.target_range.start.line, 7);
 }
+
+#[test]
+fn test_goto_definition_expected_type() {
+    fn first_link(def: &GotoDefinitionResponse) -> &LocationLink {
+        let GotoDefinitionResponse::Link(link) = def else { panic!("not a single link {def:?}") };
+        link.first().unwrap()
+    }
+
+    // A bare enum value resolved through the expected type (here the right-hand side of a
+    // comparison, and a call argument) still goes to the value's declaration.
+    let source = r#"
+enum Direction { up, down, forward }
+export component Test {
+    callback cb(Direction);
+    in property <Direction> dir;
+    out property <bool> b: dir == forward;
+    cb2 => { cb(up); }
+    callback cb2;
+}"#;
+    let (mut dc, uri, _) = crate::language::test::loaded_document_cache(source.into());
+    let doc = dc.get_document(&uri).unwrap().node.clone().unwrap();
+
+    let offset: TextSize = (source.find("dir == forward").unwrap() as u32 + 7).into();
+    let token = crate::language::token_at_offset(&doc, offset).unwrap();
+    assert_eq!(token.text(), "forward");
+    let def = goto_definition(&mut dc, token).unwrap();
+    assert_eq!(first_link(&def).target_range.start.line, 1);
+
+    let offset: TextSize = (source.find("cb(up)").unwrap() as u32 + 3).into();
+    let token = crate::language::token_at_offset(&doc, offset).unwrap();
+    assert_eq!(token.text(), "up");
+    let def = goto_definition(&mut dc, token).unwrap();
+    assert_eq!(first_link(&def).target_range.start.line, 1);
+}

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -566,6 +566,29 @@ export component Test { // not docs
     }
 
     #[test]
+    fn test_tooltip_expected_type() {
+        // A bare enum value resolved through the expected type (the comparison's rhs) hovers
+        // as that enum value.
+        let source = r#"
+enum Direction { up, down, forward }
+export component Test {
+    in property <Direction> dir;
+    out property <bool> b: dir == forward;
+}"#;
+        let (mut dc, uri, _) = crate::language::test::loaded_document_cache(source.into());
+        let doc = dc.get_document(&uri).unwrap().node.clone().unwrap();
+        let offset = TextSize::new(source.find("dir == forward").unwrap() as u32 + 7);
+        let token = crate::language::token_at_offset(&doc, offset).unwrap();
+        assert_eq!(token.text(), "forward");
+        match get_tooltip(&mut dc, token).unwrap().contents {
+            HoverContents::Markup(m) => {
+                assert!(m.value.contains("Direction.forward"), "got {:?}", m.value)
+            }
+            x => panic!("Found {x:?}"),
+        }
+    }
+
+    #[test]
     fn test_tooltip_shadowed_member() {
         // `Derived` shadows the `@shadowable` `prop` of `Base`, with a different type. The tooltip
         // for a use must describe the property declared in the same component, under its source name.


### PR DESCRIPTION
Since 1.18 a bare enum/color/easing literal resolves against the type expected at its position (a comparison's rhs, a call argument, a struct-literal field, ...), but the language server only knew the whole binding's type, so completion, goto-definition and hover did not work at those nested positions.

Let the resolving pass compute the expected type at the cursor: `LookupCtx` carries an optional probe (offset + slot), and `from_expression_node` records the expected type in effect for the innermost node holding that offset. The server resolves the binding expression with the probe set and reads the type back. Empty trailing array/argument slots have no node, so `from_array_node` and `from_function_call_node` record the element/parameter type for them directly; leading whitespace before an empty slot is matched too.

goto and hover pick this up through the existing lookup path.
