### PR TITLE
compiler: Fix the semantic_analysis benchmark build

### DIFF
--- a/internal/compiler/benches/semantic_analysis.rs
+++ b/internal/compiler/benches/semantic_analysis.rs
@@ -22,7 +22,7 @@ use i_slint_compiler::diagnostics::{BuildDiagnostics, SourceFile, SourceFileInne
 use i_slint_compiler::object_tree::Document;
 use i_slint_compiler::parser;
 use std::path::PathBuf;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[global_allocator]
 static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();


### PR DESCRIPTION
The `semantic_analysis` benchmark does not compile on master:

```
error[E0433]: cannot find type `Arc` in this scope
   --> internal/compiler/benches/semantic_analysis.rs:201:9
warning: unused import: `std::rc::Rc`
  --> internal/compiler/benches/semantic_analysis.rs:25:5
```

87f4c1f31b changed `SourceFile` to `Arc<SourceFileInner>` and updated the benchmark's call to `Arc::new`, but left the import as `std::rc::Rc`.

One line. The second `Rc` import, inside `mod phase_breakdown`, stays as it is — the type registry there is still `Rc`-based.

Verified with `cargo check -p i-slint-compiler --benches --features rust`, and by running `cargo bench -p i-slint-compiler --bench semantic_analysis --features rust -- --sample-count 1` to completion.

Worth noting for later: `cargo test` does not build benchmarks, so nothing in CI appears to compile this target. It will rot again the next time a type changes under it — a `cargo check --benches` step wherever the compiler is already checked would catch that.
