### PR TITLE
Fix "Recursion detected" for a self-constrained runtime-direction flexbox

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -2088,6 +2088,104 @@ pub fn get_flex_cell_layout_info(
     get_layout_info(elem, ctx, &effective, orientation, constraint)
 }
 
+/// Whether an assignment can replace this property's binding, which makes it
+/// unsafe to answer a read of it with the binding's value. Same test as
+/// `inline_expressions`, on the same merged analysis: a public `in`/`in-out`
+/// property counts, since the application can set it through the API.
+fn is_assigned(nr: &NamedReference) -> bool {
+    let a = super::lower_to_item_tree::get_property_analysis(&nr.element(), nr.name());
+    a.is_set || a.is_set_externally
+}
+
+/// How many alias bindings [`layout_info_field_read`] follows. A bound on the
+/// walk, not a semantic limit: binding loops are rejected earlier, and the
+/// shapes that matter are one or two hops.
+const MAX_ALIAS_HOPS: usize = 4;
+
+/// The field of `layout_info_nr` — the element's own unconstrained layout info
+/// — that `expr` reads, directly or through alias bindings: `min-height:
+/// self.preferred-height` reaches it via the implicit `preferred-height`.
+fn layout_info_field_read(
+    expr: &crate::expression_tree::Expression,
+    layout_info_nr: &NamedReference,
+    depth: usize,
+) -> Option<SmolStr> {
+    use crate::expression_tree::Expression as E;
+    match expr.ignore_debug_hooks() {
+        E::StructFieldAccess { base, name } => match base.ignore_debug_hooks() {
+            E::PropertyReference(nr) if nr == layout_info_nr => Some(name.clone()),
+            _ => None,
+        },
+        E::PropertyReference(nr) if depth > 0 && !is_assigned(nr) => {
+            let alias = nr.element();
+            let alias = alias.borrow();
+            let binding = alias.binding(nr.name())?;
+            if binding.animation.is_some() || !binding.two_way_bindings.is_empty() {
+                return None;
+            }
+            layout_info_field_read(&binding.expression, layout_info_nr, depth - 1)
+        }
+        _ => None,
+    }
+}
+
+/// An explicit restriction that reads the element's own implicit size
+/// (`min-height: self.preferred-height`) reaches the unconstrained
+/// `layoutinfo-{h,v}`, which reads back the perpendicular dimension the caller
+/// is still solving. Once the layout info above went through the parametrized
+/// function, those reads have an answer already: the `layout_info` local. Only
+/// for an element declaring the function itself — a cell that inherits it from
+/// its base component keeps the plain read, as does a restriction with no such
+/// read, which also keeps its caching.
+fn restriction_from_constrained_info(
+    elem: &ElementRc,
+    nr: &NamedReference,
+    orientation: Orientation,
+    constrained: bool,
+    ctx: &mut ExpressionLoweringCtx,
+) -> Option<llr_Expression> {
+    // Only the constrained path stores a `layout_info` local worth reading.
+    if !constrained {
+        return None;
+    }
+    // This answers the read with the binding's value, so an assignment that
+    // replaces the binding at runtime must not be possible.
+    if is_assigned(nr) {
+        return None;
+    }
+    let layout_info_nr = elem.borrow().layout_info_prop(orientation)?.clone();
+
+    let mut expr = {
+        let binding_elem = nr.element();
+        let binding_elem = binding_elem.borrow();
+        let binding = binding_elem.binding(nr.name())?;
+        // Inlining the binding here drops its animation and any two-way alias.
+        if binding.animation.is_some() || !binding.two_way_bindings.is_empty() {
+            return None;
+        }
+        binding.expression.ignore_debug_hooks().clone()
+    };
+
+    let ty = crate::typeregister::layout_info_type();
+    let mut rewritten = false;
+    expr.visit_recursive_mut(&mut |sub| {
+        let Some(field) = layout_info_field_read(sub, &layout_info_nr, MAX_ALIAS_HOPS) else {
+            return;
+        };
+        *sub = crate::expression_tree::Expression::StructFieldAccess {
+            base: crate::expression_tree::Expression::ReadLocalVariable {
+                name: "layout_info".into(),
+                ty: ty.clone().into(),
+            }
+            .into(),
+            name: field,
+        };
+        rewritten = true;
+    });
+
+    rewritten.then(|| super::lower_expression::lower_expression(&expr, ctx))
+}
+
 pub fn get_layout_info(
     elem: &ElementRc,
     ctx: &mut ExpressionLoweringCtx,
@@ -2095,6 +2193,9 @@ pub fn get_layout_info(
     orientation: Orientation,
     constraint: Option<crate::expression_tree::Expression>,
 ) -> llr_Expression {
+    // Whether the layout info below went through the parametrized function,
+    // so `layout_info` holds the element's constrained info.
+    let mut constrained = false;
     // With a constraint and a parameterized layout-info function on the
     // child, call that function instead of reading the plain
     // `layoutinfo-{h,v}` property — breaks the recursion via the child's
@@ -2104,6 +2205,7 @@ pub fn get_layout_info(
             Orientation::Vertical => elem.borrow().layout_info_v_with_constraint.clone(),
             Orientation::Horizontal => elem.borrow().layout_info_h_with_constraint.clone(),
         }) {
+        constrained = true;
         let call = crate::expression_tree::Expression::FunctionCall {
             function: crate::expression_tree::Callable::Function(parameterized_nr),
             arguments: vec![c.clone()],
@@ -2150,10 +2252,11 @@ pub fn get_layout_info(
             .collect::<BTreeMap<_, _>>();
 
         for (nr, s) in constraints.for_each_restrictions(orientation) {
-            values.insert(
-                s.into(),
-                llr_Expression::PropertyReference(ctx.map_property_reference(nr)),
-            );
+            let value = restriction_from_constrained_info(elem, nr, orientation, constrained, ctx)
+                .unwrap_or_else(|| {
+                    llr_Expression::PropertyReference(ctx.map_property_reference(nr))
+                });
+            values.insert(s.into(), value);
         }
         llr_Expression::CodeBlock([store, llr_Expression::Struct { ty, values }].into())
     } else {

--- a/internal/compiler/llr/lower_to_item_tree.rs
+++ b/internal/compiler/llr/lower_to_item_tree.rs
@@ -1025,7 +1025,13 @@ fn lower_geometry(
     super::Expression::Struct { ty: Arc::new(Struct::new(fields, StructName::None)), values }
 }
 
-fn get_property_analysis(elem: &ElementRc, p: &str) -> crate::object_tree::PropertyAnalysis {
+/// The analysis of `p` on `elem`, merged with the base chain and its aliases,
+/// like `inline_expressions` uses to decide whether a binding may stand in for
+/// a property read.
+pub(super) fn get_property_analysis(
+    elem: &ElementRc,
+    p: &str,
+) -> crate::object_tree::PropertyAnalysis {
     let mut a = elem.borrow().property_analysis.borrow().get(p).cloned().unwrap_or_default();
     let mut elem = elem.clone();
     loop {

--- a/tests/cases/layout/flexbox_runtime_direction_self_min_height.slint
+++ b/tests/cases/layout/flexbox_runtime_direction_self_min_height.slint
@@ -1,0 +1,64 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A FlexboxLayout whose direction is only known at runtime constrains itself
+// with its own preferred height. The direction is unknown at compile time, so
+// the flex reports both height-for-width and width-for-height to its parents:
+// the HorizontalLayout then asks the VerticalLayout for its width at a known
+// height, and that has to reach the flex's height info without reading back the
+// width the HorizontalLayout is still solving. slint-ui/slint#13059.
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 200px;
+
+    in property <bool> horizontal: true;
+
+    HorizontalLayout {
+        Rectangle { width: 40px; }
+        VerticalLayout {
+            alignment: start;
+            // Required: without a repeated/conditional sibling the VerticalLayout
+            // takes a different measurement path and the bug does not reproduce.
+            if false: Rectangle { }
+            fl := FlexboxLayout {
+                min-height: fl.preferred-height;
+                flex-direction: horizontal ? FlexboxLayoutDirection.row : FlexboxLayoutDirection.column;
+                flex-wrap: wrap;
+
+                r1 := Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+                r2 := Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+                r3 := Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+            }
+        }
+    }
+
+    // The 40px sidebar leaves 160px, so two 60px items fit per line and the
+    // three items wrap onto two lines of 20px.
+    out property <bool> test_width: fl.width == 160px;
+    out property <bool> test_preferred: fl.preferred-height == 40px;
+    // min-height picks up those two lines, and `alignment: start` gives the
+    // flex exactly that height instead of stretching it.
+    out property <bool> test_height: fl.height == 40px;
+    out property <bool> test_line1: r1.x == 0px && r1.y == 0px && r2.x == 60px && r2.y == 0px;
+    out property <bool> test_line2: r3.x == 0px && r3.y == 20px;
+
+    out property <bool> test: test_width && test_preferred && test_height && test_line1 && test_line2;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/

--- a/tests/cases/layout/flexbox_runtime_direction_self_min_height_indirect.slint
+++ b/tests/cases/layout/flexbox_runtime_direction_self_min_height_indirect.slint
@@ -1,0 +1,63 @@
+// Copyright © Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com, author David Faure <david.faure@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Same cycle as flexbox_runtime_direction_self_min_height, with the flexbox's
+// self-reference routed through a property instead of naming the implicit size
+// directly: the restriction reaches its own layout info one alias hop further
+// away. `out` matters — through an `in`/`in-out` property the binding can be
+// replaced from the API, so the restriction keeps its plain read and the cycle
+// remains. slint-ui/slint#13059.
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 200px;
+
+    in property <bool> horizontal: true;
+    out property <length> exposed-h: fl.preferred-height;
+
+    HorizontalLayout {
+        Rectangle { width: 40px; }
+        VerticalLayout {
+            alignment: start;
+            // Required: without a repeated/conditional sibling the VerticalLayout
+            // takes a different measurement path and the bug does not reproduce.
+            if false: Rectangle { }
+            fl := FlexboxLayout {
+                min-height: root.exposed-h;
+                flex-direction: horizontal ? FlexboxLayoutDirection.row : FlexboxLayoutDirection.column;
+                flex-wrap: wrap;
+
+                r1 := Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+                r2 := Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+                r3 := Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+            }
+        }
+    }
+
+    // The 40px sidebar leaves 160px, so two 60px items fit per line and the
+    // three items wrap onto two lines of 20px.
+    out property <bool> test_width: fl.width == 160px;
+    out property <bool> test_preferred: exposed-h == 40px;
+    out property <bool> test_height: fl.height == 40px;
+    out property <bool> test_line1: r1.x == 0px && r1.y == 0px && r2.x == 60px && r2.y == 0px;
+    out property <bool> test_line2: r3.x == 0px && r3.y == 20px;
+
+    out property <bool> test: test_width && test_preferred && test_height && test_line1 && test_line2;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
A FlexboxLayout whose flex-direction is not known at compile time reports both
height-for-width and width-for-height, so an enclosing layout computes its info
through layoutinfo-*-with-constraint. An explicit restriction that reads the
element's own implicit size, e.g. `min-height: self.preferred-height`, was
still a plain property read there: it reaches the unconstrained layoutinfo-v
and its read of self.width, the dimension the caller is still solving.

Answer those reads from the constrained info the layout already computed. The
restriction's whole expression is walked and alias bindings are followed, so a
read nested in an expression or behind an intermediate property is covered too.

This answers a read with the binding's value, so it is only done when nothing
can replace that binding: a restriction that is assigned, or routed through a
public in/in-out property, keeps its plain property read and so keeps
panicking, as it did before. Same test as inline_expressions, on the same
merged analysis.

Fixes #13059