### PR TITLE
Visual Editor: Fix window dragging

### DIFF
--- a/tools/editor/Cargo.toml
+++ b/tools/editor/Cargo.toml
@@ -53,7 +53,7 @@ tracing-subscriber = { workspace = true }
 slint-build = { workspace = true }
 
 [dev-dependencies]
-i-slint-backend-testing = { path = "../../internal/backends/testing" }
+i-slint-backend-testing = { path = "../../internal/backends/testing", features = ["internal"] }
 i-slint-editor-preview = { path = "../../internal/editor-preview", features = ["testing"] }
 spin_on = { workspace = true }
 

--- a/tools/editor/build.rs
+++ b/tools/editor/build.rs
@@ -1,11 +1,19 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+use slint_build::CompilerConfiguration;
+
 fn main() {
     // Safety: there are no other threads at this point
     unsafe {
         // Make the compiler handle ComponentContainer:
         std::env::set_var("SLINT_ENABLE_EXPERIMENTAL_FEATURES", "1");
     }
-    slint_build::compile("ui/main.slint").unwrap();
+
+    // Some tests use the ElementHandle API, which requires debug info
+    slint_build::compile_with_config(
+        "ui/main.slint",
+        CompilerConfiguration::new().with_debug_info(true),
+    )
+    .unwrap();
 }

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -1619,9 +1619,44 @@ pub fn ui_set_properties(
 mod tests {
     use crate::preview::preview_data;
 
-    use slint::{Model, SharedString, ToSharedString, VecModel};
+    use slint::{
+        ComponentHandle, LogicalPosition, Model, SharedString, ToSharedString, VecModel,
+        platform::{PointerEventButton, WindowEvent},
+    };
 
     use super::{PropertyInformation, PropertyValue, PropertyValueKind};
+
+    #[test]
+    fn title_area_requests_window_move_on_first_drag() {
+        i_slint_backend_testing::init_no_event_loop();
+        let editor = super::EditorUi::new().unwrap();
+        editor.show().unwrap();
+
+        let title_move_area = i_slint_backend_testing::ElementHandle::find_by_element_id(
+            &editor,
+            "EditorUi::title-move-area",
+        )
+        .next()
+        .expect("the title move area must be inside EditorUi's FocusScope");
+        let position = title_move_area.absolute_position();
+        let size = title_move_area.size();
+        let start =
+            LogicalPosition::new(position.x + size.width / 2., position.y + size.height / 2.);
+        editor.window().dispatch_event(WindowEvent::PointerPressed {
+            position: start,
+            button: PointerEventButton::Left,
+        });
+        editor.window().dispatch_event(WindowEvent::PointerMoved {
+            position: LogicalPosition::new(start.x + 20., start.y),
+        });
+
+        assert_eq!(
+            i_slint_backend_testing::access_testing_window(editor.window(), |window| {
+                window.window_move_request_count()
+            }),
+            1
+        );
+    }
 
     fn create_test_property(name: &str, value: &str) -> PropertyInformation {
         PropertyInformation {

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -100,7 +100,11 @@ export component EditorUi inherits Window {
                 }
 
                 VerticalLayout {
-                    EditorTopBar { }
+                    title-move-area := WindowMoveArea {
+                        height: EditorMetrics.top-bar-height;
+
+                        EditorTopBar { }
+                    }
 
                     HorizontalLayout {
                         vertical-stretch: 1;


### PR DESCRIPTION
Due to being nested inside a FocusScope the first attempt to drag a window by the title area would often fail