### PR TITLE
DataTransfer: return a plain Iterator from file_paths

### DIFF
--- a/internal/core/data_transfer.rs
+++ b/internal/core/data_transfer.rs
@@ -325,7 +325,7 @@ impl DataTransfer {
     #[cfg(feature = "std")]
     pub fn file_paths(
         &self,
-    ) -> Result<impl ExactSizeIterator<Item = &std::path::Path> + '_, DataTransferError> {
+    ) -> Result<impl Iterator<Item = &std::path::Path> + '_, DataTransferError> {
         self.inner
             .as_ref()
             .and_then(|inner| inner.file_paths.as_ref())


### PR DESCRIPTION
Don't promise ExactSizeIterator, so the representation can change.

As discussed in the API review.
