### PR TITLE
Rename the cross-size local from flex_cross_* to cross_*

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -479,7 +479,9 @@ use crate::langtype::{
 };
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
-use crate::llr::lower_layout_expression::{MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL};
+use crate::llr::lower_layout_expression::{
+    CROSS_HEIGHT_LOCAL, CROSS_WIDTH_LOCAL, MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL,
+};
 use crate::llr::{
     self, EvaluationContext as llr_EvaluationContext, EvaluationScope, ParentScope,
     TypeResolutionContext as _,
@@ -3117,13 +3119,13 @@ fn generate_layout_item_info_at_cross_decls(
         decl(
             root_sc.layout_info_v_at_cross_width_for_repeated.as_ref(),
             "layout_item_info_at_cross_width",
-            "flex_cross_width",
+            CROSS_WIDTH_LOCAL,
             "Vertical",
         ),
         decl(
             root_sc.layout_info_h_at_cross_height_for_repeated.as_ref(),
             "layout_item_info_at_cross_height",
-            "flex_cross_height",
+            CROSS_HEIGHT_LOCAL,
             "Horizontal",
         ),
     ]
@@ -3188,7 +3190,7 @@ fn generate_flexbox_layout_item_info_decl(
 
     // A column FlexboxLayout calls this with its real container width so a
     // height-for-width instance wraps to the same height as a static cell. The
-    // expression reads the `flex_cross_width` parameter.
+    // expression reads the `cross_width` parameter.
     //
     // `layout_info_v_at_cross_width_for_repeated` is only set for a
     // height-for-width root, which also forces `flexbox_layout_item_info_for_repeated`
@@ -3216,7 +3218,7 @@ fn generate_flexbox_layout_item_info_decl(
 
     // Mirror of `at_cross_width_body`: a FlexboxLayout calls this with the
     // height it assigned so a width-for-height instance resolves to the width
-    // it really needs. The expression reads the `flex_cross_height` parameter.
+    // it really needs. The expression reads the `cross_height` parameter.
     let at_cross_height_body = match (
         &for_repeated_compiled,
         root_sc.layout_info_h_at_cross_height_for_repeated.as_ref(),
@@ -3243,17 +3245,17 @@ fn generate_flexbox_layout_item_info_decl(
         }),
         Declaration::Function(Function {
             name: "flexbox_layout_item_info_at_cross_width".into(),
-            signature:
-                "([[maybe_unused]] float flex_cross_width) const -> slint::cbindgen_private::FlexboxLayoutItemInfo"
-                    .to_owned(),
+            signature: format!(
+                "([[maybe_unused]] float {CROSS_WIDTH_LOCAL}) const -> slint::cbindgen_private::FlexboxLayoutItemInfo"
+            ),
             statements: Some(vec![at_cross_width_body]),
             ..Function::default()
         }),
         Declaration::Function(Function {
             name: "flexbox_layout_item_info_at_cross_height".into(),
-            signature:
-                "([[maybe_unused]] float flex_cross_height) const -> slint::cbindgen_private::FlexboxLayoutItemInfo"
-                    .to_owned(),
+            signature: format!(
+                "([[maybe_unused]] float {CROSS_HEIGHT_LOCAL}) const -> slint::cbindgen_private::FlexboxLayoutItemInfo"
+            ),
             statements: Some(vec![at_cross_height_body]),
             ..Function::default()
         }),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -18,7 +18,9 @@ use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp, OperatorCla
 use crate::langtype::{DeclNode, Enumeration, EnumerationValue, Struct, StructName, Type};
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
-use crate::llr::lower_layout_expression::{MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL};
+use crate::llr::lower_layout_expression::{
+    CROSS_HEIGHT_LOCAL, CROSS_WIDTH_LOCAL, MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL,
+};
 use crate::llr::{
     self, ArrayOutput, EvaluationContext as llr_EvaluationContext, EvaluationScope, Expression,
     ParentScope, TypeResolutionContext as _,
@@ -2987,7 +2989,7 @@ fn generate_repeated_component(
                 // so a height-for-width instance wraps to the same height as an
                 // equivalent static cell (instead of the preferred-width single
                 // line that `flexbox_layout_item_info` returns). The expression
-                // reads the `flex_cross_width` local (matches FLEX_CROSS_WIDTH_LOCAL).
+                // reads the `cross_width` local (matches CROSS_WIDTH_LOCAL).
                 let at_cross_width_body = root_sc
                     .layout_info_v_at_cross_width_for_repeated
                     .as_ref()
@@ -3018,7 +3020,7 @@ fn generate_repeated_component(
                 // width-for-height instance resolves to the same width as an
                 // equivalent static cell (instead of the unbounded, unwrapped one
                 // that `flexbox_layout_item_info` returns). The expression reads
-                // the `flex_cross_height` local (matches FLEX_CROSS_HEIGHT_LOCAL).
+                // the `cross_height` local (matches CROSS_HEIGHT_LOCAL).
                 let at_cross_height_body = root_sc
                     .layout_info_h_at_cross_height_for_repeated
                     .as_ref()
@@ -3032,6 +3034,8 @@ fn generate_repeated_component(
                                 self.layout_item_info(sp::Orientation::Horizontal, sp::None).constraint;
                         }
                     });
+                let cross_width_param = ident(CROSS_WIDTH_LOCAL);
+                let cross_height_param = ident(CROSS_HEIGHT_LOCAL);
                 quote! {
                     fn flexbox_layout_item_info(
                         self: ::core::pin::Pin<&Self>,
@@ -3049,7 +3053,7 @@ fn generate_repeated_component(
                     #[allow(unused_variables)]
                     fn flexbox_layout_item_info_at_cross_width(
                         self: ::core::pin::Pin<&Self>,
-                        flex_cross_width: f32,
+                        #cross_width_param: f32,
                     ) -> sp::FlexboxLayoutItemInfo {
                         #[allow(unused)]
                         let _self = self.as_ref();
@@ -3060,7 +3064,7 @@ fn generate_repeated_component(
                     #[allow(unused_variables)]
                     fn flexbox_layout_item_info_at_cross_height(
                         self: ::core::pin::Pin<&Self>,
-                        flex_cross_height: f32,
+                        #cross_height_param: f32,
                     ) -> sp::FlexboxLayoutItemInfo {
                         #[allow(unused)]
                         let _self = self.as_ref();
@@ -3096,12 +3100,12 @@ fn generate_repeated_component(
         let layout_item_info_at_cross_width_fn = layout_item_info_at_cross_fn(
             root_sc.layout_info_v_at_cross_width_for_repeated.as_ref(),
             "layout_item_info_at_cross_width",
-            "flex_cross_width",
+            CROSS_WIDTH_LOCAL,
         );
         let layout_item_info_at_cross_height_fn = layout_item_info_at_cross_fn(
             root_sc.layout_info_h_at_cross_height_for_repeated.as_ref(),
             "layout_item_info_at_cross_height",
-            "flex_cross_height",
+            CROSS_HEIGHT_LOCAL,
         );
         quote! {
             #layout_item_info_fn

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -563,7 +563,7 @@ pub struct SubComponent {
     /// `layoutinfo-v-with-constraint`. See `flexbox_layout_item_info`.
     pub layout_info_v_constrained_for_repeated: Option<MutExpression>,
     /// Same as `layout_info_v_constrained_for_repeated`, but measured at the
-    /// width passed in the `flex_cross_width` local instead of the preferred
+    /// width passed in the `cross_width` local instead of the preferred
     /// width. Drives the generated `flexbox_layout_item_info_at_cross_width` method,
     /// which a column FlexboxLayout calls with its real container width so a
     /// repeated cell wraps to the same height as an equivalent static cell.
@@ -575,7 +575,7 @@ pub struct SubComponent {
     /// when the element carries a `layoutinfo-h-with-constraint`.
     pub layout_info_h_constrained_for_repeated: Option<MutExpression>,
     /// Same as `layout_info_h_constrained_for_repeated`, but measured at the
-    /// height passed in the `flex_cross_height` local. Drives the generated
+    /// height passed in the `cross_height` local. Drives the generated
     /// `flexbox_layout_item_info_at_cross_height` method, which a FlexboxLayout
     /// calls with the height it assigned so a repeated cell resolves to the
     /// same width as an equivalent static cell.

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -2222,11 +2222,13 @@ pub fn get_layout_info_v_constrained_for_repeated(
 }
 
 /// Name of the local that carries the cross-axis (container) width into the
-/// generated `flexbox_layout_item_info_at_cross_width` method body.
-pub const FLEX_CROSS_WIDTH_LOCAL: &str = "flex_cross_width";
+/// generated `flexbox_layout_item_info_at_cross_width` and
+/// `layout_item_info_at_cross_width` method bodies (the parameter name is
+/// derived from it).
+pub const CROSS_WIDTH_LOCAL: &str = "cross_width";
 
 /// Like [`get_layout_info_v_constrained_for_repeated`], but measures at the
-/// width passed in the [`FLEX_CROSS_WIDTH_LOCAL`] local instead of the
+/// width passed in the [`CROSS_WIDTH_LOCAL`] local instead of the
 /// element's preferred width. A column FlexboxLayout (or a box layout)
 /// supplies the width it assigns the instance here at solve time, so a
 /// repeated height-for-width instance gets the same wrapped height as an
@@ -2247,7 +2249,7 @@ pub fn get_layout_info_v_at_cross_width_for_repeated(
         return None;
     }
     let width_constraint = crate::expression_tree::Expression::ReadLocalVariable {
-        name: FLEX_CROSS_WIDTH_LOCAL.into(),
+        name: CROSS_WIDTH_LOCAL.into(),
         ty: Type::LogicalLength,
     };
     let get = if for_flex_cell { get_flex_cell_layout_info } else { get_layout_info };
@@ -2284,11 +2286,13 @@ pub fn get_layout_info_h_constrained_for_repeated(
 }
 
 /// Name of the local that carries the cross-axis (assigned) height into the
-/// generated `flexbox_layout_item_info_at_cross_height` method body.
-pub const FLEX_CROSS_HEIGHT_LOCAL: &str = "flex_cross_height";
+/// generated `flexbox_layout_item_info_at_cross_height` and
+/// `layout_item_info_at_cross_height` method bodies (the parameter name is
+/// derived from it).
+pub const CROSS_HEIGHT_LOCAL: &str = "cross_height";
 
 /// Like [`get_layout_info_h_constrained_for_repeated`], but measures at the
-/// height passed in the [`FLEX_CROSS_HEIGHT_LOCAL`] local instead of leaving it
+/// height passed in the [`CROSS_HEIGHT_LOCAL`] local instead of leaving it
 /// unbounded. A FlexboxLayout (or a box layout) supplies the height it
 /// assigned at solve time, so a repeated width-for-height instance gets the
 /// same width as an equivalent static cell. Returns `None` when the element
@@ -2302,7 +2306,7 @@ pub fn get_layout_info_h_at_cross_height_for_repeated(
 ) -> Option<llr_Expression> {
     element.borrow().inherited_layout_info_h_with_constraint()?;
     let height_constraint = crate::expression_tree::Expression::ReadLocalVariable {
-        name: FLEX_CROSS_HEIGHT_LOCAL.into(),
+        name: CROSS_HEIGHT_LOCAL.into(),
         ty: Type::LogicalLength,
     };
     let get = if for_flex_cell { get_flex_cell_layout_info } else { get_layout_info };

--- a/internal/core/model/repeater.rs
+++ b/internal/core/model/repeater.rs
@@ -97,7 +97,7 @@ pub trait RepeatedItemTree:
     /// cells); the generated code overrides it for height-for-width instances.
     fn flexbox_layout_item_info_at_cross_width(
         self: Pin<&Self>,
-        _flex_cross_width: f32,
+        _cross_width: f32,
     ) -> crate::layout::FlexboxLayoutItemInfo {
         self.flexbox_layout_item_info(Orientation::Vertical, None)
     }
@@ -109,7 +109,7 @@ pub trait RepeatedItemTree:
     /// overrides it for width-for-height instances.
     fn flexbox_layout_item_info_at_cross_height(
         self: Pin<&Self>,
-        _flex_cross_height: f32,
+        _cross_height: f32,
     ) -> crate::layout::FlexboxLayoutItemInfo {
         self.flexbox_layout_item_info(Orientation::Horizontal, None)
     }

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -1215,21 +1215,18 @@ impl i_slint_core::model::RepeatedItemTree for Instance {
 
     fn layout_item_info_at_cross_width(
         self: Pin<&Self>,
-        flex_cross_width: f32,
+        cross_width: f32,
     ) -> i_slint_core::layout::LayoutItemInfo {
-        self.box_layout_item_info_at_cross(
-            i_slint_core::items::Orientation::Vertical,
-            flex_cross_width,
-        )
+        self.box_layout_item_info_at_cross(i_slint_core::items::Orientation::Vertical, cross_width)
     }
 
     fn layout_item_info_at_cross_height(
         self: Pin<&Self>,
-        flex_cross_height: f32,
+        cross_height: f32,
     ) -> i_slint_core::layout::LayoutItemInfo {
         self.box_layout_item_info_at_cross(
             i_slint_core::items::Orientation::Horizontal,
-            flex_cross_height,
+            cross_height,
         )
     }
 
@@ -1302,16 +1299,16 @@ impl Instance {
         cross_size: f32,
     ) -> i_slint_core::layout::LayoutItemInfo {
         use i_slint_compiler::llr::lower_layout_expression::{
-            FLEX_CROSS_HEIGHT_LOCAL, FLEX_CROSS_WIDTH_LOCAL,
+            CROSS_HEIGHT_LOCAL, CROSS_WIDTH_LOCAL,
         };
         let cu = self.root_sub_component.compilation_unit.clone();
         let sc = &cu.sub_components[self.root_sub_component.sub_component_idx];
         let (expr, local) = match orientation {
             i_slint_core::items::Orientation::Vertical => {
-                (sc.layout_info_v_at_cross_width_for_repeated.as_ref(), FLEX_CROSS_WIDTH_LOCAL)
+                (sc.layout_info_v_at_cross_width_for_repeated.as_ref(), CROSS_WIDTH_LOCAL)
             }
             i_slint_core::items::Orientation::Horizontal => {
-                (sc.layout_info_h_at_cross_height_for_repeated.as_ref(), FLEX_CROSS_HEIGHT_LOCAL)
+                (sc.layout_info_h_at_cross_height_for_repeated.as_ref(), CROSS_HEIGHT_LOCAL)
             }
         };
         let Some(expr) = expr.filter(|_| sc.flexbox_layout_item_info_for_repeated.is_none()) else {
@@ -1333,7 +1330,7 @@ impl Instance {
     /// cell wraps to the same height as an equivalent static cell.
     pub fn flexbox_layout_item_info_at_cross_width(
         self: Pin<&Self>,
-        flex_cross_width: f32,
+        cross_width: f32,
     ) -> i_slint_core::layout::FlexboxLayoutItemInfo {
         use i_slint_core::items::Orientation;
         use i_slint_core::model::RepeatedItemTree;
@@ -1344,8 +1341,8 @@ impl Instance {
         if let Some(v_expr) = &sc.layout_info_v_at_cross_width_for_repeated {
             let mut ctx = crate::eval::EvalContext::new(self.root_sub_component.clone());
             ctx.locals.insert(
-                i_slint_compiler::llr::lower_layout_expression::FLEX_CROSS_WIDTH_LOCAL.into(),
-                crate::Value::Number(flex_cross_width as f64),
+                i_slint_compiler::llr::lower_layout_expression::CROSS_WIDTH_LOCAL.into(),
+                crate::Value::Number(cross_width as f64),
             );
             info.constraint = crate::eval::eval_expression(&mut ctx, &v_expr.borrow())
                 .try_into()
@@ -1359,7 +1356,7 @@ impl Instance {
     /// an equivalent static cell.
     pub fn flexbox_layout_item_info_at_cross_height(
         self: Pin<&Self>,
-        flex_cross_height: f32,
+        cross_height: f32,
     ) -> i_slint_core::layout::FlexboxLayoutItemInfo {
         use i_slint_core::items::Orientation;
         use i_slint_core::model::RepeatedItemTree;
@@ -1370,8 +1367,8 @@ impl Instance {
         if let Some(h_expr) = &sc.layout_info_h_at_cross_height_for_repeated {
             let mut ctx = crate::eval::EvalContext::new(self.root_sub_component.clone());
             ctx.locals.insert(
-                i_slint_compiler::llr::lower_layout_expression::FLEX_CROSS_HEIGHT_LOCAL.into(),
-                crate::Value::Number(flex_cross_height as f64),
+                i_slint_compiler::llr::lower_layout_expression::CROSS_HEIGHT_LOCAL.into(),
+                crate::Value::Number(cross_height as f64),
             );
             info.constraint = crate::eval::eval_expression(&mut ctx, &h_expr.borrow())
                 .try_into()


### PR DESCRIPTION
The local (and the generated accessor parameter derived from it) is
shared by the flexbox and box layout at-cross accessors, so the flex
prefix was misleading; also stop hardcoding the parameter names in the
generators.