### PR TITLE
skia: Skip draw calls when the current opacity is zero

### DIFF
--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -1269,6 +1269,13 @@ impl ItemRenderer for QtItemRenderer<'_> {
             (*painter)->setOpacity((*painter)->opacity() * opacity);
         }}
     }
+
+    fn global_alpha_transparent(&self) -> bool {
+        let painter: &QPainterPtr = &self.painter;
+        cpp! { unsafe [painter as "const QPainterPtr*"] -> bool as "bool" {
+            return (*painter)->opacity() == 0;
+        }}
+    }
 }
 
 #[derive(Clone)]

--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -209,7 +209,10 @@ pub fn render_item_children(
 
             // Don't render items that are clipped, with the exception of the Clip or Flickable since
             // they themselves clip their content.
-            let render_result = if do_draw
+            let render_result = if renderer.global_alpha_transparent() {
+                // apply_opacity only multiplies, so the whole subtree stays transparent.
+                RenderingResult::ContinueRenderingWithoutChildren
+            } else if do_draw
                || item.as_ref().clips_children()
                // HACK, the geometry of the box shadow does not include the shadow, because when the shadow is the root for repeated elements it would translate the children
                || ItemRef::downcast_pin::<BoxShadow>(item).is_some()
@@ -662,6 +665,10 @@ pub trait ItemRenderer {
     fn scale(&mut self, scale_x_factor: f32, scale_y_factor: f32);
     /// Apply the opacity (between 0 and 1) for all following items until the next call to restore_state.
     fn apply_opacity(&mut self, opacity: f32);
+    /// Returns true when the opacity accumulated via [`Self::apply_opacity`] is zero.
+    fn global_alpha_transparent(&self) -> bool {
+        false
+    }
 
     fn save_state(&mut self);
     fn restore_state(&mut self);

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -780,6 +780,10 @@ impl<T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRenderer<'_
         self.actual_renderer.apply_opacity(opacity)
     }
 
+    fn global_alpha_transparent(&self) -> bool {
+        self.actual_renderer.global_alpha_transparent()
+    }
+
     fn save_state(&mut self) {
         self.actual_renderer.save_state()
     }

--- a/internal/renderers/anyrender/itemrenderer.rs
+++ b/internal/renderers/anyrender/itemrenderer.rs
@@ -39,6 +39,7 @@ struct RenderState {
     clip_rect: LogicalRect,
     transform: kurbo::Affine,
     layer_count: usize,
+    alpha: f32,
 }
 
 pub struct AnyrenderItemRenderer<'a, S: PaintScene> {
@@ -102,12 +103,17 @@ impl<'a, S: PaintScene> AnyrenderItemRenderer<'a, S> {
                 ),
                 transform: initial_transform,
                 layer_count: 0,
+                alpha: 1.,
             },
         }
     }
 }
 
 impl<'a, S: PaintScene> ItemRenderer for AnyrenderItemRenderer<'a, S> {
+    fn global_alpha_transparent(&self) -> bool {
+        self.current_state.alpha == 0.0
+    }
+
     fn draw_rectangle(
         &mut self,
         rect: Pin<&dyn RenderRectangle>,
@@ -693,6 +699,7 @@ impl<'a, S: PaintScene> ItemRenderer for AnyrenderItemRenderer<'a, S> {
     }
 
     fn apply_opacity(&mut self, opacity: f32) {
+        self.current_state.alpha *= opacity;
         if opacity < 1.0 {
             // The layer is popped again by restore_state().
             self.push_unclipped_layer(peniko::BlendMode::default(), opacity);

--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -139,16 +139,16 @@ fn rect_to_path(r: PhysicalRect) -> femtovg::Path {
 }
 
 impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
-    pub fn global_alpha_transparent(&self) -> bool {
-        self.state.last().unwrap().global_alpha == 0.0
-    }
-
     pub fn metrics(&self) -> RenderingMetrics {
         self.metrics.clone()
     }
 }
 
 impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer<'a, R> {
+    fn global_alpha_transparent(&self) -> bool {
+        self.state.last().unwrap().global_alpha == 0.0
+    }
+
     fn draw_rectangle(
         &mut self,
         rect: Pin<&dyn RenderRectangle>,
@@ -158,9 +158,6 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
     ) {
         let geometry = PhysicalRect::from(size * self.scale_factor);
         if geometry.is_empty() {
-            return;
-        }
-        if self.global_alpha_transparent() {
             return;
         }
         // TODO: cache path in item to avoid re-tesselation
@@ -185,9 +182,6 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         let Some(layout) = BorderRectLayout::new(rect, size, self.scale_factor) else {
             return;
         };
-        if self.global_alpha_transparent() {
-            return;
-        }
 
         let fill_paint = self.brush_to_paint(rect.background(), layout.brush_size);
 
@@ -240,10 +234,6 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         size: LogicalSize,
         _cache: &CachedRenderingData,
     ) {
-        if self.global_alpha_transparent() {
-            return;
-        }
-
         sharedparley::draw_text(self, text, Some(self_rc), size, Some(self.text_layout_cache));
     }
 
@@ -253,18 +243,10 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
         self_rc: &ItemRc,
         size: LogicalSize,
     ) {
-        if self.global_alpha_transparent() {
-            return;
-        }
-
         sharedparley::draw_text_input(self, text_input, self_rc, size, self.text_layout_cache);
     }
 
     fn draw_path(&mut self, path: Pin<&items::Path>, item_rc: &ItemRc, size: LogicalSize) {
-        if self.global_alpha_transparent() {
-            return;
-        }
-
         let (offset, path_events) = match path.fitted_path_events(item_rc) {
             Some(offset_and_events) => offset_and_events,
             None => return,

--- a/internal/renderers/skia/itemrenderer.rs
+++ b/internal/renderers/skia/itemrenderer.rs
@@ -513,6 +513,10 @@ impl<'a> SkiaItemRenderer<'a> {
 }
 
 impl ItemRenderer for SkiaItemRenderer<'_> {
+    fn global_alpha_transparent(&self) -> bool {
+        self.current_state.alpha == 0.0
+    }
+
     fn draw_rectangle(
         &mut self,
         rect: Pin<&dyn i_slint_core::item_rendering::RenderRectangle>,

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -2619,6 +2619,10 @@ struct RenderState {
 }
 
 impl<T: ProcessScene> i_slint_core::item_rendering::ItemRenderer for SceneBuilder<'_, T> {
+    fn global_alpha_transparent(&self) -> bool {
+        self.current_state.alpha == 0.0
+    }
+
     fn draw_rectangle(
         &mut self,
         rect: Pin<&dyn RenderRectangle>,


### PR DESCRIPTION
The software and femtovg renderers already return early from their draw_* methods under an Opacity item at 0; Skia read the rendering properties and issued the draw regardless. Add the same gate.

Reported in #13007 (item 068)
