### PR TITLE
window: Set up the focus visibility tracker only on accepted focus

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1466,7 +1466,6 @@ impl WindowInner {
         match item {
             Some(item) => {
                 *self.focus_item.borrow_mut() = item.downgrade();
-                self.track_focus_item_visibility(item);
                 let result = item.borrow().as_ref().focus_event(
                     &FocusEvent::FocusIn(reason),
                     &self.window_adapter(),
@@ -1474,6 +1473,7 @@ impl WindowInner {
                 );
                 // Reveal offscreen item when it gains focus
                 if result == crate::input::FocusEventResult::FocusAccepted {
+                    self.track_focus_item_visibility(item);
                     item.try_scroll_into_visible();
                 }
 


### PR DESCRIPTION
publish_focus_item walked the candidate's ancestor clips and initialized the visibility change tracker before knowing whether the item accepts focus. During move_focus every rejected candidate paid that setup just to have it overwritten by the next one. Do it only in the accepted branch. When no candidate accepts, the tracker now stays cleared (by take_focus_item) instead of tracking the last rejected item.

Reported in #13007 (item 077)
