### PR TITLE
femtovg: Render before reading the buffer back in take_snapshot

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -1034,6 +1034,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
         window: &'a i_slint_core::api::Window,
         width: u32,
         height: u32,
+        render_target: femtovg::RenderTarget,
     ) -> Self {
         let scale_factor = ScaleFactor::new(window.scale_factor());
         Self {
@@ -1052,7 +1053,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> GLItemRenderer<'a, R> {
                     PhysicalSize::new(width as f32, height as f32) / scale_factor,
                 ),
                 global_alpha: 1.,
-                current_render_target: femtovg::RenderTarget::Screen,
+                current_render_target: render_target,
             }],
             metrics: RenderingMetrics { layers_created: Some(0), ..Default::default() },
         }

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -45,6 +45,26 @@ pub use wgpu::FemtoVGWGPURenderer;
 
 pub trait WindowSurface<R: femtovg::Renderer> {
     fn render_output(&self) -> impl Into<R::RenderOutput>;
+    /// Return [`femtovg::RenderTarget::Image`] to redirect the frame when
+    /// [`Self::render_output`] cannot select an offscreen target, as for OpenGL, which
+    /// renders into whatever framebuffer is bound.
+    fn initial_render_target(&self) -> femtovg::RenderTarget {
+        femtovg::RenderTarget::Screen
+    }
+}
+
+/// Call after every [`femtovg::Canvas::set_size`], which queues a `SetRenderTarget(Screen)` of
+/// its own without updating the cached target. [`femtovg::Canvas::set_render_target`] does
+/// nothing when the target matches that cache, so switch through `Screen` to force the frame's
+/// target to be queued again.
+fn select_render_target<R: femtovg::Renderer>(
+    canvas: &mut femtovg::Canvas<R>,
+    target: femtovg::RenderTarget,
+) {
+    if target != femtovg::RenderTarget::Screen {
+        canvas.set_render_target(femtovg::RenderTarget::Screen);
+        canvas.set_render_target(target);
+    }
 }
 
 /// Result of [`GraphicsBackend::begin_surface_rendering`]. `Skipped` carries the reason,
