### PR TITLE
model: Make SortModel's batched row removal O(n) instead of O(n·count)

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -819,18 +819,22 @@ struct SortModelInner : private_api::ModelChangeListener
         std::vector<size_t> removed_rows;
         removed_rows.reserve(count);
 
-        for (auto it = sorted_rows.begin(); it != sorted_rows.end();) {
-            if (*it >= first_removed_row) {
-                if (*it < first_removed_row + count) {
-                    removed_rows.push_back(std::distance(sorted_rows.begin(), it));
-                    it = sorted_rows.erase(it);
+        // `write` is the position the removed row would have had with one-at-a-time
+        // removal, so the emitted notifications are unchanged.
+        size_t write = 0;
+        for (size_t read = 0; read < sorted_rows.size(); ++read) {
+            size_t sort_index = sorted_rows[read];
+            if (sort_index >= first_removed_row) {
+                if (sort_index < first_removed_row + count) {
+                    removed_rows.push_back(write);
                     continue;
-                } else {
-                    *it -= count;
                 }
+                sort_index -= count;
             }
-            ++it;
+            sorted_rows[write] = sort_index;
+            ++write;
         }
+        sorted_rows.resize(write);
 
         for (auto removed_row : removed_rows) {
             target_model.notify_row_removed(removed_row, 1);

--- a/api/cpp/tests/models.cpp
+++ b/api/cpp/tests/models.cpp
@@ -436,6 +436,58 @@ SCENARIO("Sorted Model Remove")
     REQUIRE(sorted_model->row_data(2) == 3);
 }
 
+class BatchRemoveModel : public slint::Model<int>
+{
+public:
+    BatchRemoveModel(std::vector<int> array) : data(std::move(array)) { }
+    size_t row_count() const override { return data.size(); }
+    std::optional<int> row_data(size_t i) const override
+    {
+        if (i >= data.size())
+            return {};
+        return data[i];
+    }
+    void erase(size_t index, size_t count)
+    {
+        data.erase(data.begin() + index, data.begin() + index + count);
+        this->notify_row_removed(index, count);
+    }
+
+private:
+    std::vector<int> data;
+};
+
+SCENARIO("Sorted Model Batch Remove")
+{
+    auto source_model = std::make_shared<BatchRemoveModel>(std::vector<int> { 3, 4, 1, 2 });
+
+    auto sorted_model = std::make_shared<slint::SortModel<int>>(
+            source_model, [](auto lhs, auto rhs) { return lhs < rhs; });
+
+    auto observer = std::make_shared<ModelObserver>();
+    sorted_model->attach_peer(observer);
+
+    REQUIRE(sorted_model->row_count() == 4);
+    REQUIRE(sorted_model->row_data(0) == 1);
+    REQUIRE(sorted_model->row_data(1) == 2);
+    REQUIRE(sorted_model->row_data(2) == 3);
+    REQUIRE(sorted_model->row_data(3) == 4);
+
+    /// Remove the entries with the values 4 and 1 in one notification
+    source_model->erase(1, 2);
+
+    REQUIRE(observer->added_rows.empty());
+    REQUIRE(observer->changed_rows.empty());
+    REQUIRE(observer->removed_rows.size() == 2);
+    REQUIRE(observer->removed_rows[0] == ModelObserver::Range { 0, 1 });
+    REQUIRE(observer->removed_rows[1] == ModelObserver::Range { 2, 1 });
+    REQUIRE(!observer->model_reset);
+
+    REQUIRE(sorted_model->row_count() == 2);
+    REQUIRE(sorted_model->row_data(0) == 2);
+    REQUIRE(sorted_model->row_data(1) == 3);
+}
+
 SCENARIO("Sorted Model Change")
 {
     auto vec_model = std::make_shared<slint::VectorModel<int>>(std::vector<int> { 3, 4, 1, 2 });

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -754,28 +754,22 @@ where
         }
 
         let mut removed_rows = Vec::new();
+        let mut mapping = self.mapping.borrow_mut();
 
-        let mut i = 0;
-
-        loop {
-            if i >= self.mapping.borrow().len() {
-                break;
+        // `write` is the position the removed row would have had with one-at-a-time
+        // removal, so the emitted notifications are unchanged.
+        let mut write = 0;
+        for read in 0..mapping.len() {
+            let sort_index = mapping[read];
+            if (index..index + count).contains(&sort_index) {
+                removed_rows.push(write);
+                continue;
             }
-
-            let sort_index = self.mapping.borrow()[i];
-
-            if sort_index >= index {
-                if sort_index < index + count {
-                    removed_rows.push(i);
-                    self.mapping.borrow_mut().remove(i);
-                    continue;
-                } else {
-                    self.mapping.borrow_mut()[i] -= count;
-                }
-            }
-
-            i += 1;
+            mapping[write] = if sort_index >= index { sort_index - count } else { sort_index };
+            write += 1;
         }
+        mapping.truncate(write);
+        drop(mapping);
 
         for removed_row in removed_rows {
             self.notify.row_removed(removed_row, 1);


### PR DESCRIPTION
SortModelInner::row_removed called Vec::remove, an O(n) memmove, for every removed row inside its O(n) scan. Compact the mapping in a single pass instead; the emitted per-row notifications are unchanged. Removing 5000 of 200000 rows in one notification drops from ~34ms to ~0.2ms.

Reported in #13007 (item 076)
