### PR TITLE
Implement layout-order for HorizontalLayout/VerticalLayout

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -56,6 +56,7 @@ blogicb
 boing
 boolprop
 bootsel
+boxlayout
 briefcasex
 brushprop
 brushval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ All notable changes to this project are documented in this file.
    to the next line when they don't fit.
  - Added the per-item `cross-axis-self-alignment` property: the children of a `FlexboxLayout`,
    `HorizontalLayout`, or `VerticalLayout` can override the container's `cross-axis-alignment`.
+ - Added the per-item `layout-order` property: the children of a `FlexboxLayout`, `HorizontalLayout`,
+   or `VerticalLayout` are laid out in ascending `layout-order` value rather than declaration order,
+   children with the same value keeping their declaration order.
  - Struct fields can now declare a default value: `struct Player { name: string = "unknown" }`.
  - Added `push`, `remove`, and `insert` functions on arrays and models, with matching `Model` API
    additions in every language binding. (#9457)

--- a/docs/astro/src/content/docs/reference/layouts/overview.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/overview.mdx
@@ -23,13 +23,21 @@ See <Link type="GridLayout" />.
 ### cross-axis-self-alignment
 <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
 Overrides the container's `cross-axis-alignment` for this element.
-Valid on the children of a <Link type="HorizontalLayout" />, <Link type="VerticalLayout" />, or `FlexboxLayout`.
+Valid on the children of a <Link type="HorizontalLayout" />, <Link type="VerticalLayout" />, or <Link type="FlexboxLayout" />.
 </SlintProperty>
 
 ### horizontal-stretch, vertical-stretch
 <SlintProperty propName="horizontal-stretch, vertical-stretch" typeName="float" propertyVisibility="in-out">
 Specify how much relative space these elements are stretching in a layout. When 0, this means that the
 elements won't be stretched unless all elements are 0. Builtin widgets have a value of either 0 or 1.
+</SlintProperty>
+
+### layout-order
+<SlintProperty propName="layout-order" typeName="int" defaultValue="0">
+Controls the visual order of the elements: they are laid out in ascending order value,
+and elements with the same value keep their declaration order.
+Valid on the children of a <Link type="HorizontalLayout" />, <Link type="VerticalLayout" />, or <Link type="FlexboxLayout" />.
+Only the visual order changes: keyboard focus still moves in declaration order.
 </SlintProperty>
 
 ### max-width, max-height

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2051,12 +2051,25 @@ export component GridLayout {
 /// they will be computed by the layout respecting the minimum and maximum sizes and the stretch factor.
 /// \footer
 /// ## Cell elements
-/// Cell elements inside a `VerticalLayout` obtain the following new property:
+/// Cell elements inside a `VerticalLayout` obtain the following new properties:
 ///
 /// ### cross-axis-self-alignment
 /// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
 /// Overrides the container's `cross-axis-alignment` for this element.
 /// The default value `auto` uses the container's `cross-axis-alignment`.
+/// </SlintProperty>
+///
+/// ### layout-order
+/// <SlintProperty propName="layout-order" typeName="int" defaultValue="0">
+/// Controls the visual order of the elements: they are laid out in ascending
+/// order value, and elements with the same value keep their declaration order.
+/// ```slint no-test
+/// VerticalLayout {
+///     Rectangle { layout-order: 2; }
+///     Rectangle { layout-order: 1; }  // appears first
+/// }
+/// ```
+/// Only the visual order changes: keyboard focus still moves in declaration order.
 /// </SlintProperty>
 /// \group:layouts
 export component VerticalLayout {
@@ -2125,12 +2138,25 @@ export component VerticalLayout {
 /// they will be computed by the layout respecting the minimum and maximum sizes and the stretch factor.
 /// \footer
 /// ## Cell elements
-/// Cell elements inside a `HorizontalLayout` obtain the following new property:
+/// Cell elements inside a `HorizontalLayout` obtain the following new properties:
 ///
 /// ### cross-axis-self-alignment
 /// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
 /// Overrides the container's `cross-axis-alignment` for this element.
 /// The default value `auto` uses the container's `cross-axis-alignment`.
+/// </SlintProperty>
+///
+/// ### layout-order
+/// <SlintProperty propName="layout-order" typeName="int" defaultValue="0">
+/// Controls the visual order of the elements: they are laid out in ascending
+/// order value, and elements with the same value keep their declaration order.
+/// ```slint no-test
+/// HorizontalLayout {
+///     Rectangle { layout-order: 2; }
+///     Rectangle { layout-order: 1; }  // appears first
+/// }
+/// ```
+/// Only the visual order changes: keyboard focus still moves in declaration order.
 /// </SlintProperty>
 /// \group:layouts
 export component HorizontalLayout {
@@ -2255,6 +2281,7 @@ export component HorizontalLayout {
 ///     Rectangle { layout-order: 1; }  // appears first
 /// }
 /// ```
+/// Only the visual order changes: keyboard focus still moves in declaration order.
 /// </SlintProperty>
 ///
 /// ## CSS Mapping

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2976,6 +2976,41 @@ fn generate_sub_component(
     }
 }
 
+/// The `cross-axis-self-alignment` and `layout-order` fields of a repeated box
+/// layout cell's `LayoutItemInfo`, as C++ expressions reading the `o` orientation
+/// in scope: the first is returned for the cross axis only, so the main-axis
+/// cache stays independent of it, the second for the main axis only. `{}` value-
+/// initializes the field when the cell sets no such property.
+fn repeated_layout_item_fields(
+    root_sc: &llr::SubComponent,
+    ctx: &EvaluationContext,
+) -> (String, String) {
+    let orientation_name = |o: &crate::layout::Orientation| match o {
+        crate::layout::Orientation::Horizontal => "Horizontal",
+        crate::layout::Orientation::Vertical => "Vertical",
+    };
+    let align_self = match &root_sc.cross_axis_self_alignment_for_repeated {
+        Some((cross_o, expr)) => {
+            let expr = compile_expression(&expr.borrow(), ctx);
+            let cross_o = orientation_name(cross_o);
+            format!(
+                "(o == slint::cbindgen_private::Orientation::{cross_o}) ? ({expr}) \
+                 : slint::cbindgen_private::CrossAxisSelfAlignment::Auto"
+            )
+        }
+        None => "{}".to_owned(),
+    };
+    let order = match &root_sc.layout_order_for_repeated {
+        Some((main_o, expr)) => {
+            let expr = compile_expression(&expr.borrow(), ctx);
+            let main_o = orientation_name(main_o);
+            format!("(o == slint::cbindgen_private::Orientation::{main_o}) ? ({expr}) : 0")
+        }
+        None => "{}".to_owned(),
+    };
+    (align_self, order)
+}
+
 /// Generates the `layout_item_info` member function for a repeated component struct.
 /// Dispatches by `child_index` to per-child layout info queries, supporting static children
 /// and inner repeaters within a row child template.
@@ -2989,24 +3024,12 @@ fn generate_layout_item_info_decl(
         || (root_sc.grid_layout_children.is_empty()
             && !llr::has_inner_repeaters(&root_sc.row_child_templates))
     {
-        // The cell's `cross-axis-self-alignment` in a box layout, returned for
-        // the cross axis only, so the main-axis cache stays independent of it.
-        // The aggregate init otherwise leaves the field value-initialized (`Auto`).
-        let statement = match &root_sc.cross_axis_self_alignment_for_repeated {
-            Some((cross_o, expr)) => {
-                let align_self = compile_expression(&expr.borrow(), ctx);
-                let cross_o = match cross_o {
-                    crate::layout::Orientation::Horizontal => "Horizontal",
-                    crate::layout::Orientation::Vertical => "Vertical",
-                };
-                format!(
-                    "[[maybe_unused]] auto self = this; \
-                     return {{ layout_info({{&static_vtable, const_cast<void *>(static_cast<const void *>(this))}}, o), \
-                     (o == slint::cbindgen_private::Orientation::{cross_o}) ? ({align_self}) : slint::cbindgen_private::CrossAxisSelfAlignment::Auto }};"
-                )
-            }
-            None => "return { layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, o), {} };".to_owned(),
-        };
+        let (align_self, order) = repeated_layout_item_fields(root_sc, ctx);
+        let statement = format!(
+            "[[maybe_unused]] auto self = this; \
+             return {{ layout_info({{&static_vtable, const_cast<void *>(static_cast<const void *>(this))}}, o), \
+             {align_self}, {order} }};"
+        );
         return Declaration::Function(Function {
             name: "layout_item_info".into(),
             signature: SIGNATURE.to_owned(),
@@ -3015,9 +3038,10 @@ fn generate_layout_item_info_decl(
         });
     }
 
-    // Row templates only exist for repeated grid Rows, which cannot carry
-    // cross-axis-self-alignment; the scan below hardcodes `{}` for the field.
+    // Row templates only exist for repeated grid Rows, which cannot carry per-item
+    // box layout properties; the scan below hardcodes `{}` for those fields.
     debug_assert!(root_sc.cross_axis_self_alignment_for_repeated.is_none());
+    debug_assert!(root_sc.layout_order_for_repeated.is_none());
 
     let templates = root_sc.row_child_templates.as_ref().unwrap();
     let n = templates.len();
@@ -3042,7 +3066,7 @@ fn generate_layout_item_info_decl(
                 write!(
                     body,
                     "if (count == index) {{\n\
-                         return {{ (o == slint::cbindgen_private::Orientation::Horizontal) ? ({layout_info_h_code}) : ({layout_info_v_code}), {{}} }};\n\
+                         return {{ (o == slint::cbindgen_private::Orientation::Horizontal) ? ({layout_info_h_code}) : ({layout_info_v_code}), {{}}, {{}} }};\n\
                      }}\n\
                      {advance}",
                 )
@@ -3060,7 +3084,7 @@ fn generate_layout_item_info_decl(
                      if (index >= count && index - count < inner_len) {{\n\
                          if (auto vrc = {inner_rep_id}.instance_at(index - count).lock()) {{\n\
                              auto vref = vrc->borrow();\n\
-                             return {{ vref.vtable->layout_info(vref, o), {{}} }};\n\
+                             return {{ vref.vtable->layout_info(vref, o), {{}}, {{}} }};\n\
                          }}\n\
                      }}\n\
                      {advance}}}\n",
@@ -3072,9 +3096,9 @@ fn generate_layout_item_info_decl(
     body.push_str(
         // Phantom cell: return "unconstrained" info (matches Rust's LayoutInfo::default()).
         // field order: max, max_percent, min, min_percent, preferred, stretch
-        "return { slint::cbindgen_private::LayoutInfo{ std::numeric_limits<float>::max(), 100.f, 0, 0, 0, 0 }, {} };\n\
+        "return { slint::cbindgen_private::LayoutInfo{ std::numeric_limits<float>::max(), 100.f, 0, 0, 0, 0 }, {}, {} };\n\
          }\n\
-         return { layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, o), {} };",
+         return { layout_info({&static_vtable, const_cast<void *>(static_cast<const void *>(this))}, o), {}, {} };",
     );
     Declaration::Function(Function {
         name: "layout_item_info".into(),
@@ -3096,11 +3120,20 @@ fn generate_layout_item_info_at_cross_decls(
     ctx: &EvaluationContext,
 ) -> Vec<Declaration> {
     let is_flexbox_cell = root_sc.flexbox_layout_item_info_for_repeated.is_some();
+    // The per-item fields are the same as in `layout_item_info`; `o` is fixed
+    // per accessor, so bind it locally and reuse those guards. Don't delegate to
+    // `layout_item_info` for them: it measures the constraint through
+    // `layout_info`, which is what this accessor exists to avoid.
     let decl = |expr: Option<&llr::MutExpression>, fn_name: &str, param: &str, o: &str| {
         let body = match expr {
             Some(e) if !is_flexbox_cell => {
                 let info = compile_expression(&e.borrow(), ctx);
-                format!("[[maybe_unused]] auto self = this; return {{ ({info}), {{}} }};")
+                let (align_self, order) = repeated_layout_item_fields(root_sc, ctx);
+                format!(
+                    "[[maybe_unused]] auto self = this; \
+                     [[maybe_unused]] auto o = slint::cbindgen_private::Orientation::{o}; \
+                     return {{ ({info}), {align_self}, {order} }};"
+                )
             }
             _ => format!(
                 "return layout_item_info(slint::cbindgen_private::Orientation::{o}, std::nullopt);"
@@ -3181,10 +3214,9 @@ fn generate_flexbox_layout_item_info_decl(
              return info;"
         )
     } else {
-        // Equivalent of the Rust trait default `layout_item_info(o).into()`,
-        // whose props are FlexItemProps::default().
+        // Equivalent of the Rust trait default `layout_item_info(o).into()`.
         "auto base = layout_item_info(o, child_index); \
-         return { base.constraint, { slint::cbindgen_private::CrossAxisSelfAlignment::Auto, 0 } };"
+         return { base.constraint, { base.cross_axis_self_alignment, base.layout_order } };"
             .to_owned()
     };
 
@@ -4894,7 +4926,7 @@ fn compile_expression(expr: &llr::Expression, ctx: &EvaluationContext) -> String
                             steps,
                             "{{
                                 [[maybe_unused]] float {known_size_local} = box_ortho_solved[cursor * 2 + 1];
-                                measure_cells_vector.push_back({{ ({info}), {{}} }});
+                                measure_cells_vector.push_back({{ ({info}), {{}}, {{}} }});
                                 ++cursor;
                             }}"
                         )
@@ -6160,8 +6192,8 @@ fn generate_with_flexbox_layout_item_info(
                      auto info_h = sub_comp->flexbox_layout_item_info(slint::cbindgen_private::Orientation::Horizontal, std::nullopt); \
                      auto info_v = {v_query}; \
                      {flex_push}\
-                     cells_vector_h.push_back({{ info_h.constraint, {{}} }}); \
-                     cells_vector_v.push_back({{ info_v.constraint, {{}} }}); }}); \
+                     cells_vector_h.push_back({{ info_h.constraint, {{}}, {{}} }}); \
+                     cells_vector_v.push_back({{ info_v.constraint, {{}}, {{}} }}); }}); \
                      auto repeater_len = self->repeater_{repeater_index}.len(); \
                      cells_vector_h.resize(start_offset + repeater_len); \
                      cells_vector_v.resize(start_offset + repeater_len); \

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1781,6 +1781,18 @@ fn generate_sub_component(
             }
         });
 
+    let layout_order_for_repeated_fn =
+        component.layout_order_for_repeated.as_ref().map(|(_, expr)| {
+            let expr = compile_expression(&expr.borrow(), &ctx);
+            quote! {
+                fn layout_order_for_repeated(self: ::core::pin::Pin<&Self>) -> i32 {
+                    #![allow(unused)]
+                    let _self = self;
+                    #expr
+                }
+            }
+        });
+
     // FIXME! this is only public because of the ComponentHandle::WeakInner. we should find another way
     let visibility = parent_ctx.is_none().then(|| quote!(pub));
 
@@ -1944,6 +1956,8 @@ fn generate_sub_component(
             #flexbox_layout_item_info_for_repeated_fn
 
             #cross_axis_self_alignment_for_repeated_fn
+
+            #layout_order_for_repeated_fn
 
             fn subtree_range(self: ::core::pin::Pin<&Self>, dyn_index: u32) -> sp::IndexRange {
                 #![allow(unused)]
@@ -2857,12 +2871,26 @@ fn generate_repeated_component(
                     ::core::default::Default::default()
                 },)
             });
