### PR TITLE
docs: Generate the default value documentation of builtin struct fields

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -150,7 +150,17 @@ fn builtin_structs(path: &Path) -> anyhow::Result<()> {
                         "f32" | "Coord" => "float",
                         other => other,
                     };
-                    writeln!(file, "    {} {}{{ {} }};", field_type, stringify!($field), stringify!($($field_default)*))?;
+                    // The raw tokens of the default value stringify with spaces, such as
+                    // `CapitalizationMode :: Sentences`; the header reads better without them.
+                    let default_value: String = stringify!($($field_default)*)
+                        .chars().filter(|c| !c.is_whitespace()).collect();
+                    // Doxygen documents the attribute without its initializer, so document
+                    // the default value in the comment too.
+                    if !default_value.is_empty() {
+                        let documented = default_value.trim_matches(|c| c == '(' || c == ')');
+                        writeln!(file, "    /// Defaults to `{documented}`.")?;
+                    }
+                    writeln!(file, "    {} {}{{ {} }};", field_type, stringify!($field), default_value)?;
                 )*
                 writeln!(file, "    /// \\private")?;
                 writeln!(file, "    {}", format!("friend bool operator==(const {name}&, const {name}&) = default;", name = stringify!($Name)))?;

--- a/api/node/build.rs
+++ b/api/node/build.rs
@@ -181,8 +181,15 @@ fn generate_language_module() {
     for s in &structs {
         write_jsdoc(&mut ts, "    ", &s.docs);
         ts.push_str(&format!("    export type {name} = {{\n", name = s.name));
-        for (field, rust_ty, field_docs, _) in &s.fields {
-            write_jsdoc(&mut ts, "        ", field_docs);
+        for (field, rust_ty, field_docs, declared_default) in &s.fields {
+            let mut docs: Vec<String> = field_docs.iter().map(|s| s.to_string()).collect();
+            if let Some(declared) = declared_default {
+                docs.push(format!(
+                    " Defaults to `{}`.",
+                    field_default(rust_ty, Some(declared), &enum_defaults, &struct_names)
+                ));
+            }
+            write_jsdoc(&mut ts, "        ", &docs);
             ts.push_str(&format!(
                 "        {field}: {ts_ty};\n",
                 ts_ty = map_field_type(rust_ty, &in_language),

--- a/api/python/slint/build.rs
+++ b/api/python/slint/build.rs
@@ -56,7 +56,8 @@ fn map_default(ty: &str) -> &str {
 
 /// The Python form of a field default value declared in builtin_structs.rs
 fn declared_default(tokens: &str) -> String {
-    let text: String = tokens.chars().filter(|c| !c.is_whitespace()).collect();
+    let text: String =
+        tokens.chars().filter(|c| !c.is_whitespace() && *c != '(' && *c != ')').collect();
     match text.split_once("::") {
         // Enum members are named after the kebab-case value, with underscores
         Some((enum_name, variant)) => {
@@ -115,7 +116,12 @@ macro_rules! generate_builtin_structs_pyi {
                             .map(declared_default)
                             .unwrap_or_else(|| map_default(stringify!($field_type)).to_string());
                         writeln!(writer, "    {}: {} = {}", stringify!($field), field_type, default).unwrap();
-                        let field_doc_str = vec![$($field_doc),*].join("\n").trim().to_string();
+                        let mut field_doc_str = vec![$($field_doc),*].join("\n").trim().to_string();
+                        // The rendered documentation shows the annotation without the
+                        // default value, so document it in the docstring.
+                        if declared.is_some() {
+                            field_doc_str += &format!("\n\nDefaults to `{default}`.");
+                        }
                         if !field_doc_str.is_empty() {
                             writeln!(writer, "    \"\"\"").unwrap();
                             for line in field_doc_str.lines() {

--- a/docs/astro/astro.config.mjs
+++ b/docs/astro/astro.config.mjs
@@ -767,6 +767,12 @@ export default defineConfig({
                 // checks that relative links point to existing pages.
                 slintStarlightLinksValidatorPlugin({
                     errorOnRelativeLinks: false,
+                    // The Builtin Enums page imports one `_<Enum>.md` partial
+                    // per enum, and the validator doesn't see the ids inside an
+                    // imported partial. Enum names carry no dash, so this skips
+                    // the value anchors only, and the link carries the base path
+                    // the site is deployed under, hence the leading `**`.
+                    exclude: ["**/property-types/builtin-enums/#*-*"],
                 }),
             ],
             social: slintStarlightSocial,

--- a/docs/astro/scripts/validate-md-links.mjs
+++ b/docs/astro/scripts/validate-md-links.mjs
@@ -4,10 +4,15 @@
 
 // Walks dist/**/*.md and verifies every internal link points to a real file
 // in dist/. Catches typos in the linkMap and stale targets after page renames.
-// Anchor fragments are not validated yet — file existence only.
+//
+// Then walks the built pages and verifies that every internal link with an
+// anchor points to an id (or legacy `name`) the target page really has. This
+// half runs on the HTML because that is where the ids of an imported partial
+// and the links written by an .astro component appear; starlight-links-validator
+// sees neither, because it reads the markdown files a page is written from.
 
 import { readdir, readFile, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import { visit } from "unist-util-visit";
@@ -15,15 +20,16 @@ import { visit } from "unist-util-visit";
 // Must match BASE_PATH in docs/common/src/utils/site-config.ts.
 const BASE_PATH = "/docs/";
 const DIST = "dist";
+const INDEX = "index.html";
 
 const parser = unified().use(remarkParse);
 
-async function* walk(dir) {
+async function* walk(dir, extension) {
     for (const entry of await readdir(dir, { withFileTypes: true })) {
         const p = join(dir, entry.name);
         if (entry.isDirectory()) {
-            yield* walk(p);
-        } else if (entry.isFile() && p.endsWith(".md")) {
+            yield* walk(p, extension);
+        } else if (entry.isFile() && p.endsWith(extension)) {
             yield p;
         }
     }
@@ -54,9 +60,15 @@ async function collectLinks(file) {
     return links;
 }
 
+/** The site path a built page is served under, e.g. `reference/colors/`. */
+function pageRoute(file) {
+    const path = relative(DIST, file);
+    return path.endsWith(INDEX) ? path.slice(0, -INDEX.length) : path;
+}
+
 const errors = [];
 
-for await (const file of walk(DIST)) {
+for await (const file of walk(DIST, ".md")) {
     for (const { url, line } of await collectLinks(file)) {
         if (!url.startsWith(BASE_PATH)) {
             continue;
@@ -78,12 +90,56 @@ for await (const file of walk(DIST)) {
     }
 }
 
+// Every anchor a page offers, by the route the page is served under.
+const anchors = new Map();
+const pages = [];
+for await (const file of walk(DIST, ".html")) {
+    const text = await readFile(file, "utf8");
+    pages.push({ file, text });
+    anchors.set(
+        pageRoute(file),
+        new Set(
+            [...text.matchAll(/\s(?:id|name)="([^"]+)"/g)].map(
+                (match) => match[1],
+            ),
+        ),
+    );
+}
+
+for (const { file, text } of pages) {
+    const seen = new Set();
+    for (const [, href] of text.matchAll(/\shref="([^"]+)"/g)) {
+        // Links that climb out of the base path address another Slint site
+        // (the Rust, C++ or Node.js API docs), which this build doesn't hold.
+        // A link without a path is an anchor of the page itself, whose ids
+        // Starlight generates.
+        if (!href.startsWith(BASE_PATH) || href.includes("/../")) {
+            continue;
+        }
+        const [path, anchor] = href.slice(BASE_PATH.length).split("#");
+        if (!anchor || path === "") {
+            continue;
+        }
+        // A path this build has no page for is a redirect or an asset; the
+        // markdown pass above is what checks that a link resolves at all.
+        const target = anchors.get(path.endsWith("/") ? path : `${path}/`);
+        if (target && !target.has(anchor) && !seen.has(href)) {
+            seen.add(href);
+            errors.push({
+                file,
+                line: "?",
+                url: `${BASE_PATH}${path}#${anchor}`,
+            });
+        }
+    }
+}
+
 if (errors.length > 0) {
-    console.error(`\n${errors.length} broken markdown link(s):`);
+    console.error(`\n${errors.length} broken internal link(s):`);
     for (const e of errors) {
         console.error(`  ${e.file}:${e.line} -> ${e.url}`);
     }
     process.exit(1);
 }
 
-console.log("validate-md-links: all internal markdown links resolve");
+console.log("validate-md-links: all internal links and anchors resolve");

--- a/docs/common/src/components/SlintProperty.astro
+++ b/docs/common/src/components/SlintProperty.astro
@@ -5,6 +5,7 @@ import "@astrojs/starlight/style/markdown.css";
 import {
     getEnumContent,
     getStructContent,
+    isStdWidgetStruct,
 } from "../utils/generated-reference-markdown.ts";
 import {
     type KnownType,
@@ -60,12 +61,16 @@ if (typeInfo.href !== "") {
     const base = import.meta.env.BASE_URL;
     typeInfo.href = `${base}${typeInfo.href}`;
 
-    // For enums and structs, we can assume they have a permalink to their header on the target page.
-    // (These permalinks are also always lower-case.)
+    // An enum, and a struct documented on the Built-in Structs page, has a
+    // permalink to its header there. (These permalinks are always lower-case.)
     if (typeName === "enum") {
         typeInfo.href += "#" + enumName.toLowerCase();
     } else if (typeName === "struct") {
-        typeInfo.href += "#" + structName.toLowerCase();
+        // A struct documented with its widgets has no section of its own to
+        // link to; its fields are inlined below the property instead.
+        typeInfo.href = isStdWidgetStruct(structName)
+            ? ""
+            : typeInfo.href + "#" + structName.toLowerCase();
     }
 }
 const enumContent = await getEnumContent(enumName);

--- a/docs/common/src/utils/generated-reference-markdown.ts
+++ b/docs/common/src/utils/generated-reference-markdown.ts
@@ -67,6 +67,15 @@ export async function getEnumContent(enumName: string | undefined) {
     }
 }
 
+/**
+ * Whether a struct is documented with the widgets that use it rather than on the
+ * Built-in Structs page, which is where a struct type otherwise links to.
+ */
+export function isStdWidgetStruct(structName: string | undefined): boolean {
+    const baseStruct = structName?.replace(/[\[\]]/g, "");
+    return baseStruct === "Time" || baseStruct === "Date";
+}
+
 export async function getStructContent(
     structName: string | undefined,
 ): Promise<string> {
@@ -75,7 +84,7 @@ export async function getStructContent(
     }
     const baseStruct = structName.replace(/[\[\]]/g, "");
 
-    if (baseStruct === "Time" || baseStruct === "Date") {
+    if (isStdWidgetStruct(baseStruct)) {
         const load = findGlobLoader(
             stdWidgetMarkdownLoaders,
             "std-widgets",

--- a/docs/python/gen_mdx.py
+++ b/docs/python/gen_mdx.py
@@ -417,12 +417,15 @@ def render_class(
     if is_enum(cls):
         lines += ["## Values", ""]
         for m in members:
+            # The manifest points cross-references to a member at this anchor,
+            # so every value carries the id its `<XRef>` links to.
+            value = f'<span id="{m.name}">`{m.name}`</span>'
             if m.docstring:
                 lines.append(
-                    f"- **`{m.name}`** — {docstring_to_mdx(m.docstring.value, manifest)}"
+                    f"- **{value}** — {docstring_to_mdx(m.docstring.value, manifest)}"
                 )
             else:
-                lines.append(f"- **`{m.name}`**")
+                lines.append(f"- **{value}**")
         lines.append("")
         return "\n".join(lines)
 

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -179,7 +179,15 @@ description: {0} content
         }
         writeln!(file, "{}", e.description)?;
         for v in &e.values {
-            writeln!(file, r#"* **`{}`**: {}"#, v.key, v.description)?;
+            // A struct field default links to the value it takes, and every enum
+            // shares the Builtin Enums page, so the id carries the enum name.
+            writeln!(
+                file,
+                r#"* **<span id="{}">`{}`</span>**: {}"#,
+                enum_value_anchor(k, &v.key),
+                v.key,
+                v.description
+            )?;
         }
 
         file.flush()?;
@@ -401,6 +409,11 @@ fn type_href(
     Some(format!("/{page}/#{}", type_name.to_lowercase()))
 }
 
+/// The id of one value on the page documenting `enum_name`.
+fn enum_value_anchor(enum_name: &str, value: &str) -> String {
+    format!("{}-{value}", enum_name.to_lowercase())
+}
+
 /// The `.slint` form of a field default declared in builtin_structs.rs.
 fn declared_default(tokens: &str) -> String {
     let text: String =
@@ -423,10 +436,18 @@ fn struct_field_line(
     let name = &field.type_name;
     let type_name = type_href(name, enums, structs)
         .map_or_else(|| format!("_{name}_"), |href| format!("[_{name}_]({href})"));
-    let default_value = field
-        .default_value
-        .as_ref()
-        .map_or_else(String::new, |value| format!(" Defaults to `{value}`."));
+    let default_value = field.default_value.as_ref().map_or_else(String::new, |value| {
+        // An enum value links to its own documentation, next to the values it could
+        // take instead; `type_href` decides whether the enum is documented there.
+        let documented = enums.contains_key(name) && type_href(name, enums, structs).is_some();
+        match documented {
+            true => format!(
+                " Defaults to [`{value}`](/{BUILTIN_ENUMS_SLUG}/#{}).",
+                enum_value_anchor(name, value)
+            ),
+            false => format!(" Defaults to `{value}`."),
+        }
+    });
     format!("- **`{}`** ({}): {}{}", field.key, type_name, field.description, default_value)
 }
 
@@ -575,7 +596,7 @@ fn test_type_href() {
     };
     assert_eq!(
         struct_field_line(&with_default, &enums, &structs),
-        "- **`field`** ([_CapitalizationMode_](/reference/property-types/builtin-enums/#capitalizationmode)): The docs Defaults to `sentences`."
+        "- **`field`** ([_CapitalizationMode_](/reference/property-types/builtin-enums/#capitalizationmode)): The docs Defaults to [`sentences`](/reference/property-types/builtin-enums/#capitalizationmode-sentences)."
     );
     let field = StructFieldDoc { type_name: "int".to_string(), ..field };
     assert_eq!(struct_field_line(&field, &enums, &structs), "- **`field`** (_int_): The docs");

--- a/docs/slint-doc-generator/mdx.rs
+++ b/docs/slint-doc-generator/mdx.rs
@@ -247,6 +247,9 @@ pub struct StructFieldDoc {
     key: String,
     description: String,
     type_name: String,
+    /// The value the field takes when it isn't set, written in `.slint` syntax,
+    /// or `None` for the zero value of the field's type.
+    default_value: Option<String>,
 }
 
 pub struct StructDoc {
@@ -271,11 +274,13 @@ pub fn extract_builtin_structs(
                         key: "x".to_string(),
                         description: String::new(),
                         type_name: "length".to_string(),
+                        default_value: None,
                     },
                     StructFieldDoc {
                         key: "y".to_string(),
                         description: String::new(),
                         type_name: "length".to_string(),
+                        default_value: None,
                     },
                 ],
             },
@@ -289,11 +294,13 @@ pub fn extract_builtin_structs(
                         key: "width".to_string(),
                         description: String::new(),
                         type_name: "length".to_string(),
+                        default_value: None,
                     },
                     StructFieldDoc {
                         key: "height".to_string(),
                         description: String::new(),
                         type_name: "length".to_string(),
+                        default_value: None,
                     },
                 ],
             },
@@ -346,7 +353,10 @@ pub fn extract_builtin_structs(
                     $(
                         f_description += &format!("{}", $field_doc);
                     )*
-                    fields.push(StructFieldDoc { key, description: f_description, type_name });
+                    let default_value =
+                        i_slint_common::builtin_struct_field_default_tokens!($($field_default)?)
+                            .map(declared_default);
+                    fields.push(StructFieldDoc { key, description: f_description, type_name, default_value });
                 )*
                 structs.insert(name, StructDoc { description, fields });
             )*
@@ -391,6 +401,18 @@ fn type_href(
     Some(format!("/{page}/#{}", type_name.to_lowercase()))
 }
 
+/// The `.slint` form of a field default declared in builtin_structs.rs.
+fn declared_default(tokens: &str) -> String {
+    let text: String =
+        tokens.chars().filter(|c| !c.is_whitespace() && *c != '(' && *c != ')').collect();
+    match text.split_once("::") {
+        // Enum values are written in kebab case in .slint
+        Some((_, variant)) => to_kebab_case(variant.trim_start_matches("r#")),
+        // bool and number literals are written the same way
+        None => text,
+    }
+}
+
 /// The list entry documenting one field of a struct, with the field's type
 /// linked to its own documentation when it has any.
 fn struct_field_line(
@@ -401,7 +423,11 @@ fn struct_field_line(
     let name = &field.type_name;
     let type_name = type_href(name, enums, structs)
         .map_or_else(|| format!("_{name}_"), |href| format!("[_{name}_]({href})"));
-    format!("- **`{}`** ({}): {}", field.key, type_name, field.description)
+    let default_value = field
+        .default_value
+        .as_ref()
+        .map_or_else(String::new, |value| format!(" Defaults to `{value}`."));
+    format!("- **`{}`** ({}): {}{}", field.key, type_name, field.description, default_value)
 }
 
 fn write_individual_struct_files(
@@ -534,10 +560,22 @@ fn test_type_href() {
         key: "field".to_string(),
         description: "The docs".to_string(),
         type_name: "CapitalizationMode".to_string(),
+        default_value: None,
     };
     assert_eq!(
         struct_field_line(&field, &enums, &structs),
         "- **`field`** ([_CapitalizationMode_](/reference/property-types/builtin-enums/#capitalizationmode)): The docs"
+    );
+    // A declared default value is documented after the description.
+    let with_default = StructFieldDoc {
+        key: "field".to_string(),
+        description: "The docs".to_string(),
+        type_name: "CapitalizationMode".to_string(),
+        default_value: Some(declared_default("(CapitalizationMode::Sentences)")),
+    };
+    assert_eq!(
+        struct_field_line(&with_default, &enums, &structs),
+        "- **`field`** ([_CapitalizationMode_](/reference/property-types/builtin-enums/#capitalizationmode)): The docs Defaults to `sentences`."
     );
     let field = StructFieldDoc { type_name: "int".to_string(), ..field };
     assert_eq!(struct_field_line(&field, &enums, &structs), "- **`field`** (_int_): The docs");

--- a/internal/common/builtin_structs.rs
+++ b/internal/common/builtin_structs.rs
@@ -31,6 +31,8 @@ macro_rules! builtin_struct_field_default_tokens {
 /// (see [`builtin_struct_field_default_tokens!`](crate::builtin_struct_field_default_tokens))
 /// and fail their build on anything outside the supported subset.
 /// Fields without a default value default to the zero value of their type.
+/// The consumers that generate documentation render the declared value themselves,
+/// so don't mention it in the field's doc comment.
 ///
 /// ## Example
 /// ```rust
@@ -168,13 +170,10 @@ macro_rules! for_each_builtin_structs {
             #[non_exhaustive]
             pub struct InputMethodHints {
                 /// The auto-capitalization behavior that the input method should apply.
-                /// Defaults to sentences.
                 capitalization: CapitalizationMode = (CapitalizationMode::Sentences),
                 /// Hint that the input method may automatically correct spelling mistakes as the user types.
-                /// Defaults to true.
                 auto_correct: bool = true,
                 /// Hint that the input method may offer auto-completion suggestions for the entered text.
-                /// Defaults to true.
                 auto_complete: bool = true,
             }
 

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2191,17 +2191,18 @@ macro_rules! builtin_struct_field_default {
     };
 }
 
-/// Expands to the documentation text of a builtin struct field's declared default value,
-/// dropping the parentheses that an enum value needs to be a single token tree.
+/// Expands to the documentation text of a builtin struct field's declared default value:
+/// an intra-doc link to the variant for an enum value, plain code for a literal.
+/// The parentheses an enum value needs to be a single token tree are dropped.
 macro_rules! builtin_struct_field_default_doc {
     (($($default:tt)*)) => {
         builtin_struct_field_default_doc!($($default)*)
     };
     ($enum:ident :: $value:ident) => {
-        concat!(stringify!($enum), "::", stringify!($value))
+        concat!("[`", stringify!($enum), "::", stringify!($value), "`]")
     };
     ($default:literal) => {
-        stringify!($default)
+        concat!("`", stringify!($default), "`")
     };
 }
 
@@ -2221,7 +2222,7 @@ macro_rules! declare_builtin_structs {
                     $(#[$field_attr])*
                     $(
                         #[doc = ""]
-                        #[doc = concat!("Defaults to `", builtin_struct_field_default_doc!($field_default), "`.")]
+                        #[doc = concat!("Defaults to ", builtin_struct_field_default_doc!($field_default), ".")]
                     )?
                     pub $field : $field_type,
                 )*

--- a/internal/core/items.rs
+++ b/internal/core/items.rs
@@ -2191,11 +2191,25 @@ macro_rules! builtin_struct_field_default {
     };
 }
 
+/// Expands to the documentation text of a builtin struct field's declared default value,
+/// dropping the parentheses that an enum value needs to be a single token tree.
+macro_rules! builtin_struct_field_default_doc {
+    (($($default:tt)*)) => {
+        builtin_struct_field_default_doc!($($default)*)
+    };
+    ($enum:ident :: $value:ident) => {
+        concat!(stringify!($enum), "::", stringify!($value))
+    };
+    ($default:literal) => {
+        stringify!($default)
+    };
+}
+
 macro_rules! declare_builtin_structs {
     ($(
         $(#[$struct_attr:meta])*
         $vis:vis struct $Name:ident {
-            $( $(#[$field_attr:meta])* $field:ident : $field_type:ident $(= $field_default:expr)?, )*
+            $( $(#[$field_attr:meta])* $field:ident : $field_type:ident $(= $field_default:tt)?, )*
         }
     )*) => {
         $(
@@ -2205,6 +2219,10 @@ macro_rules! declare_builtin_structs {
             pub struct $Name {
                 $(
                     $(#[$field_attr])*
+                    $(
+                        #[doc = ""]
+                        #[doc = concat!("Defaults to `", builtin_struct_field_default_doc!($field_default), "`.")]
+                    )?
                     pub $field : $field_type,
                 )*
             }


### PR DESCRIPTION
The defaults of `InputMethodHints` were written by hand in the doc comments ("Defaults to sentences."), so they could easily go out of sync with the value the field actually declares. Now the docs write that sentence themselves from the declared value, everywhere: the `.slint` reference, rustdoc, the C++ headers, the TypeScript types and the Python stubs.

If the doc tool can resolve it, the value links to the enum member. Doxygen and TypeDoc can't, so there it's just code.

cc #13066
