### PR TITLE
run_clippy.sh: stop forking the shared target/ dir

### DIFF
--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -6,10 +6,6 @@
 
 set -e
 
-export RUSTFLAGS="-D warnings"
-export CARGO_INCREMENTAL=false
-export CARGO_PROFILE_DEV_DEBUG=0
-
 # The repository is split into several workspaces (root libraries/tools,
 # examples, demos and tests) that all share the same target directory, so the
 # common library crates are only built once across these clippy runs.


### PR DESCRIPTION
Setting RUSTFLAGS changes the build fingerprint, so every artifact in the
shared target/ dir gets built a second time just for the clippy runs. The
`-- -D warnings` already passed to each clippy invocation covers the crates
we care about (cargo does not apply our lint levels to registry deps
either way), and the CI jobs set RUSTFLAGS in their own env.