### PR TITLE
Fix GridLayout rows sized too short for repeated word-wrapped cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project are documented in this file.
  - Fixed a memory leak where a window with a native menu bar was kept alive forever. (#12971)
  - Fixed min/max size constraints on layout cells being ignored when `cross-axis-alignment`
    is not `stretch`, and percentage sizes not applied correctly in states. (#8988)
+ - Fixed rows of a `VerticalLayout` and a `GridLayout` being too short for a repeated cell with
+   word-wrapped text: the cell is now measured at the width the layout assigns it. (#12776)
  - Fixed a code generation error for a conditional `opacity` binding on a repeated `GridLayout` child. (#12442)
  - Fixed a panic when an item is reached through a parent component that was deleted while a callback
    is still running. (#12877)

--- a/docs/development/layout-system.md
+++ b/docs/development/layout-system.md
@@ -89,7 +89,8 @@ When items fit without shrinking, alignment determines positioning:
 
 ### Grid Layout
 
-Grid layouts solve independently for each axis:
+Grid layouts solve each axis on its own, except that the vertical pass measures
+height-for-width cells at the width the horizontal pass solved:
 1. **Organize**: Convert cell definitions to row/column assignments
 2. **Solve horizontal**: Calculate column widths and x positions
 3. **Solve vertical**: Calculate row heights and y positions
@@ -275,6 +276,79 @@ These are represented as `Expression::LayoutCacheAccess` (standard, for box layo
 `Expression::GridRepeaterCacheAccess` (grid repeaters with any repeater structure) in the expression tree, which
 the code generators compile to the appropriate runtime access pattern.
 
+## Measuring repeated cells
+
+Where no cross size is passed in — the GridLayout solve, a `VerticalLayout` main
+pass — a static height-for-width cell (a word-wrapped `Text`, say) sizes itself:
+its `width` is bound to the layout cache, so the `Text` reads the width the
+layout gave it while the layout-info is computed (`text_layout_info` in
+`i-slint-core` treats a cross constraint below zero as "use the current width").
+Other passes hand static cells an explicit constraint.
+
+A repeated cell cannot read its own width that way: the layout asks the whole
+instance for its layout-info, and the instance goes through
+`layoutinfo-v-with-constraint` rather than reading `self.width` (see
+`synthesize_layoutinfo_v_with_constraint`), so it is measured at a fixed cross
+size — the instance's preferred width for the vertical info, an unbounded height
+for the horizontal one. The layout therefore passes the real size in, through
+the accessors on `RepeatedItemTree`:
+
+| Accessor | Backed by | Supplied by |
+|---|---|---|
+| `layout_item_info_at_cross_width(w)` | `SubComponent::layout_info_v_at_cross_width_for_repeated` | any vertical pass at a known width: `VerticalLayout` main pass, `HorizontalLayout` ortho pass, GridLayout vertical pass |
+| `layout_item_info_at_cross_height(h)` | `SubComponent::layout_info_h_at_cross_height_for_repeated` | any horizontal pass at a known height: `HorizontalLayout` main pass, `VerticalLayout` ortho pass |
+| `flexbox_layout_item_info_at_cross_width(w)` / `_height(h)` | the same two expressions | FlexboxLayout solve |
+
+Which accessor is used depends on the orientation being computed, not on the box
+layout's own direction: a `VerticalLayout` calls
+`layout_item_info_at_cross_width` from its main pass and
+`layout_item_info_at_cross_height` from its ortho pass, a `HorizontalLayout` the
+other way around. GridLayout appears in the first row only. It solves horizontal
+first, so measuring a cell at a solved height would make the horizontal solve
+read the vertical cache, which the end of this section explains it must not.
+
+The `SubComponent` fields are in `internal/compiler/llr/item_tree.rs`; the
+generators emit the accessors in `internal/compiler/generator/rust.rs` and
+`generator/cpp.rs`, and the interpreter mirrors them in
+`internal/interpreter/eval_layout.rs` and `instance.rs`.
+
+Where the size comes from differs per layout kind:
+
+- **Box layout, main pass** forwards one size for all cells (the layout's cross
+  content size), in `Expression::WithLayoutItemInfo::repeated_cross_size`.
+- **Box layout, ortho pass** has no single size to forward:
+  `Expression::BoxLayoutInfoOrthoWithMeasure` solves the main axis first, then
+  measures each instance at its *own* solved main size, as a
+  `BoxMeasureCell::Repeated`. `repeated_cross_size` is `None` here.
+- **GridLayout** has one width per column, so it reads each cell's own slot out
+  of `layout-cache-h`: `LayoutRepeatedElement::cross_width`
+  (`internal/compiler/layout.rs`) is the cell's own `width` binding with the
+  repeater index replaced by the `GRID_MEASURE_REPEATER_INDEX_LOCAL` local,
+  which the generated loop binds to the instance index. A *repeated* child of a
+  repeated `Row` uses `SubComponent::grid_row_child_cross_width` instead,
+  addressed by the child's flattened index (`GRID_MEASURE_CHILD_INDEX_LOCAL`).
+  One expression serves every such child, and
+  `RowChildTemplateInfo::Repeated::measure_at_cross_width` records which ones it
+  applies to. A static child of a `Row` keeps its plain, unconstrained
+  layout-info.
+- **FlexboxLayout** passes a size twice: the container's cross width up front,
+  in `Expression::WithFlexboxLayoutItemInfo::repeated_cross_width` (column flex
+  only), and then per cell from taffy's measure callback
+  (`SolveFlexboxLayoutWithMeasure`, `FlexboxLayoutInfoCrossAxisWithMeasure`),
+  which re-measures at the size taffy actually assigns.
+
+Reading the horizontal cache from the vertical pass is only sound while the
+horizontal solve does not read back into the vertical cache. A *repeated*
+width-for-height cell breaks that: the grid measures it through its plain
+`layout_info_h`, which pulls the instance's own height, and that height comes
+from the grid's vertical cache. `mark_grid_h_solve_reads_v_cache` sets
+`GridLayoutCell::h_solve_reads_v_cache` on every cell of such a grid, and the
+vertical pass then falls back to the instance's plain layout-info instead of
+closing a binding loop. Static cells are safe: on the grid solve
+`cell_layout_info` passes no cross size, so a cell with
+`layoutinfo-h-with-constraint` is measured at an unbounded height and one
+without it never reads its own height.
+
 ## Common Modification Patterns
 
 ### Adding a New Layout Property
@@ -302,7 +376,7 @@ the code generators compile to the appropriate runtime access pattern.
 ## Key Concepts for Agents
 
 1. **Two-phase architecture**: Compile-time creates structure, runtime evaluates values
-2. **Independent axis solving**: Horizontal and vertical are solved separately (for horizontal, vertical and grid layouts)
+2. **Independent axis solving**: Horizontal and vertical are solved separately (for horizontal, vertical and grid layouts), except where the vertical pass measures a height-for-width cell at the solved width
 3. **Constraint tightening**: Merging takes the most restrictive bounds
 4. **Stretch factors**: Control how extra space is distributed (0 = don't grow)
 5. **Cache indirection**: Enables repeaters without runtime structure changes

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -480,7 +480,8 @@ use crate::langtype::{
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
 use crate::llr::lower_layout_expression::{
-    CROSS_HEIGHT_LOCAL, CROSS_WIDTH_LOCAL, MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL,
+    CROSS_HEIGHT_LOCAL, CROSS_WIDTH_LOCAL, GRID_MEASURE_CHILD_INDEX_LOCAL,
+    GRID_MEASURE_REPEATER_INDEX_LOCAL, MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL,
 };
 use crate::llr::{
     self, EvaluationContext as llr_EvaluationContext, EvaluationScope, ParentScope,
@@ -2999,6 +3000,27 @@ fn generate_layout_item_info_decl(
     let templates = root_sc.row_child_templates.as_ref().unwrap();
     let n = templates.len();
 
+    // A GridLayout measures an inner repeated child at the column width it
+    // assigns it, like the static children measure at their own (lazily
+    // pulled) width.
+    let inner_at_cross_width = |inner_rep_id: &str, measure_at_cross_width: bool| -> String {
+        let Some(e) =
+            root_sc.grid_row_child_cross_width.as_ref().filter(|_| measure_at_cross_width)
+        else {
+            return String::new();
+        };
+        let idx = ident(GRID_MEASURE_CHILD_INDEX_LOCAL);
+        let width = compile_expression(&e.borrow(), ctx);
+        format!(
+            "if (o == slint::cbindgen_private::Orientation::Vertical) {{\n\
+                 if (auto *inner = {inner_rep_id}.typed_instance_at(index - count)) {{\n\
+                     [[maybe_unused]] size_t {idx} = index;\n\
+                     return inner->layout_item_info_at_cross_width(static_cast<float>({width}));\n\
+                 }}\n\
+             }}\n"
+        )
+    };
+
     // Generate a sequential scan through all templates in declaration order.
     // Count up from 0; for Static entries check count == index, for Repeated entries
     // check whether index falls within [count, count + inner_len).
@@ -3025,16 +3047,18 @@ fn generate_layout_item_info_decl(
                 )
                 .unwrap();
             }
-            llr::RowChildTemplateInfo::Repeated { repeater_index } => {
+            llr::RowChildTemplateInfo::Repeated { repeater_index, measure_at_cross_width } => {
                 let inner_rep_id = format!("repeater_{}", usize::from(*repeater_index));
                 let advance =
                     if is_last { String::new() } else { "count += inner_len;\n".to_owned() };
+                let at_cross_width = inner_at_cross_width(&inner_rep_id, *measure_at_cross_width);
                 write!(
                     body,
                     "{{\n\
                      self->{inner_rep_id}.track_instance_changes();\n\
                      size_t inner_len = {inner_rep_id}.len();\n\
                      if (index >= count && index - count < inner_len) {{\n\
+                         {at_cross_width}\
                          if (auto vrc = {inner_rep_id}.instance_at(index - count).lock()) {{\n\
                              auto vref = vrc->borrow();\n\
                              return {{ vref.vtable->layout_info(vref, o), {{}} }};\n\
@@ -3293,7 +3317,7 @@ fn generate_grid_layout_input_decl(
                     )
                     .unwrap();
                 }
-                llr::RowChildTemplateInfo::Repeated { repeater_index } => {
+                llr::RowChildTemplateInfo::Repeated { repeater_index, .. } => {
                     let inner_rep_id = format!("repeater_{}", usize::from(*repeater_index));
                     // Let the inner cell report its own col/row/colspan/rowspan.
                     write!(
@@ -5710,7 +5734,7 @@ fn build_inner_ensure_code(templates: &[llr::RowChildTemplateInfo], static_count
     templates
         .iter()
         .filter_map(|e| match e {
-            llr::RowChildTemplateInfo::Repeated { repeater_index } => {
+            llr::RowChildTemplateInfo::Repeated { repeater_index, .. } => {
                 let inner_rep_id = format!("repeater_{}", usize::from(*repeater_index));
                 Some(format!(
                     "sub_comp->{inner_rep_id}.track_instance_changes();\n\
@@ -5786,6 +5810,11 @@ fn generate_with_layout_item_info(
                 let repeater_index = usize::from(repeater.repeater_index);
                 write!(push_code, "self->repeater_{repeater_index}.track_instance_changes();")
                     .unwrap();
+                // A grid measures each instance at its own solved column width,
+                // read from the horizontal cache with the loop counter bound to
+                // `GRID_MEASURE_REPEATER_INDEX_LOCAL`.
+                let grid_cross_width =
+                    repeater.cross_width.as_ref().map(|e| compile_expression(e, ctx));
 
                 if let Some(ri) = &repeated_indices_var_name {
                     write!(
@@ -5835,6 +5864,22 @@ fn generate_with_layout_item_info(
                     |repeater_id, step, is_column_repeater, rs_init| {
                         if step == 0 {
                             rs_init
+                        } else if let Some(width) = &grid_cross_width {
+                            // Grid column-repeater: measure each instance at the
+                            // column width the grid assigns it. `typed_instance_at`
+                            // (unlike `for_each`) keeps the index in step with the
+                            // cache, including not-yet-instantiated slots.
+                            debug_assert!(step == 1 && is_column_repeater);
+                            let idx = ident(GRID_MEASURE_REPEATER_INDEX_LOCAL);
+                            format!(
+                                "{rs_init}for (size_t {idx} = 0; {idx} < self->{repeater_id}.len(); ++{idx}) {{
+                                    if (auto *sub_comp = self->{repeater_id}.typed_instance_at({idx})) {{
+                                        cells_vector.push_back(sub_comp->layout_item_info_at_cross_width(static_cast<float>({width})));
+                                    }} else {{
+                                        cells_vector.push_back({{}});
+                                    }}
+                                }}",
+                            )
                         } else if step == 1 && is_column_repeater {
                             // Column-repeater: each sub-component IS a cell; nullopt returns its own layout_info
                             let item_info = match (repeated_cross_size, orientation) {

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -19,7 +19,8 @@ use crate::langtype::{DeclNode, Enumeration, EnumerationValue, Struct, StructNam
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
 use crate::llr::lower_layout_expression::{
-    CROSS_HEIGHT_LOCAL, CROSS_WIDTH_LOCAL, MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL,
+    CROSS_HEIGHT_LOCAL, CROSS_WIDTH_LOCAL, GRID_MEASURE_CHILD_INDEX_LOCAL,
+    GRID_MEASURE_REPEATER_INDEX_LOCAL, MEASURE_KNOWN_H_LOCAL, MEASURE_KNOWN_W_LOCAL,
 };
 use crate::llr::{
     self, ArrayOutput, EvaluationContext as llr_EvaluationContext, EvaluationScope, Expression,
@@ -2740,7 +2741,7 @@ fn generate_repeated_component(
                         write_idx += 1;
                         static_idx += 1;
                     },
-                    llr::RowChildTemplateInfo::Repeated { repeater_index } => {
+                    llr::RowChildTemplateInfo::Repeated { repeater_index, .. } => {
                         let inner_rep_id =
                             format_ident!("repeater{}", usize::from(*repeater_index));
                         quote! {
@@ -2855,6 +2856,25 @@ fn generate_repeated_component(
                     argument_types: &[],
                 };
 
+                // A GridLayout measures an inner repeated child at the column
+                // width it assigns it, like the static children measure at
+                // their own (lazily pulled) width.
+                let inner_constraint = |measure_at_cross_width: bool| {
+                    let Some(e) =
+                        root_sc.grid_row_child_cross_width.as_ref().filter(|_| measure_at_cross_width)
+                    else {
+                        return quote!(inner.as_pin_ref().layout_info(o));
+                    };
+                    let idx = ident(GRID_MEASURE_CHILD_INDEX_LOCAL);
+                    let w = compile_expression(&e.borrow(), &layout_ctx);
+                    quote!(match o {
+                        sp::Orientation::Vertical => inner
+                            .as_pin_ref()
+                            .layout_item_info_at_cross_width(({ let #idx = index; #w }) as f32)
+                            .constraint,
+                        sp::Orientation::Horizontal => inner.as_pin_ref().layout_info(o),
+                    })
+                };
                 let body = if let Some(templates) = &root_sc.row_child_templates {
                     // Generate a sequential scan through all templates in declaration order.
                     // For each Static: check if count == index and return the precomputed info.
@@ -2886,9 +2906,13 @@ fn generate_repeated_component(
                                     #advance
                                 }
                             }
-                            llr::RowChildTemplateInfo::Repeated { repeater_index } => {
+                            llr::RowChildTemplateInfo::Repeated {
+                                repeater_index,
+                                measure_at_cross_width,
+                            } => {
                                 let inner_rep_id =
                                     format_ident!("repeater{}", usize::from(*repeater_index));
+                                let inner_constraint = inner_constraint(*measure_at_cross_width);
                                 let advance = (!is_last).then(|| quote! { count += inner_len; });
                                 quote! {
                                     {
@@ -2897,7 +2921,7 @@ fn generate_repeated_component(
                                         if index >= count && index - count < inner_len {
                                             if let Some(inner) = _self.#inner_rep_id.instance_at(index - count) {
                                                 return sp::LayoutItemInfo {
-                                                    constraint: inner.as_pin_ref().layout_info(o),
+                                                    constraint: #inner_constraint,
                                                     ..::core::default::Default::default()
                                                 };
                                             }
@@ -5549,7 +5573,7 @@ fn build_inner_track_and_len(
     templates
         .iter()
         .filter_map(|e| match e {
-            llr::RowChildTemplateInfo::Repeated { repeater_index } => {
+            llr::RowChildTemplateInfo::Repeated { repeater_index, .. } => {
                 let inner_rep_id = format_ident!("repeater{}", usize::from(*repeater_index));
                 Some(quote! {
                     #row_inner_component_id::FIELD_OFFSETS.#inner_rep_id().apply_pin(pin).track_instance_changes();
@@ -5765,6 +5789,14 @@ fn generate_with_layout_item_info(
                 push_code.push(quote!(items_vec.push(#value);))
             }
             Either::Right(repeater) => {
+                // A grid measures each instance at its own solved column width,
+                // read from the horizontal cache with the loop counter bound to
+                // `GRID_MEASURE_REPEATER_INDEX_LOCAL`.
+                let grid_cross_width = repeater.cross_width.as_ref().map(|e| {
+                    let idx = ident(GRID_MEASURE_REPEATER_INDEX_LOCAL);
+                    let w = compile_expression(e, ctx);
+                    quote!({ let #idx = i; #w })
+                });
                 let repeater_push_code = generate_repeater_push_code(
                     repeater.repeater_index,
                     &repeater.row_child_templates,
@@ -5809,18 +5841,24 @@ fn generate_with_layout_item_info(
                             quote!()
                         } else if step == 1 && is_column_repeater {
                             // Column-repeater: each sub-component IS a cell; None returns its own layout_info
-                            let item_info = match (&cross_size_init, orientation) {
-                                (Some(_), Orientation::Vertical) => quote!(
+                            let item_info = match (&cross_size_init, &grid_cross_width, orientation)
+                            {
+                                (Some(_), _, Orientation::Vertical) => quote!(
                                     sub_comp
                                         .as_pin_ref()
                                         .layout_item_info_at_cross_width(box_cross_size)
                                 ),
-                                (Some(_), Orientation::Horizontal) => quote!(
+                                (Some(_), _, Orientation::Horizontal) => quote!(
                                     sub_comp
                                         .as_pin_ref()
                                         .layout_item_info_at_cross_height(box_cross_size)
                                 ),
-                                (None, _) => quote!(
+                                (None, Some(w), _) => quote!(
+                                    sub_comp
+                                        .as_pin_ref()
+                                        .layout_item_info_at_cross_width((#w) as f32)
+                                ),
+                                (None, None, _) => quote!(
                                     sub_comp.as_pin_ref().layout_item_info(#orientation, None)
                                 ),
                             };

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -467,6 +467,13 @@ pub struct GridLayoutCell {
     pub colspan_expr: RowColExpr,
     pub rowspan_expr: RowColExpr,
     pub child_items: Option<Vec<RowChildTemplate>>, // for repeated rows
+    /// Set on every cell of a grid whose horizontal solve can read back into
+    /// its vertical cache, i.e. one holding a repeated width-for-height cell.
+    /// The vertical pass must then not measure repeated cells at their solved
+    /// column width, because reading the horizontal cache would close a
+    /// binding loop. Computed by `mark_grid_h_solve_reads_v_cache`, which runs
+    /// once the `layoutinfo-h-with-constraint` functions exist.
+    pub h_solve_reads_v_cache: bool,
 }
 
 impl GridLayoutCell {

--- a/internal/compiler/llr/expression.rs
+++ b/internal/compiler/llr/expression.rs
@@ -683,7 +683,14 @@ macro_rules! visit_impl {
                 if let Some(s) = repeated_cross_size {
                     $visitor(s);
                 }
-                elements.$iter().filter_map(|x| x.$as_ref().left()).for_each($visitor);
+                elements.$iter().for_each(|x| match x.$as_ref() {
+                    Either::Left(e) => $visitor(e),
+                    Either::Right(r) => {
+                        if let Some(w) = r.cross_width.$as_ref() {
+                            $visitor(w);
+                        }
+                    }
+                });
             }
             Expression::WithFlexboxLayoutItemInfo {
                 elements,
@@ -695,27 +702,39 @@ macro_rules! visit_impl {
                 if let Some(w) = repeated_cross_width {
                     $visitor(w);
                 }
-                elements.$iter().filter_map(|x| x.$as_ref().left()).for_each(|(h, v, f)| {
-                    $visitor(h);
-                    $visitor(v);
-                    // Visited even when `flex_props_variable` is `None` and the
-                    // generators skip `f`: this only over-counts property use,
-                    // and the layout's solve binding reads the same properties.
-                    $visitor(f);
+                elements.$iter().for_each(|x| match x.$as_ref() {
+                    Either::Left((h, v, f)) => {
+                        $visitor(h);
+                        $visitor(v);
+                        // Visited even when `flex_props_variable` is `None` and the
+                        // generators skip `f`: this only over-counts property use,
+                        // and the layout's solve binding reads the same properties.
+                        $visitor(f);
+                    }
+                    Either::Right(r) => {
+                        if let Some(w) = r.cross_width.$as_ref() {
+                            $visitor(w);
+                        }
+                    }
                 });
             }
             Expression::SolveFlexboxLayoutWithMeasure { data, repeater_indices, measure_cells } => {
                 $visitor(data);
                 $visitor(repeater_indices);
-                measure_cells.$iter().for_each(|x| {
-                    if let FlexboxMeasureCell {
+                measure_cells.$iter().for_each(|x| match x {
+                    FlexboxMeasureCell {
                         kind: FlexboxMeasureCellKind::Static { h_info, v_info },
                         ..
-                    } = x
-                    {
+                    } => {
                         $visitor(h_info);
                         $visitor(v_info);
                     }
+                    FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Repeated(r), .. } => {
+                        if let Some(w) = r.cross_width.$as_ref() {
+                            $visitor(w);
+                        }
+                    }
+                    FlexboxMeasureCell { kind: FlexboxMeasureCellKind::Fixed, .. } => {}
                 });
             }
             Expression::BoxLayoutInfoOrthoWithMeasure {
@@ -726,9 +745,12 @@ macro_rules! visit_impl {
             } => {
                 $visitor(solve_data);
                 $visitor(padding_ortho);
-                measure_cells.$iter().for_each(|x| {
-                    if let BoxMeasureCell::Static { info } = x {
-                        $visitor(info);
+                measure_cells.$iter().for_each(|x| match x {
+                    BoxMeasureCell::Static { info } => $visitor(info),
+                    BoxMeasureCell::Repeated(r) => {
+                        if let Some(w) = r.cross_width.$as_ref() {
+                            $visitor(w);
+                        }
                     }
                 });
             }

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -39,7 +39,15 @@ pub enum RowChildTemplateInfo {
     /// A static child. `child_index` is an index into `SubComponent::grid_layout_children`.
     Static { child_index: GridLayoutChildIdx },
     /// An inner repeated child.
-    Repeated { repeater_index: RepeatedElementIdx },
+    Repeated {
+        repeater_index: RepeatedElementIdx,
+        /// Whether this child's width comes from the grid's horizontal cache,
+        /// so `layout_item_info(Vertical, ..)` may measure it at that width
+        /// through `SubComponent::grid_row_child_cross_width`. False for a
+        /// child that is not height-for-width (nothing to re-measure) or that
+        /// has a fixed width (the grid never assigns it one).
+        measure_at_cross_width: bool,
+    },
 }
 
 /// Returns `true` if the optional template list contains at least one inner repeater.
@@ -60,6 +68,13 @@ pub struct LayoutRepeatedElement {
     /// Template of children for a repeated Row (statics and inner repeaters in declaration order).
     /// `None` means a single child per repeater entry (no Row with multiple children).
     pub row_child_templates: Option<Vec<RowChildTemplateInfo>>,
+    /// GridLayout vertical pass only: reads this cell's solved column width out
+    /// of the grid's horizontal cache, once per instance with
+    /// `GRID_MEASURE_REPEATER_INDEX_LOCAL` bound to the instance index. The
+    /// generated code measures each instance through
+    /// `layout_item_info_at_cross_width` at that width, so a height-for-width
+    /// instance wraps like an equivalent static cell. `None` everywhere else.
+    pub cross_width: Option<Expression>,
 }
 
 #[derive(Debug, Clone)]
@@ -580,6 +595,15 @@ pub struct SubComponent {
     /// calls with the height it assigned so a repeated cell resolves to the
     /// same width as an equivalent static cell.
     pub layout_info_h_at_cross_height_for_repeated: Option<MutExpression>,
+    /// GridLayout repeated Row only: reads the solved column width of the child
+    /// at `GRID_MEASURE_CHILD_INDEX_LOCAL` out of the grid's horizontal cache.
+    /// `layout_item_info(Vertical, Some(i))` measures an inner repeated child at
+    /// that width, so it wraps like a static one — which reads its own width
+    /// through its geometry binding. A Row child's cache slot is addressed by
+    /// its flattened index, so this one expression serves every child; which
+    /// children it applies to is `RowChildTemplateInfo::Repeated`'s
+    /// `measure_at_cross_width`. `Some` when at least one of them sets it.
+    pub grid_row_child_cross_width: Option<MutExpression>,
     /// True when this is a repeated Row in a GridLayout, meaning layout_item_info
     /// needs to be able to return layout info for individual children
     pub is_repeated_row: bool,
@@ -832,6 +856,9 @@ impl CompilationUnit {
                 visitor(e, ctx);
             }
             if let Some(e) = &sc.layout_info_h_at_cross_height_for_repeated {
+                visitor(e, ctx);
+            }
+            if let Some(e) = &sc.grid_row_child_cross_width {
                 visitor(e, ctx);
             }
             for e in sc.accessible_prop.values() {

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -207,6 +207,7 @@ fn box_measure_cells_for(
                 return BoxMeasureCell::Repeated(LayoutRepeatedElement {
                     repeater_index,
                     row_child_templates: None,
+                    cross_width: None,
                 });
             }
             let measure_local = crate::expression_tree::Expression::ReadLocalVariable {
@@ -686,6 +687,7 @@ fn measure_cells_for(
                     kind: FlexboxMeasureCellKind::Repeated(LayoutRepeatedElement {
                         repeater_index,
                         row_child_templates: None,
+                        cross_width: None,
                     }),
                     w4h_only,
                 };
@@ -1164,6 +1166,7 @@ fn flexbox_layout_data(
                 elements.push(Either::Right(LayoutRepeatedElement {
                     repeater_index,
                     row_child_templates: None,
+                    cross_width: None,
                 }))
             } else {
                 // For static elements, we need both orientations
@@ -1343,6 +1346,7 @@ fn box_layout_data(
                 elements.push(Either::Right(LayoutRepeatedElement {
                     repeater_index,
                     row_child_templates: None,
+                    cross_width: None,
                 }))
             } else {
                 let layout_info = cell_layout_info(
@@ -1602,6 +1606,75 @@ struct GridLayoutCellConstraintsResult {
     compute_cells: Option<(String, Vec<Either<llr_Expression, LayoutRepeatedElement>>)>,
 }
 
+/// Name of the local the generated GridLayout vertical pass binds to the index
+/// of the repeated instance it is about to measure.
+pub const GRID_MEASURE_REPEATER_INDEX_LOCAL: &str = "grid_measure_repeater_index";
+
+/// Name of the local the generated repeated-Row `layout_item_info` binds to the
+/// flattened index of the child it is about to measure.
+pub const GRID_MEASURE_CHILD_INDEX_LOCAL: &str = "grid_measure_child_index";
+
+/// Which slot of the cell's cache read the measuring loop fills in, and so
+/// which local it binds. These are the only locals [`grid_measure_cross_width`]
+/// introduces.
+pub enum GridMeasureIndex {
+    /// A repeated cell of the grid, addressed by its repeater index.
+    Instance,
+    /// A child of a repeated Row, addressed by its flattened index within the
+    /// Row. That index is what the cache slot uses, so the expression built
+    /// from one child serves every child that returns `Some` here — which is
+    /// what `RowChildTemplateInfo::Repeated`'s `measure_at_cross_width` records.
+    RowChild,
+}
+
+/// Reads a repeated grid cell's solved column width out of the grid's
+/// horizontal cache: the cell's own `width` binding with `index`'s slot swapped
+/// for a local, so the measuring loop can evaluate it once per instance.
+///
+/// `None` when the instance is not height-for-width (nothing to re-measure) or
+/// when its width is fixed — the grid then never assigns it one, so there is no
+/// cache binding to read.
+pub fn grid_measure_cross_width(
+    ctx: &mut ExpressionLoweringCtx,
+    elem: &ElementRc,
+    index: GridMeasureIndex,
+) -> Option<llr_Expression> {
+    let comp = elem.borrow().base_type.as_component().clone();
+    let root = &comp.root_element;
+    if !root.borrow().has_inherited_layout_info_v_with_constraint() {
+        return None;
+    }
+    let mut width = repeated_cell_width_binding(root)?;
+    let crate::expression_tree::Expression::GridRepeaterCacheAccess {
+        repeater_index,
+        inner_repeater_index,
+        ..
+    } = width.ignore_debug_hooks_mut()
+    else {
+        return None;
+    };
+    let local = |name: &str| crate::expression_tree::Expression::ReadLocalVariable {
+        name: name.into(),
+        ty: Type::Int32,
+    };
+    match index {
+        GridMeasureIndex::Instance => **repeater_index = local(GRID_MEASURE_REPEATER_INDEX_LOCAL),
+        GridMeasureIndex::RowChild => {
+            *inner_repeater_index = Some(Box::new(local(GRID_MEASURE_CHILD_INDEX_LOCAL)))
+        }
+    }
+    Some(super::lower_expression::lower_expression(&width, ctx))
+}
+
+/// The `width` binding a GridLayout gave a repeated cell, followed through
+/// `geometry_props`: an injected wrapper (`Opacity`, `Transform`, …) becomes the
+/// repeated component's root but leaves the binding on the element below it.
+fn repeated_cell_width_binding(root: &ElementRc) -> Option<crate::expression_tree::Expression> {
+    let width = root.borrow().geometry_props.as_ref()?.width.clone();
+    let expr = width.element().borrow().binding(width.name())?.expression.clone();
+    Some(expr)
+}
+
 fn grid_layout_cell_constraints(
     layout: &crate::layout::GridLayout,
     orientation: Orientation,
@@ -1649,9 +1722,28 @@ fn grid_layout_cell_constraints(
                     _ => panic!(),
                 };
                 let row_child_templates = get_row_child_templates(&item.item.element, ctx);
+                // Measure a height-for-width instance at the width the grid
+                // assigns it, instead of its preferred width. Skipped when
+                // reading the horizontal cache would close a binding loop
+                // (`h_solve_reads_v_cache`), and on the
+                // `layoutinfo-v-with-constraint` path, where the caller has
+                // not settled the grid's width yet.
+                let cross_width = (orientation == Orientation::Vertical
+                    && cross_axis_size_override.is_none()
+                    && row_child_templates.is_none()
+                    && !item.cell.borrow().h_solve_reads_v_cache)
+                    .then(|| {
+                        grid_measure_cross_width(
+                            ctx,
+                            &item.item.element,
+                            GridMeasureIndex::Instance,
+                        )
+                    })
+                    .flatten();
                 elements.push(Either::Right(LayoutRepeatedElement {
                     repeater_index,
                     row_child_templates,
+                    cross_width,
                 }));
             } else {
                 let layout_info = cell_layout_info(

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -394,6 +394,7 @@ fn lower_sub_component(
         layout_info_v_at_cross_width_for_repeated: None,
         layout_info_h_constrained_for_repeated: None,
         layout_info_h_at_cross_height_for_repeated: None,
+        grid_row_child_cross_width: None,
         is_repeated_row: component
             .root_element
             .borrow()
@@ -845,6 +846,20 @@ fn lower_sub_component(
             .map(Into::into);
     }
 
+    if component.root_element.borrow().grid_layout_cell.is_some() {
+        // A GridLayout measures a height-for-width instance at the column width
+        // it assigns, through `layout_item_info_at_cross_width`; the plain
+        // `layout_info` measures at the instance's preferred width.
+        sub_component.layout_info_v_at_cross_width_for_repeated =
+            super::lower_layout_expression::get_layout_info_v_at_cross_width_for_repeated(
+                &mut ctx,
+                &component.root_element,
+                &component.root_constraints.borrow(),
+                false,
+            )
+            .map(Into::into);
+    }
+
     if let Some(grid_layout_cell) = component.root_element.borrow().grid_layout_cell.as_ref() {
         let grid_cell_ref = grid_layout_cell.borrow();
         sub_component.grid_layout_input_for_repeated = Some(
@@ -885,6 +900,24 @@ fn lower_sub_component(
                             .push(super::RowChildTemplateInfo::Static { child_index });
                     }
                     crate::layout::RowChildTemplate::Repeated { repeated_element, .. } => {
+                        // Measure this child at the column width the grid
+                        // assigns it, unless reading the horizontal cache would
+                        // close a binding loop. The expression is the same for
+                        // every child of the Row, so only the first one that
+                        // needs it builds it.
+                        let cross_width = (!grid_cell_ref.h_solve_reads_v_cache)
+                            .then(|| {
+                                super::lower_layout_expression::grid_measure_cross_width(
+                                    &mut ctx,
+                                    repeated_element,
+                                    super::lower_layout_expression::GridMeasureIndex::RowChild,
+                                )
+                            })
+                            .flatten();
+                        let measure_at_cross_width = cross_width.is_some();
+                        if sub_component.grid_row_child_cross_width.is_none() {
+                            sub_component.grid_row_child_cross_width = cross_width.map(Into::into);
+                        }
                         // Inner repeater: layout_info is computed at runtime per instance.
                         if let Some(super::lower_to_item_tree::LoweredElement::Repeated {
                             repeated_index,
@@ -892,6 +925,7 @@ fn lower_sub_component(
                         {
                             row_child_templates.push(super::RowChildTemplateInfo::Repeated {
                                 repeater_index: *repeated_index,
+                                measure_at_cross_width,
                             });
                         }
                     }

--- a/internal/compiler/llr/optim_passes/count_property_use.rs
+++ b/internal/compiler/llr/optim_passes/count_property_use.rs
@@ -105,6 +105,9 @@ pub fn count_property_use(root: &CompilationUnit) {
         if let Some(e) = &sc.layout_info_h_at_cross_height_for_repeated {
             e.borrow().visit_property_references(ctx, &mut visit_property);
         }
+        if let Some(e) = &sc.grid_row_child_cross_width {
+            e.borrow().visit_property_references(ctx, &mut visit_property);
+        }
         for child in &sc.grid_layout_children {
             child.layout_info_h.borrow().visit_property_references(ctx, &mut visit_property);
             child.layout_info_v.borrow().visit_property_references(ctx, &mut visit_property);

--- a/internal/compiler/llr/optim_passes/remove_unused.rs
+++ b/internal/compiler/llr/optim_passes/remove_unused.rs
@@ -333,6 +333,7 @@ mod visitor {
             layout_info_v_at_cross_width_for_repeated,
             layout_info_h_constrained_for_repeated,
             layout_info_h_at_cross_height_for_repeated,
+            grid_row_child_cross_width,
             is_repeated_row: _,
             grid_layout_children,
             accessible_prop,
@@ -450,6 +451,9 @@ mod visitor {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         if let Some(e) = layout_info_h_at_cross_height_for_repeated {
+            visit_expression(e.get_mut(), &scope, state, visitor);
+        }
+        if let Some(e) = grid_row_child_cross_width {
             visit_expression(e.get_mut(), &scope, state, visitor);
         }
         for child in grid_layout_children {

--- a/internal/compiler/llr/pretty_print.rs
+++ b/internal/compiler/llr/pretty_print.rs
@@ -656,8 +656,14 @@ impl<'a, T> Display for DisplayExpression<'a, T> {
                         .iter()
                         .map(|x| match x {
                             Either::Left(x) => e(x).to_string(),
-                            Either::Right(r) =>
-                                format!("@repeater({})", usize::from(r.repeater_index)),
+                            Either::Right(r) => match &r.cross_width {
+                                Some(w) => format!(
+                                    "@repeater({} at cross-width {})",
+                                    usize::from(r.repeater_index),
+                                    e(w)
+                                ),
+                                None => format!("@repeater({})", usize::from(r.repeater_index)),
+                            },
                         })
                         .join(", "),
                     match orientation {

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -211,6 +211,11 @@ pub async fn run_passes(
     for root_component in doc.exported_roots() {
         lower_layout::check_window_layout(&root_component);
     }
+    // After the loop above: needs every component's `layoutinfo-h-with-constraint`
+    // and the wrapper elements the `lower_property_to_element` passes inject.
+    doc.visit_all_used_components(|component| {
+        lower_layout::mark_grid_h_solve_reads_v_cache(component);
+    });
     collect_globals::collect_globals(doc, diag);
     // Must be done before passes that rely on `NamedReference::is_constant`.
     collect_globals::mark_library_globals(doc);

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -249,6 +249,67 @@ fn rewrite_layoutinfo_h_for_constraint(expr: &mut Expression, height_param: &Exp
 /// horizontal axis. Fires on any element whose `layoutinfo-h` depends
 /// (transitively) on a flex with horizontal cross-axis — directly
 /// (column-direction flex) or via a descendant / base component.
+/// Record on every cell of a GridLayout whether solving that grid's horizontal
+/// axis can read back into its vertical cache — see
+/// [`crate::layout::GridLayoutCell::h_solve_reads_v_cache`].
+///
+/// Only a *repeated* width-for-height cell does that: the grid measures it
+/// through its plain `layout_info_h`, which pulls the instance's own height,
+/// and that height comes from the grid's vertical cache. A static cell is
+/// measured at an unbounded height instead (see `cell_layout_info`), and any
+/// other way for a cell's horizontal info to reach its own height is a binding
+/// loop `binding_analysis` already rejects.
+///
+/// Must run after `synthesize_layoutinfo_h_with_constraint` (the marker it
+/// tests is created there) and after the wrapper-injecting passes (an injected
+/// `Opacity`/`Transform` takes over the cell role).
+pub fn mark_grid_h_solve_reads_v_cache(component: &Rc<Component>) {
+    /// The element carrying the layout-info: a repeated cell moved its body
+    /// into a sub-component.
+    fn measured_element(elem: &ElementRc) -> ElementRc {
+        let elem_b = elem.borrow();
+        match (&elem_b.repeated, &elem_b.base_type) {
+            (Some(_), ElementType::Component(base)) => base.root_element.clone(),
+            _ => elem.clone(),
+        }
+    }
+    fn reads_v_cache(grid: &GridLayout) -> bool {
+        grid.elems.iter().any(|e| {
+            if e.item.element.borrow().repeated.is_none() {
+                return false;
+            }
+            if measured_element(&e.item.element)
+                .borrow()
+                .has_inherited_layout_info_h_with_constraint()
+            {
+                return true;
+            }
+            // A repeated Row measures its children the same unconstrained way.
+            e.cell.borrow().child_items.iter().flatten().any(|c| {
+                measured_element(&c.layout_item().element)
+                    .borrow()
+                    .has_inherited_layout_info_h_with_constraint()
+            })
+        })
+    }
+    // Every binding holds its own clone of the `GridLayout`, so stamp them all
+    // rather than relying on the cells still being shared through their `Rc`.
+    crate::object_tree::visit_all_expressions(component, |expr, _| {
+        expr.visit_recursive_mut(&mut |sub| {
+            let grid = match sub {
+                Expression::OrganizeGridLayout(grid) => grid,
+                Expression::SolveGridLayout { layout, .. } => layout,
+                Expression::ComputeGridLayoutInfo { layout, .. } => layout,
+                _ => return,
+            };
+            let unsafe_h = reads_v_cache(grid);
+            for e in &grid.elems {
+                e.cell.borrow_mut().h_solve_reads_v_cache = unsafe_h;
+            }
+        });
+    });
+}
+
 pub fn synthesize_layoutinfo_h_with_constraint(component: &Rc<Component>) {
     /// Bottom-up walk, returns `true` if the subtree contains an
     /// h-cross-axis dependency (a flex with cross axis on horizontal,
@@ -1071,6 +1132,7 @@ impl GridLayout {
                     colspan_expr: colspan_expr.unwrap_or(RowColExpr::Literal(1)),
                     rowspan_expr: rowspan_expr.unwrap_or(RowColExpr::Literal(1)),
                     child_items: None,
+                    h_solve_reads_v_cache: false,
                 }));
                 // Attach to the element the solver reads: the sub-component root for an inner
                 // repeater (so it reports its own colspan/rowspan), or `child` for a static child.
@@ -1190,6 +1252,7 @@ impl GridLayout {
                 colspan_expr: RowColExpr::Literal(1),
                 rowspan_expr: RowColExpr::Literal(1),
                 child_items: Some(children_layout_items),
+                h_solve_reads_v_cache: false,
             }));
             let grid_layout_element = GridLayoutElement {
                 cell: grid_layout_cell.clone(),
@@ -1261,6 +1324,7 @@ impl GridLayout {
             colspan_expr: expr_or_default(colspan_expr, RowColExpr::Literal(1)),
             rowspan_expr: expr_or_default(rowspan_expr, RowColExpr::Literal(1)),
             child_items: None,
+            h_solve_reads_v_cache: false,
         }));
         let grid_layout_element =
             GridLayoutElement { cell: grid_layout_cell.clone(), item: layout_item.item.clone() };

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1127,6 +1127,7 @@ fn with_layout_item_info(
                     repeater.row_child_templates.as_deref(),
                     orientation,
                     cross_size,
+                    repeater.cross_width.as_ref(),
                     &mut cells,
                 );
                 repeated_indices.push(offset);
@@ -1162,6 +1163,7 @@ fn push_repeater_layout_items(
     row_child_templates: Option<&[i_slint_compiler::llr::RowChildTemplateInfo]>,
     orientation: i_slint_compiler::layout::Orientation,
     cross_size: Option<f32>,
+    grid_cross_width: Option<&Expression>,
     cells: &mut Vec<Value>,
 ) -> (u32, u32) {
     use i_slint_core::model::RepeatedItemTree;
@@ -1191,7 +1193,7 @@ fn push_repeater_layout_items(
             // Column repeater: one cell per instance, asking the sub-component
             // for its own layout info — at the layout's cross size when the
             // main-axis pass forwards one.
-            for instance in &instances {
+            for (i, instance) in instances.iter().enumerate() {
                 let info = match (cross_size, core_orientation) {
                     (Some(cs), i_slint_core::items::Orientation::Vertical) => {
                         RepeatedItemTree::layout_item_info_at_cross_width(instance.as_pin_ref(), cs)
@@ -1202,11 +1204,21 @@ fn push_repeater_layout_items(
                             cs,
                         )
                     }
-                    (None, _) => RepeatedItemTree::layout_item_info(
-                        instance.as_pin_ref(),
-                        core_orientation,
-                        None,
-                    ),
+                    // A grid re-measures each instance at its own solved
+                    // column width instead of one size shared by all cells.
+                    (None, _) => {
+                        match grid_cross_width.and_then(|e| eval_grid_measure_width(ctx, e, i)) {
+                            Some(w) => RepeatedItemTree::layout_item_info_at_cross_width(
+                                instance.as_pin_ref(),
+                                w,
+                            ),
+                            None => RepeatedItemTree::layout_item_info(
+                                instance.as_pin_ref(),
+                                core_orientation,
+                                None,
+                            ),
+                        }
+                    }
                 };
                 push_cell(cells, info);
             }
@@ -1240,6 +1252,20 @@ fn push_repeater_layout_items(
     (instances.len() as u32, step)
 }
 
+/// Evaluate a [`i_slint_compiler::llr::LayoutRepeatedElement::cross_width`]
+/// cache read for one instance. `None` on a non-numeric value, so the caller
+/// falls back to the plain layout info rather than measuring at 0.
+fn eval_grid_measure_width(ctx: &mut EvalContext, expr: &Expression, index: usize) -> Option<f32> {
+    use i_slint_compiler::llr::lower_layout_expression::GRID_MEASURE_REPEATER_INDEX_LOCAL;
+    let prev = ctx.locals.insert(
+        SmolStr::new_static(GRID_MEASURE_REPEATER_INDEX_LOCAL),
+        Value::Number(index as f64),
+    );
+    let value = eval_expression(ctx, expr);
+    restore_local(ctx, GRID_MEASURE_REPEATER_INDEX_LOCAL, prev);
+    value.try_into().ok()
+}
+
 fn total_row_child_count(
     sub: &Pin<std::rc::Rc<crate::instance::SubComponentInstance>>,
     templates: &[i_slint_compiler::llr::RowChildTemplateInfo],
@@ -1247,7 +1273,7 @@ fn total_row_child_count(
     use i_slint_compiler::llr::{RowChildTemplateInfo, static_child_count};
     let mut total = static_child_count(templates);
     for entry in templates {
-        if let RowChildTemplateInfo::Repeated { repeater_index } = entry {
+        if let RowChildTemplateInfo::Repeated { repeater_index, .. } = entry {
             let repeater = &sub.repeaters[*repeater_index];
             repeater.track_instance_changes();
             total += repeater.range().len();
@@ -1559,7 +1585,7 @@ fn push_repeater_grid_input_data(
                         cells.push(v);
                         written += 1;
                     }
-                    RowChildTemplateInfo::Repeated { repeater_index } => {
+                    RowChildTemplateInfo::Repeated { repeater_index, .. } => {
                         let inner_rep = &inner_sub.repeaters[*repeater_index];
                         inner_rep.track_instance_changes();
                         // Let each inner cell report its own

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -1373,6 +1373,9 @@ fn row_child_layout_item_info(
 ) -> i_slint_core::layout::LayoutItemInfo {
     use i_slint_compiler::llr::RowChildTemplateInfo;
     use i_slint_core::model::RepeatedItemTree;
+    // `index` is consumed as the walk advances; the cache read below addresses
+    // the child by its flattened index.
+    let flat_index = index;
     for entry in templates {
         match entry {
             RowChildTemplateInfo::Static { child_index } => {
@@ -1395,12 +1398,24 @@ fn row_child_layout_item_info(
                 }
                 index -= 1;
             }
-            RowChildTemplateInfo::Repeated { repeater_index } => {
+            RowChildTemplateInfo::Repeated { repeater_index, measure_at_cross_width } => {
                 let repeater = &this.root_sub_component.repeaters[*repeater_index];
                 repeater.track_instance_changes();
                 let count = repeater.range().len();
                 if index < count {
                     if let Some(inner) = repeater.instance_at(index) {
+                        // A GridLayout measures an inner repeated child at the
+                        // column width it assigns it, like a static child
+                        // measures at its own (lazily pulled) width.
+                        if *measure_at_cross_width
+                            && orientation == i_slint_core::items::Orientation::Vertical
+                            && let Some(w) = row_child_cross_width(this, sc, flat_index)
+                        {
+                            return RepeatedItemTree::layout_item_info_at_cross_width(
+                                inner.as_pin_ref(),
+                                w,
+                            );
+                        }
                         return RepeatedItemTree::layout_item_info(
                             inner.as_pin_ref(),
                             orientation,
@@ -1414,6 +1429,23 @@ fn row_child_layout_item_info(
         }
     }
     i_slint_core::layout::LayoutItemInfo::default()
+}
+
+/// Evaluate a repeated Row's `grid_row_child_cross_width` for one child.
+/// `None` when the Row has no such expression, or on a non-numeric value —
+/// the caller then falls back to the plain layout info rather than measuring
+/// at 0.
+fn row_child_cross_width(
+    this: &Instance,
+    sc: &i_slint_compiler::llr::SubComponent,
+    flat_index: usize,
+) -> Option<f32> {
+    use i_slint_compiler::llr::lower_layout_expression::GRID_MEASURE_CHILD_INDEX_LOCAL;
+    let expr = sc.grid_row_child_cross_width.as_ref()?;
+    let mut ctx = crate::eval::EvalContext::new(this.root_sub_component.clone());
+    ctx.locals
+        .insert(GRID_MEASURE_CHILD_INDEX_LOCAL.into(), crate::Value::Number(flat_index as f64));
+    crate::eval::eval_expression(&mut ctx, &expr.borrow()).try_into().ok()
 }
 
 fn value_to_flexbox_layout_item_info(

--- a/tests/cases/layout/grid_repeated_width_for_height_sibling.slint
+++ b/tests/cases/layout/grid_repeated_width_for_height_sibling.slint
@@ -1,0 +1,121 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A repeated width-for-height cell (the wrapping column FlexboxLayout on the
+// right) makes the grid's horizontal solve read the instance's own height,
+// which comes from the grid's vertical cache. The vertical pass must therefore
+// not measure repeated cells at their solved column width here — reading the
+// horizontal cache would close that loop and panic with "Recursion detected".
+//
+// The wrapped text is consequently measured at its preferred width, so its row
+// can be shorter than the text needs. That is the older, unfixed behavior,
+// kept on purpose: see `h_solve_reads_v_cache`. The blue cell painting over
+// the magenta bar is what that looks like, and is expected here.
+//
+// Reading the rendered window: the caption reports the row height the grid
+// settled on; the test only asserts that the layout solves at all and lands
+// somewhere sane.
+
+// The width-for-height cell: a column flex that wraps into more columns as it
+// gets shorter, so its width depends on its height.
+component WrapCol inherits FlexboxLayout {
+    flex-direction: column;
+    flex-wrap: wrap;
+    spacing: 0px;
+    padding: 0px;
+    cross-axis-line-alignment: start;
+    Rectangle { width: 44px; height: 30px; background: #dcdcdc; border-width: 1px; border-color: #a0a0a0;
+        Text { x: 0px; width: 100%; height: 100%; text: "w4h"; font-size: 9px; color: #333333;
+            horizontal-alignment: center; vertical-alignment: center; } }
+    Rectangle { width: 44px; height: 30px; background: #dcdcdc; border-width: 1px; border-color: #a0a0a0;
+        Text { x: 0px; width: 100%; height: 100%; text: "w4h"; font-size: 9px; color: #333333;
+            horizontal-alignment: center; vertical-alignment: center; } }
+    Rectangle { width: 44px; height: 30px; background: #dcdcdc; border-width: 1px; border-color: #a0a0a0;
+        Text { x: 0px; width: 100%; height: 100%; text: "w4h"; font-size: 9px; color: #333333;
+            horizontal-alignment: center; vertical-alignment: center; } }
+    Rectangle { width: 44px; height: 30px; background: #dcdcdc; border-width: 1px; border-color: #a0a0a0;
+        Text { x: 0px; width: 100%; height: 100%; text: "w4h"; font-size: 9px; color: #333333;
+            horizontal-alignment: center; vertical-alignment: center; } }
+}
+
+export component TestCase inherits Window {
+    width: 460px;
+    height: block.y + block-height + 20px;
+
+    property <[int]> one: [1];
+    property <length> block-height: 30px + ref.height * 8;
+
+    // Single-line reference for a font-independent line height.
+    ref := Text {
+        x: 420px;
+        y: 2px;
+        text: "Word";
+        color: #555555;
+    }
+
+    legend := Text {
+        x: 4px;
+        y: 2px;
+        width: 400px;
+        font-size: 11px;
+        color: #555555;
+        wrap: word-wrap;
+        text: "blue = the wrapped-text cell; gray = the repeated width-for-height cell that forces the grid to keep the old measurement\nmagenta bar = the asserted extent, its top is the text row's height";
+    }
+
+    cap := Text { x: 4px; y: legend.y + legend.height + 10px; width: 440px;
+        font-size: 11px; color: #555555; wrap: word-wrap;
+        text: "repeated width-for-height sibling — row \{round(marker.y / 1px)}px (the text may overflow it)"; }
+
+    block := GridLayout {
+        x: 0; y: cap.y + cap.height + 4px;
+        width: 440px; height: block-height;
+        spacing: 0px; padding: 0px;
+        Row {
+            for x in one: Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text {
+                        text: "A long wrapped cell: the quick brown fox jumps over the lazy dog, twice over.";
+                        wrap: word-wrap;
+                        color: #003366;
+                    }
+                }
+            }
+            for y in one: WrapCol { }
+        }
+        Row {
+            marker := Rectangle {
+                height: 14px;
+                background: #ffe6ff;
+                border-width: 1px;
+                border-color: #f0f;
+            }
+        }
+        Row { Rectangle { vertical-stretch: 1; } }
+    }
+
+    // The layout solved instead of panicking, and the text row is a real row:
+    // at least one line tall, and no taller than the block of tiles beside it.
+    out property <bool> test: marker.y >= ref.height && marker.y <= 4 * 30px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/grid_wrapped_text_row_height.slint
+++ b/tests/cases/layout/grid_wrapped_text_row_height.slint
@@ -1,0 +1,317 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A GridLayout row must be tall enough for the height its word-wrapped Text
+// needs at the column width the grid assigns — also when the cell is repeated.
+// A repeated instance cannot pull its own width the way a static cell does, so
+// the grid measures it at the width it hands out.
+//
+// Each block's magenta bar is the asserted extent: it sits right under the
+// text row, so its y is the sizer row plus that row's height. Every repeated
+// block must match the static reference at the top of its column.
+//
+// The two right-hand columns hold two text cells of different lengths, in grid
+// columns pinned to different widths by the sizer row. A repeated cell there
+// lands in a different column per instance, so measuring every instance at the
+// first one's width is not good enough.
+
+// The plain, fixed-width label column.
+component Label inherits Rectangle {
+    background: #dcdcdc;
+    border-width: 1px;
+    border-color: #a0a0a0;
+    width: 90px;
+    Text {
+        x: 0px;
+        width: 100%;
+        height: 100%;
+        text: "90px";
+        font-size: 9px;
+        color: #333333;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+// Pins a grid column to a minimum width and reports the width it ended up with.
+component ColumnSizer inherits Rectangle {
+    in property <length> pin;
+    min-width: pin;
+    height: 14px;
+    background: #dcdcdc;
+    border-width: 1px;
+    border-color: #a0a0a0;
+    Text {
+        x: 0px;
+        width: 100%;
+        height: 100%;
+        text: "w=\{round(root.width / 1px)}";
+        font-size: 9px;
+        color: #333333;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+    }
+}
+
+// The cell under test is written out inline at every use on purpose. A
+// repeated element whose body is a user-defined component (`for t in m: Cell
+// { }`) is measured through a different, already-correct path, so factoring
+// this markup into a component silently stops the test exercising the bug.
+// The static reference cells are inlined the same way so both sides match.
+
+// The asserted extent: the top of this bar is the height under test.
+component Marker inherits Rectangle {
+    height: 14px;
+    background: #ffe6ff;
+    border-width: 1px;
+    border-color: #f0f;
+}
+
+export component TestCase inherits Window {
+    width: 1080px;
+    // Derived from the content so the blocks fit at any font size.
+    height: max(bare-block.y, max(cell-block.y, nested-block.y)) + block-height + 20px;
+
+    property <[int]> one: [1];
+    property <[string]> texts: [
+        "A long wrapped cell: the quick brown fox jumps over the lazy dog, twice over.",
+        "A shorter wrapped cell, still more than one line.",
+    ];
+    // The sizer row is the same in every block, so the marker positions are
+    // directly comparable.
+    property <length> sizer-height: 14px;
+    // Generous, so the last (stretching) row absorbs the slack and the marker
+    // bar sits right under the text row.
+    property <length> block-height: 30px + ref.height * 8;
+    property <length> top: legend.y + legend.height + 10px;
+
+    // Single-line reference for a font-independent line height.
+    ref := Text {
+        x: 1040px;
+        y: 2px;
+        text: "Word";
+        color: #555555;
+    }
+
+    legend := Text {
+        x: 4px;
+        y: 2px;
+        width: 1020px;
+        font-size: 11px;
+        color: #555555;
+        wrap: word-wrap;
+        text: "blue = the wrapped-text cell under test; gray = plain cells (the sizer row's label is the width its grid column ended up with)\nmagenta bar = the asserted extent, its top is the text row's height; the top block of each column is the static reference";
+    }
+
+    cap-static2 := Text { x: 4px; y: top; width: 340px; font-size: 11px; color: #555555; wrap: word-wrap;
+        text: "static cell — row \{round((static2-marker.y - sizer-height) / 1px)}px"; }
+    static2-block := GridLayout {
+        x: 0; y: cap-static2.y + cap-static2.height + 4px;
+        width: 340px; height: block-height;
+        spacing: 0px; padding: 0px;
+        Row {
+            ColumnSizer { pin: 90px; }
+            ColumnSizer { pin: 245px; }
+        }
+        Row {
+            Label { }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text { text: texts[0]; wrap: word-wrap; color: #003366; }
+                }
+            }
+        }
+        Row { static2-marker := Marker { } }
+        Row { Rectangle { vertical-stretch: 1; } }
+    }
+
+    // The bare repeated element has no Row of its own; the sizer row is what
+    // establishes the two columns it addresses with `col`.
+    cap-bare := Text { x: 4px; y: static2-block.y + block-height + 8px; width: 340px;
+        font-size: 11px; color: #555555; wrap: word-wrap;
+        text: "bare repeated element (col: 1) — row \{round((bare-marker.y - sizer-height) / 1px)}px"; }
+    bare-block := GridLayout {
+        x: 0; y: cap-bare.y + cap-bare.height + 4px;
+        width: 340px; height: block-height;
+        spacing: 0px; padding: 0px;
+        Row {
+            ColumnSizer { pin: 90px; }
+            ColumnSizer { pin: 245px; }
+        }
+        for x in one: Rectangle {
+            col: 1;
+            background: #cce6ff;
+            border-width: 1px;
+            border-color: #5b8db8;
+            VerticalLayout {
+                padding: 0px;
+                Text { text: texts[0]; wrap: word-wrap; color: #003366; }
+            }
+        }
+        Row { bare-marker := Marker { } }
+        Row { Rectangle { vertical-stretch: 1; } }
+    }
+
+    cap-static3 := Text { x: 364px; y: top; width: 340px; font-size: 11px; color: #555555; wrap: word-wrap;
+        text: "two static cells — row \{round((static3-marker.y - sizer-height) / 1px)}px"; }
+    static3-block := GridLayout {
+        x: 360px; y: cap-static3.y + cap-static3.height + 4px;
+        width: 340px; height: block-height;
+        spacing: 0px; padding: 0px;
+        Row {
+            ColumnSizer { pin: 90px; }
+            sizer-a := ColumnSizer { pin: 100px; }
+            sizer-b := ColumnSizer { pin: 145px; }
+        }
+        Row {
+            Label { }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text { text: texts[0]; wrap: word-wrap; color: #003366; }
+                }
+            }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text { text: texts[1]; wrap: word-wrap; color: #003366; }
+                }
+            }
+        }
+        Row { static3-marker := Marker { } }
+        Row { Rectangle { vertical-stretch: 1; } }
+    }
+
+    cap-cell := Text { x: 364px; y: static3-block.y + block-height + 8px; width: 340px;
+        font-size: 11px; color: #555555; wrap: word-wrap;
+        text: "repeated cells in a static Row — row \{round((rep-cell-marker.y - sizer-height) / 1px)}px"; }
+    cell-block := GridLayout {
+        x: 360px; y: cap-cell.y + cap-cell.height + 4px;
+        width: 340px; height: block-height;
+        spacing: 0px; padding: 0px;
+        Row {
+            ColumnSizer { pin: 90px; }
+            ColumnSizer { pin: 100px; }
+            ColumnSizer { pin: 145px; }
+        }
+        Row {
+            Label { }
+            for t in texts: Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text { text: t; wrap: word-wrap; color: #003366; }
+                }
+            }
+        }
+        Row { rep-cell-marker := Marker { } }
+        Row { Rectangle { vertical-stretch: 1; } }
+    }
+
+    cap-row := Text { x: 724px; y: top; width: 340px; font-size: 11px; color: #555555; wrap: word-wrap;
+        text: "repeated Row, static cells — row \{round((rep-row-marker.y - sizer-height) / 1px)}px"; }
+    row-block := GridLayout {
+        x: 720px; y: cap-row.y + cap-row.height + 4px;
+        width: 340px; height: block-height;
+        spacing: 0px; padding: 0px;
+        Row {
+            ColumnSizer { pin: 90px; }
+            ColumnSizer { pin: 100px; }
+            ColumnSizer { pin: 145px; }
+        }
+        for x in one: Row {
+            Label { }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text { text: texts[0]; wrap: word-wrap; color: #003366; }
+                }
+            }
+            Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text { text: texts[1]; wrap: word-wrap; color: #003366; }
+                }
+            }
+        }
+        Row { rep-row-marker := Marker { } }
+        Row { Rectangle { vertical-stretch: 1; } }
+    }
+
+    cap-nested := Text { x: 724px; y: row-block.y + block-height + 8px; width: 340px;
+        font-size: 11px; color: #555555; wrap: word-wrap;
+        text: "repeated cells in a repeated Row — row \{round((nested-marker.y - sizer-height) / 1px)}px"; }
+    nested-block := GridLayout {
+        x: 720px; y: cap-nested.y + cap-nested.height + 4px;
+        width: 340px; height: block-height;
+        spacing: 0px; padding: 0px;
+        Row {
+            ColumnSizer { pin: 90px; }
+            ColumnSizer { pin: 100px; }
+            ColumnSizer { pin: 145px; }
+        }
+        for x in one: Row {
+            Label { }
+            for t in texts: Rectangle {
+                background: #cce6ff;
+                border-width: 1px;
+                border-color: #5b8db8;
+                VerticalLayout {
+                    padding: 0px;
+                    Text { text: t; wrap: word-wrap; color: #003366; }
+                }
+            }
+        }
+        Row { nested-marker := Marker { } }
+        Row { Rectangle { vertical-stretch: 1; } }
+    }
+
+    // Sanity: the reference text really does wrap at the cell width.
+    out property <bool> test-wraps: static3-marker.y - sizer-height >= 2 * ref.height;
+    // Sanity: the two text columns really are different widths, so a repeated
+    // cell measured at the wrong instance's width comes out wrong.
+    out property <bool> test-columns-differ: abs(sizer-a.width - sizer-b.width) > 10px;
+    // Every repeated shape must match the static reference of its column.
+    out property <bool> test-bare: abs(bare-marker.y - static2-marker.y) < 1px;
+    out property <bool> test-rep-cell: abs(rep-cell-marker.y - static3-marker.y) < 1px;
+    out property <bool> test-rep-row: abs(rep-row-marker.y - static3-marker.y) < 1px;
+    out property <bool> test-nested: abs(nested-marker.y - static3-marker.y) < 1px;
+
+    out property <bool> test: test-wraps && test-columns-differ && test-bare && test-rep-cell
+        && test-rep-row && test-nested;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
A repeated cell was measured at its preferred (unwrapped) width, so its row
came out one line tall and the text painted over the next row. A static cell
gets this right by itself: its geometry is a lazy cache binding, so the
wrapped Text pulls the real column width. A repeated instance cannot — the
grid asks the whole instance for its layout-info, which is measured at the
instance's preferred width.

Follow-up to #13003 reusing its machinery: the grid's vertical pass measures 
each repeated cell through layout_item_info_at_cross_width, passing the width 
it solved for that cell's column, read from the horizontal cache. A cell nested in a
repeated Row is measured the same way, from the Row's layout_item_info.

Reading the horizontal cache from the vertical pass is only sound while the
horizontal solve does not read back into the vertical cache. A repeated
width-for-height cell does exactly that, through the instance's own height,
so grids holding one are marked (h_solve_reads_v_cache) and keep the old
measurement instead of closing a binding loop. The measurement is likewise
skipped on the layoutinfo-v-with-constraint path, where the caller has not
settled the grid's width yet.

Before:
<img width="1080" height="440" alt="testcase-before" src="https://github.com/user-attachments/assets/a1274740-b961-4033-82a2-8e61d34f11ca" />

After:
<img width="1080" height="440" alt="testcase-after" src="https://github.com/user-attachments/assets/f72e7c9d-8f1e-4a89-9045-a44b09b81054" />
