### PR TITLE
Visual Editor: Make content static

### DIFF
--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -837,7 +837,13 @@ impl ComponentCompiler {
             }
         };
 
-        let r = build_compilation_result(source, path.into(), self.config.clone(), false).await;
+        let r = build_compilation_result(
+            source,
+            path.into(),
+            self.config.clone(),
+            AnimationMode::Running,
+        )
+        .await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -863,7 +869,13 @@ impl ComponentCompiler {
         source_code: String,
         path: PathBuf,
     ) -> Option<ComponentDefinition> {
-        let r = build_compilation_result(source_code, path, self.config.clone(), false).await;
+        let r = build_compilation_result(
+            source_code,
+            path,
+            self.config.clone(),
+            AnimationMode::Running,
+        )
+        .await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -1019,7 +1031,8 @@ impl Compiler {
             }
         };
 
-        build_compilation_result(source, path.into(), self.config.clone(), false).await
+        build_compilation_result(source, path.into(), self.config.clone(), AnimationMode::Running)
+            .await
     }
 
     /// Compile some .slint code
@@ -1035,7 +1048,8 @@ impl Compiler {
     /// If that is not used, then it is fine to use a very simple executor, such as the one
     /// provided by the `spin_on` crate
     pub async fn build_from_source(&self, source_code: String, path: PathBuf) -> CompilationResult {
-        build_compilation_result(source_code, path, self.config.clone(), false).await
+        build_compilation_result(source_code, path, self.config.clone(), AnimationMode::Running)
+            .await
     }
 
     /// Compile Slint code without timers or animations.
@@ -1045,19 +1059,29 @@ impl Compiler {
         &self,
         source_code: String,
         path: PathBuf,
+        _: i_slint_core::InternalToken,
     ) -> CompilationResult {
-        build_compilation_result(source_code, path, self.config.clone(), true).await
+        build_compilation_result(source_code, path, self.config.clone(), AnimationMode::Static)
+            .await
     }
+}
+
+pub(crate) enum AnimationMode {
+    /// In static mode, all timers & animations are disabled.
+    /// The item tree should not update anything without interaction.
+    #[cfg(feature = "internal")]
+    Static,
+    Running,
 }
 
 async fn build_compilation_result(
     source_code: String,
     path: PathBuf,
     config: i_slint_compiler::CompilerConfiguration,
-    static_preview: bool,
+    animation_mode: AnimationMode,
 ) -> CompilationResult {
     let result =
-        crate::component::build_from_source(source_code, path, config, static_preview).await;
+        crate::component::build_from_source(source_code, path, config, animation_mode).await;
     let components = result
         .components
         .into_iter()

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -837,7 +837,7 @@ impl ComponentCompiler {
             }
         };
 
-        let r = build_compilation_result(source, path.into(), self.config.clone()).await;
+        let r = build_compilation_result(source, path.into(), self.config.clone(), false).await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -863,7 +863,7 @@ impl ComponentCompiler {
         source_code: String,
         path: PathBuf,
     ) -> Option<ComponentDefinition> {
-        let r = build_compilation_result(source_code, path, self.config.clone()).await;
+        let r = build_compilation_result(source_code, path, self.config.clone(), false).await;
         self.diagnostics = r.diagnostics.into_iter().collect();
         r.components.into_values().next()
     }
@@ -1019,7 +1019,7 @@ impl Compiler {
             }
         };
 
-        build_compilation_result(source, path.into(), self.config.clone()).await
+        build_compilation_result(source, path.into(), self.config.clone(), false).await
     }
 
     /// Compile some .slint code
@@ -1035,7 +1035,18 @@ impl Compiler {
     /// If that is not used, then it is fine to use a very simple executor, such as the one
     /// provided by the `spin_on` crate
     pub async fn build_from_source(&self, source_code: String, path: PathBuf) -> CompilationResult {
-        build_compilation_result(source_code, path, self.config.clone()).await
+        build_compilation_result(source_code, path, self.config.clone(), false).await
+    }
+
+    /// Compile Slint code without timers or animations.
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub async fn build_static_from_source(
+        &self,
+        source_code: String,
+        path: PathBuf,
+    ) -> CompilationResult {
+        build_compilation_result(source_code, path, self.config.clone(), true).await
     }
 }
 
