### PR TITLE
model: Skip SortModel's index adjustment when rows are appended

### DIFF
--- a/api/cpp/include/private/slint_models.h
+++ b/api/cpp/include/private/slint_models.h
@@ -748,10 +748,13 @@ struct SortModelInner : private_api::ModelChangeListener
             return;
         }
 
-        // Adjust the existing sorted row indices to match the updated source model
-        for (auto &row : sorted_rows) {
-            if (row >= first_inserted_row)
-                row += count;
+        // Adjust the existing sorted row indices to match the updated source model.
+        // Skipped for an append: every existing index is below `first_inserted_row` then.
+        if (first_inserted_row + count < source_model->row_count()) {
+            for (auto &row : sorted_rows) {
+                if (row >= first_inserted_row)
+                    row += count;
+            }
         }
 
         for (size_t row = first_inserted_row; row < first_inserted_row + count; ++row) {

--- a/api/cpp/tests/models.cpp
+++ b/api/cpp/tests/models.cpp
@@ -457,6 +457,37 @@ private:
     std::vector<int> data;
 };
 
+SCENARIO("Sorted Model Insert Adjustment")
+{
+    // Insertions before the end shift the mapping entries above them; appends skip that.
+    for (size_t insert_at : { size_t(0), size_t(3), size_t(7), size_t(10) }) {
+        auto origin = std::make_shared<slint::VectorModel<int>>(
+                std::vector<int> { 50, 10, 40, 20, 30, 90, 60, 80, 70, 0 });
+        auto sorted = std::make_shared<slint::SortModel<int>>(
+                origin, [](auto lhs, auto rhs) { return lhs < rhs; });
+        REQUIRE(sorted->row_count() == 10);
+        origin->insert(insert_at, 35);
+        origin->insert(insert_at, 45);
+        std::vector<int> result;
+        for (size_t i = 0; i < sorted->row_count(); ++i)
+            result.push_back(*sorted->row_data(i));
+        REQUIRE(result == std::vector<int> { 0, 10, 20, 30, 35, 40, 45, 50, 60, 70, 80, 90 });
+    }
+
+    auto origin =
+            std::make_shared<slint::VectorModel<int>>(std::vector<int> { 50, 10, 40, 20, 30 });
+    auto sorted = std::make_shared<slint::SortModel<int>>(
+            origin, [](auto lhs, auto rhs) { return lhs < rhs; });
+    REQUIRE(sorted->row_count() == 5);
+    origin->push_back(35);
+    origin->push_back(5);
+    origin->push_back(100);
+    std::vector<int> result;
+    for (size_t i = 0; i < sorted->row_count(); ++i)
+        result.push_back(*sorted->row_data(i));
+    REQUIRE(result == std::vector<int> { 5, 10, 20, 30, 35, 40, 50, 100 });
+}
+
 SCENARIO("Sorted Model Batch Remove")
 {
     auto source_model = std::make_shared<BatchRemoveModel>(std::vector<int> { 3, 4, 1, 2 });

--- a/internal/core/model/adapters.rs
+++ b/internal/core/model/adapters.rs
@@ -720,10 +720,13 @@ where
             return;
         }
 
-        // Adjust the existing sorted row indices to match the updated source model
-        for row in self.mapping.borrow_mut().iter_mut() {
-            if *row >= index {
-                *row += count;
+        // Adjust the existing sorted row indices to match the updated source model.
+        // (Skipped for an append: every existing index is below `index` then.)
+        if index + count < self.wrapped_model.row_count() {
+            for row in self.mapping.borrow_mut().iter_mut() {
+                if *row >= index {
+                    *row += count;
+                }
             }
         }
 
@@ -1551,4 +1554,37 @@ fn test_long_chain_integrity() {
     origin_model.insert(45, 3006);
     origin_model.insert(45, 3007);
     check_all();
+}
+
+#[test]
+fn test_sorted_model_row_added_adjustment() {
+    use tests_helper::*;
+
+    // Insertions before the end still shift the mapping entries above them.
+    for insert_at in [0usize, 3, 7, 10] {
+        let origin = Rc::new(VecModel::from(alloc::vec![50, 10, 40, 20, 30, 90, 60, 80, 70, 0]));
+        let sorted = Rc::new(SortModel::new(origin.clone(), |lhs, rhs| lhs.cmp(rhs)));
+        let checker = ModelChecker::new(sorted.clone());
+        origin.insert(insert_at, 35);
+        origin.insert(insert_at, 45);
+        checker.check();
+        assert_eq!(
+            (0..sorted.row_count()).filter_map(|row| sorted.row_data(row)).collect::<Vec<_>>(),
+            alloc::vec![0, 10, 20, 30, 35, 40, 45, 50, 60, 70, 80, 90],
+            "inserting at {insert_at}"
+        );
+    }
+
+    // Appends take the path that skips the adjustment.
+    let origin = Rc::new(VecModel::from(alloc::vec![50, 10, 40, 20, 30]));
+    let sorted = Rc::new(SortModel::new(origin.clone(), |lhs, rhs| lhs.cmp(rhs)));
+    let checker = ModelChecker::new(sorted.clone());
+    origin.push(35);
+    origin.push(5);
+    origin.push(100);
+    checker.check();
+    assert_eq!(
+        (0..sorted.row_count()).filter_map(|row| sorted.row_data(row)).collect::<Vec<_>>(),
+        alloc::vec![5, 10, 20, 30, 35, 40, 50, 100]
+    );
 }


### PR DESCRIPTION
row_added scanned the whole mapping to shift indices at or above the insertion point. For an append, every existing index is below the insertion point and the scan finds nothing, yet it made each append O(model). Appending 200 rows to a 200000-row sorted model: 9.2ms to 2.3ms per frame, flat in model size.

Reported in #13007 (item 029)
