### PR TITLE
Address review comments on the GridLayout repeated-cell fix

### DIFF
--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -3038,7 +3038,7 @@ fn generate_layout_item_info_decl(
         format!(
             "if (o == slint::cbindgen_private::Orientation::Vertical) {{\n\
                  if (auto *inner = {inner_rep_id}.typed_instance_at(index - count)) {{\n\
-                     [[maybe_unused]] size_t {idx} = index;\n\
+                     size_t {idx} = index;\n\
                      return inner->layout_item_info_at_cross_width(static_cast<float>({width}));\n\
                  }}\n\
              }}\n"

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -245,10 +245,6 @@ fn rewrite_layoutinfo_h_for_constraint(expr: &mut Expression, height_param: &Exp
     });
 }
 
-/// Same as `synthesize_layoutinfo_v_with_constraint`, but for the
-/// horizontal axis. Fires on any element whose `layoutinfo-h` depends
-/// (transitively) on a flex with horizontal cross-axis — directly
-/// (column-direction flex) or via a descendant / base component.
 /// Record on every cell of a GridLayout whether solving that grid's horizontal
 /// axis can read back into its vertical cache — see
 /// [`crate::layout::GridLayoutCell::h_solve_reads_v_cache`].
@@ -310,6 +306,10 @@ pub fn mark_grid_h_solve_reads_v_cache(component: &Rc<Component>) {
     });
 }
 
+/// Same as `synthesize_layoutinfo_v_with_constraint`, but for the
+/// horizontal axis. Fires on any element whose `layoutinfo-h` depends
+/// (transitively) on a flex with horizontal cross-axis — directly
+/// (column-direction flex) or via a descendant / base component.
 pub fn synthesize_layoutinfo_h_with_constraint(component: &Rc<Component>) {
     /// Bottom-up walk, returns `true` if the subtree contains an
     /// h-cross-axis dependency (a flex with cross axis on horizontal,


### PR DESCRIPTION
Restore the doc comment that ended up on the wrong function, and drop a
`[[maybe_unused]]` on a local the generated code does use.