### PR TITLE
item_tree: Fix O(2^k) recursion in absolute_clip_rect_and_geometry

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -480,35 +480,51 @@ impl ItemRc {
             if stop_condition(&parent) {
                 break;
             }
-            if supports_transformations
-                && let Some(children_transform) = parent.children_transform()
-            {
-                transform = transform.then(&children_transform);
-            }
-            transform = transform.then_translate(parent.geometry().origin.to_vector().cast());
+            transform = transform.then(&parent.step_transform(supports_transformations));
             current = parent;
         }
         transform
     }
 
+    /// The transform from this item's children's coordinate space to its parent's:
+    /// the children transform (scale/rotate), then the translation to the item's origin.
+    fn step_transform(&self, supports_transformations: bool) -> ItemTransform {
+        let origin = self.geometry().origin.to_vector().cast();
+        let mut step = ItemTransform::translation(origin.x, origin.y);
+        if supports_transformations && let Some(children_transform) = self.children_transform() {
+            step = children_transform.then(&step);
+        }
+        step
+    }
+
     /// Returns the clip rect that applies to this item (in window coordinates) as well as the
     /// item's (unclipped) geometry (also in window coordinates).
     fn absolute_clip_rect_and_geometry(&self) -> (LogicalRect, LogicalRect) {
-        let geometry = self
-            .local_to_window_transform(|_| false)
-            .outer_transformed_rect(&self.geometry().cast())
-            .cast();
+        let supports_transformations = self
+            .window_adapter()
+            .is_none_or(|adapter| adapter.renderer().supports_transformations());
 
-        // Intersect the clip rects contributed by all clipping ancestors.
-        let mut clip = LogicalRect::from_size((crate::Coord::MAX, crate::Coord::MAX).into());
+        let mut ancestors = Vec::new();
         let mut cur = self.parent_item(ParentItemTraversalMode::StopAtPopups);
-        while let Some(ref ancestor) = cur {
+        while let Some(ancestor) = cur {
+            cur = ancestor.parent_item(ParentItemTraversalMode::StopAtPopups);
+            ancestors.push(ancestor);
+        }
+
+        // `transform` maps the ancestor's parent's space to window coordinates; each step
+        // composes before the accumulated chain, like in `local_to_window_transform`.
+        let mut clip = LogicalRect::from_size((crate::Coord::MAX, crate::Coord::MAX).into());
+        let mut transform = ItemTransform::identity();
+        for ancestor in ancestors.iter().rev() {
             if ancestor.borrow().as_ref().clips_children() {
-                let (_, ancestor_geom) = ancestor.absolute_clip_rect_and_geometry();
+                let ancestor_geom =
+                    transform.outer_transformed_rect(&ancestor.geometry().cast()).cast();
                 clip = ancestor_geom.intersection(&clip).unwrap_or_default();
             }
-            cur = ancestor.parent_item(ParentItemTraversalMode::StopAtPopups);
+            transform = ancestor.step_transform(supports_transformations).then(&transform);
         }
+
+        let geometry = transform.outer_transformed_rect(&self.geometry().cast()).cast();
 
         (clip, geometry)
     }
@@ -2890,6 +2906,32 @@ mod tests {
         let (clip_rect, leaf_geometry) = leaf.absolute_clip_rect_and_geometry();
         assert!(clip_rect.intersection(&leaf_geometry).is_some());
         assert!(!clip_rect.contains(hidden_point));
+    }
+
+    #[test]
+    fn test_absolute_clip_rect_and_geometry_under_transform() {
+        let (_window_adapter, item_tree) = create_transform_test_items();
+        let root = ItemRc::new_root(item_tree);
+        let transform = root.first_child().unwrap();
+        let clip = transform.first_child().unwrap();
+        let leaf = clip.first_child().unwrap();
+
+        let (clip_rect, leaf_geometry) = leaf.absolute_clip_rect_and_geometry();
+        // The clip item (5,6,20x20) scaled by (2,3) and offset by the transform
+        // item's position (10,20).
+        assert_point_approx_eq(clip_rect.origin, Point2D::new(20., 38.));
+        assert_point_approx_eq(
+            Point2D::new(clip_rect.width(), clip_rect.height()),
+            Point2D::new(40., 60.),
+        );
+        // The leaf (8,4,10x10) offset by the clip item's position (5,6), scaled by (2,3),
+        // and offset by the transform item's position (10,20). The scale must apply to the
+        // clip item's offset too: it lives in the transform item's coordinate space.
+        assert_point_approx_eq(leaf_geometry.origin, Point2D::new(36., 50.));
+        assert_point_approx_eq(
+            Point2D::new(leaf_geometry.width(), leaf_geometry.height()),
+            Point2D::new(20., 30.),
+        );
     }
 
     #[test]


### PR DESCRIPTION
The function called itself recursively on every clipping ancestor to get that ancestor's window geometry, re-walking overlapping ancestor chains: O(2^k) for k nested clip items. It runs on every mouse and key event via is_visible() on the focused item. Compute all ancestor geometries in one walk instead.

The patch proposed in the issue composed the transform chain in the wrong order, giving wrong geometry under a scale/rotate ancestor; fixed here and pinned by a new test with exact coordinates.

Reported in #13007 (item 100)
