### PR TITLE
Visual Editor: clippy fix (simplify a boolean expression)

### DIFF
--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -425,8 +425,7 @@ fn take_pending_file_tree_preview(
     preview_state: &mut PreviewState,
     url: &Url,
 ) -> Option<PreviewComponent> {
-    if !preview_state.pending_file_tree_preview.as_ref().is_some_and(|pending| pending.url == *url)
-    {
+    if preview_state.pending_file_tree_preview.as_ref().is_none_or(|pending| pending.url != *url) {
         return None;
     }
     preview_state.pending_file_tree_preview.take()


### PR DESCRIPTION
The pre-commit hook I'm using locally rejects the expression, and CI never had a chance to:
on #13050, which brought this code in, every check run is marked skipped, clippy included -- for some reason.