### PR TITLE
text: Bound the shaped-text cache

### DIFF
--- a/internal/core/item_rendering.rs
+++ b/internal/core/item_rendering.rs
@@ -144,6 +144,14 @@ impl<T> ItemCache<T> {
         self.map.borrow().is_empty()
     }
 
+    /// Keeps only the entries for which `f` returns true.
+    pub fn retain(&self, mut f: impl FnMut(&T) -> bool) {
+        self.map.borrow_mut().retain(|_, per_component| {
+            per_component.retain(|_, entry| f(&entry.data));
+            !per_component.is_empty()
+        });
+    }
+
     /// Returns a [`RefMut`](std::cell::RefMut) referencing the cached value associated with
     /// `item_rc`, updating the cache entry first if necessary using `update_fn`.
     ///

--- a/internal/core/textlayout/sharedparley/cache.rs
+++ b/internal/core/textlayout/sharedparley/cache.rs
@@ -33,13 +33,24 @@ struct CachedParagraphs {
     /// them back when it drops. Finding `None` here therefore means the previous caller returned
     /// without handing them back, and the entry has to be reshaped rather than served empty.
     paragraphs: Option<Vec<TextParagraph>>,
+    /// The [`TextLayoutCache::generation`] at which this entry was last served.
+    last_used: u32,
 }
 
 type InnerTextLayoutCache = crate::item_rendering::ItemCache<CachedParagraphs>;
 
+/// Entry count above which [`TextLayoutCache::sweep`] runs (~4.7KB per entry).
+const ENTRY_LIMIT: usize = 1024;
+
 /// Cache for shaped text paragraphs (before line breaking), keyed by ItemRc.
 pub struct TextLayoutCache {
     inner: InnerTextLayoutCache,
+    /// Bumped once per rendered frame; entries are stamped with it when served.
+    generation: std::cell::Cell<u32>,
+    /// Approximate entry count; a stale-high value just triggers one extra sweep.
+    entry_count_estimate: std::cell::Cell<usize>,
+    /// Estimate above which the next sweep runs; raised when the active set exceeds the limit.
+    sweep_threshold: std::cell::Cell<usize>,
     #[cfg(feature = "testing")]
     cache_miss_count: std::cell::Cell<u64>,
     #[cfg(feature = "testing")]
@@ -51,6 +62,9 @@ impl Default for TextLayoutCache {
     fn default() -> Self {
         Self {
             inner: Default::default(),
+            generation: Default::default(),
+            entry_count_estimate: Default::default(),
+            sweep_threshold: std::cell::Cell::new(ENTRY_LIMIT),
             #[cfg(feature = "testing")]
             cache_miss_count: std::cell::Cell::new(0),
             #[cfg(feature = "testing")]
@@ -72,6 +86,24 @@ impl TextLayoutCache {
     }
     pub fn clear_all(&self) {
         self.inner.clear_all();
+    }
+
+    /// Marks the beginning of a frame; called once per rendered frame.
+    pub fn begin_frame(&self) {
+        self.generation.set(self.generation.get().wrapping_add(1));
+    }
+
+    /// Drops the entries that were not served in the current or the previous frame.
+    fn sweep(&self) {
+        let generation = self.generation.get();
+        let mut kept = 0;
+        self.inner.retain(|entry| {
+            let keep = generation.wrapping_sub(entry.last_used) <= 1;
+            kept += keep as usize;
+            keep
+        });
+        self.entry_count_estimate.set(kept);
+        self.sweep_threshold.set(ENTRY_LIMIT.max(kept + ENTRY_LIMIT / 2));
     }
 }
 
@@ -179,11 +211,23 @@ pub(super) fn cached_paragraphs<'a>(
         cache.inner.release(item_rc);
     }
 
+    // Sweep before this item's entry is checked out and blocks `retain`'s access.
+    if cache.entry_count_estimate.get() > cache.sweep_threshold.get() {
+        cache.sweep();
+    }
+
     let mut entry = cache.inner.get_or_update_cache_entry_ref(item_rc, || {
         #[cfg(feature = "testing")]
         cache.cache_miss_count.set(cache.cache_miss_count.get() + 1);
-        CachedParagraphs { wrap, paragraphs: Some(shape(font_context)), line_breaking: None }
+        cache.entry_count_estimate.set(cache.entry_count_estimate.get() + 1);
+        CachedParagraphs {
+            wrap,
+            paragraphs: Some(shape(font_context)),
+            line_breaking: None,
+            last_used: 0, // stamped right below, for both a hit and this miss
+        }
     });
+    entry.last_used = cache.generation.get();
     let paragraphs = entry.paragraphs.take().unwrap_or_default();
     CachedParagraphsGuard {
         paragraphs: Some(paragraphs),

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1767,6 +1767,10 @@ impl WindowInner {
         ) -> T,
     ) -> Option<T> {
         crate::properties::evaluate_no_tracking(|| self.ensure_tree_instantiated());
+        #[cfg(feature = "shared-parley")]
+        if let Some(cache) = self.window_adapter().renderer().text_layout_cache() {
+            cache.begin_frame();
+        }
         let component_weak = ItemTreeRc::downgrade(&self.try_component()?);
         let post_render = |renderer: &mut dyn crate::item_rendering::ItemRenderer| {
             self.render_drag_image_overlay(renderer);


### PR DESCRIPTION
The TextLayoutCache only released entries on component destruction or scale-factor change, so every Text item kept its shaped paragraphs (~4.7KB each) forever: 60000 rows retained 274MB while ~25 were on screen. Renderers now mark frame boundaries, and once the cache grows past 1024 entries, a sweep drops the entries that were not used in the current or previous frame. Entries in active use are never evicted, so a scene with more visible text items than the limit doesn't thrash; an evicted entry re-shapes on next use like an invalidated one.

The issue proposed ranking by last use and keeping the newest half, which reshapes visible items every frame when more than half the limit is on screen at once.

Reported in #13007 (item 026)
