### PR TITLE
Changing the `muda` menubar rebuilding logic to only rebuild branches of the menu tree that actually changed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,7 +3364,9 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "id-pool",
  "imgref",
+ "itertools 0.15.0",
  "lyon_path",
  "muda",
  "objc2 0.6.4",
@@ -3869,6 +3871,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "id-pool"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d0df4d8a768821ee4aa2e0353f67125c4586f0e13adbf95b8ebbf8d8fdb344"
 
 [[package]]
 name = "ident_case"
@@ -6369,7 +6377,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2219,9 +2219,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2431,7 +2431,9 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "id-pool",
  "imgref",
+ "itertools 0.15.0",
  "lyon_path",
  "muda",
  "objc2 0.6.4",
@@ -2830,6 +2832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae293c039020f9ec10710af98d29ce6aa2051486638b49c9a6409f3b4a9e98ad"
 
 [[package]]
+name = "id-pool"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d0df4d8a768821ee4aa2e0353f67125c4586f0e13adbf95b8ebbf8d8fdb344"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,9 +2905,9 @@ checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -3351,9 +3359,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lyon_algorithms"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
+checksum = "cdfa8785f95e57914ddb35e3b59994aeba6f5e79e9cfd03da1c269f010f36009"
 dependencies = [
  "lyon_path",
  "num-traits",
@@ -4353,7 +4361,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi 0.5.3",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4590,9 +4590,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -4810,7 +4810,9 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "id-pool",
  "imgref",
+ "itertools 0.15.0",
  "lyon_path",
  "muda",
  "objc2 0.6.4",
@@ -5219,6 +5221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae293c039020f9ec10710af98d29ce6aa2051486638b49c9a6409f3b4a9e98ad"
 
 [[package]]
+name = "id-pool"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d0df4d8a768821ee4aa2e0353f67125c4586f0e13adbf95b8ebbf8d8fdb344"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5295,9 +5303,9 @@ checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -5740,9 +5748,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lyon_algorithms"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
+checksum = "cdfa8785f95e57914ddb35e3b59994aeba6f5e79e9cfd03da1c269f010f36009"
 dependencies = [
  "lyon_path",
  "num-traits",
@@ -6253,7 +6261,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi 0.5.3",
  "libc",
 ]
 
@@ -7152,7 +7160,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi 0.5.3",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -92,6 +92,8 @@ imgref = { version = "1.6.1", optional = true }
 rgb = { version = "0.8.27", optional = true }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 webbrowser = "1.2.0"
+itertools.workspace = true
+id-pool = "0.2.2"
 
 [target.'cfg(any(target_os = "macos", target_family = "windows"))'.dependencies]
 muda = { version = "0.19.0", optional = true, default-features = false }

--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -93,9 +93,9 @@ rgb = { version = "0.8.27", optional = true }
 bytemuck = { workspace = true, optional = true, features = ["derive"] }
 webbrowser = "1.2.0"
 itertools.workspace = true
-id-pool = "0.2.2"
 
 [target.'cfg(any(target_os = "macos", target_family = "windows"))'.dependencies]
+id-pool = "0.2.2"
 muda = { version = "0.19.0", optional = true, default-features = false }
 vtable = { workspace = true }
 

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -18,10 +18,17 @@ use winit::event_loop::EventLoopProxy;
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::window::Window;
 
+#[derive(Clone, Debug)]
+struct MenuNode {
+    entry: MenuEntry,
+    children: Vec<MenuNode>,
+}
+
 pub struct MudaAdapter {
     entries: Vec<MenuEntry>,
     tracker: Option<Pin<Box<PropertyTracker<false, MudaPropertyTracker>>>>,
     menu: Option<muda::Menu>,
+    menu_tree: Vec<MenuNode>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, strum::EnumString, strum::Display)]
@@ -53,6 +60,220 @@ impl PropertyDirtyHandler for MudaPropertyTracker {
     }
 }
 
