### PR TITLE
testing: Add hover_element and move_pointer tools to the MCP server

### DIFF
--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -926,6 +926,25 @@ pub(crate) mod dispatch {
         Ok(())
     }
 
+    /// Move the pointer to an element's center without pressing any button.
+    ///
+    /// `click` and `drag` both press, so hover-only behavior cannot be reached
+    /// through them.
+    #[cfg(feature = "mcp")]
+    pub(crate) fn move_pointer_to_element(
+        state: &IntrospectionState,
+        element: ArenaIndex,
+    ) -> Result<(), String> {
+        let element = state.element("move_pointer", element)?;
+        let position = element.absolute_center();
+        let window_adapter =
+            element.window_adapter().ok_or_else(|| "element has no window".to_string())?;
+        window_adapter
+            .window()
+            .dispatch_event(i_slint_core::platform::WindowEvent::PointerMoved { position });
+        Ok(())
+    }
+
     pub(crate) async fn drag(
         state: &IntrospectionState,
         element: ArenaIndex,
@@ -972,6 +991,14 @@ fn test_dispatch_click_double_click_stale_handle() {
         .unwrap_err();
         assert!(err.contains("Invalid element handle"), "got: {err}");
     });
+}
+
+#[test]
+#[cfg(feature = "mcp")]
+fn test_dispatch_move_pointer_stale_handle() {
+    let state = IntrospectionState::new();
+    let err = dispatch::move_pointer_to_element(&state, ArenaIndex::default()).unwrap_err();
+    assert!(err.contains("Invalid element handle"), "got: {err}");
 }
 
 #[test]

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -97,6 +97,18 @@ const TOOLS: &[ToolDef] = &[
         optional_fields: &["button"],
     },
     ToolDef {
+        name: "hover_element",
+        description: "Move the mouse pointer to the center of an element without pressing any button. Use this for hover states, tooltips and menu highlighting: click_element and drag_element both press, so they cannot produce a hover on their own. The pointer stays where it is left; move it away with move_pointer to check that a hover is cleared.",
+        request_type: "RequestHoverElement",
+        optional_fields: &[],
+    },
+    ToolDef {
+        name: "move_pointer",
+        description: "Move the mouse pointer to a position in the window, in logical coordinates, without pressing any button. Use hover_element to hover an element by handle; use this to move to an arbitrary point, such as away from an element to check that its hover state is cleared.",
+        request_type: "RequestMovePointer",
+        optional_fields: &[],
+    },
+    ToolDef {
         name: "invoke_accessibility_action",
         description: "Invoke an accessibility action: 'Default_' (activate buttons, toggle checkboxes), 'Increment'/'Decrement' (sliders, spinboxes), 'Expand' (combo boxes). Preferred over click_element when the element's role suggests a semantic action.",
         request_type: "RequestInvokeElementAccessibilityAction",
@@ -350,6 +362,28 @@ async fn handle_tool_call(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
             ))
         }
