### PR TITLE
docs(python): document updating models from a thread

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -224,6 +224,7 @@
     "tabwidget",
     "testcase",
     "textedit",
+    "threadsafe", // asyncio loop.call_soon_threadsafe()
     "tmpobj",
     "toolchain",
     "toolkit",

--- a/docs/python/src/content/docs/index.mdx
+++ b/docs/python/src/content/docs/index.mdx
@@ -132,6 +132,57 @@ component.model.append(4)
 del component.model[0]
 ```
 
+## Threading
+
+The event loop runs on the main thread, and components must be created and
+accessed from that same thread.
+Doing blocking work there stalls rendering and input, so move it to another
+thread and apply the result back on the main thread.
+
+Pass a coroutine to <XRef to="run_event_loop" /> to run `asyncio` alongside the
+Slint event loop.
+Use `asyncio.to_thread()` for blocking work: it runs the function on a worker
+thread, and the code after the `await` continues on the main thread, where it is
+safe to update a model.
+
+```python
+import asyncio
+import slint
+
+def enumerate_devices() -> list[str]:
+    # Runs on a worker thread, so it may block.
+    return scan_usb_bus()
+
+async def main(component: slint.Component) -> None:
+    names = await asyncio.to_thread(enumerate_devices)
+    # Back on the main thread: safe to touch the model.
+    for name in names:
+        component.devices.append(name)
+
+component.devices = slint.ListModel([])
+slint.run_event_loop(main(component))
+```
+
+When the work happens on a thread you don't drive yourself, such as a device
+callback or a `threading.Thread`, hand the update back with
+`loop.call_soon_threadsafe()`:
+
+```python
+import asyncio
+import slint
+import threading
+
+def worker(loop: asyncio.AbstractEventLoop, model: slint.ListModel) -> None:
+    for name in scan_usb_bus():
+        loop.call_soon_threadsafe(model.append, name)
+
+async def main(model: slint.ListModel) -> None:
+    loop = asyncio.get_running_loop()
+    threading.Thread(target=worker, args=(loop, model), daemon=True).start()
+```
+
+Calling a model method directly from another thread is not supported.
+
 ## Type mappings
 
 Each type used for properties in the Slint language translates to a specific


### PR DESCRIPTION
Adds a Threading section to the Python overview, covering how to update a model from another thread.

## Why

#3945 asked for this across all languages. Rust was documented in #8027 and C++ in #8032, but the Python half was never written — @ogoffart noted the remaining gap in [this comment](https://github.com/slint-ui/slint/issues/3945#issuecomment-2775640380). Today `docs/python/` has no threading guidance at all.

## What

Python does not expose `invoke_from_event_loop`. It gets an `asyncio` loop instead (`SlintEventLoop`), so the advice genuinely differs from Rust and C++ rather than being a translation of it. The section documents the two shapes that work:

- `asyncio.to_thread()` for blocking work started from the coroutine passed to `run_event_loop()` — the code after the `await` resumes on the main thread, where touching the model is safe.
- `loop.call_soon_threadsafe()` for handing an update back from a thread the application owns.

Placed after "Arrays and models" and before "Type mappings", since the question is specifically about models.

## Verification

Both snippets were run against a real component before being written down, not inferred from the source — each appends to a `ListModel` from a worker thread and the bound `count` property reflects the result.

`pnpm build` in `docs/python` passes, including the internal link validator, so the `XRef` targets resolve.

## Unrelated observation

While testing, every run ends with a spurious traceback at interpreter shutdown:

```
File ".../slint/loop.py", line 209, in close
AttributeError: 'NoneType' object has no attribute 'fileno'
```

`SlintEventLoop.is_closed()` (`api/python/slint/slint/loop.py:211`) always returns `False`, so asyncio's `BaseEventLoop.__del__` closes an already-closed loop and `_close_self_pipe` trips over the cleared socket. Not touched here since it is outside the scope of this PR, but it makes every Python Slint program exit noisily.
