### PR TITLE
    text: Avoid shaping single-line NoWrap text to answer its height

### DIFF
--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -575,6 +575,15 @@ impl RendererSealed for TestingWindow {
         }
     }
 
+    fn text_line_height(
+        &self,
+        font_request: i_slint_core::graphics::FontRequest,
+    ) -> Option<LogicalLength> {
+        let pixel_size = font_request.pixel_size.map_or(10., |s| s.get());
+        is_fixed_test_font(&font_request.family)
+            .then(|| LogicalLength::new(fixed_test_font_line_height(&font_request, pixel_size)))
+    }
+
     fn char_size(
         &self,
         text_item: Pin<&dyn i_slint_core::item_rendering::HasFont>,

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -641,12 +641,12 @@ impl SimpleText {
 /// The height of a plain single-line `NoWrap` text, when it can be computed without shaping.
 fn single_line_height(
     window_adapter: &Rc<dyn WindowAdapter>,
-    text: PlainOrStyledText,
-    font_request: impl FnOnce() -> crate::graphics::FontRequest,
+    text: Pin<&(impl RenderString + ?Sized)>,
+    self_rc: &ItemRc,
 ) -> Option<Coord> {
-    match text {
+    match text.text() {
         PlainOrStyledText::Plain(s) if !s.contains('\n') => {
-            window_adapter.renderer().text_line_height(font_request()).map(|h| h.get())
+            window_adapter.renderer().text_line_height(text.font_request(self_rc)).map(|h| h.get())
         }
         _ => None,
     }
@@ -699,10 +699,8 @@ fn text_layout_info(
         }
         Orientation::Vertical => {
             let h = match text.wrap() {
-                TextWrap::NoWrap => {
-                    single_line_height(window_adapter, text.text(), || text.font_request(self_rc))
-                        .unwrap_or_else(|| implicit_size(None, TextWrap::NoWrap).height)
-                }
+                TextWrap::NoWrap => single_line_height(window_adapter, text, self_rc)
+                    .unwrap_or_else(|| implicit_size(None, TextWrap::NoWrap).height),
                 wrap @ (TextWrap::WordWrap | TextWrap::CharWrap) => {
                     let w = if cross_axis_constraint >= 0 as Coord {
                         LogicalLength::new(cross_axis_constraint)
@@ -871,12 +869,8 @@ impl Item for TextInput {
             }
             Orientation::Vertical => {
                 let h = match self.wrap() {
-                    TextWrap::NoWrap => {
-                        single_line_height(window_adapter, RenderString::text(self), || {
-                            self.font_request(self_rc)
-                        })
-                        .unwrap_or_else(|| implicit_size(None, TextWrap::NoWrap).height)
-                    }
+                    TextWrap::NoWrap => single_line_height(window_adapter, self, self_rc)
+                        .unwrap_or_else(|| implicit_size(None, TextWrap::NoWrap).height),
                     wrap @ (TextWrap::WordWrap | TextWrap::CharWrap) => {
                         let w = if cross_axis_constraint >= 0 as Coord {
                             LogicalLength::new(cross_axis_constraint)

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -638,6 +638,20 @@ impl SimpleText {
     }
 }
 
+/// The height of a plain single-line `NoWrap` text, when it can be computed without shaping.
+fn single_line_height(
+    window_adapter: &Rc<dyn WindowAdapter>,
+    text: PlainOrStyledText,
+    font_request: impl FnOnce() -> crate::graphics::FontRequest,
+) -> Option<Coord> {
+    match text {
+        PlainOrStyledText::Plain(s) if !s.contains('\n') => {
+            window_adapter.renderer().text_line_height(font_request()).map(|h| h.get())
+        }
+        _ => None,
+    }
+}
+
 // The compiler's single-cell box layout lowering relies on text and image
 // items keeping the default stretch of 0 in their layout info.
 fn text_layout_info(
@@ -685,7 +699,10 @@ fn text_layout_info(
         }
         Orientation::Vertical => {
             let h = match text.wrap() {
-                TextWrap::NoWrap => implicit_size(None, TextWrap::NoWrap).height,
+                TextWrap::NoWrap => {
+                    single_line_height(window_adapter, text.text(), || text.font_request(self_rc))
+                        .unwrap_or_else(|| implicit_size(None, TextWrap::NoWrap).height)
+                }
                 wrap @ (TextWrap::WordWrap | TextWrap::CharWrap) => {
                     let w = if cross_axis_constraint >= 0 as Coord {
                         LogicalLength::new(cross_axis_constraint)

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -871,7 +871,12 @@ impl Item for TextInput {
             }
             Orientation::Vertical => {
                 let h = match self.wrap() {
-                    TextWrap::NoWrap => implicit_size(None, TextWrap::NoWrap).height,
+                    TextWrap::NoWrap => {
+                        single_line_height(window_adapter, RenderString::text(self), || {
+                            self.font_request(self_rc)
+                        })
+                        .unwrap_or_else(|| implicit_size(None, TextWrap::NoWrap).height)
+                    }
                     wrap @ (TextWrap::WordWrap | TextWrap::CharWrap) => {
                         let w = if cross_axis_constraint >= 0 as Coord {
                             LogicalLength::new(cross_axis_constraint)

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -163,6 +163,25 @@ pub trait RendererSealed {
             .unwrap_or_default()
     }
 
+    /// The height of one line of text: what a shaped single-line layout reports, without
+    /// shaping. `None` means the caller must measure through [`Self::text_size`].
+    fn text_line_height(
+        &self,
+        font_request: crate::graphics::FontRequest,
+    ) -> Option<LogicalLength> {
+        #[cfg(feature = "shared-parley")]
+        {
+            let ctx = self.slint_context()?;
+            let mut font_ctx = ctx.font_context().borrow_mut();
+            crate::textlayout::sharedparley::text_line_height(&mut font_ctx, &font_request)
+        }
+        #[cfg(not(feature = "shared-parley"))]
+        {
+            let _ = font_request;
+            None
+        }
+    }
+
     /// Returns the (UTF-8) byte offset in the text property that refers to the character that contributed to
     /// the glyph cluster that's visually nearest to the given coordinate. This is used for hit-testing,
     /// for example when receiving a mouse click into a text field. Then this function returns the "cursor"

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -567,6 +567,15 @@ pub fn char_size(
     Some(LogicalSize::from_lengths(advance_width, LogicalLength::new(line_height)))
 }
 
+/// The height of one line of text: what a shaped single-line layout reports.
+pub fn text_line_height(
+    font_ctx: &mut parley::FontContext,
+    font_request: &FontRequest,
+) -> Option<LogicalLength> {
+    let pixel_size = font_request.pixel_size.unwrap_or(DEFAULT_FONT_SIZE);
+    shaping::line_height_ratio(font_ctx, font_request).map(|ratio| pixel_size * ratio)
+}
+
 pub fn font_metrics(
     font_ctx: &mut parley::FontContext,
     font_request: FontRequest,

--- a/internal/core/textlayout/sharedparley/shaping.rs
+++ b/internal/core/textlayout/sharedparley/shaping.rs
@@ -245,9 +245,7 @@ pub(super) fn line_height_ratio(
     font_ctx: &mut parley::FontContext,
     font_request: &FontRequest,
 ) -> Option<f32> {
-    let font = font_request
-        .clone()
-        .query_fontique(&mut font_ctx.collection, &mut font_ctx.source_cache)?;
+    let font = font_request.query_fontique(&mut font_ctx.collection, &mut font_ctx.source_cache)?;
     let face = skrifa::FontRef::from_index(font.blob.data(), font.index).ok()?;
     let location = face.axes().location(font.synthesis.variation_settings());
     let metrics = face.metrics(skrifa::instance::Size::unscaled(), &location);

--- a/internal/core/textlayout/sharedparley/shaping.rs
+++ b/internal/core/textlayout/sharedparley/shaping.rs
@@ -41,7 +41,7 @@ pub(super) struct LayoutWithoutLineBreaksBuilder {
 }
 
 impl LayoutWithoutLineBreaksBuilder {
-    fn new(
+    pub(super) fn new(
         font_request: Option<FontRequest>,
         text_wrap: TextWrap,
         stroke: Option<TextStrokeStyle>,
@@ -70,24 +70,9 @@ impl LayoutWithoutLineBreaksBuilder {
     ) -> parley::RangedBuilder<'a, Brush> {
         // Use the requested font's natural line-height ratio for every run so fallback fonts,
         // such as the symbol font used for password characters, don't enlarge the line box.
-        // The line-height factor scales this natural ratio.
         // `FontSizeRelative` scales the result with each styled span's font size.
-        let line_height_ratio = self.font_request.as_ref().and_then(|font_request| {
-            let font = font_request
-                .clone()
-                .query_fontique(&mut font_ctx.collection, &mut font_ctx.source_cache)?;
-            let face = skrifa::FontRef::from_index(font.blob.data(), font.index).ok()?;
-            let location = face.axes().location(font.synthesis.variation_settings());
-            let metrics = face.metrics(skrifa::instance::Size::unscaled(), &location);
-            let units_per_em = metrics.units_per_em as f32;
-            (units_per_em > 0.0)
-                .then(|| (metrics.ascent - metrics.descent + metrics.leading) / units_per_em)
-                .map(|natural_ratio| {
-                    font_request
-                        .line_height_for_natural_height(natural_ratio)
-                        .unwrap_or(natural_ratio)
-                })
-        });
+        let line_height_ratio =
+            self.font_request.as_ref().and_then(|fr| line_height_ratio(font_ctx, fr));
 
         let mut builder = layout_ctx.ranged_builder(font_ctx, text, self.scale_factor.get(), false);
 
@@ -253,6 +238,25 @@ impl LayoutWithoutLineBreaksBuilder {
             builder.build(text)
         })
     }
+}
+
+/// The line-height ratio, relative to the font size, that every shaped line gets.
+pub(super) fn line_height_ratio(
+    font_ctx: &mut parley::FontContext,
+    font_request: &FontRequest,
+) -> Option<f32> {
+    let font = font_request
+        .clone()
+        .query_fontique(&mut font_ctx.collection, &mut font_ctx.source_cache)?;
+    let face = skrifa::FontRef::from_index(font.blob.data(), font.index).ok()?;
+    let location = face.axes().location(font.synthesis.variation_settings());
+    let metrics = face.metrics(skrifa::instance::Size::unscaled(), &location);
+    let units_per_em = metrics.units_per_em as f32;
+    (units_per_em > 0.0)
+        .then(|| (metrics.ascent - metrics.descent + metrics.leading) / units_per_em)
+        .map(|natural_ratio| {
+            font_request.line_height_for_natural_height(natural_ratio).unwrap_or(natural_ratio)
+        })
 }
 
 /// Splits plain text into paragraph byte ranges at `'\n'`. The `'\n'` and any preceding `'\r'`

--- a/internal/core/textlayout/sharedparley/tests.rs
+++ b/internal/core/textlayout/sharedparley/tests.rs
@@ -14,13 +14,9 @@ fn layout_text_with_options(text: &str, options: LayoutOptions) -> Layout {
     layout_text_with_builder(text, super::shaping::plain_builder_for_tests(), options)
 }
 
-fn layout_text_with_builder(
-    text: &str,
-    builder: super::shaping::LayoutWithoutLineBreaksBuilder,
-    options: LayoutOptions,
-) -> Layout {
-    // Don't load system fonts: that goes through fontconfig FFI, which Miri
-    // can't execute. Use the bundled Inter font instead.
+// Don't load system fonts: that goes through fontconfig FFI, which Miri
+// can't execute. Use the bundled Inter font instead.
+fn test_font_context() -> parley::FontContext {
     let mut font_ctx = parley::FontContext {
         collection: fontique::Collection::new(fontique::CollectionOptions {
             system_fonts: false,
@@ -34,6 +30,15 @@ fn layout_text_with_builder(
         fontique::GenericFamily::SansSerif,
         families.iter().map(|(id, _)| *id),
     );
+    font_ctx
+}
+
+fn layout_text_with_builder(
+    text: &str,
+    builder: super::shaping::LayoutWithoutLineBreaksBuilder,
+    options: LayoutOptions,
+) -> Layout {
+    let mut font_ctx = test_font_context();
     let paragraphs = create_text_paragraphs(
         &builder,
         &mut font_ctx,
@@ -86,6 +91,31 @@ fn bidi_selection_spans_are_ascending_in_x() {
     }
     // Otherwise the ranges above stopped producing a split line and this proves nothing.
     assert!(saw_line_with_several_spans, "expected a bidi selection to split into spans");
+}
+
+#[test]
+fn test_text_line_height_matches_shaped_single_line() {
+    for (pixel_size, line_height_factor) in [(12.0, None), (25.5, None), (12.0, Some(1.5))] {
+        let font_request = FontRequest {
+            pixel_size: Some(LogicalLength::new(pixel_size)),
+            line_height_factor,
+            ..Default::default()
+        };
+        let builder = super::shaping::LayoutWithoutLineBreaksBuilder::new(
+            Some(font_request.clone()),
+            TextWrap::NoWrap,
+            None,
+            ScaleFactor::new(1.0),
+        );
+        let shaped = layout_text_with_builder("Hello world", builder, LayoutOptions::default());
+        let fast = text_line_height(&mut test_font_context(), &font_request).unwrap();
+        assert!(
+            (shaped.height.get() - fast.get()).abs() < 0.01,
+            "shaped {} != estimated {} (size {pixel_size}, factor {line_height_factor:?})",
+            shaped.height.get(),
+            fast.get(),
+        );
+    }
 }
 
 #[test]

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -899,6 +899,26 @@ impl RendererSealed for SoftwareRenderer {
         })
     }
 
+    // Bitmap fonts fall back to text_size() with the same font.
+    fn text_line_height(
+        &self,
+        font_request: i_slint_core::graphics::FontRequest,
+    ) -> Option<LogicalLength> {
+        #[cfg(feature = "systemfonts")]
+        {
+            let scale_factor = self.scale_factor()?;
+            let slint_ctx = self.slint_context()?;
+            let mut font_ctx = slint_ctx.font_context().borrow_mut();
+            let font = fonts::match_font(&font_request, scale_factor, &mut font_ctx);
+            if uses_parley(&font) {
+                return sharedparley::text_line_height(&mut font_ctx, &font_request);
+            }
+        }
+        #[cfg(not(feature = "systemfonts"))]
+        let _ = font_request;
+        None
+    }
+
     fn char_size(
         &self,
         text_item: Pin<&dyn i_slint_core::item_rendering::HasFont>,


### PR DESCRIPTION
A VerticalLayout queries every Text child's vertical layout_info, and
the NoWrap arm shaped the whole text through parley just to read the
resulting height. For plain text without hard line break that height
only depends on the font, so ask the renderer for the line height via
the new RendererSealed::text_line_height, computed from the same
metrics the shaper uses. The first frame of a scene with 20000
off-screen rows gets ~80% faster and uses ~70% less memory.

Renderers that don't lay text out with parley return None and keep
shaping: the software renderer for bitmap fonts, and the testing
backend which answers with its fixed test font's deterministic height.
    
Reported in #13007 (item 070)

Use the line-height fast path for TextInput too
Same single-line NoWrap height computation as for Text.
    
Reported in #13007 (item 098)