+        // Likewise `layout-order`, for the main axis only: it just reorders that
+        // solve.
+        let order_field = root_sc.layout_order_for_repeated.as_ref().map(|(main_o, _)| {
+            let main_o = match main_o {
+                Orientation::Horizontal => quote!(sp::Orientation::Horizontal),
+                Orientation::Vertical => quote!(sp::Orientation::Vertical),
+            };
+            quote!(layout_order: if o == #main_o {
+                self.as_ref().layout_order_for_repeated()
+            } else {
+                0
+            },)
+        });
         let layout_item_info_fn = root_sc.child_of_layout.then(|| {
             // Generate layout_item_info (from the RepeatedItemTree trait) in terms of ItemTree::layout_info
             if root_sc.is_repeated_row {
-                // Repeated grid Rows cannot carry cross-axis-self-alignment; the
-                // row-scan literals below default the field.
+                // Repeated grid Rows cannot carry per-item box layout properties;
+                // the row-scan literals below default those fields.
                 debug_assert!(root_sc.cross_axis_self_alignment_for_repeated.is_none());
+                debug_assert!(root_sc.layout_order_for_repeated.is_none());
                 // Create a context with proper global_access for compiling layout info expressions
                 let layout_ctx = EvaluationContext {
                     compilation_unit: unit,
@@ -2938,12 +2966,12 @@ fn generate_repeated_component(
                             #(#scan_steps)*
                             sp::LayoutItemInfo::default()
                         } else {
-                            sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field ..::core::default::Default::default() }
+                            sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field #order_field ..::core::default::Default::default() }
                         }
                     }
                 } else {
                     quote! {
-                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field ..::core::default::Default::default() }
+                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field #order_field ..::core::default::Default::default() }
                     }
                 };
 
@@ -2963,7 +2991,7 @@ fn generate_repeated_component(
                         o: sp::Orientation,
                         _child_index: sp::Option<usize>,
                     ) -> sp::LayoutItemInfo {
-                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field ..::core::default::Default::default() }
+                        sp::LayoutItemInfo { constraint: self.as_ref().layout_info(o), #align_self_field #order_field ..::core::default::Default::default() }
                     }
                 }
             }
