### PR TITLE
software: Use core's u32::isqrt instead of the integer-sqrt crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,7 +3617,6 @@ dependencies = [
  "euclid",
  "i-slint-common",
  "i-slint-core",
- "integer-sqrt",
  "lyon_path",
  "num-traits",
  "skrifa",
@@ -3975,15 +3974,6 @@ name = "input-sys"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
-
-[[package]]
-name = "integer-sqrt"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "interpolate_name"

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2627,7 +2627,6 @@ dependencies = [
  "euclid",
  "i-slint-common",
  "i-slint-core",
- "integer-sqrt",
  "lyon_path",
  "num-traits",
  "skrifa",
@@ -2923,15 +2922,6 @@ name = "input-sys"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
-
-[[package]]
-name = "integer-sqrt"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "interpolate_name"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6241,7 +6241,6 @@ dependencies = [
  "euclid",
  "i-slint-common",
  "i-slint-core",
- "integer-sqrt",
  "lyon_path",
  "num-traits",
  "skrifa 0.44.0",
@@ -7028,15 +7027,6 @@ name = "input-sys"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
-
-[[package]]
-name = "integer-sqrt"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "interpolate_name"

--- a/internal/renderers/software/Cargo.toml
+++ b/internal/renderers/software/Cargo.toml
@@ -42,7 +42,6 @@ bytemuck = { workspace = true, features = ["derive"] }
 clru = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["error"] }
 euclid = { workspace = true }
-integer-sqrt = { version = "0.1.5" }
 num-traits = { version = "0.2", default-features = false }
 skrifa = { workspace = true, optional = true }
 swash = { workspace = true, optional = true, features = ["scale", "render"] }

--- a/internal/renderers/software/draw_functions.rs
+++ b/internal/renderers/software/draw_functions.rs
@@ -12,7 +12,6 @@ use derive_more::{Add, Mul, Sub};
 use i_slint_core::Color;
 use i_slint_core::graphics::{Rgb8Pixel, TexturePixelFormat};
 use i_slint_core::lengths::{PointLengths, SizeLengths};
-use integer_sqrt::IntegerSquareRoot;
 #[allow(unused_imports)]
 use num_traits::Float;
 
@@ -347,7 +346,7 @@ pub(super) fn draw_rounded_rectangle_line(
         }
         #[inline(always)]
         pub fn sqrt(self) -> Self {
-            Self(self.0.integer_sqrt())
+            Self(self.0.isqrt())
         }
     }
     impl core::ops::Mul for Shifted {

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2579,7 +2579,6 @@ dependencies = [
  "euclid",
  "i-slint-common",
  "i-slint-core",
- "integer-sqrt",
  "lyon_path",
  "num-traits",
  "skrifa",
@@ -2914,15 +2913,6 @@ name = "input-sys"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
-
-[[package]]
-name = "integer-sqrt"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "interpolate_name"


### PR DESCRIPTION
Continuation of the dependency feature audit (#13030, #13031, #13053).

`Shifted::sqrt` in the software renderer was the only user of the `integer-sqrt` crate. `u32::isqrt` has been in core since Rust 1.84 and computes the same value — the integer square root, rounded down — so the dependency can go.

- The workspace already requires Rust 1.92, so the API is available.
- `isqrt` is an inherent method on the primitive, living in `core`, so this is fine for the `#![no_std]` MCU builds.

### Verification

`Shifted::sqrt` feeds the rounded rectangle anti-aliasing (the per-scanline coverage spans), so `cargo check` proves little here. The software renderer screenshot tests do: all **44 pass**, including the six cases that exercise `border-radius` — `border`, `clip-border`, `gradient-borders`, `drop-shadow-per-corner-radius`, `drop-shadow-spread` and `inner-shadow`. Those are pixel comparisons against reference images, so an off-by-one in the root would fail them.

```
cargo test --manifest-path tests/Cargo.toml -p test-driver-screenshots \
    --no-default-features --features software
```

All four lockfiles are updated.
