### PR TITLE
docs: link to the source instead of copying definitions, part 2

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -99,7 +99,9 @@
         "TSCHÜSS",
         "ὈΔΥΣΣΕΎΣ",
         "ὀδυσσεύς",
+        "animatable",
         "commonmark",
+        "newtype",
         "strikethroughs",
         "unlocalized",
         "binstall"

--- a/docs/development/compiler-internals.md
+++ b/docs/development/compiler-internals.md
@@ -110,9 +110,9 @@ The interpreter (`internal/interpreter/`) compiles `.slint` at runtime and uses 
 ### Adding a New Compiler Pass
 
 1. **Create pass file** in `internal/compiler/passes/your_pass.rs`
-2. **Add to mod.rs** in `internal/compiler/passes/mod.rs`
-3. **Register in pipeline** in `internal/compiler/passes.rs` (choose appropriate phase)
-4. **Add tests** - either unit tests in the pass file or `.slint` test cases
+2. **Declare the module and register it in the pipeline**, both in
+   `internal/compiler/passes.rs` (choose appropriate phase)
+3. **Add tests** - either unit tests in the pass file or `.slint` test cases
 
 ### Adding a New Property Type
 

--- a/docs/development/custom-renderer.md
+++ b/docs/development/custom-renderer.md
@@ -64,77 +64,39 @@ The drawing interface for all UI elements. Each renderer provides its own implem
 
 ### FemtoVG Pattern: Generic Backend
 
-FemtoVG abstracts over graphics APIs using generics:
-
-```rust
-pub struct FemtoVGRenderer<B: GraphicsBackend> { ... }
-
-pub trait GraphicsBackend {
-    type Renderer: femtovg::Renderer + TextureImporter;
-    type WindowSurface: WindowSurface<Self::Renderer>;
-
-    fn new_suspended() -> Self;
-    fn begin_surface_rendering(&self) -> Result<BeginRendering<Self::WindowSurface>, ...>;
-    fn submit_commands(&self, commands: ...);
-    fn present_surface(&self, surface: Self::WindowSurface) -> Result<(), ...>;
-    fn resize(&self, width: NonZeroU32, height: NonZeroU32) -> Result<(), ...>;
-}
-```
+FemtoVG abstracts over graphics APIs with the `GraphicsBackend` trait: a backend names its
+femtovg renderer and window surface types, creates itself suspended, hands out a surface to draw
+into, submits the command buffer, presents, resizes, and optionally exposes the native graphics
+API and a snapshot path. `FemtoVGRenderer<B>` is generic over it.
+See `GraphicsBackend` in `internal/renderers/femtovg/lib.rs`.
 
 ### Skia Pattern: Trait Object Surfaces
 
-Skia uses trait objects for dynamic surface selection:
+Skia selects its surface dynamically through the `Surface` trait: construct from a window and a
+display handle plus the requested graphics API, render through a callback that gets the Skia
+canvas and direct context, resize, and report the bits per pixel and whether partial rendering is
+available. `render()` returns a `DrawOutcome`, so a surface can say it was occluded or timed out
+instead of drawing. See `Surface` in `internal/renderers/skia/lib.rs`.
 
-```rust
-pub trait Surface {
-    fn new(
-        shared_context: &SkiaSharedContext,
-        window_handle: Arc<dyn HasWindowHandle + Sync + Send>,
-        display_handle: Arc<dyn HasDisplayHandle + Sync + Send>,
-        size: PhysicalWindowSize,
-        requested_graphics_api: Option<RequestedGraphicsAPI>,
-    ) -> Result<Self, PlatformError>;
-
-    fn name(&self) -> &'static str;
-    fn render(&self, window: &Window, size: PhysicalWindowSize,
-              render_callback: &dyn Fn(&Canvas, ...), ...) -> Result<(), ...>;
-    fn resize_event(&self, size: PhysicalWindowSize) -> Result<(), ...>;
-    fn use_partial_rendering(&self) -> bool { false }
-}
-```
-
-Available surface implementations: `OpenGLSurface`, `MetalSurface`, `VulkanSurface`, `D3DSurface`, `SoftwareSurface`
+Available surface implementations: `OpenGLSurface`, `MetalSurface`, `VulkanSurface`, `D3DSurface`,
+`SoftwareSurface`, and one `WGPUSurface` per supported wgpu version.
 
 ### Software Renderer Pattern: Scene Building
 
-The software renderer builds a scene graph then rasterizes:
-
-```rust
-pub struct SoftwareRenderer { ... }
-
-impl SoftwareRenderer {
-    pub fn render(&self, buffer: &mut [impl TargetPixel], pixel_stride: usize) -> PhysicalRegion;
-    pub fn render_by_line(&self, line_buffer: impl LineBufferProvider) -> PhysicalRegion;
-}
-```
-
-Supports memory-constrained devices via line-by-line rendering.
+The software renderer builds a scene graph then rasterizes it. `SoftwareRenderer::render()` draws
+into a whole pixel buffer, while `render_by_line()` drives a `LineBufferProvider` one line at a
+time for memory-constrained devices. Both return the `PhysicalRegion` that was painted.
+See `internal/renderers/software/lib.rs`.
 
 ## Backend Integration
 
 ### WinitCompatibleRenderer (`internal/backends/winit/`)
 
-For winit-based applications, renderers implement:
-
-```rust
-pub trait WinitCompatibleRenderer: std::any::Any {
-    fn render(&self, window: &Window) -> Result<DrawOutcome, PlatformError>;
-    fn as_core_renderer(&self) -> &dyn Renderer;
-    fn suspend(&self) -> Result<(), PlatformError>;
-    fn resume(&self, event_loop: &ActiveEventLoop,
-              attrs: WindowAttributes) -> Result<Arc<winit::window::Window>, ...>;
-}
-```
+For winit-based applications a renderer implements `WinitCompatibleRenderer`: render a frame
+(returning a `DrawOutcome`), expose itself as a core `Renderer`, react to the window becoming
+occluded, and suspend/resume around the winit `Resumed` event — `resume()` is what creates the
+actual `winit::window::Window`.
+See `WinitCompatibleRenderer` in `internal/backends/winit/lib.rs`.
 
 ## Key Supporting Types
 

