### PR TITLE
Deprecate SkiaWGPURenderer

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -461,7 +461,7 @@ pub mod platform {
         pub use i_slint_renderer_femtovg::opengl::OpenGLInterface;
     }
 
-    /// This module contains the [`skia_renderer::SkiaWGPURenderer`] and related types.
+    /// This module contains the Skia WGPU renderers and related types.
     ///
     /// It is only enabled when the `renderer-skia` Slint feature is enabled.
     #[cfg(all(
@@ -477,6 +477,7 @@ pub mod platform {
         pub use i_slint_renderer_skia::SkiaWGPU29Renderer;
         #[cfg(feature = "unstable-wgpu-30")]
         pub use i_slint_renderer_skia::SkiaWGPU30Renderer;
+        #[allow(deprecated)]
         pub use i_slint_renderer_skia::SkiaWGPURenderer;
     }
 

--- a/examples/bevy/bevy-hosts-slint-gpu/README.md
+++ b/examples/bevy/bevy-hosts-slint-gpu/README.md
@@ -7,7 +7,7 @@ It shows how to render a Slint component with WGPU into a Bevy `Image` (texture)
 ## Features
 
 - **Custom Platform Backend**: Implements a `slint::platform::Platform` to bridge Slint's windowing to Bevy.
-- **Texture Rendering**: Uses Slint's `SkiaWGPURenderer` to render the UI straight into a Bevy-owned `wgpu::Texture` via `render_to_texture()`. There is no CPU pixel buffer and no upload step, which is the difference from the `bevy-hosts-slint`.
+- **Texture Rendering**: Uses Slint's `SkiaWGPU29Renderer` to render the UI straight into a Bevy-owned `wgpu::Texture` via `render_to_texture()`. There is no CPU pixel buffer and no upload step, which is the difference from the `bevy-hosts-slint`.
 - **Input Forwarding**: Raycasts from the camera through the mouse position to detect intersection with the UI quad, then translates hit coordinates to Slint pointer events, enabling interactive UI elements like buttons and sliders.
 - **3D Scene Integration**: The UI is rendered on a quad mesh attached to a rotating cube. The Slint component's transparent background (`background: #00000000`) combines with the material's `alpha_mode: Blend` so the scene shows through the UI.
 - **Keyboard Controls**: Use arrow keys to rotate the cube and observe the UI from different angles.
@@ -29,7 +29,7 @@ cargo run --release
 The integration consists of a few key parts:
 
 1.  **`SlintBevyPlatform`**: A custom implementation of `slint::platform::Platform` that manages window adapters.
-2.  **`BevyWindowAdapter`**: Implements `slint::platform::WindowAdapter`. It doesn't create a native OS window but instead owns a `SkiaWGPURenderer` built on Bevy's wgpu device, queue, adapter and instance.
+2.  **`BevyWindowAdapter`**: Implements `slint::platform::WindowAdapter`. It doesn't create a native OS window but instead owns a `SkiaWGPU29Renderer` built on Bevy's wgpu device, queue, adapter and instance.
 3.  **`SlintSharedTexture`**: Gets the `wgpu::Texture` behind the Bevy `Image` across the world boundary — see below.
 4.  **`render_slint` System**: A Bevy system that runs every frame. It calls `slint::platform::update_timers_and_animations()`, then `render_to_texture()` on the shared texture.
 5.  **`handle_input` System**: Raycasts from the camera through the mouse position, checks for intersection with the UI quad, converts the 3D hit point to UV coordinates, then to Slint's logical coordinates, and dispatches pointer events to the Slint window.

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -67,7 +67,10 @@ pub use wgpu_renderer::SkiaWGPU29Renderer;
 #[cfg(feature = "wgpu-30")]
 pub use wgpu_renderer::SkiaWGPU30Renderer;
 #[cfg(any(feature = "wgpu-29", feature = "wgpu-30"))]
