### PR TITLE
Rename `set-selection-offsets()` parameters to `anchor` and `focus`

### DIFF
--- a/demos/usecases/ui/widgets/extended_line_edit.slint
+++ b/demos/usecases/ui/widgets/extended_line_edit.slint
@@ -24,8 +24,8 @@ component LineEditBase inherits Rectangle {
     callback accepted( /* text */ string);
     callback edited(/* text */ string);
 
-    public function set-selection-offsets(start: int, end: int) {
-        text-input.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        text-input.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {
@@ -107,8 +107,8 @@ export component ExtendedLineEdit {
     accessible-role: text-input;
     accessible-value <=> text;
 
-    public function set-selection-offsets(start: int, end: int) {
-        base.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        base.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
@@ -108,8 +108,8 @@ Call this function to focus the LineEdit and make it receive future keyboard eve
 ### clear-focus()
 Call this function to remove keyboard focus from this `LineEdit` if it currently has the focus. See also <Link type="FocusHandling" />.
 
-### set-selection-offsets(int, int)
-Selects the text between two UTF-8 offsets.
+### set-selection-offsets(anchor: int, focus: int)
+Selects the text between two UTF-8 offsets: `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to, so `focus` may precede `anchor` to select backwards.
 
 ### select-all()
 Selects all text.

--- a/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
@@ -134,7 +134,7 @@ The height of the visible area of the text edit (not including the scrollbar)
 
 -   **`focus()`** Call this function to focus the TextEdit and make it receive future keyboard events.
 -   **`clear-focus()`** Call this function to remove keyboard focus from this `TextEdit` if it currently has the focus. See also <Link type="FocusHandling" label="focus handling" />.
--   **`set-selection-offsets(int, int)`** Selects the text between two UTF-8 offsets.
+-   **`set-selection-offsets(anchor: int, focus: int)`** Selects the text between two UTF-8 offsets: `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to, so `focus` may precede `anchor` to select backwards.
 -   **`select-all()`** Selects all text.
 -   **`clear-selection()`** Clears the selection. This function takes effect regardless of the `read-only` and `enabled` properties.
 -   **`copy()`** Copies the selected text to the clipboard.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1836,7 +1836,9 @@ export component TextInput {
     //-default_size_binding:expands_to_parent_geometry
     //-accepts_focus
     /// Selects the text between two UTF-8 offsets.
-    function set-selection-offsets(start: int, end: int) {
+    /// `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to,
+    /// so `focus` may precede `anchor` to select backwards.
+    function set-selection-offsets(anchor: int, focus: int) {
         BuiltinFunction.SetSelectionOffsets
     }
     /// Selects all text.

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -5561,13 +5561,13 @@ fn compile_builtin_function_call(
             })
         }
         BuiltinFunction::SetSelectionOffsets => {
-            if let [llr::Expression::PropertyReference(pr), from, to] = arguments {
+            if let [llr::Expression::PropertyReference(pr), anchor_expr, focus_expr] = arguments {
                 let window = access_window_field(ctx);
-                let start = compile_expression(from, ctx);
-                let end = compile_expression(to, ctx);
+                let anchor = compile_expression(anchor_expr, ctx);
+                let focus = compile_expression(focus_expr, ctx);
                 item_owner(pr).then(|owner| {
                     let (item, item_rc) = native_item_from_owner(pr, ctx, owner);
-                    format!("slint_textinput_set_selection_offsets(&{item}, &{window}.handle(), &{item_rc}, static_cast<int>({start}), static_cast<int>({end}))")
+                    format!("slint_textinput_set_selection_offsets(&{item}, &{window}.handle(), &{item_rc}, static_cast<int>({anchor}), static_cast<int>({focus}))")
                 })
             } else {
                 panic!("internal error: invalid args to set-selection-offsets {arguments:?}")

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -4910,15 +4910,15 @@ fn compile_builtin_function_call(
             })
         }
         BuiltinFunction::SetSelectionOffsets => {
-            if let [llr::Expression::PropertyReference(pr), from, to] = arguments {
+            if let [llr::Expression::PropertyReference(pr), anchor_expr, focus_expr] = arguments {
                 let window_adapter_tokens = access_window_adapter_field(ctx);
-                let start = compile_expression(from, ctx);
-                let end = compile_expression(to, ctx);
+                let anchor = compile_expression(anchor_expr, ctx);
+                let focus = compile_expression(focus_expr, ctx);
 
                 item_owner(pr).then(|owner| {
                     let (item, item_rc) = native_item_from_owner(pr, ctx, &owner);
                     quote!(
-                        #item.set_selection_offsets(#window_adapter_tokens, &#item_rc, #start as i32, #end as i32)
+                        #item.set_selection_offsets(#window_adapter_tokens, &#item_rc, #anchor as i32, #focus as i32)
                     )
                 })
             } else {

--- a/internal/compiler/widgets/common/lineedit-base.slint
+++ b/internal/compiler/widgets/common/lineedit-base.slint
@@ -41,8 +41,8 @@ export component LineEditBase inherits Rectangle {
     callback key-pressed(event: KeyEvent) -> EventResult;
     callback key-released(event: KeyEvent) -> EventResult;
 
-    public function set-selection-offsets(start: int, end: int) {
-        text-input.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        text-input.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/internal/compiler/widgets/common/textedit-base.slint
+++ b/internal/compiler/widgets/common/textedit-base.slint
@@ -35,8 +35,8 @@ export component TextEditBase inherits Rectangle {
     callback key-pressed(event: KeyEvent) -> EventResult;
     callback key-released(event: KeyEvent) -> EventResult;
 
-    public function set-selection-offsets(start: int, end: int) {
-        text-input.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        text-input.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/internal/compiler/widgets/cosmic/textedit.slint
+++ b/internal/compiler/widgets/cosmic/textedit.slint
@@ -39,8 +39,8 @@ export component TextEdit {
     accessible-read-only: root.read-only;
     accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
-    public function set-selection-offsets(start: int, end: int) {
-        base.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        base.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/internal/compiler/widgets/cupertino/textedit.slint
+++ b/internal/compiler/widgets/cupertino/textedit.slint
@@ -93,8 +93,8 @@ export component TextEdit {
     accessible-read-only: root.read-only;
     accessible-action-set-selection-offsets(anchor, focus) => { text-input.set-selection-offsets(anchor, focus); }
 
-    public function set-selection-offsets(start: int, end: int) {
-        text-input.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        text-input.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/internal/compiler/widgets/fluent/textedit.slint
+++ b/internal/compiler/widgets/fluent/textedit.slint
@@ -39,8 +39,8 @@ export component TextEdit {
     accessible-read-only: root.read-only;
     accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
-    public function set-selection-offsets(start: int, end: int) {
-        base.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        base.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/internal/compiler/widgets/interfaces/lineedit.slint
+++ b/internal/compiler/widgets/interfaces/lineedit.slint
@@ -21,7 +21,7 @@ export interface LineEdit {
     callback key-pressed(event: KeyEvent) -> EventResult;
     callback key-released(event: KeyEvent) -> EventResult;
 
-    public function set-selection-offsets(start: int, end: int);
+    public function set-selection-offsets(anchor: int, focus: int);
     public function select-all();
     public function clear-selection();
     public function cut();

--- a/internal/compiler/widgets/material/textedit.slint
+++ b/internal/compiler/widgets/material/textedit.slint
@@ -39,8 +39,8 @@ export component TextEdit {
     accessible-read-only: root.read-only;
     accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
-    public function set-selection-offsets(start: int, end: int) {
-        base.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        base.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/internal/compiler/widgets/qt/textedit.slint
+++ b/internal/compiler/widgets/qt/textedit.slint
@@ -38,8 +38,8 @@ export component TextEdit {
     accessible-read-only: root.read-only;
     accessible-action-set-selection-offsets(anchor, focus) => { base.set-selection-offsets(anchor, focus); }
 
-    public function set-selection-offsets(start: int, end: int) {
-        base.set-selection-offsets(start, end);
+    public function set-selection-offsets(anchor: int, focus: int) {
+        base.set-selection-offsets(anchor, focus);
     }
 
     public function select-all() {

--- a/internal/core/items/text.rs
+++ b/internal/core/items/text.rs
@@ -1976,16 +1976,16 @@ impl TextInput {
         self: Pin<&Self>,
         window_adapter: &Rc<dyn WindowAdapter>,
         self_rc: &ItemRc,
-        start: i32,
-        end: i32,
+        anchor: i32,
+        focus: i32,
     ) {
         let text = self.text();
-        let safe_start = safe_byte_offset(start, &text);
-        let safe_end = safe_byte_offset(end, &text);
+        let safe_anchor = safe_byte_offset(anchor, &text);
+        let safe_focus = safe_byte_offset(focus, &text);
 
-        self.as_ref().anchor_position_byte_offset.set(safe_start as i32);
+        self.as_ref().anchor_position_byte_offset.set(safe_anchor as i32);
         self.set_cursor_position(
-            safe_end as i32,
+            safe_focus as i32,
             true,
             TextChangeNotify::TriggerCallbacks,
             window_adapter,
@@ -2457,13 +2457,13 @@ pub unsafe extern "C" fn slint_textinput_set_selection_offsets(
     window_adapter: *const crate::window::ffi::WindowAdapterRcOpaque,
     self_component: &vtable::VRc<crate::item_tree::ItemTreeVTable>,
     self_index: u32,
-    start: i32,
-    end: i32,
+    anchor: i32,
+    focus: i32,
 ) {
     unsafe {
         let window_adapter = &*(window_adapter as *const Rc<dyn WindowAdapter>);
         let self_rc = ItemRc::new(self_component.clone(), self_index);
-        text_input.set_selection_offsets(window_adapter, &self_rc, start, end);
+        text_input.set_selection_offsets(window_adapter, &self_rc, anchor, focus);
     }
 }
 

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -2268,13 +2268,13 @@ fn call_builtin_function(
             }
         }
         BuiltinFunction::SetSelectionOffsets => {
-            // (item_ref, start, end) — applied to a TextInput.
+            // (item_ref, anchor, focus) -> applied to a TextInput.
             use i_slint_core::items::TextInput;
-            let [Expression::PropertyReference(mr), start_expr, end_expr] = arguments else {
+            let [Expression::PropertyReference(mr), anchor_expr, focus_expr] = arguments else {
                 return Value::Void;
             };
-            let start: i32 = eval_expression(ctx, start_expr).try_into().unwrap_or(0);
-            let end: i32 = eval_expression(ctx, end_expr).try_into().unwrap_or(0);
+            let anchor: i32 = eval_expression(ctx, anchor_expr).try_into().unwrap_or(0);
+            let focus: i32 = eval_expression(ctx, focus_expr).try_into().unwrap_or(0);
             let Some((parent_inst, flat_idx)) = resolve_item_rc_from_ref(ctx, mr) else {
                 return Value::Void;
             };
@@ -2284,7 +2284,7 @@ fn call_builtin_function(
             let parent_dyn = vtable::VRc::into_dyn(parent_inst);
             let item_rc = i_slint_core::items::ItemRc::new(parent_dyn, flat_idx as u32);
             if let Some(text_input) = vtable::VRef::downcast_pin::<TextInput>(item_rc.borrow()) {
-                text_input.set_selection_offsets(&adapter, &item_rc, start, end);
+                text_input.set_selection_offsets(&adapter, &item_rc, anchor, focus);
             }
             Value::Void
         }

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -2033,7 +2033,7 @@ mod tests {
             ("add(..)", "add(${1:a}, ${2:b})"),
             ("caller()", "caller()"),
             ("clear-focus()", "clear-focus()"),
-            ("set-selection-offsets(..)", "set-selection-offsets(${1:start}, ${2:end})"),
+            ("set-selection-offsets(..)", "set-selection-offsets(${1:anchor}, ${2:focus})"),
             ("my-callback(..)", "my-callback(${1:hello}, ${2:world})"),
         ]
         .map(|(label, insert_text)| CompletionItem {

--- a/ui-libraries/material/docs/src/content/docs/components/text_field.mdx
+++ b/ui-libraries/material/docs/src/content/docs/components/text_field.mdx
@@ -75,8 +75,8 @@ An icon displayed at the end of the text input.
 
 ## Functions
 
-### set-selection-offsets(int, int)
-Selects the text between two UTF-8 offsets.
+### set-selection-offsets(anchor: int, focus: int)
+Selects the text between two UTF-8 offsets: `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to, so `focus` may precede `anchor` to select backwards.
 
 ### select-all()
 Selects all text in the text field.

--- a/ui-libraries/material/src/ui/components/text_field.slint
+++ b/ui-libraries/material/src/ui/components/text_field.slint
@@ -174,8 +174,8 @@ export component TextField {
         }
     }
 
-    public function set_selection_offsets(start: int, end: int) {
-        input.set_selection_offsets(start, end);
+    public function set_selection_offsets(anchor: int, focus: int) {
+        input.set_selection_offsets(anchor, focus);
     }
 
     public function select_all() {


### PR DESCRIPTION
The names now match `accessible-action-set-selection-offsets()` and say what the arguments do: the first end stays put, the second is where the cursor lands. The behavior is unchanged.

cc #13066

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
