### PR TITLE
core: Keep WindowEvent Send and Sync

### DIFF
--- a/api/cpp/cbindgen.rs
+++ b/api/cpp/cbindgen.rs
@@ -740,7 +740,7 @@ fn gen_corelib(
             }",
         ),
         (
-            vec!["MouseEvent", "TouchPhase"],
+            vec!["MouseEvent", "BackendMouseEvent", "TouchPhase"],
             "slint_events_internal.h",
             "#include \"private/slint_point.h\"
             #include \"private/slint_builtin_structs_internal.h\"
@@ -1056,6 +1056,7 @@ namespace slint {
         struct ItemVTable;
         using types::IntRect;
         using types::Size;
+        using types::BackendMouseEvent;
         using types::MouseEvent;
 
         template<typename T> struct Option;

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -310,7 +310,7 @@ public:
     }
 
     /// Send a pointer event to this window
-    void dispatch_pointer_event(const cbindgen_private::MouseEvent &event)
+    void dispatch_pointer_event(const cbindgen_private::BackendMouseEvent &event)
     {
         private_api::assert_main_thread();
         cbindgen_private::slint_windowrc_dispatch_pointer_event(&inner, &event);
@@ -582,8 +582,8 @@ public:
     void dispatch_pointer_press_event(LogicalPosition pos, PointerEventButton button)
     {
         private_api::assert_main_thread();
-        inner.dispatch_pointer_event(
-                slint::cbindgen_private::MouseEvent::Pressed({ pos.x, pos.y }, button, 0, 0));
+        inner.dispatch_pointer_event(slint::cbindgen_private::BackendMouseEvent::Pressed(
+                { pos.x, pos.y }, button, 0, 0));
     }
     /// Dispatches a pointer or mouse release event to the scene.
     ///
@@ -595,8 +595,8 @@ public:
     void dispatch_pointer_release_event(LogicalPosition pos, PointerEventButton button)
     {
         private_api::assert_main_thread();
-        inner.dispatch_pointer_event(
-                slint::cbindgen_private::MouseEvent::Released({ pos.x, pos.y }, button, 0, 0));
+        inner.dispatch_pointer_event(slint::cbindgen_private::BackendMouseEvent::Released(
+                { pos.x, pos.y }, button, 0, 0));
     }
     /// Dispatches a pointer exit event to the scene.
     ///
@@ -607,7 +607,7 @@ public:
     void dispatch_pointer_exit_event()
     {
         private_api::assert_main_thread();
-        inner.dispatch_pointer_event(slint::cbindgen_private::MouseEvent::Exit());
+        inner.dispatch_pointer_event(slint::cbindgen_private::BackendMouseEvent::Exit());
     }
 
     /// Dispatches a pointer move event to the scene.
@@ -620,7 +620,7 @@ public:
     {
         private_api::assert_main_thread();
         inner.dispatch_pointer_event(
-                slint::cbindgen_private::MouseEvent::Moved({ pos.x, pos.y }, 0));
+                slint::cbindgen_private::BackendMouseEvent::Moved({ pos.x, pos.y }, 0));
     }
 
     /// Dispatches a scroll (or wheel) event to the scene.
@@ -638,7 +638,7 @@ public:
                                                slint::cbindgen_private::types::TouchPhase::Moved)
     {
         private_api::assert_main_thread();
-        inner.dispatch_pointer_event(slint::cbindgen_private::MouseEvent::Wheel(
+        inner.dispatch_pointer_event(slint::cbindgen_private::BackendMouseEvent::Wheel(
                 { pos.x, pos.y }, delta_x, delta_y, scroll_phase));
     }
 

--- a/docs/development/input-event-system.md
+++ b/docs/development/input-event-system.md
@@ -39,6 +39,9 @@ Slint's input system handles mouse, touch, keyboard events and focus management.
   with a position, a delta and a `TouchPhase`
 - `Exit`, when the pointer leaves the item
 
+A backend dispatches a `BackendMouseEvent`: the same variants without `DragMove` and `Drop`,
+so that `WindowEvent` stays `Send` and `Sync`.
+
 ### Click Counting
 
 `ClickState` (`internal/core/input.rs`) tracks multi-clicks (double-click, triple-click) by
@@ -71,7 +74,7 @@ remembering the timestamp, count, position and button of the last press.
 
 Every event a backend delivers goes through `Window::dispatch_event_with_result()`.
 Events that the public `WindowEvent` variants can't express travel as `WindowEvent::Internal(InternalEvent)`,
-a doc-hidden variant that carries the runtime's own `MouseEvent`, `InternalKeyEvent` or touch point.
+a doc-hidden variant that carries the runtime's own `BackendMouseEvent`, `InternalKeyEvent` or touch point.
 The dispatch reports them to the window event hook as the public event they correspond to,
 or not at all when there is none (gestures, touch, input method composition).
 
@@ -79,6 +82,9 @@ or not at all when there is none (gestures, touch, input method composition).
 so backends can't bypass that funnel and each event is observed exactly once.
 Drag and drop is the exception: it uses `WindowInner::process_drag_event()`,
 because the backend needs the negotiated `DragAction` back, which the public dispatch result can't express.
+`WindowEvent` can't carry it anyway, being `Send` and `Sync` while the dragged payload is
+reference counted.
+That entry point takes a `BackendDragEvent`, so drag and drop is the only input that can travel it.
 
 ### Mouse Event Flow
 

--- a/internal/backends/qt/qt_window.rs
+++ b/internal/backends/qt/qt_window.rs
@@ -14,7 +14,9 @@ use i_slint_core::graphics::{
     Brush, Color, ImageCacheKey, IntRect, Point, Rgba8Pixel, SharedImageBuffer, SharedPixelBuffer,
     euclid,
 };
-use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};
+use i_slint_core::input::{
+    BackendDragEvent, BackendMouseEvent, InternalKeyEvent, KeyEvent, KeyEventType, TouchPhase,
+};
 use i_slint_core::item_rendering::{
     CachedRenderingData, ItemCache, ItemRenderer, RenderBorderRectangle, RenderImage,
     RenderRectangle, RenderText,
@@ -209,7 +211,7 @@ cpp! {{
             rust!(Slint_mousePressEvent [rust_window: &QtWindow as "void*", pos: qttypes::QPoint as "QPoint", button: u32 as "int" ] {
                 let position = LogicalPoint::new(pos.x as _, pos.y as _);
                 let button = from_qt_button(button);
-                rust_window.mouse_event(MouseEvent::Pressed{ position, button, click_count: 0, touch_finger_id: 0 })
+                rust_window.mouse_event(BackendMouseEvent::Pressed{ position, button, click_count: 0, touch_finger_id: 0 })
             });
         }
         void mouseReleaseEvent(QMouseEvent *event) override {
@@ -239,7 +241,7 @@ cpp! {{
             rust!(Slint_mouseReleaseEvent [rust_window: &QtWindow as "void*", pos: qttypes::QPoint as "QPoint", button: u32 as "int" ] {
                 let position = LogicalPoint::new(pos.x as _, pos.y as _);
                 let button = from_qt_button(button);
-                rust_window.mouse_event(MouseEvent::Released{ position, button, click_count: 0, touch_finger_id: 0 })
+                rust_window.mouse_event(BackendMouseEvent::Released{ position, button, click_count: 0, touch_finger_id: 0 })
             });
         }
         void mouseMoveEvent(QMouseEvent *event) override {
@@ -248,7 +250,7 @@ cpp! {{
                 return;
             rust!(Slint_mouseMoveEvent [rust_window: &QtWindow as "void*", pos: qttypes::QPoint as "QPoint"] {
                 let position = LogicalPoint::new(pos.x as _, pos.y as _);
-                rust_window.mouse_event(MouseEvent::Moved{position, touch_finger_id: 0})
+                rust_window.mouse_event(BackendMouseEvent::Moved{position, touch_finger_id: 0})
             });
         }
         void wheelEvent(QWheelEvent *event) override {
@@ -275,14 +277,14 @@ cpp! {{
                         TouchPhase::Cancelled
                     },
                 };
-                rust_window.mouse_event(MouseEvent::Wheel{position, delta_x: delta.x as _, delta_y: delta.y as _, phase})
+                rust_window.mouse_event(BackendMouseEvent::Wheel{position, delta_x: delta.x as _, delta_y: delta.y as _, phase})
             });
         }
         void leaveEvent(QEvent *) override {
             if (!rust_window)
                 return;
             rust!(Slint_mouseLeaveEvent [rust_window: &QtWindow as "void*"] {
-                rust_window.mouse_event(MouseEvent::Exit)
+                rust_window.mouse_event(BackendMouseEvent::Exit)
             });
         }
 
@@ -534,7 +536,7 @@ cpp! {{
                             2 => i_slint_core::input::TouchPhase::Ended,
                             _ => i_slint_core::input::TouchPhase::Cancelled,
                         };
-                        rust_window.mouse_event(MouseEvent::PinchGesture {
+                        rust_window.mouse_event(BackendMouseEvent::PinchGesture {
                             position, delta: scale_delta, phase,
                         });
                         if rotation_delta != 0.0 || matches!(phase,
@@ -542,7 +544,7 @@ cpp! {{
                             | i_slint_core::input::TouchPhase::Ended
                             | i_slint_core::input::TouchPhase::Cancelled)
                         {
-                            rust_window.mouse_event(MouseEvent::RotationGesture {
+                            rust_window.mouse_event(BackendMouseEvent::RotationGesture {
                                 position, delta: rotation_delta, phase,
                             });
                         }
@@ -2151,7 +2153,7 @@ impl QtWindow {
         });
     }
 
-    fn mouse_event(&self, event: MouseEvent) {
+    fn mouse_event(&self, event: BackendMouseEvent) {
         self.window.dispatch_event(WindowEvent::internal(event));
         timer_event();
     }
@@ -2159,7 +2161,7 @@ impl QtWindow {
     /// A drag left the window: tear down the hover state like a pointer exit,
     /// but off the `dispatch_event` path, so that it isn't observed as the pointer leaving the window.
     fn drag_leave_event(&self) {
-        WindowInner::from_pub(&self.window).process_drag_event(MouseEvent::Exit);
+        WindowInner::from_pub(&self.window).process_drag_event(BackendDragEvent::Leave);
         timer_event();
     }
 
@@ -2204,12 +2206,12 @@ impl QtWindow {
         drop_event.data = data;
         drop_event.position = position;
         drop_event.proposed_action = qt_drop_action_to_slint(proposed);
-        let mouse_event = if is_drop {
-            MouseEvent::Drop { event: drop_event, allowed: allowed_actions }
+        let drag_event = if is_drop {
+            BackendDragEvent::Drop { event: drop_event, allowed: allowed_actions }
         } else {
-            MouseEvent::DragMove { event: drop_event, allowed: allowed_actions }
+            BackendDragEvent::Move { event: drop_event, allowed: allowed_actions }
         };
-        let chosen = WindowInner::from_pub(&self.window).process_drag_event(mouse_event);
+        let chosen = WindowInner::from_pub(&self.window).process_drag_event(drag_event);
         timer_event();
         chosen.map(slint_drag_action_to_qt).unwrap_or(key_generated::Qt_DropAction_IgnoreAction)
     }

--- a/internal/backends/testing/internal_tests.rs
+++ b/internal/backends/testing/internal_tests.rs
@@ -6,7 +6,7 @@
 use crate::TestingWindow;
 use i_slint_core::SharedString;
 use i_slint_core::api::ComponentHandle;
-pub use i_slint_core::input::MouseEvent;
+pub use i_slint_core::input::BackendMouseEvent;
 pub use i_slint_core::input::TouchPhase;
 use i_slint_core::item_tree::ItemTreeVTable;
 pub use i_slint_core::lengths::LogicalPoint;
@@ -146,7 +146,7 @@ pub fn send_pinch_gesture<
     phase: i_slint_core::input::TouchPhase,
 ) {
     component.window().dispatch_event(WindowEvent::internal(
-        i_slint_core::input::MouseEvent::PinchGesture {
+        i_slint_core::input::BackendMouseEvent::PinchGesture {
             position: i_slint_core::lengths::logical_point_from_api(
                 i_slint_core::api::LogicalPosition::new(center_x, center_y),
             ),
@@ -171,7 +171,7 @@ pub fn send_rotation_gesture<
     phase: i_slint_core::input::TouchPhase,
 ) {
     component.window().dispatch_event(WindowEvent::internal(
-        i_slint_core::input::MouseEvent::RotationGesture {
+        i_slint_core::input::BackendMouseEvent::RotationGesture {
             position: i_slint_core::lengths::logical_point_from_api(
                 i_slint_core::api::LogicalPosition::new(center_x, center_y),
             ),

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -1158,7 +1158,9 @@ fn test_accessibility_enum_mapping_complete() {
 #[cfg(test)]
 mod dispatch_result_tests {
     use i_slint_core::api::LogicalPosition;
-    use i_slint_core::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};
+    use i_slint_core::input::{
+        BackendMouseEvent, InternalKeyEvent, KeyEvent, KeyEventType, TouchPhase,
+    };
     use i_slint_core::items::PointerEventButton;
     use i_slint_core::lengths::LogicalPoint;
     use i_slint_core::platform::{InternalEvent, WindowEvent, WindowEventDispatchResult};
@@ -1347,7 +1349,7 @@ mod dispatch_result_tests {
         assert_eq!(
             record_dispatch(
                 app.window(),
-                WindowEvent::internal(MouseEvent::Pressed {
+                WindowEvent::internal(BackendMouseEvent::Pressed {
                     position: LogicalPoint::new(50.0, 50.0),
                     button: PointerEventButton::Left,
                     click_count: 0,
@@ -1375,7 +1377,7 @@ mod dispatch_result_tests {
         }
         let app = App::new().unwrap();
         assert_eq!(
-            record_dispatch(app.window(), WindowEvent::internal(MouseEvent::Exit)),
+            record_dispatch(app.window(), WindowEvent::internal(BackendMouseEvent::Exit)),
             vec![(WindowEvent::PointerExited, WindowEventDispatchResult::Accepted)]
         );
     }

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -17,7 +17,7 @@ use i_slint_core::window::{
 
 use i_slint_core::SharedString;
 use i_slint_core::api::LogicalPosition;
-use i_slint_core::input::MouseEvent;
+use i_slint_core::input::BackendDragEvent;
 use i_slint_core::items::{AllowedDragActions, DragAction, DropEvent, TextWrap};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -397,9 +397,9 @@ impl TestingWindow {
         event.proposed_action =
             i_slint_core::items::compute_proposed_action(Default::default(), allowed);
         let event = if drop {
-            MouseEvent::Drop { event, allowed }
+            BackendDragEvent::Drop { event, allowed }
         } else {
-            MouseEvent::DragMove { event, allowed }
+            BackendDragEvent::Move { event, allowed }
         };
         WindowInner::from_pub(target).process_drag_event(event).unwrap_or(DragAction::None)
     }

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -402,7 +402,7 @@ impl BackendBuilder {
 fn dispatch_mouse_move(window: &Weak<WinitWindowAdapter>, position: LogicalPoint) {
     if let Some(window) = window.upgrade() {
         window.window().dispatch_event(i_slint_core::platform::WindowEvent::internal(
-            i_slint_core::input::MouseEvent::Moved { position, touch_finger_id: 0 },
+            i_slint_core::input::BackendMouseEvent::Moved { position, touch_finger_id: 0 },
         ));
     }
 }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -34,7 +34,7 @@ use crate::renderer::WinitCompatibleRenderer;
 use crate::winit_compat::WindowSurfaceSizeExt;
 
 use corelib::SharedString;
-use corelib::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent};
+use corelib::input::{BackendMouseEvent, InternalKeyEvent, KeyEvent, KeyEventType};
 use corelib::item_tree::ItemTreeRc;
 #[cfg(enable_accesskit)]
 use corelib::item_tree::{ItemTreeRef, ItemTreeRefPin};
@@ -1399,7 +1399,7 @@ impl WinitWindowAdapter {
                 // On the html canvas, we don't get the mouse move or release event when outside the canvas. So we have no choice but canceling the event
                 if cfg!(target_arch = "wasm32") || !self.pressed.get() {
                     self.pressed.set(false);
-                    self.dispatch_internal_event(MouseEvent::Exit);
+                    self.dispatch_internal_event(BackendMouseEvent::Exit);
                 }
             }
             WinitWindowEvent::MouseWheel { delta, phase, .. } => {
@@ -1411,7 +1411,7 @@ impl WinitWindowAdapter {
                     }
                 };
                 let phase = winit_touch_phase(phase);
-                self.dispatch_internal_event(MouseEvent::Wheel {
+                self.dispatch_internal_event(BackendMouseEvent::Wheel {
                     position: self.cursor_pos.get(),
                     delta_x,
                     delta_y,
@@ -1437,7 +1437,7 @@ impl WinitWindowAdapter {
                         }
 
                         self.pressed.set(true);
-                        MouseEvent::Pressed {
+                        BackendMouseEvent::Pressed {
                             position: self.cursor_pos.get(),
                             button,
                             click_count: 0,
@@ -1446,7 +1446,7 @@ impl WinitWindowAdapter {
                     }
                     winit::event::ElementState::Released => {
                         self.pressed.set(false);
-                        MouseEvent::Released {
+                        BackendMouseEvent::Released {
                             position: self.cursor_pos.get(),
                             button,
                             click_count: 0,
@@ -1511,7 +1511,7 @@ impl WinitWindowAdapter {
             // known cursor position as the best available approximation. On macOS
             // trackpads, CursorMoved events typically precede gesture events.
             WinitWindowEvent::PinchGesture { delta, phase, .. } => {
-                self.dispatch_internal_event(MouseEvent::PinchGesture {
+                self.dispatch_internal_event(BackendMouseEvent::PinchGesture {
                     position: self.cursor_pos.get(),
                     delta: delta as f32,
                     phase: winit_touch_phase(phase),
@@ -1520,7 +1520,7 @@ impl WinitWindowAdapter {
             WinitWindowEvent::RotationGesture { delta, phase, .. } => {
                 // macOS/winit: positive = counterclockwise. Negate to match
                 // Slint convention (positive = clockwise).
-                self.dispatch_internal_event(MouseEvent::RotationGesture {
+                self.dispatch_internal_event(BackendMouseEvent::RotationGesture {
                     position: self.cursor_pos.get(),
                     delta: -delta,
                     phase: winit_touch_phase(phase),

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -7,7 +7,7 @@ This module contains types that are public and re-exported in the slint-rs as we
 
 #![warn(missing_docs)]
 
-use crate::input::{InternalKeyEvent, KeyEventType, MouseEvent, TouchPhase};
+use crate::input::{BackendMouseEvent, InternalKeyEvent, KeyEventType, MouseEvent, TouchPhase};
 use crate::platform::WindowEventDispatchResult;
 use crate::window::{WindowAdapter, WindowInner};
 use alloc::boxed::Box;
@@ -763,13 +763,13 @@ impl Window {
                 WindowEventDispatchResult::Accepted
             }
             crate::platform::WindowEvent::Internal(event) => match event.into_inner() {
-                crate::platform::InternalEvent::Mouse(MouseEvent::Exit) => {
+                crate::platform::InternalEvent::Mouse(BackendMouseEvent::Exit) => {
                     // Teardown event, always accepted like `WindowEvent::PointerExited`.
                     self.0.process_mouse_input(MouseEvent::Exit);
                     WindowEventDispatchResult::Accepted
                 }
                 crate::platform::InternalEvent::Mouse(event) => {
-                    self.0.process_mouse_input(event).into()
+                    self.0.process_mouse_input(event.into()).into()
                 }
                 crate::platform::InternalEvent::Key(event) => {
                     self.0.process_key_input(event).into()

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -200,6 +200,86 @@ impl MouseEvent {
     }
 }
 
+/// The mouse events a backend can deliver to the runtime.
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BackendMouseEvent {
+    /// The mouse or finger was pressed
+    Pressed {
+        position: LogicalPoint,
+        button: PointerEventButton,
+        click_count: u8,
+        touch_finger_id: i32,
+    },
+    /// The mouse or finger was released
+    Released {
+        position: LogicalPoint,
+        button: PointerEventButton,
+        click_count: u8,
+        touch_finger_id: i32,
+    },
+    /// The position of the pointer has changed
+    Moved { position: LogicalPoint, touch_finger_id: i32 },
+    /// Wheel was operated.
+    Wheel { position: LogicalPoint, delta_x: Coord, delta_y: Coord, phase: TouchPhase },
+    /// A platform-recognized pinch gesture (macOS/iOS trackpad, Qt).
+    PinchGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
+    /// A platform-recognized rotation gesture (macOS/iOS trackpad, Qt).
+    RotationGesture { position: LogicalPoint, delta: f32, phase: TouchPhase },
+    /// The mouse exited the item or component
+    Exit,
+}
+
+impl From<BackendMouseEvent> for MouseEvent {
+    fn from(event: BackendMouseEvent) -> Self {
+        match event {
+            BackendMouseEvent::Pressed { position, button, click_count, touch_finger_id } => {
+                Self::Pressed { position, button, click_count, touch_finger_id }
+            }
+            BackendMouseEvent::Released { position, button, click_count, touch_finger_id } => {
+                Self::Released { position, button, click_count, touch_finger_id }
+            }
+            BackendMouseEvent::Moved { position, touch_finger_id } => {
+                Self::Moved { position, touch_finger_id }
+            }
+            BackendMouseEvent::Wheel { position, delta_x, delta_y, phase } => {
+                Self::Wheel { position, delta_x, delta_y, phase }
+            }
+            BackendMouseEvent::PinchGesture { position, delta, phase } => {
+                Self::PinchGesture { position, delta, phase }
+            }
+            BackendMouseEvent::RotationGesture { position, delta, phase } => {
+                Self::RotationGesture { position, delta, phase }
+            }
+            BackendMouseEvent::Exit => Self::Exit,
+        }
+    }
+}
+
+/// The drag and drop events a backend can deliver, through [`WindowInner::process_drag_event`].
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq)]
+pub enum BackendDragEvent {
+    /// A drag is hovering over the window.
+    Move { event: DropEvent, allowed: AllowedDragActions },
+    /// A drag was released over the window.
+    Drop { event: DropEvent, allowed: AllowedDragActions },
+    /// A drag left the window, or was cancelled while hovering over it.
+    Leave,
+}
+
+impl From<BackendDragEvent> for MouseEvent {
+    fn from(event: BackendDragEvent) -> Self {
+        match event {
+            BackendDragEvent::Move { event, allowed } => Self::DragMove { event, allowed },
+            BackendDragEvent::Drop { event, allowed } => Self::Drop { event, allowed },
+            // A drag leaving tears down the hover state the same way the pointer leaving does.
+            BackendDragEvent::Leave => Self::Exit,
+        }
+    }
+}
+
 /// Phase of a touch, gesture event or wheel event.
 /// A touchpad is recognized as wheel event and therefore
 /// we need to find out when the touch event starts and ends

--- a/internal/core/platform.rs
+++ b/internal/core/platform.rs
@@ -492,6 +492,20 @@ impl WindowEvent {
 #[repr(transparent)]
 pub struct InternalEventBox(core::ptr::NonNull<InternalEvent>);
 
+// Safety: the box exclusively owns the event it points to, which the assertion below keeps
+// `Send` and `Sync`.
+#[allow(unsafe_code)]
+unsafe impl Send for InternalEventBox {}
+#[allow(unsafe_code)]
+unsafe impl Sync for InternalEventBox {}
+
+// A backend may build events on one thread and dispatch them from the event loop's thread.
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<WindowEvent>();
+    assert_send_sync::<InternalEvent>();
+};
+
 #[allow(unsafe_code)]
 impl InternalEventBox {
     fn new(event: InternalEvent) -> Self {
@@ -555,9 +569,8 @@ impl core::fmt::Debug for InternalEventBox {
 #[doc(hidden)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum InternalEvent {
-    /// A pointer event, including the ones that have no public representation,
-    /// such as gestures and drag and drop.
-    Mouse(crate::input::MouseEvent),
+    /// A pointer event, including the ones that have no public representation, such as gestures.
+    Mouse(crate::input::BackendMouseEvent),
     /// A key event, including input method composition updates.
     Key(crate::input::InternalKeyEvent),
     /// A touch point update, which the runtime turns into pointer or gesture events.
@@ -571,8 +584,8 @@ pub enum InternalEvent {
     },
 }
 
-impl From<crate::input::MouseEvent> for InternalEvent {
-    fn from(event: crate::input::MouseEvent) -> Self {
+impl From<crate::input::BackendMouseEvent> for InternalEvent {
+    fn from(event: crate::input::BackendMouseEvent) -> Self {
         Self::Mouse(event)
     }
 }
@@ -589,38 +602,38 @@ impl InternalEvent {
     /// This is what the window event hook observes,
     /// so that hooks only ever see events they could dispatch themselves.
     /// Events without a public representation aren't reported:
-    /// gestures, drag and drop, touch and input method composition.
+    /// gestures, touch and input method composition.
     pub(crate) fn public_representation(&self) -> Option<WindowEvent> {
-        use crate::input::{KeyEventType, MouseEvent};
+        use crate::input::{BackendMouseEvent, KeyEventType};
         use crate::lengths::logical_position_to_api;
 
         match self {
             Self::Mouse(event) => match event {
-                MouseEvent::Pressed { position, button, .. } => Some(WindowEvent::PointerPressed {
-                    position: logical_position_to_api(*position),
-                    button: *button,
-                }),
-                MouseEvent::Released { position, button, .. } => {
+                BackendMouseEvent::Pressed { position, button, .. } => {
+                    Some(WindowEvent::PointerPressed {
+                        position: logical_position_to_api(*position),
+                        button: *button,
+                    })
+                }
+                BackendMouseEvent::Released { position, button, .. } => {
                     Some(WindowEvent::PointerReleased {
                         position: logical_position_to_api(*position),
                         button: *button,
                     })
                 }
-                MouseEvent::Moved { position, .. } => {
+                BackendMouseEvent::Moved { position, .. } => {
                     Some(WindowEvent::PointerMoved { position: logical_position_to_api(*position) })
                 }
-                MouseEvent::Wheel { position, delta_x, delta_y, .. } => {
+                BackendMouseEvent::Wheel { position, delta_x, delta_y, .. } => {
                     Some(WindowEvent::PointerScrolled {
                         position: logical_position_to_api(*position),
                         delta_x: *delta_x as f32,
                         delta_y: *delta_y as f32,
                     })
                 }
-                MouseEvent::Exit => Some(WindowEvent::PointerExited),
-                MouseEvent::DragMove { .. }
-                | MouseEvent::Drop { .. }
-                | MouseEvent::PinchGesture { .. }
-                | MouseEvent::RotationGesture { .. } => None,
+                BackendMouseEvent::Exit => Some(WindowEvent::PointerExited),
+                BackendMouseEvent::PinchGesture { .. }
+                | BackendMouseEvent::RotationGesture { .. } => None,
             },
             Self::Key(event) => {
                 let text = event.key_event.text.clone();
@@ -642,7 +655,9 @@ impl InternalEvent {
     /// The position of the pointer or finger for this event, if any.
     fn position(&self) -> Option<LogicalPosition> {
         match self {
-            Self::Mouse(event) => event.position().map(crate::lengths::logical_position_to_api),
+            Self::Mouse(event) => crate::input::MouseEvent::from(*event)
+                .position()
+                .map(crate::lengths::logical_position_to_api),
             Self::Key(_) => None,
             Self::Touch { position, .. } => {
                 Some(crate::lengths::logical_position_to_api(*position))

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -11,9 +11,9 @@ use crate::api::{
 };
 use crate::cursor::MouseCursorInner;
 use crate::input::{
-    ClickState, DragData, FocusEvent, FocusReason, InternalKeyEvent, KeyEventResult, KeyEventType,
-    Keys, MouseEvent, MouseInputState, PointerEventButton, TextCursorBlinker, TouchPhase,
-    TouchState, key_codes,
+    BackendDragEvent, ClickState, DragData, FocusEvent, FocusReason, InternalKeyEvent,
+    KeyEventResult, KeyEventType, Keys, MouseEvent, MouseInputState, PointerEventButton,
+    TextCursorBlinker, TouchPhase, TouchState, key_codes,
 };
 use crate::item_tree::{
     ItemRc, ItemTreeRc, ItemTreeRef, ItemTreeRefPin, ItemTreeVTable, ItemTreeWeak, ItemWeak,
@@ -1087,22 +1087,17 @@ impl WindowInner {
         Some(MouseDispatchResult { drag_action, accepted })
     }
 
-    /// Dispatch a drag and drop event: a `DragMove`, a `Drop`,
-    /// or the `Exit` that ends a drag hovering over the window.
+    /// Dispatch a drag and drop event.
     /// Returns the action negotiated with the accepting `DropArea`, or `None` when none accepted.
     ///
     /// Drag and drop is the one kind of input that backends don't deliver through
     /// [`crate::api::Window::dispatch_event_with_result()`]:
     /// they need the negotiated action back, which [`crate::platform::WindowEventDispatchResult`] can't express,
     /// and a drag leaving the window isn't the pointer leaving the window.
-    /// These events have no [`crate::platform::WindowEvent`] representation either,
-    /// so nothing is lost for the window event hook.
-    pub fn process_drag_event(&self, event: MouseEvent) -> Option<crate::items::DragAction> {
-        debug_assert!(matches!(
-            event,
-            MouseEvent::DragMove { .. } | MouseEvent::Drop { .. } | MouseEvent::Exit
-        ));
-        self.process_mouse_input(event).and_then(|result| result.drag_action)
+    /// [`BackendDragEvent`] keeps this entry point to drag and drop,
+    /// so that nothing else bypasses the window event hook.
+    pub fn process_drag_event(&self, event: BackendDragEvent) -> Option<crate::items::DragAction> {
+        self.process_mouse_input(event.into()).and_then(|result| result.drag_action)
     }
 
     /// Remember (or clear) the in-flight native drag, so a backend can report completion or fall
@@ -2993,13 +2988,11 @@ pub mod ffi {
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_dispatch_pointer_event(
         handle: *const WindowAdapterRcOpaque,
-        event: &crate::input::MouseEvent,
+        event: &crate::input::BackendMouseEvent,
     ) {
         unsafe {
             let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
-            window_adapter
-                .window()
-                .dispatch_event(crate::platform::WindowEvent::internal(event.clone()));
+            window_adapter.window().dispatch_event(crate::platform::WindowEvent::internal(*event));
         }
     }
 

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -258,12 +258,12 @@ if !cfg!(target_os = "macos") {
 // Test 2b
 // Standalone wheel move events animate without a synthetic settle callback
 use slint::platform::WindowEvent;
-use slint_testing::{LogicalPoint, MouseEvent, TouchPhase};
+use slint_testing::{LogicalPoint, BackendMouseEvent, TouchPhase};
 let instance = TestCase::new().unwrap();
 let window = instance.window();
 
 assert_eq!(instance.get_flicked(), 0);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel {
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel {
     position: LogicalPoint::new(175., 175.),
     delta_x: -30.,
     delta_y: -50.,

--- a/tests/cases/elements/listview_differing_heights.slint
+++ b/tests/cases/elements/listview_differing_heights.slint
@@ -42,7 +42,7 @@ export component Test inherits Window {
 
 ```rust
 use slint::{platform::PointerEventButton, platform::WindowEvent, LogicalPosition};
-use slint_testing::{LogicalPoint, MouseEvent, TouchPhase};
+use slint_testing::{LogicalPoint, BackendMouseEvent, TouchPhase};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ScrollDirection {
@@ -93,7 +93,7 @@ let send_moved_event = |x, y| {
 };
 
 let send_wheel_event = |delta_y, phase| {
-    send_event(WindowEvent::internal(MouseEvent::Wheel {
+    send_event(WindowEvent::internal(BackendMouseEvent::Wheel {
         position: scroll_position,
         delta_x: 0.0,
         delta_y,

--- a/tests/cases/elements/listview_scroll_touch_pad.slint
+++ b/tests/cases/elements/listview_scroll_touch_pad.slint
@@ -34,7 +34,7 @@ export component TestCase inherits Window {
 // Because we move with the mouse only straight up
 use slint::*;
 use slint::platform::WindowEvent;
-use slint_testing::{MouseEvent, TouchPhase, LogicalPoint};
+use slint_testing::{BackendMouseEvent, TouchPhase, LogicalPoint};
 
 let instance = TestCase::new().unwrap();
 let window = instance.window();
@@ -43,18 +43,18 @@ assert!(instance.get_content_height() > instance.get_height_(), "{} > {} not ful
 
 // // Scroll down
 let pressed_position = LogicalPoint::new(0., 0.);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(1);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(10000); // No animation shall be triggered
 assert_eq!(instance.get_content_y(), -10.);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Moved })); // To reduce the delta t
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Moved })); // To reduce the delta t
 slint_testing::mock_elapsed_time(5);
 assert_eq!(instance.get_content_y(), -10.);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -10., phase: TouchPhase::Moved }));
 assert_eq!(instance.get_content_y(), -20.);
 slint_testing::mock_elapsed_time(5);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 slint_testing::mock_elapsed_time(10000000); // Let the animation finish
 assert!(instance.get_content_y() < -20., "Received: {}, Desired: smaller than {}", instance.get_content_y(), -20.);
 
@@ -62,14 +62,14 @@ let content_y = instance.get_content_y();
 println!("Viewport y: {}", content_y);
 
 // // Scroll up again until the limit
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(1);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 10., phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 10., phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(10000); // No animation shall be triggered
 assert!(instance.get_content_y() == content_y + 10., "Received: {}, Desired: {}", instance.get_content_y(),content_y + 10.);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 100., phase: TouchPhase::Moved })); // To reduce the delta t
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 100., phase: TouchPhase::Moved })); // To reduce the delta t
 slint_testing::mock_elapsed_time(1);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 slint_testing::mock_elapsed_time(10000); // Let the animation finish
 assert!(instance.get_content_y() == 0., "Received: {}, Desired: {}", instance.get_content_y(), 0.);
 ```
@@ -77,7 +77,7 @@ assert!(instance.get_content_y() == 0., "Received: {}, Desired: {}", instance.ge
 ```rust
 // Testing that the application does not crash when flicking with the mouse wheel and an animation is applied
 use slint::*;
-use slint_testing::{MouseEvent, TouchPhase, LogicalPoint};
+use slint_testing::{BackendMouseEvent, TouchPhase, LogicalPoint};
 use slint::{platform::WindowEvent, LogicalPosition};
 
 let instance = TestCase::new().unwrap();
@@ -87,32 +87,32 @@ assert!(instance.get_content_height() > instance.get_height_(), "{} > {} not ful
 
 // Scroll down
 let pressed_position = LogicalPoint::new(0., 0.);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(12);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -47.164063, phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -47.164063, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(14);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -43.35547, phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -43.35547, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(8);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.625, phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.625, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(21);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -37.003906, phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -37.003906, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(0);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.441406, phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -44.441406, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(4);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -38.45703, phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -38.45703, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(34);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -19.953125, phase: TouchPhase::Moved }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: -19.953125, phase: TouchPhase::Moved }));
 slint_testing::mock_elapsed_time(0);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 
 slint_testing::mock_elapsed_time(362);
 
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(300.0, 100.0) }); // This move is required to trigger a ensure_updated_listview()
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Started }));
 slint_testing::mock_elapsed_time(12);
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 42.085938, phase: TouchPhase::Moved })); // Going up again
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 42.085938, phase: TouchPhase::Moved })); // Going up again
 slint_testing::mock_elapsed_time(10000); // No animation shall be triggered
-window.dispatch_event(WindowEvent::internal(MouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
+window.dispatch_event(WindowEvent::internal(BackendMouseEvent::Wheel { position: pressed_position, delta_x: 0., delta_y: 0., phase: TouchPhase::Ended }));
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(300.0, 100.0) });
 // No crash
 ```


### PR DESCRIPTION
WindowEvent::Internal carried the runtime's MouseEvent, whose drag and drop variants hold a reference counted payload. A backend could therefore no longer build an event on one thread and dispatch it from the one running the event loop.

Carry a BackendMouseEvent instead, the variants a backend actually delivers, and assert that WindowEvent and InternalEvent stay Send and Sync. Drag and drop keeps its own entry point, which now takes a BackendDragEvent rather than a MouseEvent, so that it remains the only input a backend can deliver without the window event hook observing it.

cc #13066

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