@@ -3079,12 +3107,20 @@ fn generate_repeated_component(
         // measures like an equivalent static cell. Mirrors the flexbox
         // `flexbox_layout_item_info_at_cross_*` pair; the trait default (the
         // plain `layout_item_info`) covers the other repeated components.
+        // The per-item fields are the same as in `layout_item_info`; `o` is
+        // fixed per accessor, so bind it locally and reuse those guards. Don't
+        // delegate to `layout_item_info` for them: it measures the constraint
+        // through `layout_info`, which is what this accessor exists to avoid.
         let layout_item_info_at_cross_fn =
-            |expr: Option<&llr::MutExpression>, fn_name: &str, param: &str| {
+            |expr: Option<&llr::MutExpression>, fn_name: &str, param: &str, o: Orientation| {
                 expr.filter(|_| root_sc.flexbox_layout_item_info_for_repeated.is_none()).map(|e| {
                 let info = compile_expression(&e.borrow(), &ctx);
                 let fn_name = ident(fn_name);
                 let param = ident(param);
+                let o = match o {
+                    Orientation::Horizontal => quote!(sp::Orientation::Horizontal),
+                    Orientation::Vertical => quote!(sp::Orientation::Vertical),
+                };
                 quote! {
                     fn #fn_name(
                         self: ::core::pin::Pin<&Self>,
@@ -3092,7 +3128,9 @@ fn generate_repeated_component(
                     ) -> sp::LayoutItemInfo {
                         #[allow(unused)]
                         let _self = self.as_ref();
-                        sp::LayoutItemInfo { constraint: #info, ..::core::default::Default::default() }
+                        #[allow(unused)]
+                        let o = #o;
+                        sp::LayoutItemInfo { constraint: #info, #align_self_field #order_field ..::core::default::Default::default() }
                     }
                 }
             })
@@ -3101,11 +3139,13 @@ fn generate_repeated_component(
             root_sc.layout_info_v_at_cross_width_for_repeated.as_ref(),
             "layout_item_info_at_cross_width",
             CROSS_WIDTH_LOCAL,
+            Orientation::Vertical,
         );
         let layout_item_info_at_cross_height_fn = layout_item_info_at_cross_fn(
             root_sc.layout_info_h_at_cross_height_for_repeated.as_ref(),
             "layout_item_info_at_cross_height",
             CROSS_HEIGHT_LOCAL,
+            Orientation::Horizontal,
         );
         quote! {
             #layout_item_info_fn

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -82,7 +82,7 @@ pub struct LayoutItem {
     /// Used by box layouts and FlexboxLayout; always `None` in a GridLayout.
     pub cross_axis_self_alignment: Option<NamedReference>,
     /// The `layout-order` property, if set.
-    /// Used by FlexboxLayout; always `None` in the other layouts.
+    /// Used by box layouts and FlexboxLayout; always `None` in a GridLayout.
     pub layout_order: Option<NamedReference>,
 }
 
@@ -739,6 +739,9 @@ impl BoxLayout {
         for cell in &mut self.elems {
             cell.constraints.visit_named_references(visitor);
             if let Some(e) = cell.cross_axis_self_alignment.as_mut() {
+                visitor(&mut *e);
+            }
+            if let Some(e) = cell.layout_order.as_mut() {
                 visitor(&mut *e);
             }
         }

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -81,13 +81,9 @@ pub struct LayoutItem {
     /// The `cross-axis-self-alignment` property, if set.
     /// Used by box layouts and FlexboxLayout; always `None` in a GridLayout.
     pub cross_axis_self_alignment: Option<NamedReference>,
-}
-
-/// A FlexboxLayout child item, wrapping a LayoutItem with flex-specific properties.
-#[derive(Debug, Clone)]
-pub struct FlexboxLayoutItem {
-    pub item: LayoutItem,
-    pub order: Option<NamedReference>,
+    /// The `layout-order` property, if set.
+    /// Used by FlexboxLayout; always `None` in the other layouts.
+    pub layout_order: Option<NamedReference>,
 }
 
 /// A child within a repeated Row in a GridLayout.
@@ -756,7 +752,7 @@ impl BoxLayout {
 /// Internal representation of a FlexboxLayout (row or column direction with wrapping)
 #[derive(Debug, Clone)]
 pub struct FlexboxLayout {
-    pub elems: Vec<FlexboxLayoutItem>,
+    pub elems: Vec<LayoutItem>,
     pub geometry: LayoutGeometry,
     pub direction: Option<NamedReference>,
     pub cross_axis_line_alignment: Option<NamedReference>,
@@ -833,11 +829,11 @@ impl FlexboxLayout {
 
     pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
         for cell in &mut self.elems {
-            cell.item.constraints.visit_named_references(visitor);
-            if let Some(e) = cell.item.cross_axis_self_alignment.as_mut() {
+            cell.constraints.visit_named_references(visitor);
+            if let Some(e) = cell.cross_axis_self_alignment.as_mut() {
                 visitor(&mut *e)
             }
-            if let Some(e) = cell.order.as_mut() {
+            if let Some(e) = cell.layout_order.as_mut() {
                 visitor(&mut *e)
             }
         }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -556,6 +556,12 @@ pub struct SubComponent {
     /// of it. The cross-axis layout-info pass shares that accessor and so also
     /// evaluates it, unlike static cells (`box_layout_info_ortho` ignores it).
     pub cross_axis_self_alignment_for_repeated: Option<(crate::layout::Orientation, MutExpression)>,
+    /// The root's `layout-order` for a repeated element in a box layout,
+    /// returned by the generated `layout_item_info` for the given (main-axis)
+    /// orientation only, so the cross-axis cache stays independent of it. The
+    /// main-axis layout-info pass shares that accessor and so also evaluates
+    /// it, unlike static cells (`box_layout_info` ignores the field).
+    pub layout_order_for_repeated: Option<(crate::layout::Orientation, MutExpression)>,
     /// Vertical `LayoutInfo` for a repeated element, computed with a width
     /// constraint (its preferred width) so a height-for-width instance in a
     /// column FlexboxLayout doesn't read `self.width` and recurse through the
@@ -820,6 +826,9 @@ impl CompilationUnit {
                 visitor(e, ctx);
             }
             if let Some((_, e)) = &sc.cross_axis_self_alignment_for_repeated {
+                visitor(e, ctx);
+            }
+            if let Some((_, e)) = &sc.layout_order_for_repeated {
                 visitor(e, ctx);
             }
             if let Some(e) = &sc.layout_info_v_constrained_for_repeated {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1098,7 +1098,7 @@ fn flexbox_layout_data(
                         Orientation::Horizontal,
                         constraint,
                     );
-                    make_layout_cell_data_struct(layout_info_h, None)
+                    make_layout_cell_data_struct(layout_info_h, None, None)
                 })
                 .collect(),
             element_ty: cell_ty.clone(),
@@ -1121,7 +1121,7 @@ fn flexbox_layout_data(
                         Orientation::Vertical,
                         constraint,
                     );
-                    make_layout_cell_data_struct(layout_info_v, None)
+                    make_layout_cell_data_struct(layout_info_v, None, None)
                 })
                 .collect(),
             element_ty: cell_ty,
@@ -1179,8 +1179,8 @@ fn flexbox_layout_data(
                     constraint,
                 );
                 elements.push(Either::Left((
-                    make_layout_cell_data_struct(layout_info_h, None),
-                    make_layout_cell_data_struct(layout_info_v, None),
+                    make_layout_cell_data_struct(layout_info_h, None, None),
+                    make_layout_cell_data_struct(layout_info_v, None, None),
                     make_flex_props_struct(flex_prop(item, ctx)),
                 )));
             }
@@ -1237,16 +1237,21 @@ fn default_align_self() -> (Type, llr_Expression) {
 
 /// Build a LayoutItemInfo struct expression with the canonical (full) field
 /// list as its type, so the generators default the fields that are not set.
-/// `align_self` is only set for a box layout's cross-axis cells.
+/// `align_self` is only set for a box layout's cross-axis cells, `order` only
+/// for its main-axis ones.
 fn make_layout_cell_data_struct(
     layout_info: llr_Expression,
     align_self: Option<llr_Expression>,
+    order: Option<llr_Expression>,
 ) -> llr_Expression {
     let Type::Struct(ty) = crate::typeregister::layout_item_info_type() else { unreachable!() };
     let mut values = BTreeMap::<SmolStr, llr_Expression>::new();
     values.insert("constraint".into(), layout_info);
     if let Some(align_self) = align_self {
         values.insert("cross-axis-self-alignment".into(), align_self);
+    }
+    if let Some(order) = order {
+        values.insert("layout-order".into(), order);
     }
     llr_Expression::Struct { ty, values }
 }
@@ -1303,6 +1308,15 @@ fn box_layout_data(
             .filter(|_| for_solve && orientation != layout.orientation)
             .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
     };
+    // `layout-order` is the mirror image: it only reorders the main-axis solve,
+    // so keep it out of the cross-axis cache and of the layout-info cells (a
+    // permutation changes neither the sum nor the merge of the constraints).
+    let cell_order = |li: &crate::layout::LayoutItem, ctx: &mut ExpressionLoweringCtx| {
+        li.layout_order
+            .as_ref()
+            .filter(|_| for_solve && orientation == layout.orientation)
+            .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
+    };
     if repeater_count == 0 {
         let cells = llr_Expression::Array {
             values: layout
@@ -1319,7 +1333,8 @@ fn box_layout_data(
                         for_measure_solve,
                     );
                     let align_self = cell_align_self(li, ctx);
-                    make_layout_cell_data_struct(layout_info, align_self)
+                    let order = cell_order(li, ctx);
+                    make_layout_cell_data_struct(layout_info, align_self, order)
                 })
                 .collect(),
             element_ty,
@@ -1350,7 +1365,12 @@ fn box_layout_data(
                     for_measure_solve,
                 );
                 let align_self = cell_align_self(item, ctx);
-                elements.push(Either::Left(make_layout_cell_data_struct(layout_info, align_self)));
+                let order = cell_order(item, ctx);
+                elements.push(Either::Left(make_layout_cell_data_struct(
+                    layout_info,
+                    align_self,
+                    order,
+                )));
             }
         }
         let cells = llr_Expression::ReadLocalVariable {
@@ -1624,7 +1644,7 @@ fn grid_layout_cell_constraints(
                         None,
                         false,
                     );
-                    make_layout_cell_data_struct(layout_info, None)
+                    make_layout_cell_data_struct(layout_info, None, None)
                 })
                 .collect(),
             output: llr_ArrayOutput::Slice,
@@ -1658,7 +1678,7 @@ fn grid_layout_cell_constraints(
                     None,
                     false,
                 );
-                elements.push(Either::Left(make_layout_cell_data_struct(layout_info, None)));
+                elements.push(Either::Left(make_layout_cell_data_struct(layout_info, None, None)));
             }
         }
         let cells = llr_Expression::ReadLocalVariable {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -652,7 +652,7 @@ fn cell_measure_capability(elem: &ElementRc) -> (bool, bool) {
 /// capable, so a solve or cross-axis info computation needs a measure callback.
 fn flexbox_needs_measure(layout: &crate::layout::FlexboxLayout) -> bool {
     layout.elems.iter().any(|li| {
-        let (h4w, w4h) = cell_measure_capability(&li.item.element);
+        let (h4w, w4h) = cell_measure_capability(&li.element);
         h4w || w4h
     })
 }
@@ -673,7 +673,7 @@ fn measure_cells_for(
         .elems
         .iter()
         .map(|li| {
-            let elem = &li.item.element;
+            let elem = &li.element;
             if elem.borrow().repeated.is_some() {
                 let (h4w, w4h) = cell_measure_capability(elem);
                 let w4h_only = w4h && !h4w;
@@ -701,7 +701,7 @@ fn measure_cells_for(
             let v_info = get_flex_cell_layout_info(
                 elem,
                 ctx,
-                &li.item.constraints,
+                &li.constraints,
                 Orientation::Vertical,
                 v_constraint,
             );
@@ -712,7 +712,7 @@ fn measure_cells_for(
             let h_info = get_flex_cell_layout_info(
                 elem,
                 ctx,
-                &li.item.constraints,
+                &li.constraints,
                 Orientation::Horizontal,
                 h_constraint,
             );
@@ -1020,22 +1020,21 @@ fn flexbox_layout_data(
     };
 
     let repeater_count =
-        layout.elems.iter().filter(|i| i.item.element.borrow().repeated.is_some()).count();
+        layout.elems.iter().filter(|i| i.element.borrow().repeated.is_some()).count();
 
     let cell_ty = crate::typeregister::layout_item_info_type();
     let flex_props_ty = crate::typeregister::flex_item_props_type();
 
     let flex_prop =
-        |li: &crate::layout::FlexboxLayoutItem, ctx: &mut ExpressionLoweringCtx| -> FlexItemProps {
+        |li: &crate::layout::LayoutItem, ctx: &mut ExpressionLoweringCtx| -> FlexItemProps {
             FlexItemProps {
                 align_self: li
-                    .item
                     .cross_axis_self_alignment
                     .as_ref()
                     .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
                     .unwrap_or(default_align_self().1),
                 order: li
-                    .order
+                    .layout_order
                     .as_ref()
                     .map(|nr| llr_Expression::PropertyReference(ctx.map_property_reference(nr)))
                     .unwrap_or(llr_Expression::NumberLiteral(0.0)),
@@ -1091,11 +1090,11 @@ fn flexbox_layout_data(
                 .elems
                 .iter()
                 .map(|li| {
-                    let constraint = cell_h_constraint(&li.item.element);
+                    let constraint = cell_h_constraint(&li.element);
                     let layout_info_h = get_flex_cell_layout_info(
-                        &li.item.element,
+                        &li.element,
                         ctx,
-                        &li.item.constraints,
+                        &li.constraints,
                         Orientation::Horizontal,
                         constraint,
                     );
@@ -1114,11 +1113,11 @@ fn flexbox_layout_data(
                 .elems
                 .iter()
                 .map(|li| {
-                    let constraint = cell_v_constraint(&li.item.element);
+                    let constraint = cell_v_constraint(&li.element);
                     let layout_info_v = get_flex_cell_layout_info(
-                        &li.item.element,
+                        &li.element,
                         ctx,
-                        &li.item.constraints,
+                        &li.constraints,
                         Orientation::Vertical,
                         constraint,
                     );
@@ -1151,35 +1150,31 @@ fn flexbox_layout_data(
     } else {
         let mut elements = Vec::new();
         for item in &layout.elems {
-            if item.item.element.borrow().repeated.is_some() {
-                let repeater_index = match ctx
-                    .mapping
-                    .element_mapping
-                    .get(&item.item.element.clone().into())
-                    .unwrap()
-                {
-                    LoweredElement::Repeated { repeated_index } => *repeated_index,
-                    _ => panic!(),
-                };
+            if item.element.borrow().repeated.is_some() {
+                let repeater_index =
+                    match ctx.mapping.element_mapping.get(&item.element.clone().into()).unwrap() {
+                        LoweredElement::Repeated { repeated_index } => *repeated_index,
+                        _ => panic!(),
+                    };
                 elements.push(Either::Right(LayoutRepeatedElement {
                     repeater_index,
                     row_child_templates: None,
                 }))
             } else {
                 // For static elements, we need both orientations
-                let h_constraint = cell_h_constraint(&item.item.element);
+                let h_constraint = cell_h_constraint(&item.element);
                 let layout_info_h = get_flex_cell_layout_info(
-                    &item.item.element,
+                    &item.element,
                     ctx,
-                    &item.item.constraints,
+                    &item.constraints,
                     Orientation::Horizontal,
                     h_constraint,
                 );
-                let constraint = cell_v_constraint(&item.item.element);
+                let constraint = cell_v_constraint(&item.element);
                 let layout_info_v = get_flex_cell_layout_info(
-                    &item.item.element,
+                    &item.element,
                     ctx,
-                    &item.item.constraints,
+                    &item.constraints,
                     Orientation::Vertical,
                     constraint,
                 );

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -390,6 +390,7 @@ fn lower_sub_component(
         grid_layout_input_for_repeated: None,
         flexbox_layout_item_info_for_repeated: None,
         cross_axis_self_alignment_for_repeated: None,
+        layout_order_for_repeated: None,
         layout_info_v_constrained_for_repeated: None,
         layout_info_v_at_cross_width_for_repeated: None,
         layout_info_h_constrained_for_repeated: None,
@@ -811,12 +812,20 @@ fn lower_sub_component(
         component.root_element.borrow().parent_box_layout_orientation
     {
         // A repeated element in a box layout returns its `cross-axis-self-alignment`
-        // through the generated `layout_item_info`, on the cross axis only.
+        // through the generated `layout_item_info`, on the cross axis only, and its
+        // `layout-order` on the main axis only.
         if let Some(nr) =
             crate::layout::binding_reference(&component.root_element, "cross-axis-self-alignment")
         {
             sub_component.cross_axis_self_alignment_for_repeated = Some((
                 box_orientation.orthogonal(),
+                super::Expression::PropertyReference(ctx.map_property_reference(&nr)).into(),
+            ));
+        }
+        if let Some(nr) = crate::layout::binding_reference(&component.root_element, "layout-order")
+        {
+            sub_component.layout_order_for_repeated = Some((
+                box_orientation,
                 super::Expression::PropertyReference(ctx.map_property_reference(&nr)).into(),
             ));
         }

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -93,6 +93,9 @@ pub fn count_property_use(root: &CompilationUnit) {
         if let Some((_, e)) = &sc.cross_axis_self_alignment_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }
+        if let Some((_, e)) = &sc.layout_order_for_repeated {
+            e.borrow().visit_property_references(ctx, &mut visit_property);
+        }
         if let Some(e) = &sc.layout_info_v_constrained_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -329,6 +329,7 @@ mod visitor {
             grid_layout_input_for_repeated,
             flexbox_layout_item_info_for_repeated,
             cross_axis_self_alignment_for_repeated,
+            layout_order_for_repeated,
             layout_info_v_constrained_for_repeated,
             layout_info_v_at_cross_width_for_repeated,
             layout_info_h_constrained_for_repeated,
@@ -438,6 +439,9 @@ mod visitor {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some((_, e)) = cross_axis_self_alignment_for_repeated {
+            visit_expression(e.get_mut(), &scope, state, visitor);
+        }
+        if let Some((_, e)) = layout_order_for_repeated {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some(e) = layout_info_v_constrained_for_repeated {

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -193,6 +193,14 @@ impl PrettyPrinter<'_> {
                 DisplayExpression(&e.borrow(), &ctx)
             )?
         }
+        if let Some((main_o, e)) = &sc.layout_order_for_repeated {
+            self.indent()?;
+            writeln!(
+                self.writer,
+                "layout-order-for-repeated ({main_o:?}): {};",
+                DisplayExpression(&e.borrow(), &ctx)
+            )?
+        }
         for (i, c) in sc.grid_layout_children.iter_enumerated() {
             self.indent()?;
             writeln!(

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -4940,8 +4940,6 @@ pub fn inject_element_as_repeated_element(repeated_element: &ElementRc, new_root
     // root (now the wrapper). Link them to the inner element that still carries the
     // bindings (and the layout's captured references keeping them alive), rather
     // than moving them, which would leave those references dangling.
-    // cross-axis-self-alignment is read by both the flexbox and the box layout
-    // accessor; layout-order only by the flexbox one.
     for prop in ["layout-order", "cross-axis-self-alignment"].iter() {
         if old_root.borrow().binding(prop).is_some() {
             new_root.borrow_mut().set_binding(

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -678,7 +678,7 @@ fn recurse_expression(
                             vis(&nr.clone().into(), P);
                         }
                         visit_layout_items_layoutinfo_cross_axis_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Vertical,
                             vis,
                         );
@@ -688,7 +688,7 @@ fn recurse_expression(
                             vis(&nr.clone().into(), P);
                         }
                         visit_layout_items_layoutinfo_cross_axis_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Horizontal,
                             vis,
                         );
@@ -702,12 +702,12 @@ fn recurse_expression(
                             vis(&nr.clone().into(), P);
                         }
                         visit_layout_items_layoutinfo_cross_axis_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Horizontal,
                             vis,
                         );
                         visit_layout_items_layoutinfo_cross_axis_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Vertical,
                             vis,
                         );
@@ -719,11 +719,7 @@ fn recurse_expression(
                 match layout.axis_relation(orientation) {
                     FlexboxAxisRelation::MainAxis => {
                         // Main axis: only visit same-axis item dependencies
-                        visit_layout_items_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
-                            orientation,
-                            vis,
-                        );
+                        visit_layout_items_dependencies(layout.elems.iter(), orientation, vis);
                     }
                     FlexboxAxisRelation::CrossAxis => {
                         // Cross axis: depends on the perpendicular (main-axis)
@@ -745,12 +741,12 @@ fn recurse_expression(
                             vis(&nr.clone().into(), P);
                         }
                         visit_layout_items_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Horizontal,
                             vis,
                         );
                         visit_layout_items_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Vertical,
                             vis,
                         );
@@ -760,12 +756,12 @@ fn recurse_expression(
                         // dependencies but NOT perpendicular dimensions (adding
                         // those leads to binding loops for runtime direction).
                         visit_layout_items_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Horizontal,
                             vis,
                         );
                         visit_layout_items_dependencies(
-                            layout.elems.iter().map(|fi| &fi.item),
+                            layout.elems.iter(),
                             Orientation::Vertical,
                             vis,
                         );

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -886,12 +886,12 @@ fn fixup_element_references(expr: &mut Expression, mapping: &Mapping) {
         }
         Expression::SolveFlexboxLayout(layout) => {
             for e in &mut layout.elems {
-                fxe(&mut e.item.element);
+                fxe(&mut e.element);
             }
         }
         Expression::ComputeFlexboxLayoutInfo { layout, cross_axis_size, .. } => {
             for e in &mut layout.elems {
-                fxe(&mut e.item.element);
+                fxe(&mut e.element);
             }
             if let Some(cas) = cross_axis_size {
                 fixup_element_references(cas, mapping);

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1901,8 +1901,9 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
                 diag,
             );
         }
-        let order = crate::layout::binding_reference(actual_elem, "layout-order");
-        layout.elems.push(crate::layout::FlexboxLayoutItem { item: item.item, order });
+        let mut cell = item.item;
+        cell.layout_order = crate::layout::binding_reference(actual_elem, "layout-order");
+        layout.elems.push(cell);
     }
     layout_element.borrow_mut().children = layout_children;
     let span = layout_element.borrow().to_source_location();
@@ -2277,7 +2278,12 @@ fn create_layout_item(
     let cross_axis_self_alignment =
         crate::layout::binding_reference(&actual_elem, "cross-axis-self-alignment");
     CreateLayoutItemResult {
-        item: LayoutItem { element: item_element.clone(), constraints, cross_axis_self_alignment },
+        item: LayoutItem {
+            element: item_element.clone(),
+            constraints,
+            cross_axis_self_alignment,
+            layout_order: None,
+        },
         elem: actual_elem,
         repeater_index,
     }

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1696,8 +1696,9 @@ fn lower_box_layout(
     let items: Vec<_> =
         layout_children.iter().map(|child| create_layout_item(child, diag)).collect();
     // A repeated cell needs the layout's orientation: `lower_to_item_tree` uses
-    // it to restrict a `cross-axis-self-alignment` to the cross axis, and to
-    // generate `layout_item_info_at_cross_width` / `_at_cross_height` for a
+    // it to restrict a `cross-axis-self-alignment` to the cross axis and a
+    // `layout-order` to the main axis, and to generate
+    // `layout_item_info_at_cross_width` / `_at_cross_height` for a
     // height-for-width (resp. width-for-height) instance.
     for item in &items {
         if item.repeater_index.is_some() {
@@ -1901,9 +1902,7 @@ fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics)
                 diag,
             );
         }
-        let mut cell = item.item;
-        cell.layout_order = crate::layout::binding_reference(actual_elem, "layout-order");
-        layout.elems.push(cell);
+        layout.elems.push(item.item);
     }
     layout_element.borrow_mut().children = layout_children;
     let span = layout_element.borrow().to_source_location();
@@ -2277,12 +2276,13 @@ fn create_layout_item(
     let constraints = LayoutConstraints::new(&actual_elem, Some((diag, DiagnosticLevel::Error)));
     let cross_axis_self_alignment =
         crate::layout::binding_reference(&actual_elem, "cross-axis-self-alignment");
+    let layout_order = crate::layout::binding_reference(&actual_elem, "layout-order");
     CreateLayoutItemResult {
         item: LayoutItem {
             element: item_element.clone(),
             constraints,
             cross_axis_self_alignment,
-            layout_order: None,
+            layout_order,
         },
         elem: actual_elem,
         repeater_index,
@@ -2554,10 +2554,7 @@ fn check_no_layout_properties(
         {
             diag.push_error(format!("{prop} used outside of a GridLayout's cell"), &*expr.borrow());
         }
-        if prop == "layout-order" && parent_layout_type.as_deref() != Some("FlexboxLayout") {
-            diag.push_error(format!("{prop} used outside of a FlexboxLayout"), &*expr.borrow());
-        }
-        if prop == "cross-axis-self-alignment"
+        if matches!(prop.as_ref(), "layout-order" | "cross-axis-self-alignment")
             && !matches!(
                 parent_layout_type.as_deref(),
                 Some("FlexboxLayout" | "HorizontalLayout" | "VerticalLayout")

--- a/internal/compiler/passes/remove_constant_conditions.rs
+++ b/internal/compiler/passes/remove_constant_conditions.rs
@@ -39,7 +39,7 @@ pub fn remove_constant_conditions(component: &Rc<Component>) {
             if let Expression::SolveFlexboxLayout(l)
             | Expression::ComputeFlexboxLayoutInfo { layout: l, .. } = e
             {
-                dead.retain(|c| !l.elems.iter().any(|it| Rc::ptr_eq(&it.item.element, c)));
+                dead.retain(|c| !l.elems.iter().any(|it| Rc::ptr_eq(&it.element, c)));
             }
         })
     });

--- a/internal/compiler/tests/layout_cell_properties.rs
+++ b/internal/compiler/tests/layout_cell_properties.rs
@@ -1,16 +1,21 @@
 // Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! The per-item properties of a `FlexboxLayout` (`layout-order`, `cross-axis-self-alignment`)
-//! are stable API. The syntax tests can't verify that because they always enable the
-//! experimental features, so these tests compile with them disabled.
+//! The per-item properties of a `FlexboxLayout`, `HorizontalLayout` or `VerticalLayout`
+//! cell (`layout-order`, `cross-axis-self-alignment`) are stable API. The syntax tests
+//! can't verify that because they always enable the experimental features, so these
+//! tests compile with them disabled.
 
 use i_slint_compiler::diagnostics::{BuildDiagnostics, DiagnosticLevel};
 use i_slint_compiler::generator::OutputFormat;
 use i_slint_compiler::parser::parse;
 use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
 
-const FLEX_ITEM_PROPERTIES: &[&str] = &["layout-order: 3"];
+const LAYOUT_CELL_PROPERTIES: &[&str] = &["layout-order: 3", "cross-axis-self-alignment: center"];
+
+const CELL_LAYOUTS: &[&str] = &["FlexboxLayout", "HorizontalLayout", "VerticalLayout"];
+
+const OUTSIDE_ERROR: &str = "used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout";
 
 /// Compile `source` without experimental features and return its errors
 /// (warnings are not of interest here).
@@ -29,11 +34,11 @@ fn errors(source: String) -> Vec<String> {
         .collect()
 }
 
-fn in_flexbox(binding: &str) -> Vec<String> {
+fn in_layout(layout: &str, binding: &str) -> Vec<String> {
     errors(format!(
         r#"
 export component TestCase inherits Window {{
-    FlexboxLayout {{
+    {layout} {{
         Rectangle {{ {binding}; }}
     }}
 }}
@@ -46,82 +51,40 @@ fn name_of(binding: &str) -> &str {
 }
 
 #[test]
-fn flex_item_properties_are_stable() {
-    for binding in FLEX_ITEM_PROPERTIES {
-        assert_eq!(in_flexbox(binding), Vec::<String>::new());
+fn layout_cell_properties_are_stable() {
+    for layout in CELL_LAYOUTS {
+        for binding in LAYOUT_CELL_PROPERTIES {
+            assert_eq!(in_layout(layout, binding), Vec::<String>::new());
+        }
     }
 }
 
-/// `cross-axis-self-alignment` is usable in a FlexboxLayout and in the box layouts.
+/// In a GridLayout (or outside of any layout) the properties are rejected.
 #[test]
-fn cross_axis_self_alignment_is_stable() {
-    assert_eq!(in_flexbox("cross-axis-self-alignment: center"), Vec::<String>::new());
-    for layout in ["HorizontalLayout", "VerticalLayout"] {
-        let source = format!(
-            r#"
-export component TestCase inherits Window {{
-    {layout} {{
-        Rectangle {{ cross-axis-self-alignment: center; }}
-    }}
-}}
-"#
-        );
-        assert_eq!(errors(source), Vec::<String>::new());
-    }
-}
-
-/// In a GridLayout (or outside of any layout) the property is rejected.
-#[test]
-fn cross_axis_self_alignment_rejected_in_grid() {
-    let source = r#"
-export component TestCase inherits Window {
-    GridLayout {
-        Rectangle { cross-axis-self-alignment: center; }
-    }
-}
-"#;
-    assert_eq!(
-        errors(source.into()),
-        [
-            "cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout"
-        ]
-    );
-}
-
-#[test]
-fn used_outside_of_a_flexbox_is_rejected() {
-    for binding in FLEX_ITEM_PROPERTIES {
-        let source = format!(
-            r#"
-export component TestCase inherits Window {{
-    VerticalLayout {{
-        Rectangle {{ {binding}; }}
-    }}
-}}
-"#
-        );
+fn rejected_in_grid() {
+    for binding in LAYOUT_CELL_PROPERTIES {
         assert_eq!(
-            errors(source),
-            [format!("{} used outside of a FlexboxLayout", name_of(binding))]
+            in_layout("GridLayout", binding),
+            [format!("{} {OUTSIDE_ERROR}", name_of(binding))]
         );
     }
 }
 
-/// A repeated or conditional cell gets an element injected around it, onto which the `flex-*`
-/// bindings are linked. Check that this doesn't report the error a second time.
+/// A repeated or conditional cell gets an element injected around it, onto which the
+/// per-item bindings are linked. Check that this doesn't report the error a second time.
 #[test]
 fn repeated_and_conditional_cells_report_once() {
     for cell in ["for i in 3:", "if true:"] {
         let source = format!(
             r#"
 export component TestCase inherits Window {{
-    VerticalLayout {{
+    GridLayout {{
         {cell} Rectangle {{ layout-order: 1; }}
     }}
 }}
 "#
         );
-        assert_eq!(errors(source), ["layout-order used outside of a FlexboxLayout"]);
+        assert_eq!(errors(source), [format!("layout-order {OUTSIDE_ERROR}")]);
     }
 }
 

--- a/internal/compiler/tests/syntax/layout/layout_cell_properties_outside_layout.slint
+++ b/internal/compiler/tests/syntax/layout/layout_cell_properties_outside_layout.slint
@@ -13,31 +13,32 @@ export component X inherits Rectangle {
                 cross-axis-self-alignment: center;
 //                                         >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
                 layout-order: 3;
-//                            ><error{layout-order used outside of a FlexboxLayout}
+//                            ><error{layout-order used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
             }
         }
     }
 
-    // flex properties used outside of FlexboxLayout should error
+    // per-item properties used outside of a layout should error
     Text {
         cross-axis-self-alignment: center;
 //                                 >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
         layout-order: 3;
-//                    ><error{layout-order used outside of a FlexboxLayout}
+//                    ><error{layout-order used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
     }
 
     GridLayout {
         Text {
             cross-axis-self-alignment: center;
 //                                     >     <error{cross-axis-self-alignment used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
+            layout-order: 3;
+//                        ><error{layout-order used outside of a FlexboxLayout, HorizontalLayout, or VerticalLayout}
         }
     }
 
     HorizontalLayout {
         Text {
-            layout-order: 5;
-//                        ><error{layout-order used outside of a FlexboxLayout}
             // valid in a box layout
+            layout-order: 5;
             cross-axis-self-alignment: center;
         }
     }
@@ -45,6 +46,7 @@ export component X inherits Rectangle {
     VerticalLayout {
         Text {
             // valid in a box layout
+            layout-order: -1;
             cross-axis-self-alignment: end;
         }
     }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -48,9 +48,10 @@ pub const RESERVED_GRIDLAYOUT_PROPERTIES: &[(&str, Type)] = &[
     ("rowspan", Type::Int32),
 ];
 
-// Note: the per-item cross-axis-self-alignment (flexbox and box layouts) is added
-// in reserved_properties() because Type::Enumeration requires a runtime Arc allocation.
-pub const RESERVED_FLEXBOXLAYOUT_PROPERTIES: &[(&str, Type)] = &[("layout-order", Type::Int32)];
+// Per-item properties of a FlexboxLayout, HorizontalLayout or VerticalLayout cell.
+// Note: cross-axis-self-alignment is added in reserved_properties() instead,
+// because Type::Enumeration requires a runtime Arc allocation.
+pub const RESERVED_LAYOUT_CELL_PROPERTIES: &[(&str, Type)] = &[("layout-order", Type::Int32)];
 
 macro_rules! declare_enums {
     ($( $(#[$enum_doc:meta])* $vis:vis enum $Name:ident { $( $(#[$value_doc:meta])* $Value:ident,)* })*) => {
@@ -190,6 +191,7 @@ impl BuiltinTypes {
                         "cross-axis-self-alignment".into(),
                         Type::Enumeration(enums.CrossAxisSelfAlignment.clone()),
                     ),
+                    ("layout-order".into(), Type::Int32),
                 ])
                 .collect(),
                 BuiltinStruct::LayoutItemInfo,
@@ -324,7 +326,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
                 .map(|(k, v)| (*k, v.clone(), PropertyVisibility::Input)),
         )
         .chain(
-            RESERVED_FLEXBOXLAYOUT_PROPERTIES
+            RESERVED_LAYOUT_CELL_PROPERTIES
                 .iter()
                 .map(|(k, v)| (*k, v.clone(), PropertyVisibility::Input)),
         )

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1170,6 +1170,12 @@ pub struct LayoutItemInfo {
     /// Per-item cross-axis alignment override for box layouts
     /// (`Auto` = use the container's `cross-axis-alignment`)
     pub cross_axis_self_alignment: CrossAxisSelfAlignment,
+    /// Visual ordering of box layout cells (lower values appear first, default 0).
+    /// Only [`solve_box_layout`] reads it; the cross-axis solve and both
+    /// layout-info functions ignore it. A FlexboxLayout carries it in
+    /// [`FlexItemProps`] instead, and a GridLayout orders its cells with
+    /// `row`/`col`, so both leave this at 0.
+    pub layout_order: i32,
 }
 
 /// The per-item flex properties of a FlexboxLayout cell.
@@ -1203,7 +1209,7 @@ impl From<LayoutItemInfo> for FlexboxLayoutItemInfo {
             constraint: info.constraint,
             props: FlexItemProps {
                 cross_axis_self_alignment: info.cross_axis_self_alignment,
-                ..Default::default()
+                layout_order: info.layout_order,
             },
         }
     }
@@ -1238,6 +1244,19 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indices: Slice<u32>) -> S
             }
         })
         .collect();
+
+    // `layout-order` reorders the cells like the CSS `order` property. Solve on
+    // the reordered list; the results are written back in declaration order
+    // below, as a cell's cache slot is fixed by its declaration index.
+    let order_map: Vec<usize> = if data.cells.iter().any(|c| c.layout_order != 0) {
+        let mut indices: Vec<usize> = (0..layout_data.len()).collect();
+        // sort_by_key is a stable sort, so equal orders keep declaration order
+        indices.sort_by_key(|&i| data.cells[i].layout_order);
+        layout_data = indices.iter().map(|&i| layout_data[i].clone()).collect();
+        indices
+    } else {
+        Vec::new()
+    };
 
     let pref_size: Coord = layout_data.iter().map(|it| it.pref).sum();
 
@@ -1289,8 +1308,19 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indices: Slice<u32>) -> S
     }
 
     let mut generator = LayoutCacheGenerator::new(&repeater_indices, &mut result);
-    for layout in layout_data.iter() {
-        generator.add(layout.pos, layout.size);
+    if order_map.is_empty() {
+        for layout in layout_data.iter() {
+            generator.add(layout.pos, layout.size);
+        }
+    } else {
+        let mut geom = alloc::vec![(0 as Coord, 0 as Coord); layout_data.len()];
+        for (sorted_idx, &declared_idx) in order_map.iter().enumerate() {
+            let layout = &layout_data[sorted_idx];
+            geom[declared_idx] = (layout.pos, layout.size);
+        }
+        for (pos, size) in geom {
+            generator.add(pos, size);
+        }
     }
     result
 }

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1184,6 +1184,11 @@ fn push_repeater_layout_items(
                 ),
             );
         }
+        // Likewise `layout-order`, read back on the main-axis solve.
+        if info.layout_order != 0 {
+            struct_value
+                .set_field("layout-order".to_string(), Value::Number(info.layout_order as f64));
+        }
         cells.push(Value::Struct(struct_value));
     };
     let step = match row_child_templates {

--- a/internal/interpreter/eval_layout.rs
+++ b/internal/interpreter/eval_layout.rs
@@ -59,6 +59,11 @@ fn to_cells(v: &Value) -> Vec<LayoutItemInfo> {
                     .get_field("cross-axis-self-alignment")
                     .map(to_enum)
                     .unwrap_or_default(),
+                // Only set for a box layout's main-axis cells; absent means 0.
+                layout_order: match s.get_field("layout-order") {
+                    Some(Value::Number(n)) => *n as i32,
+                    _ => 0,
+                },
             })
         })
         .collect()

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -1082,6 +1082,39 @@ fn build_tree_nodes(
     (out, dyn_table, item_table, z_sort_table)
 }
 
+/// The cell's `cross-axis-self-alignment` in a box layout, returned for the
+/// cross axis only, so the main-axis cache stays independent of it.
+fn repeated_align_self(
+    sc: &i_slint_compiler::llr::SubComponent,
+    ctx: &mut crate::eval::EvalContext,
+    orientation: i_slint_core::items::Orientation,
+) -> i_slint_core::items::CrossAxisSelfAlignment {
+    match &sc.cross_axis_self_alignment_for_repeated {
+        Some((cross_o, expr)) if crate::eval::llr_to_core_orientation(*cross_o) == orientation => {
+            crate::eval::eval_expression(ctx, &expr.borrow()).try_into().unwrap_or_default()
+        }
+        _ => Default::default(),
+    }
+}
+
+/// The cell's `layout-order` in a box layout, returned for the main axis
+/// only: only that solve reorders the cells.
+fn repeated_layout_order(
+    sc: &i_slint_compiler::llr::SubComponent,
+    ctx: &mut crate::eval::EvalContext,
+    orientation: i_slint_core::items::Orientation,
+) -> i32 {
+    match &sc.layout_order_for_repeated {
+        Some((main_o, expr)) if crate::eval::llr_to_core_orientation(*main_o) == orientation => {
+            match crate::eval::eval_expression(ctx, &expr.borrow()) {
+                crate::Value::Number(n) => n as i32,
+                _ => 0,
+            }
+        }
+        _ => 0,
+    }
+}
+
 /// Lets [`Instance`] be used inside a `Repeater<C>`.
 ///
 /// `update(idx, data)` writes the repeater's `index_prop` and `data_prop` on
@@ -1198,19 +1231,11 @@ impl i_slint_core::model::RepeatedItemTree for Instance {
         let mut ctx = crate::eval::EvalContext::new(this.root_sub_component.clone());
         let constraint =
             crate::eval::eval_expression(&mut ctx, &expr).try_into().unwrap_or_default();
-        // The cell's `cross-axis-self-alignment` in a box layout, returned for
-        // the cross axis only, so the main-axis cache stays independent of it.
-        let cross_axis_self_alignment = match &sc.cross_axis_self_alignment_for_repeated {
-            Some((cross_o, align_expr))
-                if crate::eval::llr_to_core_orientation(*cross_o) == orientation =>
-            {
-                crate::eval::eval_expression(&mut ctx, &align_expr.borrow())
-                    .try_into()
-                    .unwrap_or_default()
-            }
-            _ => Default::default(),
-        };
-        i_slint_core::layout::LayoutItemInfo { constraint, cross_axis_self_alignment }
+        i_slint_core::layout::LayoutItemInfo {
+            constraint,
+            cross_axis_self_alignment: repeated_align_self(sc, &mut ctx, orientation),
+            layout_order: repeated_layout_order(sc, &mut ctx, orientation),
+        }
     }
 
     fn layout_item_info_at_cross_width(
@@ -1322,7 +1347,14 @@ impl Instance {
         ctx.locals.insert(local.into(), crate::Value::Number(cross_size as f64));
         let constraint =
             crate::eval::eval_expression(&mut ctx, &expr.borrow()).try_into().unwrap_or_default();
-        i_slint_core::layout::LayoutItemInfo { constraint, ..Default::default() }
+        // The per-item fields are the same as in `layout_item_info`, which is
+        // not called here: it measures the constraint through `layout_info`,
+        // which is what this accessor exists to avoid.
+        i_slint_core::layout::LayoutItemInfo {
+            constraint,
+            cross_axis_self_alignment: repeated_align_self(sc, &mut ctx, orientation),
+            layout_order: repeated_layout_order(sc, &mut ctx, orientation),
+        }
     }
 
     /// Vertical flexbox info for a repeated instance measured at the container

--- a/tests/cases/layout/boxlayout_order.slint
+++ b/tests/cases/layout/boxlayout_order.slint
@@ -1,0 +1,361 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test the per-item layout-order property of HorizontalLayout and VerticalLayout
+//
+// Reading the rendered window: each gray-outlined band is one layout. Every
+// cell is labeled with its declaration letter and its layout-order, so the
+// test passes when the letters read out of alphabetical order exactly as the
+// caption above the band says. Blue cells carry a layout-order, gray ones
+// don't.
+//
+// The cells keep their exact geometry: the labels set `x` so they stay out of
+// their parent's layout-info (see gen_layout_info_prop in default_geometry.rs),
+// and the captions live outside the bands.
+
+component Caption inherits Text {
+    font-size: 11px;
+    color: #555555;
+}
+
+// One labeled cell of a layout under test. `accent` marks the cells that
+// carry a layout-order.
+component Cell inherits Rectangle {
+    in property <string> label;
+    in property <bool> accent: true;
+    background: accent ? #cce6ff : #dcdcdc;
+    border-width: 1px;
+    border-color: accent ? #5b8db8 : #a0a0a0;
+    Text {
+        x: 0px;
+        width: 100%;
+        height: 100%;
+        text: root.label;
+        font-size: 10px;
+        color: root.accent ? #003366 : #333333;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+// Test 1: layout-order changes the visual placement in a HorizontalLayout.
+component TestOrderRow inherits Rectangle {
+    width: 520px;
+    height: 70px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "declared A B C, ascending layout-order → C A B"; }
+        Rectangle {
+            width: 300px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                r_a := Cell { width: 100px; label: "A · 2"; layout-order: 2; }
+                r_b := Cell { width: 100px; label: "B · 3"; layout-order: 3; }
+                r_c := Cell { width: 100px; label: "C · 1"; layout-order: 1; }
+            }
+        }
+    }
+
+    out property <bool> test: r_c.x == 0px && r_a.x == 100px && r_b.x == 200px;
+}
+
+// Test 2: no layout-order at all keeps the declaration order.
+component TestOrderDefault inherits Rectangle {
+    width: 520px;
+    height: 70px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "no layout-order anywhere → declaration order A B C"; }
+        Rectangle {
+            width: 300px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                r1 := Cell { width: 100px; label: "A"; accent: false; }
+                r2 := Cell { width: 100px; label: "B"; accent: false; }
+                r3 := Cell { width: 100px; label: "C"; accent: false; }
+            }
+        }
+    }
+
+    out property <bool> test: r1.x == 0px && r2.x == 100px && r3.x == 200px;
+}
+
+// Test 3: a negative order pulls one cell in front of cells that set none.
+component TestOrderPullToFront inherits Rectangle {
+    width: 520px;
+    height: 70px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "only B is annotated: -1 pulls it in front of A and C, which default to 0"; }
+        Rectangle {
+            width: 300px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                p_a := Cell { width: 100px; label: "A"; accent: false; }
+                p_b := Cell { width: 100px; label: "B · -1"; layout-order: -1; }
+                p_c := Cell { width: 100px; label: "C"; accent: false; }
+            }
+        }
+    }
+
+    out property <bool> test: p_b.x == 0px && p_a.x == 100px && p_c.x == 200px;
+}
+
+// Test 4: VerticalLayout — each cell keeps its own height while moving.
+component TestOrderColumn inherits Rectangle {
+    width: 520px;
+    height: 205px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "VerticalLayout: top to bottom B C A, each cell keeping its own height (30 / 60 / 90)"; }
+        Rectangle {
+            width: 100px;
+            height: 180px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            VerticalLayout {
+                r_a := Cell { height: 90px; label: "A · 2"; layout-order: 2; }
+                r_b := Cell { height: 30px; label: "B · 0"; layout-order: 0; }
+                r_c := Cell { height: 60px; label: "C · 1"; layout-order: 1; }
+            }
+        }
+    }
+
+    out property <bool> test: r_b.y == 0px && r_b.height == 30px
+        && r_c.y == 30px && r_c.height == 60px
+        && r_a.y == 90px && r_a.height == 90px;
+}
+
+// Test 5: equal layout-order values keep the declaration order (stable sort).
+component TestOrderStable inherits Rectangle {
+    width: 520px;
+    height: 70px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "equal values keep the declaration order → B D A C, not B D C A"; }
+        Rectangle {
+            width: 400px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                s_a := Cell { width: 100px; label: "A · 1"; layout-order: 1; }
+                s_b := Cell { width: 100px; label: "B · 0"; layout-order: 0; }
+                s_c := Cell { width: 100px; label: "C · 1"; layout-order: 1; }
+                s_d := Cell { width: 100px; label: "D · 0"; layout-order: 0; }
+            }
+        }
+    }
+
+    out property <bool> test: s_b.x == 0px && s_d.x == 100px && s_a.x == 200px && s_c.x == 300px;
+}
+
+// Test 6: the order permutes the main axis only — `alignment` still packs the
+// reordered cells, and the cross axis is left to cross-axis-self-alignment.
+component TestOrderAlignment inherits Rectangle {
+    width: 520px;
+    height: 145px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "alignment: end packs the reordered pair B A against the right edge;\nthe cross axis still obeys cross-axis-self-alignment (B start → top, A end → bottom)"; }
+        Rectangle {
+            width: 300px;
+            height: 100px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                alignment: end;
+                a_a := Cell {
+                    width: 80px;
+                    height: 20px;
+                    label: "A · 1";
+                    layout-order: 1;
+                    cross-axis-self-alignment: end;
+                }
+                a_b := Cell {
+                    width: 80px;
+                    height: 20px;
+                    label: "B · 0";
+                    layout-order: 0;
+                    cross-axis-self-alignment: start;
+                }
+            }
+        }
+    }
+
+    out property <bool> test: a_b.x == 140px && a_a.x == 220px
+        && a_b.y == 0px && a_a.y == 80px;
+}
+
+// Test 7: layout-order on repeated cells, read through the item-info accessor.
+component TestOrderRepeated inherits Rectangle {
+    width: 520px;
+    height: 70px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "repeated cells take their order from the model: rep 1, rep 2, then the static 3 declared first"; }
+        Rectangle {
+            width: 300px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                r_static := Cell { width: 100px; label: "static · 3"; layout-order: 3; }
+                for order in [1, 2]: rep := Cell {
+                    width: 100px;
+                    label: "rep · " + order;
+                    layout-order: order;
+                }
+            }
+        }
+    }
+
+    out property <bool> test: r_static.x == 200px;
+}
+
+// Test 8: changing layout-order at runtime re-runs the solve.
+component TestOrderDynamic inherits Rectangle {
+    width: 520px;
+    height: 70px;
+    in-out property <int> order-a: 0;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "dynamic: A starts at 0 (A B C); the drivers set it to 3, moving A last (B C A)"; }
+        Rectangle {
+            width: 300px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                d_a := Cell { width: 100px; label: "A · " + root.order-a; layout-order: root.order-a; }
+                d_b := Cell { width: 100px; label: "B · 1"; layout-order: 1; }
+                d_c := Cell { width: 100px; label: "C · 2"; layout-order: 2; }
+            }
+        }
+    }
+
+    out property <length> a-x: d_a.x;
+    out property <bool> test: d_a.x == 0px && d_b.x == 100px && d_c.x == 200px;
+}
+
+// Test 9: the reordered cells keep their own stretch factor and the spacing
+// stays between the visual neighbors.
+component TestOrderStretch inherits Rectangle {
+    width: 520px;
+    height: 85px;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "spacing 10 and stretch survive the reorder:\nC (stretch 3) 140 wide first, then the fixed B, then A (stretch 1) 60 wide"; }
+        Rectangle {
+            width: 320px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                spacing: 10px;
+                w_a := Cell { min-width: 20px; horizontal-stretch: 1; label: "A · 3"; layout-order: 3; }
+                w_b := Cell { width: 100px; label: "B · 2"; layout-order: 2; }
+                w_c := Cell { min-width: 20px; horizontal-stretch: 3; label: "C · 1"; layout-order: 1; }
+            }
+        }
+    }
+
+    // 320 - 2*10 spacing - 100 fixed - 2*20 min = 160 free, split 1:3 → A 60, C 140
+    out property <bool> test: w_c.x == 0px && w_c.width == 140px
+        && w_b.x == 150px && w_b.width == 100px
+        && w_a.x == 260px && w_a.width == 60px;
+}
+
+// Test 10: a conditional cell is wrapped in an injected element; the order must
+// be linked onto that wrapper to reach the solve.
+component TestOrderConditional inherits Rectangle {
+    width: 520px;
+    height: 70px;
+    in-out property <bool> show-first: true;
+    VerticalLayout {
+        alignment: start;
+        spacing: 4px;
+        Caption { text: "the conditional cell (1) overtakes the static one (2), declared first"; }
+        Rectangle {
+            width: 200px;
+            height: 44px;
+            border-width: 1px;
+            border-color: #c8c8c8;
+            HorizontalLayout {
+                c_static := Cell { width: 100px; label: "static · 2"; layout-order: 2; }
+                if show-first: Cell { width: 100px; label: "if · 1"; layout-order: 1; }
+            }
+        }
+    }
+
+    out property <bool> test: c_static.x == 100px;
+}
+
+export component TestCase inherits Window {
+
+    VerticalLayout {
+        alignment: start;
+        spacing: 8px;
+        padding: 8px;
+        Caption {
+            text: "blue = cell with a layout-order, label = declaration letter · its layout-order value\ngray = cell without one; gray outline = the layout's area";
+        }
+        t1 := TestOrderRow { }
+        t2 := TestOrderDefault { }
+        t3 := TestOrderPullToFront { }
+        t4 := TestOrderColumn { }
+        t5 := TestOrderStable { }
+        t6 := TestOrderAlignment { }
+        t7 := TestOrderRepeated { }
+        t8 := TestOrderDynamic { }
+        t9 := TestOrderStretch { }
+        t10 := TestOrderConditional { }
+    }
+
+    in-out property <int> dynamic-order <=> t8.order-a;
+    out property <length> dynamic-a-x <=> t8.a-x;
+
+    out property <bool> test: t1.test && t2.test && t3.test && t4.test && t5.test
+        && t6.test && t7.test && t8.test && t9.test && t10.test;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+// Move A last at runtime: visual order becomes B(1), C(2), A(3)
+handle->set_dynamic_order(3);
+assert_eq(handle->get_dynamic_a_x(), 200.);
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+// Move A last at runtime: visual order becomes B(1), C(2), A(3)
+instance.set_dynamic_order(3);
+assert_eq!(instance.get_dynamic_a_x(), 200.);
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+// Move A last at runtime: visual order becomes B(1), C(2), A(3)
+instance.dynamic_order = 3;
+assert.equal(instance.dynamic_a_x, 200);
+```
+*/

--- a/tests/cases/layout/boxlayout_order_wrapped.slint
+++ b/tests/cases/layout/boxlayout_order_wrapped.slint
@@ -1,0 +1,49 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Test layout-order on a height-for-width repeated cell of a VerticalLayout.
+//
+// Such a cell is measured through the generated `layout_item_info_at_cross_width`
+// accessor instead of the plain `layout_item_info`, so that accessor has to
+// report the order too.
+//
+// This case is deliberately bare, unlike the captioned scenarios in
+// boxlayout_order.slint: the layout must be the window's own for it to know its
+// cross size and take that measure path, and adding chrome (a border on a row,
+// a caption beside the layout, a fixed size on the wrapped row) makes the
+// layout take a different path, so the test would pass with the accessor
+// reporting no order at all. The static row must also stay without a
+// layout-order: losing the repeated row's order then leaves the two tied and
+// declaration order wins, which is what the assertion detects.
+export component TestCase inherits Window {
+    width: 200px;
+    height: 300px;
+    VerticalLayout {
+        st := Rectangle { height: 30px; background: #dcdcdc; }
+        for t in ["one two three four five six seven eight nine ten eleven"]: Rectangle {
+            background: #cce6ff;
+            layout-order: -1;
+            Text { width: 100%; text: t; wrap: word-wrap; }
+        }
+    }
+    // Font-independent: the static row is not first, so it starts below the
+    // wrapped one, whatever height that one measures.
+    out property <bool> test: st.y > 0px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -557,14 +557,13 @@ fn is_reserved_prop_valid(
     if name_in(i_slint_compiler::typeregister::RESERVED_GRIDLAYOUT_PROPERTIES) {
         return matches!(parent_name, Some("GridLayout" | "Row"));
     }
-    if prop == "cross-axis-self-alignment" {
+    if prop == "cross-axis-self-alignment"
+        || name_in(i_slint_compiler::typeregister::RESERVED_LAYOUT_CELL_PROPERTIES)
+    {
         return matches!(
             parent_name,
             Some("FlexboxLayout" | "HorizontalLayout" | "VerticalLayout")
         );
-    }
-    if name_in(i_slint_compiler::typeregister::RESERVED_FLEXBOXLAYOUT_PROPERTIES) {
-        return parent_name == Some("FlexboxLayout");
     }
     if name_in(i_slint_compiler::typeregister::RESERVED_DROP_SHADOW_PROPERTIES)
         || name_in(i_slint_compiler::typeregister::RESERVED_INNER_SHADOW_PROPERTIES)
@@ -2910,30 +2909,8 @@ component Foo {
     }
 
     #[test]
-    fn flex_item_properties_in_flexbox() {
-        let source = r#"
-export component Foo {
-    FlexboxLayout {
-        Rectangle {
-            🔺
-        }
-    }
-}
-"#;
-        let results = get_completions(source).unwrap();
-        assert!(
-            results.iter().any(|completion| completion.label == "layout-order"),
-            "no 'layout-order' completion"
-        );
-        assert!(
-            results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
-            "no 'cross-axis-self-alignment' completion"
-        );
-    }
-
-    #[test]
-    fn cross_axis_self_alignment_in_box_layouts() {
-        for layout in ["HorizontalLayout", "VerticalLayout"] {
+    fn layout_cell_properties_in_layouts() {
+        for layout in ["FlexboxLayout", "HorizontalLayout", "VerticalLayout"] {
             let source = format!(
                 r#"
 component Foo {{
@@ -2946,10 +2923,12 @@ component Foo {{
 "#
             );
             let results = get_completions(&source).unwrap();
-            assert!(
-                results.iter().any(|completion| completion.label == "cross-axis-self-alignment"),
-                "no 'cross-axis-self-alignment' completion in a {layout}"
-            );
+            for prop in ["layout-order", "cross-axis-self-alignment"] {
+                assert!(
+                    results.iter().any(|completion| completion.label == prop),
+                    "no '{prop}' completion in a {layout}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
compiler: fold FlexboxLayoutItem into LayoutItem

layout-order is about to apply to Horizontal/VerticalLayout as well, so
its NamedReference belongs next to cross-axis-self-alignment on the
shared LayoutItem rather than in a flexbox-only wrapper struct.

No behavior change.

---

HorizontalLayout/VerticalLayout: support layout-order

The per-item layout-order property, so far only accepted in a
FlexboxLayout, now also reorders the cells of a box layout, like the CSS
order property: cells are laid out in ascending order value, and equal
values keep their declaration order.

The order only permutes the main-axis solve — it changes neither the
cross-axis positions nor the aggregated layout info — so a cell's layout
cache slot keeps following its declaration index, and for static cells
the order stays out of the cross-axis and layout-info expressions. A
repeated cell returns it through the generated layout_item_info, which
the main-axis layout-info pass shares, so box_layout_info evaluates it
there before ignoring it.

<img width="696" height="1366" alt="Screenshot_20260826_150306" src="https://github.com/user-attachments/assets/df9d5f85-9354-42af-baf1-fe4bd3c4207a" />
