### PR TITLE
window: Fix O(n²) cycle detection in move_focus

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1518,6 +1518,12 @@ impl WindowInner {
         reason: FocusReason,
     ) -> Option<ItemRc> {
         let mut current_item = start_item.clone();
+        // The walk normally comes back to `start_item`, but ends in a cycle that misses it
+        // when the tree changed under it, e.g. when the focus was on a removed item.
+        // Comparing against a checkpoint (Brent's cycle detection) still terminates then.
+        let mut checkpoint = start_item.clone();
+        let mut steps = 0usize;
+        let mut next_checkpoint = 1usize;
 
         loop {
             let can_receive_focus = match reason {
@@ -1533,10 +1539,14 @@ impl WindowInner {
             }
             current_item = forward(current_item);
 
-            // `forward` visits the items in a cycle, so the walk comes back to `start_item`
-            // before revisiting any other item.
-            if current_item == start_item {
+            if current_item == start_item || current_item == checkpoint {
                 return None; // Nothing to do: We took the focus_item already
+            }
+            steps += 1;
+            if steps == next_checkpoint {
+                checkpoint = current_item.clone();
+                steps = 0;
+                next_checkpoint *= 2;
             }
         }
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1517,8 +1517,7 @@ impl WindowInner {
         forward: impl Fn(ItemRc) -> ItemRc,
         reason: FocusReason,
     ) -> Option<ItemRc> {
-        let mut current_item = start_item;
-        let mut visited = Vec::new();
+        let mut current_item = start_item.clone();
 
         loop {
             let can_receive_focus = match reason {
@@ -1532,10 +1531,11 @@ impl WindowInner {
             {
                 return Some(current_item); // Item was just published.
             }
-            visited.push(current_item.clone());
             current_item = forward(current_item);
 
-            if visited.contains(&current_item) {
+            // `forward` visits the items in a cycle, so the walk comes back to `start_item`
+            // before revisiting any other item.
+            if current_item == start_item {
                 return None; // Nothing to do: We took the focus_item already
             }
         }

--- a/tests/cases/focus/focus_on_removed_item.slint
+++ b/tests/cases/focus/focus_on_removed_item.slint
@@ -1,0 +1,50 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Focusing an item whose repeater row was just removed must not hang while
+// searching the tree for another item to focus.
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 200px;
+    in-out property <[int]> model: [0, 1];
+    out property <bool> test: true;
+
+    VerticalLayout {
+        alignment: start;
+        for x[i] in root.model: Rectangle {
+            height: 40px;
+            fs := FocusScope {
+                enabled: false;
+            }
+            TouchArea {
+                clicked => {
+                    root.model.remove(i);
+                    fs.focus();
+                }
+            }
+        }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+slint_testing::send_mouse_click(&instance, 150., 20.);
+use slint::Model;
+assert_eq!(instance.get_model().row_count(), 1);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+slint_testing::send_mouse_click(&instance, 150., 20.);
+assert_eq(instance.get_model()->row_count(), 1);
+```
+
+```js
+var instance = new slint.TestCase({});
+slintlib.private_api.send_mouse_click(instance, 150., 20.);
+assert.equal(instance.model.rowCount(), 1);
+```
+*/


### PR DESCRIPTION
The walk pushed every visited item into a Vec and scanned it after every step. The traversal visits items in a cycle, so comparing against the start item is enough. A Tab press in a window with 100000 items and nothing focusable drops from ~1s to ~16ms.

Reported in #13007 (item 055)