+fn menu_entry_count(node: &MenuNode) -> usize {
+    1 + node.children.iter().fold(0usize, |count, child| count + menu_entry_count(child))
+}
+
+fn flatten_menu_tree(tree: &[MenuNode], result: &mut Vec<MenuEntry>) {
+    for item in tree {
+        result.push(item.entry.clone());
+        if item.entry.has_sub_menu {
+            flatten_menu_tree(&item.children, result);
+        }
+    }
+}
+
+fn build_menu_item(
+    node: &MenuNode,
+    start_index: usize,
+    window_id: &str,
+    muda_type: MudaType,
+) -> Box<dyn muda::IsMenuItem> {
+    let id = muda::MenuId(format!("{window_id}|{start_index}|{muda_type}"));
+    if node.entry.is_separator {
+        return Box::new(muda::PredefinedMenuItem::separator());
+    }
+
+    if !node.entry.has_sub_menu {
+        let accelerator = keys_to_accelerator(&node.entry.shortcut);
+        let err_handler = |err| {
+            i_slint_core::debug_log!(
+                "Warning: Could not set accelerator {} for menu item {}: {err}",
+                node.entry.shortcut,
+                node.entry.title
+            )
+        };
+
+        if node.entry.checkable {
+            let check_menu = muda::CheckMenuItem::with_id(
+                id.clone(),
+                &node.entry.title,
+                node.entry.enabled,
+                node.entry.checked,
+                None,
+            );
+            check_menu.set_key_accelerator(accelerator).map_err(err_handler).ok();
+            return Box::new(check_menu);
+        }
+
+        if let Some(rgba) = node.entry.icon.to_rgba8() {
+            let icon =
+                muda::Icon::from_rgba(rgba.as_bytes().to_vec(), rgba.width(), rgba.height()).ok();
+            let icon_menu = muda::IconMenuItem::with_id(
+                id.clone(),
+                &node.entry.title,
+                node.entry.enabled,
+                icon,
+                None,
+            );
+            icon_menu.set_key_accelerator(accelerator).map_err(err_handler).ok();
+            return Box::new(icon_menu);
+        }
+
+        let menu_item =
+            muda::MenuItem::with_id(id.clone(), &node.entry.title, node.entry.enabled, None);
+        menu_item.set_key_accelerator(accelerator).map_err(err_handler).ok();
+        return Box::new(menu_item);
+    }
+
+    let sub_menu = muda::Submenu::with_id(id.clone(), &node.entry.title, node.entry.enabled);
+    let mut next_index = start_index + 1;
+    for child in &node.children {
+        sub_menu.append(&*build_menu_item(child, next_index, window_id, muda_type)).unwrap();
+        next_index += menu_entry_count(child);
+    }
+    Box::new(sub_menu)
+}
+
+fn rebuild_root_menu(
+    menu: &muda::Menu,
+    tree: &[MenuNode],
+    start_index: usize,
+    window_id: &str,
+    muda_type: MudaType,
+) {
+    while menu.remove_at(0).is_some() {}
+    let mut next_index = start_index;
+    for item in tree {
+        menu.append(&*build_menu_item(item, next_index, window_id, muda_type)).unwrap();
+        next_index += menu_entry_count(item);
+    }
+}
+
+fn update_submenu(
+    submenu: &muda::Submenu,
+    old_items: &[MenuNode],
+    new_items: &[MenuNode],
+    start_index: usize,
+    window_id: &str,
+    muda_type: MudaType,
+) {
+    if old_items.len() != new_items.len() {
+        rebuild_submenu(submenu, new_items, start_index, window_id, muda_type);
+        return;
+    }
+
+    let mut local_index = 0usize;
+    let mut next_index = start_index;
+    for (old_item, new_item) in old_items.iter().zip(new_items) {
+        if old_item.entry == new_item.entry {
+            if old_item.entry.has_sub_menu
+                && let Some(muda::MenuItemKind::Submenu(child_submenu)) =
+                    submenu.items().get(local_index)
+            {
+                update_submenu(
+                    child_submenu,
+                    &old_item.children,
+                    &new_item.children,
+                    next_index + 1,
+                    window_id,
+                    muda_type,
+                );
+            }
+        } else {
+            submenu.remove_at(local_index);
+            submenu
+                .insert(&*build_menu_item(new_item, next_index, window_id, muda_type), local_index)
+                .unwrap();
+        }
+
+        local_index += 1;
+        next_index += menu_entry_count(old_item);
+    }
+}
+
+fn rebuild_submenu(
+    submenu: &muda::Submenu,
+    tree: &[MenuNode],
+    start_index: usize,
+    window_id: &str,
+    muda_type: MudaType,
+) {
+    while submenu.remove_at(0).is_some() {}
+    let mut next_index = start_index;
+    for item in tree {
+        submenu.append(&*build_menu_item(item, next_index, window_id, muda_type)).unwrap();
+        next_index += menu_entry_count(item);
+    }
+}
+
+fn build_menu_tree_for_parent(
+    menu: vtable::VRef<'_, MenuVTable>,
+    parent: Option<&MenuEntry>,
+    depth: usize,
+) -> Vec<MenuNode> {
+    let mut raw_entries = Default::default();
+    match parent {
+        Some(parent) => menu.sub_menu(Some(parent), &mut raw_entries),
+        None => menu.sub_menu(None, &mut raw_entries),
+    }
+
+    let mut tree = Vec::new();
+    for entry in raw_entries {
+        let children = if entry.has_sub_menu && depth < 15 {
+            build_menu_tree_for_parent(menu, Some(&entry), depth + 1)
+        } else {
+            Vec::new()
+        };
+        tree.push(MenuNode { entry: entry.clone(), children });
+    }
+    tree
+}
+
+fn build_menu_tree(menu: &vtable::VRc<MenuVTable>) -> Vec<MenuNode> {
+    build_menu_tree_for_parent(vtable::VRc::borrow(menu), None, 0)
+}
+
+fn update_menu_branch(
+    menu: &muda::Menu,
+    old_items: &[MenuNode],
+    new_items: &[MenuNode],
+    start_index: usize,
+    window_id: &str,
+    muda_type: MudaType,
+) {
+    if old_items.len() != new_items.len() {
+        rebuild_root_menu(menu, new_items, start_index, window_id, muda_type);
+        return;
+    }
+
+    let mut local_index = 0usize;
+    let mut next_index = start_index;
+    for (old_item, new_item) in old_items.iter().zip(new_items) {
+        if old_item.entry == new_item.entry {
+            if old_item.entry.has_sub_menu
+                && let Some(muda::MenuItemKind::Submenu(submenu)) = menu.items().get(local_index)
+            {
+                update_submenu(
+                    submenu,
+                    &old_item.children,
+                    &new_item.children,
+                    next_index + 1,
+                    window_id,
+                    muda_type,
+                );
+            }
+        } else {
+            menu.remove_at(local_index);
+            menu.insert(&*build_menu_item(new_item, next_index, window_id, muda_type), local_index)
+                .unwrap();
+        }
+
+        local_index += 1;
+        next_index += menu_entry_count(old_item);
+    }
+}
+
 impl MudaAdapter {
     pub fn setup(
         menubar: &vtable::VRc<MenuVTable>,
@@ -67,7 +288,8 @@ impl MudaAdapter {
                 window_adapter_weak,
             })));
 
-        let mut s = Self { entries: Default::default(), tracker, menu: None };
+        let mut s =
+            Self { entries: Default::default(), tracker, menu: None, menu_tree: Vec::new() };
         s.rebuild_menu(winit_window, Some(menubar), MudaType::Menubar);
         s
     }
