### PR TITLE
Flickable: include for/if children in the content size (#407)

### DIFF
--- a/internal/compiler/builtin_elements.rs
+++ b/internal/compiler/builtin_elements.rs
@@ -1542,9 +1542,8 @@ fn build(l: &mut Loader) {
         /// respectively, the element becomes scrollable.
         ///
         /// When unset, the `content-width` and `content-height` are
-        /// calculated automatically based on the `Flickable`'s children. This isn't the
-        /// case when using a `for` loop to populate the elements. This is a bug tracked in
-        /// issue [#407](https://github.com/slint-ui/slint/issues/407).
+        /// calculated automatically based on the `Flickable`'s layout children,
+        /// including ones populated with a `for`/`if`.
         /// The maximum and preferred size of the `Flickable` are based on the content size.
         ///
         /// Note that the `Flickable` doesn't create a scrollbar.

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -739,6 +739,17 @@ pub struct BoxLayout {
     pub geometry: LayoutGeometry,
     /// The `cross-axis-alignment` property, if set.
     pub cross_alignment: Option<NamedReference>,
+    /// Whether this is the one-cell wrapper [`repeated_element_layout_info`]
+    /// synthesizes to merge a repeated element's constraints, rather than a real
+    /// layout solving positions and sizes.
+    ///
+    /// `binding_analysis` skips a repeated cell's *model* expression for it: the
+    /// merge's consumer tracks the repeater's instantiated row count
+    /// (`Repeater::track_instance_changes`) rather than the model property, so the
+    /// model doesn't need to be a static dependency to stay reactive. Counting it
+    /// reports a binding loop for a model that reads an enclosing size — a
+    /// breakpoint picking a UI variant, say.
+    pub is_synthesized_repeated_merge: bool,
 }
 
 impl BoxLayout {
@@ -1033,4 +1044,96 @@ pub fn is_layout(base_type: &ElementType) -> bool {
         }
         _ => false,
     }
+}
+
+/// The merged `LayoutInfo` of every instance of a repeated (`if`/`for`) element,
+/// along `orientation`.
+///
+/// A repeated element has no single width/height: it exists as N runtime
+/// instances. This synthesizes a one-cell orthogonal `BoxLayout` over `elem`
+/// and computes its layout info, which reuses the existing box-layout-info
+/// runtime machinery (`WithLayoutItemInfo` + `box_layout_info_ortho`) to
+/// enumerate the repeater's instances and fold their `LayoutInfo` together —
+/// the same merge two static siblings get. See issue #407.
+///
+/// Also populates the repeated body's `root_constraints` — the same thing
+/// `lower_layout.rs`'s `create_layout_item` does for a repeated cell of a
+/// *real* layout, and for the same reason: without it, the generated
+/// `layout_info`/`layout_item_info` never applies an explicit
+/// `min-height`/`preferred-width`/etc. set directly on the body's root, and
+/// silently drops it. This must happen here, at the point of use, rather
+/// than in a later pass over the whole tree: the call site (`flickable.rs`)
+/// runs *before* `default_geometry` visits this same
+/// element's own root and gives it a default-fill `height`/`width` binding
+/// (every lowered layout has `default_fill_parent = (true, true)`) — computed
+/// any later, that synthesized binding would look like an explicit `height`
+/// conflicting with the user's `min-height`, a false positive. No
+/// diagnostics are threaded through: this can run up to several times for
+/// the same element (once per orientation, more from `flickable.rs`'s
+/// several folds), and re-reporting a real conflict that many times would be
+/// worse than not reporting it at all here — the same conflict on a *static*
+/// layout is still caught by `gen_layout_info_prop`'s own diagnostic pass.
+pub fn repeated_element_layout_info(elem: &ElementRc, orientation: Orientation) -> Expression {
+    debug_assert!(elem.borrow().repeated.is_some());
+    let ElementType::Component(base) = elem.borrow().base_type.clone() else {
+        unreachable!("a repeated element's base_type is always Component")
+    };
+    *base.root_constraints.borrow_mut() = LayoutConstraints::new(&base.root_element, None);
+    let layout = BoxLayout {
+        // `ComputeBoxLayoutInfo` only folds cells via `box_layout_info_ortho` (the
+        // merge, not the sum) when queried for the axis orthogonal to the box's own
+        // orientation.
+        orientation: orientation.orthogonal(),
+        elems: vec![LayoutItem {
+            element: elem.clone(),
+            constraints: LayoutConstraints::default(),
+            cross_axis_self_alignment: None,
+            layout_order: None,
+        }],
+        geometry: LayoutGeometry {
+            rect: LayoutRect::default(),
+            spacing: Spacing { horizontal: None, vertical: None },
+            alignment: None,
+            padding: Padding { left: None, right: None, top: None, bottom: None },
+        },
+        cross_alignment: None,
+        is_synthesized_repeated_merge: true,
+    };
+    // KNOWN LIMITATION: a height-for-width instance — a word-wrapped `Text`, say —
+    // is measured unconstrained rather than at the size it is given, so it can
+    // under-report its cross size. That needs a known cross size here, the way a
+    // real enclosing layout threads one through `repeated_cross_size`; no single
+    // such value exists in the outer scope, where the instance's own width does
+    // not yet exist.
+    Expression::ComputeBoxLayoutInfo { layout, orientation, cross_axis_size: None }
+}
+
+/// Mark the inner root of every repeated cell of a `ComputeBoxLayoutInfo` as
+/// `child_of_layout`, which is what makes the Rust generator emit a
+/// `layout_item_info` override for it. Without one,
+/// `RepeatedItemTree::layout_item_info`'s default returns a zero `LayoutItemInfo`
+/// and the merge silently contributes nothing. The C++ generator emits it
+/// unconditionally and doesn't need this.
+///
+/// Cells of a real layout already have the flag from `create_layout_item`, so
+/// matching every `ComputeBoxLayoutInfo` rather than only the synthesized merges
+/// costs nothing.
+///
+/// Runs after `default_geometry`: a cell merged only to propagate constraints is
+/// still positioned normally, so `default_geometry`'s own `child_of_layout` checks
+/// (default sizing, centering) must see the pre-merge value.
+pub fn mark_repeated_cells_child_of_layout(component: &Rc<Component>) {
+    crate::object_tree::visit_all_expressions(component, |expr, _| {
+        expr.visit_recursive_mut(&mut |e| {
+            if let Expression::ComputeBoxLayoutInfo { layout, .. } = e {
+                for item in &layout.elems {
+                    if item.element.borrow().repeated.is_some()
+                        && let ElementType::Component(base) = &item.element.borrow().base_type
+                    {
+                        base.root_element.borrow_mut().child_of_layout = true;
+                    }
+                }
+            }
+        });
+    });
 }

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -173,6 +173,7 @@ pub async fn run_passes(
         flickable::handle_flickable(component, &global_type_registry.borrow());
         lower_layout::lower_layouts(component, type_loader, &style_metrics, diag);
         default_geometry::default_geometry(component, diag, &symbol_counters);
+        crate::layout::mark_repeated_cells_child_of_layout(component);
         lower_layout::optimize_single_cell_layouts(component);
         lower_layout::synthesize_layoutinfo_v_with_constraint(component);
         lower_layout::synthesize_layoutinfo_h_with_constraint(component);

--- a/internal/compiler/passes/binding_analysis.rs
+++ b/internal/compiler/passes/binding_analysis.rs
@@ -634,7 +634,12 @@ fn recurse_expression(
             {
                 vis(&nr.clone().into(), P);
             }
-            visit_layout_items_dependencies(l.elems.iter(), *o, vis);
+            visit_layout_items_dependencies(
+                l.elems.iter(),
+                *o,
+                l.is_synthesized_repeated_merge,
+                vis,
+            );
 
             // The orthogonal solve depends on `cross-axis-alignment` and on the
             // cells' `cross-axis-self-alignment`.
@@ -719,7 +724,12 @@ fn recurse_expression(
                 match layout.axis_relation(orientation) {
                     FlexboxAxisRelation::MainAxis => {
                         // Main axis: only visit same-axis item dependencies
-                        visit_layout_items_dependencies(layout.elems.iter(), orientation, vis);
+                        visit_layout_items_dependencies(
+                            layout.elems.iter(),
+                            orientation,
+                            false,
+                            vis,
+                        );
                     }
                     FlexboxAxisRelation::CrossAxis => {
                         // Cross axis: depends on the perpendicular (main-axis)
@@ -743,11 +753,13 @@ fn recurse_expression(
                         visit_layout_items_dependencies(
                             layout.elems.iter(),
                             Orientation::Horizontal,
+                            false,
                             vis,
                         );
                         visit_layout_items_dependencies(
                             layout.elems.iter(),
                             Orientation::Vertical,
+                            false,
                             vis,
                         );
                     }
@@ -758,11 +770,13 @@ fn recurse_expression(
                         visit_layout_items_dependencies(
                             layout.elems.iter(),
                             Orientation::Horizontal,
+                            false,
                             vis,
                         );
                         visit_layout_items_dependencies(
                             layout.elems.iter(),
                             Orientation::Vertical,
+                            false,
                             vis,
                         );
                     }
@@ -795,6 +809,7 @@ fn recurse_expression(
             visit_layout_items_dependencies(
                 layout.elems.iter().map(|it| &it.item),
                 *orientation,
+                false,
                 vis,
             );
             let mut g = layout.geometry.clone();
@@ -872,9 +887,16 @@ fn recurse_expression(
     }
 }
 
+/// `skip_model_dependency` is set for the one-cell `BoxLayout`
+/// [`crate::layout::repeated_element_layout_info`] synthesizes to merge a
+/// repeated element's constraints into a non-layout parent (issue #407) —
+/// see [`crate::layout::BoxLayout::is_synthesized_repeated_merge`] for why a
+/// repeated cell's *model* expression isn't a dependency there, unlike for a
+/// real layout.
 fn visit_layout_items_dependencies<'a>(
     items: impl Iterator<Item = &'a LayoutItem>,
     orientation: Orientation,
+    skip_model_dependency: bool,
     vis: &mut impl FnMut(&PropertyPath, ReadType),
 ) {
     for it in items {
@@ -883,7 +905,11 @@ fn visit_layout_items_dependencies<'a>(
             .borrow()
             .repeated
             .as_ref()
-            .map(|r| recurse_expression(&element, &r.model, vis))
+            .map(|r| {
+                if !skip_model_dependency {
+                    recurse_expression(&element, &r.model, vis);
+                }
+            })
             .is_some()
         {
             element = it.element.borrow().base_type.as_component().root_element.clone();

--- a/internal/compiler/passes/flickable.rs
+++ b/internal/compiler/passes/flickable.rs
@@ -10,9 +10,9 @@
 //! This pass must be called before the materialize_fake_properties as it going to be generate
 //! binding reference to fake properties
 
-use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedReference};
+use crate::expression_tree::{BindingExpression, Expression, MinMaxOp, NamedReference, Unit};
 use crate::langtype::{ElementType, NativeClass, Type};
-use crate::layout::is_layout;
+use crate::layout::{Orientation, is_layout, repeated_element_layout_info};
 use crate::object_tree::{Component, Element, ElementRc};
 use crate::typeregister::TypeRegister;
 use smol_str::{SmolStr, format_smolstr};
@@ -126,30 +126,88 @@ fn create_content_element(flickable: &ElementRc, native_empty: &Arc<NativeClass>
     flickable.borrow_mut().children.push(content);
 }
 
+/// The scalar `scalar_prop` (e.g. `max-height`) of a `is_layout` child `x` of the
+/// Flickable, for use in `fixup_geometry`'s folds.
+///
+/// A repeated (`if`/`for`) child has no such property of its own — it exists as N
+/// runtime instances — so its merged `LayoutInfo` (issue #407) is synthesized
+/// instead and the matching `struct_field` (`max`, `preferred`, or `min`) is read
+/// back out of it.
+///
+/// A repeater with no live instance merges to `LayoutInfo::default()`, whose
+/// `preferred` is zero. The folds below take the *smallest* preferred size, so
+/// that zero would collapse the Flickable: an `if` whose condition is false would
+/// shrink it to nothing. Zero means "no preference" here, so it is folded as the
+/// identity instead. `max` needs no such care — it defaults to `Coord::MAX`,
+/// already the identity of its own fold.
+fn layout_child_scalar(
+    x: &ElementRc,
+    orientation: Orientation,
+    scalar_prop: &'static str,
+    struct_field: &'static str,
+) -> Expression {
+    if x.borrow().repeated.is_none() {
+        return Expression::PropertyReference(NamedReference::new(
+            x,
+            SmolStr::new_static(scalar_prop),
+        ));
+    }
+    let merged = Expression::StructFieldAccess {
+        base: Box::new(repeated_element_layout_info(x, orientation)),
+        name: SmolStr::new_static(struct_field),
+    };
+    if struct_field != "preferred" {
+        return merged;
+    }
+    let name = SmolStr::new_static("repeated_preferred");
+    let read = || Expression::ReadLocalVariable { name: name.clone(), ty: Type::LogicalLength };
+    Expression::CodeBlock(
+        [
+            Expression::StoreLocalVariable { name: name.clone(), value: Box::new(merged) },
+            Expression::Condition {
+                condition: Box::new(Expression::BinaryExpression {
+                    lhs: Box::new(read()),
+                    rhs: Box::new(Expression::NumberLiteral(0., Unit::Px)),
+                    op: '=',
+                }),
+                true_expr: Box::new(Expression::NumberLiteral(f32::MAX as f64, Unit::Px)),
+                false_expr: Box::new(read()),
+            },
+        ]
+        .into(),
+    )
+}
+
 fn fixup_geometry(flickable_elem: &ElementRc) {
-    let forward_minmax_of = |prop: &'static str, op: MinMaxOp| {
-        set_binding_if_not_explicit(flickable_elem, prop, || {
-            flickable_elem
-                .borrow()
-                .children
-                .iter()
-                .filter(|x| is_layout(&x.borrow().base_type))
-                // FIXME: we should ideally add runtime code to merge layout info of all elements that are repeated (#407)
-                .filter(|x| x.borrow().repeated.is_none())
-                .map(|x| {
-                    Expression::PropertyReference(NamedReference::new(x, SmolStr::new_static(prop)))
-                })
-                .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, op))
-        })
+    // A ListView's repeater only materializes the currently-visible instances
+    // (`ensure_updated_listview`), so folding it here would make the constraint
+    // change as the user scrolls. Any other repeated child is fully
+    // materialized before layout runs and is safe to merge.
+    let is_mergeable = |x: &&ElementRc| {
+        is_layout(&x.borrow().base_type)
+            && x.borrow().repeated.as_ref().is_none_or(|r| r.is_listview.is_none())
     };
 
+    let forward_minmax_of =
+        |prop: &'static str, struct_field: &'static str, orientation: Orientation, op: MinMaxOp| {
+            set_binding_if_not_explicit(flickable_elem, prop, || {
+                flickable_elem
+                    .borrow()
+                    .children
+                    .iter()
+                    .filter(is_mergeable)
+                    .map(|x| layout_child_scalar(x, orientation, prop, struct_field))
+                    .reduce(|lhs, rhs| crate::builtin_macros::min_max_expression(lhs, rhs, op))
+            })
+        };
+
     if !flickable_elem.borrow().is_binding_set("height", false) {
-        forward_minmax_of("max-height", MinMaxOp::Min);
-        forward_minmax_of("preferred-height", MinMaxOp::Min);
+        forward_minmax_of("max-height", "max", Orientation::Vertical, MinMaxOp::Min);
+        forward_minmax_of("preferred-height", "preferred", Orientation::Vertical, MinMaxOp::Min);
     }
     if !flickable_elem.borrow().is_binding_set("width", false) {
-        forward_minmax_of("max-width", MinMaxOp::Min);
-        forward_minmax_of("preferred-width", MinMaxOp::Min);
+        forward_minmax_of("max-width", "max", Orientation::Horizontal, MinMaxOp::Min);
+        forward_minmax_of("preferred-width", "preferred", Orientation::Horizontal, MinMaxOp::Min);
     }
     set_binding_if_not_explicit(flickable_elem, "content-width", || {
         Some(
@@ -157,15 +215,8 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 .borrow()
                 .children
                 .iter()
-                .filter(|x| is_layout(&x.borrow().base_type))
-                // FIXME: (#407)
-                .filter(|x| x.borrow().repeated.is_none())
-                .map(|x| {
-                    Expression::PropertyReference(NamedReference::new(
-                        x,
-                        SmolStr::new_static("min-width"),
-                    ))
-                })
+                .filter(is_mergeable)
+                .map(|x| layout_child_scalar(x, Orientation::Horizontal, "min-width", "min"))
                 .fold(
                     Expression::PropertyReference(NamedReference::new(
                         flickable_elem,
@@ -181,15 +232,8 @@ fn fixup_geometry(flickable_elem: &ElementRc) {
                 .borrow()
                 .children
                 .iter()
-                .filter(|x| is_layout(&x.borrow().base_type))
-                // FIXME: (#407)
-                .filter(|x| x.borrow().repeated.is_none())
-                .map(|x| {
-                    Expression::PropertyReference(NamedReference::new(
-                        x,
-                        SmolStr::new_static("min-height"),
-                    ))
-                })
+                .filter(is_mergeable)
+                .map(|x| layout_child_scalar(x, Orientation::Vertical, "min-height", "min"))
                 .fold(
                     Expression::PropertyReference(NamedReference::new(
                         flickable_elem,

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1756,6 +1756,7 @@ fn lower_box_layout(
         elems: Default::default(),
         geometry: LayoutGeometry::new(layout_element),
         cross_alignment: binding_reference(layout_element, "cross-axis-alignment"),
+        is_synthesized_repeated_merge: false,
     };
 
     let layout_info_prop_v = create_new_prop(

--- a/internal/compiler/tests/flickable_repeated_model.rs
+++ b/internal/compiler/tests/flickable_repeated_model.rs
@@ -1,0 +1,85 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Merging a Flickable's repeated children into its own geometry (#407) makes
+//! the repeater's model reachable from that geometry. Counting the model as a
+//! static dependency then reports a binding loop for a model that reads an
+//! enclosing size -- picking a variant by breakpoint, say -- which is a build
+//! failure under `SLINT_COMPILER_DENY_WARNINGS`. It doesn't need to be one: the
+//! merge tracks the repeater's instantiated row count rather than the model.
+//!
+//! A `.slint` behavior test can't see this: it only checks geometry, and the
+//! loop is reported as a warning.
+
+use i_slint_compiler::diagnostics::BuildDiagnostics;
+use i_slint_compiler::generator::OutputFormat;
+use i_slint_compiler::parser::parse;
+use i_slint_compiler::{CompilerConfiguration, compile_syntax_node};
+
+/// Every diagnostic compiling `source` produces, at any level.
+fn diagnostics(source: &str) -> Vec<String> {
+    let mut diag = BuildDiagnostics::default();
+    let syntax_node = parse(source.into(), None, &mut diag);
+    let config = CompilerConfiguration::new(OutputFormat::Llr);
+    let (_doc, diag, _loader) = spin_on::spin_on(compile_syntax_node(syntax_node, diag, config));
+    diag.to_string_vec()
+}
+
+fn assert_no_diagnostic(name: &str, source: &str) {
+    let diagnostics = diagnostics(source);
+    assert!(diagnostics.is_empty(), "{name}: {diagnostics:?}");
+}
+
+#[test]
+fn model_reading_the_flickables_own_width() {
+    assert_no_diagnostic(
+        "model reads the Flickable's width",
+        r#"
+export component Main inherits Window {
+    VerticalLayout {
+        f := Flickable {
+            for i in (f.width > 100px ? [1, 2] : [1]): HorizontalLayout {
+                Rectangle { height: 20px; }
+            }
+        }
+        Rectangle { }
+    }
+}"#,
+    );
+}
+
+#[test]
+fn model_reading_an_enclosing_size() {
+    assert_no_diagnostic(
+        "model reads the window width",
+        r#"
+export component Main inherits Window {
+    VerticalLayout {
+        Flickable {
+            for i in (root.width > 100px ? [1, 2] : [1]): HorizontalLayout {
+                Rectangle { height: 20px; }
+            }
+        }
+        Rectangle { }
+    }
+}"#,
+    );
+}
+
+#[test]
+fn condition_reading_an_enclosing_size() {
+    assert_no_diagnostic(
+        "condition reads the window width",
+        r#"
+export component Main inherits Window {
+    VerticalLayout {
+        Flickable {
+            if root.width > 100px: HorizontalLayout {
+                Rectangle { height: 20px; }
+            }
+        }
+        Rectangle { }
+    }
+}"#,
+    );
+}

--- a/tests/cases/layout/issue_407_for_layout_in_flickable.slint
+++ b/tests/cases/layout/issue_407_for_layout_in_flickable.slint
@@ -1,23 +1,99 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-export Testcase := Window {
+export component TestCase inherits Window {
     preferred-width: 640px;
     preferred-height: 480px;
+
     f := Flickable {
         for blah in 1: HorizontalLayout {
             Rectangle { height: 55px; }
         }
     }
 
-    VerticalLayout {
-        r := Rectangle {
-            for blah in 1: HorizontalLayout {
-                Rectangle { height: 44px; }
-            }
+    // A second Flickable with `height` pinned below the content's natural size, so
+    // `content-height`'s `max(self.height, child.min-height)` fold actually reflects
+    // the child instead of saturating at the first Flickable's (parent-filling)
+    // height -- fixing `height` explicitly disables that same fold's forwarding of
+    // `preferred-height`, so this needs its own element from `f` above.
+    fc := Flickable {
+        height: 10px;
+        for blah in 1: HorizontalLayout {
+            Rectangle { height: 55px; }
         }
     }
 
-    // FIXME(#407)
-    //property <bool> test: f.preferred-height == 55px && f.content-height == 55px && r.preferred-height == 44px;
+    // An empty repeater merges to a zero `preferred`, and the fold takes the
+    // smallest: it must not drag the Flickable down to nothing. `height` is
+    // deliberately not set here -- pinning it disables the very fold under test.
+    fe := Flickable {
+        HorizontalLayout { Rectangle { height: 15px; } }
+        for blah in 0: HorizontalLayout { Rectangle { height: 999px; } }
+    }
+    fe-ref := Flickable {
+        HorizontalLayout { Rectangle { height: 15px; } }
+    }
+
+    // Same, for a condition that is false rather than an empty model.
+    fi := Flickable {
+        HorizontalLayout { Rectangle { height: 15px; } }
+        if false: HorizontalLayout { Rectangle { height: 999px; } }
+    }
+
+    // Differing per-row constraints: the merge must pick up the largest row.
+    fr := Flickable {
+        height: 10px;
+        for h in [10, 30, 20]: HorizontalLayout {
+            Rectangle { height: h * 1px; }
+        }
+    }
+
+    // The horizontal axis, which reverses the orientation the merge is computed
+    // at: a repeated column contributes its width.
+    fw := Flickable {
+        width: 10px;
+        for w in [10, 40, 20]: VerticalLayout {
+            Rectangle { width: w * 1px; }
+        }
+    }
+
+    // An explicit constraint on the repeated body's own root applies too, not
+    // just what its children merge into it (covers `root_constraints`).
+    fk := Flickable {
+        height: 10px;
+        for blah in 1: HorizontalLayout {
+            min-height: 100px;
+            Rectangle { height: 10px; }
+        }
+    }
+
+    out property <bool> test: t-f-pref && t-f-content && t-empty && t-if-false
+        && t-rows && t-width && t-constrained;
+    out property <bool> t-f-pref: f.preferred-height == 55px;
+    out property <bool> t-f-content: fc.content-height == 55px;
+    out property <bool> t-empty: fe.preferred-height == fe-ref.preferred-height;
+    out property <bool> t-if-false: fi.preferred-height == fe-ref.preferred-height;
+    out property <bool> t-rows: fr.content-height == 30px;
+    out property <bool> t-width: fw.content-width == 40px;
+    out property <bool> t-constrained: fk.content-height == 100px;
 }
+
+/*
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+
+*/


### PR DESCRIPTION
A repeated `if`/`for` layout inside a Flickable previously contributed
nothing to the Flickable's own geometry -- the `FIXME(https://github.com/slint-ui/slint/issues/407)` sites in
flickable.rs simply skipped it, so `content-width`/`content-height`
didn't cover `for`-generated content and it couldn't be scrolled to.
Fix by synthesizing a one-cell orthogonal BoxLayout over the repeated
element and reusing the existing WithLayoutItemInfo /
box_layout_info_ortho runtime machinery to merge every instance's
LayoutInfo, the same way two static siblings already merge.

This also forwards `preferred-*` and `max-*`, which a parent layout
reads, so a Flickable with a repeated layout child can now be sized by
it. That is the same class of change as letting a repeated child
constrain any non-layout parent -- the other `FIXME(https://github.com/slint-ui/slint/issues/407)`, in
`default_geometry::gen_layout_info_prop` -- but over a far smaller set
of code: only a layout child of a Flickable, as for a static child
today. The larger one is left for a follow-up so it can be discussed on
its own.

A repeater with no live instance merges to a zero `preferred`, which the
folds would take as the smallest and collapse the Flickable to nothing;
zero means "no preference" there and is folded as the identity instead.

`binding_analysis` skips the repeated cell's model expression for this
merge: the merge tracks the repeater's instantiated row count rather than
the model property, so counting the model would report a binding loop for
a model that reads an enclosing size, and fail the build under
SLINT_COMPILER_DENY_WARNINGS.

ListView repeaters are excluded explicitly, since only the
currently-visible rows are materialized.

Also adds a pass marking such cells `child_of_layout`, which is what
makes the Rust generator emit `layout_item_info` for them; without one,
`RepeatedItemTree::layout_item_info`'s all-zero default made the merge
silently contribute nothing.

Known limitation: a height-for-width (or width-for-height) repeated body
-- a word-wrapped `Text`, say -- measures at its unconstrained preferred
size rather than the size it is actually given, and so can under-report
its needed cross size. Fixing that needs a known cross size threaded into
the merge the way a real enclosing layout does via `repeated_cross_size`;
no single such value exists in the outer scope where the expression is
evaluated. Left for follow-up.

changelog: Fixed a Flickable's content-width/content-height not covering
children populated with an if/for. Such a Flickable now also reports a
preferred and maximum size to its parent layout (https://github.com/slint-ui/slint/issues/407).

Co-authored-by: David Faure <david.faure@kdab.com>