### PR TITLE
Improve Settings directory structure

### DIFF
--- a/internal/editor-preview/settings_store.rs
+++ b/internal/editor-preview/settings_store.rs
@@ -14,29 +14,38 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Load the raw contents of the settings file `name`, or `None` if it is
+/// Load the raw contents of the `tool_name` settings file `name`, or `None` if it is
 /// missing, unreadable, or no config directory can be determined.
-pub fn load(name: &str) -> Option<String> {
-    let path = settings_path(name)?;
+pub fn load(tool_name: &str, name: &str) -> Option<String> {
+    let path = settings_path(tool_name, name)?;
     load_from_path(&path)
 }
 
-/// Persist `contents` verbatim to the settings file `name`.
-pub fn save(name: &str, contents: &str) -> crate::Result<()> {
-    let path = settings_path(name).ok_or_else(|| {
+/// Persist `contents` verbatim to the `tool_name` settings file `name`.
+pub fn save(tool_name: &str, name: &str, contents: &str) -> crate::Result<()> {
+    let path = settings_path(tool_name, name).ok_or_else(|| {
         std::io::Error::other("cannot determine OS config directory for preview settings")
     })?;
     save_to_path(&path, contents)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn settings_path(name: &str) -> Option<PathBuf> {
-    let project_dirs = directories::ProjectDirs::from("dev", "Slint", "slint-lsp")?;
-    settings_path_from_config_dir(project_dirs.config_dir(), name)
+fn settings_path(tool_name: &str, name: &str) -> Option<PathBuf> {
+    let application = if cfg!(target_os = "linux") { "slint" } else { tool_name };
+    let project_dirs = directories::ProjectDirs::from("dev", "Slint", application)?;
+    let mut config_dir = project_dirs.config_dir().to_owned();
+
+    // On Linux, place everything in a subdirectory of the "slint" config directory.
+    // Linux usually uses ~/.config/[tool_name] without the organization, so add a "slint" prefix
+    // manually.
+    if cfg!(target_os = "linux") {
+        config_dir.push(tool_name);
+    }
+    settings_path_from_config_dir(&config_dir, name)
 }
 
 #[cfg(target_arch = "wasm32")]
-fn settings_path(_name: &str) -> Option<PathBuf> {
+fn settings_path(_tool_name: &str, _name: &str) -> Option<PathBuf> {
     None
 }
 
@@ -92,7 +101,15 @@ mod tests {
 
     /// A not-yet-existing directory, so `save_to_path()` has to create it.
     fn config_dir(parent: &tempfile::TempDir) -> PathBuf {
-        parent.path().join("slint-lsp")
+        parent.path().join("slint").join("lsp")
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_settings_path_uses_tool_subdirectory() {
+        assert!(
+            settings_path("lsp", "settings.json").unwrap().ends_with("slint/lsp/settings.json")
+        );
     }
 
     #[test]

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -373,7 +373,8 @@ async fn handle_preview_message(
                 session.send_files_to_preview(files, |_| true);
             }
             for name in settings {
-                if let Some(contents) = i_slint_editor_preview::settings_store::load(name) {
+                if let Some(contents) = i_slint_editor_preview::settings_store::load("editor", name)
+                {
                     session.to_preview.send(&LspToPreviewMessage::SetUserSettings {
                         name: name.clone(),
                         contents,
@@ -383,7 +384,9 @@ async fn handle_preview_message(
             requested_project_root
         }
         UpdateUserSettings { name, contents } => {
-            if let Err(error) = i_slint_editor_preview::settings_store::save(name, contents) {
+            if let Err(error) =
+                i_slint_editor_preview::settings_store::save("editor", name, contents)
+            {
                 tracing::warn!("Failed to save preview user settings: {error}");
             }
             None

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -115,7 +115,7 @@ pub fn send_requested_state_to_preview(
         any(feature = "preview-external", feature = "preview-engine")
     ))]
     for name in settings {
-        if let Some(contents) = i_slint_editor_preview::settings_store::load(name) {
+        if let Some(contents) = i_slint_editor_preview::settings_store::load("lsp", name) {
             ctx.session
                 .to_preview
                 .send(&LspToPreviewMessage::SetUserSettings { name: name.clone(), contents });
@@ -134,7 +134,7 @@ pub fn send_requested_state_to_preview(
 #[cfg(any(feature = "preview-external", feature = "preview-engine", feature = "preview-remote"))]
 pub fn store_user_settings(name: &str, contents: &str) {
     #[cfg(not(target_arch = "wasm32"))]
-    if let Err(err) = i_slint_editor_preview::settings_store::save(name, contents) {
+    if let Err(err) = i_slint_editor_preview::settings_store::save("lsp", name, contents) {
         tracing::warn!("Failed to save preview user settings: {err}");
     }
     #[cfg(target_arch = "wasm32")]

--- a/tools/lsp/preview/user_settings.rs
+++ b/tools/lsp/preview/user_settings.rs
@@ -10,7 +10,7 @@
 
 /// Name of the file the preview stores its settings in. The LSP treats this as
 /// an opaque key.
-pub const PREVIEW_SETTINGS_FILE: &str = "preview-user-settings.json";
+pub const PREVIEW_SETTINGS_FILE: &str = "preview-settings.json";
 
 /// Preview UI state persisted for the local user.
 ///


### PR DESCRIPTION
For Linux, we now bundle everything under a shared "slint" config dir.
So this config path:

~/.config/slint-lsp/preview-user-settings.json

turns into:

~/.config/slint/lsp/preview-settings.json

For Windows/MacOS, we just shorten the tool name to "lsp" instead of
"slint-lsp", which then results in these paths:

~/Library/Application Support/dev.Slint.lsp

and

%APPDATA%\Slint\lsp\config

Which is already scoped by the "Slint" organization.