@@ -82,9 +102,9 @@ pub trait GraphicsBackend {
         height: NonZeroU32,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
-    /// Implement screenshot capture for this backend. The `canvas` is the FemtoVG canvas
-    /// (available for GL backends to call `canvas.screenshot()`). The `render` closure triggers
-    /// a full render pass, which WGPU-style implementations may redirect to an offscreen texture.
+    /// Redirect the full frame drawn by `render` offscreen and read back its pixels, using
+    /// `canvas` if this backend reads back through it. `width` and `height` are the window
+    /// size, guaranteed non-zero by the caller.
     /// Return `None` if this backend does not support `take_snapshot`.
     fn take_snapshot_pixels(
         &self,
@@ -155,6 +175,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
             BeginRendering::Acquired(s) => s,
             BeginRendering::Skipped(outcome) => return Ok(outcome),
         };
+        let render_target = surface.initial_render_target();
 
         if self.rendering_first_time.take() {
             *self.rendering_metrics_collector.borrow_mut() = RenderingMetricsCollector::new(
@@ -201,6 +222,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     // dpi / device pixel ratio as the anti-alias of femtovg needs that to draw text clearly.
                     // We need to care about that `ceil()` when calculating metrics.
                     femtovg_canvas.set_size(surface_size.width, surface_size.height, scale);
+                    select_render_target(&mut femtovg_canvas, render_target);
 
                     // Clear with window background if it is a solid color otherwise it will drawn as gradient
                     if let Some(Brush::SolidColor(clear_color)) = window_background_brush {
@@ -231,6 +253,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     self.graphics_backend.submit_commands(commands);
 
                     femtovg_canvas.set_size(width.get(), height.get(), scale);
+                    select_render_target(&mut femtovg_canvas, render_target);
                     drop(femtovg_canvas);
 
                     self.with_graphics_api(|api| {
@@ -252,6 +275,7 @@ impl<B: GraphicsBackend> FemtoVGRenderer<B> {
                     window,
                     width.get(),
                     height.get(),
+                    render_target,
                 );
 
                 if let Some(window_item_rc) = window_inner.window_item_rc() {
@@ -401,6 +425,9 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
             .and_then(|w| w.upgrade())
             .map(|a| a.size())
             .unwrap_or_default();
+        if size.width == 0 || size.height == 0 {
+            return Err("take_snapshot: window size is zero".into());
+        }
         let canvas = self.canvas.borrow().as_ref().cloned();
         self.graphics_backend
             .take_snapshot_pixels(canvas, size.width, size.height, &|| self.render())

--- a/internal/renderers/femtovg/lib.rs
+++ b/internal/renderers/femtovg/lib.rs
@@ -393,7 +393,6 @@ impl<B: GraphicsBackend> RendererSealed for FemtoVGRenderer<B> {
         Ok(())
     }
 
-    /// Returns an image buffer of what was rendered last.
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         let size = self
             .maybe_window_adapter

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -245,7 +245,7 @@ impl GraphicsBackend for OpenGLBackend {
         canvas: Option<CanvasRc<Self::Renderer>>,
         _width: u32,
         _height: u32,
-        _render: &dyn Fn() -> Result<(), PlatformError>,
+        render: &dyn Fn() -> Result<(), PlatformError>,
     ) -> Option<
         Result<
             i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
@@ -258,6 +258,10 @@ impl GraphicsBackend for OpenGLBackend {
                 .borrow()
                 .ensure_current()
                 .map_err(|e| PlatformError::Other(e.to_string()))?;
+            // Render the scene before reading the buffer back, like the wgpu backends do.
+            // Without this the snapshot is the last presented frame,
+            // which predates any change made since.
+            render()?;
             let screenshot = canvas
                 .borrow_mut()
                 .screenshot()

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -89,8 +89,19 @@ unsafe impl OpenGLInterface for SuspendedRenderer {
     }
 }
 
+/// Stops a panic in the snapshot's render pass from leaving every later frame redirected
+/// offscreen, which would stop the window ever presenting again.
+struct SnapshotTargetGuard<'a>(&'a RefCell<Option<femtovg::ImageId>>);
+
+impl Drop for SnapshotTargetGuard<'_> {
+    fn drop(&mut self) {
+        self.0.borrow_mut().take();
+    }
+}
+
 pub struct OpenGLBackend {
     opengl_context: RefCell<Box<dyn OpenGLInterface>>,
+    snapshot_target: RefCell<Option<femtovg::ImageId>>,
     #[cfg(target_family = "wasm")]
     html_canvas: RefCell<Option<web_sys::HtmlCanvasElement>>,
 }
@@ -153,14 +164,72 @@ impl OpenGLBackend {
         renderer.reset_canvas(canvas);
         Ok(())
     }
+
+    /// Renders one frame into `image_id` and reads it back. The caller owns `image_id` and must
+    /// restore the canvas' render target and delete the texture afterwards, including on error.
+    fn render_snapshot(
+        &self,
+        canvas: &CanvasRc<femtovg::renderer::OpenGl>,
+        image_id: femtovg::ImageId,
+        width: u32,
+        height: u32,
+        render: &dyn Fn() -> Result<(), PlatformError>,
+    ) -> Result<
+        i_slint_core::graphics::SharedPixelBuffer<i_slint_core::graphics::Rgba8Pixel>,
+        PlatformError,
+    > {
+        *self.snapshot_target.borrow_mut() = Some(image_id);
+        let guard = SnapshotTargetGuard(&self.snapshot_target);
+        let render_result = render();
+        drop(guard);
+        render_result?;
+
+        // `screenshot()` reads the bound framebuffer, which the `AfterRendering` notifier may
+        // rebind after the frame's last flush. Select the texture again and flush before reading
+        // back: the window back buffer has the same dimensions and would pass the check below.
+        let mut canvas = canvas.borrow_mut();
+        crate::select_render_target(&mut canvas, femtovg::RenderTarget::Image(image_id));
+        // The flush issues the GL calls itself; its `()` command buffer needs no submission.
+        canvas.flush_to_output(());
+
+        let screenshot = canvas
+            .screenshot()
+            .map_err(|e| format!("FemtoVG error reading back snapshot texture: {e}"))?;
+
+        if screenshot.width() as u32 != width || screenshot.height() as u32 != height {
+            return Err(format!(
+                "take_snapshot: read back {}x{} pixels instead of the requested {width}x{height}",
+                screenshot.width(),
+                screenshot.height()
+            )
+            .into());
+        }
+
+        use rgb::ComponentBytes;
+        Ok(i_slint_core::graphics::SharedPixelBuffer::clone_from_slice(
+            screenshot.buf().as_bytes(),
+            width,
+            height,
+        ))
+    }
 }
 
-pub struct GLWindowSurface {}
+pub enum GLWindowSurface {
+    Screen,
+    Snapshot(femtovg::ImageId),
+}
 
 impl WindowSurface<femtovg::renderer::OpenGl> for GLWindowSurface {
     fn render_output(
         &self,
     ) -> impl Into<<femtovg::renderer::OpenGl as femtovg::Renderer>::RenderOutput> {
+    }
+
+    fn initial_render_target(&self) -> femtovg::RenderTarget {
+        match self {
+            Self::Screen => femtovg::RenderTarget::Screen,
+            Self::Snapshot(image_id) => femtovg::RenderTarget::Image(*image_id),
+        }
     }
 }
 
@@ -172,6 +241,7 @@ impl GraphicsBackend for OpenGLBackend {
     fn new_suspended() -> Self {
         Self {
             opengl_context: RefCell::new(Box::new(SuspendedRenderer {})),
+            snapshot_target: RefCell::new(None),
             #[cfg(target_family = "wasm")]
             html_canvas: RefCell::new(None),
         }
@@ -186,7 +256,10 @@ impl GraphicsBackend for OpenGLBackend {
         &self,
     ) -> Result<BeginRendering<GLWindowSurface>, Box<dyn std::error::Error + Send + Sync>> {
         self.opengl_context.borrow().ensure_current()?;
-        Ok(BeginRendering::Acquired(GLWindowSurface {}))
+        Ok(BeginRendering::Acquired(match *self.snapshot_target.borrow() {
+            Some(image_id) => GLWindowSurface::Snapshot(image_id),
+            None => GLWindowSurface::Screen,
+        }))
     }
 
     fn submit_commands(&self, _commands: <Self::Renderer as femtovg::Renderer>::CommandBuffer) {}
@@ -196,9 +269,14 @@ impl GraphicsBackend for OpenGLBackend {
     /// this to platform specific APIs such as eglSwapBuffers.
     fn present_surface(
         &self,
-        _surface: GLWindowSurface,
+        surface: GLWindowSurface,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.opengl_context.borrow().swap_buffers()
+        match surface {
+            GLWindowSurface::Screen => self.opengl_context.borrow().swap_buffers(),
+            // Rendered offscreen, and outside a draw request: presenting would push a frame
+            // to the window that nothing asked for.
+            GLWindowSurface::Snapshot(_) => Ok(()),
+        }
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -243,8 +321,8 @@ impl GraphicsBackend for OpenGLBackend {
     fn take_snapshot_pixels(
         &self,
         canvas: Option<CanvasRc<Self::Renderer>>,
-        _width: u32,
-        _height: u32,
+        width: u32,
+        height: u32,
         render: &dyn Fn() -> Result<(), PlatformError>,
     ) -> Option<
         Result<
@@ -258,17 +336,32 @@ impl GraphicsBackend for OpenGLBackend {
                 .borrow()
                 .ensure_current()
                 .map_err(|e| PlatformError::Other(e.to_string()))?;
-            render()?;
-            let screenshot = canvas
+
+            // Outside a draw request the back buffer's contents are undefined, and getting a
+            // defined result out of it would mean presenting. Render offscreen instead, so
+            // capturing a frame never puts one on screen.
+            //
+            // Omit `FLIP_Y`: `screenshot()` flips rows assuming a bottom-up framebuffer, so the
+            // offscreen target has to use that orientation too.
+            let image_id = canvas
                 .borrow_mut()
-                .screenshot()
-                .map_err(|e| format!("FemtoVG error reading current back buffer: {e}"))?;
-            use rgb::ComponentBytes;
-            Ok(i_slint_core::graphics::SharedPixelBuffer::clone_from_slice(
-                screenshot.buf().as_bytes(),
-                screenshot.width() as u32,
-                screenshot.height() as u32,
-            ))
+                .create_image_empty(
+                    width as usize,
+                    height as usize,
+                    femtovg::PixelFormat::Rgba8,
+                    femtovg::ImageFlags::empty(),
+                )
+                .map_err(|e| format!("FemtoVG error allocating snapshot texture: {e}"))?;
+
+            let snapshot = self.render_snapshot(&canvas, image_id, width, height, render);
+
+            // femtovg deletes the texture and its framebuffer immediately, so this has to come
+            // after the read back.
+            let mut canvas = canvas.borrow_mut();
+            canvas.set_render_target(femtovg::RenderTarget::Screen);
+            canvas.delete_image(image_id);
+
+            snapshot
         })())
     }
 }

--- a/internal/renderers/femtovg/opengl.rs
+++ b/internal/renderers/femtovg/opengl.rs
@@ -258,9 +258,6 @@ impl GraphicsBackend for OpenGLBackend {
                 .borrow()
                 .ensure_current()
                 .map_err(|e| PlatformError::Other(e.to_string()))?;
-            // Render the scene before reading the buffer back, like the wgpu backends do.
-            // Without this the snapshot is the last presented frame,
-            // which predates any change made since.
             render()?;
             let screenshot = canvas
                 .borrow_mut()

--- a/internal/renderers/femtovg/wgpu.rs
+++ b/internal/renderers/femtovg/wgpu.rs
@@ -64,10 +64,6 @@ fn wgpu_take_snapshot_pixels(
 > {
     use i_slint_core::graphics::{Rgba8Pixel, SharedPixelBuffer};
 
-    if width == 0 || height == 0 {
-        return Err("take_snapshot: window size is zero".into());
-    }
-
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("slint_take_snapshot_wgpu"),
         size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },


### PR DESCRIPTION
`FemtoVGRenderer<OpenGLBackend>::take_snapshot_pixels` receives a `render` callback but never calls it, reading back the current back buffer instead. What comes out is the last **presented** frame, so a snapshot taken after anything changed silently returns the old pixels — no error, and a perfectly valid-looking image.

The item tree is correct at the same instant, so the accessible state and the pixels disagree.

## What I measured

The test file below moves one rectangle, resizes a second, recolors a third, and instantiates a fourth when `n` changes. Taking a snapshot, clicking, and taking another — with the click confirmed to land (`accessible-label` reads `n=1`) in every row:

| renderer | pixels differing between the two snapshots |
| --- | --- |
| `winit-femtovg` | **0 — completely frozen** |
| `winit-skia` | 36000 |
| `winit-software` | 36000 |

Nothing gets through under FemtoVG: not color, position or size, and not the newly instantiated element. A window with a running animation looks correct only because the animation keeps presenting frames, which is why this is easy to miss.

```slint
export component W inherits Window {
    width: 300px;
    height: 200px;
    in-out property <int> n;

    Rectangle { x: root.n > 0 ? 200px : 10px; y: 10px; width: 50px; height: 40px; background: #ff0000; }
    Rectangle { x: 10px; y: 60px; width: root.n > 0 ? 200px : 50px; height: 20px; background: #00ff00; }
    Rectangle { x: 10px; y: 90px; width: 50px; height: 20px; background: root.n > 0 ? #0000ff : #ffff00; }
    if root.n > 0 : Rectangle { x: 10px; y: 120px; width: 50px; height: 20px; background: #ff00ff; }

    ta := TouchArea { y: 160px; height: 40px; clicked => { root.n += 1; } }
}
```

## The change

Both FemtoVG wgpu backends already call `render`, and Skia's `take_snapshot` renders into a fresh buffer, so the OpenGL path was the outlier. Calling `render()` before the read-back brings it in line: the 0 above becomes 36000, matching Skia and the software renderer exactly.

Verified stable — five consecutive runs all report 36000, and repeated snapshots within one session are identical to each other and current.

## Two things worth a reviewer's judgment

1. **Semantics.** The doc comment on `FemtoVGRenderer::take_snapshot` says "Returns an image buffer of what was rendered last", which describes the OpenGL behavior rather than the wgpu or Skia one. If any caller depends on the last-presented-frame meaning, this changes it for them. I assumed the wgpu/Skia behavior is the intended contract, since `Window::take_snapshot()` is public API and documents no such caveat.

2. **Presenting an extra frame.** On the OpenGL path `render()` draws and presents, so a snapshot now costs a frame. That is what makes the read-back correct, but if you would rather render to an offscreen target here, say so and I will redo it that way.

## Note on coverage

`tests/screenshots/` has runners for Skia, software and anyrender, but none for FemtoVG — which is consistent with this going unnoticed. I have not added one, since it needs a GL context in CI; happy to if you want it.

Found while using the MCP server's `take_screenshot` to verify UI behavior. The viewer's default renderer is FemtoVG, so this is the path that tooling actually hits.
