### PR TITLE
Warn when a struct conversion drops extra fields

### DIFF
--- a/demos/printerdemo/ui/common.slint
+++ b/demos/printerdemo/ui/common.slint
@@ -91,7 +91,6 @@ export global ComponentTheme {
         active-background: #1D293D,
         active-icon-color: Colors.white,
         inactive-icon-color: #90A1B9,
-        header-background: #F8FAFC
     };
     property <SideBarTheme> minimalist: {
         icon-size: 40px,

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1626,6 +1626,24 @@ impl Expression {
                             }
                         }
                     }
+                    if !diag.is_slint_sc() {
+                        let extra = left
+                            .fields
+                            .keys()
+                            .filter(|f| !right.fields.contains_key(*f))
+                            .map(|f| format!("'{f}'"))
+                            .collect::<Vec<_>>();
+                        if let Some((last, rest)) = extra.split_last() {
+                            let (noun, list) = match rest {
+                                [] => ("field", last.clone()),
+                                _ => ("fields", format!("{} and {last}", rest.join(", "))),
+                            };
+                            diag.push_warning(
+                                format!("Conversion from {from_ty} to {target_type} ignores the extra {noun} {list}"),
+                                node,
+                            );
+                        }
+                    }
                     if let Expression::Struct { mut values, .. } = self {
                         let mut new_values = BTreeMap::new();
                         for (key, ty) in &right.fields {

--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1639,7 +1639,9 @@ impl Expression {
                                 _ => ("fields", format!("{} and {last}", rest.join(", "))),
                             };
                             diag.push_warning(
-                                format!("Conversion from {from_ty} to {target_type} ignores the extra {noun} {list}"),
+                                format!(
+                                    "Conversion to {target_type} ignores the extra {noun} {list}"
+                                ),
                                 node,
                             );
                         }

--- a/internal/compiler/tests/syntax/lookup/conversion.slint
+++ b/internal/compiler/tests/syntax/lookup/conversion.slint
@@ -55,6 +55,25 @@ export X := Rectangle {
     property <Data> object2: { a: "123", typo: 42};
 //                           >                    <error{Cannot convert { a: string,typo: float,} to Data: Field 'typo' not found. Available fields: 'a', 'b'}
 
+    property <Data> object3: { a: "123", b: 42, extra: 1};
+//                           >                           <warning{Conversion from { a: string,b: float,extra: float,} to Data ignores the extra field 'extra'}
+    property <{x: int}> object4: { x: 1, y: 2};
+//                               >            <warning{Conversion from { x: float,y: float,} to { x: int,} ignores the extra field 'y'}
+    property <{x: int}> object5: { x: 1, y: 2, z: 3};
+//                               >                  <warning{Conversion from { x: float,y: float,z: float,} to { x: int,} ignores the extra fields 'y' and 'z'}
+    property <[Data]> object6: [{ a: "1", b: 2, extra: 3 }];
+//                             >                           <warning{Conversion from { a: string,b: float,extra: float,} to Data ignores the extra field 'extra'}
+
+    property <{a: int, b: int, c: int}> src: { a: 1, b: 2, c: 3 };
+    property <{a: int, b: int}> from_var: src;
+//                                        >  <warning{Conversion from { a: int,b: int,c: int,} to { a: int,b: int,} ignores the extra field 'c'}
+    property <{inner: {x: int}}> sub: { inner: { x: 1, extra: 2 } };
+//                                    >                            <warning{Conversion from { extra: float,x: float,} to { x: int,} ignores the extra field 'extra'}
+    property <{items: [float], name: string}> arr_conv: { items: [1, 2], name: "x", extra: 5 };
+//                                                      >                                     <warning{Conversion from { extra: float,items: [float],name: string,} to { items: [float],name: string,} ignores the extra field 'extra'}
+    property <{inner: {x: int, y: int}}> sub_err: { inner: { x: 1, typo: 2 } };
+//                                                >                           <error{Cannot convert { typo: float,x: float,} to { x: int,y: int,}: Field 'typo' not found}
+
     property <[{a: [int]}]> ccc: [{a: []}, {}, {a: ["123"]}, {a: [123]}]; //  (FIXME: error location)  (FIXME: duplicated)
 //                               >                                      <error{Cannot convert string to int}
 //                               >                                      <^error{Cannot convert string to int}

--- a/internal/compiler/tests/syntax/lookup/conversion.slint
+++ b/internal/compiler/tests/syntax/lookup/conversion.slint
@@ -21,6 +21,12 @@ struct Data {
     b: int
 }
 
+struct DataMore {
+    a: string,
+    b: int,
+    c: int
+}
+
 export X := Rectangle {
 //       ><warning{':=' to declare a component is deprecated. The new syntax declare components with 'component MyComponent {'. Read the documentation for more info}
 
@@ -56,21 +62,24 @@ export X := Rectangle {
 //                           >                    <error{Cannot convert { a: string,typo: float,} to Data: Field 'typo' not found. Available fields: 'a', 'b'}
 
     property <Data> object3: { a: "123", b: 42, extra: 1};
-//                           >                           <warning{Conversion from { a: string,b: float,extra: float,} to Data ignores the extra field 'extra'}
+//                           >                           <warning{Conversion to Data ignores the extra field 'extra'}
     property <{x: int}> object4: { x: 1, y: 2};
-//                               >            <warning{Conversion from { x: float,y: float,} to { x: int,} ignores the extra field 'y'}
+//                               >            <warning{Conversion to { x: int,} ignores the extra field 'y'}
     property <{x: int}> object5: { x: 1, y: 2, z: 3};
-//                               >                  <warning{Conversion from { x: float,y: float,z: float,} to { x: int,} ignores the extra fields 'y' and 'z'}
+//                               >                  <warning{Conversion to { x: int,} ignores the extra fields 'y' and 'z'}
     property <[Data]> object6: [{ a: "1", b: 2, extra: 3 }];
-//                             >                           <warning{Conversion from { a: string,b: float,extra: float,} to Data ignores the extra field 'extra'}
+//                             >                           <warning{Conversion to Data ignores the extra field 'extra'}
 
     property <{a: int, b: int, c: int}> src: { a: 1, b: 2, c: 3 };
     property <{a: int, b: int}> from_var: src;
-//                                        >  <warning{Conversion from { a: int,b: int,c: int,} to { a: int,b: int,} ignores the extra field 'c'}
+//                                        >  <warning{Conversion to { a: int,b: int,} ignores the extra field 'c'}
+    property <DataMore> data_more;
+    property <Data> named_conv: data_more;
+//                              >        <warning{Conversion to Data ignores the extra field 'c'}
     property <{inner: {x: int}}> sub: { inner: { x: 1, extra: 2 } };
-//                                    >                            <warning{Conversion from { extra: float,x: float,} to { x: int,} ignores the extra field 'extra'}
+//                                    >                            <warning{Conversion to { x: int,} ignores the extra field 'extra'}
     property <{items: [float], name: string}> arr_conv: { items: [1, 2], name: "x", extra: 5 };
-//                                                      >                                     <warning{Conversion from { extra: float,items: [float],name: string,} to { items: [float],name: string,} ignores the extra field 'extra'}
+//                                                      >                                     <warning{Conversion to { items: [float],name: string,} ignores the extra field 'extra'}
     property <{inner: {x: int, y: int}}> sub_err: { inner: { x: 1, typo: 2 } };
 //                                                >                           <error{Cannot convert { typo: float,x: float,} to { x: int,y: int,}: Field 'typo' not found}
 

--- a/tools/lsp/ui/components/spreadsheet.slint
+++ b/tools/lsp/ui/components/spreadsheet.slint
@@ -289,7 +289,6 @@ export component Spreadsheet {
                     root.current-cell-data = {
                         property-group-id: root.property-group-id,
                         property-name: preview-data.name,
-                        property-value: root.current-table.values[row][col],
                         row: row,
                         col: col,
                         x: self.x,

--- a/tools/lsp/ui/components/widgets/brush-helpers.slint
+++ b/tools/lsp/ui/components/widgets/brush-helpers.slint
@@ -12,7 +12,7 @@ export component ColorIndicator {
     in property <color> color;
     in property <length> border-radius;
     in property <length> border-width;
-    property <{hue: float, saturation: float, value: float}> hsv-color: color.to-hsv();
+    property <{hue: float, saturation: float, value: float, alpha: float}> hsv-color: color.to-hsv();
 
     Rectangle {
         width: 100%;
@@ -29,9 +29,9 @@ export component ColorIndicator {
             x: parent.width / 2;
             width: 50%;
             // work around lack of masking by hiding the background and checkerboard when alpha is 1
-            background: root.color.to-hsv().alpha < 1 ? white : transparent;
+            background: hsv-color.alpha < 1 ? white : transparent;
             Image {
-                visible: root.color.to-hsv().alpha < 1;
+                visible: hsv-color.alpha < 1;
                 width: 100%;
                 height: 100%;
                 vertical-alignment: top;

--- a/tools/lsp/ui/components/widgets/floating-brush-sections/gradient-ui.slint
+++ b/tools/lsp/ui/components/widgets/floating-brush-sections/gradient-ui.slint
@@ -199,16 +199,15 @@ component GradientStopValue {
                 letter-spacing: 0.8px;
                 input-type: text;
 
-                property <{hue: float, saturation: float, value: float}> hsv-color;
                 function apply-text(text: string) {
                     if Api.string-is-color("#\{self.text}") {
-                        PickerData.hue = Api.string-to-color("#\{self.text}").to-hsv().hue;
-                        PickerData.saturation = Api.string-to-color("#\{self.text}").to-hsv().saturation;
-                        PickerData.value = Api.string-to-color("#\{self.text}").to-hsv().value;
+                        let hsv-color = Api.string-to-color("#\{self.text}").to-hsv();
+                        PickerData.hue = hsv-color.hue;
+                        PickerData.saturation = hsv-color.saturation;
+                        PickerData.value = hsv-color.value;
                         if self.text.character-count > 6 {
                             PickerData.current-gradient-stops[stop-index].color = Api.string-to-color("#\{self.text}");
                         } else {
-                            hsv-color = Api.string-to-color("#\{self.text}").to-hsv();
                             PickerData.current-gradient-stops[stop-index].color = hsv(hsv-color.hue, hsv-color.saturation, hsv-color.value, PickerData.current-gradient-stops[stop-index].color.to-hsv().alpha);
                         }
                     } else {


### PR DESCRIPTION
An extra field in a struct value or literal is still dropped, but a warning is now emitted instead of silently ignoring it. When a target field is also missing it stays an error, and it is not added in Slint SC mode where dropping a field is already an error.

Also drop such an ignored field from a printerdemo SideBarTheme literal.
