### PR TITLE
viewer: add an mcp feature so it can serve the MCP server

### DIFF
--- a/internal/interpreter/Cargo.toml
+++ b/internal/interpreter/Cargo.toml
@@ -38,6 +38,15 @@ system-tray = ["i-slint-core/system-tray"]
 ## enable the [`print_diagnostics`] function to show diagnostic in the console output
 display-diagnostics = ["i-slint-compiler/display-diagnostics"]
 
+## Enable the embedded MCP (Model Context Protocol) server.
+##
+## When this feature is enabled and the `SLINT_MCP_PORT` environment variable is set
+## at runtime, the application starts an HTTP server implementing the MCP Streamable HTTP
+## transport. This allows MCP clients to inspect and interact with the running UI.
+##
+## This is a developer/debug feature. It is not recommended to enable it in production builds.
+mcp = ["std", "i-slint-backend-selector/mcp"]
+
 ## Enable the default image formats from the `image` crate, to support additional image formats in [`Image::load_from_path`]
 ## and `@image-url`. When this feature is disabled, only PNG and JPEG are supported. When enabled,
 ## the following image formats are supported:

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["gui", "development-tools", "command-line-utilities"]
 keywords = ["viewer", "gui", "ui", "toolkit"]
 
 [features]
+# Enable the embedded MCP server; requires SLINT_MCP_PORT to be set at runtime.
+mcp = ["slint-interpreter/mcp"]
+
 backend-default = ["slint-interpreter/backend-default"]
 backend-qt = ["slint-interpreter/backend-qt"]
 backend-winit = ["slint-interpreter/backend-winit"]


### PR DESCRIPTION
Lets `slint-viewer` serve the embedded MCP server, so a `.slint` file can be inspected and driven without writing a host application first.

## The gap

The `mcp` feature exists on `slint`, `slint-cpp`, `slint-python` and `slint-node` — but not on `slint-interpreter`, so `slint-viewer` had no way to enable it. Running the viewer with `SLINT_MCP_PORT` set did nothing, and `SLINT_BACKEND=headless` failed with:

```
Error: headless backend requested but it is not available
```

That makes the viewer the one place a `.slint` file cannot be driven over MCP, even though it is the natural tool for looking at one.

## The change

Two opt-in features:

- `slint-interpreter`: `mcp = ["std", "i-slint-backend-selector/mcp"]`, documented with the same wording the `slint` crate uses
- `slint-viewer`: `mcp = ["slint-interpreter/mcp"]`

Default builds are unchanged.

## Verification

With `--features mcp` and `SLINT_MCP_PORT` set, the viewer serves all 14 tools:

```
list_windows, get_window_properties, get_element_tree, get_element_properties,
find_elements_by_id, query_element_descendants, take_screenshot, click_element,
drag_element, invoke_accessibility_action, set_element_value, dispatch_key_event,
start_event_recording, stop_event_recording
```

- `cargo build -p slint-viewer` (default) — unchanged, and `SLINT_MCP_PORT` alone does nothing without the feature
- `cargo build -p slint-interpreter` without the feature — still builds
- default and `--no-default-features` + `mcp` configurations both pass `cargo check`

## Why this is useful

I hit this while triaging old issues: verifying a rendering claim needs a screenshot from the real backend, and `slint-viewer --screenshot` goes through the headless *software* renderer, which does no transforms and does not render colour emoji. For https://github.com/slint-ui/slint/issues/12603 it produced a blank button; only an MCP `take_screenshot` against a real Skia window showed the actual defect, which could then be measured (the emoji centroid sits 4.3px right and 1.6px above the button centre).

## Not addressed here

`SLINT_BACKEND=headless` still does not work in the viewer even with this feature. The selector gates the headless backend behind `supports_headless`, which requires `renderer-software` or `renderer-skia` to be enabled *on the selector*, while the viewer's renderer features are forwarded to the interpreter instead. A real window works, so this was not needed for the above; wiring up headless for CI use would be a separate change.
