### PR TITLE
C++: accept any range in set_file_paths and Keys::from_parts

### DIFF
--- a/api/cpp/include/private/slint_data_transfer.h
+++ b/api/cpp/include/private/slint_data_transfer.h
@@ -110,7 +110,8 @@ public:
     ///
     /// \a paths may be any range whose elements are convertible to
     /// `std::filesystem::path`, such as a `std::vector<std::filesystem::path>`.
-    template<std::ranges::input_range R>
+    template<std::ranges::input_range R = std::initializer_list<std::filesystem::path>>
+        // Defaulting R lets a braced call like set_file_paths({}) deduce to initializer_list.
         requires std::convertible_to<std::ranges::range_reference_t<R>, std::filesystem::path>
     void set_file_paths(R &&paths)
     {
@@ -132,13 +133,6 @@ public:
             }
             send_file_paths(owned);
         }
-    }
-
-    /// \overload
-    /// Handles braced initializer lists such as `set_file_paths({})`.
-    void set_file_paths(std::initializer_list<std::filesystem::path> paths)
-    {
-        set_file_paths(std::ranges::subrange(paths.begin(), paths.end()));
     }
 
 private:

--- a/api/cpp/include/private/slint_data_transfer.h
+++ b/api/cpp/include/private/slint_data_transfer.h
@@ -8,8 +8,9 @@
 
 #ifndef SLINT_FEATURE_FREESTANDING
 #    include <any>
+#    include <concepts>
 #    include <filesystem>
-#    include <span>
+#    include <ranges>
 #    include <vector>
 #endif
 
@@ -106,19 +107,60 @@ public:
 #if !defined(SLINT_FEATURE_FREESTANDING) || defined(DOXYGEN)
     /// Sets the list of local file paths transferred by this `DataTransfer`,
     /// overwriting any previously set list. An empty list clears the file paths.
