### PR TITLE
Rust codegen: fix global access in repeated component layout accessors

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -2727,7 +2727,7 @@ fn generate_repeated_component(
     let ctx = EvaluationContext {
         compilation_unit: unit,
         current_scope: EvaluationScope::SubComponent(repeated.sub_tree.root, Some(parent_ctx)),
-        generator_state: RustGeneratorContext { global_access: quote!(_self) },
+        generator_state: RustGeneratorContext { global_access: quote!(_self.globals()) },
         argument_types: &[],
     };
 
@@ -2871,18 +2871,6 @@ fn generate_repeated_component(
                 // the row-scan literals below default those fields.
                 debug_assert!(root_sc.cross_axis_self_alignment_for_repeated.is_none());
                 debug_assert!(root_sc.layout_order_for_repeated.is_none());
-                // Create a context with proper global_access for compiling layout info expressions
-                let layout_ctx = EvaluationContext {
-                    compilation_unit: unit,
-                    current_scope: EvaluationScope::SubComponent(
-                        repeated.sub_tree.root,
-                        Some(parent_ctx),
-                    ),
-                    generator_state: RustGeneratorContext {
-                        global_access: quote!(_self.globals()),
-                    },
-                    argument_types: &[],
-                };
 
                 // A GridLayout measures an inner repeated child at the column
                 // width it assigns it, like the static children measure at
@@ -2894,7 +2882,7 @@ fn generate_repeated_component(
                         return quote!(inner.as_pin_ref().layout_info(o));
                     };
                     let idx = ident(GRID_MEASURE_CHILD_INDEX_LOCAL);
-                    let w = compile_expression(&e.borrow(), &layout_ctx);
+                    let w = compile_expression(&e.borrow(), &ctx);
                     quote!(match o {
                         sp::Orientation::Vertical => inner
                             .as_pin_ref()
@@ -2917,9 +2905,9 @@ fn generate_repeated_component(
                             llr::RowChildTemplateInfo::Static { child_index } => {
                                 let child = &root_sc.grid_layout_children[*child_index];
                                 let layout_info_h_code =
-                                    compile_expression(&child.layout_info_h.borrow(), &layout_ctx);
+                                    compile_expression(&child.layout_info_h.borrow(), &ctx);
                                 let layout_info_v_code =
-                                    compile_expression(&child.layout_info_v.borrow(), &layout_ctx);
+                                    compile_expression(&child.layout_info_v.borrow(), &ctx);
                                 let advance = (!is_last).then(|| quote! { count += 1; });
                                 quote! {
                                     if count == index {

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -711,7 +711,8 @@ fn lower_grid_layout(
             );
             collected_children.push(layout_child);
             new_row = true;
-        } else if layout_child.borrow().base_type.type_name() == Some("Row") {
+        } else if matches!(&layout_child.borrow().base_type, ElementType::Builtin(b) if b.name == "Row")
+        {
             new_row = true;
             let row_children = std::mem::take(&mut layout_child.borrow_mut().children);
             for row_child in row_children {

--- a/tests/cases/layout/box_layout_repeated_global_no_wrap.slint
+++ b/tests/cases/layout/box_layout_repeated_global_no_wrap.slint
@@ -1,0 +1,63 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test: a repeated component placed in a box layout, whose size
+// depends on a global property, must generate valid global access in its
+// synthesized cross-axis layout-info accessor.
+//
+// The rust code generator built the repeated component's evaluation context with
+// a global-access of `_self`, so the cross-width accessor emitted
+// `_self.global_Metrics` instead of `_self.globals().global_Metrics` and failed
+// to compile (the repeated-item-tree wrapper has no such field).
+//
+// The Text with `wrap: no-wrap` is only there to synthesize the cross-axis
+// layout-info accessor on the repeated cell; the assertion checks the marker's
+// position, which reflects the global-driven cell height.
+
+global Metrics {
+    in-out property <length> item-height: 40px;
+}
+
+component Row inherits Rectangle {
+    height: Metrics.item-height;
+    Text { text: "hello"; wrap: no-wrap; color: black; }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 300px;
+    callback set-h(length);
+    set-h(h) => { Metrics.item-height = h; }
+    VerticalLayout {
+        alignment: start;
+        for i in 3: Row {}
+        marker := Rectangle { height: 10px; }
+    }
+    out property <bool> test: marker.y == 3 * 40px;
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.invoke_set_h(50.0);
+assert!(!instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+instance.invoke_set_h(50.0);
+assert(!instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+instance.set_h(50);
+assert(!instance.test);
+```
+
+*/

--- a/tests/cases/layout/box_layout_repeated_global_no_wrap.slint
+++ b/tests/cases/layout/box_layout_repeated_global_no_wrap.slint
@@ -13,6 +13,11 @@
 // The Text with `wrap: no-wrap` is only there to synthesize the cross-axis
 // layout-info accessor on the repeated cell; the assertion checks the marker's
 // position, which reflects the global-driven cell height.
+//
+// The same user component is named `Row` and also placed as a GridLayout cell:
+// GridLayout lowering must treat it as a normal (constrained) cell, not as the
+// builtin grid `Row`. Doing the latter used to steal its children and mark a
+// `Component`-based element as optimized, tripping an `unreachable!` later.
 
 global Metrics {
     in-out property <length> item-height: 40px;
@@ -20,11 +25,12 @@ global Metrics {
 
 component Row inherits Rectangle {
     height: Metrics.item-height;
+    max-width: 50px;
     Text { text: "hello"; wrap: no-wrap; color: black; }
 }
 
 export component TestCase inherits Window {
-    width: 200px;
+    width: 300px;
     height: 300px;
     callback set-h(length);
     set-h(h) => { Metrics.item-height = h; }
@@ -33,7 +39,13 @@ export component TestCase inherits Window {
         for i in 3: Row {}
         marker := Rectangle { height: 10px; }
     }
-    out property <bool> test: marker.y == 3 * 40px;
+    GridLayout {
+        the-cell := Row { }
+    }
+    out property <bool> box-ok: marker.y == 3 * 40px;
+    // The custom `Row` cell honors its own max-width instead of filling the column.
+    out property <bool> grid-ok: the-cell.width == 50px;
+    out property <bool> test: box-ok && grid-ok;
 }
 
 /*

--- a/tests/cases/layout/grid_layout_repeated_global_no_wrap.slint
+++ b/tests/cases/layout/grid_layout_repeated_global_no_wrap.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Companion to box_layout_repeated_global_no_wrap for the GridLayout repeated-row
+// path: a repeated `Row` sized from a global property, with a non-wrapping Text,
+// must generate valid global access in the row's cross-axis measurement code.
+//
+// The repeated grid-row path used to build its own evaluation context so that
+// global access resolved through `_self.globals()`; that access is now correct
+// in the shared context and reused directly, so keep exercising it here.
+
+global Metrics {
+    in-out property <length> item-height: 40px;
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 300px;
+    callback set-h(length);
+    set-h(h) => { Metrics.item-height = h; }
+    GridLayout {
+        for i in 2: Row {
+            Rectangle {
+                height: Metrics.item-height;
+                Text { text: "hi"; wrap: no-wrap; color: black; }
+            }
+        }
+        Row { marker := Rectangle { height: 10px; } }
+    }
+    out property <bool> test: marker.y == 2 * 40px;
+}
+
+/*
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.invoke_set_h(50.0);
+assert!(!instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+instance.invoke_set_h(50.0);
+assert(!instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+instance.set_h(50);
+assert(!instance.test);
+```
+
+*/


### PR DESCRIPTION
The evaluation context for a repeated component used `_self` as the global access, so the synthesized cross-axis layout-info accessor emitted `_self.global_Foo` instead of `_self.globals().global_Foo`. The repeated item tree wrapper has no such field, so the generated code failed to compile when a repeated cell in a layout sized itself from a global and contained a non-wrapping Text.

This is a regression from commit e0f0179e45, which added the box-layout cross-axis accessor that consumes this context.

Fixes: #13093

Also fix panic when a component named Row is a GridLayout cell
