### PR TITLE
core: Make glyph byte offsets absolute so a click maps to the right character

### DIFF
--- a/internal/core/textlayout/glyphclusters.rs
+++ b/internal/core/textlayout/glyphclusters.rs
@@ -65,8 +65,9 @@ impl<Length: Copy + Clone + Zero + core::ops::AddAssign> Iterator
         let mut cluster_byte_offset;
         loop {
             let glyph = &self.shaped_text.glyphs[self.glyph_index];
-            // Rustybuzz uses a relative byte offset as cluster index
-            cluster_byte_offset = current_run.byte_range.start + glyph.text_byte_offset;
+            // ShapeBuffer::new folds the run's start into the cluster index
+            // the shaper reports, so this offset is already absolute.
+            cluster_byte_offset = glyph.text_byte_offset;
             if cluster_byte_offset != self.byte_offset {
                 break;
             }

--- a/internal/core/textlayout/shaping.rs
+++ b/internal/core/textlayout/shaping.rs
@@ -216,6 +216,19 @@ impl<Length> ShapeBuffer<Length> {
 
                 layout.font.shape_text(&text[*run_start..run_end], &mut glyphs);
 
+                // Make the cluster index absolute.
+                //
+                // A shaper sees one run's slice, so the offset it reports is
+                // relative to that slice. Everything downstream compares these
+                // against indices into the whole string: TextLine::byte_range,
+                // a selection range, and the byte offset a click maps to. This
+                // is the one place the run's start is still in hand, and
+                // folding it in here makes TextRun::byte_range and the glyph
+                // offsets mean the same thing.
+                for glyph in &mut glyphs[glyphs_start..] {
+                    glyph.text_byte_offset += *run_start;
+                }
+
                 if let Some(letter_spacing) = layout.letter_spacing
                     && glyphs.len() > glyphs_start
                 {
@@ -398,6 +411,43 @@ fn test_shaping() {
             assert!(shaped_glyphs[2].glyph_id.is_some());
             assert_eq!(shaped_glyphs[2].text_byte_offset, 2);
         }
+    });
+}
+
+/// The byte offset on a glyph is an index into the whole string, on every run.
+///
+/// A shaper sees one run's slice, so the offset it reports is relative to that slice.
+/// Text that changes script part way through is more than one run,
+/// and a line that opens with a bracketed number is exactly that shape.
+/// Line breaking, selection and the byte offset a click maps to
+/// all compare these offsets against indices into the whole string.
+#[test]
+#[cfg_attr(
+    not(feature = "unicode-script"),
+    ignore = "Not supported without the unicode-script feature"
+)]
+fn test_byte_offsets_are_absolute() {
+    with_default_font(|face| {
+        // `Common` script up to the space, `Latin` from `a` on.
+        let text = "[01] abc";
+        let layout = TextLayout { font: &face, letter_spacing: None, line_height: None };
+        let buffer = ShapeBuffer::new(&layout, text);
+
+        assert_eq!(buffer.text_runs.len(), 2, "expected a run boundary at the script change");
+        let second_run = &buffer.text_runs[1];
+        assert_eq!(second_run.byte_range.start, 5);
+
+        // Every offset is an index into `text`, and the first glyph of the second
+        // run points at the character that run starts with.
+        for glyph in &buffer.glyphs {
+            assert!(
+                text.is_char_boundary(glyph.text_byte_offset),
+                "{} is not an index into {text:?}",
+                glyph.text_byte_offset
+            );
+        }
+        assert_eq!(buffer.glyphs[second_run.glyph_range.start].text_byte_offset, 5);
+        assert_eq!(buffer.glyphs.last().unwrap().text_byte_offset, text.len() - 1);
     });
 }
 


### PR DESCRIPTION
`ShapeBuffer::new` itemizes a string into script runs and hands each run's **slice** to `shape_text`. Every shaper reports `Glyph::text_byte_offset` relative to the slice it was given: rustybuzz's cluster index, and `char_indices()` of the slice in the software renderer's pixel and vector fonts. Nothing folded the run's start back in, while `TextRun::byte_range` and every consumer of these offsets work in indices into the whole string. On every run after the first the offsets were therefore short by exactly the number of bytes before it.

The visible fault is in `TextParagraphLayout`: a click in a `TextInput` on a line that changes script part way through resolves to the wrong byte offset. A line opening with a bracketed number is a `Common` run followed by a `Latin` run, so a click in the words came back 11 characters early and a typed character was inserted 11 characters too far left. `byte_offset_for_position`, `cursor_pos_for_byte_offset`, the selection band, the trailing-whitespace trim and the software renderer's selected-glyph test all read the offsets as absolute. `GlyphClusterIterator` was the only consumer that knew, and added `current_run.byte_range.start` by hand.

This adds the run's start to each glyph's offset immediately after `shape_text`, which is the one place the run start is still in hand, and removes the correction in `glyphclusters.rs` that is now redundant. Two source files, four lines of code, and the comments explaining why. The changelog entry is a `ChangeLog:` trailer on the commit, as the template asks.

**Regression test.** `test_byte_offsets_are_absolute` in `shaping.rs` shapes `"[01] abc"`, asserts that it is two runs, that every glyph offset is a character boundary in the whole string, and that the second run's first glyph reports 5 rather than 0. It is `#[cfg_attr(not(feature = "unicode-script"), ignore)]`, because without that feature `ShapeBoundaries` yields a single run and there is nothing to get wrong. Reverting the fix fails it with `left: 0, right: 5`.

**Scope.** Only the `TextParagraphLayout` path is affected. The parley path computes these offsets itself and was already correct, and FemtoVG and Skia have their own text layout.

The issue has a clip of the same steps against 1.17.1 and against this change, and the measurements behind it: a click swept across the field at 4px steps reports exactly 11 too few at all 96 positions over the words, and the unpatched mapping is not even monotonic.

Fixes #13055



<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