+        "hover_element" => {
+            let p: proto::RequestHoverElement = deserialize_params(args)?;
+            let element_index = handle_to_index(
+                p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
+            )?;
+            dispatch::move_pointer_to_element(state, element_index)?;
+            Ok(ToolResult::Json(serde_json::json!({})))
+        }
+        "move_pointer" => {
+            let p: proto::RequestMovePointer = deserialize_params(args)?;
+            let window_index = handle_to_index(
+                p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
+            )?;
+            let position = p.position.ok_or_else(|| "missing position".to_string())?;
+            state.dispatch_window_event(
+                window_index,
+                i_slint_core::platform::WindowEvent::PointerMoved {
+                    position: i_slint_core::api::LogicalPosition::new(position.x, position.y),
+                },
+            )?;
+            Ok(ToolResult::Json(serde_json::json!({})))
+        }
         "drag_element" => {
             let p: proto::RequestElementDrag = deserialize_params(args)?;
             let element_index = handle_to_index(
@@ -493,6 +527,9 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "5. get_element_properties → full details on a specific element\n",
                     "6. take_screenshot → visual snapshot (returned as inline image)\n",
                     "7. Interact: click_element, drag_element, set_element_value, invoke_accessibility_action, dispatch_key_event\n",
+                    "   Hover without pressing: hover_element (an element's center) or move_pointer (a position). ",
+                    "click_element and drag_element both press, so neither can produce a hover on its own. ",
+                    "The pointer stays where it is left, so clear a hover with move_pointer to a point away from the element.\n",
                     "8. start_event_recording → then interact → stop_event_recording to verify the runtime received and processed expected input/window events\n",
                     "9. take_screenshot again to verify the visual effect\n\n",
 

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -933,7 +933,7 @@ impl ElementHandle {
         }
     }
 
-    fn window_adapter(&self) -> Option<Rc<dyn i_slint_core::window::WindowAdapter>> {
+    pub(crate) fn window_adapter(&self) -> Option<Rc<dyn i_slint_core::window::WindowAdapter>> {
         self.item.upgrade().and_then(|item| item.window_adapter())
     }
 
@@ -1074,7 +1074,7 @@ impl ElementHandle {
     /// The center of the element in the coordinate system that input events are dispatched in.
     /// Unlike [`Self::absolute_position()`] this includes the location of an enclosing popup that's
     /// rendered inside the window, such as a menu.
-    fn absolute_center(&self) -> LogicalPosition {
+    pub(crate) fn absolute_center(&self) -> LogicalPosition {
         let Some(item) = self.item.upgrade() else {
             return Default::default();
         };

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -229,6 +229,19 @@ message RequestDispatchWindowEvent {
     WindowEvent event = 2;
 }
 
+// Not part of RequestToAUT: moving the pointer, hovering, and clearing a hover
+// all boil down to dispatching a PointerMoveEvent via RequestDispatchWindowEvent,
+// which the wire protocol already supports. These messages exist only to give the
+// move_pointer/hover_element MCP tools their own minimal input schema.
+message RequestMovePointer {
+    Handle window_handle = 1;
+    LogicalPosition position = 2;
+}
+
+message RequestHoverElement {
+    Handle element_handle = 1;
+}
+
 message RequestDispatchKeyEvent {
     Handle window_handle = 1;
     string text = 2;


### PR DESCRIPTION
`click_element` and `drag_element` both press a button, so there is currently no way to produce a plain hover over MCP: every way of getting the pointer onto an element also delivers a press to it. Hover states, tooltips and menu highlighting are therefore untestable.

This adds two tools, neither of which presses anything:

- **`hover_element`** — moves the pointer to an element's center. Reuses the same `absolute_center` that `click_element` targets, so a hover lands exactly where a click would.
- **`move_pointer`** — moves it to a position in the window. Needed for the other half of hover testing: moving *away*, to check that a hover is cleared.

Two tools rather than one with alternative targeting fields, so that each `inputSchema` states exactly which arguments are required:

| tool | required |
| --- | --- |
| `hover_element` | `["elementHandle"]` |
| `move_pointer` | `["windowHandle", "position"]` |

That matches every other tool that takes arguments. A single tool would have had to mark all three fields optional, leaving `{}` valid against the schema but rejected by the handler.

## Verified

A rectangle whose accessible label follows `TouchArea::has-hover`:

| step | label |
| --- | --- |
| initial | `not hovered` |
| `hover_element` on it | **`HOVERED`** |
| `move_pointer` to `5,5` | `not hovered` |

And on a real case — #8603, "right-click menu disappears when the cursor is on top of an entry", which I had been unable to test for exactly this reason. Opening the context menu and hovering entries, the menu stays open with all four entries, and screenshots taken while hovering entry 0 versus entry 2 differ by 63770 pixels as the highlight follows the pointer. That test could not be written before.

## Notes

- Both proto messages are wired into the systest `oneof` as well, since every other request is, so the tools are available over both transports.
- `ElementHandle::absolute_center` and `::window_adapter` go from private to `pub(crate)` so the dispatch module can reuse them rather than recomputing a center that might drift from the one `click_element` uses.
- Added `test_dispatch_move_pointer_stale_handle`, matching the existing stale-handle tests.
- **Known limitation, shared with the existing tools:** the pointer's position is dispatched only to the target element's own window, so hovering in window A and then in window B leaves A's hover state stale — B never causes a `PointerExited` in A. `click_element` and `drag_element` behave the same way today, since `ElementHandle::pointer_pressed` also dispatches only to `self.window_adapter()`. Fixing it properly means tracking the pointer's current window in `IntrospectionState` and synthesizing an exit when it crosses, which changes click and drag semantics too. That felt like it belonged in its own change rather than being bundled here, but say the word and I will add it.
- `cargo test -p i-slint-backend-testing --all-features` gives 49 passed / 8 failed here; the same 8 `search_api::` tests fail identically on an unmodified master checkout on this machine, so they look unrelated to this change. Worth a look separately if they are not expected to fail on macOS.
