### PR TITLE
compiler: Use IndexSet for the binding analysis stack

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -291,6 +291,7 @@ impls
 incididunt
 Inconsolata
 incpath
+indexmap
 inputchip
 intprop
 intval

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,8 +3375,8 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
  "image",
+ "indexmap",
  "itertools 0.15.0",
- "linked_hash_set",
  "lyon_extra",
  "lyon_path",
  "nalgebra",
@@ -4382,21 +4382,6 @@ name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "linux-raw-sys"

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2481,8 +2481,8 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
  "image",
+ "indexmap",
  "itertools 0.15.0",
- "linked_hash_set",
  "lyon_extra",
  "lyon_path",
  "num_enum",
@@ -2891,9 +2891,9 @@ checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "imgref"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
@@ -3287,21 +3287,6 @@ name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "linux-raw-sys"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2566,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
  "digest 0.11.3",
 ]
@@ -3047,9 +3047,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -6085,8 +6085,8 @@ dependencies = [
  "icu_normalizer 2.3.0",
  "icu_properties 2.3.0",
  "image",
+ "indexmap",
  "itertools 0.15.0",
- "linked_hash_set",
  "lyon_extra",
  "lyon_path",
  "num_enum",
@@ -6941,9 +6941,9 @@ checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "imgref"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "imsz"
@@ -7480,21 +7480,6 @@ name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "linux-raw-sys"

--- a/internal/compiler/Cargo.toml
+++ b/internal/compiler/Cargo.toml
@@ -78,7 +78,7 @@ lyon_extra = "1.0.1"
 by_address = { workspace = true }
 itertools = { workspace = true }
 url = "2.2.1"
-linked_hash_set = "0.1.4"
+indexmap = "2.14"
 typed-index-collections = { workspace = true }
 
 # for processing and embedding the rendered image (texture)

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -169,7 +169,7 @@ impl From<NamedReference> for PropertyPath {
 struct AnalysisContext<'a> {
     visited: HashSet<PropertyPath>,
     /// The stack of properties that depends on each other
-    currently_analyzing: linked_hash_set::LinkedHashSet<PropertyPath>,
+    currently_analyzing: indexmap::IndexSet<PropertyPath>,
     /// When set, one of the property in the `currently_analyzing` stack is the window layout property
     /// And we should issue a warning if that's part of a loop instead of an error
     window_layout_property: Option<PropertyPath>,
@@ -316,7 +316,7 @@ fn analyze_binding(
     let mut depends_on_external = DependsOnExternal(false);
     let element = current.prop.element();
     let name = current.prop.name();
-    if (context.currently_analyzing.back() == Some(current))
+    if (context.currently_analyzing.last() == Some(current))
         && !element
             .borrow()
             .binding_cell_including_synthetic(name)
@@ -496,7 +496,7 @@ fn analyze_binding(
         None => (),
     }
 
-    let o = context.currently_analyzing.pop_back();
+    let o = context.currently_analyzing.pop();
     assert_eq!(&o.unwrap(), current);
 
     depends_on_external

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2407,8 +2407,8 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
  "image",
+ "indexmap",
  "itertools 0.15.0",
- "linked_hash_set",
  "lyon_extra",
  "lyon_path",
  "num_enum",
@@ -2843,9 +2843,9 @@ checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "imgref"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "include_dir"
@@ -3251,21 +3251,6 @@ checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 dependencies = [
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -6362,9 +6347,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
`binding_analysis` keeps a stack of the properties currently under analysis, used to detect binding loops and to print the loop path. It was a `LinkedHashSet`, but every operation it needs — insert, `contains`, reverse iteration, last element, pop-last — maps directly onto `indexmap`'s `IndexSet`, which is already in the compiler's dependency graph.

Dropping `linked_hash_set` takes `i-slint-compiler` from **81 to 79 crates** without default features (`linked_hash_set` and `linked-hash-map` both go). Arguably the better reason than the count: both are long dormant, while `indexmap` is maintained and already trusted here.

### Why this is safe

The usual hazard when replacing a linked hash set is that `IndexSet::remove` is a *swap*-removal, which silently reorders — and this set's order is meaningful, since it is iterated in reverse to build the `a -> b -> a` loop description. That hazard doesn't arise: the stack is never used to remove an arbitrary element, only to `pop()` the last one, which preserves order.

The other difference — re-inserting an element that is already present — can't happen either: the `contains` branch returns before reaching the `insert`.

### Verification

`cargo test -p i-slint-compiler` passes, which is the check that matters here: there are 23 `binding_loop*.slint` syntax tests whose expectations encode the exact loop path (e.g. `inner.first -> inner.second -> inner.first`) produced by iterating this stack in reverse. A reordering regression fails them.
