### PR TITLE
ci: lint scripts/ with ruff and ty

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -139,6 +139,17 @@ depends = ["prepare:pnpm-install"]
 
 ### Lints
 
+["lint:python"]
+description = "Run Ruff and ty on the standalone scripts"
+# scripts/ has no uv project of its own, so borrow the ruff and ty pinned in
+# api/python/slint's dev group, the versions the Python packages are linted with.
+# The packages themselves are checked from their own directories in the python
+# workflow, which ruff needs to resolve their first-party imports.
+run = """
+uv run --project api/python/slint --only-group dev ruff check scripts
+uv run --project api/python/slint --only-group dev ty check scripts
+"""
+
 ["lint:spell"]
 description = "Run cspell"
 run = "pnpm spellcheck"
@@ -213,4 +224,4 @@ depends = [
 
 ["ci:autofix:lint"]
 description = "CI autofix job -- lint steps"
-depends = ["lint:legal:reuse", "lint:rust:profiles", "lint:ts:typecheck", "lint:ts:knip"]
+depends = ["lint:legal:reuse", "lint:python", "lint:rust:profiles", "lint:ts:typecheck", "lint:ts:knip"]

--- a/scripts/flatpak-skia-generator.py
+++ b/scripts/flatpak-skia-generator.py
@@ -34,7 +34,7 @@ raw = f"https://raw.githubusercontent.com/rust-skia/skia/{tag}"
 
 # Skia's DEPS is Python, listing every checkout its own build expects
 ns = {"Var": lambda name: ns["vars"][name]}
-exec(fetch(f"{raw}/DEPS"), ns)
+exec(fetch(f"{raw}/DEPS"), ns)  # noqa: S102 -- evaluating DEPS is the point
 
 fork = "https://github.com/rust-skia/skia.git"
 sources = [{"type": "git", "url": fork, "tag": tag, "dest": dest}]


### PR DESCRIPTION
The Python packages are checked from their own directories in the python workflow, but that only runs when api/python/, internal/ or tests/ change, so the standalone scripts in scripts/ were never linted at all. Add a lint:python task to the autofix lint job, which runs on every pull request. It borrows the ruff and ty pinned in api/python/slint's dev group, so the versions stay in step.

Checking from the repository root would not work for the packages themselves: ruff needs to run from their own directories to resolve their first-party imports. Formatting is already covered everywhere, since fix:python:format runs ruff format from the root.

flatpak-skia-generator.py evaluates Skia's DEPS, which is a Python file, so silence the S102 that surfaces.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
