### PR TITLE
Make array.index-of, and MouseCursor.custom experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ All notable changes to this project are documented in this file.
  - Struct fields can now declare a default value: `struct Player { name: string = "unknown" }`.
  - Added `push`, `remove`, and `insert` functions on arrays and models, with matching `Model` API
    additions in every language binding. (#9457)
- - Added the `array.index-of(value)` function, returning the index of the first equal element. (#12790)
  - Added the `string.starts-with()` and `string.ends-with()` functions. (#9877)
  - Added the `string.replace-all(from, to)` function. (#12782)
  - Added the `WindowMoveArea` element to start an interactive window move, like a native title bar. (#613)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,6 @@ All notable changes to this project are documented in this file.
  - Added the `string.replace-all(from, to)` function. (#12782)
  - Added the `WindowMoveArea` element to start an interactive window move, like a native title bar. (#613)
  - Added `angle-at` and `position-at` functions to the `Path` element to support animating objects along a path.
- - Added `MouseCursor.custom()` to set a custom cursor from an image with a hotspot. (#10270)
  - Added the `input-method-hints` property to `TextInput` and `LineEdit` to hint the platform's input method
    about auto-capitalization, auto-correction, and auto-completion. (#9016)
  - Added the `max-lines` property to `Text` and `StyledText` to limit the number of rendered lines.

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -307,7 +307,7 @@ export default defineConfig({
                                                   slug: "guide/experimental/match-elements",
                                               },
                                               {
-                                                  label: "Array Predicates",
+                                                  label: "Array Search Functions",
                                                   slug: "guide/experimental/array-predicates",
                                               },
                                               {

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -322,6 +322,10 @@ export default defineConfig({
                                                   label: "Shadowable Members",
                                                   slug: "guide/experimental/shadowable",
                                               },
+                                              {
+                                                  label: "Custom Mouse Cursor",
+                                                  slug: "guide/experimental/custom-mouse-cursor",
+                                              },
                                           ],
                                       },
                                   ]

--- a/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
@@ -1,13 +1,27 @@
 ---
-title: Array Predicates
-description: Experimental predicate expressions for the array operations any, all and find-index.
+title: Array Search Functions
+description: Experimental array search functions index-of, any, all and find-index.
 ---
 
-The array operations `any`, `all` and `find-index` test the elements of an array against a
-predicate expression.
+The array function `index-of` looks up a value in an array, and the operations `any`,
+`all` and `find-index` test the elements of an array against a predicate expression.
 
-> **Note**: Array predicates are experimental and subject to change.
+> **Note**: These functions are experimental and subject to change.
+> They report "no match" with a `-1` or `false` result; once the language has optional
+> types, `index-of` and `find-index` should return an optional index instead.
 > Tracking issue: [slint-ui/slint#12777](https://github.com/slint-ui/slint/issues/12777).
+
+## index-of
+
+`array.index-of(value)` reads the index of the first element that equals `value`,
+or `-1` if the array contains no such element.
+
+```slint no-test
+export component Example {
+    in-out property<[string]> names: ["Aardvark", "Beaver"];
+    out property <int> beaver-index: names.index-of("Beaver"); // 1
+}
+```
 
 ## Syntax
 
@@ -29,9 +43,8 @@ and its type is inferred from the array element type.
 `any` returns `false` for an empty array, `all` returns `true` for an empty array, and
 `find-index` returns `-1` for an empty array.
 
-For a plain value-equality lookup, prefer the stable
-[`array.index-of(value)`](../../property-types/arrays-and-models/#operations) over
-`find-index((name) => name == value)`: it needs no predicate and isn't experimental.
+For a plain value-equality lookup, prefer `array.index-of(value)` over
+`find-index((name) => name == value)`: it needs no predicate.
 Reach for `find-index` when the match condition is more than equality against a single value.
 
 ## Example

--- a/docs/astro/src/content/docs/guide/experimental/custom-mouse-cursor.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/custom-mouse-cursor.mdx
@@ -1,0 +1,20 @@
+---
+title: Custom Mouse Cursor
+description: Experimental MouseCursor.custom() to set a custom mouse cursor from an image.
+---
+
+In addition to the built-in shapes, the `mouse-cursor` property accepts a custom cursor
+created with `MouseCursor.custom(image, hotspot-x, hotspot-y)`.
+
+The hotspot is the point in the image, given in image pixels from the top-left corner,
+that is aligned with the actual pointer position. It is clamped to the image bounds.
+
+> **Note**: `MouseCursor.custom()` is experimental and subject to change.
+> A function on a type namespace is a stand-in for an enum variant with data;
+> once the language has such variants, `custom` should become one.
+
+```slint no-test
+TouchArea {
+    mouse-cursor: MouseCursor.custom(@image-url("cursor.png"), 0, 0);
+}
+```

--- a/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/arrays-and-models.mdx
@@ -48,10 +48,8 @@ The following operations apply to a value of an array type.
 - `array.remove(index)` removes the element at `index`.
 - `array.insert(index, value)` inserts `value` before the element at `index`, shifting later elements up.
   `value` must have the element type.
-- `array.index-of(value)` returns the index of the first element equal to `value` as an `int`,
-  or `-1` if no element matches. `value` must have the element type.
 
-`length`, `push`, `remove`, `insert`, and `index-of` are members of the array; `index` is written with the `[ ]` operator.
+`length`, `push`, `remove`, and `insert` are members of the array; `index` is written with the `[ ]` operator.
 
 ## Out-of-bounds behavior
 

--- a/docs/astro/src/content/docs/reference/property-types/other-types.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/other-types.mdx
@@ -157,8 +157,6 @@ In Python, properties or struct fields of the data-transfer type are mapped to <
 <SlintProperty propName="mouse-cursor" typeName="MouseCursor" defaultValue='default'>
 The `MouseCursor` type is used in the <Link type="TouchArea" label="TouchArea element"/>.
 
-#### Built-in shape
-
 Set to one of the built-in shapes by specifying the name:
 
 ```slint
@@ -172,15 +170,5 @@ TouchArea {
 ```
 
 <BuiltInMouseCursor />
-
-#### Custom shape
-
-To set a custom mouse cursor, provide an `image` and a hotspot. The hotspot is the point in the image, given in image pixels from the top-left corner, that is aligned with the actual pointer position. It is clamped to the image bounds.
-
-```slint
-TouchArea {
-    mouse-cursor: MouseCursor.custom(@image-url("cursor.png"), 0, 0);
-}
-```
 
 </SlintProperty>

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -92,6 +92,12 @@ impl<'a> LookupCtx<'a> {
         }
     }
 
+    /// Whether lookup offers experimental entries: enabled experimental features,
+    /// or the builtin widget library, which may use them.
+    fn experimental_lookup_enabled(&self) -> bool {
+        self.diag.enable_experimental || self.type_register.expose_internal_types
+    }
+
     /// Run `f` with `expected_type` temporarily set to `ty`, restoring it afterwards.
     pub fn with_expected_type<R>(&mut self, ty: Type, f: impl FnOnce(&mut Self) -> R) -> R {
         let old = std::mem::replace(&mut self.expected_type, ty);
@@ -1270,13 +1276,13 @@ impl LookupObject for ArrayExpression<'_> {
             .or_else(|| f("push", member_macro(BuiltinMacroFunction::ArrayPush)))
             .or_else(|| f("remove", member_macro(BuiltinMacroFunction::ArrayRemove)))
             .or_else(|| f("insert", member_macro(BuiltinMacroFunction::ArrayInsert)))
-            .or_else(|| f("index-of", member_macro(BuiltinMacroFunction::ArrayIndexOf)))
             .or_else(|| {
-                // `any`, `all` and `find-index` take a closure argument; closures are experimental.
-                if !ctx.diag.enable_experimental && !ctx.type_register.expose_internal_types {
+                // Experimental: pending optional types for the -1 result, and closures.
+                if !ctx.experimental_lookup_enabled() {
                     return None;
                 }
-                f("any", member_function(BuiltinFunction::ArrayAny))
+                f("index-of", member_macro(BuiltinMacroFunction::ArrayIndexOf))
+                    .or_else(|| f("any", member_function(BuiltinFunction::ArrayAny)))
                     .or_else(|| f("all", member_function(BuiltinFunction::ArrayAll)))
                     .or_else(|| f("find-index", member_function(BuiltinFunction::ArrayFindIndex)))
             })

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -911,7 +911,7 @@ struct MouseCursorSpecific;
 impl LookupObject for MouseCursorSpecific {
     fn for_each_entry<R>(
         &self,
-        _ctx: &LookupCtx,
+        ctx: &LookupCtx,
         f: &mut impl FnMut(&SmolStr, LookupResult) -> Option<R>,
     ) -> Option<R> {
         let e = crate::typeregister::BUILTIN.enums.BuiltInMouseCursor.clone();
@@ -923,6 +923,10 @@ impl LookupObject for MouseCursorSpecific {
             }
         }
         r.or_else(|| {
+            // Experimental until the language has enums with data.
+            if !ctx.experimental_lookup_enabled() {
+                return None;
+            }
             f(&SmolStr::new_static("custom"), BuiltinMacroFunction::CustomMouseCursor.into())
         })
     }

--- a/internal/compiler/tests/array_function_stability.rs
+++ b/internal/compiler/tests/array_function_stability.rs
@@ -1,7 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! `array.index-of` must stay usable without `enable_experimental` (unlike find-index/any/all).
+//! The array functions `index-of`, `find-index`, `any`, and `all` require
+//! `enable_experimental`, but the builtin widget library may still use them internally.
 //! The syntax-test corpus and every runtime test driver force that flag on uniformly for their
 //! whole corpus, so a regression here wouldn't be caught there — this test controls the flag
 //! directly instead.
@@ -24,24 +25,32 @@ fn compile(
 }
 
 #[test]
-fn index_of_does_not_require_experimental_features() {
-    let src = r#"
-        export component Test {
-            in property <[string]> model: ["A", "B"];
-            out property <int> idx: model.index-of("B");
-        }
-    "#;
-    assert!(!compile(src, false).has_errors());
+fn array_search_functions_require_experimental_features() {
+    for expression in ["model.index-of(\"B\")", "model.find-index((x) => x == \"B\")"] {
+        let src = format!(
+            r#"
+            export component Test {{
+                in property <[string]> model: ["A", "B"];
+                out property <int> idx: {expression};
+            }}
+        "#
+        );
+        assert!(compile(&src, false).has_errors());
+        assert!(!compile(&src, true).has_errors());
+    }
 }
 
+/// The ComboBox implementation uses `index-of` internally: the widget library
+/// passes the `expose_internal_types` gate, so it keeps working without
+/// experimental features.
 #[test]
-fn find_index_still_requires_experimental_features() {
+fn combobox_works_without_experimental_features() {
     let src = r#"
+        import { ComboBox } from "std-widgets.slint";
         export component Test {
-            in property <[string]> model: ["A", "B"];
-            out property <int> idx: model.find-index((x) => x == "B");
+            ComboBox { model: ["A", "B"]; current-value: "B"; }
         }
     "#;
-    assert!(compile(src, false).has_errors());
-    assert!(!compile(src, true).has_errors());
+    let diag = compile(src, false);
+    assert!(!diag.has_errors(), "{:?}", diag.to_string_vec());
 }

--- a/internal/compiler/widgets/common/combobox-base.slint
+++ b/internal/compiler/widgets/common/combobox-base.slint
@@ -82,9 +82,8 @@ export component ComboBoxBase {
 
     // A write to `current-value` (host or declarative) expresses "select the row with this
     // value": look it up in `model` and resolve `current-index` — and, through it,
-    // `current-value` itself — to match, or to "" if not found. Uses the stable `index-of`,
-    // not the experimental `find-index` it lowers to, so ComboBox doesn't depend on an
-    // experimental feature. `current-index` and `current-value` each resolve the other to
+    // `current-value` itself — to match, or to "" if not found.
+    // `current-index` and `current-value` each resolve the other to
     // match on every write, so of two writes made right after each other, whichever came
     // last determines the final state — there's no inherent priority between the two
     // properties.


### PR DESCRIPTION
Follow-up from the 1.18 API review: each of these has a better shape waiting on a language feature, so ship them experimental instead of freezing them in 1.18.

- array.index-of: the -1 result should become an optional index, once the language has optional types.
-  MouseCursor.custom(): a function on a type namespace is a stand-in for an enum variant with data; once the language has such variants, custom should become one.

Non-controversial part of #13029