### PR TITLE
winit: handle window events in WinitWindowAdapter

### DIFF
--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -8,14 +8,8 @@
     aspects of windows on the screen.
 */
 use crate::EventResult;
-use crate::drag_resize_window::{handle_cursor_move_for_resize, handle_resize};
-use crate::winitwindowadapter::{WindowVisibility, WinitWindowAdapter};
+use crate::winitwindowadapter::WindowVisibility;
 use crate::{SharedBackendData, SlintEvent};
-use corelib::SharedString;
-use corelib::graphics::euclid;
-use corelib::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};
-use corelib::items::{ColorScheme, PointerEventButton};
-use corelib::lengths::LogicalPoint;
 use corelib::platform::PlatformError;
 use corelib::window::*;
 use i_slint_core as corelib;
@@ -24,19 +18,7 @@ use i_slint_core as corelib;
 use std::cell::{RefCell, RefMut};
 use std::rc::Rc;
 use winit::event::WindowEvent;
-use winit::event_loop::ActiveEventLoop;
-use winit::keyboard::Key;
-
-fn winit_touch_phase(phase: winit::event::TouchPhase) -> corelib::input::TouchPhase {
-    match phase {
-        winit::event::TouchPhase::Started => corelib::input::TouchPhase::Started,
-        winit::event::TouchPhase::Moved => corelib::input::TouchPhase::Moved,
-        winit::event::TouchPhase::Ended => corelib::input::TouchPhase::Ended,
-        winit::event::TouchPhase::Cancelled => corelib::input::TouchPhase::Cancelled,
-    }
-}
-use winit::event_loop::ControlFlow;
-use winit::window::ResizeDirection;
+use winit::event_loop::{ActiveEventLoop, ControlFlow};
 
 /// This enum captures run-time specific events that can be dispatched to the event loop in
 /// addition to the winit events.
@@ -72,26 +54,11 @@ impl std::fmt::Debug for CustomEvent {
 
 pub struct EventLoopState {
     shared_backend_data: Rc<SharedBackendData>,
-    // last seen cursor position
-    cursor_pos: LogicalPoint,
-    /// Whether a *mouse* button is currently pressed. Touch input is handled
-    /// separately via `process_touch_input` and does not affect this flag.
-    pressed: bool,
 
     loop_error: Option<PlatformError>,
-    current_resize_direction: Option<ResizeDirection>,
-
-    /// Buffered mouse move event pending dispatch. Consecutive `CursorMoved`
-    /// events are coalesced. Otherwise winit sends events so frequently that it can cause performance
-    /// issues (see #9038 and #10912).
-    pending_mouse_move: Option<(winit::window::WindowId, LogicalPoint)>,
 
     /// Set to true when pumping events for the shortest amount of time possible.
     pumping_events_instantly: bool,
-
-    /// Allocates small i32 finger ids for iOS's pointer-valued touch ids.
-    #[cfg(target_os = "ios")]
-    touch_finger_ids: crate::ios::TouchFingerIdAllocator,
 
     custom_application_handler: Option<Box<dyn crate::CustomApplicationHandler>>,
 }
@@ -103,14 +70,8 @@ impl EventLoopState {
     ) -> Self {
         Self {
             shared_backend_data,
-            cursor_pos: Default::default(),
-            pressed: Default::default(),
             loop_error: Default::default(),
-            current_resize_direction: Default::default(),
-            pending_mouse_move: Default::default(),
             pumping_events_instantly: Default::default(),
-            #[cfg(target_os = "ios")]
-            touch_finger_ids: Default::default(),
             custom_application_handler,
         }
     }
@@ -128,17 +89,6 @@ impl EventLoopState {
             .collect::<Vec<_>>();
         for window in windows_to_suspend.into_iter() {
             let _ = window.suspend();
-        }
-    }
-
-    /// Dispatch the buffered mouse move event, if any.
-    fn flush_pending_mouse_move(&mut self) {
-        if let Some((window_id, position)) = self.pending_mouse_move.take()
-            && let Some(window) = self.shared_backend_data.window_by_id(window_id)
-        {
-            window.window().dispatch_event(corelib::platform::WindowEvent::internal(
-                MouseEvent::Moved { position, touch_finger_id: 0 },
-            ));
         }
     }
 }
@@ -159,7 +109,6 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
         }
     }
 
-    #[allow(clippy::collapsible_match)]
     fn window_event(
         &mut self,
         event_loop: &ActiveEventLoop,
@@ -173,386 +122,27 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
             return;
         };
 