-    void set_file_paths(std::span<const std::filesystem::path> paths)
+    ///
+    /// \a paths may be any range whose elements are convertible to
+    /// `std::filesystem::path`, such as a `std::vector<std::filesystem::path>`.
+    template<std::ranges::input_range R>
+        requires std::convertible_to<std::ranges::range_reference_t<R>, std::filesystem::path>
+    void set_file_paths(R &&paths)
     {
-        // Each path crosses the FFI in its native representation, so that no
-        // path is mangled by an encoding conversion.
+        using Ref = std::ranges::range_reference_t<R>;
+        if constexpr (std::is_lvalue_reference_v<Ref>
+                      && std::is_same_v<std::remove_cvref_t<Ref>, std::filesystem::path>) {
+            // The paths already live in the caller's range: send them without
+            // copying each one into temporary storage.
+            send_file_paths(paths);
+        } else {
+            // Convertible or temporary elements: materialize once so each native()
+            // representation stays alive while its slice crosses the FFI.
+            std::vector<std::filesystem::path> owned;
+            if constexpr (std::ranges::sized_range<R>) {
+                owned.reserve(std::ranges::size(paths));
+            }
+            for (auto &&path : paths) {
+                owned.emplace_back(std::forward<decltype(path)>(path));
+            }
+            send_file_paths(owned);
+        }
+    }
+
+    /// \overload
+    /// Handles braced initializer lists such as `set_file_paths({})`.
+    void set_file_paths(std::initializer_list<std::filesystem::path> paths)
+    {
+        set_file_paths(std::ranges::subrange(paths.begin(), paths.end()));
+    }
+
+private:
+    /// Passes \a paths, a range of stored `std::filesystem::path` objects, to the FFI.
+    /// Each path crosses in its native representation, so no path is mangled by an
+    /// encoding conversion.
+    template<std::ranges::input_range R>
+    void send_file_paths(R &&paths)
+    {
         std::vector<cbindgen_private::Slice<cbindgen_private::types::PathValueType>> slices;
-        slices.reserve(paths.size());
-        for (const auto &path : paths) {
+        if constexpr (std::ranges::sized_range<R>) {
+            slices.reserve(std::ranges::size(paths));
+        }
+        for (const std::filesystem::path &path : paths) {
             const auto &native = path.native();
             slices.push_back(private_api::make_slice(native.data(), native.size()));
         }
         cbindgen_private::types::slint_data_transfer_set_file_paths(
                 this, private_api::make_slice(slices.data(), slices.size()));
     }
+
+public:
 #endif
 
     /// Returns `true` if this data transfer advertises a plain text representation.

--- a/api/cpp/include/private/slint_data_transfer.h
+++ b/api/cpp/include/private/slint_data_transfer.h
@@ -111,7 +111,7 @@ public:
     /// \a paths may be any range whose elements are convertible to
     /// `std::filesystem::path`, such as a `std::vector<std::filesystem::path>`.
     template<std::ranges::input_range R = std::initializer_list<std::filesystem::path>>
-        // Defaulting R lets a braced call like set_file_paths({}) deduce to initializer_list.
+    // Defaulting R lets a braced call like set_file_paths({}) deduce to initializer_list.
         requires std::convertible_to<std::ranges::range_reference_t<R>, std::filesystem::path>
     void set_file_paths(R &&paths)
     {

--- a/api/cpp/include/private/slint_keys.h
+++ b/api/cpp/include/private/slint_keys.h
@@ -55,7 +55,8 @@ public:
     ///
     /// \a parts may be any range whose elements are convertible to `std::string_view`,
     /// such as a `std::vector<std::string>`.
-    template<std::ranges::input_range R>
+    template<std::ranges::input_range R = std::initializer_list<std::string_view>>
+        // Defaulting R lets a braced call like from_parts({"Control", "C"}) deduce to initializer_list.
         requires std::convertible_to<std::ranges::range_reference_t<R>, std::string_view>
     static std::optional<Keys> from_parts(R &&parts)
     {
@@ -74,13 +75,6 @@ public:
             return result;
         }
         return std::nullopt;
-    }
-
-    /// \overload
-    /// Handles braced initializer lists such as `from_parts({"Control", "C"})`.
-    static std::optional<Keys> from_parts(std::initializer_list<std::string_view> parts)
-    {
-        return from_parts(std::ranges::subrange(parts.begin(), parts.end()));
     }
 
     /// Decompose this `Keys` value into a list of string parts that `from_parts` accepts.

--- a/api/cpp/include/private/slint_keys.h
+++ b/api/cpp/include/private/slint_keys.h
@@ -56,7 +56,7 @@ public:
     /// \a parts may be any range whose elements are convertible to `std::string_view`,
     /// such as a `std::vector<std::string>`.
     template<std::ranges::input_range R = std::initializer_list<std::string_view>>
-        // Defaulting R lets a braced call like from_parts({"Control", "C"}) deduce to initializer_list.
+    // Defaulting R lets a braced call like from_parts({"Control", "C"}) deduce to initializer_list.
         requires std::convertible_to<std::ranges::range_reference_t<R>, std::string_view>
     static std::optional<Keys> from_parts(R &&parts)
     {

--- a/api/cpp/include/private/slint_keys.h
+++ b/api/cpp/include/private/slint_keys.h
@@ -6,8 +6,9 @@
 #include "private/slint_sharedvector.h"
 #include "private/slint_string.h"
 
+#include <concepts>
 #include <optional>
-#include <span>
+#include <ranges>
 #include <string_view>
 #include <vector>
 
@@ -39,7 +40,7 @@ public:
     /// Move assignment operator
     slint::Keys &operator=(Keys &&) = default;
 
-    /// Create a `Keys` from a span of string parts, e.g. `{"Control", "Shift?", "Z"}`.
+    /// Create a `Keys` from a range of string parts, e.g. `{"Control", "Shift?", "Z"}`.
     ///
     /// Each element is either a modifier (`Control`, `Shift`, `Alt`, `Meta`, `Shift?`, `Alt?`)
     /// or a key name from the Key namespace (case-sensitive). If not found, it is treated as
@@ -51,12 +52,19 @@ public:
     /// `Control` modifier. Empty parts are skipped.
     ///
     /// Returns `std::nullopt` on parse failure.
-    static std::optional<Keys> from_parts(std::span<const std::string_view> parts)
+    ///
+    /// \a parts may be any range whose elements are convertible to `std::string_view`,
+    /// such as a `std::vector<std::string>`.
+    template<std::ranges::input_range R>
+        requires std::convertible_to<std::ranges::range_reference_t<R>, std::string_view>
+    static std::optional<Keys> from_parts(R &&parts)
     {
         std::vector<SharedString> converted;
-        converted.reserve(parts.size());
-        for (const auto &sv : parts) {
-            converted.emplace_back(sv);
+        if constexpr (std::ranges::sized_range<R>) {
+            converted.reserve(std::ranges::size(parts));
+        }
+        for (auto &&part : parts) {
+            converted.emplace_back(std::string_view(part));
         }
         Keys result;
         SharedString empty;
@@ -69,9 +77,10 @@ public:
     }
 
     /// \overload
+    /// Handles braced initializer lists such as `from_parts({"Control", "C"})`.
     static std::optional<Keys> from_parts(std::initializer_list<std::string_view> parts)
     {
-        return from_parts(std::span<const std::string_view> { parts.begin(), parts.size() });
+        return from_parts(std::ranges::subrange(parts.begin(), parts.end()));
     }
 
     /// Decompose this `Keys` value into a list of string parts that `from_parts` accepts.

--- a/api/cpp/tests/datastructures.cpp
+++ b/api/cpp/tests/datastructures.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <vector>
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch_all.hpp"
@@ -596,6 +597,35 @@ TEST_CASE("DataTransfer")
         REQUIRE(a.is_empty());
     }
 
+    SECTION("File paths accept arbitrary ranges")
+    {
+        DataTransfer a;
+
+        // A non-contiguous container, not expressible as a std::span.
+        std::set<std::filesystem::path> as_set = { "/tmp/a.txt", "/tmp/b.txt" };
+        a.set_file_paths(as_set);
+        auto from_set = a.file_paths();
+        REQUIRE(from_set.has_value());
+        REQUIRE(from_set->size() == 2);
+
+        // Elements merely convertible to std::filesystem::path.
+        std::vector<std::string> as_strings = { "/tmp/one.txt", "/tmp/two.txt" };
+        a.set_file_paths(as_strings);
+        auto from_strings = a.file_paths();
+        REQUIRE(from_strings.has_value());
+        REQUIRE(from_strings->size() == 2);
+        REQUIRE((*from_strings)[0] == std::filesystem::path("/tmp/one.txt"));
+
+        // A lazy view producing path temporaries on the fly.
+        a.set_file_paths(as_strings | std::views::transform([](const std::string &s) {
+                             return std::filesystem::path(s + ".bak");
+                         }));
+        auto from_view = a.file_paths();
+        REQUIRE(from_view.has_value());
+        REQUIRE(from_view->size() == 2);
+        REQUIRE((*from_view)[0] == std::filesystem::path("/tmp/one.txt.bak"));
+    }
+
 #ifdef _WIN32
     SECTION("File paths keep unpaired surrogates")
     {
@@ -728,5 +758,41 @@ TEST_CASE("DataTransfer")
         std::any v = a.user_data();
         REQUIRE(std::any_cast<int>(&v) != nullptr);
         REQUIRE(*std::any_cast<int>(&v) == 42);
+    }
+}
+
+TEST_CASE("Keys::from_parts accepts arbitrary ranges")
+{
+    using slint::Keys;
+
+    // Braced initializer list, handled by the initializer_list overload.
+    auto braced = Keys::from_parts({ "Control", "C" });
+    REQUIRE(braced.has_value());
+
+    SECTION("Ranges of different container and element types")
+    {
+        // A std::vector of std::string: not accepted by the former std::span
+        // overload without an explicit conversion to std::string_view.
+        std::vector<std::string> as_strings = { "Control", "C" };
+        auto from_strings = Keys::from_parts(as_strings);
+        REQUIRE(from_strings.has_value());
+        REQUIRE(*from_strings == *braced);
+
+        // A non-contiguous container.
+        std::set<std::string> as_set = { "Control", "C" };
+        auto from_set = Keys::from_parts(as_set);
+        REQUIRE(from_set.has_value());
+        REQUIRE(*from_set == *braced);
+
+        // A lazy view producing std::string temporaries on the fly.
+        auto from_view = Keys::from_parts(
+                as_strings | std::views::transform([](const std::string &s) { return s; }));
+        REQUIRE(from_view.has_value());
+        REQUIRE(*from_view == *braced);
+    }
+
+    SECTION("Parse failure still returns nullopt")
+    {
+        REQUIRE(!Keys::from_parts({ "NotARealKeyName" }).has_value());
     }
 }


### PR DESCRIPTION
These public functions took a std::span, which forced callers to hold the elements in contiguous storage of the exact element type. Take any input_range whose elements are convertible to the target type instead, so a std::set, a std::vector<std::string>, or a lazy view work directly. The braced-list overloads stay, since template argument deduction can't deduce from {}.

