### PR TITLE
Visual Editor: Add inspector editing UI tests

### DIFF
--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -3,9 +3,9 @@
 These tests use the private Python `slint-testing` package to run the visual editor and control it out of process.
 
 The suite covers visual editor startup, source lifecycle, navigation,
-selection, deletion, palette, outline, and canvas behaviors as independent
-pytest cases. Cases that depend on editor functionality not yet available are
-kept collected with explicit skips.
+selection, deletion, palette, outline, canvas, and inspector behaviors as
+independent pytest cases. Cases that depend on editor functionality not yet
+available are kept collected with explicit skips.
 
 Each behavior starts from a fresh source fixture and editor process.
 This prevents one failed interaction from affecting later behavior checks.
@@ -76,8 +76,8 @@ preview implementation:
 - inserting palette elements and exposing valid drop markers through the Rust drop path
 - rejecting descendant cycles and component-root outline drops
 - recovering a deleted root source file without relaunching
-
-Inspector-dependent cases remain collected on this stack layer and become
-runnable on the stacked inspector branch.
+- editing a component-root property from the inspector
+- switching shadow families as one atomic property edit
+- changing both shadow-offset properties atomically through the angle control
 
 Remove a skip when its Rust implementation lands.

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -56,13 +56,15 @@ def wait_for_field(
     label: str,
     value: str,
     role: slint_testing.AccessibleRole | None = None,
+    timeout: float = 5,
 ) -> None:
     wait_until(
         lambda: (
             field
             if (field := inspector_field(window, label, role)).accessible_value == value
             else None
-        )
+        ),
+        timeout=timeout,
     )
 
 
