### PR TITLE
Move WindowEventDispatchResult to slint::platform

### DIFF
--- a/api/node/__test__/window.spec.mts
+++ b/api/node/__test__/window.spec.mts
@@ -3,11 +3,7 @@
 
 import { test, expect } from "vitest";
 
-import {
-    language,
-    private_api,
-    WindowEventDispatchResult,
-} from "../dist/index.js";
+import { language, platform, private_api } from "../dist/index.js";
 import type { Window } from "../dist/index.d.ts";
 
 private_api.initTesting();
@@ -258,7 +254,7 @@ test("Window dispatch event result", () => {
     const window = instance!.window() as Window;
 
     expect(window.dispatchEvent({ type: "pointer-exited" })).toBe(
-        WindowEventDispatchResult.Accepted,
+        platform.WindowEventDispatchResult.Accepted,
     );
 
     expect(
@@ -267,7 +263,7 @@ test("Window dispatch event result", () => {
             button: language.PointerEventButton.Left,
             position: { x: 10, y: 10 },
         }),
-    ).toBe(WindowEventDispatchResult.Accepted);
+    ).toBe(platform.WindowEventDispatchResult.Accepted);
     window.dispatchEvent({
         type: "pointer-released",
         button: language.PointerEventButton.Left,
@@ -280,9 +276,9 @@ test("Window dispatch event result", () => {
             button: language.PointerEventButton.Left,
             position: { x: 90, y: 90 },
         }),
-    ).toBe(WindowEventDispatchResult.Ignored);
+    ).toBe(platform.WindowEventDispatchResult.Rejected);
 
     expect(window.dispatchEvent({ type: "key-pressed", text: "a" })).toBe(
-        WindowEventDispatchResult.Ignored,
+        platform.WindowEventDispatchResult.Rejected,
     );
 });

--- a/api/node/rust/types/window_display_result.rs
+++ b/api/node/rust/types/window_display_result.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use slint_interpreter::WindowEventDispatchResult;
+use i_slint_core::platform::WindowEventDispatchResult;
 
 /// Result of dispatching a window event through Slint's runtime.
 #[derive(Clone, Debug, PartialEq)]
@@ -10,11 +10,9 @@ pub enum JsWindowEventDispatchResult {
     /// The event was handled. For example, a key handler consumed a key press, or
     /// the window acted on a resize or close request.
     Accepted,
-    /// The event was actively refused. For example, a `close-requested` callback
-    /// returned `reject` to prevent the window from closing.
+    /// The event wasn't handled: no element consumed it, or a handler actively refused it,
+    /// such as a `close-requested` callback returning `reject` to keep the window open.
     Rejected,
-    /// The event was not handled by any element.
-    Ignored,
 }
 
 impl From<WindowEventDispatchResult> for JsWindowEventDispatchResult {
@@ -22,8 +20,7 @@ impl From<WindowEventDispatchResult> for JsWindowEventDispatchResult {
         match value {
             WindowEventDispatchResult::Accepted => JsWindowEventDispatchResult::Accepted,
             WindowEventDispatchResult::Rejected => JsWindowEventDispatchResult::Rejected,
-            WindowEventDispatchResult::Ignored => JsWindowEventDispatchResult::Ignored,
-            _ => JsWindowEventDispatchResult::Ignored,
+            _ => JsWindowEventDispatchResult::Rejected,
         }
     }
 }

