### PR TITLE
testing: List the test fonts explicitly instead of embedding a directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,7 +3283,6 @@ dependencies = [
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
  "image",
- "include_dir",
  "pbjson",
  "pbjson-build",
  "prost",
@@ -3905,25 +3904,6 @@ name = "imgref"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "indexmap"

--- a/internal/backends/testing/Cargo.toml
+++ b/internal/backends/testing/Cargo.toml
@@ -19,7 +19,7 @@ path = "lib.rs"
 
 [features]
 # Internal feature that is only enabled for Slint's own tests
-internal = ["include_dir"]
+internal = []
 # ffi for C++ bindings
 ffi = []
 renderer-software = ["dep:i-slint-renderer-software", "i-slint-renderer-software/std"]
@@ -72,7 +72,6 @@ async-net = { version = "2.0.0", optional = true }
 futures-lite = { version = "2.3.0", optional = true }
 byteorder = { version = "1.5.0", optional = true }
 image = { workspace = true, optional = true, features = ["png"] }
-include_dir = { version = "0.7", optional = true }
 i-slint-renderer-software = { workspace = true, optional = true }
 i-slint-renderer-skia = { workspace = true, default-features = false, optional = true }
 

--- a/internal/backends/testing/lib.rs
+++ b/internal/backends/testing/lib.rs
@@ -102,12 +102,17 @@ pub fn set_system_accent_color(color: i_slint_core::Color) {
 #[cfg(feature = "internal")]
 pub fn configure_test_fonts() {
     use i_slint_common::sharedfontique::{FALLBACK_FAMILIES, fontique};
-    use include_dir::{Dir, include_dir};
 
-    static FONTS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../../tests/screenshots/fonts");
-    // Pin the primary by name so its position in the fallback chain doesn't depend on
-    // filesystem iteration order. NotoSans-Regular wins as the default upright face.
-    const PRIMARY: &str = "NotoSans-Regular.ttf";
+    // Listed explicitly, in the order they take in the fallback chain: NotoSans-Regular is
+    // the default upright face and comes first. Embedding the whole directory instead would
+    // make the chain depend on filesystem iteration order, and would pull in whatever else
+    // lives there - the `.license` files, `convert.sh`, and the gitignored upstream fonts
+    // that script downloads into a subdirectory.
+    static FONTS: &[&[u8]] = &[
+        include_bytes!("../../../tests/screenshots/fonts/NotoSans-Regular.ttf"),
+        include_bytes!("../../../tests/screenshots/fonts/NotoSans-Italic.ttf"),
+        include_bytes!("../../../tests/screenshots/fonts/NotoSansSymbols2-Regular.ttf"),
+    ];
 
     i_slint_core::with_global_context(
         || panic!("platform not set, initialize the testing backend first"),
@@ -120,22 +125,11 @@ pub fn configure_test_fonts() {
             font_context.source_cache = fontique::SourceCache::new_shared();
             font_context.clear_registered_static_fonts();
 
-            let primary =
-                FONTS_DIR.get_file(PRIMARY).expect("primary test font missing from fonts dir");
-            let mut fallback_files: Vec<_> = FONTS_DIR
-                .files()
-                .filter(|f| f.path().extension().is_some_and(|ext| ext == "ttf"))
-                .filter(|f| f.path().file_name().and_then(|n| n.to_str()) != Some(PRIMARY))
-                .collect();
-            // Sort fallbacks lexicographically so the chain is reproducible across platforms.
-            fallback_files.sort_by_key(|f| f.path().to_owned());
-
             let mut chain_families: Vec<fontique::FamilyId> = Vec::new();
-            for file in core::iter::once(primary).chain(fallback_files) {
-                let fonts = font_context.collection.register_fonts(
-                    fontique::Blob::new(std::sync::Arc::new(file.contents())),
-                    None,
-                );
+            for font in FONTS {
+                let fonts = font_context
+                    .collection
+                    .register_fonts(fontique::Blob::new(std::sync::Arc::new(*font)), None);
                 for (family_id, _) in &fonts {
                     if !chain_families.contains(family_id) {
                         chain_families.push(*family_id);

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2330,7 +2330,6 @@ dependencies = [
  "i-slint-common",
  "i-slint-core",
  "i-slint-renderer-software",
- "include_dir",
  "vtable",
 ]
 
@@ -2846,25 +2845,6 @@ name = "imgref"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "indexmap"


### PR DESCRIPTION
Continuation of the dependency feature audit (#13030, #13031, #13053, #13057).

`configure_test_fonts()` embedded `tests/screenshots/fonts` with `include_dir`, then filtered by extension, excluded the primary by name, collected into a `Vec` and sorted it — all to get back to a deterministic order. Listing the three fonts explicitly says the same thing in five lines and removes `include_dir` and `include_dir_macros`.

### The part that isn't just tidying

`include_dir!` embeds **recursively**, but the code reads it with `Dir::files()`, which only walks the top level. So the binary also carried the three `.license` files and `convert.sh` — and, on any machine where `convert.sh` has been run, everything it downloads into the gitignored `NotoSans-unhinted/` subdirectory:

```sh
mkdir -p NotoSans-unhinted
fetch "NotoSans-unhinted/NotoSans-VariableFont_wdth,wght.ttf" ...
```

That is several megabytes of full upstream variable fonts that no code path can reach, and it makes the build output differ between a clean checkout and a developer's working copy — an odd property for the function whose entire job is deterministic test rendering.

### Behaviour

Registration order is unchanged — `NotoSans-Regular` (primary), then `NotoSans-Italic`, then `NotoSansSymbols2-Regular`, which is exactly what primary-plus-lexicographic-sort produced.

Verified with the software renderer screenshot tests, since those are what `configure_test_fonts` exists to make deterministic and a reordered fallback chain would show up as text pixel diffs:

```
cargo test --manifest-path tests/Cargo.toml -p test-driver-screenshots \
    --no-default-features --features software
```

44 passed, 0 failed.