--- a/docs/development/ffi-language-bindings.md
+++ b/docs/development/ffi-language-bindings.md
@@ -91,46 +91,25 @@ pub extern "C" fn slint_run_event_loop(quit_on_last_window_closed: bool) {
 
 ### Opaque Pointer Types
 
-Hide internal Rust types from C++:
+Hide internal Rust types from C++. Each is a `#[repr(C)]` struct of the same size as the type it
+stands for, so C++ can hold it by value without knowing its layout — `PropertyHandleOpaque` wraps
+the real type, the other two are two pointer-sized fields with a static size assertion:
 
-```rust
-/// Opaque type for Rc<dyn WindowAdapter>
-#[repr(C)]
-pub struct WindowAdapterRcOpaque(*const c_void, *const c_void);
-
-/// Opaque type for PropertyHandle
-#[repr(C)]
-pub struct PropertyHandleOpaque(PropertyHandle);
-
-/// Opaque type for callbacks
-#[repr(C)]
-pub struct CallbackOpaque(*const c_void, *const c_void);
-```
+| Opaque type | Stands for | Defined in |
+|-------------|------------|------------|
+| `WindowAdapterRcOpaque` | `Rc<dyn WindowAdapter>` | `internal/core/window.rs` |
+| `PropertyHandleOpaque` | `PropertyHandle` | `internal/core/properties/ffi.rs` |
+| `CallbackOpaque` | `Callback` | `internal/core/callbacks.rs` |
 
 ### cbindgen Code Generation
 
-The `cbindgen.rs` file (900+ lines) generates C++ headers:
-
-```rust
-// api/cpp/cbindgen.rs
-fn enums(include_dir: &Path) {
-    // Generates slint_enums.h and slint_enums_internal.h
-    i_slint_common::for_each_enums!(print_enums);
-}
-
-fn builtin_structs(include_dir: &Path) {
-    // Generates slint_builtin_structs.h
-    i_slint_common::for_each_builtin_structs!(print_structs);
-}
-
-// Type renaming for C++
-config.export.rename = [
-    ("Callback".into(), "private_api::CallbackHelper".into()),
-    ("Coord".into(), "float".into()),
-    ("SharedString".into(), "slint::SharedString".into()),
-    // ... more mappings
-];
-```
+`api/cpp/cbindgen.rs` generates the C++ headers. Enums and built-in structs are not read from
+the Rust source at all: they are printed from the `for_each_enums!` and `for_each_builtin_structs!`
+macros in `i-slint-common`, which are the single definition both the Rust types and the C++
+headers come from. Everything else goes through cbindgen proper, with a rename table mapping Rust
+names to their C++ equivalents (`Coord` to `float`, `StringArg` to `slint::SharedString`, ...) and
+an exclude list for the types the hand-written headers declare themselves, `SharedString` among
+them.
 
 **Generated headers:**
 - `slint_enums.h` / `slint_enums_internal.h` - Public/private enums
@@ -142,17 +121,14 @@ config.export.rename = [
 
 ### CMake Integration
 
-Uses Corrosion to bridge CMake and Cargo:
+Uses Corrosion to bridge CMake and Cargo. `api/cpp/CMakeLists.txt` declares one CMake option per
+Cargo feature with `define_cargo_feature(<cargo-feature> <description> <default>)`, or
+`define_cargo_dependent_feature(...)` with a trailing condition for the ones that only make sense
+in some configurations — most are conditioned on `NOT SLINT_FEATURE_FREESTANDING`, since a
+bare-metal build has no windowing system.
 
-```cmake
-# api/cpp/CMakeLists.txt
-define_cargo_feature(freestanding "Enable freestanding environment" OFF)
-define_cargo_dependent_feature(interpreter "Enable .slint loading" ON)
-define_cargo_feature(backend-winit "Enable winit windowing" ON)
-
-# Feature flags map: CMake options → Cargo features
-# SLINT_FEATURE_BACKEND_WINIT → --features backend-winit
-```
+Each becomes a `SLINT_FEATURE_<FEATURE>` option that maps back to `--features <feature>`, so
+`SLINT_FEATURE_BACKEND_WINIT` turns into `--features backend-winit`.
 
 ### Building C++ Library
 
@@ -189,11 +165,10 @@ api/node/
 
 ### NAPI Function Pattern
 
-```rust
-// api/node/rust/lib.rs
-use napi::{Env, JsFunction};
-extern crate napi_derive;
+A `#[napi]` attribute on a free function exports it to JavaScript, and on an enum or struct
+exports the type:
 
+```rust
 #[napi]
 pub fn mock_elapsed_time(_ms: f64) {
     #[cfg(feature = "testing")]
@@ -205,66 +180,26 @@ pub enum ProcessEventsResult {
     Continue,
     Exited,
 }
-
-#[napi]
-pub fn process_events() -> napi::Result<ProcessEventsResult> {
-    i_slint_backend_selector::with_platform(|b| {
-        b.process_events(Some(std::time::Duration::ZERO), i_slint_core::InternalToken)
-    })
-    .map_err(|e| napi::Error::from_reason(e.to_string()))
-    .map(|result| match result {
-        core::ops::ControlFlow::Continue(()) => ProcessEventsResult::Continue,
-        core::ops::ControlFlow::Break(()) => ProcessEventsResult::Exited,
-    })
-}
 ```
+
+Anything fallible returns `napi::Result` so the error surfaces as a JavaScript exception, which
+means mapping the Rust error through `napi::Error::from_reason` — `process_events()` in the same
+file does both. See `api/node/rust/lib.rs`.
 
 ### Type Bindings
 
-```rust
-// api/node/rust/types/brush.rs
-#[napi(object)]
-pub struct RgbaColor {
-    pub red: f64,
-    pub green: f64,
-    pub blue: f64,
-    pub alpha: Option<f64>,
-}
-
-#[napi]
-pub struct SlintRgbaColor {
-    inner: Color,
-}
-
-#[napi]
-impl SlintRgbaColor {
-    #[napi(constructor)]
-    pub fn new() -> Self { ... }
-
-    #[napi]
-    pub fn red(&self) -> f64 { self.inner.red() as f64 }
-}
-```
+Two shapes appear in `api/node/rust/types/`. A `#[napi(object)]` struct such as `RgbaColor` is a
+plain JavaScript object, converted field by field. A `#[napi]` struct such as `SlintRgbaColor` or
+`SlintBrush` is a JavaScript class wrapping the Rust value, with `#[napi]` methods on its `impl`
+and `From` conversions to and from the core type.
 
 ### Callback Handling
 
-```rust
-#[napi]
-pub fn invoke_from_event_loop(env: Env, callback: JsFunction) -> napi::Result<napi::JsUndefined> {
-    let function_ref = RefCountedReference::new(&env, callback)?;
-    let function_ref = send_wrapper::SendWrapper::new(function_ref);
-
-    i_slint_core::api::invoke_from_event_loop(move || {
-        let guard = function_ref.get();
-        if let Err(e) = guard.call::<JsUnknown>(None, &[]) {
-            eprintln!("Callback error: {:?}", e);
-        }
-    })
-    .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-
-    env.get_undefined()
-}
-```
+A JavaScript function that has to outlive the call cannot be held directly: it must become a
+reference that keeps it alive, and that reference plus the `Env` must be wrapped in a
+`send_wrapper::SendWrapper` to satisfy the `Send` bound of whatever holds it. Calling it back
+means borrowing it against the `Env` again. `invoke_from_event_loop()` in `api/node/rust/lib.rs`
+is the smallest example of the whole shape.
 
 ### Building Node.js Module
 
@@ -293,95 +228,34 @@ api/python/slint/
 
 ### PyO3 Function Pattern
 
-```rust
-// api/python/slint/lib.rs
-use pyo3::prelude::*;
+`#[pyfunction]` exports a function, `#[pymodule]` marks the module initializer, and each class
+and function is registered there with `add_class::<T>()` and `add_function(wrap_pyfunction!(...))`.
+`api/python/slint/lib.rs` has two `#[pymodule]` entry points — one for the released `slint`
+extension and one for the dev distribution — both delegating to the same `register_module()`.
 
-#[gen_stub_pyfunction]
-#[pyfunction]
-fn run_event_loop(py: Python<'_>) -> Result<(), PyErr> {
-    EVENT_LOOP_EXCEPTION.replace(None);
-    EVENT_LOOP_RUNNING.set(true);
-
-    let result = py.allow_threads(|| slint_interpreter::run_event_loop());
-
-    EVENT_LOOP_RUNNING.set(false);
-    result.map_err(|e| errors::PyPlatformError::from(e))?;
-    EVENT_LOOP_EXCEPTION.take().map_or(Ok(()), |err| Err(err))
-}
-
-#[pymodule]
-fn slint(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Compiler>()?;
-    m.add_class::<CompilationResult>()?;
-    m.add_class::<ComponentInstance>()?;
-    m.add_function(wrap_pyfunction!(run_event_loop, m)?)?;
-    Ok(())
-}
-```
+A function that blocks must release the GIL around the blocking part with `py.detach()`, or other
+Python threads stall for as long as it runs. `run_event_loop()` does that, and stashes any
+exception raised from a callback in a thread-local so it can be re-raised once the loop returns.
 
 ### Class Bindings
 
-```rust
-// api/python/slint/interpreter.rs
-#[gen_stub_pyclass]
-#[pyclass(unsendable)]
-pub struct Compiler {
-    compiler: slint_interpreter::Compiler,
-}
-
-#[gen_stub_pymethods]
-#[pymethods]
-impl Compiler {
-    #[new]
-    fn py_new() -> PyResult<Self> {
-        Ok(Self { compiler: slint_interpreter::Compiler::new() })
-    }
-
-    #[getter]
-    fn get_include_paths(&self) -> PyResult<Vec<PathBuf>> {
-        Ok(self.compiler.include_paths().map(|p| p.to_owned()).collect())
-    }
-
-    #[setter]
-    fn set_include_paths(&mut self, paths: Vec<PathBuf>) {
-        self.compiler.set_include_paths(paths);
-    }
-
-    fn build_from_path(&mut self, py: Python<'_>, path: PathBuf) -> CompilationResult {
-        py.allow_threads(|| {
-            self.compiler.build_from_path(&path).into()
-        })
-    }
-}
-```
+A class is a `#[pyclass]` struct wrapping the Rust type, with its methods in a `#[pymethods]`
+impl: `#[new]` for the constructor, `#[getter]` and `#[setter]` pairs for what looks like an
+attribute from Python. `unsendable` says the object may only be touched from the thread that
+created it, which is what the interpreter types require. `Compiler` in
+`api/python/slint/interpreter.rs` is the model to copy.
 
 ### Value Conversion
 
-```rust
-// api/python/slint/value.rs
-impl<'py> IntoPyObject<'py> for SlintToPyValue {
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        match self.slint_value {
-            slint_interpreter::Value::Void => ().into_bound_py_any(py),
-            slint_interpreter::Value::Number(num) => num.into_bound_py_any(py),
-            slint_interpreter::Value::String(str) => str.into_bound_py_any(py),
-            slint_interpreter::Value::Bool(b) => b.into_bound_py_any(py),
-            slint_interpreter::Value::Image(image) => {
-                crate::image::PyImage::from(image).into_bound_py_any(py)
-            }
-            slint_interpreter::Value::Model(model) => {
-                crate::models::PyModelShared::rust_into_py_model(&model, py)
-                    .map_or_else(
-                        || type_collection.model_to_py(&model).into_bound_py_any(py),
-                        |m| Ok(m),
-                    )
-            }
-            // ... more conversions
-        }
-    }
-}
-```
+`api/python/slint/value.rs` converts in both directions. Rust to Python goes through an
+`IntoPyObject` impl for `SlintToPyValue`, which matches on the interpreter `Value` and produces
+the corresponding Python object — a plain `int`, `float`, `str` or `bool` where one fits, and a
+dedicated class (`PyImage`, a model wrapper, `LogicalPosition`, ...) otherwise.
+
+`SlintToPyValue` carries the expected `.slint` type alongside the value, because the `Value` alone
+does not always determine the Python type: a `Value::Number` becomes a Python `int` when the
+property is declared `int` and a `float` otherwise, and a `Value::Model` needs its element type to
+convert its rows.
 
 ### Building Python Module
 
@@ -395,136 +269,47 @@ maturin build    # Release wheel
 
 ### Property FFI (`internal/core/properties/ffi.rs`)
 
-```rust
-#[repr(C)]
-pub struct PropertyHandleOpaque(PropertyHandle);
+Everything here works on a `PropertyHandleOpaque`, the opaque `PropertyHandle`. The
+`slint_property_*` functions cover the whole property lifecycle: `init` and `drop`, `update`, `set_changed`,
+`register_as_dependency`, the binding calls (`set_binding`, `delete_binding`, `evaluate_binding`,
+`intercept_set_binding`), and one `set_animated_value_*` / `set_animated_binding_*` pair per
+animatable type (int, float, color, brush).
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_property_init(out: *mut PropertyHandleOpaque) {
-    // Initialize property handle
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_property_update(
-    handle: &PropertyHandleOpaque,
-    val: *mut c_void,
-) {
-    // Update property value
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn slint_property_set_changed(
-    handle: &PropertyHandleOpaque,
-    value: *const c_void,
-) {
-    // Mark property as changed
-}
-
-// C function binding support
-fn make_c_function_binding(
-    binding: extern "C" fn(*mut c_void, *mut c_void),
-    user_data: *mut c_void,
-    drop_user_data: Option<extern "C" fn(*mut c_void)>,
-    intercept_set: Option<extern "C" fn(*mut c_void, ...) -> bool>,
-) -> impl Fn() -> T {
-    // Creates Rust closure from C function pointers
-}
-```
+`make_c_function_binding()` is what turns the C side into something the property system can hold:
+it takes the binding's function pointer, the user data and its drop function, and the two optional
+interception hooks (one for a value being set, one for a binding being set), and returns an
+`impl BindingCallable<c_void>`.
 
 ### Window FFI (`internal/core/window.rs`, plus `slint_windowrc_init` in `api/cpp/lib.rs`)
 
-```rust
-pub mod ffi {
-    #[repr(C)]
-    pub struct WindowAdapterRcOpaque(*const c_void, *const c_void);
+The `ffi` module of `internal/core/window.rs` defines `WindowAdapterRcOpaque` and some forty
+`slint_windowrc_*` functions — the lifecycle ones (`drop`, `clone`), showing and hiding, the
+scale factor, the focus item and text-input-focused flag, setting the component, the popups, the
+event dispatch entry points, the fullscreen/maximized/minimized state, the rendering notifier and
+close-requested callbacks, `request_redraw`, `take_snapshot`, and the position and size accessors.
+A second module, `ffi_window`, follows it with the ones that work on a `Window` rather than the
+adapter.
 
-    // Defined in api/cpp/lib.rs, not window.rs's ffi module
-    #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_init(out: *mut WindowAdapterRcOpaque) { ... }
-
-    #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_drop(handle: *mut WindowAdapterRcOpaque) { ... }
-
-    #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_clone(
-        source: &WindowAdapterRcOpaque,
-        target: *mut WindowAdapterRcOpaque,
-    ) { ... }
-
-    #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_show(handle: *const WindowAdapterRcOpaque) { ... }
-
-    #[unsafe(no_mangle)]
-    pub unsafe extern "C" fn slint_windowrc_hide(handle: &WindowAdapterRcOpaque) { ... }
-}
-```
+`slint_windowrc_init`, which creates the window adapter through the platform, is the exception:
+it lives in `api/cpp/lib.rs`, because that is where the platform is bound.
 
 ### Item Tree VTables (`internal/core/item_tree.rs`)
 
-```rust
-/// VTable for component instances
-pub struct ItemTreeVTable {
-    /// Visit children in traversal order
-    pub visit_children_item: extern "C" fn(
-        Pin<VRef<ItemTreeVTable>>,
-        index: isize,
-        order: TraversalOrder,
-        visitor: VRefMut<ItemVisitorVTable>,
-    ) -> VisitChildrenResult,
-
-    /// Get item reference by index
-    pub get_item_ref: extern "C" fn(
-        Pin<VRef<ItemTreeVTable>>,
-        index: u32,
-    ) -> Pin<VRef<ItemVTable>>,
-
-    /// Get subtree range for repeaters
-    pub get_subtree_range: extern "C" fn(
-        Pin<VRef<ItemTreeVTable>>,
-        index: u32,
-    ) -> IndexRange,
-
-    // ... more vtable entries
-}
-```
+`ItemTreeVTable` is the vtable every component instance provides, on both the Rust and the C++
+side. Its entries are all `extern "C" fn` taking a `Pin<VRef<ItemTreeVTable>>` as the receiver;
+see [item-tree.md](item-tree.md#itemtreevtable) for what they do.
 
 ### Interpreter FFI (`internal/interpreter/ffi.rs`)
 
-```rust
-/// Value type enum for FFI
-#[repr(C)]
-pub enum ValueType {
-    Void, Number, String, Bool, Model, Struct, Brush, Image,
-}
+`Value` crosses the boundary as a `Box<Value>`, so the `slint_interpreter_value_*` functions come
+in sets: a `_new` and a `_new_<kind>` constructor per kind, a `_type` returning the `ValueType`,
+and a `_to_<kind>` accessor. Most of those return `Option<&T>` — `None` when the value holds
+something else — but `_to_struct` and `_to_model` return a raw pointer and `_to_array` writes
+through an out parameter and returns a `bool`.
 
-#[unsafe(no_mangle)]
-pub extern "C" fn slint_interpreter_value_new() -> Box<Value> {
-    Box::new(Value::Void)
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn slint_interpreter_value_new_string(str: &SharedString) -> Box<Value> {
-    Box::new(Value::String(str.clone()))
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn slint_interpreter_value_type(val: &Value) -> ValueType {
-    match val {
-        Value::Void => ValueType::Void,
-        Value::Number(_) => ValueType::Number,
-        Value::String(_) => ValueType::String,
-        // ...
-    }
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn slint_interpreter_value_to_string(val: &Value) -> Option<&SharedString> {
-    match val {
-        Value::String(s) => Some(s),
-        _ => None,
-    }
-}
-```
+`ValueType` (`internal/interpreter/api.rs`, not the ffi module) is `Void`, `Number`, `String`,
+`Bool`, `Model`, `Struct`, `Brush`, `Image`, plus a hidden `Other = -1` for values whose type is
+not part of the public API.
 
 ## Core FFI Patterns
 
@@ -664,7 +449,6 @@ namespace slint {
 
 ```rust
 // api/python/slint/mymodule.rs
-#[gen_stub_pyfunction]
 #[pyfunction]
 fn new_function(param: i32) -> PyResult<ResultType> {
     Ok(internal_function(param))
@@ -688,28 +472,15 @@ pub fn new_function(param: i32) -> napi::Result<ResultType> {
 
 ### Cargo Features
 
-```toml
-# api/cpp/Cargo.toml
-[lib]
-crate-type = ["lib", "cdylib", "staticlib"]
-links = "slint_cpp"
+`api/cpp/Cargo.toml` builds `slint-cpp` as `["lib", "cdylib", "staticlib"]` and sets
+`links = "slint_cpp"` so the build script's metadata reaches the CMake side.
 
-[features]
-# Renderers
-renderer-femtovg = ["i-slint-backend-selector/renderer-femtovg"]
-renderer-skia = ["i-slint-backend-selector/renderer-skia"]
-renderer-software = ["i-slint-backend-selector/renderer-software"]
-
-# Backends
-backend-winit = ["i-slint-backend-selector/backend-winit"]
-backend-qt = ["i-slint-backend-selector/backend-qt"]
-backend-linuxkms = ["i-slint-backend-selector/backend-linuxkms"]
-
-# Other
-freestanding = ["i-slint-core/freestanding"]
-interpreter = ["slint-interpreter"]
-testing = ["i-slint-backend-testing"]
-```
+Two thirds of its features just forward to `i-slint-backend-selector`, one per renderer
+(`renderer-femtovg`, `renderer-skia` and its per-API variants, `renderer-software`) and one per
+backend (`backend-winit` and its X11/Wayland-only variants, `backend-qt`, `backend-linuxkms`).
+The rest are its own: `interpreter` and `live-preview`, `testing`, `gettext`, `system-tray`, and
+the two that decide the environment — `std`, which the default set enables, and `freestanding`
+for bare metal.
 
 ### CMake Feature Mapping
 
@@ -777,8 +548,8 @@ cargo test -p i-slint-core ffi
 | Memory leak | Missing drop_user_data | Ensure cleanup function is called |
 | Type mismatch | cbindgen out of sync | Rebuild the project to regenerate headers |
 | Undefined symbol | FFI function not exported | Add to `config.export.include` |
-| Python crash | GIL issues | Use `py.allow_threads()` for blocking calls |
-| Node crash | Ref counting | Use `RefCountedReference` for callbacks |
+| Python crash | GIL issues | Use `py.detach()` around blocking calls |
+| Node crash | Ref counting | Keep the JS function alive with `create_ref()` |
 
 ### Checking ABI Compatibility
 
@@ -816,42 +587,24 @@ pub extern "C" fn slint_debug_function(param: i32) -> i32 {
 
 ### Private Unstable API
 
-Generated code uses internal helpers:
+Generated code uses the helpers in `api/rs/slint/private_unstable_api.rs`. Its `re_exports`
+module re-exports everything the generated code names — core types, the native widgets, `vtable`,
+`const_field_offset` — so the generated file only ever has to `use` that one module.
 
-```rust
-// api/rs/slint/private_unstable_api.rs
-pub mod re_exports {
-    pub use i_slint_core::{*, properties::*, item_tree::*};
-    pub use vtable::*;
-    pub use pin_weak::rc::PinWeak;
-}
-
-pub fn set_property_binding<T, StrongRef>(
-    property: Pin<&Property<T>>,
-    component_strong: &StrongRef,
-    binding: fn(StrongRef) -> T,
-) {
-    let weak = component_strong.to_weak();
-    property.set_binding(move || {
-        StrongRef::from_weak(&weak).map(binding).unwrap_or_default()
-    })
-}
-```
+Alongside it are the helpers that keep the generated code short, such as
+`set_property_binding()`, which installs a binding that holds only a weak reference to the
+component and falls back to the default value once it is gone.
 
 ### Build Script Support
 
-```rust
-// api/rs/build/lib.rs
-pub struct CompilerConfiguration {
-    pub include_paths: Vec<PathBuf>,
-    pub library_paths: HashMap<String, PathBuf>,
-    pub style: Option<String>,
-}
+`api/rs/build/lib.rs` is what a `build.rs` calls. `compile_with_config()` takes the path of the
+`.slint` file, relative to the crate manifest, and a `CompilerConfiguration`, and writes the
+generated Rust into the build output directory.
 
-pub fn compile_with_config(
-    path: impl AsRef<Path>,
-    config: CompilerConfiguration,
-) -> Result<(), CompileError> {
-    // Compile .slint file and generate Rust code
-}
-```
+`CompilerConfiguration` wraps the compiler's own configuration and is built by chaining consuming
+`with_*` methods: `with_include_paths()`, `with_library_paths()`, `with_style()`,
+`with_scale_factor()`, `with_bundled_translations()`, `with_default_translation_context()`,
+`with_debug_info()`, `with_sdf_fonts()`,
+`as_library()`, `rust_module()`, and `embed_resources()`, which takes an `EmbedResourcesKind`
+saying whether resources are loaded from an absolute path at run-time, embedded as-is, or
+pre-processed into raw pixel data for the software renderer.

--- a/docs/development/input-event-system.md
+++ b/docs/development/input-event-system.md
@@ -28,59 +28,21 @@ Slint's input system handles mouse, touch, keyboard events and focus management.
 
 ### MouseEvent Enum
 
-```rust
-pub enum MouseEvent {
-    /// Mouse/finger pressed
-    Pressed {
-        position: LogicalPoint,
-        button: PointerEventButton,
-        click_count: u8,
-        touch_finger_id: i32,  // Set for touch input, 0 for mouse
-    },
+`MouseEvent` (`internal/core/input.rs`) is what an item's input handlers receive:
 
-    /// Mouse/finger released
-    Released {
-        position: LogicalPoint,
-        button: PointerEventButton,
-        click_count: u8,
-        touch_finger_id: i32,
-    },
-
-    /// Pointer moved
-    Moved { position: LogicalPoint, touch_finger_id: i32 },
-
-    /// Mouse wheel or touchpad scroll
-    Wheel { position: LogicalPoint, delta_x: Coord, delta_y: Coord, phase: TouchPhase },
-
-    /// Drag operation in progress over item
-    DragMove { event: DropEvent, allowed: AllowedDragActions },
-
-    /// Drop occurred on item
-    Drop { event: DropEvent, allowed: AllowedDragActions },
-
-    /// A platform-recognized pinch gesture (macOS/iOS trackpad, Qt)
-    PinchGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
-
-    /// A platform-recognized rotation gesture (macOS/iOS trackpad, Qt)
-    RotationGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
-
-    /// Mouse exited the item
-    Exit,
-}
-```
+- `Pressed` and `Released`, with a position, a `PointerEventButton`, the click count, and a touch
+  finger id (set for touch input, 0 for the mouse); `Moved`, with a position and finger id
+- `Wheel` for the mouse wheel or a touchpad scroll: a position, an x and y delta, and a
+  `TouchPhase`
+- `DragMove` and `Drop`, each with the `DropEvent` and the allowed drag actions
+- `PinchGesture` and `RotationGesture`, platform-recognized gestures (macOS/iOS trackpad, Qt),
+  with a position, a delta and a `TouchPhase`
+- `Exit`, when the pointer leaves the item
 
 ### Click Counting
 
-The `ClickState` tracks multi-clicks (double-click, triple-click):
-
-```rust
-pub struct ClickState {
-    click_count_time_stamp: Cell<Option<Instant>>,
-    click_count: Cell<u8>,
-    click_position: Cell<LogicalPoint>,
-    click_button: Cell<PointerEventButton>,
-}
-```
+`ClickState` (`internal/core/input.rs`) tracks multi-clicks (double-click, triple-click) by
+remembering the timestamp, count, position and button of the last press.
 
 **Logic:**
 - If press occurs within `click_interval` of previous press, at same position, with same button → increment `click_count`
@@ -89,29 +51,19 @@ pub struct ClickState {
 
 ### Mouse Input State
 
-Tracks the current state of mouse interaction:
+`MouseInputState` (`internal/core/input.rs`) tracks the current state of mouse interaction:
 
-```rust
-pub struct MouseInputState {
-    /// Stack of items under cursor, with their filter results
-    item_stack: Vec<(ItemWeak, InputEventFilterResult)>,
-
-    /// Offset for popup positioning
-    pub(crate) offset: LogicalPoint,
-
-    /// True if an item has grabbed the mouse
-    grabbed: bool,
-
-    /// Active drag-drop data
-    pub(crate) drag_data: Option<DragData>,
-
-    /// Delayed event (for Flickable touch handling)
-    delayed: Option<(Timer, MouseEvent)>,
-
-    /// Items pending exit events
-    delayed_exit_items: Vec<ItemWeak>,
-}
-```
+- The stack of items containing the cursor (or the grab), each with the last result of its filter
+  function, and whether the top item holds the mouse grab
+- The passive observers that saw the last event without claiming it. They are kept out of the
+  stack so it stays a single root-to-leaf path, and get a synthesized `MouseEvent::Exit` once they
+  stop appearing
+- The offset to apply to the first item of the stack, used when there is a popup
+- The drag-and-drop state: the dragged data, the `DragArea` that started the drag (`None` for a
+  native cross-window drag), and the `DropArea` that accepted the last `DragMove` — on release
+  only that one gets the `Drop`, matching how OS drag-and-drop pipelines behave
+- The delayed event and its timer (for `Flickable` touch handling), the items still owed an exit
+  event, and the current mouse cursor
 
 ## Event Processing Flow
 
@@ -173,68 +125,37 @@ because the backend needs the negotiated `DragAction` back, which the public dis
 
 ### Item Event Handlers
 
-Each item has two event handlers:
+Each item has two event handlers, both taking the `MouseEvent`, the window adapter, the item's
+own `ItemRc`, and the mouse cursor to set: `input_event_filter_before_children()` runs before the
+children and returns an `InputEventFilterResult`; `input_event()` runs after them, unless the
+filter said otherwise, and returns an `InputEventResult`.
 
-```rust
-// Called before children process the event
-fn input_event_filter_before_children(
-    &self,
-    event: &MouseEvent,
-    window_adapter: &Rc<dyn WindowAdapter>,
-    self_rc: &ItemRc,
-) -> InputEventFilterResult;
-
-// Called after children (unless filtered)
-fn input_event(
-    &self,
-    event: &MouseEvent,
-    window_adapter: &Rc<dyn WindowAdapter>,
-    self_rc: &ItemRc,
-) -> InputEventResult;
-```
+They are entries of `ItemVTable` in `internal/core/items.rs`, and the `Item` trait every item
+implements is generated from it by `#[vtable]`. That trait has no defaults: an item that does not
+care still has to write both out, returning `ForwardAndIgnore` and `EventIgnored` — `Empty` in the
+same file is the shortest example.
 
 ### InputEventFilterResult
 
-Controls how events are forwarded:
+Controls how events are forwarded.
+`InputEventFilterResult` (`internal/core/input.rs`) is one of:
 
-```rust
-pub enum InputEventFilterResult {
-    /// Forward to children, then call input_event on self
-    ForwardEvent,
-
-    /// Forward to children, don't call input_event on self
-    ForwardAndIgnore,
-
-    /// Forward, but keep receiving events even if child grabs
-    ForwardAndInterceptGrab,
-
-    /// Don't forward to children, handle here
-    Intercept,
-
-    /// Delay forwarding (for touch scrolling detection)
-    DelayForwarding(u64),  // milliseconds
-}
-```
+- `ForwardEvent` - forward to the children, then call `input_event` on self
+- `ForwardAndIgnore` - forward to the children, don't call `input_event` on self
+- `ForwardAndInterceptGrab` - like `ForwardEvent`, but keep receiving events even if a child grabs
+- `ForwardAndObserve` - like `ForwardAndIgnore`, but still get the `Exit` when the pointer leaves,
+  even if a sibling handled the event in between
+- `Intercept` - don't forward to the children; a child that already had the grab has it cancelled
+  with an `Exit`
+- `DelayForwarding(ms)` - forward after a delay, unless intercepted. Only for press events, and
+  the event is sent early if a release arrives first (this is what `Flickable` uses)
 
 ### InputEventResult
 
-Returned by `input_event`:
-
-```rust
-pub enum InputEventResult {
-    /// Event was handled
-    EventAccepted,
-
-    /// Event was not handled, continue propagation
-    EventIgnored,
-
-    /// Grab all future mouse events until release
-    GrabMouse,
-
-    /// Start drag-drop operation (DragArea only)
-    StartDrag,
-}
-```
+Returned by `input_event`: `EventAccepted` (which may result in further events, e.g. accepting a
+move leads to a later `Exit`), `EventIgnored`, `GrabMouse` to route all further mouse events to
+this item, or `StartDrag`, which only a `DragArea` may return.
+See `InputEventResult` in `internal/core/input.rs`.
 
 ## Mouse Grab
 
@@ -247,22 +168,12 @@ When an item returns `GrabMouse`:
    - Mouse is released
    - An intercepting ancestor calls `Intercept`
 
-```rust
-// In handle_mouse_grab()
-if mouse_input_state.grabbed {
-    // Send event directly to grabber
-    let grabber = mouse_input_state.top_item().unwrap();
-    let result = grabber.input_event(&event, ...);
-
-    match result {
-        InputEventResult::GrabMouse => None,  // Keep grab
-        _ => {
-            mouse_input_state.grabbed = false;
-            Some(MouseEvent::Moved { ... })  // Resume normal processing
-        }
-    }
-}
-```
+`handle_mouse_grab()` (`internal/core/input.rs`) walks the item stack, translating the event into
+each item's coordinates, and delivers it to the grabber. Items that asked for
+`ForwardAndInterceptGrab` or `DelayForwarding` see it on the way down and may intercept, which
+sends an `Exit` to everything below and drops it from the stack. It returns a `MouseGrabResult`:
+the event that still needs normal hit-test dispatch (`None` when the grabber fully handled it),
+and whether the grabber accepted the original event.
 
 ## Drag and Drop
 
@@ -283,8 +194,12 @@ InputEventResult::StartDrag => {
 Items receive `DragMove` events:
 
 ```rust
-MouseEvent::DragMove { event: DropEvent { mime_type, data, position }, allowed }
+MouseEvent::DragMove { event: DropEvent { data, position, proposed_action }, allowed }
 ```
+
+`data` is the `DataTransfer` payload the source set, `position` is in the item's local
+coordinates, and `proposed_action` is the action negotiated from the current modifier state,
+clamped to `allowed`.
 
 Items return `EventAccepted` to indicate they can receive the drop.
 
@@ -293,53 +208,42 @@ Items return `EventAccepted` to indicate they can receive the drop.
 When mouse is released during drag:
 
 ```rust
-MouseEvent::Drop { event: DropEvent { mime_type, data, position }, allowed }
+MouseEvent::Drop { event: DropEvent { data, position, proposed_action }, allowed }
 ```
+
+Only a `DropArea` that accepted the preceding `DragMove` receives it.
 
 ## Keyboard Events
 
 ### KeyEvent Structure
 
-```rust
-pub struct KeyEvent {
-    pub text: SharedString,           // Character or key code
-    pub modifiers: KeyboardModifiers, // Alt, Ctrl, Shift, Meta
-    pub event_type: KeyEventType,
-    // ... IME composition fields
-}
+There are two: the public `KeyEvent` that reaches .slint callbacks, and the runtime's own
+`InternalKeyEvent`.
 
-pub enum KeyEventType {
-    KeyPressed,
-    KeyReleased,
-    UpdateComposition,  // IME pre-edit
-    CommitComposition,  // IME finalized
-}
+`KeyEvent` (`internal/common/builtin_structs.rs`) has just the unicode `text` of the key, the
+`KeyboardModifiers` active at the time, and a `repeat` flag that is true for auto-repeat presses
+and always false for releases.
 
-pub struct KeyboardModifiers {
-    pub alt: bool,
-    pub control: bool,
-    pub meta: bool,
-    pub shift: bool,
-}
-```
+`KeyboardModifiers` (same file) is four bools: `alt`, `control`, `shift` and `meta`. On macOS
+`control` is the Command key (⌘) and `meta` is the Control key; on Windows `meta` is the Windows
+key.
+
+`InternalKeyEvent` (`internal/core/input.rs`) wraps that public event and adds what the runtime
+needs: the `KeyEventType`, the input-method composition fields (the replacement range, the
+pre-edit text and its selection, the cursor and anchor positions) and, on Windows, the text
+without modifiers — needed to tell Ctrl+Alt apart from AltGr.
+
+`KeyEventType` is `KeyPressed`, `KeyReleased`, `UpdateComposition` (the input method updating the
+pre-edit text) or `CommitComposition` (the composition's final result replacing it).
 
 ### Key Codes
 
-Special keys are encoded as Unicode private-use characters:
-
-```rust
-pub mod key_codes {
-    pub const Backspace: char = '\u{0008}';
-    pub const Tab: char = '\u{0009}';
-    pub const Return: char = '\u{000D}';
-    pub const Escape: char = '\u{001B}';
-    pub const LeftArrow: char = '\u{F702}';
-    pub const RightArrow: char = '\u{F703}';
-    pub const UpArrow: char = '\u{F700}';
-    pub const DownArrow: char = '\u{F701}';
-    // ... more in key_codes module
-}
-```
+Special keys are encoded as characters — the control characters where one exists (Backspace, Tab,
+Return, Escape), Unicode private-use characters otherwise (the arrow keys, the function keys,
+...). One table lists them all, along with each key's winit, Qt, xkb and muda name:
+`for_each_keys!` in `internal/common/key_codes.rs`. The `key_codes` module of
+`internal/core/input.rs` expands it into the `char` constants and the public `Key` enum, and each
+backend expands the same table into its own key mapping.
 
 ### Keyboard Event Flow
 
@@ -367,109 +271,48 @@ WindowInner::process_key_input()
 
 ### Shortcuts
 
-```rust
-impl KeyEvent {
-    /// Check for standard shortcuts (Ctrl+C, etc.)
-    pub fn shortcut(&self) -> Option<StandardShortcut>;
+`InternalKeyEvent::shortcut()` recognizes the standard application shortcuts and
+`text_shortcut()` the text-editing ones. Both are in `internal/core/input.rs`, and both are
+platform-aware: Redo is Ctrl+Y on Windows and Ctrl+Shift+Z elsewhere, and the clipboard
+shortcuts are left to the browser on wasm.
 
-    /// Check for text editing shortcuts
-    pub fn text_shortcut(&self) -> Option<TextShortcut>;
-}
+`StandardShortcut` is `Copy`, `Cut`, `Paste`, `SelectAll`, `Find`, `Save`, `Print`, `Undo`,
+`Redo` and `Refresh`.
 
-pub enum StandardShortcut {
-    Copy, Cut, Paste, SelectAll, Find, Save, Print, Undo, Redo, Refresh,
-}
-
-pub enum TextShortcut {
-    Move(TextCursorDirection),
-    DeleteForward, DeleteBackward,
-    DeleteWordForward, DeleteWordBackward,
-    DeleteToStartOfLine,
-}
-```
+`TextShortcut` is `Move(TextCursorDirection)` plus the deletions: `DeleteForward`,
+`DeleteBackward`, `DeleteWordForward`, `DeleteWordBackward` and `DeleteToStartOfLine`.
 
 ## Focus Management
 
 ### Focus State
 
-The window tracks the currently focused item:
-
-```rust
-// In WindowInner
-focus_item: RefCell<crate::item_tree::ItemWeak>,
-```
+The window tracks the currently focused item in `WindowInner::focus_item`, an `ItemWeak`.
 
 ### Setting Focus
 
-```rust
-pub fn set_focus_item(
-    &self,
-    new_focus_item: &ItemRc,
-    set_focus: bool,       // true = focus, false = clear focus
-    reason: FocusReason,
-)
-```
+`WindowInner::set_focus_item()` takes the item, a bool saying whether to focus it or clear the
+focus, and the `FocusReason`. See `internal/core/window.rs`.
 
 ### FocusReason
 
-```rust
-#[non_exhaustive]
-pub enum FocusReason {
-    /// A built-in function invocation caused the event (`.focus()`, `.clear-focus()`)
-    Programmatic,
-    /// Keyboard navigation caused the event (tabbing)
-    TabNavigation,
-    /// A mouse click caused the event
-    PointerClick,
-    /// A popup caused the event
-    PopupActivation,
-    /// The window manager changed the active window and caused the event
-    WindowActivation,
-}
-```
+`FocusReason` (`internal/common/enums.rs`) says what caused the change: `Programmatic` (a
+`.focus()` or `.clear-focus()` call), `TabNavigation`, `PointerClick`, `PopupActivation`, or
+`WindowActivation` when the window manager changed the active window.
 
 ### Focus Events
 
-Items receive focus events:
-
-```rust
-pub enum FocusEvent {
-    FocusIn(FocusReason),
-    FocusOut(FocusReason),
-}
-
-pub enum FocusEventResult {
-    FocusAccepted,
-    FocusIgnored,
-}
-```
+Items receive a `FocusEvent` — `FocusIn` or `FocusOut`, each carrying the `FocusReason` — and
+answer with `FocusEventResult::FocusAccepted` or `FocusIgnored`; an ignored event is offered to
+other items. See `internal/core/input.rs`.
 
 ### Focus Chain Navigation
 
-Tab/Shift+Tab navigation traverses the item tree:
-
-```rust
-// Forward: depth-first, children before siblings
-fn default_next_in_local_focus_chain(index: u32, item_tree: &ItemTreeNodeArray) -> Option<u32> {
-    // First try first child
-    if let Some(child) = item_tree.first_child(index) {
-        return Some(child);
-    }
-    // Then try next sibling, or parent's next sibling
-    step_out_of_node(index, item_tree)
-}
-
-// Backward: reverse of forward
-fn default_previous_in_local_focus_chain(index: u32, item_tree: &ItemTreeNodeArray) -> Option<u32> {
-    // Try previous sibling's deepest descendant
-    if let Some(previous) = item_tree.previous_sibling(index) {
-        Some(step_into_node(item_tree, previous))
-    } else {
-        // Or parent
-        item_tree.parent(index)
-    }
-}
-```
+Tab/Shift+Tab navigation traverses the item tree depth-first, children before siblings. Forward,
+`default_next_in_local_focus_chain()` takes the first child if there is one, otherwise it steps
+out to the next sibling or the nearest ancestor's next sibling. Backward,
+`default_previous_in_local_focus_chain()` takes the deepest last descendant of the previous
+sibling, or the parent when there is no previous sibling.
+See `internal/core/item_focus.rs`, and [item-tree.md](item-tree.md#focus-management).
 
 ### Focus Delegation
 
@@ -484,29 +327,11 @@ component MyInput {
 
 ## Text Cursor Blinker
 
-For text input cursor animation:
-
-```rust
-pub struct TextCursorBlinker {
-    cursor_visible: Property<bool>,
-    cursor_blink_timer: Timer,
-}
-
-impl TextCursorBlinker {
-    /// Create binding that toggles visibility
-    pub fn set_binding(
-        instance: Pin<Rc<TextCursorBlinker>>,
-        prop: &Property<bool>,
-        cycle_duration: Duration,
-    );
-
-    /// Start blinking
-    pub fn start(self: &Pin<Rc<Self>>, cycle_duration: Duration);
-
-    /// Stop blinking (e.g., window loses focus)
-    pub fn stop(&self);
-}
-```
+For text input cursor animation. `TextCursorBlinker` (`internal/core/input.rs`) is a
+`Property<bool>` plus the timer that toggles it. `set_binding()` binds a caller's property to that
+visibility and starts the timer; `start()` and `stop()` control the blinking directly — `stop()`
+is what runs when the window loses focus. `set_binding()` and `start()` both take the
+`SlintContext` and the blink cycle duration; `stop()` takes neither.
 
 ## Delayed Event Handling
 
@@ -532,6 +357,7 @@ fn input_event(
     event: &MouseEvent,
     _window_adapter: &Rc<dyn WindowAdapter>,
     self_rc: &ItemRc,
+    _cursor: &mut MouseCursorInner,
 ) -> InputEventResult {
     match event {
         MouseEvent::Pressed { button: PointerEventButton::Left, .. } => {
@@ -559,6 +385,7 @@ fn input_event_filter_before_children(
     event: &MouseEvent,
     _window_adapter: &Rc<dyn WindowAdapter>,
     _self_rc: &ItemRc,
+    _cursor: &mut MouseCursorInner,
 ) -> InputEventFilterResult {
     if self.should_intercept(event) {
         InputEventFilterResult::Intercept
@@ -616,7 +443,7 @@ fn input_event(...) -> InputEventResult {
 
 ```rust
 // Get current focus item
-let focus = window.focus_item();
+let focus = WindowInner::from_pub(&window).focus_item.borrow().clone();
 if let Some(item) = focus.upgrade() {
     println!("Focused: {:?}", item.index());
 }

--- a/docs/development/item-tree.md
+++ b/docs/development/item-tree.md
@@ -22,27 +22,16 @@ The item tree is Slint's runtime representation of UI components:
 | `internal/core/item_focus.rs` | Focus chain traversal functions |
 | `internal/core/item_rendering.rs` | ItemCache, rendering infrastructure |
 | `internal/core/window.rs` | WindowInner, input handling |
-| `internal/interpreter/dynamic_item_tree.rs` | Runtime ItemTree for interpreter |
+| `internal/interpreter/instance.rs` | Runtime instance tree for the interpreter |
+| `internal/interpreter/item_tree_vtable.rs` | `ItemTreeVTable` implementation for that instance |
 
 ## Tree Node Structure
 
-Items are stored as a flat array with parent/child indices:
-
-```rust
-pub enum ItemTreeNode {
-    Item {
-        is_accessible: bool,      // Has accessibility info
-        children_count: u32,      // Number of children
-        children_index: u32,      // Index of first child
-        parent_index: u32,        // Parent's index
-        item_array_index: u32,    // Index in item storage
-    },
-    DynamicTree {
-        index: u32,               // Repeater index
-        parent_index: u32,
-    },
-}
-```
+Items are stored as a flat array with parent/child indices. An `ItemTreeNode` is either a
+static `Item` — its parent index, the index and count of its children, its slot in the item
+array, and whether it carries accessibility properties — or a `DynamicTree` placeholder holding
+its parent index and the index passed to the `visit_dynamic` callback.
+See `ItemTreeNode` in `internal/core/item_tree.rs`.
 
 - Root item always at index 0
 - Children stored contiguously
@@ -52,12 +41,8 @@ pub enum ItemTreeNode {
 
 ### ItemRc - Reference to an Item
 
-```rust
-pub struct ItemRc {
-    item_tree: VRc<ItemTreeVTable>,  // Containing tree
-    index: u32,                       // Index within tree
-}
-```
+A strong reference to the containing item tree plus the item's index within it.
+See `ItemRc` in `internal/core/item_tree.rs`.
 
 **Navigation methods:**
 - `parent_item()` - Get parent (with optional popup boundary)
@@ -91,37 +76,31 @@ Both paths implement the same `ItemTreeVTable`:
 
 | Aspect | Compiled | Interpreted |
 |--------|----------|-------------|
-| Tree structure | Compile-time array | `ItemTreeDescription` |
-| Properties | Struct fields | Dynamic offsets |
-| Bindings | Generated code | Runtime evaluation |
-| VTable | Static | `dynamic_item_tree.rs` |
+| Tree structure | Compile-time array | Flat array built at instantiation |
+| Properties | Struct fields | Individually heap-allocated, indexed by LLR index |
+| Bindings | Generated code | Runtime evaluation of the LLR expression |
+| VTable | Generated per component | One static vtable shared by every instance |
 
-**Interpreter key types:**
-- `ItemTreeDescription<'id>` - Component metadata
-- `ItemTreeBox<'id>` - Instance container
-- `InstanceRef<'a, 'id>` - Runtime instance access
+**Interpreter key types** (`internal/interpreter/`):
+- `Instance` (`instance.rs`) - the top-level item tree handed to i-slint-core, owning the flat
+  node array and the tables that map each flat index back to its sub-component
+- `SubComponentInstance` (`instance.rs`) - the runtime instance of one LLR sub-component: its
+  properties, callbacks, items, nested sub-components and repeaters
+- `ComponentDefinitionInner` / `ComponentInstanceInner` (`component.rs`) - what the public
+  `ComponentDefinition` and `ComponentInstance` wrap
 
 ## Tree Traversal
 
 ### Traversal Order
 
-```rust
-pub enum TraversalOrder {
-    BackToFront,  // Rendering (background → foreground)
-    FrontToBack,  // Hit testing (foreground → background)
-}
-```
+`TraversalOrder` is `BackToFront` for rendering (background → foreground) and `FrontToBack` for
+hit testing (foreground → background). See `internal/core/item_tree.rs`.
 
 ### Visitor Pattern
 
-```rust
-pub struct VisitChildrenResult(u64);
-
-impl VisitChildrenResult {
-    pub const CONTINUE: Self;  // Keep traversing
-    pub fn abort(index, repeater_index) -> Self;  // Stop here
-}
-```
+A visitor returns a `VisitChildrenResult`: either the `CONTINUE` constant, or `abort()` with the
+item index and repeater index it stopped at. It is a packed `u64` rather than an enum because
+that crosses the FFI boundary more easily. See `internal/core/item_tree.rs`.
 
 ### Traversal Uses
 
@@ -134,18 +113,11 @@ impl VisitChildrenResult {
 
 ## Focus Management
 
-Focus traversal functions in `item_focus.rs`:
-
-```rust
-// Next item in tab order
-pub fn default_next_in_local_focus_chain(index, item_tree) -> Option<u32>
-
-// Previous item in tab order
-pub fn default_previous_in_local_focus_chain(index, item_tree) -> Option<u32>
-
-// Step out to sibling or parent's sibling
-pub fn step_out_of_node(index, item_tree) -> Option<u32>
-```
+`internal/core/item_focus.rs` has three public functions, all taking an index into an
+`ItemTreeNodeArray` and returning the next index or `None`:
+`default_next_in_local_focus_chain()` (first child, else step out),
+`default_previous_in_local_focus_chain()` (deepest last descendant of the previous sibling, else
+the parent), and `step_out_of_node()`, which walks up until it finds a next sibling.
 
 **Focus on ItemRc:**
 - `next_focus_item()` - Tab key navigation
@@ -155,42 +127,36 @@ pub fn step_out_of_node(index, item_tree) -> Option<u32>
 
 ### Creating a Component
 
-```rust
-// Interpreter path
-pub fn instantiate(
-    description: Rc<ItemTreeDescription>,
-    parent_ctx: Option<ErasedItemTreeBoxWeak>,
-    root: Option<ErasedItemTreeBoxWeak>,
-    window_options: Option<&WindowOptions>,
-    globals: GlobalStorage,
-) -> DynamicComponentVRc
-```
+On the interpreter path, `ComponentDefinition::create_with_options()`
+(`internal/interpreter/api.rs`) dispatches on a `WindowOptions` to one of the three constructors
+on `ComponentDefinitionInner` in `internal/interpreter/component.rs`.
 
 ### Window Options
 
-```rust
-pub enum WindowOptions {
-    CreateNewWindow,                    // New window
-    UseExistingWindow(WindowAdapterRc), // Attach to existing
-    Embed { parent_item_tree, parent_item_tree_index }, // Sub-component
-}
-```
+`WindowOptions` picks how the new instance gets its window: `CreateNewWindow`,
+`UseExistingWindow` with an existing `WindowAdapterRc`, or `Embed` into a parent item tree at a
+given index. See `internal/interpreter/api.rs`.
 
 ### Initialization Sequence
 
-1. Allocate instance memory
-2. Create `ItemTreeBox` wrapper
-3. Initialize properties and bindings
-4. Call `register_item_tree()` to init items
-5. Register with window adapter
+Still on the interpreter path (`Instance::new_with_options()` and `finalize_instance()` in
+`internal/interpreter/instance.rs`):
+
+1. Build the `SubComponentInstance` tree from the LLR
+2. Build the flat `ItemTreeNode` array and the tables mapping each flat index back to the
+   sub-component that owns it
+3. Wrap it in a `VRc<ItemTreeVTable, Instance>` and back-link the weak references
+4. Install the property bindings, and for a top-level instance attach the window adapter — before
+   the init code, so `set_component()` can't clear a focus that `forward-focus` just set
+5. Call `register_item_tree()`, which runs `Item::init()` on every native item and registers the
+   tree with the window adapter
+6. Run the component's `init_code`
 
 ### Cleanup
 
-```rust
-pub fn unregister_item_tree(base, item_tree, item_array, window_adapter)
-```
-- Frees graphics resources
-- Closes dependent popups
+`unregister_item_tree()` (`internal/core/item_tree.rs`) walks the items once to:
+- Free graphics resources
+- Close dependent popups
 
 ## Item VTable
 

--- a/docs/development/layout-system.md
+++ b/docs/development/layout-system.md
@@ -32,16 +32,9 @@ Layout types:
 
 ### LayoutInfo (Runtime)
 
-```rust
-pub struct LayoutInfo {
-    pub min: Coord,           // Minimum size
-    pub max: Coord,           // Maximum size
-    pub min_percent: Coord,   // Minimum as % of parent
-    pub max_percent: Coord,   // Maximum as % of parent
-    pub preferred: Coord,     // Preferred size
-    pub stretch: f32,         // Stretch factor (0.0 = don't stretch)
-}
-```
+The constraints for one item along one axis: a min and a max, the same two again as a percentage
+of the parent, a preferred size, and a stretch factor (0.0 means don't stretch). Sizes are
+`Coord`, the stretch is an `f32`. See `LayoutInfo` in `internal/core/layout.rs`.
 
 ### Constraint Merging
 
@@ -142,47 +135,27 @@ Child x/y/width/height bound to cache access expressions
 
 ### Compiler-Side
 
-```rust
-// internal/compiler/layout.rs
+All in `internal/compiler/layout.rs`:
 
-pub struct GridLayout {
-    pub elems: Vec<GridLayoutElement>,  // Cells
-    pub geometry: LayoutGeometry,        // Padding, spacing, alignment
-}
-
-pub struct BoxLayout {
-    pub orientation: Orientation,  // Horizontal or Vertical
-    pub elems: Vec<LayoutItem>,
-    pub geometry: LayoutGeometry,
-}
-
-pub struct LayoutConstraints {
-    pub min_width: Option<NamedReference>,
-    pub max_width: Option<NamedReference>,
-    // ... other constraint properties as references
-}
-```
+- `GridLayout` - the cells plus the `LayoutGeometry` (padding, spacing, alignment). It also
+  carries the button roles when the grid is really a `Dialog`, and whether any row/column
+  expression uses `auto`.
+- `BoxLayout` - the orientation, the items and the same `LayoutGeometry`, plus the
+  `cross-axis-alignment` property if one was set.
+- `LayoutConstraints` - one `Option<NamedReference>` per `min-`/`max-`/`preferred-` width and
+  height and per stretch, the two fixed-size flags, and a `LayoutConstraintLocality` with one bool
+  per named reference recording whether it was set on the element itself rather than inherited
+  from a base component. Inherited ones are already baked into the element's `layoutinfo-*`, so a
+  parent that measured the cell through its layout-info must not re-apply them.
 
 ### Runtime
 
-```rust
-// internal/core/layout.rs
+Both in `internal/core/layout.rs`:
 
-pub struct GridLayoutData {
-    pub size: Coord,
-    pub spacing: Coord,
-    pub padding: Padding,
-    pub organized_data: GridLayoutOrganizedData,
-}
-
-pub struct BoxLayoutData<'a> {
-    pub size: Coord,
-    pub spacing: Coord,
-    pub padding: Padding,
-    pub alignment: LayoutAlignment,
-    pub cells: Slice<'a, LayoutItemInfo>,
-}
-```
+- `GridLayoutData` - the available size, the spacing and padding, and the
+  `GridLayoutOrganizedData` produced by `organize_grid_layout()`.
+- `BoxLayoutData` - the available size, the spacing and padding, the `LayoutAlignment`, and a
+  borrowed slice of `LayoutItemInfo`, one per cell.
 
 ## Layout Cache Formats
 

--- a/docs/development/lsp-architecture.md
+++ b/docs/development/lsp-architecture.md
@@ -107,16 +107,9 @@ The LSP server advertises its capabilities via the `ServerCapabilities` type in 
 
 ### Completion Contexts
 
-The completion system provides different `CompletionItems` based on the context:
-
-```rust
-pub(crate) fn completion_at(
-    document_cache: &mut DocumentCache,
-    token: SyntaxToken,
-    offset: TextSize,
-    client_caps: Option<&CompletionClientCapabilities>,
-) -> Option<Vec<CompletionItem>>;
-```
+`completion_at()` (`tools/lsp/language/completion.rs`) is the entry point: it takes the token and
+offset the cursor is at, plus the client's completion capabilities (to decide whether snippets
+can be used), and returns the `CompletionItem`s for that context.
 
 **Contexts handled:**
 - **String literals**: Path completion for imports and `@image-url`
@@ -127,15 +120,7 @@ pub(crate) fn completion_at(
 
 ### Element Scope Completion
 
-```rust
-fn resolve_element_scope(
-    element: syntax_nodes::Element,
-    document_cache: &DocumentCache,
-    with_snippets: bool,
-) -> Option<Vec<CompletionItem>>;
-```
-
-Suggests:
+`resolve_element_scope()` (same file) takes the `Element` node and suggests:
 - Available child element types
 - Properties from element type
 - Callbacks from element type
@@ -144,15 +129,7 @@ Suggests:
 
 ### Expression Scope Completion
 
-```rust
-fn resolve_expression_scope(
-    lookup_ctx: &LookupCtx,
-    document_cache: &DocumentCache,
-    snippet_support: bool,
-) -> Option<Vec<CompletionItem>>;
-```
-
-Suggests:
+`resolve_expression_scope()` (same file) takes a compiler `LookupCtx` and suggests:
 - Local variables
 - Properties from scope
 - Built-in functions (`Math.*`, `Colors.*`)
@@ -166,14 +143,7 @@ The semantic token types are lookup indices into a legend of `LEGEND_TYPES` and 
 
 ## Go-to-Definition
 
-Navigates to declarations:
-
-```rust
-pub fn goto_definition(
-    document_cache: &mut DocumentCache,
-    token: SyntaxToken,
-) -> Option<GotoDefinitionResponse>;
-```
+`goto_definition()` (`tools/lsp/language/goto.rs`) resolves the token to its declaration.
 
 **Handles:**
 - Element IDs → Element definition
@@ -211,26 +181,21 @@ The LSP communicates with the preview via a protocol defined in the `i-slint-liv
 (`internal/live-preview/protocol/`), which implements the `LspToPreviewMessage` and
 `PreviewToLspMessage` enums used for message traffic.
 
-
 ### Preview State
 
-```rust
-pub struct PreviewState {
-    pub app_window: Option<ui::AppWindow>,
-    pub api: slint::Weak<ui::Api<'static>>,
-    handle: Rc<RefCell<Option<ComponentInstance>>>,
-    document_cache: Rc<RefCell<Option<Rc<DocumentCache>>>>,
-    selected: Option<ElementSelection>,
+`PreviewState` (`tools/lsp/preview.rs`) is everything the preview owns:
 
-    source_code: SourceCodeCache,
-    pub config: PreviewConfig,
-    current_previewed_component: Option<PreviewComponent>,
-    loading_state: PreviewFutureState,
-
-    pub to_lsp: RefCell<Option<Rc<dyn PreviewToLsp>>>,
-    // ... undo/redo, live-data, and dependency-tracking fields
-}
-```
+- The preview's own UI (`app_window` and the `Api` weak handle) and the property declarations it
+  shows
+- The previewed `ComponentInstance` and the `DocumentCache` it was built from
+- The current element selection, plus whether the editor still has to be told about it and
+  whether a workspace edit is already in flight
+- The known components, the currently previewed one, its load behavior, the `PreviewFutureState`
+  of the loading and the timer that delays showing it
+- The source code cache, the resources and dependencies to watch, the `PreviewConfig` and the
+  last user settings synced with the LSP
+- The undo/redo stack, and the initial and current live data
+- `to_lsp`, the channel back to the LSP, and the remote discovery when that feature is on
 
 ### Preview Loading States
 
@@ -271,16 +236,8 @@ Editor                    LSP Server
 
 ### File Watching
 
-The server registers for file change notifications via the editor:
-
-```rust
-let file_system_watcher = DidChangeWatchedFilesRegistrationOptions {
-    watchers: vec![FileSystemWatcher {
-        glob_pattern: GlobPattern::String("**/*".to_string()),
-        kind: Some(WatchKind::Change | WatchKind::Delete | WatchKind::Create),
-    }],
-};
-```
+The server registers a `DidChangeWatchedFilesRegistrationOptions` with the editor, watching
+`**/*` for create, change and delete. See `tools/lsp/language.rs`.
 
 When a file changes on disk:
 1. If the file is not open in the editor, drop it from the cache
@@ -328,15 +285,10 @@ let token = token_at_offset(document.node.as_ref()?, offset)?;
 
 ### Using Lookup Context
 
-```rust
-fn with_lookup_ctx<R>(
-    document_cache: &DocumentCache,
-    node: SyntaxNode,
-    offset: Option<TextSize>,
-    callback: impl FnOnce(&mut LookupCtx) -> R,
-) -> Option<R>;
+`with_lookup_ctx()` (`internal/editor-preview/util.rs`) builds the compiler's `LookupCtx` for a
+syntax node and hands it to a callback:
 
-// Example usage
+```rust
 with_lookup_ctx(document_cache, node, Some(offset), |lookup_context| {
     resolve_expression_scope(lookup_context, document_cache, snippet_support)
 })?
@@ -344,18 +296,9 @@ with_lookup_ctx(document_cache, node, Some(offset), |lookup_context| {
 
 ### Finding Element at Position
 
-`element_at_position` is a method on `DocumentCache`
-(`internal/editor-preview/document_cache.rs`), not a free function:
-
-```rust
-impl DocumentCache {
-    pub fn element_at_position(
-        &self,
-        text_document_uri: &Url,
-        position: &Position,
-    ) -> Option<ElementRcNode>;
-}
-```
+`element_at_position()` is a method on `DocumentCache`
+(`internal/editor-preview/document_cache.rs`), not a free function. Give it a document URI and a
+position and it returns the `ElementRcNode` there.
 
 ### Publishing Diagnostics
 
@@ -381,14 +324,10 @@ RUST_LOG=debug cargo test -p slint-lsp
 
 ### Test Utilities
 
-```rust
-// In language/test.rs
-pub use i_slint_editor_preview::test::{
-    complex_document_cache, empty_document_cache, empty_document_cache_with_experimental, load,
-    loaded_document_cache, loaded_document_cache_with_experimental,
-    loaded_document_cache_with_file_name,
-};
-```
+`tools/lsp/language/test.rs` re-exports the helpers from `i_slint_editor_preview::test` that build
+an empty, loaded or deliberately complex `DocumentCache` for a test to work against, along with
+`load()`, which loads content into an existing `EditorSession` and hands back its URL and
+diagnostics.
 
 ## Debugging Tips
 

--- a/docs/development/model-repeater-system.md
+++ b/docs/development/model-repeater-system.md
@@ -29,75 +29,41 @@ The Model system provides data for repeated elements in Slint's `for` expression
 
 ### The Model Trait
 
-```rust
-pub trait Model {
-    type Data;
+A `Model` has an associated `Data` type and three methods with no default. `row_count()` and
+`row_data()` supply the data — the latter returns `None` past the end and does *not* register a
+dependency, `ModelExt::row_data_tracked()` being the tracking equivalent — and `model_tracker()`
+returns the model's `ModelNotify`, or `&()` for a model that never changes.
 
-    /// Number of rows in the model
-    fn row_count(&self) -> usize;
+The mutating methods — `set_row_data()`, `push_row()`, `remove_row()`, `insert_row()` — all
+default to printing a warning, so a read-only model can leave them out. An implementation that
+does support them must call the matching `ModelNotify` method afterwards.
 
-    /// Get data for a row (None if out of bounds)
-    fn row_data(&self, row: usize) -> Option<Self::Data>;
-
-    /// Set data for a row (optional, default prints warning)
-    fn set_row_data(&self, row: usize, data: Self::Data) { ... }
-
-    /// Return the tracker for change notifications
-    fn model_tracker(&self) -> &dyn ModelTracker;
-
-    /// For downcasting (typically return `self`)
-    fn as_any(&self) -> &dyn core::any::Any { &() }
-}
-```
+`as_any()` defaults to `&()` and should return `self` so a concrete model can be recovered from a
+`ModelRc`. `iter()` is provided.
+See `Model` in `internal/core/model.rs`.
 
 ### ModelTracker
 
-The interface for dependency tracking:
-
-```rust
-pub trait ModelTracker {
-    /// Attach a peer to receive change notifications
-    fn attach_peer(&self, peer: ModelPeer);
-
-    /// Register dependency on row count changes
-    fn track_row_count_changes(&self);
-
-    /// Register dependency on a specific row's data
-    fn track_row_data_changes(&self, row: usize);
-}
-```
+The interface for dependency tracking: `attach_peer()` registers a peer for change
+notifications, and `track_row_count_changes()` / `track_row_data_changes(row)` register the row
+count or one row's data as a dependency of the binding currently being evaluated.
+`track_any_change(row_count)` registers both; its default implementation loops over every row,
+but `ModelNotify` overrides it with a single dependency whose cost does not grow with the model.
+See `ModelTracker` in `internal/core/model.rs`.
 
 ### ModelNotify
 
-The standard implementation of change notifications:
-
-```rust
-pub struct ModelNotify {
-    inner: OnceCell<Pin<Box<ModelNotifyInner>>>,
-}
-
-impl ModelNotify {
-    /// Notify that a row's data changed
-    pub fn row_changed(&self, row: usize);
-
-    /// Notify that rows were inserted
-    pub fn row_added(&self, index: usize, count: usize);
-
-    /// Notify that rows were removed
-    pub fn row_removed(&self, index: usize, count: usize);
-
-    /// Notify that the entire model was reset
-    pub fn reset(&self);
-}
-```
+The standard implementation of change notifications. A model owning one calls `row_changed()`,
+`row_added(index, count)`, `row_removed(index, count)` or `reset()` after mutating its data.
+See `ModelNotify` in `internal/core/model/model_peer.rs`.
 
 ### ModelRc
 
-The standard wrapper for models in Slint's public API:
+The standard wrapper for models in Slint's public API.
+`ModelRc<T>` holds an `Option<Rc<dyn Model<Data = T>>>` — `None` is the empty model, so
+`ModelRc::default()` allocates nothing. See `internal/core/model.rs`.
 
 ```rust
-pub struct ModelRc<T>(Option<Rc<dyn Model<Data = T>>>);
-
 // Construction
 ModelRc::default()                    // Empty model
 ModelRc::new(vec_model)               // From any Model impl
@@ -130,50 +96,25 @@ ModelRc::from(rc_model)              // From Rc<Model>
 
 ### ModelChangeListener
 
-Interface implemented by peers (like Repeater):
-
-```rust
-pub trait ModelChangeListener {
-    fn row_changed(self: Pin<&Self>, row: usize);
-    fn row_added(self: Pin<&Self>, index: usize, count: usize);
-    fn row_removed(self: Pin<&Self>, index: usize, count: usize);
-    fn reset(self: Pin<&Self>);
-}
-```
+Interface implemented by peers such as `RepeaterTracker`: the same four notifications
+`ModelNotify` sends, each taking `self: Pin<&Self>`. A `ModelChangeListenerContainer<T>` wraps an
+implementation and hands out the `ModelPeer` for it.
+See `internal/core/model/model_peer.rs`.
 
 ## Built-in Model Implementations
 
 ### VecModel
 
-The most common mutable model:
-
-```rust
-pub struct VecModel<T> {
-    array: RefCell<Vec<T>>,
-    notify: ModelNotify,
-}
-
-impl<T> VecModel<T> {
-    pub fn push(&self, value: T);
-    pub fn insert(&self, index: usize, value: T);
-    pub fn remove(&self, index: usize) -> T;
-    pub fn set_vec(&self, new: impl Into<Vec<T>>);
-    pub fn extend<I: IntoIterator<Item = T>>(&self, iter: I);
-    pub fn clear(&self);
-    pub fn swap(&self, a: usize, b: usize);
-}
-```
+The most common mutable model: a `RefCell<Vec<T>>` plus a `ModelNotify`. It offers `push()`,
+`insert()`, `remove()`, `swap()`, `clear()`, `set_vec()`, `extend()` and `extend_from_slice()`,
+each notifying as needed. `from_slice()` builds a `ModelRc` directly.
+See `VecModel` in `internal/core/model.rs`.
 
 ### SharedVectorModel
 
-For shared/cloneable vectors:
-
-```rust
-pub struct SharedVectorModel<T> {
-    array: RefCell<SharedVector<T>>,
-    notify: ModelNotify,
-}
-```
+A `SharedVector<T>` plus a `ModelNotify`. Its own API is much smaller than `VecModel`'s: `push()`
+to append, and `shared_vector()` to get a clone of the backing vector out.
+See `SharedVectorModel` in `internal/core/model.rs`.
 
 ### Primitive Models
 
@@ -269,53 +210,29 @@ The `Repeater<C>` manages instantiation of item trees based on model data. It (a
 
 ### Structure
 
-```rust
-pub struct Repeater<C: RepeatedItemTree>(
-    ModelChangeListenerContainer<RepeaterTracker<C>>
-);
+- `Repeater<C>` is a newtype over a `ModelChangeListenerContainer<RepeaterTracker<C>>`.
+- `RepeaterTracker<C>` is what actually listens: the instances, the model property, an `is_dirty`
+  property set when the model becomes dirty, a separate `instance_generation` property marked
+  dirty by `ensure_updated()` once instances have actually been added or removed (layout and
+  visit code depend on that one, so they re-evaluate after the update pass rather than when the
+  model first changes), and a `PropertyTracker` for the ListView geometry.
+- `RepeaterInner<C>` holds the instance vector — each entry a `RepeatedInstanceState` and an
+  optional item tree — plus the `RepeaterLayoutState`.
+- `RepeaterLayoutState` is the persistent ListView layout state: the model row index of the first
+  instance, the cached average item height, the content y from the previous pass (used to tell
+  scroll direction), and the y position of the item at `offset`.
 
-pub struct RepeaterTracker<T: RepeatedItemTree> {
-    inner: RefCell<RepeaterInner<T>>,
-    model: Property<ModelRc<T::Data>>,
-    is_dirty: Property<bool>,
-    /// Marked dirty when instances are added/removed, separately from `is_dirty`.
-    instance_generation: Property<()>,
-    listview_geometry_tracker: PropertyTracker,
-}
-
-struct RepeaterInner<C: RepeatedItemTree> {
-    instances: Vec<(RepeatedInstanceState, Option<ItemTreeRc<C>>)>,
-    /// ListView-specific layout state (offset, cached heights, scroll position).
-    layout_state: RepeaterLayoutState,
-}
-
-/// Persistent layout state for a ListView repeater.
-pub struct RepeaterLayoutState {
-    offset: usize,              // For ListView virtualization
-    cached_item_height: Coord,
-    previous_viewport_y: Coord,
-    anchor_y: Coord,
-}
-```
+All in `internal/core/model/repeater.rs`.
 
 ### RepeatedItemTree Trait
 
-Item trees that can be repeated implement:
-
-```rust
-pub trait RepeatedItemTree: ItemTree + HasStaticVTable<ItemTreeVTable> + 'static {
-    type Data: 'static;
-
-    /// Called when model data changes
-    fn update(&self, index: usize, data: Self::Data);
-
-    /// Called after first instantiation
-    fn init(&self) {}
-
-    /// For ListView layout
-    fn listview_layout(self: Pin<&Self>, offset_y: &mut LogicalLength) -> LogicalLength;
-}
-```
+`RepeatedItemTree` extends `ItemTree` with an associated `Data` type and `update(index, data)`,
+called whenever the model data for that instance changes. `init()` runs once after instantiation
+and the first `update()`. `listview_layout()` places the item and advances `offset_y` to the next
+position, returning the minimum item width for the ListView's content width. `layout_item_info()`
+returns what a surrounding layout needs, taking a child index for the repeated-`Row` case. All
+but `update()` have default implementations.
+See `RepeatedItemTree` in `internal/core/model/repeater.rs`.
 
 ### Update Flow
 
@@ -324,23 +241,12 @@ pub trait RepeatedItemTree: ItemTree + HasStaticVTable<ItemTreeVTable> + 'static
 3. **During rendering** → `ensure_updated()` called
 4. **Repeater** creates/updates/removes instances as needed
 
-```rust
-impl<C: RepeatedItemTree> Repeater<C> {
-    /// Ensure all instances are up-to-date
-    pub fn ensure_updated(self: Pin<&Self>, init: impl Fn() -> ItemTreeRc<C>);
-
-    /// For ListView with virtualization
-    pub fn ensure_updated_listview(
-        self: Pin<&Self>,
-        init: impl Fn() -> ItemTreeRc<C>,
-        viewport_width: Pin<&Property<LogicalLength>>,
-        viewport_height: Pin<&Property<LogicalLength>>,
-        viewport_y: Pin<&Property<LogicalLength>>,
-        listview_width: LogicalLength,
-        listview_height: Pin<&Property<LogicalLength>>,
-    );
-}
-```
+`Repeater::ensure_updated()` takes a closure that instantiates one item tree and brings all
+instances up to date; `ensure_updated_listview()` does the same for the virtualized case, also
+taking the ListView's content size and y properties and its own width and height. Both return
+whether anything changed. `ensure_updated_listview_callback()` is the trait-object variant the
+interpreter uses, for consumers that cannot hand out the content properties directly.
+See `internal/core/model/repeater.rs`.
 
 ### ListView Virtualization
 
@@ -359,14 +265,10 @@ The `offset` tracks which model row corresponds to `instances[0]`.
 
 ## Conditional
 
-For `if` expressions in Slint (0 or 1 instances):
-
-```rust
-pub struct Conditional<C: RepeatedItemTree> {
-    model: Property<bool>,
-    instance: RefCell<Option<ItemTreeRc<C>>>,
-}
-```
+For `if` expressions in Slint (0 or 1 instances): a `bool` property standing in for the model,
+the single optional instance, and the same `instance_generation` property `RepeaterTracker` uses.
+Unlike a repeater it keeps the existing instance while the condition stays true, so no spurious
+re-init happens. See `Conditional` in `internal/core/model/repeater.rs`.
 
 ## Row Data Tracking
 

--- a/docs/development/property-binding-deep-dive.md
+++ b/docs/development/property-binding-deep-dive.md
@@ -22,38 +22,25 @@ Slint's property system is the reactive foundation of the entire framework. Ever
 | `internal/core/properties.rs` | Core Property<T>, bindings, dependency tracking |
 | `internal/core/properties/change_tracker.rs` | ChangeTracker for property change callbacks |
 | `internal/core/properties/properties_animations.rs` | Animated property values |
+| `internal/core/properties/two_way_binding.rs` | Two-way binding via a shared common property |
 | `internal/core/properties/ffi.rs` | FFI bindings for C++ interop |
 
 ## Core Data Structures
 
 ### Property<T>
 
-The main property type that holds a value and optional binding:
-
-```rust
-#[repr(C)]
-pub struct Property<T> {
-    handle: PropertyHandle,      // Binding state + dependency list
-    value: UnsafeCell<T>,        // The actual value (interior mutability)
-    pinned: PhantomPinned,       // Must be pinned for dependency tracking
-}
-```
+A `Property<T>` is a `PropertyHandle` (the binding state and dependency list), the value itself
+in an `UnsafeCell` — only safe to touch while the handle's lock flag is clear — and a
+`PhantomPinned`. See `Property` in `internal/core/properties.rs`.
 
 **Important**: Properties must be `Pin`ned because dependency nodes store raw pointers back to them. Moving a property would invalidate these pointers.
 
 ### PropertyHandle
 
-The handle manages binding state using bit flags in a single `usize`:
-
-```rust
-struct PropertyHandle {
-    handle: Cell<usize>,
-}
-
-// Bit flags:
-const BINDING_BORROWED: usize = 0b01;           // Lock flag (prevents recursion)
-const BINDING_POINTER_TO_BINDING: usize = 0b10; // Has binding vs dependency list
-```
+`PropertyHandle` wraps a single `Cell<*mut ()>`. The pointer is always aligned, so its two least
+significant bits are free for flags: `BINDING_BORROWED` (0b01), the lock flag that catches
+recursion, and `BINDING_POINTER_TO_BINDING` (0b10), which says whether the pointer is a binding.
+See `internal/core/properties.rs`.
 
 The handle serves dual purpose:
 - **With binding**: Points to a `BindingHolder` (bit 1 set)
@@ -61,33 +48,18 @@ The handle serves dual purpose:
 
 ### BindingHolder
 
-Wraps a binding callable with metadata:
-
-```rust
-#[repr(C)]
-struct BindingHolder<B = ()> {
-    dependencies: Cell<usize>,   // Head of dependents list (who depends on us)
-    dep_nodes: Cell<...>,        // Nodes in other properties' dependency lists
-    vtable: &'static BindingVTable,
-    dirty: Cell<bool>,           // Needs re-evaluation?
-    is_two_way_binding: bool,
-    binding: B,                  // The actual binding callable
-}
-```
+`BindingHolder<B>` wraps the binding callable `B` with: the head of the list of bindings that
+depend on it, the nodes that link it into the dependency lists of the properties it reads, its
+`BindingVTable`, a `dirty` flag, and a flag saying whether `B` is a `TwoWayBinding<T>`.
+See `internal/core/properties.rs`.
 
 ### Dependency Tracking Structures
 
-```rust
-// Head of a doubly-linked list of dependents
-pub struct DependencyListHead<T>(Cell<*const DependencyNode<T>>);
-
-// Node in the dependency list
-pub struct DependencyNode<T> {
-    next: Cell<*const DependencyNode<T>>,
-    prev: Cell<*const Cell<*const DependencyNode<T>>>,  // Points to prev.next
-    binding: T,  // Pointer to the BindingHolder that depends on us
-}
-```
+`DependencyListHead<T>` is the head of a doubly-linked list of dependents: a cell holding a
+pointer to the first `DependencyNode<T>`. A `DependencyNode<T>` holds its `next` pointer, a `prev`
+pointer that points at the *cell* pointing to itself (so the head and the nodes are unlinked the
+same way), and the `T` — in practice a pointer to the `BindingHolder` that depends on us.
+See `internal/core/properties.rs`.
 
 ## Dependency Tracking Flow
 
@@ -147,35 +119,19 @@ When a property value changes:
 
 ### Lazy Evaluation
 
-Bindings don't evaluate immediately when marked dirty. Instead:
-
-```rust
-// In Property::get()
-unsafe { self.handle.update(self.value.get()) };  // Only evaluates if dirty
-
-// In PropertyHandle::update()
-if binding.dirty.get() {
-    // Clear old dependencies
-    binding.dep_nodes.set(Default::default());
-
-    // Evaluate with CURRENT_BINDING set to this binding
-    CURRENT_BINDING.set(Some(binding), || {
-        (binding.vtable.evaluate)(...)
-    });
-
-    binding.dirty.set(false);
-}
-```
+Bindings don't evaluate immediately when marked dirty. `Property::get()` calls
+`PropertyHandle::update()`, which does nothing unless the binding's `dirty` flag is set. When it
+is, it clears the binding's dependency nodes, sets it as the current binding for the duration of
+the call (`current_binding_storage::set()`, backed by the `CURRENT_BINDING` thread-local), invokes
+the vtable's `evaluate`, and clears `dirty`. If `evaluate` returns `RemoveBinding`, the binding is
+dropped and the value stays as it was left.
+See `PropertyHandle::update` in `internal/core/properties.rs`.
 
 ## Two-Way Bindings
 
-Two-way bindings link properties so changes to either propagate to both:
-
-```rust
-struct TwoWayBinding<T> {
-    common_property: Pin<Rc<Property<T>>>,  // Shared backing property
-}
-```
+Two-way bindings link properties so changes to either propagate to both. A `TwoWayBinding<T>`
+holds nothing but the shared backing property, a `Pin<Rc<Property<T>>>`.
+See `internal/core/properties/two_way_binding.rs`.
 
 **How it works:**
 1. Both properties get a `TwoWayBinding` that points to a shared "common property"
@@ -195,13 +151,12 @@ struct TwoWayBinding<T> {
 
 ## PropertyTracker
 
-For tracking dependencies outside of property bindings:
-
-```rust
-pub struct PropertyTracker<DirtyHandler = ()> {
-    holder: BindingHolder<DirtyHandler>,
-}
-```
+For tracking dependencies outside of property bindings. A `PropertyTracker` is just a
+`BindingHolder` around a dirty handler, which implements `PropertyDirtyHandler`. Its
+`NEEDS_SET_DIRTY` const parameter says whether the tracker can also be dirtied from outside via
+`set_dirty()`; when it can't — the default — a tracker with no tracked dependencies of its own
+skips registering itself as a dependency of outer bindings, since nothing could ever dirty it.
+See `internal/core/properties.rs`.
 
 **Usage:**
 ```rust
@@ -250,14 +205,10 @@ ChangeTracker::run_change_handlers();
 
 Animated properties use special bindings:
 
-```rust
-pub struct AnimatedBindingCallable<T, A> {
-    original_binding: PropertyHandle,  // The underlying binding
-    state: Cell<AnimatedBindingState>, // Animating/NotAnimating/ShouldStart
-    animation_data: RefCell<PropertyValueAnimationData<T>>,
-    compute_animation_details: A,      // Returns animation parameters
-}
-```
+`AnimatedBindingCallable<T, A>` holds the underlying binding as a `PropertyHandle`, the
+`Animating` / `NotAnimating` / `ShouldStart` state, the animation data, the closure `A` that
+returns the animation parameters, and the tick captured by `mark_dirty`.
+See `internal/core/properties/properties_animations.rs`.
 
 **Animation flow:**
 1. When the underlying binding changes, `mark_dirty` sets state to `ShouldStart`
@@ -270,14 +221,8 @@ pub struct AnimatedBindingCallable<T, A> {
 
 Properties can be marked constant to optimize dependency tracking:
 
-```rust
-static CONSTANT_PROPERTY_SENTINEL: u32 = 0;
-
-// A property is constant if its dependency list head points to the sentinel
-pub fn set_constant(&self) {
-    // ... sets dependency head to point to CONSTANT_PROPERTY_SENTINEL
-}
-```
+`set_constant()` points the property's dependency list head at the `CONSTANT_PROPERTY_SENTINEL`
+static; `is_constant()` tests for it. See `internal/core/properties.rs`.
 
 When reading a constant property, no dependency is registered (optimization).
 
@@ -299,15 +244,10 @@ Properties must be pinned because:
 
 ### Safe Accessors
 
-```rust
-// Safe way to access binding - handles lock flag
-fn access<R>(&self, f: impl FnOnce(Option<Pin<&mut BindingHolder>>) -> R) -> R {
-    assert!(!self.lock_flag(), "Recursion detected");
-    self.set_lock_flag(true);
-    scopeguard::defer! { self.set_lock_flag(false); }
-    // ... access binding ...
-}
-```
+`PropertyHandle::access()` is how the binding is reached for evaluation: it asserts the lock flag
+is clear (that assert is the "Recursion detected" panic), sets it, and clears it again from a
+`scopeguard::defer!` so an unwinding binding still leaves the flag clean.
+See `internal/core/properties.rs`.
 
 ## Common Patterns
 
@@ -359,14 +299,9 @@ Property::link_two_way(prop1.as_ref(), prop2.as_ref());
 
 ### Enable Debug Names
 
-Compile with `RUSTFLAGS='--cfg slint_debug_property'` to enable property debug names:
-
-```rust
-#[cfg(slint_debug_property)]
-pub debug_name: RefCell<String>,
-```
-
-This helps identify which property is involved in recursion errors.
+Compile with `RUSTFLAGS='--cfg slint_debug_property'` to add a `debug_name` field to `Property`
+and to `BindingHolder`. The "Recursion detected" panic then names the property involved. Note
+that the field changes the struct layout, so such a build is not binary-compatible with C++.
 
 ### Common Issues
 
@@ -380,9 +315,6 @@ This helps identify which property is involved in recursion errors.
 ### Tracing Dependency Graph
 
 ```rust
-// Check if property has binding
-prop.handle.access(|b| b.is_some())
-
 // Check if property is dirty
 prop.is_dirty()
 

--- a/docs/development/type-system.md
+++ b/docs/development/type-system.md
@@ -27,53 +27,21 @@ Slint has a rich type system that includes primitive types, unit types for dimen
 
 ## Core Type Enum
 
-The `Type` enum represents all possible types in Slint:
+The `Type` enum in `internal/compiler/langtype.rs` represents all possible types in Slint. Its
+variants group into:
 
-```rust
-pub enum Type {
-    // Error/placeholder types
-    Invalid,           // Uninitialized or error
-    Void,              // Expression returns nothing
-    InferredProperty,  // Two-way binding type not yet inferred
-    InferredCallback,  // Callback alias type not yet inferred
-
-    // Callable types
-    Callback(Rc<Function>),
-    Function(Rc<Function>),
-
-    // Primitive types
-    Float32,
-    Int32,
-    String,
-    Bool,
-
-    // Unit types (dimensional quantities)
-    Duration,          // Time (ms, s)
-    PhysicalLength,    // Physical pixels (phx)
-    LogicalLength,     // Logical pixels (px, cm, mm, in, pt)
-    Rem,               // Font-relative size
-    Angle,             // Rotation (deg, rad, turn, grad)
-    Percent,           // Percentage values
-
-    // Visual types
-    Color,
-    Brush,
-    Image,
-    Easing,
-
-    // Composite types
-    Array(Rc<Type>),
-    Struct(Rc<Struct>),
-    Enumeration(Rc<Enumeration>),
-
-    // Special types
-    Model,             // Anything convertible to a model
-    UnitProduct(Vec<(Unit, i8)>),  // Product of units (e.g., px²)
-    ElementReference,  // Reference to an element
-    ComponentFactory,  // Factory for dynamic components
-    // ... internal types
-}
-```
+- **Error and placeholder types**: `Invalid` (uninitialized or error), `Void` (an expression
+  returning nothing), and `InferredProperty` / `InferredCallback` for two-way bindings and
+  callback aliases whose type is not resolved yet.
+- **Callable types**: `Callback` and `Function`, each wrapping a `Function` signature.
+- **Primitive types**: `Float32`, `Int32`, `String`, `Bool`.
+- **Unit types** (dimensional quantities): `Duration` (ms, s), `PhysicalLength` (phx),
+  `LogicalLength` (px, cm, mm, in, pt), `Rem`, `Angle` (deg, rad, turn, grad) and `Percent`.
+- **Visual types**: `Color`, `Brush`, `Image`, `Easing`, `PathData`, `StyledText`, `MouseCursor`.
+- **Composite types**: `Array`, `Struct`, `Enumeration`.
+- **Special types**: `Model` (anything convertible to a model), `UnitProduct` (a list of
+  unit/power pairs, e.g. px²), `ElementReference`, `ComponentFactory`, `Closure`, `Keys`,
+  `DataTransfer`, and the internal `LayoutCache` and `ArrayOfU16`.
 
 ## Unit System
 
@@ -146,18 +114,11 @@ property<Large> p: { x: 5 };  // OK: y gets default value
 
 ## Element Types
 
-Elements (components/items) have their own type hierarchy:
-
-```rust
-pub enum ElementType {
-    Component(Rc<Component>),  // User-defined component
-    Builtin(Rc<BuiltinElement>),  // Built-in item (Rectangle, Text, etc.)
-    Native(Rc<NativeClass>),   // After native class resolution
-    Error,                     // Lookup failed
-    Global,                    // Global component base
-    Interface,                 // Interface base
-}
-```
+Elements (components/items) have their own type hierarchy.
+`ElementType` (`internal/compiler/langtype.rs`) is one of: `Component` for a user-defined
+component, `Builtin` for a built-in item such as `Rectangle` or `Text`, `Native` once the
+`resolve_native_classes` pass has run, `Error` when the base type couldn't be looked up, and
+`Global` / `Interface` for the root element of a global or an interface.
 
 ### Property Lookup on Elements
 
@@ -169,29 +130,18 @@ When looking up a property on an element:
 4. For item types, check reserved properties (x, y, width, height, etc.)
 5. Handle property aliases (deprecated names)
 
-```rust
-impl ElementType {
-    pub fn lookup_property(&self, name: &str) -> PropertyLookupResult {
-        // Returns type, visibility, deprecated status, etc.
-    }
-}
-```
+`ElementType::lookup_property()` does all of that and returns a `PropertyLookupResult` carrying
+the resolved name, the type, the visibility and the deprecation status, plus the flags the
+visibility check needs: whether the property is local to the current component and whether it
+came from its direct base.
 
 ## Name Resolution (Lookup)
 
-The `LookupCtx` provides context for resolving identifiers in expressions:
-
-```rust
-pub struct LookupCtx<'a> {
-    pub property_name: Option<&'a str>,     // Current property being bound
-    pub property_type: Type,                 // Type of the whole binding
-    pub expected_type: Type,                 // Type expected at the current position
-    pub component_scope: &'a [ElementRc],   // Element scope stack
-    pub arguments: Vec<SmolStr>,             // Callback/function arguments
-    pub type_register: &'a TypeRegister,    // Type registry
-    pub local_variables: Vec<Vec<(SmolStr, Type)>>,  // Local variable scopes
-}
-```
+`LookupCtx` (`internal/compiler/lookup.rs`) carries everything needed to resolve an identifier:
+the name and type of the property being bound, the type expected at the current position within
+the expression, the element scope stack, the callback/function argument names, the stack of local
+variable scopes, the type register and type loader, the counters that generate unique symbol
+names, plus somewhere to report diagnostics and the token currently being processed.
 
 ### Lookup Order
 
@@ -203,7 +153,7 @@ When resolving an identifier, lookup proceeds in this order:
 4. **Element IDs** - Named elements in the component
 5. **In-scope properties** - Properties from scope stack (legacy syntax: parent properties)
 6. **Global types** - Types from the type register
-7. **Built-in namespaces** - `Colors`, `Easing`, `Math`, `Key`, `FontWeight`
+7. **Built-in namespaces** - `Colors`, `Easing`, `Math`, `Key`, `FontWeight`, `MouseCursor`
 8. **Type-specific values** - Bare `color`, `enum` or `easing` literals (e.g. `red`, `center`), resolved against `expected_type`
 9. **Built-in functions** - Unqualified global functions (`min`, `max`, `clamp`, `abs`, `debug`, ...)
 
@@ -221,29 +171,17 @@ resolves `red` as a color even though the binding's type is the struct `S`.
 
 ### LookupResult
 
-Lookup returns one of:
-
-```rust
-pub enum LookupResult {
-    Expression { expression: Expression, deprecated: Option<String> },
-    Enumeration(Rc<Enumeration>),
-    Namespace(BuiltinNamespace),
-    Callable(LookupResultCallable),
-}
-```
+Lookup returns a `LookupResult`: an `Expression` (with an optional deprecation hint), an
+`Enumeration`, a `Namespace` (a `BuiltinNamespace` value — the ones above plus the internal
+`SlintInternal`), or a `Callable`. See `internal/compiler/lookup.rs`.
 
 ## Type Register
 
-The `TypeRegister` maintains all known types:
-
-```rust
-pub struct TypeRegister {
-    types: HashMap<SmolStr, Type>,
-    elements: HashMap<SmolStr, ElementType>,
-    pub expose_internal_types: bool,
-    // ...
-}
-```
+The `TypeRegister` (`internal/compiler/typeregister.rs`) maps names to property types and to
+element types. Registers chain: each one can have a parent registry, and a lookup that misses
+falls through to it. It also records which types are animatable, which types are only allowed
+inside a given parent (so the error can say "Row can only be within a GridLayout element"), and
+whether internal types should be exposed by lookups.
 
 ### Built-in Types
 
@@ -256,48 +194,24 @@ The register is initialized with:
 
 ### Reserved Properties
 
-All items automatically get reserved properties:
-
-```rust
-// Geometry
-("x", Type::LogicalLength),
-("y", Type::LogicalLength),
-("width", Type::LogicalLength),
-("height", Type::LogicalLength),
-
-// Layout
-("min-width", Type::LogicalLength),
-("max-width", Type::LogicalLength),
-("preferred-width", Type::LogicalLength),
-("horizontal-stretch", Type::Float32),
-// ...
-
-// Grid layout
-("col", Type::Int32),
-("row", Type::Int32),
-("colspan", Type::Int32),
-("rowspan", Type::Int32),
-
-// Accessibility
-("accessible-role", AccessibleRole),
-("accessible-label", Type::String),
-// ...
-```
+All items automatically get reserved properties. `reserved_properties()` in
+`internal/compiler/typeregister.rs` chains the per-category name/type lists — geometry (`x`, `y`,
+`width`, `height`), layout (`min-width`, `preferred-height`, `horizontal-stretch`, ...), grid and
+flexbox layout (`col`, `row`, `colspan`, `rowspan`, `cross-axis-self-alignment`, ...), drop and
+inner shadow, transform, the deprecated rotation-origin names, and accessibility
+(`accessible-role`, `accessible-label`, ...) — and yields each as a
+`(name, Type, PropertyVisibility)` triple. It is a triple rather than a pair because the
+visibility is not uniform: most are `Input`, but the last group covers `Output` (`absolute-position`),
+`Constexpr` (`forward-focus`), `Public` and `Private` (`init`).
 
 ## Property Visibility
 
 Properties have visibility levels that control access:
 
-```rust
-pub enum PropertyVisibility {
-    Private,    // Only accessible within the component
-    Input,      // Can be set from outside, read inside
-    Output,     // Can be read from outside, set inside
-    InOut,      // Both readable and writable
-    Public,     // For functions/callbacks
-    Constexpr,  // Compile-time constant
-}
-```
+`PropertyVisibility` (`internal/compiler/object_tree.rs`) is `Private`, `Input`, `Output` or
+`InOut` for ordinary properties, `Public` or `Protected` for functions, `Constexpr` for built-in
+properties that must be known at compile time, and `Fake` for built-in properties that only ever
+take a binding and can neither be read nor written (such as `Path`'s `commands`).
 
 ### Visibility Rules
 
@@ -312,23 +226,18 @@ pub enum PropertyVisibility {
 
 ### Struct Definition
 
-```rust
-pub struct Struct {
-    pub fields: BTreeMap<SmolStr, Type>,
-    pub name: StructName,  // None, User, BuiltinPublic, BuiltinPrivate
-}
-```
+A `Struct` is its fields (a sorted map from name to `Type`), the resolved and constant-folded
+default value of each field, and a `StructName`. The name is `None` for an anonymous struct,
+`User` for one declared as `struct Foo { }` in .slint (which also keeps the declaration node, the
+`@rust-attr(...)` texts and the declaration order of the fields, since the sorted field map loses
+it), or `Builtin`. See `Struct` and `StructName` in `internal/compiler/langtype.rs`.
 
 ### Enumeration Definition
 
-```rust
-pub struct Enumeration {
-    pub name: SmolStr,
-    pub values: Vec<SmolStr>,
-    pub default_value: usize,  // Index in values
-    pub node: Option<syntax_nodes::EnumDeclaration>,
-}
-```
+An `Enumeration` is its name, its values, the index of the default value within them, the
+declaration node for non-builtin enums, and the `@rust-attr(...)` texts. An `EnumerationValue` is
+an index into `values` plus the enumeration it belongs to.
+See `internal/compiler/langtype.rs`.
 
 ### Accessing Enumeration Values
 
@@ -399,11 +308,13 @@ Expression::Struct {
 ### Registering a Custom Type
 
 ```rust
-register.insert_type(Type::Struct(Rc::new(Struct {
-    fields: [("x".into(), Type::Int32)].into_iter().collect(),
-    name: StructName::User { name: "MyStruct".into(), node },
-})));
+register.insert_type(Type::Struct(Arc::new(Struct::new(
+    [("x".into(), Type::Int32)].into_iter().collect(),
+    struct_name,
+))));
 ```
+
+`Struct::new()` builds one without declared field defaults.
 
 ## Debugging Tips
 
@@ -426,15 +337,13 @@ println!("Type: {}", my_type);  // e.g., "length", "[int]", "{ x: int, y: int }"
 ### Inspecting the Type Register
 
 ```rust
-// List all types
-for (name, ty) in &register.types {
-    println!("{}: {}", name, ty);
+// List all types, including those from the parent registries
+for (name, ty) in register.all_types() {
+    println!("{name}: {ty}");
 }
 
-// Check if type exists
-if let Some(ty) = register.lookup("MyType") {
-    // ...
-}
+// Look up one type: Type::Invalid when it isn't registered
+let ty = register.lookup("MyType");
 ```
 
 ## Testing

--- a/docs/development/window-backend-integration.md
+++ b/docs/development/window-backend-integration.md
@@ -58,138 +58,70 @@ Slint's window system provides an abstraction layer between the UI framework and
 
 ## WindowAdapter Trait
 
-The main interface backends must implement:
+The main interface backends must implement. Only three methods have no default: `window()`
+returns the public `Window`, `size()` the current size in physical pixels excluding the frame,
+and `renderer()` the renderer to draw with.
 
-```rust
-pub trait WindowAdapter {
-    /// Returns the window API object
-    fn window(&self) -> &Window;
-
-    /// Show or hide the window
-    fn set_visible(&self, visible: bool) -> Result<(), PlatformError>;
-
-    /// Get window position (physical screen coordinates)
-    fn position(&self) -> Option<PhysicalPosition>;
-
-    /// Set window position
-    fn set_position(&self, position: WindowPosition);
-
-    /// Get window size (physical pixels, excluding frame)
-    fn size(&self) -> PhysicalSize;
-
-    /// Set window size
-    fn set_size(&self, size: WindowSize);
-
-    /// Request asynchronous redraw
-    fn request_redraw(&self);
-
-    /// Return the renderer
-    fn renderer(&self) -> &dyn Renderer;
-
-    /// Update window properties (title, constraints, etc.)
-    fn update_window_properties(&self, properties: WindowProperties<'_>);
-}
-```
+The rest are optional: `set_visible()`, `position()` / `set_position()`, `set_size()`,
+`request_redraw()`, `update_window_properties()` (title, constraints, ... — see
+[Window Properties](#window-properties)), `internal()` to expose the extra trait below, and
+`window_handle_06()` / `display_handle_06()` for raw-window-handle interop.
+See `WindowAdapter` in `internal/core/window.rs`.
 
 ### WindowAdapterInternal
 
-Additional internal methods (not public API):
+Additional internal methods, reached through `WindowAdapter::internal()` and not part of the
+public API. Every one has a default, so a backend implements only what it supports:
 
-```rust
-pub trait WindowAdapterInternal {
-    /// Called when component tree is created
-    fn register_item_tree(&self);
+- `register_item_tree()` / `unregister_item_tree()` when a component tree appears or goes away
+- `get_parent()` and `create_child_window_adapter()`, the latter returning a separate top-level
+  window for a popup, or `None` to render it embedded in the parent
+- `set_mouse_cursor()`, `input_method_request()`, `handle_focus_change()` (for accessibility)
+- `supports_native_menu_bar()`, `setup_menubar()`, `show_native_popup_menu()`
+- `window_handle_06_rc()` / `display_handle_06_rc()`, `bring_to_front()`, `start_window_move()`,
+  `start_drag()`
+- `safe_area_inset()` for notches and system bars
 
-    /// Called when component tree is destroyed
-    fn unregister_item_tree(&self, component: ItemTreeRef, items: &mut dyn Iterator<Item = Pin<ItemRef<'_>>>);
-
-    /// Create a separate window for popup (or None for embedded)
-    fn create_popup(&self, geometry: LogicalRect) -> Option<Rc<dyn WindowAdapter>>;
-
-    /// Set the mouse cursor
-    fn set_mouse_cursor(&self, cursor: MouseCursor);
-
-    /// Handle input method requests
-    fn input_method_request(&self, request: InputMethodRequest);
-
-    /// Handle focus change (for accessibility)
-    fn handle_focus_change(&self, old: Option<ItemRc>, new: Option<ItemRc>);
-
-    /// Get the color scheme (light/dark)
-    fn color_scheme(&self) -> ColorScheme;
-
-    /// Returns safe area insets (for notches, system bars)
-    fn safe_area_inset(&self) -> PhysicalEdges;
-}
-```
+See `WindowAdapterInternal` in `internal/core/window.rs`.
 
 ## Platform Trait
 
-Factory for windows and event loop management:
+Factory for windows and event loop management. `create_window_adapter()` is the only required
+method. The rest have defaults:
 
-```rust
-pub trait Platform {
-    /// Create a new window adapter
-    fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError>;
+- `run_event_loop()` runs the loop until it is asked to quit. `process_events()` handles the
+  pending events and waits for new ones up to a timeout, for an application driving the loop
+  itself; it is `#[doc(hidden)]` and takes an `InternalToken`, and a backend implements the two
+  separately — neither default calls the other.
+- `new_event_loop_proxy()` returns the handle for cross-thread communication. Its
+  `quit_event_loop()` exits the loop; there is no `quit_event_loop` directly on `Platform`.
+  (`set_event_loop_quit_on_last_window_closed()` is hidden and deprecated — i-slint-core owns
+  that behavior now.)
+- `clipboard_text()` / `set_clipboard_text()`, both taking which `Clipboard` to use.
+- `duration_since_start()` drives the animations, `click_interval()` the double-click detection,
+  and `cursor_flash_cycle()` the text cursor blink.
+- `debug_log()` receives the output of Slint's `debug()`, and `open_url()` hands a URL to an
+  external browser.
 
-    /// Run the event loop (blocking)
-    fn run_event_loop(&self) -> Result<(), PlatformError>;
-
-    /// Process pending events and wait for new ones up to `timeout`
-    /// (the actual per-iteration entry point; `run_event_loop()` is built on top of it)
-    fn process_events(
-        &self,
-        timeout: Option<Duration>,
-    ) -> Result<core::ops::ControlFlow<()>, PlatformError>;
-
-    /// Get event loop proxy for cross-thread communication (its `quit_event_loop()`
-    /// exits the loop; there is no `quit_event_loop` directly on `Platform`)
-    fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>>;
-
-    /// Get clipboard contents
-    fn clipboard_text(&self, clipboard: Clipboard) -> Option<String>;
-
-    /// Set clipboard contents
-    fn set_clipboard_text(&self, text: &str, clipboard: Clipboard);
-
-    /// Duration since application start (for animations)
-    fn duration_since_start(&self) -> Duration;
-
-    /// Click interval for double-click detection
-    fn click_interval(&self) -> Duration;
-}
-```
+See `Platform` in `internal/core/platform.rs`.
 
 ## WindowEvent
 
-Events dispatched from platform to Slint:
+Events dispatched from platform to Slint. `WindowEvent` has:
 
-```rust
-pub enum WindowEvent {
-    // Pointer events
-    PointerPressed { position: LogicalPosition, button: PointerEventButton },
-    PointerReleased { position: LogicalPosition, button: PointerEventButton },
-    PointerMoved { position: LogicalPosition },
-    PointerScrolled { position: LogicalPosition, delta_x: f32, delta_y: f32 },
-    PointerExited,
+- **Pointer events**: `PointerPressed` and `PointerReleased` (a logical position and a
+  `PointerEventButton`), `PointerMoved`, `PointerScrolled` (a position plus an x and y delta) and
+  `PointerExited`.
+- **Keyboard events**: `KeyPressed`, `KeyPressRepeated` and `KeyReleased`, each carrying the text
+  the key produced.
+- **Window state events**: `ScaleFactorChanged`, `Resized` (a logical size), `CloseRequested` and
+  `WindowActiveChanged`.
 
-    // Touch events
-    TouchPressed { touch_finger_id: i32, position: LogicalPosition },
-    TouchReleased { touch_finger_id: i32, position: LogicalPosition },
-    TouchMoved { touch_finger_id: i32, position: LogicalPosition },
+See `WindowEvent` in `internal/core/platform.rs`.
 
-    // Keyboard events
-    KeyPressed { text: SharedString },
-    KeyPressRepeated { text: SharedString },
-    KeyReleased { text: SharedString },
-
-    // Window state events
-    ScaleFactorChanged { scale_factor: f32 },
-    Resized { size: LogicalSize },
-    CloseRequested,
-    WindowActiveChanged(bool),
-}
-```
+There is no public touch variant. A backend with real touch input dispatches
+`WindowEvent::Internal(InternalEvent::Touch { .. })` instead, because the pointer events the
+runtime synthesizes from a touch point carry a finger id that `WindowEvent` cannot express.
 
 **Dispatching events:**
 ```rust
@@ -202,71 +134,30 @@ window.dispatch_event(WindowEvent::PointerPressed {
 
 ## WindowInner
 
-Internal state management for windows:
+`WindowInner` (`internal/core/window.rs`) holds everything the public `Window` does not. Its
+fields group into:
 
-```rust
-pub struct WindowInner {
-    window_adapter_weak: Weak<dyn WindowAdapter>,
-    component: RefCell<ItemTreeWeak>,
-    strong_component_ref: RefCell<Option<ItemTreeRc>>,
-
-    // Input state
-    mouse_input_state: Cell<MouseInputState>,
-    modifiers: Cell<InternalKeyboardModifierState>,
-    click_state: ClickState,
-
-    // Focus
-    focus_item: RefCell<ItemWeak>,
-    cursor_blinker: RefCell<PinWeak<TextCursorBlinker>>,
-
-    // Property tracking
-    pinned_fields: Pin<Box<WindowPinnedFields>>,  // scale_factor, active, etc.
-
-    // Window state
-    maximized: Cell<bool>,
-    minimized: Cell<bool>,
-
-    // Popups
-    active_popups: RefCell<Vec<PopupWindow>>,
-    next_popup_id: Cell<NonZeroU32>,
-
-    // Callbacks
-    close_requested: Callback<(), CloseRequestResponse>,
-}
-```
+- The weak adapter it belongs to, the shown component, and a strong reference to it kept only
+  while the window is visible.
+- **Input state**: the mouse input state, the touch state, and a `ClickState` for double-click
+  detection.
+- **Focus**: the focused item and a tracker for its visibility, the text cursor blinker, the last
+  text sent to the input method, and a `prevent_focus_change` flag that keeps a
+  `ComponentContainer`'s init code from stealing the focus.
+- **Property tracking**: `WindowPinnedFields`, the pinned block holding `scale_factor`, `active`,
+  `text_input_focused`, `menubar_shortcuts` and the redraw / window-properties trackers.
+- **Popups**: the stack of active popups, the id to hand out next, and whether one was open at
+  the last press.
+- The menu bar, the `close_requested` callback, the `SlintContext`, and the native drag in flight.
 
 ### Property Tracking
 
-Windows use `PropertyTracker` to automatically request updates:
-
-```rust
-// Redraw tracker - requests redraw when any rendered property changes
-struct WindowRedrawTracker {
-    window_adapter_weak: Weak<dyn WindowAdapter>,
-}
-
-impl PropertyDirtyHandler for WindowRedrawTracker {
-    fn notify(self: Pin<&Self>) {
-        if let Some(adapter) = self.window_adapter_weak.upgrade() {
-            adapter.request_redraw();
-        }
-    }
-}
-
-// Properties tracker - notifies when window properties change
-struct WindowPropertiesTracker {
-    window_adapter_weak: Weak<dyn WindowAdapter>,
-}
-
-impl PropertyDirtyHandler for WindowPropertiesTracker {
-    fn notify(self: Pin<&Self>) {
-        // Deferred update via timer
-        Timer::single_shot(Default::default(), move || {
-            // ... update_window_properties() ...
-        });
-    }
-}
-```
+Windows use `PropertyTracker`s parameterized on a `PropertyDirtyHandler`, so a dependency going
+dirty calls straight into the window. Both handlers hold a weak adapter: `WindowRedrawTracker`
+calls `request_redraw()` as soon as a rendered property goes dirty, and
+`WindowPropertiesTracker` defers `update_window_properties()` to a single-shot timer so a burst of
+changes results in one update. `PopupWindowPropertiesTracker` does the same for a popup's
+geometry. See `internal/core/window.rs`.
 
 ## Popup Management
 
@@ -276,44 +167,23 @@ impl PropertyDirtyHandler for WindowPropertiesTracker {
 `PopupClosePolicy` is defined in `internal/common/enums.rs` and re-exported via
 `crate::items::PopupClosePolicy`.
 
-```rust
-pub struct PopupWindow {
-    pub popup_id: NonZeroU32,
-    pub location: PopupWindowLocation,
-    pub component: ItemTreeRc,
-    pub close_policy: PopupClosePolicy,
-    focus_item_in_parent: ItemWeak,
-    pub parent_item: ItemWeak,
-    is_menu: bool,
-}
+A `PopupWindow` is its id, its `PopupWindowLocation`, the component providing the content, the
+`PopupClosePolicy`, the item it was invoked from, the item that had the focus in the parent
+window, a `WindowKind` (a tooltip does not steal focus and is placed unclamped, while a context
+or popup menu joins the menu chain for hit testing and cascading close), a closure returning the
+popup's desired position relative to the parent, a hook keeping the parent's
+`PopupWindow::is-open` property in sync, and its own properties tracker.
 
-pub enum PopupWindowLocation {
-    /// Separate top-level window
-    TopLevel(Rc<dyn WindowAdapter>),
-    /// Embedded in parent at position
-    ChildWindow(LogicalPoint),
-}
+A `PopupWindowLocation` is either `TopLevel`, its own window known to the windowing system, or
+`ChildWindow` at a position inside the parent.
 
-pub enum PopupClosePolicy {
-    CloseOnClick,        // Close on any click
-    CloseOnClickOutside, // Close only on click outside
-    NoAutoClose,         // Manual close only
-}
-```
+`PopupClosePolicy` is `CloseOnClick` (any click), `CloseOnClickOutside`, or `NoAutoClose`.
 
 ### Popup Placement
 
-```rust
-pub enum Placement {
-    Fixed(LogicalRect),
-}
-
-/// Place popup within clip region (window/screen bounds)
-pub fn place_popup(
-    placement: Placement,
-    clip_region: &Option<LogicalRect>,
-) -> LogicalRect;
-```
+`place_popup()` takes a `Placement` — currently only `Fixed`, a requested rectangle — and an
+optional clip region, typically the window or the screen it is on, and returns where the popup
+actually goes. See `internal/core/window/popup.rs`.
 
 The placement algorithm:
 1. If popup fits within clip region, use requested position
@@ -330,14 +200,9 @@ Cross-platform backend using the winit library:
 - **Renderers**: FemtoVG (OpenGL/WGPU), Skia, Software
 - **Features**: Accessibility (AccessKit), menus (muda)
 
-```rust
-pub trait WinitCompatibleRenderer {
-    fn render(&self, window: &Window) -> Result<DrawOutcome, PlatformError>;
-    fn as_core_renderer(&self) -> &dyn Renderer;
-    fn suspend(&self) -> Result<(), PlatformError>;
-    fn resume(&self, ...) -> Result<Arc<winit::window::Window>, PlatformError>;
-}
-```
+Renderers plug in through the `WinitCompatibleRenderer` trait in
+`internal/backends/winit/lib.rs`; see
+[custom-renderer.md](custom-renderer.md#winitcompatiblerenderer-internalbackendswinit).
 
 ### Qt Backend (`internal/backends/qt/`)
 
@@ -367,56 +232,22 @@ Headless testing:
 
 Properties exposed to backends via `WindowProperties`:
 
-```rust
-impl WindowProperties<'_> {
-    /// Window title
-    pub fn title(&self) -> SharedString;
-
-    /// Background color/brush
-    pub fn background(&self) -> Brush;
-
-    /// Layout constraints (min, max, preferred size)
-    pub fn layout_constraints(&self) -> LayoutConstraints;
-
-    /// Fullscreen state
-    pub fn is_fullscreen(&self) -> bool;
-
-    /// Maximized state
-    pub fn is_maximized(&self) -> bool;
-
-    /// Minimized state
-    pub fn is_minimized(&self) -> bool;
-}
-
-pub struct LayoutConstraints {
-    pub min: Option<LogicalSize>,
-    pub max: Option<LogicalSize>,
-    pub preferred: LogicalSize,
-}
-```
+`WindowProperties` borrows the `WindowInner` and exposes getters for the `Window` element's
+properties: `title()`, `background()`, `layout_constraints()`, and `is_fullscreen()`,
+`is_maximized()`, `is_minimized()`. `LayoutConstraints` here is the window-level one — an
+optional min and max plus a preferred `LogicalSize` — not the compiler's.
+See `internal/core/window.rs`.
 
 ## Input Method Support
 
-For text input with IME:
+For text input with IME. An `InputMethodRequest` is `Enable` or `Update` with the properties, or
+`Disable`.
 
-```rust
-pub enum InputMethodRequest {
-    Enable(InputMethodProperties),
-    Update(InputMethodProperties),
-    Disable,
-}
-
-pub struct InputMethodProperties {
-    pub text: SharedString,           // Surrounding text
-    pub cursor_position: usize,       // Cursor byte offset
-    pub anchor_position: Option<usize>, // Selection anchor
-    pub preedit_text: SharedString,   // Pre-edit/composition text
-    pub preedit_offset: usize,
-    pub cursor_rect_origin: LogicalPosition,
-    pub cursor_rect_size: LogicalSize,
-    pub input_type: InputType,        // Text, Number, Password, etc.
-}
-```
+`InputMethodProperties` carries the text surrounding the cursor (pre-edit excluded), the cursor
+byte offset within it, the selection anchor if there is one, the pre-edit text and its offset, the
+cursor rectangle's origin and size, the clip rectangle, the anchor point, the `InputType` (text,
+number, password, ...) and the `InputMethodHints`.
+See `internal/core/window.rs`.
 
 ## Common Patterns
 
@@ -496,19 +327,13 @@ window.on_close_requested(|| {
 | **Logical** | DPI-independent pixels (physical / scale_factor) |
 
 ```rust
-// Conversion
 let logical = physical_size.to_logical(scale_factor);
 let physical = logical_size.to_physical(scale_factor);
-
-// Window API uses both
-fn position(&self) -> Option<PhysicalPosition>;  // Physical
-fn set_size(&self, size: WindowSize);            // Can be either
-
-pub enum WindowSize {
-    Physical(PhysicalSize),
-    Logical(LogicalSize),
-}
 ```
+
+The window API uses both: `WindowAdapter::position()` and `size()` are physical, while
+`set_size()` takes a `WindowSize` — either `Physical` or `Logical` — and `set_position()` a
+`WindowPosition` the same way.
 
 ## Debugging Tips
 
@@ -526,7 +351,7 @@ pub enum WindowSize {
 
 ```rust
 // Get current focus
-let focus = window.focus_item();
+let focus = WindowInner::from_pub(&window).focus_item.borrow().clone();
 
 // Check scale factor
 let scale = WindowInner::from_pub(&window).scale_factor();


### PR DESCRIPTION
Same as c26cb1ee1c, for the rest of docs/development/. Nothing compiles
the rust blocks under docs/development/, so every copied struct, trait or
enum goes stale silently. This time the copies had drifted far enough that
one whole section described an interpreter that no longer exists.

Replace each definition dump with a sentence naming the type and the file
it lives in. Keep the diagrams, the usage examples and the how-to patterns:
those say how the pieces fit together, which the source does not.

Inaccuracies that disappear with the copies:

- item-tree: internal/interpreter/dynamic_item_tree.rs is gone, and with it
  ItemTreeDescription, ItemTreeBox, InstanceRef and instantiate() - the
  interpreter now builds an LLR Instance / SubComponentInstance tree. The
  initialization sequence also had init_code running before, not after,
  register_item_tree().
- custom-renderer: Skia's Surface::render() returns DrawOutcome, not
  Result<()>; the surface list omitted WGPUSurface; GraphicsBackend and
  WinitCompatibleRenderer were each missing methods.
- layout-system: GridLayout missed dialog_button_roles and uses_auto,
  BoxLayout missed cross_alignment, LayoutConstraints missed the fixed-size
  flags and the locality record.
- type-system: Type said Rc where the source says Arc and omitted eight
  variants, as did ElementType::Native; PropertyVisibility missed Fake and
  Protected; Struct missed field_defaults and StructName listed two variants
  that never existed; reserved properties are triples, not pairs, and their
  visibility is not uniform; two debug snippets used a private field and a
  wrong return type.
- property-binding: PropertyHandle holds Cell<*mut ()>, not Cell<usize>;
  dep_nodes is an UnsafeCell, so the lazy-evaluation snippet's .set() call
  was wrong, as was CURRENT_BINDING.set(); PropertyTracker gained a
  NEEDS_SET_DIRTY const generic; AnimatedBindingCallable missed dirty_time.
- model-repeater: the Model trait copy hid push_row/remove_row/insert_row,
  implying custom models cannot support insertion; RepeaterLayoutState's
  field is previous_content_y; ensure_updated* return bool and take
  content, not viewport, properties; Conditional missed instance_generation.
- window-backend: WindowAdapterInternal has no create_popup or color_scheme;
  WindowEvent has no touch variants, and touch does not travel through the
  pointer ones either; WindowInner has no modifiers, maximized or minimized
  fields; PopupWindow::is_menu is now a WindowKind; process_events() and
  set_event_loop_quit_on_last_window_closed() were presented as ordinary
  public API when they are hidden, the latter also deprecated.
- input-event: the public KeyEvent has no event_type or IME fields - those
  are on InternalKeyEvent; InputEventFilterResult missed ForwardAndObserve;
  MouseInputState missed four fields; the item handlers take Pin<&Self> and
  a mouse cursor, and have no defaults; handle_mouse_grab returns
  MouseGrabResult; DropEvent has no mime_type; the key table lives in
  i-slint-common, not in input.rs.
- lsp-architecture: the PreviewState copy was missing most of its fields.
- ffi-bindings: slint-build's CompilerConfiguration is a builder with no
  public fields; the Python bindings dropped gen_stub_* and allow_threads;
  the Node bindings dropped JsFunction and RefCountedReference; the
  api/cpp/Cargo.toml feature copy listed the wrong dependencies;
  make_c_function_binding() takes five parameters; cbindgen renames
  StringArg, and excludes SharedString rather than renaming it.
- compiler-internals: there is no internal/compiler/passes/mod.rs.

Both docs also claimed a Window::focus_item() that does not exist.