### PR TITLE
python: don't report the asyncio loop as permanently open

### DIFF
--- a/api/python/slint/slint/loop.py
+++ b/api/python/slint/slint/loop.py
@@ -205,12 +205,6 @@ class SlintEventLoop(asyncio.SelectorEventLoop):
     def is_running(self) -> bool:
         return self._is_running
 
-    def close(self) -> None:
-        super().close()
-
-    def is_closed(self) -> bool:
-        return False
-
     def call_later(self, delay, callback, *args, context=None) -> asyncio.TimerHandle:
         timer = native.Timer()
 


### PR DESCRIPTION
Every program that uses `slint.run_event_loop()` ends with a spurious traceback at interpreter shutdown:

```
Exception ignored while calling deallocator <function BaseEventLoop.__del__ ...>:
Traceback (most recent call last):
  File ".../asyncio/base_events.py", line 761, in __del__
  File ".../slint/loop.py", line 209, in close
  File ".../asyncio/selector_events.py", line 111, in _close_self_pipe
AttributeError: 'NoneType' object has no attribute 'fileno'
```

## Cause

`SlintEventLoop.is_closed()` returned `False` unconditionally. `BaseEventLoop.__del__` consults it to decide whether the loop still needs cleaning up, so at garbage-collection time it always concluded the loop was open and called `close()` on an already-closed loop. `_close_self_pipe` then dereferenced `self._ssock`, which the first close had already set to `None`.

## Fix

Drop the override and inherit the base implementation, which tracks the real state.

The adjacent `close()` override is removed with it: it only forwarded to `super().close()` and did nothing else, so it was already equivalent to not overriding.

`git log -L` traces both to the original "Python: Initial support for asyncio" commit with no accompanying rationale — they look like stubs written alongside `is_running()` rather than deliberate workarounds. Nothing else under `api/python` calls `is_closed()`.

## Verification

| | `AttributeError` at exit |
| --- | --- |
| before | 2 |
| after | 0 |

Measured with a script that runs `run_event_loop()` twice, once updating a model via `asyncio.to_thread()` and once via `loop.call_soon_threadsafe()` from a worker thread. Both still produce correct results after the change.

- `pytest tests/` — 148 passed, 3 skipped, including `test_async.py`, `test_loop.py` and `test_invoke_from_event_loop.py`
- `ruff check` — clean
- `ty check` — clean