-        if let Some(winit_window) = window.winit_window() {
-            if matches!(
-                self.custom_application_handler.as_mut().map_or(
-                    EventResult::Propagate,
-                    |handler| handler.window_event(
-                        event_loop,
-                        window_id,
-                        Some(&*winit_window),
-                        Some(window.window()),
-                        &event
-                    )
-                ),
-                EventResult::PreventDefault
-            ) {
-                return;
-            }
+        let Some(winit_window) = window.winit_window() else {
+            return;
+        };
 
-            if let Some(mut window_event_filter) = window.window_event_filter.take() {
-                let event_result = window_event_filter(window.window(), &event);
-                window.window_event_filter.set(Some(window_event_filter));
-
-                match event_result {
-                    EventResult::PreventDefault => return,
-                    EventResult::Propagate => (),
-                }
-            }
-
-            #[cfg(enable_accesskit)]
-            window
-                .accesskit_adapter()
-                .expect("internal error: accesskit adapter must exist when window exists")
-                .borrow_mut()
-                .process_event(&winit_window, &event);
-        } else {
+        if matches!(
+            self.custom_application_handler.as_mut().map_or(EventResult::Propagate, |handler| {
+                handler.window_event(
+                    event_loop,
+                    window_id,
+                    Some(&*winit_window),
+                    Some(window.window()),
+                    &event,
+                )
+            }),
+            EventResult::PreventDefault
+        ) {
             return;
         }
 
-        let runtime_window = WindowInner::from_pub(window.window());
-        self.maybe_set_custom_cursor(&window, event_loop);
-        if !matches!(event, WindowEvent::CursorMoved { .. } | WindowEvent::AxisMotion { .. }) {
-            self.flush_pending_mouse_move();
-        }
-
-        match event {
-            WindowEvent::RedrawRequested => {
-                self.loop_error = window.draw().err();
-            }
-            WindowEvent::Resized(size) => {
-                self.loop_error = window.resize_event(size).err();
-
-                // Entering fullscreen, maximizing or minimizing the window will
-                // trigger a resize event. We need to update the internal window
-                // state to match the actual window state. We simulate a "window
-                // state event" since there is not an official event for it yet.
-                // See: https://github.com/rust-windowing/winit/issues/2334
-                window.window_state_event();
-
-                // Some platforms (e.g., Windows) may not emit an Occluded event when minimized,
-                // so manually mark the window as occluded if its size is zero.
-                #[cfg(target_os = "windows")]
-                {
-                    if size.width == 0 || size.height == 0 {
-                        window.renderer.occluded(true);
-                    }
-                }
-            }
-            WindowEvent::CloseRequested => {
-                self.loop_error = window
-                    .window()
-                    .dispatch_event_with_result(corelib::platform::WindowEvent::CloseRequested)
-                    .err();
-            }
-            WindowEvent::Focused(have_focus) => {
-                // Work around https://github.com/rust-windowing/winit/issues/4371
-                let have_focus = if cfg!(target_os = "macos") {
-                    window.winit_window().map_or(have_focus, |w| w.has_focus())
-                } else {
-                    have_focus
-                };
-                self.loop_error = window.activation_changed(have_focus).err();
-            }
-
-            WindowEvent::KeyboardInput { event, is_synthetic, .. } => {
-                let key_code = event.logical_key.clone();
-                // For now: Match Qt's behavior of mapping command to control and control to meta (LWin/RWin).
-                let swap_cmd_ctrl = i_slint_core::is_apple_platform();
-
-                let key_code = if swap_cmd_ctrl {
-                    #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
-                    match key_code {
-                        winit::keyboard::Key::Named(winit::keyboard::NamedKey::Control) => {
-                            winit::keyboard::Key::Named(winit::keyboard::NamedKey::Super)
-                        }
-                        winit::keyboard::Key::Named(winit::keyboard::NamedKey::Super) => {
-                            winit::keyboard::Key::Named(winit::keyboard::NamedKey::Control)
-                        }
-                        code => code,
-                    }
-                } else {
-                    key_code
-                };
-
-                fn to_slint_key(event: &winit::event::KeyEvent, key_code: &Key) -> SharedString {
-                    macro_rules! winit_key_to_char {
-                        ($($char:literal # $name:ident # $($shifted:ident)? $(=> $($_muda:ident)? # $($_qt:ident)|* # $($winit:ident $(($pos:ident))?)|* # $($_xkb:ident)|* )? ;)*) => {
-                            #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
-                            match key_code {
-                                $( $( $(
-                                            winit::keyboard::Key::Named(winit::keyboard::NamedKey::$winit)
-                                            $(if event.location == winit::keyboard::KeyLocation::$pos)?
-                                            => $char.into(),
-                                )* )? )*
-                                    winit::keyboard::Key::Character(str) => str.as_str().into(),
-                                _ => {
-                                    if let Some(text) = &event.text {
-                                        text.as_str().into()
-                                    } else {
-                                        "".into()
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    i_slint_common::for_each_keys!(winit_key_to_char)
-                }
-                #[allow(unused_mut)]
-                let mut text = to_slint_key(&event, &key_code);
-
-                #[cfg(target_os = "windows")]
-                let text_without_modifiers = {
-                    use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
-
-                    // On Windows, if Ctrl+Alt is pressed with a key that does not use
-                    // AltGr for remapping, we need to fall back to the
-                    // key_without_modifiers.
-                    //
-                    // See: https://github.com/rust-windowing/winit/issues/2945
-                    //
-                    // The text_without_modifiers also let's us disambiguate between a Ctrl+Alt
-                    // combination used to imply AltGr or not.
-                    // The latter case should be treated as a shortcut, the former should not.
-                    let text_without_modifiers =
-                        to_slint_key(&event, &event.key_without_modifiers());
-                    // Skip the fallback for dead keys so the accent composes instead of being inserted.
-                    if text.is_empty()
-                        && !text_without_modifiers.is_empty()
-                        && !matches!(event.logical_key, winit::keyboard::Key::Dead(_))
-                    {
-                        text = text_without_modifiers.clone();
-                    }
-                    text_without_modifiers
-                };
-
-                if text.is_empty() {
-                    // Failed to translate the key event
-                    return;
-                }
-
-                if is_synthetic {
-                    // Synthetic event are sent when the focus is acquired, for all the keys currently pressed.
-                    // Don't forward these keys other than modifiers to the app
-                    use winit::keyboard::{Key::Named, NamedKey as N};
-                    if !matches!(
-                        key_code,
-                        Named(N::Control | N::Shift | N::Super | N::Alt | N::AltGraph),
-                    ) {
-                        return;
-                    }
-                }
-
-                let event_type = match event.state {
-                    winit::event::ElementState::Pressed => corelib::input::KeyEventType::KeyPressed,
-                    winit::event::ElementState::Released => {
-                        corelib::input::KeyEventType::KeyReleased
-                    }
-                };
-                let mut key_event = KeyEvent::default();
-                key_event.text = text;
-                key_event.repeat = event.repeat;
-
-                let event = corelib::input::InternalKeyEvent {
-                    key_event,
-                    event_type,
-                    #[cfg(target_os = "windows")]
-                    text_without_modifiers,
-                    ..Default::default()
-                };
-
-                window.window().dispatch_event(corelib::platform::WindowEvent::internal(event));
-            }
-            WindowEvent::Ime(winit::event::Ime::Preedit(string, preedit_selection)) => {
-                let event = InternalKeyEvent {
-                    event_type: KeyEventType::UpdateComposition,
-                    preedit_text: string.into(),
-                    preedit_selection: preedit_selection.map(|e| e.0 as i32..e.1 as i32),
-                    ..Default::default()
-                };
-                window.window().dispatch_event(corelib::platform::WindowEvent::internal(event));
-            }
-            WindowEvent::Ime(winit::event::Ime::Commit(string)) => {
-                let mut key_event = KeyEvent::default();
-                key_event.text = string.into();
-                let event = InternalKeyEvent {
-                    event_type: KeyEventType::CommitComposition,
-                    key_event,
-                    ..Default::default()
-                };
-                window.window().dispatch_event(corelib::platform::WindowEvent::internal(event));
-            }
-            WindowEvent::CursorMoved { position, .. } => {
-                self.current_resize_direction = handle_cursor_move_for_resize(
-                    &window.winit_window().unwrap(),
-                    position,
-                    self.current_resize_direction,
-                    runtime_window
-                        .window_item()
-                        .map_or(0_f64, |w| w.as_pin_ref().resize_border_width().get().into()),
-                );
-                let position = position.to_logical(runtime_window.scale_factor() as f64);
-                self.cursor_pos = euclid::point2(position.x, position.y);
-                // winit sends this event at a very high frequency. So, bunch up consecutive
-                // cursor moved events and dispatch them as soon as any other kind of event
-                // arrives.
-                self.pending_mouse_move = Some((window_id, self.cursor_pos));
-            }
-            WindowEvent::CursorLeft { .. } => {
-                // On the html canvas, we don't get the mouse move or release event when outside the canvas. So we have no choice but canceling the event
-                if cfg!(target_arch = "wasm32") || !self.pressed {
-                    self.pressed = false;
-                    window
-                        .window()
-                        .dispatch_event(corelib::platform::WindowEvent::internal(MouseEvent::Exit));
-                }
-            }
-            WindowEvent::MouseWheel { delta, phase, .. } => {
-                let (delta_x, delta_y) = match delta {
-                    winit::event::MouseScrollDelta::LineDelta(lx, ly) => (lx * 60., ly * 60.),
-                    winit::event::MouseScrollDelta::PixelDelta(d) => {
-                        let d = d.to_logical(runtime_window.scale_factor() as f64);
-                        (d.x, d.y)
-                    }
-                };
-                let phase = match phase {
-                    winit::event::TouchPhase::Started => TouchPhase::Started,
-                    winit::event::TouchPhase::Moved => TouchPhase::Moved,
-                    winit::event::TouchPhase::Ended => TouchPhase::Ended,
-                    winit::event::TouchPhase::Cancelled => TouchPhase::Cancelled,
-                };
-                window.window().dispatch_event(corelib::platform::WindowEvent::internal(
-                    MouseEvent::Wheel { position: self.cursor_pos, delta_x, delta_y, phase },
-                ));
-            }
-            WindowEvent::MouseInput { state, button, .. } => {
-                let button = match button {
-                    winit::event::MouseButton::Left => PointerEventButton::Left,
-                    winit::event::MouseButton::Right => PointerEventButton::Right,
-                    winit::event::MouseButton::Middle => PointerEventButton::Middle,
-                    winit::event::MouseButton::Back => PointerEventButton::Back,
-                    winit::event::MouseButton::Forward => PointerEventButton::Forward,
-                    winit::event::MouseButton::Other(_) => PointerEventButton::Other,
-                };
-                let ev = match state {
-                    winit::event::ElementState::Pressed => {
-                        if button == PointerEventButton::Left
-                            && self.current_resize_direction.is_some()
-                        {
-                            handle_resize(
-                                &window.winit_window().unwrap(),
-                                self.current_resize_direction,
-                            );
-                            return;
-                        }
-
-                        self.pressed = true;
-                        MouseEvent::Pressed {
-                            position: self.cursor_pos,
-                            button,
-                            click_count: 0,
-                            touch_finger_id: 0,
-                        }
-                    }
-                    winit::event::ElementState::Released => {
-                        self.pressed = false;
-                        MouseEvent::Released {
-                            position: self.cursor_pos,
-                            button,
-                            click_count: 0,
-                            touch_finger_id: 0,
-                        }
-                    }
-                };
-                window.window().dispatch_event(corelib::platform::WindowEvent::internal(ev));
-            }
-            WindowEvent::Touch(touch) => {
-                let location = touch.location.to_logical(runtime_window.scale_factor() as f64);
-                let position = euclid::point2(location.x, location.y);
-                // winit types the touch id as u64, but on all platforms except
-                // iOS it is in fact a small integer that fits in i32. Only iOS
-                // stores a UITouch pointer address in it, which
-                // TouchFingerIdAllocator maps to a small id instead.
-                #[cfg(not(target_os = "ios"))]
-                let finger_id =
-                    Some(i32::try_from(touch.id).expect("winit touch id out of i32 range"));
-                #[cfg(target_os = "ios")]
-                let finger_id = match touch.phase {
-                    winit::event::TouchPhase::Started | winit::event::TouchPhase::Moved => {
-                        self.touch_finger_ids.id_for(touch.id)
-                    }
-                    winit::event::TouchPhase::Ended | winit::event::TouchPhase::Cancelled => {
-                        self.touch_finger_ids.take(touch.id)
-                    }
-                };
-                if let Some(finger_id) = finger_id {
-                    window.window().dispatch_event(corelib::platform::WindowEvent::internal(
-                        corelib::platform::InternalEvent::Touch {
-                            id: finger_id,
-                            position,
-                            phase: winit_touch_phase(touch.phase),
-                        },
-                    ));
-                }
-            }
-            WindowEvent::ScaleFactorChanged { scale_factor, inner_size_writer: _ } => {
-                if std::env::var("SLINT_SCALE_FACTOR").is_err() {
-                    self.loop_error = window
-                        .window()
-                        .dispatch_event_with_result(
-                            corelib::platform::WindowEvent::ScaleFactorChanged {
-                                scale_factor: scale_factor as f32,
-                            },
-                        )
-                        .err();
-                    // TODO: send a resize event or try to keep the logical size the same.
-                    //window.resize_event(inner_size_writer.???)?;
-                }
-            }
-            WindowEvent::ThemeChanged(theme) => {
-                window.set_color_scheme(match theme {
-                    winit::window::Theme::Dark => ColorScheme::Dark,
-                    winit::window::Theme::Light => ColorScheme::Light,
-                });
-                window.update_accent_color();
-            }
-            WindowEvent::Occluded(x) => {
-                window.renderer.occluded(x);
-
-                // In addition to the hack done for WindowEvent::Resize, also do it for Occluded so we handle Minimized change
-                window.window_state_event();
-            }
-            // Note: winit's PinchGesture does not carry a position; we use the last
-            // known cursor position as the best available approximation. On macOS
-            // trackpads, CursorMoved events typically precede gesture events.
-            WindowEvent::PinchGesture { delta, phase, .. } => {
-                window.window().dispatch_event(corelib::platform::WindowEvent::internal(
-                    corelib::input::MouseEvent::PinchGesture {
-                        position: self.cursor_pos,
-                        delta: delta as f32,
-                        phase: winit_touch_phase(phase),
-                    },
-                ));
-            }
-            WindowEvent::RotationGesture { delta, phase, .. } => {
-                // macOS/winit: positive = counterclockwise. Negate to match
-                // Slint convention (positive = clockwise).
-                window.window().dispatch_event(corelib::platform::WindowEvent::internal(
-                    corelib::input::MouseEvent::RotationGesture {
-                        position: self.cursor_pos,
-                        delta: -delta,
-                        phase: winit_touch_phase(phase),
-                    },
-                ));
-            }
-
-            WindowEvent::AxisMotion { .. } => {
-                // Ignored, but happens often and is also ignored for the purpose of bundling CursorMoved.
-            }
-            _ => {}
-        }
-
-        if self.loop_error.is_some() {
+        if let Err(err) = window.dispatch_winit_window_event(event_loop, &winit_window, event) {
+            self.loop_error = Some(err);
             event_loop.exit();
         }
     }
@@ -626,7 +216,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        self.flush_pending_mouse_move();
+        self.shared_backend_data.flush_pending_mouse_move();
 
         if matches!(
             self.custom_application_handler
@@ -731,19 +321,6 @@ impl EventLoopState {
                 }
                 Ok(self)
             }
-        }
-    }
-
-    /// Sets the cursor to a custom source, if it needs to be set.
-    pub fn maybe_set_custom_cursor(
-        &self,
-        window: &WinitWindowAdapter,
-        event_loop: &ActiveEventLoop,
-    ) {
-        // If there is a new custom cursor, update it.
-        let custom_cursor_source = window.custom_cursor_source.take();
-        if let (Some(source), Some(winit_window)) = (custom_cursor_source, window.winit_window()) {
-            winit_window.set_cursor(event_loop.create_custom_cursor(source));
         }
     }
 

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -13,9 +13,11 @@ extern crate alloc;
 use event_loop::{CustomEvent, EventLoopState};
 use i_slint_core::api::EventLoopError;
 use i_slint_core::graphics::RequestedGraphicsAPI;
+use i_slint_core::lengths::LogicalPoint;
 use i_slint_core::platform::{EventLoopProxy, PlatformError};
 use i_slint_core::window::WindowAdapter;
 use renderer::WinitCompatibleRenderer;
+use std::cell::Cell;
 use std::cell::OnceCell;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -396,6 +398,14 @@ impl BackendBuilder {
     }
 }
 
+fn dispatch_mouse_move(window: &Weak<WinitWindowAdapter>, position: LogicalPoint) {
+    if let Some(window) = window.upgrade() {
+        window.window().dispatch_event(i_slint_core::platform::WindowEvent::internal(
+            i_slint_core::input::MouseEvent::Moved { position, touch_finger_id: 0 },
+        ));
+    }
+}
+
 pub(crate) struct SharedBackendData {
     context: OnceCell<i_slint_core::SlintContextWeak>,
     /// Allow fallback if the desired renderer is not found
@@ -408,6 +418,10 @@ pub(crate) struct SharedBackendData {
     /// List of visible windows that have been created when without the event loop and
     /// need to be mapped to a winit Window as soon as the event loop becomes active.
     inactive_windows: RefCell<Vec<Weak<WinitWindowAdapter>>>,
+    /// Buffered mouse move event pending dispatch. Consecutive `CursorMoved` events are coalesced,
+    /// as winit sends them so frequently that it can cause performance issues (see #9038 and #10912).
+    /// At most one window buffers a move at a time.
+    pending_mouse_move: Cell<Option<(Weak<WinitWindowAdapter>, LogicalPoint)>>,
     #[cfg(not(target_arch = "wasm32"))]
     clipboard: std::cell::RefCell<clipboard::ClipboardPair>,
     not_running_event_loop: RefCell<Option<winit::event_loop::EventLoop<SlintEvent>>>,
@@ -509,6 +523,7 @@ impl SharedBackendData {
             skia_context: i_slint_renderer_skia::SkiaSharedContext::default(),
             active_windows,
             inactive_windows: Default::default(),
+            pending_mouse_move: Default::default(),
             #[cfg(not(target_arch = "wasm32"))]
             clipboard: RefCell::new(clipboard),
             not_running_event_loop: RefCell::new(Some(event_loop)),
@@ -608,6 +623,28 @@ impl SharedBackendData {
 
     pub fn window_by_id(&self, id: winit::window::WindowId) -> Option<Rc<WinitWindowAdapter>> {
         self.active_windows.borrow().get(&id).and_then(|weakref| weakref.upgrade())
+    }
+
+    /// Buffer a mouse move event for the given window, coalescing it with the previously buffered
+    /// one. A move buffered for another window is dispatched first, to keep the events in order.
+    pub(crate) fn buffer_mouse_move(
+        &self,
+        window: &Weak<WinitWindowAdapter>,
+        position: LogicalPoint,
+    ) {
+        if let Some((pending_window, pending_position)) =
+            self.pending_mouse_move.replace(Some((window.clone(), position)))
+            && !Weak::ptr_eq(&pending_window, window)
+        {
+            dispatch_mouse_move(&pending_window, pending_position);
+        }
+    }
+
+    /// Dispatch the buffered mouse move event, if any.
+    pub(crate) fn flush_pending_mouse_move(&self) {
+        if let Some((window, position)) = self.pending_mouse_move.take() {
+            dispatch_mouse_move(&window, position);
+        }
     }
 }
 

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -27,15 +27,18 @@ use winit::platform::web::WindowExtWebSys;
 #[cfg(target_family = "windows")]
 use winit::platform::windows::WindowExtWindows;
 
+use crate::drag_resize_window::{handle_cursor_move_for_resize, handle_resize};
 #[cfg(muda)]
 use crate::muda::MudaType;
 use crate::renderer::WinitCompatibleRenderer;
 use crate::winit_compat::WindowSurfaceSizeExt;
 
+use corelib::SharedString;
+use corelib::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent};
 use corelib::item_tree::ItemTreeRc;
 #[cfg(enable_accesskit)]
 use corelib::item_tree::{ItemTreeRef, ItemTreeRefPin};
-use corelib::items::{BuiltInMouseCursor, ColorScheme};
+use corelib::items::{BuiltInMouseCursor, ColorScheme, PointerEventButton};
 #[cfg(enable_accesskit)]
 use corelib::items::{ItemRc, ItemRef};
 
@@ -44,14 +47,27 @@ use crate::SlintEvent;
 use crate::{EventResult, SharedBackendData};
 use corelib::api::PhysicalSize;
 use corelib::layout::Orientation;
-use corelib::lengths::LogicalLength;
+use corelib::lengths::{LogicalLength, LogicalPoint};
 use corelib::platform::{PlatformError, WindowEvent};
 use corelib::window::{WindowAdapter, WindowAdapterInternal, WindowInner};
 use corelib::{Coord, graphics::*};
 use i_slint_core::{self as corelib};
+use winit::event::WindowEvent as WinitWindowEvent;
 #[cfg(any(enable_accesskit, muda))]
 use winit::event_loop::EventLoopProxy;
-use winit::window::{CustomCursor, CustomCursorSource, WindowAttributes, WindowButtons};
+use winit::keyboard::Key;
+use winit::window::{
+    CustomCursor, CustomCursorSource, ResizeDirection, WindowAttributes, WindowButtons,
+};
+
+fn winit_touch_phase(phase: winit::event::TouchPhase) -> corelib::input::TouchPhase {
+    match phase {
+        winit::event::TouchPhase::Started => corelib::input::TouchPhase::Started,
+        winit::event::TouchPhase::Moved => corelib::input::TouchPhase::Moved,
+        winit::event::TouchPhase::Ended => corelib::input::TouchPhase::Ended,
+        winit::event::TouchPhase::Cancelled => corelib::input::TouchPhase::Cancelled,
+    }
+}
 
 pub(crate) fn position_to_winit(pos: &corelib::api::WindowPosition) -> winit::dpi::Position {
     match pos {
@@ -411,7 +427,17 @@ pub struct WinitWindowAdapter {
     /// the same as a previously set one, so keep track of that here.
     window_icon_cache_key: RefCell<Option<ImageCacheKey>>,
 
-    pub(crate) custom_cursor_source: Cell<Option<CustomCursorSource>>,
+    custom_cursor_source: Cell<Option<CustomCursorSource>>,
+
+    /// Last seen cursor position.
+    cursor_pos: Cell<LogicalPoint>,
+    /// Whether a *mouse* button is currently pressed. Touch input is handled
+    /// separately via `process_touch_input` and does not affect this flag.
+    pressed: Cell<bool>,
+    current_resize_direction: Cell<Option<ResizeDirection>>,
+    /// Allocates small i32 finger ids for iOS's pointer-valued touch ids.
+    #[cfg(target_os = "ios")]
+    touch_finger_ids: RefCell<crate::ios::TouchFingerIdAllocator>,
 }
 
 impl WinitWindowAdapter {
@@ -456,6 +482,11 @@ impl WinitWindowAdapter {
             muda_enable_default_menu_bar,
             window_icon_cache_key: Default::default(),
             custom_cursor_source: Cell::new(None),
+            cursor_pos: Default::default(),
+            pressed: Default::default(),
+            current_resize_direction: Default::default(),
+            #[cfg(target_os = "ios")]
+            touch_finger_ids: Default::default(),
         });
 
         self_rc.shared_backend_data.register_inactive_window((self_rc.clone()) as _);
@@ -1150,6 +1181,370 @@ impl WinitWindowAdapter {
         }
 
         Ok(())
+    }
+
+    fn dispatch_internal_event(&self, event: impl Into<corelib::platform::InternalEvent>) {
+        self.window().dispatch_event(WindowEvent::internal(event));
+    }
+
+    /// Handles a winit window event for this window: applies the window event filter, feeds
+    /// accesskit, updates the cursor and dispatches the corresponding Slint event.
+    /// The event loop is needed to create the custom cursor.
+    pub(crate) fn dispatch_winit_window_event(
+        &self,
+        event_loop: &ActiveEventLoop,
+        winit_window: &winit::window::Window,
+        event: WinitWindowEvent,
+    ) -> Result<(), PlatformError> {
+        if let Some(mut window_event_filter) = self.window_event_filter.take() {
+            let event_result = window_event_filter(self.window(), &event);
+            self.window_event_filter.set(Some(window_event_filter));
+
+            match event_result {
+                EventResult::PreventDefault => return Ok(()),
+                EventResult::Propagate => (),
+            }
+        }
+
+        #[cfg(enable_accesskit)]
+        self.accesskit_adapter()
+            .expect("internal error: accesskit adapter must exist when window exists")
+            .borrow_mut()
+            .process_event(winit_window, &event);
+
+        let runtime_window = WindowInner::from_pub(self.window());
+        self.maybe_set_custom_cursor(event_loop, winit_window);
+        if !matches!(
+            event,
+            WinitWindowEvent::CursorMoved { .. } | WinitWindowEvent::AxisMotion { .. }
+        ) {
+            self.shared_backend_data.flush_pending_mouse_move();
+        }
+
+        match event {
+            WinitWindowEvent::RedrawRequested => self.draw()?,
+            WinitWindowEvent::Resized(size) => {
+                let resized = self.resize_event(size);
+
+                // Entering fullscreen, maximizing or minimizing the window will
+                // trigger a resize event. We need to update the internal window
+                // state to match the actual window state. We simulate a "window
+                // state event" since there is not an official event for it yet.
+                // See: https://github.com/rust-windowing/winit/issues/2334
+                self.window_state_event();
+
+                // Some platforms (e.g., Windows) may not emit an Occluded event when minimized,
+                // so manually mark the window as occluded if its size is zero.
+                #[cfg(target_os = "windows")]
+                {
+                    if size.width == 0 || size.height == 0 {
+                        self.renderer.occluded(true);
+                    }
+                }
+
+                resized?;
+            }
+            WinitWindowEvent::CloseRequested => {
+                self.window()
+                    .dispatch_event_with_result(corelib::platform::WindowEvent::CloseRequested)?;
+            }
+            WinitWindowEvent::Focused(have_focus) => {
+                // Work around https://github.com/rust-windowing/winit/issues/4371
+                let have_focus =
+                    if cfg!(target_os = "macos") { winit_window.has_focus() } else { have_focus };
+                self.activation_changed(have_focus)?;
+            }
+
+            WinitWindowEvent::KeyboardInput { event, is_synthetic, .. } => {
+                let key_code = event.logical_key.clone();
+                // For now: Match Qt's behavior of mapping command to control and control to meta (LWin/RWin).
+                let swap_cmd_ctrl = i_slint_core::is_apple_platform();
+
+                let key_code = if swap_cmd_ctrl {
+                    #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
+                    match key_code {
+                        winit::keyboard::Key::Named(winit::keyboard::NamedKey::Control) => {
+                            winit::keyboard::Key::Named(winit::keyboard::NamedKey::Super)
+                        }
+                        winit::keyboard::Key::Named(winit::keyboard::NamedKey::Super) => {
+                            winit::keyboard::Key::Named(winit::keyboard::NamedKey::Control)
+                        }
+                        code => code,
+                    }
+                } else {
+                    key_code
+                };
+
+                fn to_slint_key(event: &winit::event::KeyEvent, key_code: &Key) -> SharedString {
+                    macro_rules! winit_key_to_char {
+                        ($($char:literal # $name:ident # $($shifted:ident)? $(=> $($_muda:ident)? # $($_qt:ident)|* # $($winit:ident $(($pos:ident))?)|* # $($_xkb:ident)|* )? ;)*) => {
+                            #[cfg_attr(slint_nightly_test, allow(non_exhaustive_omitted_patterns))]
+                            match key_code {
+                                $( $( $(
+                                            winit::keyboard::Key::Named(winit::keyboard::NamedKey::$winit)
+                                            $(if event.location == winit::keyboard::KeyLocation::$pos)?
+                                            => $char.into(),
+                                )* )? )*
+                                    winit::keyboard::Key::Character(str) => str.as_str().into(),
+                                _ => {
+                                    if let Some(text) = &event.text {
+                                        text.as_str().into()
+                                    } else {
+                                        "".into()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    i_slint_common::for_each_keys!(winit_key_to_char)
+                }
+                #[allow(unused_mut)]
+                let mut text = to_slint_key(&event, &key_code);
+
+                #[cfg(target_os = "windows")]
+                let text_without_modifiers = {
+                    use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
+
+                    // On Windows, if Ctrl+Alt is pressed with a key that does not use
+                    // AltGr for remapping, we need to fall back to the
+                    // key_without_modifiers.
+                    //
+                    // See: https://github.com/rust-windowing/winit/issues/2945
+                    //
+                    // The text_without_modifiers also let's us disambiguate between a Ctrl+Alt
+                    // combination used to imply AltGr or not.
+                    // The latter case should be treated as a shortcut, the former should not.
+                    let text_without_modifiers =
+                        to_slint_key(&event, &event.key_without_modifiers());
+                    // Skip the fallback for dead keys so the accent composes instead of being inserted.
+                    if text.is_empty()
+                        && !text_without_modifiers.is_empty()
+                        && !matches!(event.logical_key, winit::keyboard::Key::Dead(_))
+                    {
+                        text = text_without_modifiers.clone();
+                    }
+                    text_without_modifiers
+                };
+
+                if text.is_empty() {
+                    // Failed to translate the key event
+                    return Ok(());
+                }
+
+                if is_synthetic {
+                    // Synthetic event are sent when the focus is acquired, for all the keys currently pressed.
+                    // Don't forward these keys other than modifiers to the app
+                    use winit::keyboard::{Key::Named, NamedKey as N};
+                    if !matches!(
+                        key_code,
+                        Named(N::Control | N::Shift | N::Super | N::Alt | N::AltGraph),
+                    ) {
+                        return Ok(());
+                    }
+                }
+
+                let event_type = match event.state {
+                    winit::event::ElementState::Pressed => KeyEventType::KeyPressed,
+                    winit::event::ElementState::Released => KeyEventType::KeyReleased,
+                };
+                let mut key_event = KeyEvent::default();
+                key_event.text = text;
+                key_event.repeat = event.repeat;
+
+                let event = InternalKeyEvent {
+                    key_event,
+                    event_type,
+                    #[cfg(target_os = "windows")]
+                    text_without_modifiers,
+                    ..Default::default()
+                };
+
+                self.dispatch_internal_event(event);
+            }
+            WinitWindowEvent::Ime(winit::event::Ime::Preedit(string, preedit_selection)) => {
+                let event = InternalKeyEvent {
+                    event_type: KeyEventType::UpdateComposition,
+                    preedit_text: string.into(),
+                    preedit_selection: preedit_selection.map(|e| e.0 as i32..e.1 as i32),
+                    ..Default::default()
+                };
+                self.dispatch_internal_event(event);
+            }
+            WinitWindowEvent::Ime(winit::event::Ime::Commit(string)) => {
+                let mut key_event = KeyEvent::default();
+                key_event.text = string.into();
+                let event = InternalKeyEvent {
+                    event_type: KeyEventType::CommitComposition,
+                    key_event,
+                    ..Default::default()
+                };
+                self.dispatch_internal_event(event);
+            }
+            WinitWindowEvent::CursorMoved { position, .. } => {
+                self.current_resize_direction.set(handle_cursor_move_for_resize(
+                    winit_window,
+                    position,
+                    self.current_resize_direction.get(),
+                    runtime_window
+                        .window_item()
+                        .map_or(0_f64, |w| w.as_pin_ref().resize_border_width().get().into()),
+                ));
+                let position = position.to_logical(runtime_window.scale_factor() as f64);
+                let cursor_pos = euclid::point2(position.x, position.y);
+                self.cursor_pos.set(cursor_pos);
+                // winit sends this event at a very high frequency, so coalesce the moves.
+                self.shared_backend_data.buffer_mouse_move(&self.self_weak, cursor_pos);
+            }
+            WinitWindowEvent::CursorLeft { .. } => {
+                // On the html canvas, we don't get the mouse move or release event when outside the canvas. So we have no choice but canceling the event
+                if cfg!(target_arch = "wasm32") || !self.pressed.get() {
+                    self.pressed.set(false);
+                    self.dispatch_internal_event(MouseEvent::Exit);
+                }
+            }
+            WinitWindowEvent::MouseWheel { delta, phase, .. } => {
+                let (delta_x, delta_y) = match delta {
+                    winit::event::MouseScrollDelta::LineDelta(lx, ly) => (lx * 60., ly * 60.),
+                    winit::event::MouseScrollDelta::PixelDelta(d) => {
+                        let d = d.to_logical(runtime_window.scale_factor() as f64);
+                        (d.x, d.y)
+                    }
+                };
+                let phase = winit_touch_phase(phase);
+                self.dispatch_internal_event(MouseEvent::Wheel {
+                    position: self.cursor_pos.get(),
+                    delta_x,
+                    delta_y,
+                    phase,
+                });
+            }
+            WinitWindowEvent::MouseInput { state, button, .. } => {
+                let button = match button {
+                    winit::event::MouseButton::Left => PointerEventButton::Left,
+                    winit::event::MouseButton::Right => PointerEventButton::Right,
+                    winit::event::MouseButton::Middle => PointerEventButton::Middle,
+                    winit::event::MouseButton::Back => PointerEventButton::Back,
+                    winit::event::MouseButton::Forward => PointerEventButton::Forward,
+                    winit::event::MouseButton::Other(_) => PointerEventButton::Other,
+                };
+                let ev = match state {
+                    winit::event::ElementState::Pressed => {
+                        if button == PointerEventButton::Left
+                            && self.current_resize_direction.get().is_some()
+                        {
+                            handle_resize(winit_window, self.current_resize_direction.get());
+                            return Ok(());
+                        }
+
+                        self.pressed.set(true);
+                        MouseEvent::Pressed {
+                            position: self.cursor_pos.get(),
+                            button,
+                            click_count: 0,
+                            touch_finger_id: 0,
+                        }
+                    }
+                    winit::event::ElementState::Released => {
+                        self.pressed.set(false);
+                        MouseEvent::Released {
+                            position: self.cursor_pos.get(),
+                            button,
+                            click_count: 0,
+                            touch_finger_id: 0,
+                        }
+                    }
+                };
+                self.dispatch_internal_event(ev);
+            }
+            WinitWindowEvent::Touch(touch) => {
+                let location = touch.location.to_logical(runtime_window.scale_factor() as f64);
+                let position = euclid::point2(location.x, location.y);
+                // winit types the touch id as u64, but on all platforms except
+                // iOS it is in fact a small integer that fits in i32. Only iOS
+                // stores a UITouch pointer address in it, which
+                // TouchFingerIdAllocator maps to a small id instead.
+                #[cfg(not(target_os = "ios"))]
+                let finger_id =
+                    Some(i32::try_from(touch.id).expect("winit touch id out of i32 range"));
+                #[cfg(target_os = "ios")]
+                let finger_id = match touch.phase {
+                    winit::event::TouchPhase::Started | winit::event::TouchPhase::Moved => {
+                        self.touch_finger_ids.borrow_mut().id_for(touch.id)
+                    }
+                    winit::event::TouchPhase::Ended | winit::event::TouchPhase::Cancelled => {
+                        self.touch_finger_ids.borrow_mut().take(touch.id)
+                    }
+                };
+                if let Some(finger_id) = finger_id {
+                    self.dispatch_internal_event(corelib::platform::InternalEvent::Touch {
+                        id: finger_id,
+                        position,
+                        phase: winit_touch_phase(touch.phase),
+                    });
+                }
+            }
+            WinitWindowEvent::ScaleFactorChanged { scale_factor, inner_size_writer: _ } => {
+                if std::env::var("SLINT_SCALE_FACTOR").is_err() {
+                    self.window().dispatch_event_with_result(
+                        corelib::platform::WindowEvent::ScaleFactorChanged {
+                            scale_factor: scale_factor as f32,
+                        },
+                    )?;
+                    // TODO: send a resize event or try to keep the logical size the same.
+                    //self.resize_event(inner_size_writer.???)?;
+                }
+            }
+            WinitWindowEvent::ThemeChanged(theme) => {
+                self.set_color_scheme(match theme {
+                    winit::window::Theme::Dark => ColorScheme::Dark,
+                    winit::window::Theme::Light => ColorScheme::Light,
+                });
+                self.update_accent_color();
+            }
+            WinitWindowEvent::Occluded(x) => {
+                self.renderer.occluded(x);
+
+                // Same hack as in the Resized arm above, so that we handle Minimized changes
+                self.window_state_event();
+            }
+            // Note: winit's PinchGesture does not carry a position; we use the last
+            // known cursor position as the best available approximation. On macOS
+            // trackpads, CursorMoved events typically precede gesture events.
+            WinitWindowEvent::PinchGesture { delta, phase, .. } => {
+                self.dispatch_internal_event(MouseEvent::PinchGesture {
+                    position: self.cursor_pos.get(),
+                    delta: delta as f32,
+                    phase: winit_touch_phase(phase),
+                });
+            }
+            WinitWindowEvent::RotationGesture { delta, phase, .. } => {
+                // macOS/winit: positive = counterclockwise. Negate to match
+                // Slint convention (positive = clockwise).
+                self.dispatch_internal_event(MouseEvent::RotationGesture {
+                    position: self.cursor_pos.get(),
+                    delta: -delta,
+                    phase: winit_touch_phase(phase),
+                });
+            }
+
+            WinitWindowEvent::AxisMotion { .. } => {
+                // Ignored, but happens often and is also ignored for the purpose of bundling CursorMoved.
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    /// Sets the cursor to a custom source, if there is a new one.
+    fn maybe_set_custom_cursor(
+        &self,
+        event_loop: &ActiveEventLoop,
+        winit_window: &winit::window::Window,
+    ) {
+        if let Some(source) = self.custom_cursor_source.take() {
+            winit_window.set_cursor(event_loop.create_custom_cursor(source));
+        }
     }
 
     fn set_visibility(&self, visibility: WindowVisibility) -> Result<(), PlatformError> {


### PR DESCRIPTION
EventLoopState::window_event now only resolves the window and runs the CustomApplicationHandler hook; the per-window work moved into WinitWindowAdapter::dispatch_winit_window_event, which returns its error instead of reaching up to set the event loop's error field.

The input state it needs (last cursor position, whether a mouse button is down, the drag-resize direction, and the iOS touch id allocator) lived on EventLoopState and was therefore shared by every window. It's now per window, which fixes a two possible multi-window bugs:

- wheel, pinch and rotation events used the cursor position last seen in whichever window moved most recently, not their own. Not very likely to happen, but for example if a window suddenly pops up during "wheeling", then there might not be a move.
- a mouse button held in one window suppressed the pointer-exit event of another window the pointer left. Maaaybe if a dialog closes on press, something is highlighted in the window underneath, cursor moved out but the exit event isn't delivered because pressed as still true.

The coalesced mouse move stays in a single slot, now in SharedBackendData so the adapter can reach it. Buffering a move for a different window used to overwrite and drop the pending one; it's dispatched first instead.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