--- a/api/node/typescript/index.ts
+++ b/api/node/typescript/index.ts
@@ -5,7 +5,6 @@ import * as napi from "../binding.cjs";
 export {
     Diagnostic,
     DiagnosticLevel,
-    WindowEventDispatchResult,
     RgbaColor,
     Brush,
     DataTransfer,
@@ -105,9 +104,11 @@ export interface Window {
     /**
      * Dispatches a window event to the scene.
      *
-     * Returns whether the scene accepted the event, actively rejected it, or left it unhandled.
+     * Returns whether the scene accepted the event or rejected it.
      */
-    dispatchEvent(event: platform.WindowEvent): napi.WindowEventDispatchResult;
+    dispatchEvent(
+        event: platform.WindowEvent,
+    ): platform.WindowEventDispatchResult;
 }
 
 /**

--- a/api/node/typescript/platform.ts
+++ b/api/node/typescript/platform.ts
@@ -4,6 +4,8 @@
 import type { Size, Point, Window } from "./index.ts";
 import type { language } from "./generated/language";
 
+export { WindowEventDispatchResult } from "../binding.cjs";
+
 /**
  * A pointer was pressed.
  *
@@ -155,7 +157,7 @@ export interface WindowActiveChangedEvent {
  *
  * The `type` field selects the variant and determines which other fields apply.
  * Dispatch an event to a window with `Window.dispatchEvent`,
- * which reports whether the scene accepted, rejected, or ignored it.
+ * which reports whether the scene accepted or rejected it.
  *
  * @example
  * ```js
@@ -167,7 +169,7 @@ export interface WindowActiveChangedEvent {
  *     button: "left",
  * });
  *
- * if (result === slint.WindowEventDispatchResult.Accepted) {
+ * if (result === slint.platform.WindowEventDispatchResult.Accepted) {
  *     console.log("the scene handled the press");
  * }
  * ```

--- a/docs/nodejs/astro.config.mjs
+++ b/docs/nodejs/astro.config.mjs
@@ -155,6 +155,12 @@ export default defineConfig({
                                         {
                                             autogenerate: {
                                                 directory:
+                                                    "api/slint-ui/namespaces/platform/enumerations",
+                                            },
+                                        },
+                                        {
+                                            autogenerate: {
+                                                directory:
                                                     "api/slint-ui/namespaces/platform/interfaces",
                                             },
                                         },

--- a/internal/backends/android-activity/androidwindowadapter.rs
+++ b/internal/backends/android-activity/androidwindowadapter.rs
@@ -12,12 +12,12 @@ use android_activity::{InputStatus, MainEvent, PollEvent};
 use i_slint_core::SharedString;
 use i_slint_core::api::{
     LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, PlatformError, Window,
-    WindowEventDispatchResult,
 };
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, TouchPhase};
 use i_slint_core::lengths::PhysicalEdges;
 use i_slint_core::platform::{
-    InternalEvent, Key, PointerEventButton, WindowAdapter, WindowEvent, WindowProperties,
+    InternalEvent, Key, PointerEventButton, WindowAdapter, WindowEvent, WindowEventDispatchResult,
+    WindowProperties,
 };
 use i_slint_core::timers::{Timer, TimerMode};
 use i_slint_core::window::{InputMethodRequest, WindowInner};

--- a/internal/backends/android-activity/javahelper.rs
+++ b/internal/backends/android-activity/javahelper.rs
@@ -7,13 +7,13 @@ use i_slint_common::unicode_utils::{
     byte_offset_to_utf16_offset, utf16_offset_to_byte_offset_clamped,
 };
 use i_slint_core::SharedString;
-use i_slint_core::api::{PhysicalPosition, PhysicalSize, WindowEventDispatchResult};
+use i_slint_core::api::{PhysicalPosition, PhysicalSize};
 use i_slint_core::graphics::{Color, euclid};
 use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType};
 use i_slint_core::item_rendering::HasFont;
 use i_slint_core::items::{CapitalizationMode, ColorScheme, InputType};
 use i_slint_core::lengths::{LogicalLength, PhysicalEdges};
-use i_slint_core::platform::{Key, WindowAdapter, WindowEvent};
+use i_slint_core::platform::{Key, WindowAdapter, WindowEvent, WindowEventDispatchResult};
 use jni::objects::{JClass, JClassLoader, JString, LoaderContext};
 use jni::sys::{jfloat, jint};
 use jni::{Env, JavaVM, bind_java_type};

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -294,7 +294,7 @@ impl IntrospectionState {
         &self,
         adapter: &Rc<dyn WindowAdapter>,
         event: &i_slint_core::platform::WindowEvent,
-        result: i_slint_core::api::WindowEventDispatchResult,
+        result: i_slint_core::platform::WindowEventDispatchResult,
     ) {
         if !self.recording_enabled.get() {
             return;
@@ -529,17 +529,14 @@ fn convert_pointer_event_button_to_proto(
 }
 
 fn convert_event_dispatch_result(
-    result: i_slint_core::api::WindowEventDispatchResult,
+    result: i_slint_core::platform::WindowEventDispatchResult,
 ) -> proto::RecordedEventResult {
     match result {
-        i_slint_core::api::WindowEventDispatchResult::Accepted => {
+        i_slint_core::platform::WindowEventDispatchResult::Accepted => {
             proto::RecordedEventResult::Accepted
         }
-        i_slint_core::api::WindowEventDispatchResult::Rejected => {
+        i_slint_core::platform::WindowEventDispatchResult::Rejected => {
             proto::RecordedEventResult::Rejected
-        }
-        i_slint_core::api::WindowEventDispatchResult::Ignored => {
-            proto::RecordedEventResult::Ignored
         }
         _ => unreachable!(),
     }
@@ -1010,7 +1007,7 @@ fn test_event_log_filters_since_sequence_and_window() {
         proto::RecordedEvent {
             sequence: 2,
             window_handle: Some(index_to_handle(first_window)),
-            result: proto::RecordedEventResult::Ignored.into(),
+            result: proto::RecordedEventResult::Rejected.into(),
             ..Default::default()
         },
     ]);
@@ -1147,7 +1144,7 @@ fn test_accessibility_enum_mapping_complete() {
 
 // `WindowEventDispatchResult` honesty for pointer events: verify that
 // `Window::dispatch_event_with_result` reports `Accepted` only when an item consumed the
-// event, and `Ignored` otherwise. Tests install the window-event hook directly
+// event, and `Rejected` otherwise. Tests install the window-event hook directly
 // since that's the consumer the public contract is for. The same goes for the events the
 // backends deliver in the internal representation: they're reported as the public event they
 // correspond to, or not at all when there is none.
@@ -1155,11 +1152,10 @@ fn test_accessibility_enum_mapping_complete() {
 #[cfg(test)]
 mod dispatch_result_tests {
     use i_slint_core::api::LogicalPosition;
-    use i_slint_core::api::WindowEventDispatchResult;
     use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};
     use i_slint_core::items::PointerEventButton;
     use i_slint_core::lengths::LogicalPoint;
-    use i_slint_core::platform::{InternalEvent, WindowEvent};
+    use i_slint_core::platform::{InternalEvent, WindowEvent, WindowEventDispatchResult};
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -1237,7 +1233,7 @@ mod dispatch_result_tests {
     }
 
     #[test]
-    fn pointer_pressed_with_no_handler_is_ignored() {
+    fn pointer_pressed_with_no_handler_is_rejected() {
         crate::init_no_event_loop();
         slint::slint! {
             export component App inherits Window {
@@ -1253,7 +1249,7 @@ mod dispatch_result_tests {
                 position: LogicalPosition::new(50.0, 50.0),
                 button: PointerEventButton::Left,
             },
-            WindowEventDispatchResult::Ignored,
+            WindowEventDispatchResult::Rejected,
         );
     }
 
@@ -1401,7 +1397,7 @@ mod dispatch_result_tests {
                     ..Default::default()
                 })
             ),
-            vec![(WindowEvent::KeyPressRepeated { text }, WindowEventDispatchResult::Ignored)]
+            vec![(WindowEvent::KeyPressRepeated { text }, WindowEventDispatchResult::Rejected)]
         );
     }
 
@@ -1457,7 +1453,7 @@ mod dispatch_result_tests {
     }
 
     #[test]
-    fn pointer_scrolled_over_empty_area_is_ignored() {
+    fn pointer_scrolled_over_empty_area_is_rejected() {
         crate::init_no_event_loop();
         slint::slint! {
             export component App inherits Window {
@@ -1474,12 +1470,12 @@ mod dispatch_result_tests {
                 delta_x: 0.0,
                 delta_y: -30.0,
             },
-            WindowEventDispatchResult::Ignored,
+            WindowEventDispatchResult::Rejected,
         );
     }
 
     #[test]
-    fn pointer_moved_over_empty_area_is_ignored() {
+    fn pointer_moved_over_empty_area_is_rejected() {
         crate::init_no_event_loop();
         slint::slint! {
             export component App inherits Window {
@@ -1492,7 +1488,7 @@ mod dispatch_result_tests {
         assert_single_dispatch(
             app.window(),
             WindowEvent::PointerMoved { position: LogicalPosition::new(50.0, 50.0) },
-            WindowEventDispatchResult::Ignored,
+            WindowEventDispatchResult::Rejected,
         );
     }
 
@@ -1595,9 +1591,9 @@ mod dispatch_result_tests {
     }
 
     #[test]
-    fn pointer_released_at_end_of_drag_is_ignored_if_no_droparea_accepted() {
+    fn pointer_released_at_end_of_drag_is_rejected_if_no_droparea_accepted() {
         // Release is rewritten internally to `Exit` (no DropArea accepted the prior
-        // DragMove); the public PointerReleased reports Ignored.
+        // DragMove); the public PointerReleased reports Rejected.
         crate::init_no_event_loop();
         slint::slint! {
             export global Api {
@@ -1629,6 +1625,6 @@ mod dispatch_result_tests {
             .find(|(e, _)| matches!(e, WindowEvent::PointerReleased { .. }))
             .map(|(_, r)| r.clone())
             .expect("PointerReleased recorded");
-        assert_eq!(release, WindowEventDispatchResult::Ignored);
+        assert_eq!(release, WindowEventDispatchResult::Rejected);
     }
 }

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -516,7 +516,7 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "- ClickAction: SingleClick, DoubleClick\n",
                     "- ElementAccessibilityAction: Default_, Increment, Decrement, Expand\n",
                     "- KeyEventType: PressAndRelease, Press, Release\n",
-                    "- RecordedEventResult: Unspecified, Accepted, Rejected, Ignored (Unspecified appears only on malformed data)\n",
+                    "- RecordedEventResult: Unspecified, Accepted, Rejected (Unspecified appears only on malformed data)\n",
                     "- LayoutKind: NotALayout, HorizontalLayout, VerticalLayout, GridLayout, FlexboxLayout\n",
                     "Omitted enum fields default to the first value (e.g. Left, SingleClick, PressAndRelease).\n\n",
 

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -166,7 +166,6 @@ enum RecordedEventResult {
     Unspecified = 0;
     Accepted = 1;
     Rejected = 2;
-    Ignored = 3;
 }
 
 message ElementQueryInstruction {

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -8,6 +8,7 @@ This module contains types that are public and re-exported in the slint-rs as we
 #![warn(missing_docs)]
 
 use crate::input::{InternalKeyEvent, KeyEventType, MouseEvent, TouchPhase};
+use crate::platform::WindowEventDispatchResult;
 use crate::window::{WindowAdapter, WindowInner};
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -22,36 +23,6 @@ pub use crate::graphics::{
 pub use crate::input::Keys;
 pub use crate::sharedvector::SharedVector;
 pub use crate::{format, string::SharedString, string::ToSharedString};
-
-/// Result of dispatching a window event through Slint's runtime with [`Window::dispatch_event_with_result`].
-#[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
-pub enum WindowEventDispatchResult {
-    /// The event was handled. For example, a key handler consumed a key press, or
-    /// the window acted on a resize or close request.
-    Accepted,
-    /// The event was actively refused. For example, a `close-requested` callback
-    /// returned `reject` to prevent the window from closing.
-    Rejected,
-    /// The event was not handled by any element.
-    Ignored,
-}
-
-impl From<crate::input::KeyEventResult> for WindowEventDispatchResult {
-    fn from(value: crate::input::KeyEventResult) -> Self {
-        match value {
-            crate::input::KeyEventResult::EventAccepted => Self::Accepted,
-            crate::input::KeyEventResult::EventIgnored => Self::Ignored,
-        }
-    }
-}
-
-impl From<Option<crate::window::MouseDispatchResult>> for WindowEventDispatchResult {
-    /// `None` (no component to dispatch to) and `accepted: false` both map to `Ignored`.
-    fn from(value: Option<crate::window::MouseDispatchResult>) -> Self {
-        if value.is_some_and(|r| r.accepted) { Self::Accepted } else { Self::Ignored }
-    }
-}
 
 /// A position represented in the coordinate space of logical pixels. That is the space before applying
 /// a display device specific scale factor.

--- a/internal/core/context.rs
+++ b/internal/core/context.rs
@@ -18,7 +18,7 @@ use pin_weak::rc::PinWeak;
 /// Type alias for the closure type installed via [`set_window_event_hook`].
 /// Exposed so callers (notably tests) can save and restore a previously-installed hook.
 pub type WindowEventHook =
-    Box<dyn Fn(&Rc<dyn WindowAdapter>, &WindowEvent, crate::api::WindowEventDispatchResult)>;
+    Box<dyn Fn(&Rc<dyn WindowAdapter>, &WindowEvent, crate::platform::WindowEventDispatchResult)>;
 
 crate::thread_local! {
     pub(crate) static GLOBAL_CONTEXT : once_cell::unsync::OnceCell<SlintContext>

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -321,6 +321,35 @@ pub fn duration_until_next_timer_update() -> Option<core::time::Duration> {
 pub use crate::input::PointerEventButton;
 pub use crate::input::key_codes::Key;
 
+/// Result of dispatching a window event through Slint's runtime with
+/// [`Window::dispatch_event_with_result()`](crate::api::Window::dispatch_event_with_result).
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum WindowEventDispatchResult {
+    /// The event was handled. For example, a key handler consumed a key press, or
+    /// the window acted on a resize or close request.
+    Accepted,
+    /// The event wasn't handled: no element consumed it, or a handler actively refused it,
+    /// such as a `close-requested` callback returning `reject` to keep the window open.
+    Rejected,
+}
+
+impl From<crate::input::KeyEventResult> for WindowEventDispatchResult {
+    fn from(value: crate::input::KeyEventResult) -> Self {
+        match value {
+            crate::input::KeyEventResult::EventAccepted => Self::Accepted,
+            crate::input::KeyEventResult::EventIgnored => Self::Rejected,
+        }
+    }
+}
+
+impl From<Option<crate::window::MouseDispatchResult>> for WindowEventDispatchResult {
+    /// `None` (no component to dispatch to) and `accepted: false` both map to `Rejected`.
+    fn from(value: Option<crate::window::MouseDispatchResult>) -> Self {
+        if value.is_some_and(|r| r.accepted) { Self::Accepted } else { Self::Rejected }
+    }
+}
+
 /// A event that describes user input or windowing system events.
 ///
 /// Slint backends typically receive events from the windowing system, translate them to this
@@ -359,7 +388,7 @@ pub enum WindowEvent {
     },
     /// The pointer exited the window.
     ///
-    /// Always reported as [`Accepted`](crate::api::WindowEventDispatchResult::Accepted).
+    /// Always reported as [`Accepted`](WindowEventDispatchResult::Accepted).
     PointerExited,
     /// A key was pressed.
     KeyPressed {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1093,7 +1093,7 @@ impl WindowInner {
     ///
     /// Drag and drop is the one kind of input that backends don't deliver through
     /// [`crate::api::Window::dispatch_event_with_result()`]:
-    /// they need the negotiated action back, which [`crate::api::WindowEventDispatchResult`] can't express,
+    /// they need the negotiated action back, which [`crate::platform::WindowEventDispatchResult`] can't express,
     /// and a drag leaving the window isn't the pointer leaving the window.
     /// These events have no [`crate::platform::WindowEvent`] representation either,
     /// so nothing is lost for the window event hook.

--- a/tests/cases/elements/flickable_button_click.slint
+++ b/tests/cases/elements/flickable_button_click.slint
@@ -55,7 +55,7 @@ assert_eq!(instance.get_content_y(), 0.); // The flickable did not move
 
 ```rust
 use slint::*;
-use i_slint_core::api::WindowEventDispatchResult::*;
+use i_slint_core::platform::WindowEventDispatchResult::*;
 
 let instance = TestCase::new().unwrap();
 let window = instance.window();

--- a/tests/cases/elements/flickable_text_double_click.slint
+++ b/tests/cases/elements/flickable_text_double_click.slint
@@ -83,18 +83,18 @@ assert_eq!(cursor(), MouseCursorInner::BuiltIn(BuiltInMouseCursor::Text), "Curso
 
 ```rust
 use slint::*;
-use i_slint_core::api::WindowEventDispatchResult::*;
+use i_slint_core::platform::WindowEventDispatchResult::*;
 
 let instance = TestCase::new().unwrap();
 let window = instance.window();
 
 // No element has focus yet, all key events ignored
 let res = window.dispatch_event_with_result(platform::WindowEvent::KeyPressed { text: 'a'.into() });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 let res = window.dispatch_event_with_result(platform::WindowEvent::KeyPressRepeated { text: 'a'.into() });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 let res = window.dispatch_event_with_result(platform::WindowEvent::KeyReleased { text: 'a'.into() });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 
 // Click to focus the TextInput
 slint_testing::send_mouse_click(&instance, 50.0, 15.0);
@@ -108,6 +108,6 @@ assert_eq!(res.unwrap(), Accepted);
 
 // KeyReleased is always ignored
 let res = window.dispatch_event_with_result(platform::WindowEvent::KeyReleased { text: 'a'.into() });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 ```
 */

--- a/tests/cases/elements/popupwindow_size_fixed_layout .slint
+++ b/tests/cases/elements/popupwindow_size_fixed_layout .slint
@@ -220,16 +220,16 @@ assert.equal(instance.Properties.button_width, popup_width - 100);
 
 ```rust
 use slint::*;
-use i_slint_core::api::WindowEventDispatchResult::*;
+use i_slint_core::platform::WindowEventDispatchResult::*;
 
 let instance = TestCase::new().unwrap();
 let window = instance.window();
 
 // Base window has no interactive content
 let res = window.dispatch_event_with_result(platform::WindowEvent::PointerPressed { position: LogicalPosition::new(0., 0.), button: platform::PointerEventButton::Left });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 let res = window.dispatch_event_with_result(platform::WindowEvent::PointerReleased { position: LogicalPosition::new(0., 0.), button: platform::PointerEventButton::Left });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 
 // The popup button fills the full area while show-buttons is false
 instance.invoke_show_popup();
@@ -240,6 +240,6 @@ assert_eq!(res.unwrap(), Accepted);
 
 // Clicking below the popup, should be ignored
 let res = window.dispatch_event_with_result(platform::WindowEvent::PointerPressed { position: LogicalPosition::new(300., 350.), button: platform::PointerEventButton::Left });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 ```
 */

--- a/tests/cases/elements/window_actions.slint
+++ b/tests/cases/elements/window_actions.slint
@@ -167,7 +167,7 @@ assert(instance.win_full_screen);
 
 ```rust
 use slint::*;
-use i_slint_core::api::WindowEventDispatchResult::*;
+use i_slint_core::platform::WindowEventDispatchResult::*;
 
 let instance = TestCase::new().unwrap();
 let window = instance.window();
@@ -195,11 +195,11 @@ assert_eq!(res.unwrap(), Accepted);
 let res = window.dispatch_event_with_result(platform::WindowEvent::PointerExited);
 assert_eq!(res.unwrap(), Accepted);
 
-// Ignored for pointer/scroll
+// Rejected for pointer/scroll
 let pos = slint::LogicalPosition::new(200., 150.);
 let res = window.dispatch_event_with_result(platform::WindowEvent::PointerMoved { position: pos });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 let res = window.dispatch_event_with_result(platform::WindowEvent::PointerScrolled { position: pos, delta_x: 0., delta_y: -50. });
-assert_eq!(res.unwrap(), Ignored);
+assert_eq!(res.unwrap(), Rejected);
 ```
 */


### PR DESCRIPTION
The enum now sits next to WindowEvent, where backends look for it.

Drop the Ignored variant. To a backend, an event that nothing handled and one that a handler refused mean the same thing, so Rejected covers both.

The Node.js port follows: the enum moves into the platform namespace, and the docs sidebar now lists that namespace's enums. RecordedEventResult in the system testing protocol loses its Ignored value too, since nothing can produce it any more.

cc #13066

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
