### PR TITLE
partial-renderer: Don't read the geometry of items that are not drawn

### DIFF
--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -202,9 +202,8 @@ pub fn render_item_children(
             renderer.save_state();
             let item_rc = ItemRc::new(component.clone(), index);
 
-            let (do_draw, item_geometry) = renderer.filter_item(&item_rc, window_adapter);
+            let (do_draw, item_origin, item_size) = renderer.filter_item(&item_rc, window_adapter);
 
-            let item_origin = item_geometry.origin;
             renderer.translate(item_origin.to_vector());
 
             // Don't render items that are clipped, with the exception of the Clip or Flickable since
@@ -218,11 +217,10 @@ pub fn render_item_children(
                || ItemRef::downcast_pin::<Opacity>(item).is_some()
                || ItemRef::downcast_pin::<Layer>(item).is_some()
             {
-                item.as_ref().render(
-                    &mut (renderer as &mut dyn ItemRenderer),
-                    &item_rc,
-                    item_geometry.size,
-                )
+                let size = item_size.unwrap_or_else(|| {
+                    crate::properties::evaluate_no_tracking(|| item_rc.geometry()).size
+                });
+                item.as_ref().render(&mut (renderer as &mut dyn ItemRenderer), &item_rc, size)
             } else {
                 RenderingResult::ContinueRenderingChildren
             };
@@ -688,19 +686,24 @@ pub trait ItemRenderer {
     /// This is called before it is being rendered (before the draw_* function).
     /// Returns
     ///  - if the item needs to be drawn (false means it is clipped or doesn't need to be drawn)
-    ///  - the geometry of the item
+    ///  - the origin of the item
+    ///  - the size of the item, or None if it doesn't need to be drawn and the size wasn't computed
     fn filter_item(
         &mut self,
         item: &ItemRc,
         window_adapter: &WindowAdapterRc,
-    ) -> (bool, LogicalRect) {
+    ) -> (bool, LogicalPoint, Option<LogicalSize>) {
         let item_geometry = item.geometry();
         // Query bounding rect untracked, as properties that affect the bounding rect are already tracked
         // when rendering the item.
         let bounding_rect = crate::properties::evaluate_no_tracking(|| {
             item.bounding_rect(&item_geometry, window_adapter)
         });
-        (self.get_current_clip().intersects(&bounding_rect), item_geometry)
+        (
+            self.get_current_clip().intersects(&bounding_rect),
+            item_geometry.origin,
+            Some(item_geometry.size),
+        )
     }
 
     fn window(&self) -> &crate::window::WindowInner;

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -682,6 +682,15 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
     pub fn into_inner(self) -> T {
         self.actual_renderer
     }
+
+    /// Whether an item with this bounding rect is visible in the clip and dirty region.
+    fn item_is_drawn(&self, item_bounding_rect: &LogicalRect) -> bool {
+        self.get_current_clip().intersection(item_bounding_rect).is_some_and(|clipped_geom| {
+            let screen_geom =
+                self.current_transform().outer_transformed_rect(&clipped_geom.cast()).cast();
+            self.dirty_region.draw_intersects(screen_geom)
+        })
+    }
 }
 
 macro_rules! forward_rendering_call {
@@ -713,30 +722,37 @@ impl<T: ItemRenderer + ItemRendererFeatures> ItemRenderer for PartialRenderer<'_
         &mut self,
         item_rc: &ItemRc,
         window_adapter: &Rc<dyn WindowAdapter>,
-    ) -> (bool, LogicalRect) {
+    ) -> (bool, LogicalPoint, Option<LogicalSize>) {
         let item = item_rc.borrow();
+        let rendering_data = item.cached_rendering_data_offset();
+
+        // The entry is fresh: compute_dirty_regions() refreshes it every frame.
+        let cached = {
+            let mut cache = self.cache.borrow_mut();
+            rendering_data.get_entry(&mut cache).map(|e| {
+                let draw = self.item_is_drawn(e.data.bounding_rect());
+                let offset = match &e.data {
+                    CachedItemBoundingBoxAndTransform::RegularItem { offset, .. } => Some(*offset),
+                    _ => None,
+                };
+                (draw, offset)
+            })
+        };
+
+        // Items that are not drawn only need their origin; this skips e.g. shaping off-screen text.
+        if let Some((false, Some(offset))) = cached {
+            return (false, offset.to_point(), None);
+        }
 
         // Query untracked, as the bounding rect calculation already registers a dependency on the geometry.
         let item_geometry = crate::properties::evaluate_no_tracking(|| item_rc.geometry());
-
-        let rendering_data = item.cached_rendering_data_offset();
-        let mut cache = self.cache.borrow_mut();
-        let item_bounding_rect = match rendering_data.get_entry(&mut cache) {
-            Some(PartialRenderingCachedData { data, tracker: _ }) => *data.bounding_rect(),
-            None => {
-                // This item was created between the computation of the dirty region and the actual rendering.
-                item_rc.bounding_rect(&item_geometry, window_adapter)
-            }
-        };
-
-        let clipped_geom = self.get_current_clip().intersection(&item_bounding_rect);
-        let draw = clipped_geom.is_some_and(|clipped_geom| {
-            let screen_geom =
-                self.current_transform().outer_transformed_rect(&clipped_geom.cast()).cast();
-            self.dirty_region.draw_intersects(screen_geom)
+        let draw = cached.map(|(draw, _)| draw).unwrap_or_else(|| {
+            // The item was created between the computation of the dirty region and the
+            // actual rendering.
+            self.item_is_drawn(&item_rc.bounding_rect(&item_geometry, window_adapter))
         });
 
-        (draw, item_geometry)
+        (draw, item_geometry.origin, Some(item_geometry.size))
     }
 
     forward_rendering_call2!(fn draw_rectangle(dyn RenderRectangle));


### PR DESCRIPTION
filter_item read the geometry of every item, even for items that are skipped because they are outside of the visible area or the dirty region. For a Text item, reading the size computes the text layout, so off-screen text was laid out just to be thrown away. Items that are not drawn only need their position, which is already in the bounding-box cache entry that compute_dirty_regions() refreshes every frame, so return that and skip the geometry read.

filter_item now returns (bool, LogicalPoint, Option<LogicalSize>) instead of (bool, LogicalRect), so a skipped size is visible in the type. Items that render even when not drawn, such as Opacity with a cached layer, read their real size in render_item_children.

Scrolling scenes with many off-screen items get ~10-12% faster frames.

Reported in #13007 (item 035)