@@ -1043,8 +1054,10 @@ async fn build_compilation_result(
     source_code: String,
     path: PathBuf,
     config: i_slint_compiler::CompilerConfiguration,
+    static_preview: bool,
 ) -> CompilationResult {
-    let result = crate::component::build_from_source(source_code, path, config).await;
+    let result =
+        crate::component::build_from_source(source_code, path, config, static_preview).await;
     let components = result
         .components
         .into_iter()

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1069,7 +1069,7 @@ impl Compiler {
 pub(crate) enum AnimationMode {
     /// In static mode, all timers & animations are disabled.
     /// The item tree should not update anything without interaction.
-    #[cfg(feature = "internal")]
+    #[cfg_attr(not(feature = "internal"), allow(dead_code))]
     Static,
     Running,
 }

--- a/internal/interpreter/component.rs
+++ b/internal/interpreter/component.rs
@@ -9,8 +9,9 @@
 use crate::Value;
 use crate::instance::Instance;
 use crate::public_api;
+use i_slint_compiler::expression_tree::BuiltinFunction;
 use i_slint_compiler::langtype::Type as LangType;
-use i_slint_compiler::llr::{CompilationUnit, GlobalComponent};
+use i_slint_compiler::llr::{CompilationUnit, Expression, GlobalComponent};
 use i_slint_compiler::object_tree::PropertyVisibility;
 use i_slint_compiler::parser::normalize_identifier;
 use i_slint_core::item_tree::ItemTreeVTable;
@@ -319,11 +320,14 @@ pub fn build_from_document(
     document: &i_slint_compiler::object_tree::Document,
     compiler_config: &i_slint_compiler::CompilerConfiguration,
     mut type_loaders: TypeLoaders,
+    static_preview: bool,
 ) -> Vec<ComponentDefinitionInner> {
-    let unit = Rc::new(i_slint_compiler::llr::lower_to_item_tree::lower_to_item_tree(
-        document,
-        compiler_config,
-    ));
+    let mut unit =
+        i_slint_compiler::llr::lower_to_item_tree::lower_to_item_tree(document, compiler_config);
+    if static_preview {
+        make_static(&mut unit);
+    }
+    let unit = Rc::new(unit);
     // `lower_to_item_tree` builds `public_components` from `exported_roots()`
     // in iteration order, so the indices line up.
     type_loaders.originals = document.exported_roots().collect();
@@ -334,6 +338,40 @@ pub fn build_from_document(
             type_loaders: type_loaders.clone(),
         })
         .collect()
+}
+
+fn make_static(compilation_unit: &mut CompilationUnit) {
+    fn make_expression_static(expression: &mut Expression) {
+        let replacement = match expression {
+            Expression::BuiltinFunctionCall { function, .. } => match function {
+                BuiltinFunction::AnimationTick => Some(Expression::NumberLiteral(0.)),
+                BuiltinFunction::RestartTimer | BuiltinFunction::UpdateTimers => {
+                    Some(Expression::CodeBlock(Vec::new()))
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            *expression = replacement;
+        }
+    }
+
+    compilation_unit.for_each_expression(&mut |expression, _| {
+        expression.borrow_mut().visit_recursive_mut(&mut make_expression_static);
+    });
+    for sub_component in &compilation_unit.sub_components {
+        for popup in &sub_component.popup_windows {
+            popup.position.borrow_mut().visit_recursive_mut(&mut make_expression_static);
+        }
+    }
+    for sub_component in &mut compilation_unit.sub_components {
+        sub_component.timers.clear();
+        sub_component.animations.clear();
+        for (_, binding) in &mut sub_component.property_init {
+            binding.animation = None;
+        }
+    }
 }
 
 /// What [`build_from_source`] produces: the diagnostics, a map of public
@@ -354,6 +392,7 @@ pub async fn build_from_source(
     source_code: String,
     path: std::path::PathBuf,
     mut config: i_slint_compiler::CompilerConfiguration,
+    static_preview: bool,
 ) -> BuildResult {
     // If the native style should be used, resolve it here as we know the backend.
     if config.style.as_deref() == Some("native") {
@@ -438,7 +477,7 @@ pub async fn build_from_source(
         }
     };
     let mut components = std::collections::HashMap::new();
-    for def in build_from_document(doc, &config, type_loaders) {
+    for def in build_from_document(doc, &config, type_loaders, static_preview) {
         components.insert(def.name().to_string(), def);
     }
     if components.is_empty() {

--- a/internal/interpreter/component.rs
+++ b/internal/interpreter/component.rs
@@ -6,9 +6,9 @@
 //! The public API wraps these thin structs so downstream callers never
 //! see the compilation-unit surface directly.
 
-use crate::Value;
 use crate::instance::Instance;
 use crate::public_api;
+use crate::{AnimationMode, Value};
 use i_slint_compiler::expression_tree::BuiltinFunction;
 use i_slint_compiler::langtype::Type as LangType;
 use i_slint_compiler::llr::{CompilationUnit, Expression, GlobalComponent};
@@ -320,11 +320,11 @@ pub fn build_from_document(
     document: &i_slint_compiler::object_tree::Document,
     compiler_config: &i_slint_compiler::CompilerConfiguration,
     mut type_loaders: TypeLoaders,
-    static_preview: bool,
+    animation_mode: AnimationMode,
 ) -> Vec<ComponentDefinitionInner> {
     let mut unit =
         i_slint_compiler::llr::lower_to_item_tree::lower_to_item_tree(document, compiler_config);
-    if static_preview {
+    if matches!(animation_mode, AnimationMode::Static) {
         make_static(&mut unit);
     }
     let unit = Rc::new(unit);
@@ -392,7 +392,7 @@ pub async fn build_from_source(
     source_code: String,
     path: std::path::PathBuf,
     mut config: i_slint_compiler::CompilerConfiguration,
-    static_preview: bool,
+    animation_mode: AnimationMode,
 ) -> BuildResult {
     // If the native style should be used, resolve it here as we know the backend.
     if config.style.as_deref() == Some("native") {
@@ -477,7 +477,7 @@ pub async fn build_from_source(
         }
     };
     let mut components = std::collections::HashMap::new();
-    for def in build_from_document(doc, &config, type_loaders, static_preview) {
+    for def in build_from_document(doc, &config, type_loaders, animation_mode) {
         components.insert(def.name().to_string(), def);
     }
     if components.is_empty() {

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -133,6 +133,105 @@ fn llr_compile(code: &str, name: &str) -> crate::component::ComponentInstanceInn
     result.components.get(name).expect("component should compile").create()
 }
 
+#[cfg(feature = "internal")]
+fn compile_motion_test(code: &str, static_preview: bool) -> crate::ComponentInstance {
+    let compiler = crate::Compiler::default();
+    let result = if static_preview {
+        spin_on::spin_on(
+            compiler.build_static_from_source(code.into(), std::path::PathBuf::from("test.slint")),
+        )
+    } else {
+        spin_on::spin_on(
+            compiler.build_from_source(code.into(), std::path::PathBuf::from("test.slint")),
+        )
+    };
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    result.component("MotionTest").unwrap().create().unwrap()
+}
+
+#[cfg(feature = "internal")]
+#[test]
+fn static_preview_stops_runtime_motion() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::Value;
+
+    let code = r#"
+        export component MotionTest {
+            out property <int> timer-count: 0;
+            out property <int> tick: animation-tick() / 1ms;
+            out property <bool> initialized: false;
+            in-out property <int> animated-value: 0;
+            in-out property <int> active-index: 0;
+            in-out property <int> transitioned-value: 5;
+
+            animate animated-value { duration: 1s; }
+
+            timer := Timer {
+                interval: 100ms;
+                running: true;
+                triggered => { root.timer-count += 1; }
+            }
+
+            states [
+                active when root.active-index == 1: {
+                    transitioned-value: 200;
+                    in {
+                        animate transitioned-value { duration: 1s; }
+                    }
+                }
+            ]
+
+            init => {
+                root.initialized = true;
+                root.animated-value = 100;
+                timer.restart();
+            }
+
+            public function update() {
+                root.animated-value = 200;
+                root.active-index = 1;
+                timer.stop();
+                timer.start();
+                timer.restart();
+            }
+        }
+    "#;
+
+    let static_instance = compile_motion_test(code, true);
+    assert_eq!(static_instance.get_property("initialized"), Ok(Value::Bool(true)));
+    assert_eq!(static_instance.get_property("animated-value"), Ok(Value::Number(100.)));
+    static_instance.invoke("update", &[]).unwrap();
+    for (property_name, expected_value) in
+        [("timer-count", 0.), ("tick", 0.), ("animated-value", 200.), ("transitioned-value", 200.)]
+    {
+        assert_eq!(static_instance.get_property(property_name), Ok(Value::Number(expected_value)));
+    }
+    i_slint_backend_testing::mock_elapsed_time(500);
+    assert_eq!(static_instance.get_property("timer-count"), Ok(Value::Number(0.)));
+    assert_eq!(static_instance.get_property("tick"), Ok(Value::Number(0.)));
+
+    let dynamic_instance = compile_motion_test(code, false);
+    let initial_tick = dynamic_instance.get_property("tick").unwrap();
+    assert_eq!(dynamic_instance.get_property("transitioned-value"), Ok(Value::Number(5.)));
+    dynamic_instance.invoke("update", &[]).unwrap();
+    assert_eq!(dynamic_instance.get_property("transitioned-value"), Ok(Value::Number(5.)));
+    i_slint_backend_testing::mock_elapsed_time(500);
+    let Value::Number(initial_tick) = initial_tick else { unreachable!() };
+    let Ok(Value::Number(dynamic_tick)) = dynamic_instance.get_property("tick") else {
+        unreachable!()
+    };
+    let Ok(Value::Number(timer_count)) = dynamic_instance.get_property("timer-count") else {
+        unreachable!()
+    };
+    let Ok(Value::Number(transitioned_value)) = dynamic_instance.get_property("transitioned-value")
+    else {
+        unreachable!()
+    };
+    assert!(dynamic_tick > initial_tick);
+    assert!(timer_count > 0.);
+    assert!(transitioned_value > 5. && transitioned_value < 200.);
+}
+
 /// Nested sub-component composition.
 #[test]
 fn interpreter_sub_component() {

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -120,6 +120,7 @@ fn llr_compile(code: &str, name: &str) -> crate::component::ComponentInstanceInn
         code.into(),
         Default::default(),
         config,
+        false,
     ));
     assert!(
         result
@@ -388,6 +389,7 @@ fn interpreter_path_elements() {
         code.into(),
         Default::default(),
         config,
+        false,
     ));
     assert!(
         result

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -137,9 +137,13 @@ fn llr_compile(code: &str, name: &str) -> crate::component::ComponentInstanceInn
 fn compile_motion_test(code: &str, static_preview: bool) -> crate::ComponentInstance {
     let compiler = crate::Compiler::default();
     let result = if static_preview {
-        spin_on::spin_on(
-            compiler.build_static_from_source(code.into(), std::path::PathBuf::from("test.slint")),
-        )
+        use i_slint_core::InternalToken;
+
+        spin_on::spin_on(compiler.build_static_from_source(
+            code.into(),
+            std::path::PathBuf::from("test.slint"),
+            InternalToken,
+        ))
     } else {
         spin_on::spin_on(
             compiler.build_from_source(code.into(), std::path::PathBuf::from("test.slint")),

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -120,7 +120,7 @@ fn llr_compile(code: &str, name: &str) -> crate::component::ComponentInstanceInn
         code.into(),
         Default::default(),
         config,
-        false,
+        crate::AnimationMode::Running,
     ));
     assert!(
         result
@@ -492,7 +492,7 @@ fn interpreter_path_elements() {
         code.into(),
         Default::default(),
         config,
-        false,
+        crate::AnimationMode::Running,
     ));
     assert!(
         result

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -2085,7 +2085,8 @@ async fn parse_source(
             )]),
         );
 
-    let result = builder.build_static_from_source(source_code, path).await;
+    let result =
+        builder.build_static_from_source(source_code, path, i_slint_core::InternalToken).await;
 
     let compiled = result.components().next();
     (result.diagnostics().collect(), compiled, open_file_fallback, source_file_versions)

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -2085,7 +2085,7 @@ async fn parse_source(
             )]),
         );
 
-    let result = builder.build_from_source(source_code, path).await;
+    let result = builder.build_static_from_source(source_code, path).await;
 
     let compiled = result.components().next();
     (result.diagnostics().collect(), compiled, open_file_fallback, source_file_versions)


### PR DESCRIPTION
This makes the content of the visual editor static by removing all animations, timers and setting the animation tick to zero.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
