### PR TITLE
Fix compiler panic with a runtime-direction flexbox in a component

### DIFF
--- a/internal/compiler/llr/lower_layout_expression.rs
+++ b/internal/compiler/llr/lower_layout_expression.rs
@@ -1979,12 +1979,15 @@ pub(crate) fn default_cross_axis_constraint(
     // Route through `layoutinfo-h-with-constraint` when available so we
     // don't trigger a `self.height` read (which cycles for column-direction
     // flexes: their layoutinfo-h depends on self.height, itself set by the
-    // parent layout cache). The NR returned by `inherited_*` already points
-    // to the element declaring the function (which, after
-    // `move_declarations` runs, is the enclosing component's root with a
-    // renamed property), so use it as-is — re-anchoring it to `elem` would
-    // break the lookup.
+    // parent layout cache).
     if let Some(constrained_nr) = elem_b.inherited_layout_info_h_with_constraint() {
+        // An NR from the base-component chain must be anchored on `elem` to
+        // resolve through the instance; an own NR must stay as-is.
+        let constrained_nr = if elem_b.layout_info_h_with_constraint.is_some() {
+            constrained_nr
+        } else {
+            NamedReference::new(elem, constrained_nr.name().clone())
+        };
         let call = crate::expression_tree::Expression::FunctionCall {
             function: crate::expression_tree::Callable::Function(constrained_nr),
             arguments: vec![crate::expression_tree::Expression::NumberLiteral(

--- a/tests/cases/layout/flexbox_runtime_direction_in_component.slint
+++ b/tests/cases/layout/flexbox_runtime_direction_in_component.slint
@@ -1,0 +1,57 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A FlexboxLayout whose direction is only known at runtime, wrapped in a
+// reusable component and used as a height-for-width cell. Measuring the cell
+// reaches the flex's `layoutinfo-h-with-constraint` through the component
+// boundary; that reference must resolve through the instance, not point into
+// the component's private scope.
+
+component WrappedFlex {
+    in property <bool> horizontal: true;
+    FlexboxLayout {
+        flex-direction: horizontal ? FlexboxLayoutDirection.row : FlexboxLayoutDirection.column;
+        flex-wrap: wrap;
+
+        Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+        Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+        Rectangle { min-width: 60px; preferred-width: 60px; min-height: 20px; preferred-height: 20px; }
+    }
+}
+
+export component TestCase inherits Window {
+    width: 200px;
+    height: 200px;
+
+    HorizontalLayout {
+        Rectangle { width: 40px; }
+        VerticalLayout {
+            alignment: start;
+            // Required: the repeated sibling makes the VerticalLayout measure
+            // the cell instead of just forwarding its layout info.
+            if false: Rectangle { }
+            wf := WrappedFlex { }
+        }
+    }
+
+    // The 40px sidebar leaves 160px, so two 60px items fit per line and the
+    // three items wrap onto two lines of 20px.
+    out property <bool> test: wf.width == 160px && wf.height == 40px;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+assert(handle->get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
Measuring a height-for-width cell whose base component carries layoutinfo-h-with-constraint made default_cross_axis_constraint emit a call through a NamedReference into the base component's scope, which the enclosing component cannot lower:

    Could not find component "WrappedFlex" from component "TestCase"

Anchor the reference on the cell element so it resolves through the instance, like implicit_layout_info_call does.
