### PR TITLE
docs: Mention that when anchor and cursor are identical, just the cur…

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/lineedit.mdx
@@ -110,6 +110,7 @@ Call this function to remove keyboard focus from this `LineEdit` if it currently
 
 ### set-selection-offsets(anchor: int, focus: int)
 Selects the text between two UTF-8 offsets: `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to, so `focus` may precede `anchor` to select backwards.
+Pass the same value for both to place the text cursor at that offset without selecting anything.
 
 ### select-all()
 Selects all text.

--- a/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/views/textedit.mdx
@@ -134,7 +134,7 @@ The height of the visible area of the text edit (not including the scrollbar)
 
 -   **`focus()`** Call this function to focus the TextEdit and make it receive future keyboard events.
 -   **`clear-focus()`** Call this function to remove keyboard focus from this `TextEdit` if it currently has the focus. See also <Link type="FocusHandling" label="focus handling" />.
--   **`set-selection-offsets(anchor: int, focus: int)`** Selects the text between two UTF-8 offsets: `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to, so `focus` may precede `anchor` to select backwards.
+-   **`set-selection-offsets(anchor: int, focus: int)`** Selects the text between two UTF-8 offsets: `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to, so `focus` may precede `anchor` to select backwards. Pass the same value for both to place the text cursor at that offset without selecting anything.
 -   **`select-all()`** Selects all text.
 -   **`clear-selection()`** Clears the selection. This function takes effect regardless of the `read-only` and `enabled` properties.
 -   **`copy()`** Copies the selected text to the clipboard.

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1838,6 +1838,7 @@ export component TextInput {
     /// Selects the text between two UTF-8 offsets.
     /// `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to,
     /// so `focus` may precede `anchor` to select backwards.
+    /// Pass the same value for both to place the text cursor at that offset without selecting anything.
     function set-selection-offsets(anchor: int, focus: int) {
         BuiltinFunction.SetSelectionOffsets
     }

--- a/ui-libraries/material/docs/src/content/docs/components/text_field.mdx
+++ b/ui-libraries/material/docs/src/content/docs/components/text_field.mdx
@@ -77,6 +77,7 @@ An icon displayed at the end of the text input.
 
 ### set-selection-offsets(anchor: int, focus: int)
 Selects the text between two UTF-8 offsets: `anchor` is the end of the selection that stays put and `focus` the end the cursor moves to, so `focus` may precede `anchor` to select backwards.
+Pass the same value for both to place the text cursor at that offset without selecting anything.
 
 ### select-all()
 Selects all text in the text field.


### PR DESCRIPTION
…sor is set

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
