### PR TITLE
Remove Image::to_rgba8_with_target_size from the public API

### DIFF
--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1585,7 +1585,7 @@ impl WindowAdapterInternal for WinitWindowAdapter {
                     (source_size.height as f32 * scale) as u32,
                 );
                 if let Some(rgba8) =
-                    i_slint_core::graphics::image_to_rgba8_with_target_size(&image, target_size)
+                    i_slint_core::graphics::image_to_rgba8_with_target_size(image, target_size)
                 {
                     let (width, height) = (rgba8.width(), rgba8.height());
                     // winit rejects a hotspot that lies outside the image, so clamp it inside.

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -1584,7 +1584,9 @@ impl WindowAdapterInternal for WinitWindowAdapter {
                     (source_size.width as f32 * scale) as u32,
                     (source_size.height as f32 * scale) as u32,
                 );
-                if let Some(rgba8) = image.to_rgba8_with_target_size(target_size) {
+                if let Some(rgba8) =
+                    i_slint_core::graphics::image_to_rgba8_with_target_size(&image, target_size)
+                {
                     let (width, height) = (rgba8.width(), rgba8.height());
                     // winit rejects a hotspot that lies outside the image, so clamp it inside.
                     let source = CustomCursor::from_rgba(

--- a/internal/core/graphics/image.rs
+++ b/internal/core/graphics/image.rs
@@ -862,16 +862,6 @@ impl Image {
         self.render_to_rgba8(None)
     }
 
-    /// Same as [`Self::to_rgba8`], but scalable sources (such as SVGs) are rasterized to
-    /// `target_size` (in physical pixels) instead of their intrinsic size.
-    /// Returns None if the pixels cannot be obtained.
-    pub fn to_rgba8_with_target_size(
-        &self,
-        target_size: IntSize,
-    ) -> Option<SharedPixelBuffer<Rgba8Pixel>> {
-        self.render_to_rgba8(Some(target_size.cast_unit()))
-    }
-
     fn render_to_rgba8(
         &self,
         target_size: Option<euclid::Size2D<u32, PhysicalPx>>,
@@ -1090,6 +1080,16 @@ impl Image {
             _ => None,
         }
     }
+}
+
+/// Like [`Image::to_rgba8`], but scalable sources (such as SVGs) are rasterized to
+/// `target_size` (in physical pixels) instead of their intrinsic size.
+/// Returns None if the pixels cannot be obtained.
+pub fn image_to_rgba8_with_target_size(
+    image: &Image,
+    target_size: IntSize,
+) -> Option<SharedPixelBuffer<Rgba8Pixel>> {
+    image.render_to_rgba8(Some(target_size.cast_unit()))
 }
 
 #[cfg(any(feature = "image-decoders", all(target_arch = "wasm32", feature = "std")))]


### PR DESCRIPTION
As discussed in the API review.
