### PR TITLE
Fix clippy warnings in plotter, bapp and the material gallery

### DIFF
--- a/examples/plotter/main.rs
+++ b/examples/plotter/main.rs
@@ -17,8 +17,8 @@ slint::slint! {
 fn pdf(x: f64, y: f64, a: f64) -> f64 {
     const SDX: f64 = 0.1;
     const SDY: f64 = 0.1;
-    let x = x as f64 / 10.0;
-    let y = y as f64 / 10.0;
+    let x = x / 10.0;
+    let y = y / 10.0;
     a * (-x * x / 2.0 / SDX / SDX - y * y / 2.0 / SDY / SDY).exp()
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8206,9 +8206,6 @@ packages:
   vscode-languageserver-protocol@3.18.2:
     resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
 
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
   vscode-languageserver-textdocument@1.0.13:
     resolution: {integrity: sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==}
 
@@ -11593,7 +11590,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
       typescript: 6.0.3
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-uri: 3.1.0
 
   '@volar/language-core@2.4.28':
@@ -11609,14 +11606,14 @@ snapshots:
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
       vscode-languageserver-protocol: 3.18.2
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-uri: 3.1.0
 
   '@volar/language-service@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
       vscode-languageserver-protocol: 3.18.2
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-uri: 3.1.0
 
   '@volar/source-map@2.4.28': {}
@@ -11631,7 +11628,7 @@ snapshots:
     dependencies:
       emmet: 2.4.11
       jsonc-parser: 2.3.1
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
 
@@ -12434,7 +12431,7 @@ snapshots:
       gensequence: 8.0.8
       import-fresh: 4.0.0
       resolve-from: 5.0.0
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-uri: 3.1.0
       xdg-basedir: 5.1.0
 
@@ -16641,7 +16638,7 @@ snapshots:
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.28
@@ -16658,7 +16655,7 @@ snapshots:
   volar-service-html@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-html-languageservice: 5.6.2
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-uri: 3.1.0
     optionalDependencies:
       '@volar/language-service': 2.4.28
@@ -16681,7 +16678,7 @@ snapshots:
       path-browserify: 1.0.1
       semver: 7.8.5
       typescript-auto-import-cache: 0.3.6
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -16697,21 +16694,21 @@ snapshots:
   vscode-css-languageservice@6.3.10:
     dependencies:
       '@vscode/l10n': 0.0.18
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
 
   vscode-html-languageservice@5.6.2:
     dependencies:
       '@vscode/l10n': 0.0.18
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
 
   vscode-json-languageservice@4.1.8:
     dependencies:
       jsonc-parser: 3.3.1
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-languageserver-types: 3.18.0
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
@@ -16751,8 +16748,6 @@ snapshots:
     dependencies:
       vscode-jsonrpc: 9.0.1
       vscode-languageserver-types: 3.18.0
-
-  vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-textdocument@1.0.13: {}
 
@@ -16855,7 +16850,7 @@ snapshots:
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
       vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-textdocument: 1.0.13
       vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
       yaml: 2.9.0

--- a/scripts/pre-commit-clippy.sh
+++ b/scripts/pre-commit-clippy.sh
@@ -16,16 +16,26 @@
 #    pass_filenames: true
 
 declare -A seen
-pkgs=()
+declare -A workspace_of_dir
+declare -A pkgs_by_workspace
 
 for file in "$@"; do
     dir=$(dirname "$file")
     while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
         if [ -f "$dir/Cargo.toml" ]; then
             pkg=$(grep -m1 '^name\s*=' "$dir/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
-            if [ -n "$pkg" ] && [ -z "${seen[$pkg]}" ]; then
-                seen[$pkg]=1
-                pkgs+=(-p "$pkg")
+            if [ -n "$pkg" ]; then
+                workspace=${workspace_of_dir[$dir]}
+                if [ -z "$workspace" ]; then
+                    # Some directories are their own workspace, and clippy has
+                    # to run from there rather than from the repository root.
+                    workspace=$(cargo locate-project --workspace --message-format plain --manifest-path "$dir/Cargo.toml") || exit 1
+                    workspace_of_dir[$dir]=$workspace
+                fi
+                if [ -z "${seen[$workspace:$pkg]}" ]; then
+                    seen[$workspace:$pkg]=1
+                    pkgs_by_workspace[$workspace]+="$pkg "
+                fi
             fi
             break
         fi
@@ -33,8 +43,16 @@ for file in "$@"; do
     done
 done
 
-if [ ${#pkgs[@]} -eq 0 ]; then
-    exit 0
-fi
+status=0
+for workspace in "${!pkgs_by_workspace[@]}"; do
+    workspace_dir=$(dirname "$workspace")
+    args=()
+    for pkg in ${pkgs_by_workspace[$workspace]}; do
+        args+=(-p "$pkg")
+    done
+    # Only some of the workspaces have a Cargo.lock, and --locked refuses to create one.
+    [ -f "$workspace_dir/Cargo.lock" ] && args+=(--locked)
+    ( cd "$workspace_dir" && cargo clippy "${args[@]}" -- -D warnings ) || status=1
+done
 
-cargo clippy --locked "${pkgs[@]}" -- -D warnings
+exit $status

--- a/tests/manual/module-builds/app/src/main.rs
+++ b/tests/manual/module-builds/app/src/main.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 // cSpell: ignore blociga
-use blogica;
-use blogicb;
-use random_word;
 use std::error::Error;
 
 slint::include_modules!();
@@ -23,26 +20,23 @@ fn main() -> Result<(), Box<dyn Error>> {
         move || {
             let ui = ui_handle.upgrade().unwrap();
             let blogica_api = ui.global::<blogica::backend::BLogicAAPI>();
-            let mut bdata = blogica::backend::BData::default();
-
-            bdata.colors = slint::ModelRc::new(slint::VecModel::from(
-                (1..5)
-                    .into_iter()
-                    .map(|_| {
-                        let red = rand::random::<u8>();
-                        let green = rand::random::<u8>();
-                        let blue = rand::random::<u8>();
-                        slint::Color::from_rgb_u8(red, green, blue)
-                    })
-                    .collect::<Vec<_>>(),
-            ));
-
-            bdata.codes = slint::ModelRc::new(slint::VecModel::from(
-                (1..5)
-                    .into_iter()
-                    .map(|_| slint::SharedString::from(random_word::get(random_word::Lang::En)))
-                    .collect::<Vec<_>>(),
-            ));
+            let bdata = blogica::backend::BData {
+                colors: slint::ModelRc::new(slint::VecModel::from(
+                    (1..5)
+                        .map(|_| {
+                            let red = rand::random::<u8>();
+                            let green = rand::random::<u8>();
+                            let blue = rand::random::<u8>();
+                            slint::Color::from_rgb_u8(red, green, blue)
+                        })
+                        .collect::<Vec<_>>(),
+                )),
+                codes: slint::ModelRc::new(slint::VecModel::from(
+                    (1..5)
+                        .map(|_| slint::SharedString::from(random_word::get(random_word::Lang::En)))
+                        .collect::<Vec<_>>(),
+                )),
+            };
 
             blogica_api.invoke_update(bdata);
         }

--- a/ui-libraries/material/examples/gallery/src/lib.rs
+++ b/ui-libraries/material/examples/gallery/src/lib.rs
@@ -87,14 +87,14 @@ fn navigation_view(ui: &MainWindow) {
         }
     });
 
-    adapter.set_radio_buttons(radio_buttons.into());
+    adapter.set_radio_buttons(radio_buttons);
 }
 
 fn color_item(name: &str, red: u8, green: u8, blue: u8, ui: &MainWindow) -> ListItem {
     ListItem {
         text: name.into(),
         avatar_background: Color::from_rgb_u8(red, green, blue),
-        action_button_icon: OutlinedIcons::get(&ui).get_share(),
+        action_button_icon: OutlinedIcons::get(ui).get_share(),
         ..Default::default()
     }
 }
@@ -110,9 +110,9 @@ mod date_picker {
         let adapter = DatePickerAdapter::get(ui);
 
         adapter.on_month_day_count(|month, year| {
-            month_day_count(month as u32, year).unwrap_or_default() as i32
+            month_day_count(month as u32, year).unwrap_or_default()
         });
-        adapter.on_month_offset(|month, year| month_offset(month as u32, year) as i32);
+        adapter.on_month_offset(|month, year| month_offset(month as u32, year));
         adapter.on_format_date(|format, day, month, year| {
             format_date(format.as_str(), day as u32, month as u32, year)
         });
@@ -253,58 +253,58 @@ mod theme {
         pub surfaceContainerHighest: String,
     }
 
-    impl Into<crate::MaterialScheme> for MaterialScheme {
-        fn into(self) -> crate::MaterialScheme {
+    impl From<MaterialScheme> for crate::MaterialScheme {
+        fn from(scheme: MaterialScheme) -> Self {
             crate::MaterialScheme {
-                background: string_to_color(self.background),
-                error: string_to_color(self.error),
-                errorContainer: string_to_color(self.errorContainer),
-                inverseOnSurface: string_to_color(self.inverseOnSurface),
-                inversePrimary: string_to_color(self.inversePrimary),
-                inverseSurface: string_to_color(self.inverseSurface),
-                onBackground: string_to_color(self.onBackground),
-                onError: string_to_color(self.onError),
-                onErrorContainer: string_to_color(self.onErrorContainer),
-                onPrimary: string_to_color(self.onPrimary),
-                onPrimaryContainer: string_to_color(self.onPrimaryContainer),
-                onPrimaryFixed: string_to_color(self.onPrimaryFixed),
-                onPrimaryFixedVariant: string_to_color(self.onPrimaryFixedVariant),
-                onSecondary: string_to_color(self.onSecondary),
-                onSecondaryContainer: string_to_color(self.onSecondaryContainer),
-                onSecondaryFixed: string_to_color(self.onSecondaryFixed),
-                onSecondaryFixedVariant: string_to_color(self.onSecondaryFixedVariant),
-                onSurface: string_to_color(self.onSurface),
-                onSurfaceVariant: string_to_color(self.onSurfaceVariant),
-                onTertiary: string_to_color(self.onTertiary),
-                onTertiaryContainer: string_to_color(self.onTertiaryContainer),
-                onTertiaryFixed: string_to_color(self.onTertiaryFixed),
-                onTertiaryFixedVariant: string_to_color(self.onTertiaryFixedVariant),
-                outline: string_to_color(self.outline),
-                outlineVariant: string_to_color(self.outlineVariant),
-                primary: string_to_color(self.primary),
-                primaryContainer: string_to_color(self.primaryContainer),
-                primaryFixed: string_to_color(self.primaryFixed),
-                primaryFixedDim: string_to_color(self.primaryFixedDim),
-                scrim: string_to_color(self.scrim),
-                secondary: string_to_color(self.secondary),
-                secondaryContainer: string_to_color(self.secondaryContainer),
-                secondaryFixed: string_to_color(self.secondaryFixed),
-                secondaryFixedDim: string_to_color(self.secondaryFixedDim),
-                shadow: string_to_color(self.shadow),
-                surface: string_to_color(self.surface),
-                surfaceBright: string_to_color(self.surfaceBright),
-                surfaceContainer: string_to_color(self.surfaceContainer),
-                surfaceContainerHigh: string_to_color(self.surfaceContainerHigh),
-                surfaceContainerHighest: string_to_color(self.surfaceContainerHighest),
-                surfaceContainerLow: string_to_color(self.surfaceContainerLow),
-                surfaceContainerLowest: string_to_color(self.surfaceContainerLowest),
-                surfaceDim: string_to_color(self.surfaceDim),
-                surfaceTint: string_to_color(self.surfaceTint),
-                surfaceVariant: string_to_color(self.surfaceVariant),
-                tertiary: string_to_color(self.tertiary),
-                tertiaryContainer: string_to_color(self.tertiaryContainer),
-                tertiaryFixed: string_to_color(self.tertiaryFixed),
-                tertiaryFixedDim: string_to_color(self.tertiaryFixedDim),
+                background: string_to_color(scheme.background),
+                error: string_to_color(scheme.error),
+                errorContainer: string_to_color(scheme.errorContainer),
+                inverseOnSurface: string_to_color(scheme.inverseOnSurface),
+                inversePrimary: string_to_color(scheme.inversePrimary),
+                inverseSurface: string_to_color(scheme.inverseSurface),
+                onBackground: string_to_color(scheme.onBackground),
+                onError: string_to_color(scheme.onError),
+                onErrorContainer: string_to_color(scheme.onErrorContainer),
+                onPrimary: string_to_color(scheme.onPrimary),
+                onPrimaryContainer: string_to_color(scheme.onPrimaryContainer),
+                onPrimaryFixed: string_to_color(scheme.onPrimaryFixed),
+                onPrimaryFixedVariant: string_to_color(scheme.onPrimaryFixedVariant),
+                onSecondary: string_to_color(scheme.onSecondary),
+                onSecondaryContainer: string_to_color(scheme.onSecondaryContainer),
+                onSecondaryFixed: string_to_color(scheme.onSecondaryFixed),
+                onSecondaryFixedVariant: string_to_color(scheme.onSecondaryFixedVariant),
+                onSurface: string_to_color(scheme.onSurface),
+                onSurfaceVariant: string_to_color(scheme.onSurfaceVariant),
+                onTertiary: string_to_color(scheme.onTertiary),
+                onTertiaryContainer: string_to_color(scheme.onTertiaryContainer),
+                onTertiaryFixed: string_to_color(scheme.onTertiaryFixed),
+                onTertiaryFixedVariant: string_to_color(scheme.onTertiaryFixedVariant),
+                outline: string_to_color(scheme.outline),
+                outlineVariant: string_to_color(scheme.outlineVariant),
+                primary: string_to_color(scheme.primary),
+                primaryContainer: string_to_color(scheme.primaryContainer),
+                primaryFixed: string_to_color(scheme.primaryFixed),
+                primaryFixedDim: string_to_color(scheme.primaryFixedDim),
+                scrim: string_to_color(scheme.scrim),
+                secondary: string_to_color(scheme.secondary),
+                secondaryContainer: string_to_color(scheme.secondaryContainer),
+                secondaryFixed: string_to_color(scheme.secondaryFixed),
+                secondaryFixedDim: string_to_color(scheme.secondaryFixedDim),
+                shadow: string_to_color(scheme.shadow),
+                surface: string_to_color(scheme.surface),
+                surfaceBright: string_to_color(scheme.surfaceBright),
+                surfaceContainer: string_to_color(scheme.surfaceContainer),
+                surfaceContainerHigh: string_to_color(scheme.surfaceContainerHigh),
+                surfaceContainerHighest: string_to_color(scheme.surfaceContainerHighest),
+                surfaceContainerLow: string_to_color(scheme.surfaceContainerLow),
+                surfaceContainerLowest: string_to_color(scheme.surfaceContainerLowest),
+                surfaceDim: string_to_color(scheme.surfaceDim),
+                surfaceTint: string_to_color(scheme.surfaceTint),
+                surfaceVariant: string_to_color(scheme.surfaceVariant),
+                tertiary: string_to_color(scheme.tertiary),
+                tertiaryContainer: string_to_color(scheme.tertiaryContainer),
+                tertiaryFixed: string_to_color(scheme.tertiaryFixed),
+                tertiaryFixedDim: string_to_color(scheme.tertiaryFixedDim),
             }
         }
     }
@@ -320,9 +320,9 @@ mod theme {
         pub light: MaterialScheme,
     }
 
-    impl Into<crate::MaterialSchemes> for MaterialSchemes {
-        fn into(self) -> crate::MaterialSchemes {
-            crate::MaterialSchemes { dark: self.dark.into(), light: self.light.into() }
+    impl From<MaterialSchemes> for crate::MaterialSchemes {
+        fn from(schemes: MaterialSchemes) -> Self {
+            crate::MaterialSchemes { dark: schemes.dark.into(), light: schemes.light.into() }
         }
     }
 


### PR DESCRIPTION
scripts: run pre-commit clippy in the package's own workspace

examples/, demos/, tests/ and ui-libraries/ are separate workspaces, so
`cargo clippy -p <pkg>` from the repository root failed with "package ID
specification did not match any packages" for any file in them.

---

Fix clippy warnings in plotter, bapp and the material gallery

The pre-commit hook reaches these packages now, so the warnings would
block any commit touching them.