### PR TITLE
tests: fix the nodejs driver hanging on pnpm install, and un-skip the issue 9722 test

### DIFF
--- a/tests/cases/issues/issue_9722_popup_panic.slint
+++ b/tests/cases/issues/issue_9722_popup_panic.slint
@@ -1,9 +1,6 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// FIXME: Skip test on NodeJS since this not fixed for the interpreter
-//ignore: js
-
 export component TestCase inherits Window {
     property <bool> condition: true;
     in property <bool> condition-2: true;

--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -30,10 +30,7 @@ static NODE_API_JS_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
         .arg("install")
         .arg("--ignore-scripts")
         .arg("--config.confirmModulesPurge=false") // https://github.com/pnpm/pnpm/issues/9973 (and 7727 for the solution)
-        // As of pnpm 11.17, --config.confirmModulesPurge=false no longer suppresses the
-        // confirmation prompt before removing the modules directory.
-        // The output is piped, so the prompt is invisible and the driver hangs.
-        // CI=true suppresses it.
+        // Prevent the pnpm confirmation prompt for module purge.
         .env("CI", "true")
         .current_dir(node_dir.clone())
         .stdout(std::process::Stdio::piped())

--- a/tests/driver/nodejs/nodejs.rs
+++ b/tests/driver/nodejs/nodejs.rs
@@ -30,6 +30,11 @@ static NODE_API_JS_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
         .arg("install")
         .arg("--ignore-scripts")
         .arg("--config.confirmModulesPurge=false") // https://github.com/pnpm/pnpm/issues/9973 (and 7727 for the solution)
+        // As of pnpm 11.17, --config.confirmModulesPurge=false no longer suppresses the
+        // confirmation prompt before removing the modules directory.
+        // The output is piped, so the prompt is invisible and the driver hangs.
+        // CI=true suppresses it.
+        .env("CI", "true")
         .current_dir(node_dir.clone())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
Two small test-infrastructure fixes, found while verifying whether #9722 could be closed.

## Fix the nodejs driver hanging on `pnpm install`

`tests/driver/nodejs/nodejs.rs` runs `pnpm install --config.confirmModulesPurge=false` with stdout and stderr piped. As of pnpm 11.17 that flag no longer suppresses the confirmation prompt before removing the modules directory, so pnpm blocks on input that never arrives.

Because the output is piped the prompt is invisible — the driver just sits there with no diagnostic. A stack sample of the hung process:

```
nodejs.rs:36 -> Command::output -> read_output -> poll
  └── node /opt/homebrew/bin/pnpm install --ignore-scripts --config.confirmModulesPurge=false
```

It stayed there for 18 minutes at 0% CPU before I killed it. Running the identical command by hand shows the cause: pnpm wants to purge 222 packages and waits for confirmation. With `CI=true` the same install finishes in 967ms.

The existing comment cites pnpm#9973/#7727 as the source of the flag, so the workaround has simply been outgrown by a newer pnpm.

Note on verification: the direct evidence is that comparison — hangs without `CI=true`, completes in under a second with it. The test passing afterwards confirms nothing broke, but does not by itself prove the fix, since the prompt only appears when pnpm actually wants to purge, and I could not force that condition back on demand.

## Stop skipping the issue 9722 popup test on nodejs

`tests/cases/issues/issue_9722_popup_panic.slint` carried:

```
// FIXME: Skip test on NodeJS since this not fixed for the interpreter
//ignore: js
```

That is no longer true. With the skip removed, both drivers pass:

```
test test_interpreter_issues_issue_9722_popup_panic ... ok
test test_nodejs_issues_issue_9722_popup_panic ... ok
```

The first commit is what makes the second testable locally.

Closes #9722 — already closed as fixed; this makes the nodejs coverage real rather than skipped.
