### PR TITLE
Rename `accessible-action-set-selection()` to `accessible-action-set-…

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -409,23 +409,23 @@ public:
 
     /// Selects the text between two UTF-8 offsets.
     ///
-    /// This will invoke the `accessible-action-set-selection` callback.
+    /// This will invoke the `accessible-action-set-selection-offsets` callback.
     void set_accessible_selection(int anchor, int focus) const
     {
         if (inner.element_index != 0)
             return;
         if (auto item = private_api::upgrade_item_weak(inner.item)) {
-            union SetSelectionHelper {
+            union SetSelectionOffsetsHelper {
                 cbindgen_private::AccessibilityAction action;
-                SetSelectionHelper(int anchor, int focus)
+                SetSelectionOffsetsHelper(int anchor, int focus)
                 {
-                    new (&action.set_selection)
-                            cbindgen_private::AccessibilityAction::SetSelection_Body {
-                                cbindgen_private::AccessibilityAction::Tag::SetSelection, anchor,
-                                focus
+                    new (&action.set_selection_offsets)
+                            cbindgen_private::AccessibilityAction::SetSelectionOffsets_Body {
+                                cbindgen_private::AccessibilityAction::Tag::SetSelectionOffsets,
+                                anchor, focus
                             };
                 }
-                ~SetSelectionHelper() { }
+                ~SetSelectionOffsetsHelper() { }
 
             } action(anchor, focus);
             item->item_tree.vtable()->accessibility_action(item->item_tree.borrow(), item->index,

--- a/docs/astro/src/content/docs/reference/common.mdx
+++ b/docs/astro/src/content/docs/reference/common.mdx
@@ -489,5 +489,5 @@ Invoked when the user requests to decrement the value.
 ### accessible-action-expand()
 Invoked when the user requests to expand the widget, such as disclose the list of available choices for a combo box.
 
-### accessible-action-set-selection(anchor: int, focus: int)
+### accessible-action-set-selection-offsets(anchor: int, focus: int)
 Invoked when the user wants to change the selected text. The arguments are UTF-8 offsets into the element's text: `anchor` is the end that stays put and `focus` the end being moved, so `focus` may precede `anchor` when the selection was made backwards, and the two are equal when only the cursor moved.

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -644,14 +644,14 @@ impl ElementHandle {
     }
 
     /// Selects the text between two UTF-8 offsets, by invoking the element's
-    /// `accessible-action-set-selection` callback. Note that you can only do this if that callback
+    /// `accessible-action-set-selection-offsets` callback. Note that you can only do this if that callback
     /// is declared in your Slint code.
     pub fn set_accessible_selection(&self, anchor: i32, focus: i32) {
         if self.element_index != 0 {
             return;
         }
         if let Some(item) = self.item.upgrade() {
-            item.accessible_action(&AccessibilityAction::SetSelection(anchor, focus))
+            item.accessible_action(&AccessibilityAction::SetSelectionOffsets(anchor, focus))
         }
     }
 

--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -195,7 +195,7 @@ impl AccessKitAdapter {
                     &sel.anchor,
                     &sel.focus,
                 )?;
-                AccessibilityAction::SetSelection(anchor as i32, focus as i32)
+                AccessibilityAction::SetSelectionOffsets(anchor as i32, focus as i32)
             }
             _ => return None,
         };
@@ -592,7 +592,7 @@ impl NodeCollection {
         if emitted_runs
             && item
                 .supported_accessibility_actions()
-                .contains(SupportedAccessibilityAction::SetSelection)
+                .contains(SupportedAccessibilityAction::SetSelectionOffsets)
         {
             wrapper_node.add_action(Action::SetTextSelection);
         }

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -522,7 +522,7 @@ pub fn to_kebab_case(str: &str) -> String {
 }
 
 /// The number of arguments taken by the accessibility action of the given name, where the name
-/// is the `AccessibilityAction` variant in pascal case (such as `SetSelection`).
+/// is the `AccessibilityAction` variant in pascal case (such as `SetSelectionOffsets`).
 ///
 /// The `AccessibilityAction` enum of the run-time library mirrors the `accessible-action-*`
 /// callbacks declared in the type register: a variant has one field per callback argument, so

--- a/internal/compiler/passes/lower_accessibility.rs
+++ b/internal/compiler/passes/lower_accessibility.rs
@@ -118,8 +118,9 @@ fn apply_builtin(e: &ElementRc) {
             });
         }
         {
-            e.borrow_mut().set_binding_if_not_set("accessible-action-set-selection".into(), || {
-                Expression::FunctionCall {
+            e.borrow_mut().set_binding_if_not_set(
+                "accessible-action-set-selection-offsets".into(),
+                || Expression::FunctionCall {
                     function: Callable::Builtin(BuiltinFunction::SetSelectionOffsets),
                     arguments: vec![
                         Expression::ElementReference(Rc::downgrade(e)),
@@ -127,8 +128,8 @@ fn apply_builtin(e: &ElementRc) {
                         Expression::FunctionParameterReference { index: 1, ty: Type::Int32 },
                     ],
                     source_location: None,
-                }
-            });
+                },
+            );
         }
     } else if bty.name == "Image" {
         e.borrow_mut().set_binding_if_not_set("accessible-role".into(), || {

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -88,7 +88,7 @@ pub struct BuiltinTypes {
     pub enums: BuiltinEnums,
     pub noarg_callback_type: Type,
     pub strarg_callback_type: Type,
-    pub set_selection_callback_type: Type,
+    pub set_selection_offsets_callback_type: Type,
     pub logical_point_type: Arc<Struct>,
     pub logical_size_type: Arc<Struct>,
     pub font_metrics_type: Type,
@@ -164,7 +164,7 @@ impl BuiltinTypes {
                 args: vec![Type::String],
                 arg_names: Vec::new(),
             })),
-            set_selection_callback_type: Type::Callback(Arc::new(Function {
+            set_selection_offsets_callback_type: Type::Callback(Arc::new(Function {
                 return_type: Type::Void,
                 args: vec![Type::Int32, Type::Int32],
                 arg_names: vec![SmolStr::new_static("anchor"), SmolStr::new_static("focus")],
@@ -266,8 +266,8 @@ fn strarg_callback_type() -> Type {
     BUILTIN.strarg_callback_type.clone()
 }
 
-fn set_selection_callback_type() -> Type {
-    BUILTIN.set_selection_callback_type.clone()
+fn set_selection_offsets_callback_type() -> Type {
+    BUILTIN.set_selection_offsets_callback_type.clone()
 }
 
 pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str, Type)> {
@@ -291,7 +291,7 @@ pub fn reserved_accessibility_properties() -> impl Iterator<Item = (&'static str
         ("accessible-action-increment", noarg_callback_type()),
         ("accessible-action-decrement", noarg_callback_type()),
         ("accessible-action-set-value", strarg_callback_type()),
-        ("accessible-action-set-selection", set_selection_callback_type()),
+        ("accessible-action-set-selection-offsets", set_selection_offsets_callback_type()),
         ("accessible-action-expand", noarg_callback_type()),
         ("accessible-item-selectable", Type::Bool),
         ("accessible-item-selected", Type::Bool),

--- a/internal/compiler/widgets/cosmic/lineedit.slint
+++ b/internal/compiler/widgets/cosmic/lineedit.slint
@@ -15,7 +15,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     vertical-stretch: 0;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -37,7 +37,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/cupertino/lineedit.slint
+++ b/internal/compiler/widgets/cupertino/lineedit.slint
@@ -19,7 +19,7 @@ export component LineEdit {
         text = v;
         edited(v);
     }
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     vertical-stretch: 0;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -91,7 +91,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
-    accessible-action-set-selection(anchor, focus) => { text-input.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { text-input.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         text-input.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/fluent/lineedit.slint
+++ b/internal/compiler/widgets/fluent/lineedit.slint
@@ -15,7 +15,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     vertical-stretch: 0;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -37,7 +37,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/material/lineedit.slint
+++ b/internal/compiler/widgets/material/lineedit.slint
@@ -16,7 +16,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     min-width: max(120px, layout.min-width);
     min-height: max(56px, layout.min-height);

--- a/internal/compiler/widgets/material/textedit.slint
+++ b/internal/compiler/widgets/material/textedit.slint
@@ -37,7 +37,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/compiler/widgets/qt/lineedit.slint
+++ b/internal/compiler/widgets/qt/lineedit.slint
@@ -14,7 +14,7 @@ export component LineEdit {
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
     accessible-action-set-value(v) => { text = v; edited(v); }
-    accessible-action-set-selection(anchor, focus) => { inner.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { inner.set-selection-offsets(anchor, focus); }
 
     forward-focus: inner;
     horizontal-stretch: 1;

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -36,7 +36,7 @@ export component TextEdit {
     accessible-value <=> text;
     accessible-placeholder-text: placeholder-text;
     accessible-read-only: root.read-only;
-    accessible-action-set-selection(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
+    accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
     public function set-selection-offsets(start: int, end: int) {
         base.set-selection-offsets(start, end);

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -58,7 +58,7 @@ pub enum AccessibilityAction {
     SetValue(SharedString),
     /// Select the text between two UTF-8 offsets into the element's text: the first offset is the
     /// anchor, the end that stays put, the second one the focus, the end being moved.
-    SetSelection(i32, i32),
+    SetSelectionOffsets(i32, i32),
 }
 
 bitflags! {
@@ -72,7 +72,7 @@ bitflags! {
         const Expand = 1 << 3;
         const ReplaceSelectedText = 1 << 4;
         const SetValue = 1 << 5;
-        const SetSelection = 1 << 6;
+        const SetSelectionOffsets = 1 << 6;
     }
 }
 

--- a/internal/interpreter/item_tree_vtable.rs
+++ b/internal/interpreter/item_tree_vtable.rs
@@ -499,7 +499,7 @@ fn accessibility_action_name(action: &AccessibilityAction) -> &'static str {
         AccessibilityAction::Expand => "Expand",
         AccessibilityAction::ReplaceSelectedText(_) => "ReplaceSelectedText",
         AccessibilityAction::SetValue(_) => "SetValue",
-        AccessibilityAction::SetSelection(..) => "SetSelection",
+        AccessibilityAction::SetSelectionOffsets(..) => "SetSelectionOffsets",
     }
 }
 
@@ -508,7 +508,7 @@ fn accessibility_action_args(action: &AccessibilityAction) -> Vec<crate::Value> 
         AccessibilityAction::ReplaceSelectedText(s) | AccessibilityAction::SetValue(s) => {
             vec![crate::Value::String(s.clone())]
         }
-        AccessibilityAction::SetSelection(anchor, focus) => {
+        AccessibilityAction::SetSelectionOffsets(anchor, focus) => {
             vec![crate::Value::Number(*anchor as f64), crate::Value::Number(*focus as f64)]
         }
         _ => Vec::new(),


### PR DESCRIPTION
…selection-offsets()`

This came up in the API review and provides consistency with `TextInput`'s `set-selection-offsets()`. The suffix emphasizes the nature of the arguments (utf-8 byte offsets).

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
