### PR TITLE
Python: Rename Model.append to Model.push_row

### DIFF
--- a/api/python/slint/models.rs
+++ b/api/python/slint/models.rs
@@ -241,8 +241,8 @@ impl i_slint_core::model::Model for PyModelShared {
 
             let element_type = self.element_type.borrow().clone();
             let result =
-                obj.call_method1("append", (type_collection.to_py_value(data, element_type),));
-            self.map_result(py, result, "push_row(), named append(),")
+                obj.call_method1("push_row", (type_collection.to_py_value(data, element_type),));
+            self.map_result(py, result, "push_row()")
         })
         .unwrap_or(Err(ModelError::unsupported(self)))
     }

--- a/api/python/slint/slint/models.py
+++ b/api/python/slint/slint/models.py
@@ -56,7 +56,7 @@ class Model[T](native.PyModelBase, Iterable[T]):
         Re-implement this method in a sub-class to provide the data."""
         ...
 
-    def append(self, value: T) -> None:
+    def push_row(self, value: T) -> None:
         """Add a new row to the model with the provided value.
         The default implementation calls `insert_row` with the row count."""
         self.insert_row(self.row_count(), value)
@@ -98,8 +98,8 @@ class ListModel[T](Model[T]):
     """ListModel is a `Model` that stores its data in a Python list.
 
     Construct a ListMode from an iterable (such as a list itself).
-    Use `ListModel.append()` to add items to the model, and use the
-    `del` statement to remove items.
+    Use `ListModel.push_row()`, or its `append` alias, to add items to the
+    model, and use the `del` statement to remove items.
 
     Any changes to the model are automatically reflected in the views
     in UI they're used with.
@@ -147,11 +147,15 @@ class ListModel[T](Model[T]):
             del self.list[key]
             super().notify_row_removed(key, 1)
 
-    def append(self, value: T) -> None:
+    def push_row(self, value: T) -> None:
         """Appends the value to the end of the list."""
         index = len(self.list)
         self.list.append(value)
         super().notify_row_added(index, 1)
+
+    def append(self, value: T) -> None:
+        """Appends the value to the end of the list, like `push_row`."""
+        self.push_row(value)
 
     def insert(self, index: int, value: T) -> None:
         """Inserts the value at the given index. Negative indices and indices

--- a/api/python/slint/tests/test_gc.py
+++ b/api/python/slint/tests/test_gc.py
@@ -218,7 +218,7 @@ def test_model_reassignment_after_drop() -> None:
     assert instance.get_property("test-value").row_count() == 3
 
     # Mutations must still reach the views attached to the fresh model.
-    model.append(4)
+    model.push_row(4)
     assert instance.get_property("test-value").row_count() == 4
 
 

--- a/api/python/slint/tests/test_models.py
+++ b/api/python/slint/tests/test_models.py
@@ -27,7 +27,7 @@ def test_row_modification_rejection_raises() -> None:
             return 42
 
     with pytest.raises(NotImplementedError):
-        ReadOnly().append(1)
+        ReadOnly().push_row(1)
 
 
 def test_rejected_modification_logs_python_class_name(
@@ -103,7 +103,7 @@ def test_model_notify() -> None:
     assert instance.get_property("layout-height") == 100
     model.set_row_data(1, 50)
     assert instance.get_property("layout-height") == 150
-    model.append(75)
+    model.push_row(75)
     instance._process_pending_events()
     assert instance.get_property("layout-height") == 225
     del model[1:]
@@ -345,3 +345,9 @@ def test_model_modifications() -> None:
     assert len(model) == 0
     instance.invoke("insert_one_empty")
     assert len(model) == 0
+
+
+def test_list_model_append_alias() -> None:
+    model = models.ListModel([1, 2])
+    model.append(3)
+    assert list(model) == [1, 2, 3]


### PR DESCRIPTION
The other model methods are named like in the Slint API, so the method to add a row is now called push_row too. ListModel keeps append as an alias, next to insert and del.

cc #13066

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
