### PR TITLE
Merge CrossAxisSelfAlignment into CrossAxisAlignment

### DIFF
--- a/docs/astro/src/content/docs/reference/layouts/overview.mdx
+++ b/docs/astro/src/content/docs/reference/layouts/overview.mdx
@@ -21,7 +21,7 @@ See <Link type="GridLayout" />.
 </SlintProperty>
 
 ### cross-axis-self-alignment
-<SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+<SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisAlignment" defaultValue="auto">
 Overrides the container's `cross-axis-alignment` for this element.
 Valid on the children of a <Link type="HorizontalLayout" />, <Link type="VerticalLayout" />, or <Link type="FlexboxLayout" />.
 </SlintProperty>

--- a/internal/common/enums.rs
+++ b/internal/common/enums.rs
@@ -404,11 +404,16 @@ macro_rules! for_each_enums {
                 ColumnReverse,
             }
 
-            /// Controls the alignment of individual items along the cross axis of a layout.
+            /// Controls the alignment of items along the cross axis of a layout.
             /// Used as the `cross-axis-alignment` property of `HorizontalLayout`, `VerticalLayout`,
-            /// and `FlexboxLayout`.
+            /// and `FlexboxLayout`, and as the `cross-axis-self-alignment` property of their
+            /// children, which overrides the container's alignment for a single item.
             #[non_exhaustive]
             enum CrossAxisAlignment {
+                /// The default: for `cross-axis-self-alignment`, use the container's
+                /// `cross-axis-alignment` value. For an unset `cross-axis-alignment` it is
+                /// equivalent to `stretch`; it is an error to set it explicitly there.
+                Auto,
                 /// Items are stretched to fill the cross axis.
                 Stretch,
                 /// Items are placed at the start of the cross axis.
@@ -416,23 +421,6 @@ macro_rules! for_each_enums {
                 /// Items are placed at the end of the cross axis.
                 End,
                 /// Items are centered along the cross axis.
-                Center,
-            }
-
-            /// Overrides the container's `cross-axis-alignment` for a single item.
-            /// Used as the `cross-axis-self-alignment` property of the children of a
-            /// `FlexboxLayout`, `HorizontalLayout`, or `VerticalLayout`.
-            #[non_exhaustive]
-            enum CrossAxisSelfAlignment {
-                /// Use the container's `cross-axis-alignment` value (default).
-                Auto,
-                /// The item is stretched to fill the line along the cross axis.
-                Stretch,
-                /// The item is placed at the start of the cross axis.
-                Start,
-                /// The item is placed at the end of the cross axis.
-                End,
-                /// The item is centered along the cross axis.
                 Center,
             }
 

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2057,7 +2057,7 @@ export component GridLayout {
 /// Cell elements inside a `VerticalLayout` obtain the following new properties:
 ///
 /// ### cross-axis-self-alignment
-/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisAlignment" defaultValue="auto">
 /// Overrides the container's `cross-axis-alignment` for this element.
 /// The default value `auto` uses the container's `cross-axis-alignment`.
 /// </SlintProperty>
@@ -2144,7 +2144,7 @@ export component VerticalLayout {
 /// Cell elements inside a `HorizontalLayout` obtain the following new properties:
 ///
 /// ### cross-axis-self-alignment
-/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisAlignment" defaultValue="auto">
 /// Overrides the container's `cross-axis-alignment` for this element.
 /// The default value `auto` uses the container's `cross-axis-alignment`.
 /// </SlintProperty>
@@ -2268,7 +2268,7 @@ export component HorizontalLayout {
 /// Cell elements inside a `FlexboxLayout` obtain the following new properties:
 ///
 /// ### cross-axis-self-alignment
-/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisSelfAlignment" defaultValue="auto">
+/// <SlintProperty propName="cross-axis-self-alignment" typeName="enum" enumName="CrossAxisAlignment" defaultValue="auto">
 /// Overrides the container's `cross-axis-alignment` for this element. CSS Flexbox calls this "align-self".
 /// The default value `auto` uses the container's `cross-axis-alignment`.
 /// </SlintProperty>

--- a/internal/compiler/generator/cpp.rs
+++ b/internal/compiler/generator/cpp.rs
@@ -2973,7 +2973,7 @@ fn repeated_layout_item_fields(
             let cross_o = orientation_name(cross_o);
             format!(
                 "(o == slint::cbindgen_private::Orientation::{cross_o}) ? ({expr}) \
-                 : slint::cbindgen_private::CrossAxisSelfAlignment::Auto"
+                 : slint::cbindgen_private::CrossAxisAlignment::Auto"
             )
         }
         None => "{}".to_owned(),

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -1774,7 +1774,7 @@ fn generate_sub_component(
             quote! {
                 fn cross_axis_self_alignment_for_repeated(
                     self: ::core::pin::Pin<&Self>,
-                ) -> sp::CrossAxisSelfAlignment {
+                ) -> sp::CrossAxisAlignment {
                     #![allow(unused)]
                     let _self = self;
                     #expr

--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1228,7 +1228,7 @@ struct BoxLayoutDataResult {
 }
 
 fn default_align_self() -> (Type, llr_Expression) {
-    let e = crate::typeregister::BUILTIN.enums.CrossAxisSelfAlignment.clone();
+    let e = crate::typeregister::BUILTIN.enums.CrossAxisAlignment.clone();
     (
         Type::Enumeration(e.clone()),
         llr_Expression::EnumerationValue(EnumerationValue {

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -863,6 +863,13 @@ impl LookupObject for Arc<Enumeration> {
             return None;
         }
         for (value, name) in self.values.iter().enumerate() {
+            // Don't offer `auto` in completion for `cross-axis-alignment`, where setting it is an error; `lookup` stays unfiltered.
+            if name == "auto"
+                && self.name == "CrossAxisAlignment"
+                && ctx.property_name == Some("cross-axis-alignment")
+            {
+                continue;
+            }
             if let Some(r) = f(
                 name,
                 Expression::EnumerationValue(EnumerationValue { value, enumeration: self.clone() })
@@ -872,6 +879,18 @@ impl LookupObject for Arc<Enumeration> {
             }
         }
         None
+    }
+
+    fn lookup(&self, ctx: &LookupCtx, name: &SmolStr) -> Option<LookupResult> {
+        // Builtin enums are not in the Slint SC subset.
+        if ctx.diag.is_slint_sc() && self.node.is_none() {
+            return None;
+        }
+        let value = self.values.iter().position(|v| v == name)?;
+        Some(
+            Expression::EnumerationValue(EnumerationValue { value, enumeration: self.clone() })
+                .into(),
+        )
     }
 }
 

--- a/internal/compiler/lookup.rs
+++ b/internal/compiler/lookup.rs
@@ -865,7 +865,7 @@ impl LookupObject for Arc<Enumeration> {
         for (value, name) in self.values.iter().enumerate() {
             // Don't offer `auto` in completion for `cross-axis-alignment`, where setting it is an error; `lookup` stays unfiltered.
             if name == "auto"
-                && self.name == "CrossAxisAlignment"
+                && Arc::ptr_eq(self, &crate::typeregister::BUILTIN.enums.CrossAxisAlignment)
                 && ctx.property_name == Some("cross-axis-alignment")
             {
                 continue;

--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1731,11 +1731,26 @@ fn clamp_cross_stretch_size(
     size_expr
 }
 
+/// `auto` is the unset default of `cross-axis-alignment` and only valid for
+/// `cross-axis-self-alignment`; setting it explicitly is an error.
+fn check_cross_axis_alignment_not_auto(elem: &ElementRc, diag: &mut BuildDiagnostics) {
+    if let Some(b) = elem.borrow().binding("cross-axis-alignment")
+        && let Expression::EnumerationValue(ev) = b.value_expression()
+        && ev.to_string() == "auto"
+    {
+        diag.push_error(
+            "cross-axis-alignment cannot be set to 'auto', which is only valid for cross-axis-self-alignment; the default is 'stretch'".into(),
+            &*b,
+        );
+    }
+}
+
 fn lower_box_layout(
     layout_element: &ElementRc,
     diag: &mut BuildDiagnostics,
     orientation: Orientation,
 ) {
+    check_cross_axis_alignment_not_auto(layout_element, diag);
     let mut layout = BoxLayout {
         orientation,
         elems: Default::default(),
@@ -1900,6 +1915,7 @@ fn lower_box_layout(
 }
 
 fn lower_flexbox_layout(layout_element: &ElementRc, diag: &mut BuildDiagnostics) {
+    check_cross_axis_alignment_not_auto(layout_element, diag);
     let direction = crate::layout::binding_reference(layout_element, "flex-direction");
     let cross_axis_line_alignment =
         crate::layout::binding_reference(layout_element, "cross-axis-line-alignment");

--- a/internal/compiler/tests/layout_cell_properties.rs
+++ b/internal/compiler/tests/layout_cell_properties.rs
@@ -88,13 +88,13 @@ export component TestCase inherits Window {{
     }
 }
 
-/// The `CrossAxisSelfAlignment` enum is in the stable type register:
+/// The `CrossAxisAlignment` enum is in the stable type register:
 /// nameable as a type and as a qualified value without experimental features.
 #[test]
 fn cross_axis_self_alignment_enum_is_stable() {
     let source = r#"
 export component TestCase inherits Window {
-    in property <CrossAxisSelfAlignment> a: CrossAxisSelfAlignment.center;
+    in property <CrossAxisAlignment> a: CrossAxisAlignment.center;
     FlexboxLayout {
         Rectangle { cross-axis-self-alignment: root.a; }
     }

--- a/internal/compiler/tests/syntax/layout/cross_axis_alignment_auto.slint
+++ b/internal/compiler/tests/syntax/layout/cross_axis_alignment_auto.slint
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component DerivedLayout inherits VerticalLayout { }
+
+component BadLayout inherits VerticalLayout {
+    cross-axis-alignment: auto;
+//                        >   <error{cross-axis-alignment cannot be set to 'auto', which is only valid for cross-axis-self-alignment; the default is 'stretch'}
+}
+
+export component Foo {
+    in property <CrossAxisAlignment> indirect: auto;
+
+    VerticalLayout {
+        cross-axis-alignment: auto;
+//                            >   <error{cross-axis-alignment cannot be set to 'auto', which is only valid for cross-axis-self-alignment; the default is 'stretch'}
+        Rectangle { }
+    }
+    HorizontalLayout {
+        cross-axis-alignment: CrossAxisAlignment.auto;
+//                            >                      <error{cross-axis-alignment cannot be set to 'auto', which is only valid for cross-axis-self-alignment; the default is 'stretch'}
+        Rectangle { }
+    }
+    FlexboxLayout {
+        cross-axis-alignment: auto;
+//                            >   <error{cross-axis-alignment cannot be set to 'auto', which is only valid for cross-axis-self-alignment; the default is 'stretch'}
+        Rectangle { }
+    }
+    // `auto` stays valid for the per-item override, and the other values for the container.
+    VerticalLayout {
+        cross-axis-alignment: center;
+        Rectangle { cross-axis-self-alignment: auto; }
+    }
+    // Only a verbatim `auto` is an error; a value that is `auto` at run-time behaves like `stretch`.
+    VerticalLayout {
+        cross-axis-alignment: root.indirect;
+        Rectangle { }
+    }
+    // The check also applies through a component that derives from a layout.
+    DerivedLayout {
+        cross-axis-alignment: auto;
+//                            >   <error{cross-axis-alignment cannot be set to 'auto', which is only valid for cross-axis-self-alignment; the default is 'stretch'}
+        Rectangle { }
+    }
+    BadLayout {
+        Rectangle { }
+    }
+}

--- a/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
+++ b/internal/compiler/tests/syntax/layout/flexbox_layout_properties.slint
@@ -16,6 +16,6 @@ export component X inherits Rectangle {
 //      >        <error{Use spacing-horizontal instead of column-gap}
         justify-content: center;
 //      >             <error{Use alignment instead of justify-content}
-//                       >    <^error{Unknown unqualified identifier 'center'. Did you mean 'CrossAxisAlignment.center', 'CrossAxisSelfAlignment.center', 'ImageHorizontalAlignment.center', 'ImageVerticalAlignment.center', 'LayoutAlignment.center', 'TextHorizontalAlignment.center', 'TextStrokeStyle.center' or 'TextVerticalAlignment.center'?}
+//                       >    <^error{Unknown unqualified identifier 'center'. Did you mean 'CrossAxisAlignment.center', 'ImageHorizontalAlignment.center', 'ImageVerticalAlignment.center', 'LayoutAlignment.center', 'TextHorizontalAlignment.center', 'TextStrokeStyle.center' or 'TextVerticalAlignment.center'?}
     }
 }

--- a/internal/compiler/typeregister.rs
+++ b/internal/compiler/typeregister.rs
@@ -117,7 +117,7 @@ impl BuiltinTypes {
             BuiltinStruct::LayoutInfo,
         ));
         let enums = BuiltinEnums::new();
-        let align_self_type = Type::Enumeration(enums.CrossAxisSelfAlignment.clone());
+        let align_self_type = Type::Enumeration(enums.CrossAxisAlignment.clone());
         // Shared by `flex_item_props_type` and nested as `props` in
         // `flexbox_layout_item_info_type`, so the field list is defined once.
         let flex_item_props_struct = Arc::new(Struct::new(
@@ -189,7 +189,7 @@ impl BuiltinTypes {
                     ("constraint".into(), layout_info_type.clone().into()),
                     (
                         "cross-axis-self-alignment".into(),
-                        Type::Enumeration(enums.CrossAxisSelfAlignment.clone()),
+                        Type::Enumeration(enums.CrossAxisAlignment.clone()),
                     ),
                     ("layout-order".into(), Type::Int32),
                 ])
@@ -334,7 +334,7 @@ pub fn reserved_properties() -> impl Iterator<Item = (&'static str, Type, Proper
         // const array because Type::Enumeration requires a runtime Arc allocation.
         .chain(std::iter::once((
             "cross-axis-self-alignment",
-            Type::Enumeration(BUILTIN.enums.CrossAxisSelfAlignment.clone()),
+            Type::Enumeration(BUILTIN.enums.CrossAxisAlignment.clone()),
             PropertyVisibility::Input,
         )))
         .chain(IntoIterator::into_iter([

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -6,8 +6,8 @@
 // cspell:ignore coord
 
 use crate::items::{
-    CrossAxisAlignment, CrossAxisSelfAlignment, DialogButtonRole, FlexboxLayoutDirection,
-    FlexboxLayoutWrap, LayoutAlignment,
+    CrossAxisAlignment, DialogButtonRole, FlexboxLayoutDirection, FlexboxLayoutWrap,
+    LayoutAlignment,
 };
 use crate::{Coord, SharedVector, slice::Slice};
 use alloc::format;
@@ -1169,7 +1169,7 @@ pub struct LayoutItemInfo {
     pub constraint: LayoutInfo,
     /// Per-item cross-axis alignment override for box layouts
     /// (`Auto` = use the container's `cross-axis-alignment`)
-    pub cross_axis_self_alignment: CrossAxisSelfAlignment,
+    pub cross_axis_self_alignment: CrossAxisAlignment,
     /// Visual ordering of box layout cells (lower values appear first, default 0).
     /// Only [`solve_box_layout`] reads it; the cross-axis solve and both
     /// layout-info functions ignore it. A FlexboxLayout carries it in
@@ -1187,7 +1187,7 @@ pub struct LayoutItemInfo {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FlexItemProps {
     /// Per-item cross-axis alignment override (Auto = use container's cross-axis-alignment)
-    pub cross_axis_self_alignment: CrossAxisSelfAlignment,
+    pub cross_axis_self_alignment: CrossAxisAlignment,
     /// Visual ordering of flex items (lower values appear first, default 0)
     pub layout_order: i32,
 }
@@ -1325,6 +1325,22 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indices: Slice<u32>) -> S
     result
 }
 
+/// Resolves the effective alignment of an item on the cross axis: `auto` on the
+/// item uses the container's alignment, and `auto` on the container is `stretch`.
+fn resolve_cross_axis_alignment(
+    self_alignment: CrossAxisAlignment,
+    container_alignment: CrossAxisAlignment,
+) -> CrossAxisAlignment {
+    let alignment = match self_alignment {
+        CrossAxisAlignment::Auto => container_alignment,
+        other => other,
+    };
+    match alignment {
+        CrossAxisAlignment::Auto => CrossAxisAlignment::Stretch,
+        other => other,
+    }
+}
+
 /// Cross-axis solve: returns (position, size) per cell, like [`solve_box_layout`].
 pub fn solve_box_layout_ortho(
     data: &BoxLayoutOrthoData,
@@ -1338,13 +1354,8 @@ pub fn solve_box_layout_ortho(
     let size_without_padding = data.size - data.padding.begin - data.padding.end;
     let mut generator = LayoutCacheGenerator::new(&repeater_indices, &mut result);
     for c in data.cells.iter() {
-        let alignment = match c.cross_axis_self_alignment {
-            CrossAxisSelfAlignment::Auto => data.cross_axis_alignment,
-            CrossAxisSelfAlignment::Stretch => CrossAxisAlignment::Stretch,
-            CrossAxisSelfAlignment::Start => CrossAxisAlignment::Start,
-            CrossAxisSelfAlignment::End => CrossAxisAlignment::End,
-            CrossAxisSelfAlignment::Center => CrossAxisAlignment::Center,
-        };
+        let alignment =
+            resolve_cross_axis_alignment(c.cross_axis_self_alignment, data.cross_axis_alignment);
         let min =
             c.constraint.min.max(c.constraint.min_percent * size_without_padding / 100 as Coord);
         let max =
@@ -1356,7 +1367,9 @@ pub fn solve_box_layout_ortho(
         .min(max)
         .max(min);
         let pos = match alignment {
-            CrossAxisAlignment::Stretch | CrossAxisAlignment::Start => data.padding.begin,
+            CrossAxisAlignment::Auto | CrossAxisAlignment::Stretch | CrossAxisAlignment::Start => {
+                data.padding.begin
+            }
             CrossAxisAlignment::End => data.padding.begin + size_without_padding - size,
             CrossAxisAlignment::Center => {
                 data.padding.begin + (size_without_padding - size) / 2 as Coord
@@ -1418,9 +1431,8 @@ pub fn box_layout_info_ortho(cells: Slice<LayoutItemInfo>, padding: &Padding) ->
 /// Helper module for taffy-based flexbox layout
 mod flexbox_taffy {
     use super::{
-        Coord, CrossAxisAlignment, CrossAxisSelfAlignment, FlexItemProps,
-        FlexboxLayoutWrap as SlintFlexboxLayoutWrap, LayoutAlignment, LayoutInfo, LayoutItemInfo,
-        Padding, Slice,
+        Coord, CrossAxisAlignment, FlexItemProps, FlexboxLayoutWrap as SlintFlexboxLayoutWrap,
+        LayoutAlignment, LayoutInfo, LayoutItemInfo, Padding, Slice, resolve_cross_axis_alignment,
     };
     use alloc::vec::Vec;
     pub use taffy::prelude::FlexDirection as TaffyFlexDirection;
@@ -1609,13 +1621,10 @@ mod flexbox_taffy {
                     // alignment. `auto` is also what lets the measure callback
                     // decide the cross size, and what lets the minimum pass reach
                     // the item's min constraint.
-                    let stretches = match flex.cross_axis_self_alignment {
-                        CrossAxisSelfAlignment::Auto => {
-                            params.cross_axis_alignment == CrossAxisAlignment::Stretch
-                        }
-                        CrossAxisSelfAlignment::Stretch => true,
-                        _ => false,
-                    };
+                    let stretches = resolve_cross_axis_alignment(
+                        flex.cross_axis_self_alignment,
+                        params.cross_axis_alignment,
+                    ) == CrossAxisAlignment::Stretch;
                     let cross_auto =
                         stretches || params.cross_axis_sizing != CrossAxisSizing::Preferred;
                     let definite_cross = |preferred: Coord| {
@@ -1679,11 +1688,11 @@ mod flexbox_taffy {
                                 // stretch factor, as it would in a box layout.
                                 flex_shrink: 1.,
                                 align_self: match flex.cross_axis_self_alignment {
-                                    CrossAxisSelfAlignment::Auto => None,
-                                    CrossAxisSelfAlignment::Stretch => Some(AlignSelf::Stretch),
-                                    CrossAxisSelfAlignment::Start => Some(AlignSelf::FlexStart),
-                                    CrossAxisSelfAlignment::End => Some(AlignSelf::FlexEnd),
-                                    CrossAxisSelfAlignment::Center => Some(AlignSelf::Center),
+                                    CrossAxisAlignment::Auto => None,
+                                    CrossAxisAlignment::Stretch => Some(AlignSelf::Stretch),
+                                    CrossAxisAlignment::Start => Some(AlignSelf::FlexStart),
+                                    CrossAxisAlignment::End => Some(AlignSelf::FlexEnd),
+                                    CrossAxisAlignment::Center => Some(AlignSelf::Center),
                                 },
                                 ..Default::default()
                             },
@@ -1720,7 +1729,9 @@ mod flexbox_taffy {
                         },
                         justify_content: Some(to_align_content(params.alignment)),
                         align_items: Some(match params.cross_axis_alignment {
-                            CrossAxisAlignment::Stretch => AlignItems::Stretch,
+                            CrossAxisAlignment::Auto | CrossAxisAlignment::Stretch => {
+                                AlignItems::Stretch
+                            }
                             CrossAxisAlignment::Start => AlignItems::FlexStart,
                             CrossAxisAlignment::End => AlignItems::FlexEnd,
                             CrossAxisAlignment::Center => AlignItems::Center,

--- a/internal/interpreter/eval.rs
+++ b/internal/interpreter/eval.rs
@@ -1179,11 +1179,11 @@ fn push_repeater_layout_items(
         struct_value.set_field("constraint".to_string(), info.constraint.into());
         // The cell's `cross-axis-self-alignment` in a box layout; `to_cells`
         // reads it back on the cross-axis solve, an absent field means `auto`.
-        if info.cross_axis_self_alignment != i_slint_core::items::CrossAxisSelfAlignment::Auto {
+        if info.cross_axis_self_alignment != i_slint_core::items::CrossAxisAlignment::Auto {
             struct_value.set_field(
                 "cross-axis-self-alignment".to_string(),
                 Value::EnumerationValue(
-                    "CrossAxisSelfAlignment".to_string(),
+                    "CrossAxisAlignment".to_string(),
                     info.cross_axis_self_alignment.to_string(),
                 ),
             );
@@ -1428,7 +1428,7 @@ fn flex_props_to_value(props: i_slint_core::layout::FlexItemProps) -> Value {
     s.set_field(
         "cross-axis-self-alignment".to_string(),
         Value::EnumerationValue(
-            "CrossAxisSelfAlignment".to_string(),
+            "CrossAxisAlignment".to_string(),
             format!("{:?}", props.cross_axis_self_alignment).to_lowercase(),
         ),
     );

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -1071,7 +1071,7 @@ fn repeated_align_self(
     sc: &i_slint_compiler::llr::SubComponent,
     ctx: &mut crate::eval::EvalContext,
     orientation: i_slint_core::items::Orientation,
-) -> i_slint_core::items::CrossAxisSelfAlignment {
+) -> i_slint_core::items::CrossAxisAlignment {
     match &sc.cross_axis_self_alignment_for_repeated {
         Some((cross_o, expr)) if crate::eval::llr_to_core_orientation(*cross_o) == orientation => {
             crate::eval::eval_expression(ctx, &expr.borrow()).try_into().unwrap_or_default()

--- a/tests/cases/layout/boxlayout_cross_axis_self_alignment.slint
+++ b/tests/cases/layout/boxlayout_cross_axis_self_alignment.slint
@@ -345,7 +345,7 @@ export component TestCase inherits Window {
                 dyn1 := Rectangle {
                     width: 60px;
                     preferred-height: 30px;
-                    cross-axis-self-alignment: root.flip ? CrossAxisSelfAlignment.end : CrossAxisSelfAlignment.start;
+                    cross-axis-self-alignment: root.flip ? CrossAxisAlignment.end : CrossAxisAlignment.start;
                     background: #cce6ff;
                     border-width: 1px;
                     border-color: #5b8db8;
@@ -355,7 +355,7 @@ export component TestCase inherits Window {
                 for i in [0]: rep-dyn := Rectangle {
                     width: 60px;
                     preferred-height: 30px;
-                    cross-axis-self-alignment: root.flip ? CrossAxisSelfAlignment.end : CrossAxisSelfAlignment.start;
+                    cross-axis-self-alignment: root.flip ? CrossAxisAlignment.end : CrossAxisAlignment.start;
                     background: #cce6ff;
                     border-width: 1px;
                     border-color: #5b8db8;

--- a/tests/cases/layout/cross_axis_alignment_auto.slint
+++ b/tests/cases/layout/cross_axis_alignment_auto.slint
@@ -1,0 +1,70 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `auto` cannot be set verbatim on `cross-axis-alignment`, but it can reach it
+// through a property at run-time, where it behaves like `stretch`.
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 90px;
+
+    in-out property <bool> center-mode;
+    property <CrossAxisAlignment> indirect: center-mode ? CrossAxisAlignment.center : CrossAxisAlignment.auto;
+
+    VerticalLayout {
+        x: 0; y: 0; width: 100px; height: 90px;
+        cross-axis-alignment: indirect;
+        indirect-rect := Rectangle { preferred-width: 10px; }
+    }
+    VerticalLayout {
+        x: 100px; y: 0; width: 100px; height: 90px;
+        cross-axis-alignment: stretch;
+        stretch-rect := Rectangle { preferred-width: 10px; }
+    }
+    VerticalLayout {
+        x: 200px; y: 0; width: 100px; height: 90px;
+        default-rect := Rectangle { preferred-width: 10px; }
+    }
+
+    out property <int> indirect-rect-width: indirect-rect.width / 1px;
+    // `auto` through a property, an explicit `stretch`, and the unset default all stretch alike.
+    out property <bool> test: indirect-rect.width == 100px
+        && indirect-rect.width == stretch-rect.width
+        && indirect-rect.width == default-rect.width;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+// Switching the property away from `auto` and back re-solves the layout.
+instance.set_center_mode(true);
+assert_eq!(instance.get_indirect_rect_width(), 10);
+instance.set_center_mode(false);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_test(), true);
+
+// Switching the property away from `auto` and back re-solves the layout.
+instance.set_center_mode(true);
+assert_eq(instance.get_indirect_rect_width(), 10);
+instance.set_center_mode(false);
+assert_eq(instance.get_test(), true);
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+
+// Switching the property away from `auto` and back re-solves the layout.
+instance.center_mode = true;
+assert.equal(instance.indirect_rect_width, 10);
+instance.center_mode = false;
+assert(instance.test);
+```
+*/

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -2933,6 +2933,39 @@ component Foo {{
     }
 
     #[test]
+    fn no_auto_completion_for_cross_axis_alignment() {
+        // `auto` cannot be set on `cross-axis-alignment`, so don't offer it there,
+        // neither as a bare value nor after `CrossAxisAlignment.`
+        for (binding, has_auto) in [
+            ("cross-axis-alignment: @value Rectangle {}", false),
+            ("Rectangle { cross-axis-self-alignment: @value }", true),
+        ] {
+            for value in ["🔺", "CrossAxisAlignment.🔺"] {
+                let binding = binding.replace("@value", value);
+                let source = format!(
+                    r#"
+component Foo {{
+    VerticalLayout {{
+        {binding}
+    }}
+}}
+"#
+                );
+                let results = get_completions(&source).unwrap();
+                assert_eq!(
+                    results.iter().any(|completion| completion.label == "auto"),
+                    has_auto,
+                    "wrong 'auto' completion in `{binding}`"
+                );
+                assert!(
+                    results.iter().any(|completion| completion.label == "center"),
+                    "no 'center' completion in `{binding}`"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn interface_keyword_requires_experimental() {
         let sources = ["🔺", "component Foo {}\n🔺"];
         for source in sources {


### PR DESCRIPTION
CrossAxisAlignment gains the auto value, which is the default: for cross-axis-self-alignment it means using the container's alignment, and for an unset cross-axis-alignment it is equivalent to stretch. Setting cross-axis-alignment to auto explicitly is an error.

As discussed in #13029.

