### PR TITLE
Flexbox: report the items' preferred size on the cross axis

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -2255,17 +2255,29 @@ pub fn flexbox_layout_info_cross_axis_with_measure(
     builder.compute_layout(available_width, available_height, measure.as_mut().map(|m| m as _));
 
     let (total_width, total_height) = builder.container_size();
-    let cross_size = match direction {
-        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => total_height,
-        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => total_width,
+    let (cross_size, cross_padding) = match direction {
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => (total_height, padding_v),
+        FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
+            (total_width, padding_h)
+        }
     };
+
+    // A stretched item's cross axis is `auto`, so taffy's cross size covers only
+    // the items' min size. Floor the preferred cross size with the widest item's
+    // preferred size plus padding, like a box layout's orthogonal axis.
+    let max_item_cross_preferred = cross_cells
+        .iter()
+        .map(|c| c.constraint.preferred_bounded())
+        .fold(0 as Coord, Coord::max)
+        + cross_padding.begin
+        + cross_padding.end;
 
     LayoutInfo {
         min: cross_size,
         max: Coord::MAX,
         min_percent: 0 as _,
         max_percent: 100 as _,
-        preferred: cross_size,
+        preferred: cross_size.max(max_item_cross_preferred),
         stretch: 0.0,
     }
 }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -2256,7 +2256,9 @@ pub fn flexbox_layout_info_cross_axis_with_measure(
 
     let (total_width, total_height) = builder.container_size();
     let (cross_size, cross_padding) = match direction {
-        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => (total_height, padding_v),
+        FlexboxLayoutDirection::Row | FlexboxLayoutDirection::RowReverse => {
+            (total_height, padding_v)
+        }
         FlexboxLayoutDirection::Column | FlexboxLayoutDirection::ColumnReverse => {
             (total_width, padding_h)
         }
@@ -2265,12 +2267,10 @@ pub fn flexbox_layout_info_cross_axis_with_measure(
     // A stretched item's cross axis is `auto`, so taffy's cross size covers only
     // the items' min size. Floor the preferred cross size with the widest item's
     // preferred size plus padding, like a box layout's orthogonal axis.
-    let max_item_cross_preferred = cross_cells
-        .iter()
-        .map(|c| c.constraint.preferred_bounded())
-        .fold(0 as Coord, Coord::max)
-        + cross_padding.begin
-        + cross_padding.end;
+    let max_item_cross_preferred =
+        cross_cells.iter().map(|c| c.constraint.preferred_bounded()).fold(0 as Coord, Coord::max)
+            + cross_padding.begin
+            + cross_padding.end;
 
     LayoutInfo {
         min: cross_size,

--- a/tests/cases/layout/flexbox_cross_axis_preferred.slint
+++ b/tests/cases/layout/flexbox_cross_axis_preferred.slint
@@ -1,0 +1,49 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A stretched item's cross size is `auto`; the container's intrinsic cross size
+// must still reflect the item's preferred size, not just its minimum.
+
+export component TestCase inherits Window {
+    // Column: cross axis is the width.
+    col-flex := FlexboxLayout {
+        flex-direction: column;
+        Rectangle {
+            min-width: 40px;
+            preferred-width: 90px;
+            min-height: 30px;
+        }
+    }
+
+    // Row: cross axis is the height.
+    row-flex := FlexboxLayout {
+        flex-direction: row;
+        Rectangle {
+            min-height: 40px;
+            preferred-height: 90px;
+            min-width: 30px;
+        }
+    }
+
+    out property <bool> test_column: col-flex.preferred-width == 90px;
+    out property <bool> test_row: row-flex.preferred-height == 90px;
+
+    out property <bool> test: test_column && test_row;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
When the items of a FlexboxLayout are stretched to fill the cross axis (the default), taffy sizes each item's cross axis as `auto`. So when the layout was asked for its own preferred cross size, only the items' minimum size was taken into account, not their preferred size: the layout reported itself too small and its content was clipped.

For example, this column reported a preferred width of 40px instead of 90px, clipping the rectangle:

```slint
    FlexboxLayout {
        flex-direction: column;   // the width is the cross axis
        Rectangle {
            min-width: 40px;
            preferred-width: 90px;
        }
    }
```
