### PR TITLE
Update the changelog for 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,8 @@ All notable changes to this project are documented in this file.
 ### General
 
  - The FemtoVG WGPU renderer now uses WGPU 30 and works on WebAssembly, using WebGPU with a WebGL fallback.
- - Skia: The Direct3D, Metal, and Vulkan surfaces are now provided through WGPU: Direct3D 12 is the default
-   on Windows, Vulkan on Linux, and Metal on macOS, and graphics resources are shared between windows.
-   OpenGL remains available as a fallback.
- - Added an experimental renderer based on Vello, rendering on WGPU (`renderer-vello` Cargo feature and
-   CMake option). It is never selected automatically; choose it with `SLINT_BACKEND=winit-vello` or
+ - Added an experimental renderer based on Vello (`renderer-vello` Cargo feature and
+   CMake option). Select it via the BackendSelector API, via `SLINT_BACKEND=winit-vello`, or
    `SLINT_BACKEND=linuxkms-vello`.
  - WebAssembly: Images are now decoded by the browser instead of bundled Rust decoders, significantly reducing
    the size of wasm binaries. All image formats supported by the browser now work. (Compressed `.svgz` is no
@@ -22,8 +19,6 @@ All notable changes to this project are documented in this file.
  - Qt: Added native drag-and-drop: data from a `DragArea` can be dropped onto other applications.
  - Improved text layout and rendering performance, especially for long texts.
  - The generated code and bundled translations are now deterministic, for reproducible builds. (#12932)
- - The generated code now exports only the types that are reachable from the public API. Types used
-   only privately, and the old name of a renamed export (`export { X as Y }`), remain as deprecated aliases.
  - Accessibility: Exposed the content of text inputs to assistive technologies, including the text selection,
    and let assistive technologies change the selection.
  - Accessibility: Fixed a panic when the accessibility tree is rebuilt for a window without a component. (#12917)
@@ -180,8 +175,10 @@ All notable changes to this project are documented in this file.
  - Added `Image::load_from_data()` to decode an encoded image (PNG, JPEG, SVG, ...) from a memory buffer. (#2624)
  - Added `Rgb565BigEndianPixel` to `slint::platform::software_renderer` for big-endian SPI displays. (#10882)
  - Added `remove` and `insert` functions to `SharedVector`.
- - Added `Keys::from_parts()` and `Keys::to_parts()` to convert keyboard shortcuts to and from a list
-   of strings, e.g. to persist user-configured key bindings. (#12212)
+ - Added `Keys::to_parts()` to convert a keyboard shortcut into the list of strings that
+   `Keys::from_parts()` accepts, e.g. to persist user-configured key bindings. (#12212)
+ - The generated code now re-exports only the types that are reachable from the public API. Types used
+   only privately, and the old name of a renamed export (`export { X as Y }`), remain as deprecated aliases.
  - Deprecated `slint::platform::skia_renderer::SkiaWGPURenderer`; use `SkiaWGPU29Renderer` or
    `SkiaWGPU30Renderer` instead.
  - `DataTransfer` can now carry a list of file paths in addition to text and an image. (#1967)
@@ -200,8 +197,11 @@ All notable changes to this project are documented in this file.
 
  - Added `Image::load_from_data()` to decode an encoded image (PNG, JPEG, SVG, ...) from a memory buffer. (#2624)
  - `DataTransfer` can now carry a list of file paths in addition to text and an image. (#1967)
- - Added `Keys::from_parts()` and `Keys::to_parts()` to convert keyboard shortcuts to and from a list
-   of strings, e.g. to persist user-configured key bindings. (#12212)
+ - Added `Keys::to_parts()` to convert a keyboard shortcut into the list of strings that
+   `Keys::from_parts()` accepts, e.g. to persist user-configured key bindings. (#12212)
+ - `Keys::from_parts()` now accepts any range of strings, not only a `std::span`.
+ - In the generated code, the old name of a renamed export (`export { X as Y }`) is now a deprecated
+   alias; previously both names were exported as equals.
  - Fixed models marking bindings dirty when a model row was read outside of a binding evaluation. (#12806)
  - Reduced the size of the generated code.
  - `CMAKE_INSTALL_LIBDIR` is now honored when installing the library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,24 @@ All notable changes to this project are documented in this file.
 
 ### General
 
- - Upgraded WGPU dependency to version 30: Added the `unstable-wgpu-30` Cargo feature with the `slint::wgpu_30` module,
-   `GraphicsAPI::WGPU30`, `BackendSelector::require_wgpu_30()`, and `Image::to_wgpu_30_texture()`.
-   The `unstable-wgpu-28` feature was removed. `unstable-wgpu-29` remains available for Skia-based rendering.
  - The FemtoVG WGPU renderer now uses WGPU 30 and works on WebAssembly, using WebGPU with a WebGL fallback.
+ - Skia: The Direct3D, Metal, and Vulkan surfaces are now provided through WGPU: Direct3D 12 is the default
+   on Windows, Vulkan on Linux, and Metal on macOS, and graphics resources are shared between windows.
+   OpenGL remains available as a fallback.
+ - Added an experimental renderer based on Vello, rendering on WGPU (`renderer-vello` Cargo feature and
+   CMake option). It is never selected automatically; choose it with `SLINT_BACKEND=winit-vello` or
+   `SLINT_BACKEND=linuxkms-vello`.
  - WebAssembly: Images are now decoded by the browser instead of bundled Rust decoders, significantly reducing
    the size of wasm binaries. All image formats supported by the browser now work. (Compressed `.svgz` is no
    longer supported on the web.)
+ - WebAssembly: Reduced the binary size by leaving out the line-breaking dictionaries for scripts
+   without word separators and by subsetting the embedded fallback font.
+ - WebAssembly: The generated JavaScript glue no longer requires `'unsafe-eval'` in the Content-Security-Policy.
  - Qt: Added native drag-and-drop: data from a `DragArea` can be dropped onto other applications.
  - Improved text layout and rendering performance, especially for long texts.
  - The generated code and bundled translations are now deterministic, for reproducible builds. (#12932)
+ - The generated code now exports only the types that are reachable from the public API. Types used
+   only privately, and the old name of a renamed export (`export { X as Y }`), remain as deprecated aliases.
  - Accessibility: Exposed the content of text inputs to assistive technologies, including the text selection,
    and let assistive technologies change the selection.
  - Accessibility: Fixed a panic when the accessibility tree is rebuilt for a window without a component. (#12917)
@@ -24,8 +32,14 @@ All notable changes to this project are documented in this file.
  - Fixed animations restarting when a binding's dependencies change without changing the target value. (#12683)
  - Fixed small jumps in long animations using cubic-bezier easing curves. (#12813)
  - Fixed the focus not being cleared when the focused item becomes invisible. (#11079)
+ - `Flickable`: A press is now immediately forwarded to the elements underneath when there is nothing
+   to pan. (#13117)
  - Fixed box shadows being re-rendered on every frame in the FemtoVG and Skia renderers. (#12545)
  - Fixed unbounded memory growth when loading many different SVG images. (#12379)
+ - Fixed a panic when registering a custom font before the first component is created.
+ - Fixed moving the focus being slow in a window with a very large number of elements. (#13043)
+ - Fixed checking the visibility of deeply nested elements taking exponential time. (#13049)
+ - Improved the performance of `SortModel` when many rows are removed at once.
  - SVG: Text with an unknown font family now falls back to the generic font families instead of being invisible.
  - Fixed rendering of gradients with unsorted or out-of-range color stops to be consistent across renderers.
  - Fixed an out-of-memory abort when a repeater's count evaluates to a huge value, e.g. after a division by zero. (#12400)
@@ -60,6 +74,9 @@ All notable changes to this project are documented in this file.
  - Skia: Fixed changes to `Window.background` not triggering a repaint with partial rendering.
  - Software renderer: Improved performance by skipping what is covered by opaque elements. (#12366)
  - Software renderer: Fixed uneven gaps between glyphs. (#12356)
+ - Software renderer: Fixed a panic with very long lines of text. (#12994)
+ - Software renderer: Fixed a click into text mapping to the wrong character on lines that mix
+   multiple scripts.
  - wasm: Fixed keyboard modifiers being reset when the focus moves between elements. (#7347, #8606)
  - wasm: The system accent color is now picked up.
 
@@ -77,8 +94,11 @@ All notable changes to this project are documented in this file.
    additions in every language binding. (#9457)
  - Added the `string.starts-with()` and `string.ends-with()` functions. (#9877)
  - Added the `string.replace-all(from, to)` function. (#12782)
+ - Added the `spring` easing curve: a physics-based animation that keeps its velocity when the target
+   changes; `spring(bounce)` controls the bounciness. (#609)
+ - Added the `window-title-bar` accessible role, for custom title bars in frameless windows.
  - Added the `WindowMoveArea` element to start an interactive window move, like a native title bar. (#613)
- - Added `angle-at` and `position-at` functions to the `Path` element to support animating objects along a path.
+ - Added `point-at` and `angle-at` functions to the `Path` element to support animating objects along a path.
  - Added the `input-method-hints` property to `TextInput` and `LineEdit` to hint the platform's input method
    about auto-capitalization, auto-correction, and auto-completion. (#9016)
  - Added the `max-lines` property to `Text` and `StyledText` to limit the number of rendered lines.
@@ -132,6 +152,9 @@ All notable changes to this project are documented in this file.
  - The "Unknown unqualified identifier" error now suggests the qualified form for named colors and
    enum values, e.g. `red` -> `Colors.red`. (#4397)
  - Fixed a compiler panic when instantiating a component that inherits from `ContextMenuArea`. (#12833)
+ - Fixed a panic when a user-defined component named `Row` is placed in a `GridLayout`.
+ - Fixed two structs or enums with the same name declared in different files being merged into one
+   in the generated code. (#6880)
  - Fixed conditional (ternary) expressions with arrays of structs and structs with array members. (#12845)
  - Fixed referencing a private property of the base component in a state's property value. (#1461)
  - Interpreter: Compound assignments (e.g. `x += v`) now run the property's animation.
@@ -146,16 +169,25 @@ All notable changes to this project are documented in this file.
 
 ### Rust
 
+ - Added the `unstable-wgpu-30` Cargo feature with the `slint::wgpu_30` module, `GraphicsAPI::WGPU30`,
+   `BackendSelector::require_wgpu_30()`, and `Image::to_wgpu_30_texture()`. The `unstable-wgpu-28`
+   feature was removed. `unstable-wgpu-29` remains available for Skia-based rendering.
+ - The `unstable-fontique-010` Cargo feature is renamed to `unstable-fontique-011`, and the
+   `slint::fontique_010` module to `slint::fontique_011`, following the upgrade to fontique 0.11.
  - Added `slint::update_all_translations()`.
  - Added `Window::dispatch_event_with_result()` returning the new `WindowEventDispatchResult` enum,
    and deprecated `Window::try_dispatch_event()`.
  - Added `Image::load_from_data()` to decode an encoded image (PNG, JPEG, SVG, ...) from a memory buffer. (#2624)
  - Added `Rgb565BigEndianPixel` to `slint::platform::software_renderer` for big-endian SPI displays. (#10882)
  - Added `remove` and `insert` functions to `SharedVector`.
+ - Added `Keys::from_parts()` and `Keys::to_parts()` to convert keyboard shortcuts to and from a list
+   of strings, e.g. to persist user-configured key bindings. (#12212)
+ - Deprecated `slint::platform::skia_renderer::SkiaWGPURenderer`; use `SkiaWGPU29Renderer` or
+   `SkiaWGPU30Renderer` instead.
  - `DataTransfer` can now carry a list of file paths in addition to text and an image. (#1967)
- - slint-build: Software-renderer resource embedding and extra image codecs are now optional default-on
-   Cargo features (`renderer-software`, `image-default-formats`), so they can be disabled to reduce
-   build dependencies. (#11554)
+ - slint-build: Software-renderer resource embedding is now an optional default-on Cargo feature
+   (`renderer-software`), so it can be disabled to reduce build dependencies. The image formats beyond
+   PNG and JPEG are behind the opt-in `image-default-formats` feature. (#11554)
  - Reduced the size, compile time, and memory usage of the generated code. (#12853)
  - The `SkiaWGPU29Renderer` and `SkiaWGPU30Renderer` now support rendering to sRGB render targets. (#12458)
  - The `renderer-skia-vulkan` feature now also works on macOS, running on top of MoltenVK.
@@ -168,6 +200,9 @@ All notable changes to this project are documented in this file.
 
  - Added `Image::load_from_data()` to decode an encoded image (PNG, JPEG, SVG, ...) from a memory buffer. (#2624)
  - `DataTransfer` can now carry a list of file paths in addition to text and an image. (#1967)
+ - Added `Keys::from_parts()` and `Keys::to_parts()` to convert keyboard shortcuts to and from a list
+   of strings, e.g. to persist user-configured key bindings. (#12212)
+ - Fixed models marking bindings dirty when a model row was read outside of a binding evaluation. (#12806)
  - Reduced the size of the generated code.
  - `CMAKE_INSTALL_LIBDIR` is now honored when installing the library.
  - Fixed an abort when `slint::invoke_from_event_loop` is called before any other Slint API initialized
@@ -187,9 +222,10 @@ All notable changes to this project are documented in this file.
 ### Python
 
  - Fixed the garbage collector releasing model wrappers that Slint still owns.
-
  - Ctrl-C (SIGINT) now interrupts a running event loop and raises `KeyboardInterrupt`.
  - Fixed memory leaks in the asyncio integration. (#12679)
+ - Fixed a spurious traceback at interpreter shutdown after the event loop was run.
+ - Fixed the type stub of `Color.mix` declaring the wrong argument type.
  - Fixed high CPU usage while an asyncio socket receives data. (#12962)
  - Enum-typed fields of builtin structs are now annotated with their enum class in the type stubs.
  - Published musl wheels, so `pip install slint` works on Alpine Linux. (#12551)
@@ -200,6 +236,8 @@ All notable changes to this project are documented in this file.
  - live-preview: Fixed the size and position of the Edit Values window, and made it resizable. (#12463)
  - live-preview: The remote preview now validates incoming messages and only serves files that belong
    to the previewed project.
+ - live-preview: Connecting a remote preview now requires pairing with a code shown in the viewer,
+   and the connection is encrypted.
  - LSP: Renaming a Slint property or callback now offers to also rename the corresponding accessors
    in the Rust or C++ code. (#11841)
  - LSP: The import code action and auto-completion now also offer structs and enums, not just components.


### PR DESCRIPTION
Cover the changes between 34580f5b6c3e6395f155396f8a008b7f8c6d06bb and f37896a1cb5f9677ae216be1ec979a4efa8cbd08