@@ -80,7 +302,8 @@ impl MudaAdapter {
     ) -> Option<Self> {
         install_event_handler_if_necessary(proxy);
 
-        let mut s = Self { entries: Default::default(), tracker: None, menu: None };
+        let mut s =
+            Self { entries: Default::default(), tracker: None, menu: None, menu_tree: Vec::new() };
         s.rebuild_menu(winit_window, Some(context_menu), MudaType::Context);
 
         match winit_window.window_handle().ok()?.as_raw() {
@@ -123,118 +346,21 @@ impl MudaAdapter {
         menu_tree: Option<&vtable::VRc<MenuVTable>>,
         muda_type: MudaType,
     ) {
-        let must_set_window_redraw = cfg!(windows) && winit_window.is_visible() == Some(true);
-        if must_set_window_redraw {
-            win32_set_window_redraw(winit_window, false);
-        }
-
-        // clear the menu
-        self.entries.clear();
-
-        fn generate_menu_entry(
-            menu: vtable::VRef<'_, MenuVTable>,
-            entry: &MenuEntry,
-            depth: usize,
-            map: &mut Vec<MenuEntry>,
-            window_id: &str,
-            muda_type: MudaType,
-        ) -> Box<dyn muda::IsMenuItem> {
-            let id = muda::MenuId(format!("{window_id}|{}|{}", map.len(), muda_type));
-            map.push(entry.clone());
-            if entry.is_separator {
-                Box::new(muda::PredefinedMenuItem::separator())
-            } else if !entry.has_sub_menu {
-                let accelerator = keys_to_accelerator(&entry.shortcut);
-
-                let err_handler = |err| {
-                    i_slint_core::debug_log!(
-                        "Warning: Could not set accelerator {} for menu item {}: {err}",
-                        entry.shortcut,
-                        entry.title
-                    )
-                };
-
-                // the top level always has a sub menu regardless of entry.has_sub_menu
-                if entry.checkable {
-                    let check_menu = muda::CheckMenuItem::with_id(
-                        id.clone(),
-                        &entry.title,
-                        entry.enabled,
-                        entry.checked,
-                        None,
-                    );
-                    check_menu.set_key_accelerator(accelerator).map_err(err_handler).ok();
-                    Box::new(check_menu)
-                } else if let Some(rgba) = entry.icon.to_rgba8() {
-                    let icon = muda::Icon::from_rgba(
-                        rgba.as_bytes().to_vec(),
-                        rgba.width(),
-                        rgba.height(),
-                    )
-                    .ok();
-                    let icon_menu = muda::IconMenuItem::with_id(
-                        id.clone(),
-                        &entry.title,
-                        entry.enabled,
-                        icon,
-                        None,
-                    );
-                    icon_menu.set_key_accelerator(accelerator).map_err(err_handler).ok();
-                    Box::new(icon_menu)
-                } else {
-                    let menu_item =
-                        muda::MenuItem::with_id(id.clone(), &entry.title, entry.enabled, None);
-                    menu_item.set_key_accelerator(accelerator).map_err(err_handler).ok();
-                    Box::new(menu_item)
-                }
-            } else {
-                let sub_menu = muda::Submenu::with_id(id.clone(), &entry.title, entry.enabled);
-                if depth < 15 {
-                    let mut sub_entries = Default::default();
-                    menu.sub_menu(Some(entry), &mut sub_entries);
-                    for e in sub_entries {
-                        sub_menu
-                            .append(&*generate_menu_entry(
-                                menu,
-                                &e,
-                                depth + 1,
-                                map,
-                                window_id,
-                                muda_type,
-                            ))
-                            .unwrap();
-                    }
-                } else {
-                    // infinite menu depth is possible, but we want to limit the amount of item passed to muda
-                    sub_menu
-                        .append(&muda::MenuItem::new(
-                            "<Error: Menu Depth limit reached>",
-                            false,
-                            None,
-                        ))
-                        .unwrap();
-                }
-                Box::new(sub_menu)
-            }
-        }
-
         if let Some(menu_tree) = menu_tree {
             let mut build_menu = || {
-                let mut menu_entries = Default::default();
-                if vtable::VRc::borrow(menu_tree).visible() {
-                    vtable::VRc::borrow(menu_tree).sub_menu(None, &mut menu_entries);
+                let new_menu_tree = build_menu_tree(menu_tree);
+                if new_menu_tree.is_empty() && muda_type == MudaType::Menubar {
+                    self.menu = None;
+                    self.entries.clear();
+                    self.menu_tree.clear();
+                    return;
                 }
 
-                if menu_entries.is_empty() && muda_type == MudaType::Menubar {
-                    self.menu = None;
-                } else if let Some(menu) = self.menu.as_ref() {
-                    while menu.remove_at(0).is_some() {}
-                } else {
-                    self.menu = Some(muda::Menu::new());
+                // Access the menu, creating if if necessary
+                let menu = self.menu.get_or_insert_with(|| {
+                    let menu = muda::Menu::new();
 
-                    if muda_type == MudaType::Menubar
-                        && let Some(menu) = self.menu.as_ref()
-                    {
+                    if muda_type == MudaType::Menubar {
                         #[cfg(target_os = "windows")]
                         if let RawWindowHandle::Win32(handle) =
                             winit_window.window_handle().unwrap().as_raw()
@@ -253,31 +379,26 @@ impl MudaAdapter {
                         {
                             menu.init_for_nsapp();
                         }
-                    }
-                }
+                    };
+                    menu
+                });
 
-                // Until we have menu roles, always create an app menu on macOS.
                 #[cfg(target_os = "macos")]
-                if matches!(muda_type, MudaType::Menubar)
-                    && let Some(menu) = self.menu.as_ref()
-                {
+                if matches!(muda_type, MudaType::Menubar) {
                     create_default_app_menu(menu).unwrap();
                 }
 
                 let window_id = u64::from(winit_window.id()).to_string();
-                if let Some(menu) = self.menu.as_ref() {
-                    for e in menu_entries {
-                        menu.append(&*generate_menu_entry(
-                            vtable::VRc::borrow(menu_tree),
-                            &e,
-                            0,
-                            &mut self.entries,
-                            &window_id,
-                            muda_type,
-                        ))
-                        .unwrap();
-                    }
-                }
+                let old_tree = std::mem::take(&mut self.menu_tree);
+                if old_tree.is_empty() {
+                    rebuild_root_menu(menu, &new_menu_tree, 0, &window_id, muda_type);
+                } else {
+                    update_menu_branch(menu, &old_tree, &new_menu_tree, 0, &window_id, muda_type);
+                };
+                self.menu_tree = new_menu_tree;
+                let mut flat = Vec::new();
+                flatten_menu_tree(&self.menu_tree, &mut flat);
+                self.entries = flat;
             };
 
             if let Some(tracker) = self.tracker.as_ref() {
@@ -285,10 +406,6 @@ impl MudaAdapter {
             } else {
                 build_menu()
             }
-        }
-
-        if must_set_window_redraw {
-            win32_set_window_redraw(winit_window, true);
         }
     }
 
@@ -418,31 +535,4 @@ fn create_default_app_menu(menu_bar: &muda::Menu) -> Result<(), i_slint_core::ap
             i_slint_core::api::PlatformError::Other(menu_bar_err.to_string())
         })?;
     Ok(())
-}
-
-/// On Windows, we need to disable window redraw while rebuilding the menu, otherwise
-/// we might see flickering
-#[allow(unused_variables)]
-fn win32_set_window_redraw(winit_window: &Window, redraw: bool) {
-    #[cfg(target_os = "windows")]
-    if let RawWindowHandle::Win32(handle) = winit_window.window_handle().unwrap().as_raw() {
-        use std::os::raw::c_void;
-        use windows::Win32::Foundation::HWND;
-        use windows::Win32::Foundation::WPARAM;
-        use windows::Win32::UI::WindowsAndMessaging::DrawMenuBar;
-        use windows::Win32::UI::WindowsAndMessaging::SendMessageW;
-        use windows::Win32::UI::WindowsAndMessaging::WM_SETREDRAW;
-
-        let hwnd = HWND(handle.hwnd.get() as *mut c_void);
-
-        unsafe {
-            SendMessageW(hwnd, WM_SETREDRAW, Some(WPARAM(redraw as usize)), None);
-        }
-
-        if redraw {
-            unsafe {
-                let _ = DrawMenuBar(hwnd);
-            }
-        }
-    }
 }

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -10,7 +10,11 @@ use i_slint_core::api::LogicalPosition;
 use i_slint_core::items::MenuEntry;
 use i_slint_core::menus::MenuVTable;
 use i_slint_core::properties::{PropertyDirtyHandler, PropertyTracker};
+use id_pool::IdPool;
+use itertools::EitherOrBoth;
+use itertools::Itertools;
 use muda::ContextMenu;
+use std::collections::HashMap;
 use std::rc::Weak;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -25,7 +29,7 @@ struct MenuNode {
 }
 
 pub struct MudaAdapter {
-    entries: Vec<MenuEntry>,
+    map: EntryMap<MenuEntry>,
     tracker: Option<Pin<Box<PropertyTracker<false, MudaPropertyTracker>>>>,
     menu: Option<muda::Menu>,
     menu_tree: Vec<MenuNode>,
@@ -60,31 +64,37 @@ impl PropertyDirtyHandler for MudaPropertyTracker {
     }
 }
 
-fn menu_entry_count(node: &MenuNode) -> usize {
-    1 + node.children.iter().fold(0usize, |count, child| count + menu_entry_count(child))
-}
-
-fn flatten_menu_tree(tree: &[MenuNode], result: &mut Vec<MenuEntry>) {
-    for item in tree {
-        result.push(item.entry.clone());
-        if item.entry.has_sub_menu {
-            flatten_menu_tree(&item.children, result);
-        }
+fn build_menu_tree_for_parent(
+    menu: vtable::VRef<'_, MenuVTable>,
+    parent: Option<&MenuEntry>,
+    depth: usize,
+) -> Vec<MenuNode> {
+    let mut raw_entries = Default::default();
+    match parent {
+        Some(parent) => menu.sub_menu(Some(parent), &mut raw_entries),
+        None => menu.sub_menu(None, &mut raw_entries),
     }
+
+    let mut tree = Vec::new();
+    for entry in raw_entries {
+        let children = if entry.has_sub_menu && depth < 15 {
+            build_menu_tree_for_parent(menu, Some(&entry), depth + 1)
+        } else {
+            Vec::new()
+        };
+        tree.push(MenuNode { entry: entry.clone(), children });
+    }
+    tree
 }
 
-fn build_menu_item(
-    node: &MenuNode,
-    start_index: usize,
-    window_id: &str,
-    muda_type: MudaType,
-) -> Box<dyn muda::IsMenuItem> {
-    let id = muda::MenuId(format!("{window_id}|{start_index}|{muda_type}"));
+fn build_menu_tree(menu: &vtable::VRc<MenuVTable>) -> Vec<MenuNode> {
+    build_menu_tree_for_parent(vtable::VRc::borrow(menu), None, 0)
+}
+
+fn build_menu_item(node: &MenuNode, id: muda::MenuId) -> Box<dyn muda::IsMenuItem> {
     if node.entry.is_separator {
-        return Box::new(muda::PredefinedMenuItem::separator());
-    }
-
-    if !node.entry.has_sub_menu {
+        Box::new(muda::PredefinedMenuItem::separator())
+    } else if !node.entry.has_sub_menu {
         let accelerator = keys_to_accelerator(&node.entry.shortcut);
         let err_handler = |err| {
             i_slint_core::debug_log!(
@@ -123,154 +133,120 @@ fn build_menu_item(
         let menu_item =
             muda::MenuItem::with_id(id.clone(), &node.entry.title, node.entry.enabled, None);
         menu_item.set_key_accelerator(accelerator).map_err(err_handler).ok();
-        return Box::new(menu_item);
+        Box::new(menu_item)
+    } else {
+        let sub_menu = muda::Submenu::with_id(id.clone(), &node.entry.title, node.entry.enabled);
+        Box::new(sub_menu)
     }
-
-    let sub_menu = muda::Submenu::with_id(id.clone(), &node.entry.title, node.entry.enabled);
-    let mut next_index = start_index + 1;
-    for child in &node.children {
-        sub_menu.append(&*build_menu_item(child, next_index, window_id, muda_type)).unwrap();
-        next_index += menu_entry_count(child);
-    }
-    Box::new(sub_menu)
-}
-
-fn rebuild_root_menu(
-    menu: &muda::Menu,
-    tree: &[MenuNode],
-    start_index: usize,
-    window_id: &str,
-    muda_type: MudaType,
-) {
-    while menu.remove_at(0).is_some() {}
-    let mut next_index = start_index;
-    for item in tree {
-        menu.append(&*build_menu_item(item, next_index, window_id, muda_type)).unwrap();
-        next_index += menu_entry_count(item);
-    }
-}
-
-fn update_submenu(
-    submenu: &muda::Submenu,
-    old_items: &[MenuNode],
-    new_items: &[MenuNode],
-    start_index: usize,
-    window_id: &str,
-    muda_type: MudaType,
-) {
-    if old_items.len() != new_items.len() {
-        rebuild_submenu(submenu, new_items, start_index, window_id, muda_type);
-        return;
-    }
-
-    let mut local_index = 0usize;
-    let mut next_index = start_index;
-    for (old_item, new_item) in old_items.iter().zip(new_items) {
-        if old_item.entry == new_item.entry {
-            if old_item.entry.has_sub_menu
-                && let Some(muda::MenuItemKind::Submenu(child_submenu)) =
-                    submenu.items().get(local_index)
-            {
-                update_submenu(
-                    child_submenu,
-                    &old_item.children,
-                    &new_item.children,
-                    next_index + 1,
-                    window_id,
-                    muda_type,
-                );
-            }
-        } else {
-            submenu.remove_at(local_index);
-            submenu
-                .insert(&*build_menu_item(new_item, next_index, window_id, muda_type), local_index)
-                .unwrap();
-        }
-
-        local_index += 1;
-        next_index += menu_entry_count(old_item);
-    }
-}
-
-fn rebuild_submenu(
-    submenu: &muda::Submenu,
-    tree: &[MenuNode],
-    start_index: usize,
-    window_id: &str,
-    muda_type: MudaType,
-) {
-    while submenu.remove_at(0).is_some() {}
-    let mut next_index = start_index;
-    for item in tree {
-        submenu.append(&*build_menu_item(item, next_index, window_id, muda_type)).unwrap();
-        next_index += menu_entry_count(item);
-    }
-}
-
-fn build_menu_tree_for_parent(
-    menu: vtable::VRef<'_, MenuVTable>,
-    parent: Option<&MenuEntry>,
-    depth: usize,
-) -> Vec<MenuNode> {
-    let mut raw_entries = Default::default();
-    match parent {
-        Some(parent) => menu.sub_menu(Some(parent), &mut raw_entries),
-        None => menu.sub_menu(None, &mut raw_entries),
-    }
-
-    let mut tree = Vec::new();
-    for entry in raw_entries {
-        let children = if entry.has_sub_menu && depth < 15 {
-            build_menu_tree_for_parent(menu, Some(&entry), depth + 1)
-        } else {
-            Vec::new()
-        };
-        tree.push(MenuNode { entry: entry.clone(), children });
-    }
-    tree
-}
-
-fn build_menu_tree(menu: &vtable::VRc<MenuVTable>) -> Vec<MenuNode> {
-    build_menu_tree_for_parent(vtable::VRc::borrow(menu), None, 0)
 }
 
 fn update_menu_branch(
-    menu: &muda::Menu,
+    map: &mut EntryMap<MenuEntry>,
+    menu: MenuRef<'_>,
     old_items: &[MenuNode],
     new_items: &[MenuNode],
-    start_index: usize,
     window_id: &str,
     muda_type: MudaType,
+    depth: u32,
 ) {
-    if old_items.len() != new_items.len() {
-        rebuild_root_menu(menu, new_items, start_index, window_id, muda_type);
+    if depth > 15 && !new_items.is_empty() {
+        // infinite menu depth is possible, but we want to limit the amount of item passed to muda
+        menu.insert(&muda::MenuItem::new("<Error: Menu Depth limit reached>", false, None), 0)
+            .unwrap();
         return;
     }
 
-    let mut local_index = 0usize;
-    let mut next_index = start_index;
-    for (old_item, new_item) in old_items.iter().zip(new_items) {
-        if old_item.entry == new_item.entry {
-            if old_item.entry.has_sub_menu
-                && let Some(muda::MenuItemKind::Submenu(submenu)) = menu.items().get(local_index)
-            {
-                update_submenu(
-                    submenu,
-                    &old_item.children,
-                    &new_item.children,
-                    next_index + 1,
+    // Get all menu items out of the muda item
+    let menu_items = menu.items();
+
+    // Enumerate through the old and new items simultaneously
+    for (position, zipped) in Itertools::zip_longest(old_items.iter(), new_items.iter()).enumerate()
+    {
+        let (old_item_to_remove, new_item_to_build) = match zipped {
+            EitherOrBoth::Both(old_item, new_item) => {
+                // This item is there for the old and new; check for changes
+                if menu_entry_looks_same(&old_item.entry, &new_item.entry) {
+                    // Looks the same - recurse if this is a submenu
+                    if let Some(muda::MenuItemKind::Submenu(submenu)) = menu_items.get(position) {
+                        update_menu_branch(
+                            map,
+                            MenuRef::Submenu(submenu),
+                            &old_item.children,
+                            &new_item.children,
+                            window_id,
+                            muda_type,
+                            depth + 1,
+                        );
+                    }
+
+                    // We have not changed anything, but we need to refresh the item
+                    refresh_map_entry(map, &menu_items[position], new_item.entry.clone());
+                    (None, None)
+                } else {
+                    (Some(old_item), Some(new_item))
+                }
+            }
+            EitherOrBoth::Left(old_item) => {
+                // The old menu had an entry where the new menu does not; we need to remove it
+                (Some(old_item), None)
+            }
+            EitherOrBoth::Right(new_item) => {
+                // The new menu has an entry where the old menu did not; we need to append it
+                (None, Some(new_item))
+            }
+        };
+
+        // Do we have to remove the old menu?
+        if let Some(old_item_to_remove) = old_item_to_remove {
+            // If this is a submenu, we have to "update" (i.e. - delete the branch)
+            if let Some(muda::MenuItemKind::Submenu(submenu)) = menu_items.get(position) {
+                update_menu_branch(
+                    map,
+                    MenuRef::Submenu(submenu),
+                    &old_item_to_remove.children,
+                    &[],
                     window_id,
                     muda_type,
+                    depth + 1,
                 );
             }
-        } else {
-            menu.remove_at(local_index);
-            menu.insert(&*build_menu_item(new_item, next_index, window_id, muda_type), local_index)
-                .unwrap();
+
+            // Only remove if we're going to be inserting later; we'll take care of the other scenario later
+            if new_item_to_build.is_some() {
+                remove_menu_item_and_map_entry(map, &menu, position);
+            }
         }
 
-        local_index += 1;
-        next_index += menu_entry_count(old_item);
+        // Do we need to add a new item?
+        if let Some(new_item_to_build) = new_item_to_build {
+            // Allocate an id for this item
+            let entry_id = map.insert(new_item_to_build.entry.clone());
+            let menu_id = muda::MenuId(format!("{window_id}|{entry_id}|{muda_type}"));
+
+            // Create the new item
+            let new_muda_item = build_menu_item(new_item_to_build, menu_id);
+
+            // And if this is a submenu, recurse
+            if let muda::MenuItemKind::Submenu(submenu) = new_muda_item.kind() {
+                update_menu_branch(
+                    map,
+                    MenuRef::Submenu(&submenu),
+                    &[],
+                    &new_item_to_build.children,
+                    window_id,
+                    muda_type,
+                    depth + 1,
+                );
+            }
+
+            // And insert
+            let _ = menu.insert(&*new_muda_item, position);
+        }
+    }
+
+    // Purge extraneous items
+    for _ in new_items.len()..old_items.len() {
+        remove_menu_item_and_map_entry(map, &menu, new_items.len());
     }
 }
 
@@ -288,8 +264,7 @@ impl MudaAdapter {
                 window_adapter_weak,
             })));
 
-        let mut s =
-            Self { entries: Default::default(), tracker, menu: None, menu_tree: Vec::new() };
+        let mut s = Self { map: EntryMap::new(), tracker, menu: None, menu_tree: Vec::new() };
         s.rebuild_menu(winit_window, Some(menubar), MudaType::Menubar);
         s
     }
@@ -302,8 +277,7 @@ impl MudaAdapter {
     ) -> Option<Self> {
         install_event_handler_if_necessary(proxy);
 
-        let mut s =
-            Self { entries: Default::default(), tracker: None, menu: None, menu_tree: Vec::new() };
+        let mut s = Self { map: EntryMap::new(), tracker: None, menu: None, menu_tree: Vec::new() };
         s.rebuild_menu(winit_window, Some(context_menu), MudaType::Context);
 
         match winit_window.window_handle().ok()?.as_raw() {
@@ -348,57 +322,64 @@ impl MudaAdapter {
     ) {
         if let Some(menu_tree) = menu_tree {
             let mut build_menu = || {
-                let new_menu_tree = build_menu_tree(menu_tree);
-                if new_menu_tree.is_empty() && muda_type == MudaType::Menubar {
-                    self.menu = None;
-                    self.entries.clear();
-                    self.menu_tree.clear();
-                    return;
-                }
-
-                // Access the menu, creating if if necessary
-                let menu = self.menu.get_or_insert_with(|| {
-                    let menu = muda::Menu::new();
-
-                    if muda_type == MudaType::Menubar {
-                        #[cfg(target_os = "windows")]
-                        if let RawWindowHandle::Win32(handle) =
-                            winit_window.window_handle().unwrap().as_raw()
-                        {
-                            let theme = match winit_window.theme() {
-                                Some(winit::window::Theme::Dark) => muda::MenuTheme::Dark,
-                                Some(winit::window::Theme::Light) => muda::MenuTheme::Light,
-                                None => muda::MenuTheme::Auto,
-                            };
-                            unsafe {
-                                menu.init_for_hwnd_with_theme(handle.hwnd.get(), theme).unwrap()
-                            };
-                        }
-
-                        #[cfg(target_os = "macos")]
-                        {
-                            menu.init_for_nsapp();
-                        }
-                    };
-                    menu
-                });
-
-                #[cfg(target_os = "macos")]
-                if matches!(muda_type, MudaType::Menubar) {
-                    create_default_app_menu(menu).unwrap();
-                }
-
-                let window_id = u64::from(winit_window.id()).to_string();
-                let old_tree = std::mem::take(&mut self.menu_tree);
-                if old_tree.is_empty() {
-                    rebuild_root_menu(menu, &new_menu_tree, 0, &window_id, muda_type);
+                let new_menu_tree = if vtable::VRc::borrow(menu_tree).visible() {
+                    build_menu_tree(menu_tree)
                 } else {
-                    update_menu_branch(menu, &old_tree, &new_menu_tree, 0, &window_id, muda_type);
+                    Vec::new()
                 };
-                self.menu_tree = new_menu_tree;
-                let mut flat = Vec::new();
-                flatten_menu_tree(&self.menu_tree, &mut flat);
-                self.entries = flat;
+
+                // There is a very special case we need to watch out for; if there are no items in the menu bar
+                // (and not a context menu) either before or after, just leave everything alone
+                if !new_menu_tree.is_empty()
+                    || muda_type != MudaType::Menubar
+                    || !self.menu_tree.is_empty()
+                {
+                    // Access the menu, creating if if necessary
+                    let menu = self.menu.get_or_insert_with(|| {
+                        let menu = muda::Menu::new();
+
+                        if muda_type == MudaType::Menubar {
+                            #[cfg(target_os = "windows")]
+                            if let RawWindowHandle::Win32(handle) =
+                                winit_window.window_handle().unwrap().as_raw()
+                            {
+                                let theme = match winit_window.theme() {
+                                    Some(winit::window::Theme::Dark) => muda::MenuTheme::Dark,
+                                    Some(winit::window::Theme::Light) => muda::MenuTheme::Light,
+                                    None => muda::MenuTheme::Auto,
+                                };
+                                unsafe {
+                                    menu.init_for_hwnd_with_theme(handle.hwnd.get(), theme).unwrap()
+                                };
+                            }
+
+                            #[cfg(target_os = "macos")]
+                            {
+                                menu.init_for_nsapp();
+                                create_default_app_menu(menu).unwrap();
+                            }
+                        };
+                        menu
+                    });
+
+                    let window_id = u64::from(winit_window.id()).to_string();
+                    update_menu_branch(
+                        &mut self.map,
+                        MenuRef::Menu(menu),
+                        &self.menu_tree,
+                        &new_menu_tree,
+                        &window_id,
+                        muda_type,
+                        0,
+                    );
+                    self.menu_tree = new_menu_tree;
+
+                    // And related to the special case above, if the new menu bar is empty just
+                    // blow it away (the `update_menu_branch()` was necessary to clean things up)
+                    if self.menu_tree.is_empty() && muda_type == MudaType::Menubar {
+                        self.menu = None;
+                    }
+                }
             };
 
             if let Some(tracker) = self.tracker.as_ref() {
@@ -410,7 +391,7 @@ impl MudaAdapter {
     }
 
     pub fn invoke(&self, menubar: &vtable::VRc<MenuVTable>, entry_id: usize) {
-        let Some(entry) = &self.entries.get(entry_id) else { return };
+        let Some(entry) = &self.map.get(entry_id) else { return };
         vtable::VRc::borrow(menubar).activate(entry);
     }
 
@@ -446,6 +427,110 @@ impl MudaAdapter {
             menu.init_for_nsapp();
         }
     }
+}
+
+/// Used to check if these menu items look the same
+fn menu_entry_looks_same(a: &MenuEntry, b: &MenuEntry) -> bool {
+    // There are two things stopping us from using the normal `Eq` trait
+    // - `id` can change at will but is not relevant for our purposes
+    // - Comparisons with `icon` seem to always return false
+    a.title == b.title
+        && a.icon.path() == b.icon.path()
+        && a.enabled == b.enabled
+        && a.checkable == b.checkable
+        && a.checked == b.checked
+        && a.has_sub_menu == b.has_sub_menu
+        && a.is_separator == b.is_separator
+        && a.shortcut == b.shortcut
+}
+
+enum MenuRef<'a> {
+    Menu(&'a muda::Menu),
+    Submenu(&'a muda::Submenu),
+}
+
+impl<'a> MenuRef<'a> {
+    pub fn items(&self) -> Vec<muda::MenuItemKind> {
+        match self {
+            Self::Menu(menu) => menu.items(),
+            Self::Submenu(submenu) => submenu.items(),
+        }
+    }
+
+    pub fn remove_at(&self, position: usize) -> Option<muda::MenuItemKind> {
+        match self {
+            Self::Menu(menu) => menu.remove_at(position),
+            Self::Submenu(submenu) => submenu.remove_at(position),
+        }
+    }
+
+    pub fn insert(&self, item: &dyn muda::IsMenuItem, position: usize) -> muda::Result<()> {
+        match self {
+            Self::Menu(menu) => menu.insert(item, position),
+            Self::Submenu(submenu) => submenu.insert(item, position),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EntryMap<T> {
+    map: HashMap<usize, T>,
+    pool: IdPool,
+}
+
+impl<T> EntryMap<T> {
+    pub fn new() -> Self {
+        Self { map: HashMap::new(), pool: IdPool::new() }
+    }
+
+    pub fn insert(&mut self, entry: T) -> usize {
+        let id = self.pool.request_id().unwrap();
+        self.map.insert(id, entry);
+        id
+    }
+
+    pub fn release(&mut self, id: usize) {
+        let _ = self.pool.return_id(id);
+        self.map.remove(&id);
+    }
+
+    pub fn get(&self, id: usize) -> Option<&T> {
+        self.map.get(&id)
+    }
+}
+
+fn remove_menu_item_and_map_entry(
+    map: &mut EntryMap<MenuEntry>,
+    menu: &MenuRef<'_>,
+    position: usize,
+) {
+    let Some(item) = menu.remove_at(position) else {
+        return;
+    };
+    let &[_, id, _] = item.id().as_ref().split('|').collect::<Vec<_>>().as_slice() else {
+        return;
+    };
+    let Ok(id) = id.parse::<usize>() else {
+        return;
+    };
+    map.release(id);
+}
+
+fn refresh_map_entry(
+    map: &mut EntryMap<MenuEntry>,
+    item: &muda::MenuItemKind,
+    updated_entry: MenuEntry,
+) {
+    let &[_, id, _] = item.id().as_ref().split('|').collect::<Vec<_>>().as_slice() else {
+        return;
+    };
+    let Ok(id) = id.parse::<usize>() else {
+        return;
+    };
+    let Some(entry) = map.map.get_mut(&id) else {
+        return;
+    };
+    *entry = updated_entry;
 }
 
 fn key_string_to_key(string: &str) -> muda::accelerator::Key {

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -22,6 +22,8 @@ use winit::event_loop::EventLoopProxy;
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::window::Window;
 
+const MAX_DEPTH: u32 = 15;
+
 #[derive(Clone, Debug)]
 struct MenuNode {
     entry: MenuEntry,
@@ -67,7 +69,7 @@ impl PropertyDirtyHandler for MudaPropertyTracker {
 fn build_menu_tree_for_parent(
     menu: vtable::VRef<'_, MenuVTable>,
     parent: Option<&MenuEntry>,
-    depth: usize,
+    depth: u32,
 ) -> Vec<MenuNode> {
     let mut raw_entries = Default::default();
     match parent {
@@ -77,7 +79,7 @@ fn build_menu_tree_for_parent(
 
     let mut tree = Vec::new();
     for entry in raw_entries {
-        let children = if entry.has_sub_menu && depth < 15 {
+        let children = if entry.has_sub_menu && depth <= MAX_DEPTH {
             build_menu_tree_for_parent(menu, Some(&entry), depth + 1)
         } else {
             Vec::new()
@@ -92,9 +94,7 @@ fn build_menu_tree(menu: &vtable::VRc<MenuVTable>) -> Vec<MenuNode> {
 }
 
 fn build_menu_item(node: &MenuNode, id: muda::MenuId) -> Box<dyn muda::IsMenuItem> {
-    if node.entry.is_separator {
-        Box::new(muda::PredefinedMenuItem::separator())
-    } else if !node.entry.has_sub_menu {
+    if !node.entry.has_sub_menu {
         let accelerator = keys_to_accelerator(&node.entry.shortcut);
         let err_handler = |err| {
             i_slint_core::debug_log!(
@@ -149,7 +149,7 @@ fn update_menu_branch(
     muda_type: MudaType,
     depth: u32,
 ) {
-    if depth > 15 && !new_items.is_empty() {
+    if depth > MAX_DEPTH && !new_items.is_empty() {
         // infinite menu depth is possible, but we want to limit the amount of item passed to muda
         menu.insert(&muda::MenuItem::new("<Error: Menu Depth limit reached>", false, None), 0)
             .unwrap();
@@ -219,12 +219,17 @@ fn update_menu_branch(
 
         // Do we need to add a new item?
         if let Some(new_item_to_build) = new_item_to_build {
-            // Allocate an id for this item
-            let entry_id = map.insert(new_item_to_build.entry.clone());
-            let menu_id = muda::MenuId(format!("{window_id}|{entry_id}|{muda_type}"));
-
             // Create the new item
-            let new_muda_item = build_menu_item(new_item_to_build, menu_id);
+            let new_muda_item = if new_item_to_build.entry.is_separator {
+                Box::new(muda::PredefinedMenuItem::separator())
+            } else {
+                // Allocate an id for this item
+                let entry_id = map.insert(new_item_to_build.entry.clone());
+                let menu_id = muda::MenuId(format!("{window_id}|{entry_id}|{muda_type}"));
+
+                // And build it
+                build_menu_item(new_item_to_build, menu_id)
+            };
 
             // And if this is a submenu, recurse
             if let muda::MenuItemKind::Submenu(submenu) = new_muda_item.kind() {
@@ -356,7 +361,7 @@ impl MudaAdapter {
                             #[cfg(target_os = "macos")]
                             {
                                 menu.init_for_nsapp();
-                                create_default_app_menu(menu).unwrap();
+                                create_default_app_menu(&menu).unwrap();
                             }
                         };
                         menu
@@ -418,7 +423,7 @@ impl MudaAdapter {
         let menu_bar = muda::Menu::new();
         create_default_app_menu(&menu_bar)?;
         menu_bar.init_for_nsapp();
-        Ok(Self { entries: Vec::new(), menu: Some(menu_bar), tracker: None })
+        Ok(Self { map: HashMap::new(), pool: IdPool::new(), menu: Some(menu_bar), tracker: None })
     }
 
     #[cfg(target_os = "macos")]

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -423,7 +423,7 @@ impl MudaAdapter {
         let menu_bar = muda::Menu::new();
         create_default_app_menu(&menu_bar)?;
         menu_bar.init_for_nsapp();
-        Ok(Self { map: HashMap::new(), pool: IdPool::new(), menu: Some(menu_bar), tracker: None })
+        Ok(Self { map: EntryMap::new(), menu: Some(menu_bar), tracker: None })
     }
 
     #[cfg(target_os = "macos")]

--- a/internal/backends/winit/muda.rs
+++ b/internal/backends/winit/muda.rs
@@ -423,7 +423,12 @@ impl MudaAdapter {
         let menu_bar = muda::Menu::new();
         create_default_app_menu(&menu_bar)?;
         menu_bar.init_for_nsapp();
-        Ok(Self { map: EntryMap::new(), menu: Some(menu_bar), tracker: None })
+        Ok(Self {
+            map: EntryMap::new(),
+            menu: Some(menu_bar),
+            tracker: None,
+            menu_tree: Vec::new(),
+        })
     }
 
     #[cfg(target_os = "macos")]

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2237,9 +2237,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2354,7 +2354,9 @@ dependencies = [
  "i-slint-renderer-femtovg",
  "i-slint-renderer-skia",
  "i-slint-renderer-software",
+ "id-pool",
  "imgref",
+ "itertools 0.15.0",
  "lyon_path",
  "muda",
  "objc2 0.6.4",
@@ -2781,6 +2783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae293c039020f9ec10710af98d29ce6aa2051486638b49c9a6409f3b4a9e98ad"
 
 [[package]]
+name = "id-pool"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d0df4d8a768821ee4aa2e0353f67125c4586f0e13adbf95b8ebbf8d8fdb344"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,9 +2856,9 @@ checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -3300,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_algorithms"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
+checksum = "cdfa8785f95e57914ddb35e3b59994aeba6f5e79e9cfd03da1c269f010f36009"
 dependencies = [
  "lyon_path",
  "num-traits",
@@ -4284,7 +4292,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi 0.5.3",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",


### PR DESCRIPTION
Previously whenever the menu changed, the entire menubar would be rebuilt.  On Windows (and possibly other platforms), this caused problems with flickering (solved by using `WM_SETREDRAW` to suppress redraws), as well the taskbar flickering in fullscreen mode.

With these changes, only parts of the menu bar that actually change are rebuilt.  This should eliminate both the taskbar flickering, as well as the need for the Windows-specific `WM_SETREDRAW` logic.