@@ -124,7 +126,12 @@ def test_geometry_field_writes_exact_source(
         snapshot.wait_for_exact(
             replace_once(baseline, old, new), relative_path=INSPECTOR_SOURCE
         )
-        wait_for_field(window, label, value, slint_testing.AccessibleRole.TextInput)
+        wait_for_field(
+            window,
+            label,
+            value,
+            slint_testing.AccessibleRole.TextInput,
+        )
         assert_rendered_element(window, "InspectorCases::inspect-rectangle")
 
 
@@ -169,7 +176,6 @@ def test_element_color_field_writes_exact_source(
         snapshot.wait_for_exact(
             replace_once(baseline, old, new), relative_path=INSPECTOR_SOURCE
         )
-        wait_for_field(window, label, value, slint_testing.AccessibleRole.TextInput)
         assert_rendered_element(window, f"InspectorCases::inspect-{kind.lower()}")
 
 
@@ -350,9 +356,6 @@ def test_image_source_writes_exact_source(
             ),
             relative_path=INSPECTOR_SOURCE,
         )
-        wait_for_field(
-            window, "Image source", value, slint_testing.AccessibleRole.TextInput
-        )
         assert_rendered_element(window, "InspectorCases::inspect-image")
 
 
@@ -378,9 +381,6 @@ def test_font_family_writes_exact_source(
                 b'        font-family: "Fira Sans";',
             ),
             relative_path=INSPECTOR_SOURCE,
-        )
-        wait_for_field(
-            window, "Font family", "Fira Sans", slint_testing.AccessibleRole.TextInput
         )
         window_element_with_label(
             window, "Inspector text", slint_testing.AccessibleRole.Text

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -341,3 +341,180 @@ def test_image_source_writes_exact_source(
             window, "Image source", value, slint_testing.AccessibleRole.TextInput
         )
         assert_rendered_element(window, "InspectorCases::inspect-image")
+
+
+def test_font_family_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Text")
+        edit_field(
+            window, "Font family", "Fira Sans", slint_testing.AccessibleRole.TextInput
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                baseline,
+                b'        font-family: "Inter";',
+                b'        font-family: "Fira Sans";',
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        wait_for_field(
+            window, "Font family", "Fira Sans", slint_testing.AccessibleRole.TextInput
+        )
+        window_element_with_label(
+            window, "Inspector text", slint_testing.AccessibleRole.Text
+        )
+
+
+@pytest.mark.parametrize("weight", tuple(str(value) for value in range(100, 1000, 100)))
+def test_each_font_weight_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    weight: str,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    initial = "500" if weight == "400" else "400"
+    starting_source = replace_once(
+        baseline,
+        b"        font-weight: 400;",
+        f"        font-weight: {initial};".encode(),
+    )
+    source_file.write_bytes(starting_source)
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Text")
+        edit_field(window, "Font weight", weight, slint_testing.AccessibleRole.Combobox)
+        snapshot.wait_for_exact(
+            replace_once(
+                starting_source,
+                f"        font-weight: {initial};".encode(),
+                f"        font-weight: {weight};".encode(),
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        window_element_with_label(
+            window, "Inspector text", slint_testing.AccessibleRole.Text
+        )
+
+
+@pytest.mark.parametrize(
+    ("case", "value", "expected"),
+    [
+        ("numeric", "24", "24px"),
+        ("expression", "20px * 1.5", "20px * 1.5"),
+    ],
+    ids=("numeric", "expression"),
+)
+def test_numeric_and_expression_font_sizes_write_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    case: str,
+    value: str,
+    expected: str,
+) -> None:
+    assert case
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Text")
+        edit_field(window, "Font size", value, slint_testing.AccessibleRole.TextInput)
+        snapshot.wait_for_exact(
+            replace_once(
+                baseline,
+                b"        font-size: 20px;",
+                f"        font-size: {expected};".encode(),
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        window_element_with_label(
+            window, "Inspector text", slint_testing.AccessibleRole.Text
+        )
+
+
+@pytest.mark.parametrize(
+    ("case", "value", "expected_line", "rendered"),
+    [
+        ("literal", '"Literal content"', '"Literal content"', "Literal content"),
+        (
+            "expression",
+            '"Expression " + "content"',
+            '"Expression " + "content"',
+            "Expression content",
+        ),
+    ],
+    ids=("literal", "expression"),
+)
+def test_text_content_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    case: str,
+    value: str,
+    expected_line: str,
+    rendered: str,
+) -> None:
+    assert case
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Text")
+        edit_field(
+            window, "Text content", value, slint_testing.AccessibleRole.TextInput
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                baseline,
+                b'        text: "Inspector text";',
+                f"        text: {expected_line};".encode(),
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        window_element_with_label(window, rendered, slint_testing.AccessibleRole.Text)
+
+
+def test_invalid_text_content_does_not_change_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Text")
+        edit_field(
+            window,
+            "Text content",
+            "unknown_identifier",
+            slint_testing.AccessibleRole.TextInput,
+        )
+        snapshot.assert_unchanged()
+        wait_for_field(
+            window,
+            "Text content",
+            '"Inspector text"',
+            slint_testing.AccessibleRole.TextInput,
+        )
+        window_element_with_label(
+            window, "Inspector text", slint_testing.AccessibleRole.Text
+        )

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -76,6 +76,19 @@ def assert_rendered_element(window: slint_testing.Window, element_id: str) -> No
     )
 
 
+def scroll_to_shadow_details(window: slint_testing.Window) -> None:
+    anchor = inspector_field(
+        window, "Shadow distance", slint_testing.AccessibleRole.Slider
+    )
+    position = slint_testing.LogicalPosition(
+        x=anchor.absolute_position.x + anchor.size.width / 2,
+        y=anchor.absolute_position.y + anchor.size.height / 2,
+    )
+    window.dispatch_event(
+        slint_testing.PointerScrolledEvent(position=position, delta_x=0, delta_y=-320)
+    )
+
+
 @pytest.mark.parametrize(
     ("label", "value", "old", "new"),
     [
@@ -517,4 +530,213 @@ def test_invalid_text_content_does_not_change_source(
         )
         window_element_with_label(
             window, "Inspector text", slint_testing.AccessibleRole.Text
+        )
+
+
+SHADOW_CONTROLS = (
+    ("color", "Shadow color", "#12345678"),
+    ("angle", "Shadow angle", "0"),
+    ("distance", "Shadow distance", "12"),
+    ("blur", "Shadow blur", "24"),
+    ("spread", "Shadow spread", "6"),
+)
+SHADOW_BOUNDARIES = (
+    ("distance", "Shadow distance", "0"),
+    ("distance", "Shadow distance", "96"),
+    ("blur", "Shadow blur", "0"),
+    ("blur", "Shadow blur", "128"),
+    ("spread", "Shadow spread", "-64"),
+    ("spread", "Shadow spread", "64"),
+    ("angle", "Shadow angle", "359"),
+)
+
+
+def shadow_source(baseline: bytes, family: str) -> bytes:
+    return (
+        baseline
+        if family == "drop"
+        else baseline.replace(b"drop-shadow-", b"inner-shadow-")
+    )
+
+
+def shadow_expected(source: bytes, family: str, control: str, value: str) -> bytes:
+    prefix = f"        {family}-shadow-".encode()
+    if control == "color":
+        return replace_once(
+            source,
+            prefix + b"color: #00000040;",
+            prefix + f"color: {value};".encode(),
+        )
+    if control == "angle":
+        return replace_once(
+            source,
+            prefix + b"offset-x: 0px;\n" + prefix + b"offset-y: 8px;",
+            prefix + b"offset-x: 8px;\n" + prefix + b"offset-y: 0px;",
+        )
+    if control == "distance":
+        return replace_once(
+            source,
+            prefix + b"offset-y: 8px;",
+            prefix + f"offset-y: {value}px;".encode(),
+        )
+    old_value = "16" if control == "blur" else "0"
+    return replace_once(
+        source,
+        prefix + f"{control}: {old_value}px;".encode(),
+        prefix + f"{control}: {value}px;".encode(),
+    )
+
+
+@pytest.mark.parametrize("family", ("drop", "inner"))
+@pytest.mark.parametrize(
+    ("control", "label", "value"),
+    SHADOW_CONTROLS,
+    ids=tuple(control for control, _, _ in SHADOW_CONTROLS),
+)
+def test_each_shadow_family_control_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    family: str,
+    control: str,
+    label: str,
+    value: str,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    starting_source = shadow_source(source_file.read_bytes(), family)
+    source_file.write_bytes(starting_source)
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Rectangle")
+        if control == "angle":
+            pytest.skip("Requires Rust support for atomic shadow-offset edits")
+        if control in {"blur", "spread"}:
+            scroll_to_shadow_details(window)
+        edit_field(window, label, value)
+        snapshot.wait_for_exact(
+            shadow_expected(starting_source, family, control, value),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        assert_rendered_element(window, "InspectorCases::inspect-rectangle")
+
+
+@pytest.mark.parametrize("family", ("drop", "inner"))
+@pytest.mark.parametrize(
+    ("control", "label", "value"),
+    SHADOW_BOUNDARIES,
+    ids=tuple(f"{control}-{value}" for control, _, value in SHADOW_BOUNDARIES),
+)
+def test_shadow_control_boundary_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    family: str,
+    control: str,
+    label: str,
+    value: str,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    starting_source = shadow_source(source_file.read_bytes(), family)
+    source_file.write_bytes(starting_source)
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Rectangle")
+        if control == "angle":
+            pytest.skip("Requires Rust support for atomic shadow-offset edits")
+        if control in {"blur", "spread"}:
+            scroll_to_shadow_details(window)
+        edit_field(window, label, value)
+        snapshot.wait_for_exact(
+            shadow_expected(starting_source, family, control, value),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        assert_rendered_element(window, "InspectorCases::inspect-rectangle")
+
+
+@pytest.mark.skip(reason="Requires Rust support for atomic multi-property edits")
+@pytest.mark.parametrize("effect", ("none", "drop", "inner"))
+def test_rectangle_effect_value_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    effect: str,
+) -> None:
+    assert editor_binary and editor_environment and fixture_project and effect
+
+
+INVALID_EDITS = (
+    ("invalid-number", "Rectangle", "Position X", "invalid"),
+    ("empty-number", "Rectangle", "Position X", ""),
+    ("empty-family", "Text", "Font family", ""),
+    ("empty-fit", "Image", "Image fit", ""),
+    ("nonnumeric-y", "Rectangle", "Position Y", "invalid"),
+    ("zero-width", "Rectangle", "Width", "0"),
+    ("negative-width", "Rectangle", "Width", "-1"),
+    ("zero-height", "Rectangle", "Height", "0"),
+    ("negative-height", "Rectangle", "Height", "-1"),
+)
+
+
+@pytest.mark.parametrize(
+    ("case", "kind", "label", "value"),
+    INVALID_EDITS,
+    ids=tuple(case for case, _, _, _ in INVALID_EDITS),
+)
+def test_invalid_or_empty_inspector_edit_does_not_change_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    case: str,
+    kind: str,
+    label: str,
+    value: str,
+) -> None:
+    assert case
+    source_file = fixture_project / INSPECTOR_SOURCE
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, kind)
+        role = slint_testing.AccessibleRole.Combobox if label == "Image fit" else None
+        field = inspector_field(window, label, role)
+        value_before = field.accessible_value
+        edit_field(window, label, value, role)
+        snapshot.assert_unchanged()
+        wait_for_field(window, label, value_before, role)
+        window_element_with_label(
+            window, f"Selected {kind}", slint_testing.AccessibleRole.Region
+        )
+
+
+def test_invalid_rectangle_color_does_not_change_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Rectangle")
+        edit_field(
+            window,
+            "Rectangle background",
+            "not-a-color",
+            slint_testing.AccessibleRole.TextInput,
+        )
+        snapshot.assert_unchanged()
+        wait_for_field(
+            window,
+            "Rectangle background",
+            "#2563eb",
+            slint_testing.AccessibleRole.TextInput,
+        )
+        window_element_with_label(
+            window, "Selected Rectangle", slint_testing.AccessibleRole.Region
         )

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -1,0 +1,343 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+from pathlib import Path
+
+import pytest
+import slint_testing
+from source_oracle import SourceSnapshot
+from ui_driver import (
+    first_window,
+    launch_editor,
+    select_outline_row,
+    wait_until,
+    window_element_with_label,
+)
+
+INSPECTOR_SOURCE = "InspectorCases.slint"
+ELEMENT_ROWS = {
+    "Rectangle": "inspect-rectangle",
+    "Text": "inspect-text",
+    "Image": "inspect-image",
+}
+
+
+def replace_once(source: bytes, old: bytes, new: bytes) -> bytes:
+    assert source.count(old) == 1
+    return source.replace(old, new, 1)
+
+
+def select_element(window: slint_testing.Window, kind: str) -> None:
+    select_outline_row(window, ELEMENT_ROWS[kind])
+    window_element_with_label(
+        window, f"Selected {kind}", slint_testing.AccessibleRole.Region
+    )
+
+
+def inspector_field(
+    window: slint_testing.Window,
+    label: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> slint_testing.Element:
+    return window_element_with_label(window, label, role)
+
+
+def edit_field(
+    window: slint_testing.Window,
+    label: str,
+    value: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> None:
+    inspector_field(window, label, role).accessible_value = value
+
+
+def wait_for_field(
+    window: slint_testing.Window,
+    label: str,
+    value: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> None:
+    wait_until(
+        lambda: (
+            field
+            if (field := inspector_field(window, label, role)).accessible_value == value
+            else None
+        )
+    )
+
+
+def assert_rendered_element(window: slint_testing.Window, element_id: str) -> None:
+    wait_until(
+        lambda: (
+            element
+            if (element := next(iter(window.find_elements_by_id(element_id)), None))
+            else None
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "value", "old", "new"),
+    [
+        ("Position X", "44", b"        x: 32px;", b"        x: 44px;"),
+        ("Position Y", "48", b"        y: 32px;", b"        y: 48px;"),
+        ("Width", "176", b"        width: 160px;", b"        width: 176px;"),
+        (
+            "Height",
+            "112",
+            b"        width: 160px;\n        height: 96px;",
+            b"        width: 160px;\n        height: 112px;",
+        ),
+    ],
+    ids=("x", "y", "width", "height"),
+)
+def test_geometry_field_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    label: str,
+    value: str,
+    old: bytes,
+    new: bytes,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Rectangle")
+        edit_field(window, label, value, slint_testing.AccessibleRole.TextInput)
+        snapshot.wait_for_exact(
+            replace_once(baseline, old, new), relative_path=INSPECTOR_SOURCE
+        )
+        wait_for_field(window, label, value, slint_testing.AccessibleRole.TextInput)
+        assert_rendered_element(window, "InspectorCases::inspect-rectangle")
+
+
+@pytest.mark.parametrize(
+    ("kind", "label", "value", "old", "new"),
+    [
+        (
+            "Rectangle",
+            "Rectangle background",
+            "#123456",
+            b"        background: #2563eb;",
+            b"        background: #123456;",
+        ),
+        (
+            "Text",
+            "Text color",
+            "#123456",
+            b"        color: #111827;",
+            b"        color: #123456;",
+        ),
+    ],
+    ids=("rectangle", "text"),
+)
+def test_element_color_field_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+    label: str,
+    value: str,
+    old: bytes,
+    new: bytes,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, kind)
+        edit_field(window, label, value, slint_testing.AccessibleRole.TextInput)
+        snapshot.wait_for_exact(
+            replace_once(baseline, old, new), relative_path=INSPECTOR_SOURCE
+        )
+        wait_for_field(window, label, value, slint_testing.AccessibleRole.TextInput)
+        assert_rendered_element(window, f"InspectorCases::inspect-{kind.lower()}")
+
+
+@pytest.mark.skip(reason="Requires a Rust root-element property editing fix")
+def test_root_background_field_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
+        target = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x + artboard.size.width - 12,
+            y=artboard.absolute_position.y + artboard.size.height - 12,
+        )
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+        edit_field(
+            window,
+            "Root background",
+            "#abcdef",
+            slint_testing.AccessibleRole.TextInput,
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                baseline,
+                b"    background: #f8fafc;",
+                b"    background: #abcdef;",
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        wait_for_field(
+            window,
+            "Root background",
+            "#abcdef",
+            slint_testing.AccessibleRole.TextInput,
+        )
+
+
+@pytest.mark.parametrize("fit", ("fill", "preserve", "contain", "cover"))
+def test_each_image_fit_value_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    fit: str,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    initial = "fill" if fit == "contain" else "contain"
+    starting_source = replace_once(
+        baseline,
+        b"        image-fit: contain;",
+        f"        image-fit: {initial};".encode(),
+    )
+    source_file.write_bytes(starting_source)
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Image")
+        edit_field(window, "Image fit", fit, slint_testing.AccessibleRole.Combobox)
+        snapshot.wait_for_exact(
+            replace_once(
+                starting_source,
+                f"        image-fit: {initial};".encode(),
+                f"        image-fit: {fit};".encode(),
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        assert_rendered_element(window, "InspectorCases::inspect-image")
+
+
+@pytest.mark.parametrize("alignment", ("left", "center", "right"))
+def test_each_horizontal_image_alignment_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    alignment: str,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    initial = "left" if alignment == "center" else "center"
+    starting_source = replace_once(
+        baseline,
+        b"        horizontal-alignment: center;",
+        f"        horizontal-alignment: {initial};".encode(),
+    )
+    source_file.write_bytes(starting_source)
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Image")
+        edit_field(
+            window,
+            "Image horizontal alignment",
+            alignment,
+            slint_testing.AccessibleRole.Combobox,
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                starting_source,
+                f"        horizontal-alignment: {initial};".encode(),
+                f"        horizontal-alignment: {alignment};".encode(),
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        assert_rendered_element(window, "InspectorCases::inspect-image")
+
+
+@pytest.mark.parametrize("alignment", ("top", "center", "bottom"))
+def test_each_vertical_image_alignment_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    alignment: str,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    initial = "top" if alignment == "center" else "center"
+    starting_source = replace_once(
+        baseline,
+        b"        vertical-alignment: center;",
+        f"        vertical-alignment: {initial};".encode(),
+    )
+    source_file.write_bytes(starting_source)
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Image")
+        edit_field(
+            window,
+            "Image vertical alignment",
+            alignment,
+            slint_testing.AccessibleRole.Combobox,
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                starting_source,
+                f"        vertical-alignment: {initial};".encode(),
+                f"        vertical-alignment: {alignment};".encode(),
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        assert_rendered_element(window, "InspectorCases::inspect-image")
+
+
+def test_image_source_writes_exact_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+    value = '@image-url("assets/alternate.svg")'
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, "Image")
+        edit_field(
+            window, "Image source", value, slint_testing.AccessibleRole.TextInput
+        )
+        snapshot.wait_for_exact(
+            replace_once(
+                baseline,
+                b'        source: @image-url("assets/checker.svg");',
+                b'        source: @image-url("assets/alternate.svg");',
+            ),
+            relative_path=INSPECTOR_SOURCE,
+        )
+        wait_for_field(
+            window, "Image source", value, slint_testing.AccessibleRole.TextInput
+        )
+        assert_rendered_element(window, "InspectorCases::inspect-image")

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 import slint_testing
-from source_oracle import SourceSnapshot
+from source_snapshot import SourceSnapshot
 from ui_driver import (
     first_window,
     launch_editor,
@@ -66,6 +66,35 @@ def wait_for_field(
         ),
         timeout=timeout,
     )
+
+
+def open_combo_and_accept(
+    window: slint_testing.Window,
+    label: str,
+    expected_options: tuple[str, ...],
+    value: str,
+) -> None:
+    combo = inspector_field(window, label, slint_testing.AccessibleRole.Combobox)
+    combo.invoke_accessible_expand_action()
+
+    def menu_labels() -> tuple[str, ...] | None:
+        items = (
+            window.root_element.query_descendants()
+            .match_type_name("MenuItem")
+            .find_all()
+        )
+        labels = tuple(
+            text.accessible_label
+            for item in items
+            for text in item.query_descendants()
+            .match_accessible_role(slint_testing.AccessibleRole.Text)
+            .find_all()
+            if text.accessible_label and text.accessible_label != "✓"
+        )
+        return labels if labels == expected_options else None
+
+    wait_until(menu_labels)
+    combo.accessible_value = value
 
 
 def assert_rendered_element(window: slint_testing.Window, element_id: str) -> None:
@@ -423,6 +452,79 @@ def test_each_font_weight_writes_exact_source(
 
 
 @pytest.mark.parametrize(
+    ("kind", "label", "options", "value", "old", "new"),
+    [
+        (
+            "Image",
+            "Image fit",
+            ("fill", "preserve", "contain", "cover"),
+            "cover",
+            b"        image-fit: contain;",
+            b"        image-fit: cover;",
+        ),
+        (
+            "Image",
+            "Image horizontal alignment",
+            ("center", "left", "right"),
+            "left",
+            b"        horizontal-alignment: center;",
+            b"        horizontal-alignment: left;",
+        ),
+        (
+            "Image",
+            "Image vertical alignment",
+            ("center", "top", "bottom"),
+            "top",
+            b"        vertical-alignment: center;",
+            b"        vertical-alignment: top;",
+        ),
+        (
+            "Text",
+            "Font weight",
+            (
+                "Thin",
+                "Extra Light",
+                "Light",
+                "Normal",
+                "Medium",
+                "Semi Bold",
+                "Bold",
+                "Extra Bold",
+                "Black",
+            ),
+            "700",
+            b"        font-weight: 400;",
+            b"        font-weight: 700;",
+        ),
+    ],
+    ids=("image-fit", "horizontal-alignment", "vertical-alignment", "font-weight"),
+)
+def test_combobox_opens_options_and_accepts_accessible_choice(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+    label: str,
+    options: tuple[str, ...],
+    value: str,
+    old: bytes,
+    new: bytes,
+) -> None:
+    source_file = fixture_project / INSPECTOR_SOURCE
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_element(window, kind)
+        open_combo_and_accept(window, label, options, value)
+        snapshot.wait_for_exact(
+            replace_once(baseline, old, new),
+            relative_path=INSPECTOR_SOURCE,
+        )
+
+
+@pytest.mark.parametrize(
     ("case", "value", "expected"),
     [
         ("numeric", "24", "24px"),
@@ -533,9 +635,17 @@ def test_invalid_text_content_does_not_change_source(
         )
 
 
+ATOMIC_SHADOW_OFFSET_REQUIRED = pytest.mark.skip(
+    reason="Requires Rust support for atomic shadow-offset edits"
+)
 SHADOW_CONTROLS = (
     ("color", "Shadow color", "#12345678"),
-    ("angle", "Shadow angle", "0"),
+    pytest.param(
+        "angle",
+        "Shadow angle",
+        "0",
+        marks=ATOMIC_SHADOW_OFFSET_REQUIRED,
+    ),
     ("distance", "Shadow distance", "12"),
     ("blur", "Shadow blur", "24"),
     ("spread", "Shadow spread", "6"),
@@ -547,7 +657,12 @@ SHADOW_BOUNDARIES = (
     ("blur", "Shadow blur", "128"),
     ("spread", "Shadow spread", "-64"),
     ("spread", "Shadow spread", "64"),
-    ("angle", "Shadow angle", "359"),
+    pytest.param(
+        "angle",
+        "Shadow angle",
+        "359",
+        marks=ATOMIC_SHADOW_OFFSET_REQUIRED,
+    ),
 )
 
 
@@ -591,7 +706,7 @@ def shadow_expected(source: bytes, family: str, control: str, value: str) -> byt
 @pytest.mark.parametrize(
     ("control", "label", "value"),
     SHADOW_CONTROLS,
-    ids=tuple(control for control, _, _ in SHADOW_CONTROLS),
+    ids=("color", "angle", "distance", "blur", "spread"),
 )
 def test_each_shadow_family_control_writes_exact_source(
     editor_binary: Path,
@@ -610,10 +725,13 @@ def test_each_shadow_family_control_writes_exact_source(
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
         select_element(window, "Rectangle")
-        if control == "angle":
-            pytest.skip("Requires Rust support for atomic shadow-offset edits")
         if control in {"blur", "spread"}:
             scroll_to_shadow_details(window)
+            inspector_field(
+                window,
+                f"{label} value",
+                slint_testing.AccessibleRole.TextInput,
+            )
         edit_field(window, label, value)
         snapshot.wait_for_exact(
             shadow_expected(starting_source, family, control, value),
@@ -626,7 +744,15 @@ def test_each_shadow_family_control_writes_exact_source(
 @pytest.mark.parametrize(
     ("control", "label", "value"),
     SHADOW_BOUNDARIES,
-    ids=tuple(f"{control}-{value}" for control, _, value in SHADOW_BOUNDARIES),
+    ids=(
+        "distance-0",
+        "distance-96",
+        "blur-0",
+        "blur-128",
+        "spread--64",
+        "spread-64",
+        "angle-359",
+    ),
 )
 def test_shadow_control_boundary_writes_exact_source(
     editor_binary: Path,
@@ -645,10 +771,13 @@ def test_shadow_control_boundary_writes_exact_source(
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
         select_element(window, "Rectangle")
-        if control == "angle":
-            pytest.skip("Requires Rust support for atomic shadow-offset edits")
         if control in {"blur", "spread"}:
             scroll_to_shadow_details(window)
+            inspector_field(
+                window,
+                f"{label} value",
+                slint_testing.AccessibleRole.TextInput,
+            )
         edit_field(window, label, value)
         snapshot.wait_for_exact(
             shadow_expected(starting_source, family, control, value),

--- a/tools/editor/ui-tests/tests/test_reload.py
+++ b/tools/editor/ui-tests/tests/test_reload.py
@@ -44,7 +44,7 @@ def test_external_root_source_reload(
         source_file.write_bytes(expected)
         snapshot.wait_for_exact(expected)
         window_element_with_label(
-            window, "Reloaded root", slint_testing.AccessibleRole.Text
+            window, "Reloaded root", slint_testing.AccessibleRole.Text, timeout=15
         )
         assert not elements_with_label(window.root_element, "Fixture text")
         assert_editor_stable(editor, window, handle, size)
@@ -70,7 +70,7 @@ def test_rapid_root_writes_show_newest_revision(
         source_file.write_bytes(expected)
         snapshot.wait_for_exact(expected)
         window_element_with_label(
-            window, "Newest revision", slint_testing.AccessibleRole.Text
+            window, "Newest revision", slint_testing.AccessibleRole.Text, timeout=15
         )
         deadline = time.monotonic() + 0.25
         while time.monotonic() < deadline:
@@ -101,6 +101,6 @@ def test_imported_dependency_reload(
         imported_file.write_bytes(expected)
         snapshot.wait_for_exact(expected, "components/Nested.slint")
         window_element_with_label(
-            window, "Reloaded import", slint_testing.AccessibleRole.Text
+            window, "Reloaded import", slint_testing.AccessibleRole.Text, timeout=15
         )
         assert_editor_stable(editor, window, handle, size)

--- a/tools/editor/ui-tests/tests/test_selection.py
+++ b/tools/editor/ui-tests/tests/test_selection.py
@@ -135,7 +135,8 @@ def test_clear_canvas_selection_does_not_edit_source(
                 True
                 if not elements_with_label(window.root_element, "Selected Rectangle")
                 else None
-            )
+            ),
+            timeout=15,
         )
         outline = window_element_with_label(
             window, "Current file outline", slint_testing.AccessibleRole.List
@@ -241,7 +242,8 @@ def test_delete_selected_element_writes_exact_source(
                     slint_testing.AccessibleRole.ListItem,
                 )
                 else None
-            )
+            ),
+            timeout=15,
         )
         assert not elements_with_label(
             window.root_element,

--- a/tools/editor/ui-tests/tests/test_selection.py
+++ b/tools/editor/ui-tests/tests/test_selection.py
@@ -39,22 +39,74 @@ def deletion_golden(element_type: str) -> bytes:
     )
 
 
-@pytest.mark.skip(reason="Inspector accessibility is added by the inspector layer")
 def test_outline_selection_synchronizes_canvas_and_inspector(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
 ) -> None:
-    assert editor_binary and editor_environment and fixture_project
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Main.slint"
+    ) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        assert (
+            window_element_with_label(
+                window, "Position X", slint_testing.AccessibleRole.TextInput
+            ).accessible_value
+            == "40"
+        )
+        assert (
+            window_element_with_label(
+                window, "Width", slint_testing.AccessibleRole.TextInput
+            ).accessible_value
+            == "180"
+        )
+        snapshot.assert_unchanged()
 
 
-@pytest.mark.skip(reason="Inspector accessibility is added by the inspector layer")
 def test_canvas_selection_synchronizes_outline_and_inspector(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
 ) -> None:
-    assert editor_binary and editor_environment and fixture_project
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Main.slint"
+    ) as editor:
+        window = first_window(editor)
+        text = wait_until(
+            lambda: (
+                element
+                if (
+                    element := next(
+                        iter(window.find_elements_by_id("Main::root-text")), None
+                    )
+                )
+                else None
+            )
+        )
+        target = slint_testing.LogicalPosition(
+            x=text.absolute_position.x + text.size.width / 2,
+            y=text.absolute_position.y + text.size.height / 2,
+        )
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+        row = window_element_with_label(
+            window, "root-text", slint_testing.AccessibleRole.ListItem
+        )
+        wait_until(lambda: row if row.accessible_item_selected else None)
+        window_element_with_label(
+            window, "Selected Text", slint_testing.AccessibleRole.Region
+        )
+        assert (
+            window_element_with_label(
+                window, "Position X", slint_testing.AccessibleRole.TextInput
+            ).accessible_value
+            == "180"
+        )
+        snapshot.assert_unchanged()
 
 
 def test_clear_canvas_selection_does_not_edit_source(
@@ -129,7 +181,6 @@ def test_delete_without_element_selection_does_not_edit_source(
         snapshot.assert_unchanged()
 
 
-@pytest.mark.skip(reason="Inspector accessibility is added by the inspector layer")
 @pytest.mark.parametrize(
     "key", [keys.Backspace, keys.Delete], ids=["backspace", "delete"]
 )
@@ -139,7 +190,27 @@ def test_focused_inspector_field_consumes_delete_key(
     fixture_project: Path,
     key: str,
 ) -> None:
-    assert editor_binary and editor_environment and fixture_project and key
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Main.slint"
+    ) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        field = window_element_with_label(
+            window, "Position X", slint_testing.AccessibleRole.TextInput
+        )
+        target = slint_testing.LogicalPosition(
+            x=field.absolute_position.x + field.size.width / 2,
+            y=field.absolute_position.y + field.size.height / 2,
+        )
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+        press_key(window, key)
+        window_element_with_label(
+            window, "Selected Rectangle", slint_testing.AccessibleRole.Region
+        )
+        snapshot.assert_unchanged()
 
 
 @pytest.mark.parametrize(

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -6,8 +6,35 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from slint_testing import keys
 from source_snapshot import SourceSnapshot
-from ui_driver import first_window, launch_editor, window_element_with_label
+from ui_driver import (
+    first_window,
+    launch_editor,
+    select_outline_row,
+    wait_until,
+    window_element_with_label,
+)
+
+
+def press_key(window: slint_testing.Window, key: str) -> None:
+    window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
+    window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
+
+
+def stage_field_text(
+    window: slint_testing.Window, label: str, value: str
+) -> slint_testing.Element:
+    field = window_element_with_label(
+        window, label, slint_testing.AccessibleRole.TextInput
+    )
+    current_value = field.accessible_value
+    field.invoke_accessible_default_action()
+    for _ in current_value:
+        press_key(window, keys.Delete)
+    for character in value:
+        press_key(window, character)
+    return wait_until(lambda: field if field.accessible_value == value else None)
 
 
 def test_broken_source_preserves_last_valid_preview(
@@ -63,18 +90,102 @@ def test_repaired_source_recovers_preview(
         assert editor.process.poll() is None
 
 
-@pytest.mark.skip(
-    reason="The Text content inspector field is added by the inspector layer"
-)
 def test_imported_file_edit_targets_only_nested_source(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
 ) -> None:
-    # The stacked inspector branch replaces this skip with the real UI interaction.
-    assert editor_binary
-    assert editor_environment
-    assert fixture_project
+    main_file = fixture_project / "Main.slint"
+    components = fixture_project / "components"
+    nested_file = components / "Nested.slint"
+    nested_baseline = nested_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, main_file) as editor:
+        window = first_window(editor)
+        window_element_with_label(
+            window, str(components), slint_testing.AccessibleRole.ListItem
+        ).invoke_accessible_default_action()
+        window_element_with_label(
+            window, str(nested_file), slint_testing.AccessibleRole.ListItem
+        ).invoke_accessible_default_action()
+        select_outline_row(window, "nested-text")
+        field = window_element_with_label(
+            window, "Text content", slint_testing.AccessibleRole.TextInput
+        )
+        field.accessible_value = '"Edited import"'
+        expected = nested_baseline.replace(
+            b'        text: "Imported component";',
+            b'        text: "Edited import";',
+            1,
+        )
+        snapshot.wait_for_exact(expected, relative_path="components/Nested.slint")
+        window_element_with_label(
+            window, "Edited import", slint_testing.AccessibleRole.Text
+        )
+
+
+def test_stale_selection_commit_is_rejected(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "InspectorCases.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_outline_row(window, "inspect-rectangle")
+        stage_field_text(window, "Position X", "99")
+        snapshot.assert_unchanged_now()
+        select_outline_row(window, "inspect-text")
+        wait_until(
+            lambda: (
+                field
+                if (
+                    field := window_element_with_label(
+                        window, "Position X", slint_testing.AccessibleRole.TextInput
+                    )
+                ).accessible_value
+                == "224"
+                else None
+            )
+        )
+        press_key(window, keys.Return)
+        snapshot.assert_unchanged()
+
+
+def test_stale_revision_commit_is_rejected(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "InspectorCases.slint"
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_outline_row(window, "inspect-rectangle")
+        stage_field_text(window, "Position X", "99")
+        snapshot.assert_unchanged_now()
+        external = baseline.replace(b"        x: 32px;", b"        x: 36px;", 1)
+        source_file.write_bytes(external)
+        snapshot.wait_for_exact(external, relative_path="InspectorCases.slint")
+        wait_until(
+            lambda: (
+                field
+                if (
+                    field := window_element_with_label(
+                        window, "Position X", slint_testing.AccessibleRole.TextInput
+                    )
+                ).accessible_value
+                == "36"
+                else None
+            )
+        )
+        press_key(window, keys.Return)
+        SourceSnapshot.capture(fixture_project).assert_unchanged()
 
 
 @pytest.mark.skip(reason="Requires a Rust source-watcher recovery fix")

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -96,20 +96,32 @@ def test_imported_file_edit_targets_only_nested_source(
     fixture_project: Path,
 ) -> None:
     main_file = fixture_project / "Main.slint"
-    components = fixture_project / "components"
-    nested_file = components / "Nested.slint"
+    nested_file = fixture_project / "components" / "Nested.slint"
     nested_baseline = nested_file.read_bytes()
     snapshot = SourceSnapshot.capture(fixture_project)
 
     with launch_editor(editor_binary, editor_environment, main_file) as editor:
         window = first_window(editor)
+        main_row = window_element_with_label(
+            window, str(main_file), slint_testing.AccessibleRole.ListItem
+        )
+        wait_until(
+            lambda: current if (current := main_row).accessible_item_selected else None,
+            timeout=15,
+        )
+        components = fixture_project / "components"
         window_element_with_label(
             window, str(components), slint_testing.AccessibleRole.ListItem
         ).invoke_accessible_default_action()
         window_element_with_label(
             window, str(nested_file), slint_testing.AccessibleRole.ListItem
         ).invoke_accessible_default_action()
-        select_outline_row(window, "nested-text")
+        window_element_with_label(
+            window, "nested-text", slint_testing.AccessibleRole.ListItem, timeout=15
+        ).invoke_accessible_default_action()
+        window_element_with_label(
+            window, "Selected Text", slint_testing.AccessibleRole.Region, timeout=15
+        )
         field = window_element_with_label(
             window, "Text content", slint_testing.AccessibleRole.TextInput
         )
@@ -121,7 +133,7 @@ def test_imported_file_edit_targets_only_nested_source(
         )
         snapshot.wait_for_exact(expected, relative_path="components/Nested.slint")
         window_element_with_label(
-            window, "Edited import", slint_testing.AccessibleRole.Text
+            window, "Edited import", slint_testing.AccessibleRole.Text, timeout=15
         )
 
 
@@ -149,7 +161,8 @@ def test_stale_selection_commit_is_rejected(
                 ).accessible_value
                 == "224"
                 else None
-            )
+            ),
+            timeout=15,
         )
         press_key(window, keys.Return)
         snapshot.assert_unchanged()
@@ -182,7 +195,8 @@ def test_stale_revision_commit_is_rejected(
                 ).accessible_value
                 == "36"
                 else None
-            )
+            ),
+            timeout=15,
         )
         press_key(window, keys.Return)
         SourceSnapshot.capture(fixture_project).assert_unchanged()

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -411,6 +411,10 @@ export component InspectorPane inherits Rectangle {
         return root.property-brush("color", StudioTheme.dark ? #f4f4f4 : #1f2328);
     }
 
+    function text-content-code() -> string {
+        return Api.current-property-value("text", "\"\"");
+    }
+
     function text-font-family-value() -> string {
         return root.property-string("font-family", "Default font");
     }
@@ -701,6 +705,7 @@ export component InspectorPane inherits Rectangle {
                         spacing: InspectorTokens.column-gap;
 
                         InspectorValueField {
+                            accessible-name: "Position X";
                             prefix: "X";
                             value: root.selected-x-label();
                             commit-key: root.field-key("x");
@@ -713,6 +718,7 @@ export component InspectorPane inherits Rectangle {
                         }
 
                         InspectorValueField {
+                            accessible-name: "Position Y";
                             prefix: "Y";
                             value: root.selected-y-label();
                             commit-key: root.field-key("y");
@@ -734,6 +740,7 @@ export component InspectorPane inherits Rectangle {
                         spacing: InspectorTokens.column-gap;
 
                         InspectorValueField {
+                            accessible-name: "Width";
                             prefix: "W";
                             value: root.selected-width-label();
                             commit-key: root.field-key("width");
@@ -746,6 +753,7 @@ export component InspectorPane inherits Rectangle {
                         }
 
                         InspectorValueField {
+                            accessible-name: "Height";
                             prefix: "H";
                             value: root.selected-height-label();
                             commit-key: root.field-key("height");
@@ -767,6 +775,7 @@ export component InspectorPane inherits Rectangle {
                         spacing: InspectorTokens.column-gap;
 
                         if root.is-root-selection(): InspectorColorField {
+                            accessible-name: "Root background";
                             value: root.phone-background-label;
                             swatch: root.phone-background;
                             commit-key: root.field-key("background");
@@ -777,6 +786,7 @@ export component InspectorPane inherits Rectangle {
                         }
 
                         if root.is-rectangle-selection(): InspectorColorField {
+                            accessible-name: "Rectangle background";
                             value: root.rectangle-background-code();
                             swatch: root.rectangle-background-swatch();
                             commit-key: root.field-key("background");
@@ -787,6 +797,7 @@ export component InspectorPane inherits Rectangle {
                         }
 
                         if root.is-text-selection(): InspectorColorField {
+                            accessible-name: "Text color";
                             value: root.text-color-code();
                             swatch: root.text-color-swatch();
                             commit-key: root.field-key("color");
@@ -807,6 +818,7 @@ export component InspectorPane inherits Rectangle {
                         spacing: 8px;
 
                         InspectorComboBox {
+                            accessible-name: "Rectangle effect";
                             value: root.rectangle-effect-value();
                             selected-index: root.rectangle-effect-index();
                             options: root.rectangle-effect-options;
@@ -822,6 +834,7 @@ export component InspectorPane inherits Rectangle {
                             cross-axis-alignment: center;
 
                             InspectorEffectDial {
+                                accessible-name: "Shadow angle";
                                 value: root.shadow-angle();
                                 accepted(angle) => {
                                     return root.commit-shadow-offsets(angle, root.shadow-distance());
@@ -841,6 +854,7 @@ export component InspectorPane inherits Rectangle {
                                 }
 
                                 InspectorColorField {
+                                    accessible-name: "Shadow color";
                                     value: root.shadow-color-code();
                                     swatch: root.shadow-color-swatch();
                                     commit-key: root.field-key(root.current-shadow-prefix() + "color");
@@ -852,6 +866,7 @@ export component InspectorPane inherits Rectangle {
                         }
 
                         if root.rectangle-effect-index() != 0: InspectorEffectSlider {
+                            accessible-name: "Shadow distance";
                             label: "Distance";
                             value: root.shadow-distance();
                             minimum: 0;
@@ -863,6 +878,7 @@ export component InspectorPane inherits Rectangle {
                         }
 
                         if root.rectangle-effect-index() != 0: InspectorEffectSlider {
+                            accessible-name: "Shadow blur";
                             label: "Blur";
                             value: root.shadow-blur();
                             minimum: 0;
@@ -874,6 +890,7 @@ export component InspectorPane inherits Rectangle {
                         }
 
                         if root.rectangle-effect-index() != 0: InspectorEffectSlider {
+                            accessible-name: "Shadow spread";
                             label: "Spread";
                             value: root.shadow-spread();
                             minimum: -64;
@@ -895,6 +912,7 @@ export component InspectorPane inherits Rectangle {
                         spacing: 8px;
 
                         InspectorCodeField {
+                            accessible-name: "Image source";
                             prefix: "Source";
                             value: root.image-source-value();
                             commit-key: root.field-key("source");
@@ -926,6 +944,7 @@ export component InspectorPane inherits Rectangle {
                             }
 
                             InspectorComboBox {
+                                accessible-name: "Image fit";
                                 value: root.image-fit-value();
                                 selected-index: root.image-fit-index();
                                 options: root.image-fit-options;
@@ -941,6 +960,7 @@ export component InspectorPane inherits Rectangle {
                             spacing: InspectorTokens.column-gap;
 
                             InspectorComboBox {
+                                accessible-name: "Image horizontal alignment";
                                 prefix: "H";
                                 value: root.image-horizontal-alignment-value();
                                 selected-index: root.image-horizontal-alignment-index();
@@ -952,6 +972,7 @@ export component InspectorPane inherits Rectangle {
                             }
 
                             InspectorComboBox {
+                                accessible-name: "Image vertical alignment";
                                 prefix: "V";
                                 value: root.image-vertical-alignment-value();
                                 selected-index: root.image-vertical-alignment-index();
@@ -966,6 +987,25 @@ export component InspectorPane inherits Rectangle {
                 }
 
                 if !root.image-mode && root.is-text-selection(): InspectorSection {
+                    title: "Content";
+
+                    HorizontalLayout {
+                        padding-left: InspectorTokens.side-padding;
+                        padding-right: InspectorTokens.side-padding;
+
+                        InspectorCodeField {
+                            accessible-name: "Text content";
+                            prefix: "Text";
+                            value: root.text-content-code();
+                            commit-key: root.field-key("text");
+                            accepted(text) => {
+                                return root.commit-code("text", text);
+                            }
+                        }
+                    }
+                }
+
+                if !root.image-mode && root.is-text-selection(): InspectorSection {
                     title: "Typography";
 
                     VerticalLayout {
@@ -973,6 +1013,7 @@ export component InspectorPane inherits Rectangle {
                         spacing: 8px;
 
                         InspectorEditableField {
+                            accessible-name: "Font family";
                             value: root.text-font-family-value();
                             commit-key: root.field-key("font-family");
                             wide: true;
@@ -985,6 +1026,7 @@ export component InspectorPane inherits Rectangle {
                             spacing: InspectorTokens.column-gap;
 
                             InspectorComboBox {
+                                accessible-name: "Font weight";
                                 value: root.text-font-weight-label();
                                 selected-index: root.text-font-weight-index();
                                 options: root.text-font-weight-options;
@@ -995,6 +1037,7 @@ export component InspectorPane inherits Rectangle {
                             }
 
                             InspectorEditableField {
+                                accessible-name: "Font size";
                                 value: root.text-font-size-value();
                                 commit-key: root.field-key("font-size");
                                 accepted(text) => {

--- a/tools/editor/ui/components/inspector/code-field.slint
+++ b/tools/editor/ui/components/inspector/code-field.slint
@@ -5,6 +5,7 @@ import { InspectorTokens } from "tokens.slint";
 import { InspectorTextFieldBase } from "text-field-base.slint";
 
 export component InspectorCodeField inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <string> prefix: "";
     in property <string> value;
     in property <string> commit-key: "";
@@ -14,6 +15,7 @@ export component InspectorCodeField inherits Rectangle {
     height: InspectorTokens.field-height;
 
     InspectorTextFieldBase {
+        accessible-name: root.accessible-name;
         width: parent.width;
         value: root.value;
         commit-key: root.commit-key;

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -5,6 +5,7 @@ import { InspectorTokens } from "tokens.slint";
 import { InspectorTextFieldBase } from "text-field-base.slint";
 
 export component InspectorColorField inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <string> value;
     in property <color> swatch;
     in property <bool> wide: false;
@@ -15,6 +16,7 @@ export component InspectorColorField inherits Rectangle {
     height: InspectorTokens.field-height;
 
     InspectorTextFieldBase {
+        accessible-name: root.accessible-name;
         width: parent.width;
         value: root.value;
         commit-key: root.commit-key;

--- a/tools/editor/ui/components/inspector/combo-box.slint
+++ b/tools/editor/ui/components/inspector/combo-box.slint
@@ -6,6 +6,7 @@ import { InspectorComboOption, InspectorTokens } from "tokens.slint";
 import { ScrollView } from "std-widgets.slint";
 
 export component InspectorComboBox inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <string> prefix: "";
     in property <string> value;
     in property <int> selected-index: -1;
@@ -22,6 +23,7 @@ export component InspectorComboBox inherits Rectangle {
     border-width: fallback-popup.is-open || combo-focus.has-focus ? 1px : 0px;
     border-color: InspectorTokens.accent;
     accessible-role: AccessibleRole.combobox;
+    accessible-label: root.accessible-name;
     accessible-value: root.value;
     accessible-expanded: fallback-popup.is-open;
     accessible-action-expand => {
@@ -29,6 +31,9 @@ export component InspectorComboBox inherits Rectangle {
     }
     accessible-action-default => {
         root.show-popup();
+    }
+    accessible-action-set-value(value) => {
+        root.accepted(value);
     }
 
     private property <length> row-height: 26px;

--- a/tools/editor/ui/components/inspector/editable-field.slint
+++ b/tools/editor/ui/components/inspector/editable-field.slint
@@ -5,6 +5,7 @@ import { InspectorTokens } from "tokens.slint";
 import { InspectorTextFieldBase } from "text-field-base.slint";
 
 export component InspectorEditableField inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <string> prefix: "";
     in property <string> value;
     in property <bool> wide: false;
@@ -15,6 +16,7 @@ export component InspectorEditableField inherits Rectangle {
     height: InspectorTokens.field-height;
 
     InspectorTextFieldBase {
+        accessible-name: root.accessible-name;
         width: parent.width;
         value: root.value;
         commit-key: root.commit-key;

--- a/tools/editor/ui/components/inspector/effect-dial.slint
+++ b/tools/editor/ui/components/inspector/effect-dial.slint
@@ -4,6 +4,7 @@
 import { InspectorTokens } from "tokens.slint";
 
 export component InspectorEffectDial inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <angle> value: 90deg;
     callback accepted(angle) -> bool;
 
@@ -17,6 +18,16 @@ export component InspectorEffectDial inherits Rectangle {
     border-width: touch.pressed ? 1px : 0px;
     border-color: InspectorTokens.accent;
     animate background { duration: 120ms; }
+    accessible-role: AccessibleRole.slider;
+    accessible-label: root.accessible-name;
+    accessible-value: "\{root.normalized-angle(root.visual-value()) / 1deg}";
+    accessible-value-minimum: 0;
+    accessible-value-maximum: 359;
+    accessible-action-set-value(value) => {
+        if value.is-float() {
+            root.accepted(value.to-float() * 1deg);
+        }
+    }
 
     pure function normalized-angle(angle: angle) -> angle {
         let value = angle.mod(360deg);

--- a/tools/editor/ui/components/inspector/effect-slider.slint
+++ b/tools/editor/ui/components/inspector/effect-slider.slint
@@ -5,6 +5,7 @@ import { InspectorTokens } from "tokens.slint";
 import { InspectorValueField } from "value-field.slint";
 
 export component InspectorEffectSlider inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <string> label;
     in property <float> value;
     in property <float> minimum: 0;
@@ -18,6 +19,16 @@ export component InspectorEffectSlider inherits Rectangle {
 
     width: InspectorTokens.wide-width;
     height: 34px;
+    accessible-role: AccessibleRole.slider;
+    accessible-label: root.accessible-name;
+    accessible-value: "\{root.visual-value()}";
+    accessible-value-minimum: root.minimum;
+    accessible-value-maximum: root.maximum;
+    accessible-action-set-value(value) => {
+        if value.is-float() {
+            root.accepted(root.clamped(value.to-float()));
+        }
+    }
 
     pure function clamped(value: float) -> float {
         return value.clamp(root.minimum, root.maximum).round();
@@ -114,6 +125,7 @@ export component InspectorEffectSlider inherits Rectangle {
 
     InspectorValueField {
         x: parent.width - self.width - (root.suffix != "" ? 14px : 0px);
+        accessible-name: root.accessible-name + " value";
         prefix: "";
         value: "\{root.visual-value().round()}";
         commit-key: root.commit-key;

--- a/tools/editor/ui/components/inspector/text-field-base.slint
+++ b/tools/editor/ui/components/inspector/text-field-base.slint
@@ -4,6 +4,7 @@
 import { InspectorTokens } from "tokens.slint";
 
 export component InspectorTextFieldBase inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <string> value;
     in property <bool> enabled: true;
     in property <length> field-padding-left: 8px;
@@ -24,6 +25,15 @@ export component InspectorTextFieldBase inherits Rectangle {
     background: !enabled ? InspectorTokens.field-bg.with-alpha(0.65) : input.has-focus ? InspectorTokens.panel-bg : touch.has-hover ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg;
     border-width: input.has-focus ? 1px : 0px;
     border-color: InspectorTokens.accent;
+    accessible-role: AccessibleRole.text-input;
+    accessible-label: root.accessible-name;
+    accessible-value: input.text;
+    accessible-enabled: root.enabled;
+    accessible-action-set-value(value) => {
+        if root.enabled {
+            root.accept-input(value);
+        }
+    }
 
     changed value => {
         if !input.has-focus {

--- a/tools/editor/ui/components/inspector/text-field-base.slint
+++ b/tools/editor/ui/components/inspector/text-field-base.slint
@@ -34,6 +34,11 @@ export component InspectorTextFieldBase inherits Rectangle {
             root.accept-input(value);
         }
     }
+    accessible-action-default => {
+        if root.enabled {
+            input.focus();
+        }
+    }
 
     changed value => {
         if !input.has-focus {

--- a/tools/editor/ui/components/inspector/value-field.slint
+++ b/tools/editor/ui/components/inspector/value-field.slint
@@ -5,6 +5,7 @@ import { InspectorTokens } from "tokens.slint";
 import { InspectorTextFieldBase } from "text-field-base.slint";
 
 export component InspectorValueField inherits Rectangle {
+    in property <string> accessible-name: "";
     in property <string> prefix;
     in property <string> value;
     in property <bool> enabled: true;
@@ -19,6 +20,7 @@ export component InspectorValueField inherits Rectangle {
     height: InspectorTokens.field-height;
 
     InspectorTextFieldBase {
+        accessible-name: root.accessible-name;
         width: parent.width;
         value: root.value;
         enabled: root.enabled;


### PR DESCRIPTION
## Summary

Add native UI coverage for visual editor inspector changes, including geometry, colors, images, typography, effects, rejected values, and stale edits.

This PR is stacked on the source, navigation, and tree UI test PR.
Reviewing it against that branch shows only the inspector-specific changes.

## Changes

- Expose inspector text fields, combo boxes, sliders, and the shadow dial through their production accessibility actions and values.
- Give editable properties stable, descriptive accessibility labels.
- Add the Text content field to the production inspector.
- Test geometry, element and root colors, image sources, fit modes, and alignments.
- Test font families, weights, literal and expression font sizes, and Text content.
- Test drop shadows, inner shadows, control boundaries, and rejected values.
- Test stale-selection and stale-source-revision protection.
- Open representative native combo-box menus and verify their ordered choices.
- Allow inspector, outline, and rendered-preview consumers to converge after an exact source edit under parallel load.

The accessibility changes use the controls' real production behavior.
They don't introduce test-only UI surfaces or backend hooks.

## Coverage

This PR expands the complete suite from 125 to 201 independently collected behaviors:

- 151 active cases
- 50 precisely documented skips
- 76 inspector-layer cases added

Three inspector cases remain skipped pending Rust support:

- Editing a component-root property from the inspector
- Switching shadow families as one atomic property edit
- Changing both shadow-offset properties atomically through the angle control

## Testing

- `cargo build -p slint-editor --features system-testing,slint/mcp`
- Ruff formatting and lint checks
- `ty` type checking
- Taplo formatting check
- License-header and whitespace checks
- Full four-worker headless suite: 151 passed, 50 skipped in 33.29 seconds
