### PR TITLE
Publish i-slint-renderer-anyrender to crates.io

### DIFF
--- a/internal/renderers/anyrender/Cargo.toml
+++ b/internal/renderers/anyrender/Cargo.toml
@@ -11,8 +11,6 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
-# Internal for now: no public API commitment yet, and no crates.io release.
-publish = false
 
 [lib]
 path = "lib.rs"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,6 +23,7 @@ exec cargo publish "$@" \
     -p i-slint-renderer-skia --features i-slint-renderer-skia/x11 \
     -p i-slint-renderer-femtovg \
     -p i-slint-renderer-software \
+    -p i-slint-renderer-anyrender \
     -p i-slint-backend-winit --features i-slint-backend-winit/x11,i-slint-backend-winit/renderer-femtovg \
     -p slint-build \
     -p i-slint-backend-qt \


### PR DESCRIPTION
The vello renderer gave `i-slint-backend-winit` and `i-slint-backend-linuxkms` an optional dependency on `i-slint-renderer-anyrender`, which was marked `publish = false`. Cargo needs every dependency of a crate it packages to exist in the registry, even an optional one behind a feature that's off by default, so the publish dry run failed to package either backend.

Publish the crate along with the others. Like the rest of the `i-slint-*` crates it carries no public API commitment.

Adding a crate to the list needs a one-time bootstrap before the next release: publish a dummy 0.0.0 manually, then configure trusted publishing for it on crates.io, as scripts/publish.sh describes.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