-pub use wgpu_renderer::{SkiaWGPURenderer, SkiaWGPURendererGeneric};
+#[allow(deprecated)]
+pub use wgpu_renderer::SkiaWGPURenderer;
+#[cfg(any(feature = "wgpu-29", feature = "wgpu-30"))]
+pub use wgpu_renderer::SkiaWGPURendererGeneric;
 
 use itemrenderer::to_skia_rect;
 pub use skia_safe;

--- a/internal/renderers/skia/wgpu_renderer.rs
+++ b/internal/renderers/skia/wgpu_renderer.rs
@@ -43,18 +43,22 @@ pub type SkiaWGPU29Renderer = SkiaWGPURendererGeneric<crate::wgpu_29_surface::WG
 #[cfg(feature = "wgpu-30")]
 pub type SkiaWGPU30Renderer = SkiaWGPURendererGeneric<crate::wgpu_30_surface::WGPUSurface>;
 
-/// Compatibility alias for the newest enabled wgpu version: wgpu 30 when the
+/// Deprecated alias for the newest enabled wgpu version: wgpu 30 when the
 /// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise.
-/// Prefer the versioned names, `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer`, in new code;
+///
+/// Use the versioned names, `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer`, instead;
 /// they don't change meaning when another `unstable-wgpu-*` feature gets enabled elsewhere
 /// in the dependency graph.
+#[deprecated(since = "1.18.0", note = "Use `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer` instead")]
 #[cfg(feature = "wgpu-30")]
 pub type SkiaWGPURenderer = SkiaWGPU30Renderer;
-/// Compatibility alias for the newest enabled wgpu version: wgpu 30 when the
+/// Deprecated alias for the newest enabled wgpu version: wgpu 30 when the
 /// `unstable-wgpu-30` feature is enabled, wgpu 29 otherwise.
-/// Prefer the versioned names, `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer`, in new code;
+///
+/// Use the versioned names, `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer`, instead;
 /// they don't change meaning when another `unstable-wgpu-*` feature gets enabled elsewhere
 /// in the dependency graph.
+#[deprecated(since = "1.18.0", note = "Use `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer` instead")]
 #[cfg(all(feature = "wgpu-29", not(feature = "wgpu-30")))]
 pub type SkiaWGPURenderer = SkiaWGPU29Renderer;
 
@@ -249,7 +253,7 @@ impl<Surface> RendererSealed for SkiaWGPURendererGeneric<Surface> {
 
 // Assert the consumer-visible signatures of every renderer name. Building the crate only
 // compiles the definitions; these coercions prove the intended calls resolve, in particular
-// that `SkiaWGPURenderer::new` stays unambiguous with both wgpu features enabled.
+// that the deprecated `SkiaWGPURenderer::new` stays unambiguous with both wgpu features enabled.
 #[cfg(test)]
 mod signature_tests {
     use super::*;
@@ -277,6 +281,7 @@ mod signature_tests {
         SkiaWGPU30Renderer::render_to_texture;
 
     #[cfg(feature = "wgpu-30")]
+    #[allow(deprecated)]
     const _: fn(
         wgpu_30::Instance,
         wgpu_30::Adapter,
@@ -284,6 +289,7 @@ mod signature_tests {
         wgpu_30::Queue,
     ) -> Result<SkiaWGPURenderer, PlatformError> = SkiaWGPURenderer::new;
     #[cfg(all(feature = "wgpu-29", not(feature = "wgpu-30")))]
+    #[allow(deprecated)]
     const _: fn(
         wgpu_29::Instance,
         wgpu_29::Adapter,


### PR DESCRIPTION
The alias points at whichever wgpu version is enabled, so its meaning changes when another unstable-wgpu-* feature shows up in the dependency graph. The versioned names don't have that problem.

changelog: `slint::platform::skia_renderer::SkiaWGPURenderer` is deprecated. Use `SkiaWGPU29Renderer` or `SkiaWGPU30Renderer` instead.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
