### PR TITLE
Visual Editor: Lint and test the editor on fork pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,13 +81,17 @@ jobs:
             save_if: ${{ github.ref == 'refs/heads/master' }}
 
     visual_editor:
-        if: ${{ contains(fromJSON(inputs.changes), 'visual_editor') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ contains(fromJSON(inputs.changes), 'visual_editor') }}
         name: Visual Editor
         runs-on: macos-14
         timeout-minutes: 120
         env:
             RUSTFLAGS: -D warnings
             SLINT_EMIT_DEBUG_INFO: '1'
+            # The UI tests need a private package that GitHub doesn't hand the
+            # token for to pull requests from forks. Lint and build the editor
+            # there anyway, and skip only the steps that need the token.
+            UI_TESTS: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         steps:
             - uses: actions/checkout@v7
             - uses: ./.github/actions/install-skia-dependencies
@@ -101,6 +105,7 @@ jobs:
                   python-version: '3.11'
             - uses: astral-sh/setup-uv@v7
             - name: Install UI test dependencies
+              if: ${{ env.UI_TESTS == 'true' }}
               working-directory: tools/editor/ui-tests
               env:
                   UV_INDEX: slint-private=https://testing.slint.dev/simple/
@@ -114,6 +119,7 @@ jobs:
             - name: Build the visual editor UI test binary
               run: cargo build --locked -p slint-editor --all-features --features slint/mcp
             - name: Run visual editor UI tests
+              if: ${{ env.UI_TESTS == 'true' }}
               working-directory: tools/editor/ui-tests
               env:
                   SLINT_BACKEND: headless-skia


### PR DESCRIPTION
The Visual Editor job was skipped entirely for pull requests from forks, because its UI tests install a private package with a token that GitHub doesn't expose to forks. That also skipped the only clippy run covering the editor's test code, so lint errors could land unnoticed.

Guard just the two steps that need the token, and let the lint, test and build steps run everywhere.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
