### PR TITLE
Visual Editor: Do not reparent items when dragging

### DIFF
--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -1140,6 +1140,21 @@ fn resize_selected_element(x: f32, y: f32, width: f32, height: f32) {
     send_workspace_edit(label, edit, true);
 }
 
+fn persist_selected_element_geometry() {
+    let Some(element_selection) = &selected_element() else {
+        return;
+    };
+    let Some(element_node) = element_selection.as_element_node() else {
+        return;
+    };
+
+    let Some((edit, label)) = persist_selected_element_geometry_impl(&element_node) else {
+        return;
+    };
+
+    send_workspace_edit(label, edit, true);
+}
+
 fn rotate_selected_element(angle: f32) {
     let Some(element_selection) = &selected_element() else { return };
     let Some(element_node) = element_selection.as_element_node() else { return };
@@ -1502,6 +1517,12 @@ fn resize_selected_element_impl(
         rect.height(),
     );
 
+    persist_selected_element_geometry_impl(element_node)
+}
+
+fn persist_selected_element_geometry_impl(
+    element_node: &ElementRcNode,
+) -> Option<(lsp_types::WorkspaceEdit, String)> {
     let element_hash = element_node
         .element
         .borrow()
@@ -1510,14 +1531,12 @@ fn resize_selected_element_impl(
         .map(|d| d.element_hash)
         .unwrap_or(0);
     if element_hash == 0 {
-        tracing::debug!("Element does not have a hash, cannot resize");
+        tracing::debug!("Element does not have a hash, cannot persist geometry");
         return None;
     }
 
-    // They all have the same size anyway:
     let (path, offset) = element_node.path_and_offset();
 
-    // Apply the overrides permanently
     let properties = ["x", "y", "width", "height"];
     let geometry_changes = PREVIEW_STATE.with_borrow(|preview_state| {
         let overrides = (*preview_state.debug_hook_overrides).borrow();
@@ -1566,101 +1585,6 @@ fn resize_selected_element_impl(
         geometry_changes,
     )
     .map(|edit| (edit, "Repositioning element".to_owned()))
-}
-
-fn can_move_selected_element(x: f32, y: f32, mouse_x: f32, mouse_y: f32) -> bool {
-    let position = LogicalPoint::new(x, y);
-    let mouse_position = LogicalPoint::new(mouse_x, mouse_y);
-    let Some(selected) = selected_element() else {
-        return false;
-    };
-    let Some(selected_element_node) = selected.as_element_node() else {
-        return false;
-    };
-    let Some(document_cache) = document_cache() else {
-        return false;
-    };
-
-    drop_location::can_move_to(
-        &document_cache,
-        position,
-        mouse_position,
-        selected_element_node,
-        selected.instance_index,
-    )
-}
-
-fn move_selected_element(x: f32, y: f32, mouse_x: f32, mouse_y: f32) {
-    let position = LogicalPoint::new(x, y);
-    let mouse_position = LogicalPoint::new(mouse_x, mouse_y);
-    let Some(selected) = selected_element() else {
-        return;
-    };
-    let Some(selected_element_node) = selected.as_element_node() else {
-        return;
-    };
-    let Some(document_cache) = document_cache() else {
-        return;
-    };
-
-    if let Some((edit, drop_data)) = drop_location::move_element_to(
-        &document_cache,
-        selected_element_node.clone(),
-        selected.instance_index,
-        position,
-        mouse_position,
-    ) {
-        element_selection::restore_selection(
-            ElementSelection {
-                path: drop_data.path,
-                offset: drop_data.selection_offset,
-                instance_index: selected.instance_index,
-            },
-            SelectionNotification::AfterUpdate,
-        );
-
-        send_workspace_edit("Move element".to_string(), edit, false);
-    } else {
-        let Some(component_instance) = component_instance() else {
-            element_selection::reselect_element();
-            return;
-        };
-        let Some(parent_node) = selected_element_node.parent() else {
-            element_selection::reselect_element();
-            return;
-        };
-        let Some(element_size) = selected_element_node
-            .geometries(&component_instance)
-            .get(selected.instance_index)
-            .map(|geometry| geometry.rect.size)
-        else {
-            element_selection::reselect_element();
-            return;
-        };
-        let Some((parent_position, parent_angle)) = parent_node
-            .geometries(&component_instance)
-            .get(selected.instance_index)
-            .map(|geometry| (geometry.rect.origin, geometry.angle))
-        else {
-            element_selection::reselect_element();
-            return;
-        };
-        if parent_angle != 0.0 {
-            element_selection::reselect_element();
-            return;
-        }
-        let local_position =
-            LogicalPoint::new(position.x - parent_position.x, position.y - parent_position.y);
-        let Some((edit, label)) = resize_selected_element_impl(
-            &selected_element_node,
-            selected.instance_index,
-            LogicalRect::new(local_position, element_size),
-        ) else {
-            element_selection::reselect_element();
-            return;
-        };
-        send_workspace_edit(label, edit, true);
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/tools/editor/preview/drop_location.rs
+++ b/tools/editor/preview/drop_location.rs
@@ -674,22 +674,6 @@ fn find_drop_location(
     find_filtered_location(component_instance, position, filter, mark, component_type)
 }
 
-fn find_move_location(
-    component_instance: &ComponentInstance,
-    position: LogicalPoint,
-    selected_element: &i_slint_editor_preview::ElementRcNode,
-    component_type: &str,
-) -> Option<DropInformation> {
-    let se = selected_element.clone();
-    let filter = Box::new(move |e: &i_slint_editor_preview::ElementRcNode| {
-        *e == se || !e.is_same_component_as(&se)
-    });
-    let se = selected_element.clone();
-    let mark = Box::new(move |e: &i_slint_editor_preview::ElementRcNode| *e == se);
-
-    find_filtered_location(component_instance, position, filter, mark, component_type)
-}
-
 fn find_filtered_location(
     component_instance: &ComponentInstance,
     position: LogicalPoint,
@@ -871,75 +855,6 @@ pub fn edited_text_compiles(
     } else {
         preview::CompilationResult::ChangeCompiles
     }
-}
-
-/// Find the Element to insert into. None means we can not insert at this point.
-pub fn can_move_to(
-    document_cache: &i_slint_editor_preview::DocumentCache,
-    position: LogicalPoint,
-    mouse_position: LogicalPoint,
-    element_node: i_slint_editor_preview::ElementRcNode,
-    instance_index: usize,
-) -> bool {
-    let Some(component_instance) = preview::component_instance() else {
-        return false;
-    };
-
-    let component_type = element_node.component_type();
-    let dm =
-        find_move_location(&component_instance, mouse_position, &element_node, &component_type);
-
-    let can_move = if let Some(dm) = &dm {
-        // Cache compilation results:
-        #[derive(Clone, Debug, Hash, Eq, PartialEq)]
-        struct CacheEntry {
-            source_element: by_address::ByAddress<object_tree::ElementRc>,
-            source_node_index: usize,
-            target_element: by_address::ByAddress<object_tree::ElementRc>,
-            target_node_index: usize,
-            child_index: usize,
-        }
-        let cache_entry = CacheEntry {
-            source_element: by_address::ByAddress(element_node.element.clone()),
-            source_node_index: element_node.debug_index,
-            target_element: by_address::ByAddress(dm.target_element_node.element.clone()),
-            target_node_index: dm.target_element_node.debug_index,
-            child_index: dm.child_index,
-        };
-
-        thread_local!(static CACHE: RefCell<clru::CLruCache<CacheEntry, bool>> = RefCell::new(clru::CLruCache::new(NonZeroUsize::new(10).unwrap())));
-        CACHE.with_borrow_mut(|cache| {
-            if let Some(does_compile) = cache.get(&cache_entry) {
-                *does_compile
-            } else {
-                let does_compile = if let Some((edit, _)) = create_move_element_workspace_edit(
-                    &component_instance,
-                    dm,
-                    &element_node,
-                    instance_index,
-                    position,
-                    document_cache.format,
-                ) {
-                    workspace_edit_compiles(document_cache, &edit)
-                        == preview::CompilationResult::ChangeCompiles
-                } else {
-                    false
-                };
-                cache.put(cache_entry, does_compile);
-                does_compile
-            }
-        })
-    } else {
-        false
-    };
-
-    if can_move {
-        preview::set_drop_mark(&dm.unwrap().drop_mark);
-    } else {
-        preview::set_drop_mark(&None);
-    }
-
-    can_move
 }
 
 /// Extra data on an added Element, relevant to the Preview side only.
@@ -1321,54 +1236,6 @@ pub fn create_drop_element_workspace_edit_with_properties(
     ))
 }
 
-pub fn create_move_element_workspace_edit(
-    component_instance: &ComponentInstance,
-    drop_info: &DropInformation,
-    element: &i_slint_editor_preview::ElementRcNode,
-    instance_index: usize,
-    position: LogicalPoint,
-    format: i_slint_editor_preview::ByteFormat,
-) -> Option<(lsp_types::WorkspaceEdit, DropData)> {
-    let parent_of_element = element.parent();
-
-    let placeholder_text = if Some(&drop_info.target_element_node) == parent_of_element.as_ref() {
-        // We are moving within ourselves!
-
-        let size =
-            element.geometries(component_instance).get(instance_index).map(|g| g.rect.size)?;
-
-        if drop_info.target_element_node.layout_kind() == ui::LayoutKind::None {
-            let (edit, _) = preview::resize_selected_element_impl(
-                element,
-                instance_index,
-                LogicalRect::new(position, size),
-            )?;
-            let (path, selection_offset) = element.path_and_offset();
-            return Some((edit, DropData { selection_offset, path }));
-        } else {
-            let children = &drop_info.target_element_node.children();
-            let drop_index = if drop_info.child_index == usize::MAX {
-                children.len() - 1
-            } else {
-                drop_info.child_index
-            };
-            if children.get(drop_index).is_some_and(|c| c == element) {
-                // Dropped onto myself: Ignore the move
-                return None;
-            }
-        }
-
-        /* fall trough to the general case here */
-        String::new()
-    } else if parent_of_element.map(|p| p.children().len()).unwrap_or_default() == 1 {
-        placeholder()
-    } else {
-        String::new()
-    };
-
-    create_swap_element_workspace_edit(drop_info, element, placeholder_text, format)
-}
-
 pub fn create_swap_element_workspace_edit(
     drop_info: &DropInformation,
     element: &i_slint_editor_preview::ElementRcNode,
@@ -1483,41 +1350,6 @@ pub fn create_swap_element_workspace_edit(
         i_slint_editor_preview::editing::create_workspace_edit_from_single_text_edits(edits),
         DropData { selection_offset, path },
     ))
-}
-
-/// Find a location in a file that would be a good place to insert the new component at
-///
-/// Return a WorkspaceEdit to send to the editor and extra info for the live preview in
-/// the DropData struct.
-pub fn move_element_to(
-    document_cache: &i_slint_editor_preview::DocumentCache,
-    element: i_slint_editor_preview::ElementRcNode,
-    instance_index: usize,
-    position: LogicalPoint,
-    mouse_position: LogicalPoint,
-) -> Option<(lsp_types::WorkspaceEdit, DropData)> {
-    let component_instance = preview::component_instance()?;
-    let Some(drop_info) = find_move_location(
-        &component_instance,
-        mouse_position,
-        &element,
-        &element.component_type(),
-    ) else {
-        // Can not drop here: Ignore the move
-        return None;
-    };
-    create_move_element_workspace_edit(
-        &component_instance,
-        &drop_info,
-        &element,
-        instance_index,
-        position,
-        document_cache.format,
-    )
-    .and_then(|(e, d)| {
-        (workspace_edit_compiles(document_cache, &e) == preview::CompilationResult::ChangeCompiles)
-            .then_some((e, d))
-    })
 }
 
 #[cfg(test)]

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -229,9 +229,8 @@ pub fn create_ui(
         },
     );
     api.on_selected_element_resize(super::resize_selected_element);
+    api.on_persist_selected_element_geometry(super::persist_selected_element_geometry);
     api.on_selected_element_rotate(super::rotate_selected_element);
-    api.on_selected_element_can_move_to(super::can_move_selected_element);
-    api.on_selected_element_move(super::move_selected_element);
     api.on_selected_element_delete(super::delete_selected_element);
     api.on_override_selected_element_geometry(super::override_selected_element_geometry);
     api.on_override_selected_element_rotation(super::override_selected_element_rotation);

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -635,12 +635,10 @@ export global Api {
 
     callback rename-component(old-name: string, defined-at: string, new-name: string);
 
-    callback selected-element-can-move-to(x: length, y: length, mouse-x: length, mouse-y: length) -> bool;
-    callback selected-element-move(x: length, y: length, mouse-x: length, mouse-y: length);
-
     callback override-selected-element-border-radius(corner: CanvasCorner, radius: length, single-corner: bool);
     callback persist-selected-element-border-radius();
     callback selected-element-resize(x: length, y: length, width: length, height: length);
+    callback persist-selected-element-geometry();
     callback selected-element-rotate(rotation: angle);
     callback override-selected-element-geometry(x: length, y: length, width: length, height: length);
     callback override-selected-element-rotation(rotation: angle);

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -38,12 +38,9 @@ export component EditorCanvas inherits Rectangle {
         ? Api.highlight-positions(Api.current-element.source-uri, Api.current-element.offset)
         : [];
     // Outline-drag state: while dragging a handle the frame follows the pointer locally
-    // (no disk write); on release we commit once via Api.selected-element-resize.
     private property <bool> selection-drag-active: false;
     private property <Point> selection-drag-position;
     private property <Size> selection-drag-size;
-    private property <bool> selection-move-active: false;
-    private property <Point> selection-move-pointer;
     private property <bool> selection-rotation-active: false;
     private property <angle> selection-rotation;
 
@@ -268,7 +265,6 @@ export component EditorCanvas inherits Rectangle {
 
             resized-to(corner, position, size) => {
                 root.selection-drag-active = true;
-                root.selection-move-active = false;
                 root.selection-drag-position = position;
                 root.selection-drag-size = size;
                 // Push live geometry (content space) so the previewed element follows the
@@ -285,27 +281,9 @@ export component EditorCanvas inherits Rectangle {
                     x: position.x - EditorMetrics.phone-outer-padding,
                     y: position.y - EditorMetrics.phone-outer-padding,
                 };
-                let content-pointer = {
-                    x: self.move-pointer-position.x - EditorMetrics.phone-outer-padding,
-                    y: self.move-pointer-position.y - EditorMetrics.phone-outer-padding,
-                };
-                let pointer-outside-artboard = content-pointer.x < 0px
-                    || content-pointer.y < 0px
-                    || content-pointer.x > phone.width - 2 * EditorMetrics.phone-outer-padding
-                    || content-pointer.y > phone.height - 2 * EditorMetrics.phone-outer-padding;
-                if !Api.selected-element-can-move-to(
-                    content-position.x,
-                    content-position.y,
-                    content-pointer.x,
-                    content-pointer.y,
-                ) && !pointer-outside-artboard {
-                    return;
-                }
                 root.selection-drag-active = true;
-                root.selection-move-active = true;
                 root.selection-drag-position = position;
                 root.selection-drag-size = { width: s.width, height: s.height };
-                root.selection-move-pointer = self.move-pointer-position;
                 Api.override-selected-element-geometry(
                     content-position.x,
                     content-position.y,
@@ -314,23 +292,8 @@ export component EditorCanvas inherits Rectangle {
                 );
             }
             interaction-ended => {
-                if root.selection-move-active {
-                    Api.selected-element-move(
-                        root.selection-drag-position.x - EditorMetrics.phone-outer-padding,
-                        root.selection-drag-position.y - EditorMetrics.phone-outer-padding,
-                        root.selection-move-pointer.x - EditorMetrics.phone-outer-padding,
-                        root.selection-move-pointer.y - EditorMetrics.phone-outer-padding,
-                    );
-                    root.selection-move-active = false;
-                } else if root.selection-drag-active {
-                    // Convert from phone (frame-parent) space back to content space
-                    // by subtracting the 1px phone-outer-padding, then commit once.
-                    Api.selected-element-resize(
-                        root.selection-drag-position.x - EditorMetrics.phone-outer-padding,
-                        root.selection-drag-position.y - EditorMetrics.phone-outer-padding,
-                        root.selection-drag-size.width,
-                        root.selection-drag-size.height,
-                    );
+                if root.selection-drag-active {
+                    Api.persist-selected-element-geometry();
                 }
                 if root.selection-rotation-active {
                     Api.selected-element-rotate(root.selection-rotation);


### PR DESCRIPTION
Reparenting can be confusing, so for now only allow reparenting from the
Outline, which makes the parent hierarchy explicit.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
