### PR TITLE
CI: Exclude the slint-editor from the x86 win32 build test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -715,7 +715,7 @@ jobs:
                   CFLAGS: -msse2
                   CXXFLAGS: -msse2
               # The excluded crates need a dedicated toolchain or don't cross-compile here.
-              run: cargo xwin build --target i686-pc-windows-msvc --locked --workspace --exclude slint-node --exclude slint-cpp --exclude slint-python --exclude slint-sc --exclude slint-doc-generator --exclude i-slint-renderer-skia
+              run: cargo xwin build --target i686-pc-windows-msvc --locked --workspace --exclude slint-node --exclude slint-cpp --exclude slint-python --exclude slint-sc --exclude slint-doc-generator --exclude i-slint-renderer-skia --exclude slint-editor
 
     qa-tree-sitter-latest:
         if: ${{ inputs.full }}


### PR DESCRIPTION
The editor pulls in skia, which we don't want to cover here.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
