### PR TITLE
Visual Editor: Indicate item on hover

### DIFF
--- a/tools/editor/preview/element_selection.rs
+++ b/tools/editor/preview/element_selection.rs
@@ -81,15 +81,16 @@ fn element_covers_point(
     position: LogicalPoint,
     component_instance: &ComponentInstance,
     selected_element: &ElementRc,
-) -> Option<HighlightedRect> {
+) -> Option<(HighlightedRect, usize)> {
     slint_interpreter::highlight::element_positions(
         &component_instance.clone_strong().into(),
         selected_element,
         slint_interpreter::highlight::ElementPositionFilter::ExcludeClipped,
     )
-    .iter()
-    .find(|p| p.contains(position))
-    .copied()
+    .into_iter()
+    .enumerate()
+    .find(|(_, p)| p.contains(position))
+    .map(|(instance_index, geometry)| (geometry, instance_index))
 }
 
 pub fn unselect_element() {
@@ -288,6 +289,7 @@ pub struct SelectionCandidate {
     pub element: ElementRc,
     pub debug_index: usize,
     pub geometry: HighlightedRect,
+    pub instance_index: usize,
     pub is_in_root_component: bool,
 }
 
@@ -324,7 +326,9 @@ fn collect_all_element_nodes_covering_impl(
         collect_all_element_nodes_covering_impl(position, component_instance, c, result);
     }
 
-    if let Some(geometry) = element_covers_point(position, component_instance, current_element) {
+    if let Some((geometry, instance_index)) =
+        element_covers_point(position, component_instance, current_element)
+    {
         for (i, d) in ce.borrow().debug.iter().enumerate().rev() {
             if !i_slint_editor_preview::is_element_node_ignored(&d.node)
                 && !d.node.source_file.path().starts_with("builtin:/")
@@ -335,6 +339,7 @@ fn collect_all_element_nodes_covering_impl(
                     debug_index: i,
                     is_in_root_component: false,
                     geometry,
+                    instance_index,
                 });
             }
         }
@@ -377,17 +382,23 @@ pub fn collect_all_element_nodes_covering(
     elements
 }
 
+fn selection_candidate_at_impl(
+    component_instance: &ComponentInstance,
+    position: LogicalPoint,
+    enter_component: bool,
+) -> Option<SelectionCandidate> {
+    collect_all_element_nodes_covering(position, component_instance)
+        .into_iter()
+        .find(|candidate| filter_nodes_for_selection(candidate, enter_component).is_some())
+}
+
 fn select_element_at_impl(
     component_instance: &ComponentInstance,
     position: LogicalPoint,
     enter_component: bool,
 ) -> Option<i_slint_editor_preview::ElementRcNode> {
-    for sc in &collect_all_element_nodes_covering(position, component_instance) {
-        if let Some(en) = filter_nodes_for_selection(sc, enter_component) {
-            return Some(en);
-        }
-    }
-    None
+    selection_candidate_at_impl(component_instance, position, enter_component)
+        .and_then(|candidate| candidate.as_element_node())
 }
 
 pub fn select_element_at(x: f32, y: f32, enter_component: bool) {
@@ -402,6 +413,73 @@ pub fn select_element_at(x: f32, y: f32, enter_component: bool) {
     };
 
     select_element_node(&component_instance, &en, Some(position));
+}
+
+fn type_name(en: &i_slint_editor_preview::ElementRcNode) -> String {
+    en.with_element_debug(|di| {
+        di.node
+            .parent()
+            .and_then(|p| {
+                if p.kind() == SyntaxKind::Component {
+                    p.child_node(SyntaxKind::DeclaredIdentifier).map(|t| t.text().to_string())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| di.node.QualifiedName().map(|qn| qn.text().to_string().trim().to_string()))
+            .unwrap_or_default()
+            .trim()
+            .to_string()
+    })
+}
+
+fn hovered_element_at_impl(
+    component_instance: &ComponentInstance,
+    position: LogicalPoint,
+    enter_component: bool,
+    selected: Option<&ElementSelection>,
+) -> ui::HoveredElement {
+    let Some(candidate) =
+        selection_candidate_at_impl(component_instance, position, enter_component)
+    else {
+        return Default::default();
+    };
+    let Some(element_node) = candidate.as_element_node() else {
+        return Default::default();
+    };
+
+    let (path, offset) = element_node.path_and_offset();
+    let is_selected = selected.is_some_and(|selection| {
+        selection.path == path
+            && selection.offset == offset
+            && selection.instance_index == candidate.instance_index
+    });
+
+    ui::HoveredElement {
+        valid: true,
+        is_selected,
+        element_path: path.to_string_lossy().to_string().into(),
+        element_offset: i32::try_from(u32::from(offset)).unwrap_or_default(),
+        type_name: type_name(&element_node).into(),
+        x: candidate.geometry.rect.origin.x,
+        y: candidate.geometry.rect.origin.y,
+        width: candidate.geometry.rect.size.width,
+        height: candidate.geometry.rect.size.height,
+        angle: candidate.geometry.angle,
+    }
+}
+
+pub fn hovered_element_at(x: f32, y: f32, enter_component: bool) -> ui::HoveredElement {
+    let Some(component_instance) = super::component_instance() else {
+        return Default::default();
+    };
+
+    hovered_element_at_impl(
+        &component_instance,
+        LogicalPoint::new(x, y),
+        enter_component,
+        super::selected_element().as_ref(),
+    )
 }
 
 pub fn selection_stack_at(x: f32, y: f32) -> slint::ModelRc<ui::SelectionStackFrame> {
@@ -686,6 +764,7 @@ mod tests {
 
     use std::path::PathBuf;
 
+    use i_slint_compiler::parser::TextSize;
     use i_slint_core::lengths::LogicalPoint;
     use slint_interpreter::ComponentInstance;
 
@@ -1027,5 +1106,137 @@ export component MyInput {
             "selection without `enter_component` should land on the MyInput use site \
              in the main file, not on a node inside the imported component"
         );
+    }
+
+    #[test]
+    fn test_hovered_element_matches_click_selection_and_geometry() {
+        let component_instance = demo_app();
+        let position = LogicalPoint::new(100.0, 100.0);
+        let selected = super::select_element_at_impl(&component_instance, position, false)
+            .expect("a click on the center should select an element");
+        let expected_path_and_offset = selected.path_and_offset();
+        let candidate = super::selection_candidate_at_impl(&component_instance, position, false)
+            .expect("a selectable element should cover the center");
+
+        let hovered = super::hovered_element_at_impl(&component_instance, position, false, None);
+
+        assert!(hovered.valid);
+        assert_eq!(hovered.element_path, expected_path_and_offset.0.to_string_lossy());
+        assert_eq!(
+            hovered.element_offset,
+            i32::try_from(u32::from(expected_path_and_offset.1)).unwrap()
+        );
+        assert_eq!(hovered.x, candidate.geometry.rect.origin.x);
+        assert_eq!(hovered.y, candidate.geometry.rect.origin.y);
+        assert_eq!(hovered.width, candidate.geometry.rect.size.width);
+        assert_eq!(hovered.height, candidate.geometry.rect.size.height);
+        assert_eq!(hovered.angle, candidate.geometry.angle);
+
+        let outside = super::hovered_element_at_impl(
+            &component_instance,
+            LogicalPoint::new(201.0, 100.0),
+            false,
+            None,
+        );
+        assert!(!outside.valid);
+    }
+
+    #[test]
+    fn test_hovered_element_respects_component_boundary() {
+        use crate::preview::test::interpret_test_with_sources;
+        use i_slint_editor_preview::test::{main_test_file_name, test_file_name};
+        use std::collections::HashMap;
+
+        let main_path = main_test_file_name();
+        let controls_path = test_file_name("controls.slint");
+        let main_source = format!(
+            r#"import {{ MyInput }} from "{controls}";
+
+export component Demo inherits Window {{
+    width: 200px;
+    height: 200px;
+
+    MyInput {{
+        x: 0px; y: 0px;
+        width: 200px;
+        height: 200px;
+    }}
+}}
+"#,
+            controls = controls_path.to_string_lossy()
+        );
+        let controls_source = r#"export component MyInput {
+    width: 100%;
+    height: 100%;
+    Rectangle { }
+}
+"#;
+        let component_instance = interpret_test_with_sources(
+            "fluent",
+            HashMap::from([
+                (main_path.clone(), main_source),
+                (controls_path, controls_source.to_string()),
+            ]),
+        );
+        let position = LogicalPoint::new(100.0, 100.0);
+        let hovered = super::hovered_element_at_impl(&component_instance, position, false, None);
+
+        assert!(hovered.valid);
+        assert_eq!(PathBuf::from(hovered.element_path.to_string()), main_path);
+    }
+
+    #[test]
+    fn test_hovered_element_distinguishes_repeated_instances() {
+        let component_instance = crate::preview::test::interpret_test(
+            "fluent",
+            r#"export component Main inherits Window {
+    width: 120px;
+    height: 60px;
+
+    for i in [0, 1]: Rectangle {
+        x: i * 60px;
+        width: 50px;
+        height: 50px;
+    }
+}
+"#,
+        );
+
+        let first = super::hovered_element_at_impl(
+            &component_instance,
+            LogicalPoint::new(10.0, 10.0),
+            false,
+            None,
+        );
+        let second = super::hovered_element_at_impl(
+            &component_instance,
+            LogicalPoint::new(70.0, 10.0),
+            false,
+            None,
+        );
+        assert!(first.valid && second.valid);
+        assert_eq!(first.element_path, second.element_path);
+        assert_eq!(first.element_offset, second.element_offset);
+        assert_ne!(first.x, second.x);
+
+        let selection = super::ElementSelection {
+            path: PathBuf::from(first.element_path.to_string()),
+            offset: TextSize::from(first.element_offset as u32),
+            instance_index: 1,
+        };
+        let selected_second = super::hovered_element_at_impl(
+            &component_instance,
+            LogicalPoint::new(70.0, 10.0),
+            false,
+            Some(&selection),
+        );
+        let selected_first = super::hovered_element_at_impl(
+            &component_instance,
+            LogicalPoint::new(10.0, 10.0),
+            false,
+            Some(&selection),
+        );
+        assert!(selected_second.is_selected);
+        assert!(!selected_first.is_selected);
     }
 }

--- a/tools/editor/preview/element_selection.rs
+++ b/tools/editor/preview/element_selection.rs
@@ -415,18 +415,26 @@ pub fn select_element_at(x: f32, y: f32, enter_component: bool) {
     select_element_node(&component_instance, &en, Some(position));
 }
 
-fn type_name(en: &i_slint_editor_preview::ElementRcNode) -> String {
-    en.with_element_debug(|di| {
-        di.node
+fn type_name(element_node: &i_slint_editor_preview::ElementRcNode) -> String {
+    element_node.with_element_debug(|debug_info| {
+        debug_info
+            .node
             .parent()
-            .and_then(|p| {
-                if p.kind() == SyntaxKind::Component {
-                    p.child_node(SyntaxKind::DeclaredIdentifier).map(|t| t.text().to_string())
+            .and_then(|parent| {
+                if parent.kind() == SyntaxKind::Component {
+                    parent
+                        .child_node(SyntaxKind::DeclaredIdentifier)
+                        .map(|identifier| identifier.text().to_string())
                 } else {
                     None
                 }
             })
-            .or_else(|| di.node.QualifiedName().map(|qn| qn.text().to_string().trim().to_string()))
+            .or_else(|| {
+                debug_info
+                    .node
+                    .QualifiedName()
+                    .map(|qualified_name| qualified_name.text().to_string().trim().to_string())
+            })
             .unwrap_or_default()
             .trim()
             .to_string()
@@ -454,18 +462,26 @@ fn hovered_element_at_impl(
             && selection.offset == offset
             && selection.instance_index == candidate.instance_index
     });
+    let is_over_selected_element = selected.is_some_and(|selection| {
+        component_instance
+            .component_positions(&selection.path, selection.offset.into())
+            .get(selection.instance_index)
+            .is_some_and(|geometry| geometry.contains(position))
+    });
 
     ui::HoveredElement {
         valid: true,
         is_selected,
+        is_over_selected_element,
         element_path: path.to_string_lossy().to_string().into(),
         element_offset: i32::try_from(u32::from(offset)).unwrap_or_default(),
         type_name: type_name(&element_node).into(),
-        x: candidate.geometry.rect.origin.x,
-        y: candidate.geometry.rect.origin.y,
-        width: candidate.geometry.rect.size.width,
-        height: candidate.geometry.rect.size.height,
-        angle: candidate.geometry.angle,
+        geometry: Rc::new(VecModel::from(selection_rectangles(
+            component_instance,
+            &path,
+            offset.into(),
+        )))
+        .into(),
     }
 }
 
@@ -766,6 +782,7 @@ mod tests {
 
     use i_slint_compiler::parser::TextSize;
     use i_slint_core::lengths::LogicalPoint;
+    use slint::Model;
     use slint_interpreter::ComponentInstance;
 
     fn demo_app() -> ComponentInstance {
@@ -1126,11 +1143,15 @@ export component MyInput {
             hovered.element_offset,
             i32::try_from(u32::from(expected_path_and_offset.1)).unwrap()
         );
-        assert_eq!(hovered.x, candidate.geometry.rect.origin.x);
-        assert_eq!(hovered.y, candidate.geometry.rect.origin.y);
-        assert_eq!(hovered.width, candidate.geometry.rect.size.width);
-        assert_eq!(hovered.height, candidate.geometry.rect.size.height);
-        assert_eq!(hovered.angle, candidate.geometry.angle);
+        let hovered_geometry = hovered
+            .geometry
+            .row_data(candidate.instance_index)
+            .expect("the hovered instance should have geometry");
+        assert_eq!(hovered_geometry.x, candidate.geometry.rect.origin.x);
+        assert_eq!(hovered_geometry.y, candidate.geometry.rect.origin.y);
+        assert_eq!(hovered_geometry.width, candidate.geometry.rect.size.width);
+        assert_eq!(hovered_geometry.height, candidate.geometry.rect.size.height);
+        assert_eq!(hovered_geometry.angle, candidate.geometry.angle);
 
         let outside = super::hovered_element_at_impl(
             &component_instance,
@@ -1217,7 +1238,9 @@ export component Demo inherits Window {{
         assert!(first.valid && second.valid);
         assert_eq!(first.element_path, second.element_path);
         assert_eq!(first.element_offset, second.element_offset);
-        assert_ne!(first.x, second.x);
+        assert_eq!(first.geometry.row_count(), 2);
+        assert_eq!(second.geometry.row_count(), 2);
+        assert_ne!(first.geometry.row_data(0).unwrap().x, first.geometry.row_data(1).unwrap().x);
 
         let selection = super::ElementSelection {
             path: PathBuf::from(first.element_path.to_string()),
@@ -1238,5 +1261,7 @@ export component Demo inherits Window {{
         );
         assert!(selected_second.is_selected);
         assert!(!selected_first.is_selected);
+        assert!(selected_second.is_over_selected_element);
+        assert!(!selected_first.is_over_selected_element);
     }
 }

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -134,6 +134,7 @@ pub fn initialize_editor(
     api.on_unselect(super::element_selection::unselect_element);
     api.on_reselect(super::element_selection::reselect_element);
     api.on_select_at(super::element_selection::select_element_at);
+    api.on_hovered_element_at(super::element_selection::hovered_element_at);
     api.on_selection_stack_at(super::element_selection::selection_stack_at);
     api.on_filter_sort_selection_stack(super::element_selection::filter_sort_selection_stack);
     api.on_find_selected_selection_stack_frame(|stack| {

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -84,6 +84,7 @@ pub fn initialize_editor(
 ) {
     let api = editor_ui.global::<Api>();
     let api_weak = <Api as slint::Global<'_, EditorUi>>::as_weak(&api);
+    let hover = editor_ui.global::<Hover>();
     let project = editor_ui.global::<Project>();
     let project_weak = <Project as slint::Global<'_, EditorUi>>::as_weak(&project);
 
@@ -134,7 +135,7 @@ pub fn initialize_editor(
     api.on_unselect(super::element_selection::unselect_element);
     api.on_reselect(super::element_selection::reselect_element);
     api.on_select_at(super::element_selection::select_element_at);
-    api.on_hovered_element_at(super::element_selection::hovered_element_at);
+    hover.on_element_at(super::element_selection::hovered_element_at);
     api.on_selection_stack_at(super::element_selection::selection_stack_at);
     api.on_filter_sort_selection_stack(super::element_selection::filter_sort_selection_stack);
     api.on_find_selected_selection_stack_frame(|stack| {

--- a/tools/editor/ui-tests/tests/canvas_interactions.py
+++ b/tools/editor/ui-tests/tests/canvas_interactions.py
@@ -35,6 +35,25 @@ def selection_frame(window: slint_testing.Window, kind: str) -> Frame:
     return (position.x, position.y, size.width, size.height)
 
 
+def fixture_element(window: slint_testing.Window, kind: str) -> slint_testing.Element:
+    return wait_until(
+        lambda: next(
+            iter(window.find_elements_by_id(f"Main::root-{kind.lower()}")), None
+        )
+    )
+
+
+def hover_fixture_element(
+    window: slint_testing.Window, kind: str
+) -> slint_testing.Element:
+    window.dispatch_event(
+        slint_testing.PointerMoveEvent(center(fixture_element(window, kind)))
+    )
+    return window_element_with_label(
+        window, f"Hovered {kind}", slint_testing.AccessibleRole.Region
+    )
+
+
 def same_state(left: Frame, right: Frame) -> bool:
     return all(abs(a - b) < 0.01 for a, b in zip(left, right))
 

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -338,7 +338,7 @@ def test_overlapping_elements_update_hover_outline_to_topmost_item(
         snapshot.assert_unchanged()
 
 
-def test_selected_element_frame_refreshes_hover_outline_for_overlapping_item(
+def test_overlapping_hover_does_not_intercept_selected_element_drag(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
@@ -355,28 +355,51 @@ def test_selected_element_frame_refreshes_hover_outline_for_overlapping_item(
             x=artboard.absolute_position.x + 200,
             y=artboard.absolute_position.y + 80,
         )
+        window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
+        window_element_with_label(window, "Hovered Text")
+        initial_frame = selection_frame(window, "Rectangle")
+        target = slint_testing.LogicalPosition(
+            x=overlapping.x + 20,
+            y=overlapping.y + 16,
+        )
         button = slint_testing.PointerEventButton.Left
         window.dispatch_event(slint_testing.PointerPressEvent(overlapping, button))
-        window.dispatch_event(
-            slint_testing.PointerMoveEvent(
-                slint_testing.LogicalPosition(
-                    x=overlapping.x + 1,
-                    y=overlapping.y + 1,
-                )
-            )
-        )
-        assert not elements_with_label(window.root_element, "Hovered Text")
-        window.dispatch_event(slint_testing.PointerReleaseEvent(overlapping, button))
-        window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
+        window.dispatch_event(slint_testing.PointerMoveEvent(target))
+        assert selection_frame(window, "Rectangle") != initial_frame
+        assert not elements_with_label(window.root_element, "Selected Text")
         wait_until(
             lambda: (
                 True
-                if elements_with_label(window.root_element, "Hovered Text")
-                and not elements_with_label(window.root_element, "Hovered Rectangle")
+                if not elements_with_label(window.root_element, "Hovered Text")
                 else None
             )
         )
-        snapshot.assert_unchanged()
+        snapshot.assert_unchanged_now()
+        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+
+
+def test_hover_outside_selected_element_can_select_and_drag_child(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        start = center(fixture_element(window, "Text"))
+        window.dispatch_event(slint_testing.PointerMoveEvent(start))
+        window_element_with_label(window, "Hovered Text")
+        target = slint_testing.LogicalPosition(x=start.x + 20, y=start.y + 16)
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        window_element_with_label(window, "Selected Text")
+        initial_frame = selection_frame(window, "Text")
+        window.dispatch_event(slint_testing.PointerMoveEvent(target))
+        assert selection_frame(window, "Text") != initial_frame
+        snapshot.assert_unchanged_now()
+        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
 
 
 def test_selected_element_does_not_get_a_duplicate_hover_outline(

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -9,6 +9,8 @@ import slint_testing
 from canvas_interactions import (
     cancel_pointer_interaction,
     center,
+    fixture_element,
+    hover_fixture_element,
     live_modifier_resize,
     manual_drag,
     manual_radius_drag,
@@ -242,6 +244,252 @@ def test_palette_preview_follows_rejected_pointer(
         )
         finish_palette_drag(window, second_rejected_position)
         snapshot.assert_unchanged()
+
+
+@pytest.mark.parametrize("kind", MOVE_KINDS)
+def test_unselected_element_shows_hover_outline_without_side_effects(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
+        hover = hover_fixture_element(window, kind)
+        expected = {
+            "Rectangle": (40, 40, 180, 120),
+            "Text": (180, 56, 180, 48),
+            "Image": (230, 132, 128, 96),
+        }[kind]
+        x, y, width, height = expected
+        assert hover.absolute_position.x == pytest.approx(
+            artboard.absolute_position.x + x
+        )
+        assert hover.absolute_position.y == pytest.approx(
+            artboard.absolute_position.y + y
+        )
+        assert hover.size.width == pytest.approx(width)
+        assert hover.size.height == pytest.approx(height)
+        assert not elements_with_label(window.root_element, f"Selected {kind}")
+        snapshot.assert_unchanged()
+
+        blank = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x + artboard.size.width - 12,
+            y=artboard.absolute_position.y + artboard.size.height - 12,
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(blank))
+        wait_until(
+            lambda: (
+                True
+                if not elements_with_label(window.root_element, f"Hovered {kind}")
+                else None
+            )
+        )
+        snapshot.assert_unchanged()
+
+        outside = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x - 12,
+            y=artboard.absolute_position.y - 12,
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(outside))
+        wait_until(
+            lambda: (
+                True
+                if not elements_with_label(window.root_element, f"Hovered {kind}")
+                else None
+            )
+        )
+        snapshot.assert_unchanged()
+
+
+def test_overlapping_elements_update_hover_outline_to_topmost_item(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
+        rectangle_only = center(fixture_element(window, "Rectangle"))
+        overlapping = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x + 200,
+            y=artboard.absolute_position.y + 80,
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(rectangle_only))
+        window_element_with_label(window, "Hovered Rectangle")
+        window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
+        wait_until(
+            lambda: (
+                True
+                if elements_with_label(window.root_element, "Hovered Text")
+                and not elements_with_label(window.root_element, "Hovered Rectangle")
+                else None
+            )
+        )
+        snapshot.assert_unchanged()
+
+
+def test_selected_element_frame_refreshes_hover_outline_for_overlapping_item(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
+        select_fixture_element(window, "Rectangle")
+        overlapping = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x + 200,
+            y=artboard.absolute_position.y + 80,
+        )
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(overlapping, button))
+        window.dispatch_event(
+            slint_testing.PointerMoveEvent(
+                slint_testing.LogicalPosition(
+                    x=overlapping.x + 1,
+                    y=overlapping.y + 1,
+                )
+            )
+        )
+        assert not elements_with_label(window.root_element, "Hovered Text")
+        window.dispatch_event(slint_testing.PointerReleaseEvent(overlapping, button))
+        window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
+        wait_until(
+            lambda: (
+                True
+                if elements_with_label(window.root_element, "Hovered Text")
+                and not elements_with_label(window.root_element, "Hovered Rectangle")
+                else None
+            )
+        )
+        snapshot.assert_unchanged()
+
+
+def test_selected_element_does_not_get_a_duplicate_hover_outline(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Text")
+        window.dispatch_event(
+            slint_testing.PointerMoveEvent(center(fixture_element(window, "Text")))
+        )
+        assert not elements_with_label(window.root_element, "Hovered Text")
+        snapshot.assert_unchanged()
+
+
+@pytest.mark.parametrize("kind", MOVE_KINDS)
+def test_unselected_element_click_selects_without_editing_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        hover = hover_fixture_element(window, kind)
+        target = center(hover)
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+        below_threshold = slint_testing.LogicalPosition(
+            x=target.x + 1,
+            y=target.y + 1,
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(below_threshold))
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(below_threshold, button)
+        )
+        window_element_with_label(
+            window, f"Selected {kind}", slint_testing.AccessibleRole.Region
+        )
+        assert not elements_with_label(window.root_element, f"Hovered {kind}")
+        snapshot.assert_unchanged()
+
+
+@pytest.mark.parametrize("kind", ["Text", "Image"])
+def test_unselected_element_can_be_dragged_in_one_gesture(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    kind: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    snapshot = SourceSnapshot.capture(fixture_project)
+    original = {
+        "Text": b"        x: 180px;\n        y: 56px;",
+        "Image": b"        x: 230px;\n        y: 132px;",
+    }[kind]
+    updated = {
+        "Text": b"        x: 200px;\n        y: 72px;",
+        "Image": b"        x: 250px;\n        y: 148px;",
+    }[kind]
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        hover = hover_fixture_element(window, kind)
+        start = center(hover)
+        end = slint_testing.LogicalPosition(x=start.x + 20, y=start.y + 16)
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        window_element_with_label(
+            window, f"Selected {kind}", slint_testing.AccessibleRole.Region
+        )
+        initial_frame = selection_frame(window, kind)
+        for step in range(1, 4):
+            fraction = step / 3
+            position = slint_testing.LogicalPosition(
+                x=start.x + (end.x - start.x) * fraction,
+                y=start.y + (end.y - start.y) * fraction,
+            )
+            window.dispatch_event(slint_testing.PointerMoveEvent(position))
+        assert selection_frame(window, kind) != initial_frame
+        assert not elements_with_label(window.root_element, f"{kind} resize top-left")
+        snapshot.assert_unchanged_now()
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+        snapshot.wait_for_exact(replace_once(baseline, original, updated))
+
+
+def test_unselected_rectangle_direct_drag_starts_before_release(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        hover = hover_fixture_element(window, "Rectangle")
+        start = center(hover)
+        end = slint_testing.LogicalPosition(x=start.x + 20, y=start.y + 16)
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        window_element_with_label(window, "Selected Rectangle")
+        initial_frame = selection_frame(window, "Rectangle")
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        assert selection_frame(window, "Rectangle") != initial_frame
+        assert not elements_with_label(window.root_element, "Rectangle resize top-left")
+        snapshot.assert_unchanged_now()
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
 
 
 @pytest.mark.parametrize("kind", PALETTE_DROP_SIZES)

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -826,6 +826,44 @@ def radius_handle_positions(
     }
 
 
+def assert_radius_handle_positions(
+    window: slint_testing.Window,
+    initial_positions: dict[str, slint_testing.LogicalPosition],
+    active_corner: str,
+    radius_delta: float,
+    single_corner: bool,
+) -> None:
+    current_positions = radius_handle_positions(window)
+    for corner in CORNERS:
+        direction = RADIUS_DELTAS[corner]
+        expected_position = (
+            slint_testing.LogicalPosition(
+                x=initial_positions[corner].x
+                + math.copysign(radius_delta, direction[0]),
+                y=initial_positions[corner].y
+                + math.copysign(radius_delta, direction[1]),
+            )
+            if not single_corner or corner == active_corner
+            else initial_positions[corner]
+        )
+        assert position_distance(current_positions[corner], expected_position) < 1.5
+
+
+def wait_for_radius_tooltip(window: slint_testing.Window, radius: float) -> None:
+    wait_until(
+        lambda: (
+            True
+            if float(
+                window_element_with_label(
+                    window, "Radius value", slint_testing.AccessibleRole.Text
+                ).accessible_value
+            )
+            == radius
+            else None
+        )
+    )
+
+
 @pytest.mark.parametrize(
     "kind",
     [pytest.param("Rectangle", marks=RUST_FIX_REQUIRED), "Text", "Image"],
@@ -1382,35 +1420,190 @@ def test_radius_handles_follow_preview_during_drag(
         window.dispatch_event(slint_testing.PointerPressEvent(start, button))
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
 
-        wait_until(
-            lambda: (
-                True
-                if float(
-                    window_element_with_label(
-                        window, "Radius value", slint_testing.AccessibleRole.Text
-                    ).accessible_value
-                )
-                == 16
-                else None
-            )
-        )
-        current_positions = radius_handle_positions(window)
-        for name in CORNERS:
-            delta = RADIUS_DELTAS[name]
-            expected_position = (
-                slint_testing.LogicalPosition(
-                    x=initial_positions[name].x + delta[0],
-                    y=initial_positions[name].y + delta[1],
-                )
-                if not single or name == corner
-                else initial_positions[name]
-            )
-            assert position_distance(current_positions[name], expected_position) < 1.5
+        wait_for_radius_tooltip(window, 16)
+        assert_radius_handle_positions(window, initial_positions, corner, 4, single)
         snapshot.assert_unchanged_now()
 
         window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
         if single:
             window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
+@pytest.mark.parametrize("corner", CORNERS)
+def test_explicit_corner_radius_makes_every_handle_independent(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    corner: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(
+        replace_once(
+            baseline,
+            b"        border-radius: 12px;",
+            b"        border-radius: 12px;\n        border-top-left-radius: 12px;",
+        )
+    )
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        handle = radius_handle(window, corner)
+        initial_positions = radius_handle_positions(window)
+        start = center(handle)
+        end = slint_testing.LogicalPosition(
+            x=start.x + RADIUS_DELTAS[corner][0],
+            y=start.y + RADIUS_DELTAS[corner][1],
+        )
+        button = slint_testing.PointerEventButton.Left
+        snapshot = SourceSnapshot.capture(fixture_project)
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+
+        wait_for_radius_tooltip(window, 16)
+        assert_radius_handle_positions(window, initial_positions, corner, 4, True)
+        snapshot.assert_unchanged_now()
+
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+
+
+@pytest.mark.parametrize(
+    ("shift_before_press", "shift_during_drag", "single_corner"),
+    [
+        pytest.param(False, True, False, id="press-shift-after-pointer-press"),
+        pytest.param(True, False, True, id="release-shift-after-pointer-press"),
+    ],
+)
+def test_radius_drag_mode_does_not_change_after_pointer_press(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    shift_before_press: bool,
+    shift_during_drag: bool,
+    single_corner: bool,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        corner = "top-left"
+        handle = radius_handle(window, corner)
+        initial_positions = radius_handle_positions(window)
+        start = center(handle)
+        end = slint_testing.LogicalPosition(
+            x=start.x + RADIUS_DELTAS[corner][0],
+            y=start.y + RADIUS_DELTAS[corner][1],
+        )
+        button = slint_testing.PointerEventButton.Left
+        snapshot = SourceSnapshot.capture(fixture_project)
+        if shift_before_press:
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        if shift_during_drag:
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+        else:
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+
+        wait_for_radius_tooltip(window, 16)
+        assert_radius_handle_positions(
+            window, initial_positions, corner, 4, single_corner
+        )
+        snapshot.assert_unchanged_now()
+
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+        if shift_during_drag:
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
+def test_clamped_radius_drag_keeps_handles_aligned_with_preview(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        corner = "top-left"
+        handle = radius_handle(window, corner)
+        initial_positions = radius_handle_positions(window)
+        start = center(handle)
+        end = slint_testing.LogicalPosition(x=start.x + 100, y=start.y + 100)
+        button = slint_testing.PointerEventButton.Left
+        snapshot = SourceSnapshot.capture(fixture_project)
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+
+        wait_for_radius_tooltip(window, 60)
+        assert_radius_handle_positions(window, initial_positions, corner, 48, False)
+        snapshot.assert_unchanged_now()
+
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+
+
+def test_repeated_rectangles_show_radius_handles_only_on_primary_instance(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    repeated_source = replace_once(
+        source_file.read_bytes(),
+        b"    root-rectangle := Rectangle {\n        x: 40px;\n        y: 40px;",
+        b"    for index in [0, 1, 2]: root-rectangle := Rectangle {\n"
+        b"        x: 20px + index * 120px;\n        y: 400px;",
+    )
+    repeated_source = replace_once(
+        repeated_source,
+        b"        width: 180px;\n        height: 120px;",
+        b"        width: 100px;\n        height: 80px;",
+    )
+    source_file.write_bytes(repeated_source)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        instances = wait_until(
+            lambda: (
+                elements
+                if len(elements := window.find_elements_by_id("Main::root-rectangle"))
+                == 3
+                else None
+            )
+        )
+        target = center(instances[1])
+        button = slint_testing.PointerEventButton.Left
+        window.dispatch_event(slint_testing.PointerMoveEvent(target))
+        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+        wait_until(
+            lambda: (
+                selected
+                if len(
+                    selected := elements_with_label(
+                        window.root_element,
+                        "Selected Rectangle",
+                        slint_testing.AccessibleRole.Region,
+                    )
+                )
+                == 3
+                else None
+            )
+        )
+
+        for corner in CORNERS:
+            handles = elements_with_label(
+                window.root_element,
+                f"Rectangle radius {corner}",
+                slint_testing.AccessibleRole.Button,
+            )
+            assert len(handles) == 1
+            assert position_distance(center(handles[0]), target) < 100
+        snapshot.assert_unchanged()
 
 
 @RUST_FIX_REQUIRED
@@ -1532,7 +1725,6 @@ def test_handle_click_below_drag_threshold_does_not_edit_source(
         button = slint_testing.PointerEventButton.Left
         window.dispatch_event(slint_testing.PointerPressEvent(start, button))
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
-        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
         assert same_state(selection_frame(window, "Rectangle"), before)
         if radius_position_before is not None:
             assert (
@@ -1546,6 +1738,7 @@ def test_handle_click_below_drag_threshold_does_not_edit_source(
                 )
                 < 1.5
             )
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
         snapshot.assert_unchanged()
 
 

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -20,6 +20,7 @@ from canvas_interactions import (
     same_state,
     selection_frame,
 )
+from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
     elements_with_label,
@@ -816,6 +817,15 @@ def radius_handle(window: slint_testing.Window, corner: str) -> slint_testing.El
     return window_element_with_label(window, f"Rectangle radius {corner}")
 
 
+def radius_handle_positions(
+    window: slint_testing.Window,
+) -> dict[str, slint_testing.LogicalPosition]:
+    return {
+        corner: center(window_element_with_label(window, f"Rectangle radius {corner}"))
+        for corner in CORNERS
+    }
+
+
 @pytest.mark.parametrize(
     "kind",
     [pytest.param("Rectangle", marks=RUST_FIX_REQUIRED), "Text", "Image"],
@@ -1337,6 +1347,72 @@ def test_each_radius_handle_writes_exact_source(
         snapshot.wait_for_exact(expected)
 
 
+@pytest.mark.parametrize(
+    ("single", "corner"),
+    [
+        pytest.param(single, corner, id=f"{single}-{corner}")
+        for single in (False, True)
+        for corner in CORNERS
+    ],
+)
+def test_radius_handles_follow_preview_during_drag(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    single: bool,
+    corner: str,
+) -> None:
+    source_file = fixture_project / "Main.slint"
+    baseline = source_file.read_bytes()
+    source_file.write_bytes(baseline)
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        handle = radius_handle(window, corner)
+        initial_positions = radius_handle_positions(window)
+        start = center(handle)
+        end = slint_testing.LogicalPosition(
+            x=start.x + RADIUS_DELTAS[corner][0],
+            y=start.y + RADIUS_DELTAS[corner][1],
+        )
+        button = slint_testing.PointerEventButton.Left
+        snapshot = SourceSnapshot.capture(fixture_project)
+        if single:
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+
+        wait_until(
+            lambda: (
+                True
+                if float(
+                    window_element_with_label(
+                        window, "Radius value", slint_testing.AccessibleRole.Text
+                    ).accessible_value
+                )
+                == 16
+                else None
+            )
+        )
+        current_positions = radius_handle_positions(window)
+        for name in CORNERS:
+            delta = RADIUS_DELTAS[name]
+            expected_position = (
+                slint_testing.LogicalPosition(
+                    x=initial_positions[name].x + delta[0],
+                    y=initial_positions[name].y + delta[1],
+                )
+                if not single or name == corner
+                else initial_positions[name]
+            )
+            assert position_distance(current_positions[name], expected_position) < 1.5
+        snapshot.assert_unchanged_now()
+
+        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+        if single:
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
 @RUST_FIX_REQUIRED
 def test_radius_is_clamped_to_half_the_shortest_side(
     editor_binary: Path,
@@ -1451,12 +1527,25 @@ def test_handle_click_below_drag_threshold_does_not_edit_source(
         )
         before = selection_frame(window, "Rectangle")
         start = center(handle)
+        radius_position_before = start if label == "Rectangle radius top-left" else None
         end = slint_testing.LogicalPosition(x=start.x + 1, y=start.y + 1)
         button = slint_testing.PointerEventButton.Left
         window.dispatch_event(slint_testing.PointerPressEvent(start, button))
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
         window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
         assert same_state(selection_frame(window, "Rectangle"), before)
+        if radius_position_before is not None:
+            assert (
+                position_distance(
+                    center(
+                        window_element_with_label(
+                            window, label, slint_testing.AccessibleRole.Button
+                        )
+                    ),
+                    radius_position_before,
+                )
+                < 1.5
+            )
         snapshot.assert_unchanged()
 
 

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -119,14 +119,15 @@ export struct SelectionRectangle {
 export struct HoveredElement {
     valid: bool,
     is-selected: bool,
+    is-over-selected-element: bool,
     element-path: string,
     element-offset: int,
     type-name: string,
-    x: length,
-    y: length,
-    width: length,
-    height: length,
-    angle: angle,
+    geometry: [SelectionRectangle],
+}
+
+export global Hover {
+    in-out property <HoveredElement> element;
 }
 
 /// A `Selection`

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -128,6 +128,7 @@ export struct HoveredElement {
 
 export global Hover {
     in-out property <HoveredElement> element;
+    pure callback element-at(x: length, y: length, enter-component: bool) -> HoveredElement;
 }
 
 /// A `Selection`
@@ -422,7 +423,6 @@ export global Api {
     // ## Drawing Area
     // Borders around things
     pure callback highlight-positions(source-uri: string, offset: int) -> [SelectionRectangle];
-    pure callback hovered-element-at(x: length, y: length, enter-component: bool) -> HoveredElement;
     in-out property <Selection> selection;
     in-out property <DropMark> drop-mark;
     // The actual preview

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -115,6 +115,20 @@ export struct SelectionRectangle {
     angle: angle,
 }
 
+/// The topmost selectable element under a canvas position.
+export struct HoveredElement {
+    valid: bool,
+    is-selected: bool,
+    element-path: string,
+    element-offset: int,
+    type-name: string,
+    x: length,
+    y: length,
+    width: length,
+    height: length,
+    angle: angle,
+}
+
 /// A `Selection`
 export struct Selection {
     highlight-index: int,
@@ -407,6 +421,7 @@ export global Api {
     // ## Drawing Area
     // Borders around things
     pure callback highlight-positions(source-uri: string, offset: int) -> [SelectionRectangle];
+    pure callback hovered-element-at(x: length, y: length, enter-component: bool) -> HoveredElement;
     in-out property <Selection> selection;
     in-out property <DropMark> drop-mark;
     // The actual preview

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -13,10 +13,6 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
     in property <length> bottom-left-radius;
     callback radius-changed(CanvasCorner, length, bool);
 
-    private property <[CanvasCorner]> name;
-
-    width: 240px;
-    height: 96px;
     out property <bool> radius-tooltip-visible;
     out property <Point> radius-tooltip-position;
     out property <length> radius-tooltip-value;
@@ -87,7 +83,6 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
         width: EditorMetrics.radius-handle-size;
         height: EditorMetrics.radius-handle-size;
         border-radius: EditorMetrics.radius-handle-size / 2;
-        background: #00000000;
         border-width: 1px;
         border-color: StudioTheme.accent-strong;
 
@@ -116,7 +111,6 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                     root.radius-preview = root.corner-radius(corner);
                     root.radius-single-corner = root.shift-pressed || self.event-shift-pressed;
                     root.radius-dragging = false;
-                    root.selected();
                     root.interaction-started();
                     root.radius-tooltip-visible = true;
                     root.radius-tooltip-position = { x: pointer-x, y: pointer-y };
@@ -144,7 +138,6 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                 root.radius-preview = radius;
                 root.radius-single-corner = root.shift-pressed || self.event-shift-pressed;
                 root.radius-dragging = true;
-                root.radius-tooltip-visible = true;
                 root.radius-tooltip-position = { x: pointer-x, y: pointer-y };
                 root.radius-tooltip-value = radius;
                 root.radius-changed(corner, radius, root.radius-single-corner);

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -21,6 +21,10 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
     out property <Point> radius-tooltip-position;
     out property <length> radius-tooltip-value;
     private property <bool> radius-handle-active;
+    private property <CanvasCorner> radius-edit-corner: CanvasCorner.top-left;
+    private property <length> radius-preview;
+    private property <bool> radius-single-corner;
+    private property <bool> radius-dragging;
 
     function radius-from-handle(corner: CanvasCorner, pointer-x: length, pointer-y: length) -> length {
         let from-left = root.corner-on-left(corner) ? pointer-x : root.width - pointer-x;
@@ -45,13 +49,27 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
         return root.bottom-left-radius;
     }
 
+    function preview-radius(corner: CanvasCorner) -> length {
+        return root.radius-dragging
+            && (!root.radius-single-corner || corner == root.radius-edit-corner)
+            ? root.radius-preview
+            : root.corner-radius(corner);
+    }
+
+    function reset-radius-edit() {
+        root.radius-edit-corner = CanvasCorner.top-left;
+        root.radius-preview = 0px;
+        root.radius-single-corner = false;
+        root.radius-dragging = false;
+    }
+
     for corner in [
         CanvasCorner.top-left,
         CanvasCorner.top-right,
         CanvasCorner.bottom-right,
         CanvasCorner.bottom-left,
     ]: Rectangle {
-        property <length> radius: root.corner-radius(corner);
+        property <length> radius: root.preview-radius(corner);
         property <length> handle-center-x: root.corner-on-left(corner)
             ? EditorMetrics.radius-handle-inset + radius
             : root.width - EditorMetrics.radius-handle-inset - radius;
@@ -94,6 +112,10 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                     self.press-position = { x: self.mouse-x, y: self.mouse-y };
                     let pointer-x = parent.x + self.mouse-x;
                     let pointer-y = parent.y + self.mouse-y;
+                    root.radius-edit-corner = corner;
+                    root.radius-preview = root.corner-radius(corner);
+                    root.radius-single-corner = root.shift-pressed || self.event-shift-pressed;
+                    root.radius-dragging = false;
                     root.selected();
                     root.interaction-started();
                     root.radius-tooltip-visible = true;
@@ -102,6 +124,7 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                 } else {
                     root.interaction-ended();
                     root.radius-tooltip-visible = false;
+                    root.reset-radius-edit();
                 }
             }
 
@@ -117,10 +140,14 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                 let pointer-x = parent.x + self.mouse-x;
                 let pointer-y = parent.y + self.mouse-y;
                 let radius = root.radius-from-handle(corner, pointer-x, pointer-y);
+                root.radius-edit-corner = corner;
+                root.radius-preview = radius;
+                root.radius-single-corner = root.shift-pressed || self.event-shift-pressed;
+                root.radius-dragging = true;
                 root.radius-tooltip-visible = true;
                 root.radius-tooltip-position = { x: pointer-x, y: pointer-y };
                 root.radius-tooltip-value = radius;
-                root.radius-changed(corner, radius, root.shift-pressed || self.event-shift-pressed);
+                root.radius-changed(corner, radius, root.radius-single-corner);
             }
         }
     }

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -18,8 +18,7 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
     out property <Point> radius-tooltip-position;
     out property <length> radius-tooltip-value;
     private property <bool> radius-handle-active;
-    private property <CanvasCorner> radius-edit-corner: CanvasCorner.top-left;
-    private property <length> radius-preview;
+    private property <CanvasCorner> radius-edit-corner;
     private property <bool> radius-single-corner;
     private property <bool> radius-dragging;
 
@@ -49,15 +48,8 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
     function preview-radius(corner: CanvasCorner) -> length {
         return root.radius-dragging
             && (!root.radius-single-corner || corner == root.radius-edit-corner)
-            ? root.radius-preview
+            ? root.radius-tooltip-value
             : root.corner-radius(corner);
-    }
-
-    function reset-radius-edit() {
-        root.radius-edit-corner = CanvasCorner.top-left;
-        root.radius-preview = 0px;
-        root.radius-single-corner = false;
-        root.radius-dragging = false;
     }
 
     for corner in [
@@ -109,7 +101,6 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                     let pointer-x = parent.x + self.mouse-x;
                     let pointer-y = parent.y + self.mouse-y;
                     root.radius-edit-corner = corner;
-                    root.radius-preview = root.corner-radius(corner);
                     root.radius-single-corner = root.independent-corner-radii
                         || root.shift-pressed
                         || self.event-shift-pressed;
@@ -121,7 +112,7 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                 } else {
                     root.interaction-ended();
                     root.radius-tooltip-visible = false;
-                    root.reset-radius-edit();
+                    root.radius-dragging = false;
                 }
             }
 
@@ -138,7 +129,6 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                 let pointer-y = parent.y + self.mouse-y;
                 let radius = root.radius-from-handle(corner, pointer-x, pointer-y);
                 root.radius-edit-corner = corner;
-                root.radius-preview = radius;
                 root.radius-dragging = true;
                 root.radius-tooltip-position = { x: pointer-x, y: pointer-y };
                 root.radius-tooltip-value = radius;

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -17,10 +17,10 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
 
     width: 240px;
     height: 96px;
-    out property <bool> radius-tooltip-visible: false;
-    out property <Point> radius-tooltip-position: { x: 0px, y: 0px };
-    out property <length> radius-tooltip-value: 0px;
-    private property <bool> radius-handle-active: false;
+    out property <bool> radius-tooltip-visible;
+    out property <Point> radius-tooltip-position;
+    out property <length> radius-tooltip-value;
+    private property <bool> radius-handle-active;
 
     function radius-from-handle(corner: CanvasCorner, pointer-x: length, pointer-y: length) -> length {
         let from-left = root.corner-on-left(corner) ? pointer-x : root.width - pointer-x;
@@ -77,8 +77,8 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
             mouse-cursor: pointer;
             accessible-role: AccessibleRole.button;
             accessible-label: root.accessible-prefix + " radius " + root.corner-name(corner);
-            private property <bool> event-shift-pressed: false;
-            private property <Point> press-position: { x: 0px, y: 0px };
+            private property <bool> event-shift-pressed;
+            private property <Point> press-position;
 
             pointer-event(event) => {
                 self.event-shift-pressed = event.modifiers.shift;

--- a/tools/editor/ui/components/border-radius-frame.slint
+++ b/tools/editor/ui/components/border-radius-frame.slint
@@ -7,6 +7,7 @@ import { MoveResizeFrame } from "move-resize-frame.slint";
 
 export component BorderRadiusFrame inherits MoveResizeFrame {
     in property <bool> enable-border-radius-edits: true;
+    in property <bool> independent-corner-radii;
     in property <length> top-left-radius;
     in property <length> top-right-radius;
     in property <length> bottom-right-radius;
@@ -109,7 +110,9 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                     let pointer-y = parent.y + self.mouse-y;
                     root.radius-edit-corner = corner;
                     root.radius-preview = root.corner-radius(corner);
-                    root.radius-single-corner = root.shift-pressed || self.event-shift-pressed;
+                    root.radius-single-corner = root.independent-corner-radii
+                        || root.shift-pressed
+                        || self.event-shift-pressed;
                     root.radius-dragging = false;
                     root.interaction-started();
                     root.radius-tooltip-visible = true;
@@ -136,7 +139,6 @@ export component BorderRadiusFrame inherits MoveResizeFrame {
                 let radius = root.radius-from-handle(corner, pointer-x, pointer-y);
                 root.radius-edit-corner = corner;
                 root.radius-preview = radius;
-                root.radius-single-corner = root.shift-pressed || self.event-shift-pressed;
                 root.radius-dragging = true;
                 root.radius-tooltip-position = { x: pointer-x, y: pointer-y };
                 root.radius-tooltip-value = radius;

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { Api, Hover, SelectionRectangle } from "../api.slint";
-import { EditorCursors, EditorMetrics, StudioTheme } from "common.slint";
+import { EditorCursors, StudioTheme } from "common.slint";
 import { BorderRadiusFrame } from "border-radius-frame.slint";
 import { MoveResizeFrame } from "move-resize-frame.slint";
 
@@ -43,11 +43,11 @@ component SelectedCanvasFrame inherits Rectangle {
     in property <bool> interaction-disabled;
     callback pointer-hovered(Point);
 
-    private property <bool> geometry-drag-active: false;
-    private property <Point> geometry-drag-position: { x: 0px, y: 0px };
-    private property <Size> geometry-drag-size: { width: 0px, height: 0px };
-    private property <bool> rotation-active: false;
-    private property <angle> pending-rotation: 0deg;
+    private property <bool> geometry-drag-active;
+    private property <Point> geometry-drag-position;
+    private property <Size> geometry-drag-size;
+    private property <bool> rotation-active;
+    private property <angle> pending-rotation;
 
     function current-corner-radius(property-name: string) -> length {
         let corner = Api.current-property-value-data(property-name);
@@ -63,8 +63,8 @@ component SelectedCanvasFrame inherits Rectangle {
         // Push live geometry so the previewed element follows the drag through
         // debug-hook overrides without writing to disk.
         Api.override-selected-element-geometry(
-            position.x - EditorMetrics.phone-outer-padding,
-            position.y - EditorMetrics.phone-outer-padding,
+            position.x,
+            position.y,
             size.width,
             size.height,
         );
@@ -87,10 +87,10 @@ component SelectedCanvasFrame inherits Rectangle {
     frame := BorderRadiusFrame {
         x: root.geometry-drag-active && root.primary
             ? root.geometry-drag-position.x
-            : root.selection.x + EditorMetrics.phone-outer-padding;
+            : root.selection.x;
         y: root.geometry-drag-active && root.primary
             ? root.geometry-drag-position.y
-            : root.selection.y + EditorMetrics.phone-outer-padding;
+            : root.selection.y;
         width: root.geometry-drag-active && root.primary
             ? root.geometry-drag-size.width
             : root.selection.width;
@@ -126,10 +126,7 @@ component SelectedCanvasFrame inherits Rectangle {
         }
         pointer-moved(position) => {
             if !self.move-pressed {
-                root.pointer-hovered({
-                    x: position.x - EditorMetrics.phone-outer-padding,
-                    y: position.y - EditorMetrics.phone-outer-padding,
-                });
+                root.pointer-hovered(position);
             }
         }
         radius-changed(corner, radius, single-corner) => {
@@ -183,16 +180,16 @@ component HoverCanvasFrame inherits MoveResizeFrame {
     callback pointer-hovered(Point);
     callback real-element-selected();
 
-    private property <bool> geometry-drag-active: false;
-    private property <Point> geometry-drag-position: { x: 0px, y: 0px };
-    private property <Size> geometry-drag-size: { width: 0px, height: 0px };
+    private property <bool> geometry-drag-active;
+    private property <Point> geometry-drag-position;
+    private property <Size> geometry-drag-size;
 
     visible: Hover.element.valid && !Hover.element.is-selected;
     enabled: root.visible
         && !Hover.element.is-over-selected-element
         && (!root.gesture-active || root.move-pressed);
-    x: root.geometry.x + EditorMetrics.phone-outer-padding;
-    y: root.geometry.y + EditorMetrics.phone-outer-padding;
+    x: root.geometry.x;
+    y: root.geometry.y;
     width: root.geometry.width;
     height: root.geometry.height;
     rotation: root.geometry.angle;
@@ -213,8 +210,8 @@ component HoverCanvasFrame inherits MoveResizeFrame {
             height: root.geometry.height,
         };
         Api.override-selected-element-geometry(
-            position.x - EditorMetrics.phone-outer-padding,
-            position.y - EditorMetrics.phone-outer-padding,
+            position.x,
+            position.y,
             root.geometry.width,
             root.geometry.height,
         );
@@ -256,10 +253,7 @@ component HoverCanvasFrame inherits MoveResizeFrame {
     }
     pointer-moved(position) => {
         if !root.gesture-active {
-            root.pointer-hovered({
-                x: position.x - EditorMetrics.phone-outer-padding,
-                y: position.y - EditorMetrics.phone-outer-padding,
-            });
+            root.pointer-hovered(position);
         }
     }
 
@@ -274,10 +268,10 @@ component HoverCanvasFrame inherits MoveResizeFrame {
 }
 
 export component CanvasInteractionLayer inherits Rectangle {
-    in property <bool> shift-pressed: false;
-    private property <Point> hovered-hit-position: { x: 0px, y: 0px };
+    in property <bool> shift-pressed;
+    private property <Point> hovered-hit-position;
     // Coordinates the selected and hover frames while a hovered item owns the pointer gesture.
-    private property <bool> hover-selection-active: false;
+    private property <bool> hover-selection-active;
     // Guard on highlight-index >= 0: after Api.unselect(), the backend still populates
     // current-element with the component root. Its frame would intercept future selections.
     private property <[SelectionRectangle]> selections: Api.selection.highlight-index >= 0
@@ -297,10 +291,8 @@ export component CanvasInteractionLayer inherits Rectangle {
     // Click to select the real previewed element. This sits on top of the live
     // preview so it intercepts clicks. Its pointer positions are in content coordinates.
     selection-area := TouchArea {
-        x: EditorMetrics.phone-outer-padding;
-        y: EditorMetrics.phone-outer-padding;
-        width: parent.width - 2 * EditorMetrics.phone-outer-padding;
-        height: parent.height - 2 * EditorMetrics.phone-outer-padding;
+        width: root.width;
+        height: root.height;
         mouse-cursor: EditorCursors.canvas-default;
         clicked => {
             Api.unselect();

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -57,6 +57,13 @@ component SelectedCanvasFrame inherits Rectangle {
             : Api.current-property-value-data("border-radius").value-float * 1px;
     }
 
+    function has-independent-corner-radii() -> bool {
+        return Api.current-property-value-data("border-top-left-radius").code != ""
+            || Api.current-property-value-data("border-top-right-radius").code != ""
+            || Api.current-property-value-data("border-bottom-right-radius").code != ""
+            || Api.current-property-value-data("border-bottom-left-radius").code != "";
+    }
+
     function preview-geometry(position: Point, size: Size) {
         root.geometry-drag-active = true;
         root.geometry-drag-position = position;
@@ -98,6 +105,7 @@ component SelectedCanvasFrame inherits Rectangle {
         show-resize-handles: root.primary;
         show-rotation-handles: root.primary;
         enable-border-radius-edits: root.primary && Api.current-element.type-name == "Rectangle";
+        independent-corner-radii: root.has-independent-corner-radii();
         top-left-radius: root.current-corner-radius("border-top-left-radius");
         top-right-radius: root.current-corner-radius("border-top-right-radius");
         bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -1,55 +1,293 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Api, CanvasCorner, Hover, SelectionRectangle } from "../api.slint";
+import { Api, Hover, SelectionRectangle } from "../api.slint";
 import { EditorCursors, EditorMetrics, StudioTheme } from "common.slint";
 import { BorderRadiusFrame } from "border-radius-frame.slint";
 import { MoveResizeFrame } from "move-resize-frame.slint";
 
-export component CanvasInteractionLayer inherits Rectangle {
-    in property <bool> shift-pressed: false;
-    private property <bool> radius-tooltip-visible: false;
-    private property <Point> radius-tooltip-position: { x: 0px, y: 0px };
-    private property <length> radius-tooltip-value: 0px;
-    private property <bool> rotation-tooltip-visible: false;
-    private property <Point> rotation-tooltip-position: { x: 0px, y: 0px };
-    private property <angle> rotation-tooltip-value: 0deg;
-    // Bounding rectangles of the currently selected element, in phone-content coordinates.
-    // Guard on highlight-index >= 0: after Api.unselect(), the backend still populates
-    // current-element with the component root (for the property panel), which would make
-    // highlight-positions return a component-sized rect. That rect's move-touch would
-    // silently swallow all subsequent clicks, preventing re-selection.
-    property <[SelectionRectangle]> selections: Api.selection.highlight-index >= 0
-        ? Api.highlight-positions(Api.current-element.source-uri, Api.current-element.offset)
-        : [];
-    // Outline-drag state: while dragging a handle the frame follows the pointer locally
-    private property <bool> selection-drag-active: false;
-    private property <Point> selection-drag-position;
-    private property <Size> selection-drag-size;
-    private property <bool> selection-rotation-active: false;
-    private property <angle> selection-rotation;
-    private property <Point> hovered-hit-position: { x: 0px, y: 0px };
-    private property <bool> hover-press-active: false;
-    private property <int> hover-press-index: -1;
+component CanvasValueTooltip inherits Rectangle {
+    in property <string> label;
+    in property <string> value;
+    in property <string> raw-value;
+    in property <string> value-label;
+    in property <Point> pointer-position;
 
-    callback real-element-selected();
+    x: root.pointer-position.x - self.width - 12px;
+    y: root.pointer-position.y - self.height - 12px;
+    width: tip.width + 14px;
+    height: tip.height + 8px;
+    border-radius: 6px;
+    background: StudioTheme.accent-strong;
+    drop-shadow-blur: 12px;
+    drop-shadow-offset-y: 4px;
+    drop-shadow-color: #33415535;
+    accessible-role: AccessibleRole.text;
+    accessible-label: root.value-label;
+    accessible-value: root.raw-value;
 
-    function normalized-angle(value: angle) -> angle {
-        let normalized = value.mod(360deg);
-        return normalized < 0deg ? normalized + 360deg : normalized;
+    tip := Text {
+        text: root.label + " " + root.value;
+        color: white;
+        font-size: 12px;
+        horizontal-alignment: center;
+        vertical-alignment: center;
+        accessible-role: none;
     }
+}
 
-    function current-length-property(property-name: string) -> length {
-        return Api.current-property-value-data(property-name).value-float * 1px;
-    }
+component SelectedCanvasFrame inherits Rectangle {
+    in property <SelectionRectangle> selection;
+    in property <bool> primary;
+    in property <bool> shift-pressed;
+    in property <bool> interaction-disabled;
+    callback pointer-hovered(Point);
+
+    private property <bool> geometry-drag-active: false;
+    private property <Point> geometry-drag-position: { x: 0px, y: 0px };
+    private property <Size> geometry-drag-size: { width: 0px, height: 0px };
+    private property <bool> rotation-active: false;
+    private property <angle> pending-rotation: 0deg;
 
     function current-corner-radius(property-name: string) -> length {
         let corner = Api.current-property-value-data(property-name);
-        return corner.code != "" ? corner.value-float * 1px : root.current-length-property("border-radius");
+        return corner.code != ""
+            ? corner.value-float * 1px
+            : Api.current-property-value-data("border-radius").value-float * 1px;
     }
 
+    function preview-geometry(position: Point, size: Size) {
+        root.geometry-drag-active = true;
+        root.geometry-drag-position = position;
+        root.geometry-drag-size = size;
+        // Push live geometry so the previewed element follows the drag through
+        // debug-hook overrides without writing to disk.
+        Api.override-selected-element-geometry(
+            position.x - EditorMetrics.phone-outer-padding,
+            position.y - EditorMetrics.phone-outer-padding,
+            size.width,
+            size.height,
+        );
+    }
+
+    function finish-interaction(radius-active: bool) {
+        if root.geometry-drag-active {
+            Api.persist-selected-element-geometry();
+        }
+        if root.rotation-active {
+            Api.selected-element-rotate(root.pending-rotation);
+        }
+        if radius-active {
+            Api.persist-selected-element-border-radius();
+        }
+        root.geometry-drag-active = false;
+        root.rotation-active = false;
+    }
+
+    frame := BorderRadiusFrame {
+        x: root.geometry-drag-active && root.primary
+            ? root.geometry-drag-position.x
+            : root.selection.x + EditorMetrics.phone-outer-padding;
+        y: root.geometry-drag-active && root.primary
+            ? root.geometry-drag-position.y
+            : root.selection.y + EditorMetrics.phone-outer-padding;
+        width: root.geometry-drag-active && root.primary
+            ? root.geometry-drag-size.width
+            : root.selection.width;
+        height: root.geometry-drag-active && root.primary
+            ? root.geometry-drag-size.height
+            : root.selection.height;
+        rotation: root.rotation-active && root.primary ? root.pending-rotation : root.selection.angle;
+        accessible-prefix: Api.current-element.type-name;
+        active: !root.interaction-disabled;
+        shift-pressed: root.shift-pressed;
+        show-resize-handles: root.primary;
+        show-rotation-handles: root.primary;
+        enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
+        top-left-radius: root.current-corner-radius("border-top-left-radius");
+        top-right-radius: root.current-corner-radius("border-top-right-radius");
+        bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");
+        bottom-left-radius: root.current-corner-radius("border-bottom-left-radius");
+        // Only allow move/resize for elements that have geometry outside a layout, and only
+        // when the element is not rotated (we don't support rotating + repositioning at once).
+        resizable: root.primary && Api.selection.is-resizable && root.selection.angle == 0deg;
+        moveable: root.primary && Api.selection.is-moveable && root.selection.angle == 0deg;
+        accessible-role: AccessibleRole.region;
+        accessible-label: "Selected " + Api.current-element.type-name;
+
+        rotated-to(rotation) => {
+            root.rotation-active = true;
+            root.pending-rotation = rotation;
+            Api.override-selected-element-rotation(rotation);
+        }
+        interaction-started => {
+            root.rotation-active = false;
+            Hover.element = {};
+        }
+        pointer-moved(position) => {
+            if !self.move-pressed {
+                root.pointer-hovered({
+                    x: position.x - EditorMetrics.phone-outer-padding,
+                    y: position.y - EditorMetrics.phone-outer-padding,
+                });
+            }
+        }
+        radius-changed(corner, radius, single-corner) => {
+            Api.override-selected-element-border-radius(corner, radius, single-corner);
+        }
+        resized-to(corner, position, size) => {
+            root.preview-geometry(position, size);
+        }
+        moved-to(position) => {
+            root.preview-geometry(position, {
+                width: root.selection.width,
+                height: root.selection.height,
+            });
+        }
+        interaction-ended => {
+            root.finish-interaction(self.radius-tooltip-visible);
+        }
+    }
+
+    if frame.radius-tooltip-visible: CanvasValueTooltip {
+        label: "Radius";
+        value: (frame.radius-tooltip-value / 1px).to-fixed(0);
+        raw-value: self.value;
+        value-label: "Radius value";
+        pointer-position: {
+            x: frame.x + frame.radius-tooltip-position.x,
+            y: frame.y + frame.radius-tooltip-position.y,
+        };
+    }
+
+    if frame.rotation-tooltip-visible: CanvasValueTooltip {
+        private property <angle> normalized-angle: {
+            let normalized = frame.rotation-tooltip-value.mod(360deg);
+            normalized < 0deg ? normalized + 360deg : normalized
+        };
+        label: "Rotation";
+        raw-value: "\{(self.normalized-angle / 1deg).round()}";
+        value: self.raw-value + "°";
+        value-label: "Rotation angle";
+        pointer-position: frame.rotation-tooltip-position;
+    }
+}
+
+component HoverCanvasFrame inherits MoveResizeFrame {
+    in property <SelectionRectangle> geometry;
+    in property <bool> gesture-active;
+    in property <bool> selection-area-has-hover;
+    in property <Point> hovered-hit-position;
+    callback gesture-started();
+    callback gesture-ended();
+    callback pointer-hovered(Point);
+    callback real-element-selected();
+
+    private property <bool> geometry-drag-active: false;
+    private property <Point> geometry-drag-position: { x: 0px, y: 0px };
+    private property <Size> geometry-drag-size: { width: 0px, height: 0px };
+
+    visible: Hover.element.valid && !Hover.element.is-selected;
+    enabled: root.visible
+        && !Hover.element.is-over-selected-element
+        && (!root.gesture-active || root.move-pressed);
+    x: root.geometry.x + EditorMetrics.phone-outer-padding;
+    y: root.geometry.y + EditorMetrics.phone-outer-padding;
+    width: root.geometry.width;
+    height: root.geometry.height;
+    rotation: root.geometry.angle;
+    active: !root.gesture-active || root.move-pressed;
+    moveable: root.geometry.angle == 0deg;
+    resizable: false;
+    show-resize-handles: false;
+    show-rotation-handles: false;
+    accessible-prefix: "Hovered " + Hover.element.type-name;
+    accessible-role: AccessibleRole.region;
+    accessible-label: "Hovered " + Hover.element.type-name;
+
+    function preview-geometry(position: Point) {
+        root.geometry-drag-active = true;
+        root.geometry-drag-position = position;
+        root.geometry-drag-size = {
+            width: root.geometry.width,
+            height: root.geometry.height,
+        };
+        Api.override-selected-element-geometry(
+            position.x - EditorMetrics.phone-outer-padding,
+            position.y - EditorMetrics.phone-outer-padding,
+            root.geometry.width,
+            root.geometry.height,
+        );
+    }
+
+    function finish-interaction() {
+        if root.geometry-drag-active {
+            Api.persist-selected-element-geometry();
+        }
+        root.geometry-drag-active = false;
+        root.gesture-ended();
+        Hover.element = {};
+    }
+
+    changed frame-hover => {
+        if !root.frame-hover && !root.selection-area-has-hover && !root.gesture-active {
+            Hover.element = {};
+        }
+    }
+    selected => {
+        if !root.gesture-active {
+            root.gesture-started();
+            Api.select-element(
+                Hover.element.element-path,
+                Hover.element.element-offset,
+                root.hovered-hit-position.x,
+                root.hovered-hit-position.y,
+            );
+            root.real-element-selected();
+        }
+    }
+    moved-to(position) => {
+        root.preview-geometry(position);
+    }
+    move-released => {
+        if root.gesture-active {
+            root.finish-interaction();
+        }
+    }
+    pointer-moved(position) => {
+        if !root.gesture-active {
+            root.pointer-hovered({
+                x: position.x - EditorMetrics.phone-outer-padding,
+                y: position.y - EditorMetrics.phone-outer-padding,
+            });
+        }
+    }
+
+    states [
+        dragging when root.move-pressed && root.geometry-drag-active: {
+            x: root.geometry-drag-position.x;
+            y: root.geometry-drag-position.y;
+            width: root.geometry-drag-size.width;
+            height: root.geometry-drag-size.height;
+        }
+    ]
+}
+
+export component CanvasInteractionLayer inherits Rectangle {
+    in property <bool> shift-pressed: false;
+    private property <Point> hovered-hit-position: { x: 0px, y: 0px };
+    // Coordinates the selected and hover frames while a hovered item owns the pointer gesture.
+    private property <bool> hover-selection-active: false;
+    // Guard on highlight-index >= 0: after Api.unselect(), the backend still populates
+    // current-element with the component root. Its frame would intercept future selections.
+    private property <[SelectionRectangle]> selections: Api.selection.highlight-index >= 0
+        ? Api.highlight-positions(Api.current-element.source-uri, Api.current-element.offset)
+        : [];
+
+    callback real-element-selected();
+
     function update-hover(position: Point) {
-        if root.hover-press-active || root.selection-drag-active || selection-area.pressed {
+        if root.hover-selection-active || selection-area.pressed {
             return;
         }
         root.hovered-hit-position = position;
@@ -76,260 +314,33 @@ export component CanvasInteractionLayer inherits Rectangle {
         }
     }
 
-    // Selection frame(s) for the currently selected element. Rendered after
-    // selection-area so the active frame intercepts clicks on the selected element.
-    for selection[idx] in root.selections : BorderRadiusFrame {
-        property <SelectionRectangle> s: selection;
-        property <bool> primary: idx == Api.selection.highlight-index;
-        // During a drag the frame follows the pointer locally (no disk write).
-        // When idle it tracks the backend geometry from selections[].
-        x: root.selection-drag-active && primary
-            ? root.selection-drag-position.x
-            : s.x + EditorMetrics.phone-outer-padding;
-        y: root.selection-drag-active && primary
-            ? root.selection-drag-position.y
-            : s.y + EditorMetrics.phone-outer-padding;
-        width: root.selection-drag-active && primary ? root.selection-drag-size.width : s.width;
-        height: root.selection-drag-active && primary ? root.selection-drag-size.height : s.height;
-        rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
-        accessible-prefix: Api.current-element.type-name;
-        active: !root.hover-press-active;
+    // Selected frames precede hover frames so an enabled hover frame receives input.
+    for selection[idx] in root.selections: SelectedCanvasFrame {
+        selection: selection;
+        primary: idx == Api.selection.highlight-index;
         shift-pressed: root.shift-pressed;
-        show-resize-handles: primary;
-        show-rotation-handles: primary;
-        enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
-        top-left-radius: root.current-corner-radius("border-top-left-radius");
-        top-right-radius: root.current-corner-radius("border-top-right-radius");
-        bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");
-        bottom-left-radius: root.current-corner-radius("border-bottom-left-radius");
-        // Only allow move/resize for elements that have geometry outside a layout, and only
-        // when the element is not rotated (we don't support rotating + repositioning at once).
-        resizable: primary && Api.selection.is-resizable && s.angle == 0deg;
-        moveable: primary && Api.selection.is-moveable && s.angle == 0deg;
-        accessible-role: AccessibleRole.region;
-        accessible-label: "Selected " + Api.current-element.type-name;
-
-        rotated-to(rotation) => {
-            root.selection-rotation-active = true;
-            root.selection-rotation = rotation;
-            Api.override-selected-element-rotation(rotation);
-        }
-        interaction-started => {
-            root.selection-rotation-active = false;
-            Hover.element = {};
-        }
-        pointer-moved(position) => {
-            if !self.move-pressed {
-                root.update-hover({
-                    x: position.x - EditorMetrics.phone-outer-padding,
-                    y: position.y - EditorMetrics.phone-outer-padding,
-                });
-            }
-        }
-        changed rotation-tooltip-visible => {
-            root.rotation-tooltip-visible = self.rotation-tooltip-visible;
-        }
-        changed rotation-tooltip-position => {
-            root.rotation-tooltip-position = self.rotation-tooltip-position;
-        }
-        changed rotation-tooltip-value => {
-            root.rotation-tooltip-value = self.rotation-tooltip-value;
-        }
-        changed radius-tooltip-visible => {
-            root.radius-tooltip-visible = self.radius-tooltip-visible;
-        }
-        changed radius-tooltip-position => {
-            root.radius-tooltip-position = {
-                x: self.x + self.radius-tooltip-position.x,
-                y: self.y + self.radius-tooltip-position.y,
-            };
-        }
-        changed radius-tooltip-value => {
-            root.radius-tooltip-value = self.radius-tooltip-value;
-        }
-        radius-changed(corner, radius, single-corner) => {
-            Api.override-selected-element-border-radius(corner, radius, single-corner);
-        }
-
-        resized-to(corner, position, size) => {
-            root.selection-drag-active = true;
-            root.selection-drag-position = position;
-            root.selection-drag-size = size;
-            // Push live geometry (content space) so the previewed element follows the
-            // drag via debug-hook overrides, without writing to disk.
-            Api.override-selected-element-geometry(
-                position.x - EditorMetrics.phone-outer-padding,
-                position.y - EditorMetrics.phone-outer-padding,
-                size.width,
-                size.height,
-            );
-        }
-        moved-to(position) => {
-            let content-position = {
-                x: position.x - EditorMetrics.phone-outer-padding,
-                y: position.y - EditorMetrics.phone-outer-padding,
-            };
-            root.selection-drag-active = true;
-            root.selection-drag-position = position;
-            root.selection-drag-size = { width: s.width, height: s.height };
-            Api.override-selected-element-geometry(
-                content-position.x,
-                content-position.y,
-                s.width,
-                s.height,
-            );
-        }
-        interaction-ended => {
-            if root.selection-drag-active {
-                Api.persist-selected-element-geometry();
-            }
-            if root.selection-rotation-active {
-                Api.selected-element-rotate(root.selection-rotation);
-                root.selection-rotation-active = false;
-            }
-            root.selection-drag-active = false;
-            if self.radius-tooltip-visible {
-                Api.persist-selected-element-border-radius();
-            }
+        interaction-disabled: root.hover-selection-active;
+        pointer-hovered(position) => {
+            root.update-hover(position);
         }
     }
 
-    for geometry[geometry-index] in Hover.element.geometry: hover-frame := MoveResizeFrame {
-        private property <bool> pressed-frame: geometry-index == root.hover-press-index;
-        visible: Hover.element.valid && !Hover.element.is-selected;
-        enabled: self.visible
-            && !Hover.element.is-over-selected-element
-            && (!root.hover-press-active || self.pressed-frame);
-        x: geometry.x + EditorMetrics.phone-outer-padding;
-        y: geometry.y + EditorMetrics.phone-outer-padding;
-        width: geometry.width;
-        height: geometry.height;
-        rotation: geometry.angle;
-        active: !root.hover-press-active || self.pressed-frame;
-        moveable: geometry.angle == 0deg;
-        resizable: false;
-        show-resize-handles: false;
-        show-rotation-handles: false;
-        accessible-prefix: "Hovered " + Hover.element.type-name;
-        accessible-role: AccessibleRole.region;
-        accessible-label: "Hovered " + Hover.element.type-name;
-
-        states [
-            pressed when self.pressed-frame && root.hover-press-active && !root.selection-drag-active: {
-                visible: Hover.element.valid;
-            }
-            dragging when self.pressed-frame && root.hover-press-active && root.selection-drag-active: {
-                visible: Hover.element.valid;
-                x: root.selection-drag-position.x;
-                y: root.selection-drag-position.y;
-                width: root.selection-drag-size.width;
-                height: root.selection-drag-size.height;
-            }
-        ]
-
-        changed frame-hover => {
-            if !self.frame-hover && !selection-area.has-hover && !root.hover-press-active {
-                Hover.element = {};
-            }
+    for geometry in Hover.element.geometry: HoverCanvasFrame {
+        geometry: geometry;
+        gesture-active: root.hover-selection-active;
+        selection-area-has-hover: selection-area.has-hover;
+        hovered-hit-position: root.hovered-hit-position;
+        gesture-started => {
+            root.hover-selection-active = true;
         }
-        selected => {
-            if !root.hover-press-active {
-                root.hover-press-index = geometry-index;
-                root.hover-press-active = true;
-                Api.select-element(
-                    Hover.element.element-path,
-                    Hover.element.element-offset,
-                    root.hovered-hit-position.x,
-                    root.hovered-hit-position.y,
-                );
-                root.real-element-selected();
-            }
+        gesture-ended => {
+            root.hover-selection-active = false;
         }
-        moved-to(position) => {
-            let content-position = {
-                x: position.x - EditorMetrics.phone-outer-padding,
-                y: position.y - EditorMetrics.phone-outer-padding,
-            };
-            root.selection-drag-active = true;
-            root.selection-drag-position = position;
-            root.selection-drag-size = {
-                width: geometry.width,
-                height: geometry.height,
-            };
-            Api.override-selected-element-geometry(
-                content-position.x,
-                content-position.y,
-                geometry.width,
-                geometry.height,
-            );
+        pointer-hovered(position) => {
+            root.update-hover(position);
         }
-        move-released => {
-            if root.hover-press-active {
-                if root.selection-drag-active {
-                    Api.persist-selected-element-geometry();
-                }
-                root.selection-drag-active = false;
-                root.hover-press-active = false;
-                root.hover-press-index = -1;
-                Hover.element = {};
-            }
-        }
-        pointer-moved(position) => {
-            if !root.hover-press-active {
-                root.update-hover({
-                    x: position.x - EditorMetrics.phone-outer-padding,
-                    y: position.y - EditorMetrics.phone-outer-padding,
-                });
-            }
-        }
-    }
-
-    if root.radius-tooltip-visible: Rectangle {
-        x: root.radius-tooltip-position.x - self.width - 12px;
-        y: root.radius-tooltip-position.y - self.height - 12px;
-        width: radius-tip.width + 14px;
-        height: radius-tip.height + 8px;
-        border-radius: 6px;
-        background: StudioTheme.accent-strong;
-        drop-shadow-blur: 12px;
-        drop-shadow-offset-y: 4px;
-        drop-shadow-color: #33415535;
-        accessible-role: AccessibleRole.text;
-        accessible-label: "Radius value";
-        accessible-value: (root.radius-tooltip-value / 1px).to-fixed(0);
-
-        radius-tip := Text {
-            text: "Radius \{(root.radius-tooltip-value / 1px).to-fixed(0)}";
-            color: white;
-            font-size: 12px;
-            horizontal-alignment: center;
-            vertical-alignment: center;
-            accessible-role: none;
-        }
-    }
-
-    if root.rotation-tooltip-visible: Rectangle {
-        property <int> display-angle: (root.normalized-angle(root.rotation-tooltip-value) / 1deg).round();
-        x: root.rotation-tooltip-position.x - self.width - 12px;
-        y: root.rotation-tooltip-position.y - self.height - 12px;
-        width: rotation-tip.width + 14px;
-        height: rotation-tip.height + 8px;
-        border-radius: 6px;
-        background: StudioTheme.accent-strong;
-        drop-shadow-blur: 12px;
-        drop-shadow-offset-y: 4px;
-        drop-shadow-color: #33415535;
-        accessible-role: AccessibleRole.text;
-        accessible-label: "Rotation angle";
-        accessible-value: "\{self.display-angle}";
-
-        rotation-tip := Text {
-            text: "Rotation \{parent.display-angle}°";
-            color: white;
-            font-size: 12px;
-            horizontal-alignment: center;
-            vertical-alignment: center;
-            accessible-role: none;
+        real-element-selected => {
+            root.real-element-selected();
         }
     }
 }

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -9,7 +9,7 @@ import { MoveResizeFrame } from "move-resize-frame.slint";
 component CanvasValueTooltip inherits Rectangle {
     in property <string> label;
     in property <string> value;
-    in property <string> suffix: "";
+    in property <string> suffix;
     in property <string> value-label;
     in property <Point> pointer-position;
 

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -178,7 +178,6 @@ component HoverCanvasFrame inherits MoveResizeFrame {
     in property <SelectionRectangle> geometry;
     in property <bool> gesture-active;
     in property <bool> selection-area-has-hover;
-    in property <Point> hovered-hit-position;
     callback gesture-started();
     callback gesture-ended();
     callback pointer-hovered(Point);
@@ -235,14 +234,14 @@ component HoverCanvasFrame inherits MoveResizeFrame {
             Hover.element = {};
         }
     }
-    selected => {
+    move-press-started(position) => {
         if !root.gesture-active {
             root.gesture-started();
             Api.select-element(
                 Hover.element.element-path,
                 Hover.element.element-offset,
-                root.hovered-hit-position.x,
-                root.hovered-hit-position.y,
+                position.x,
+                position.y,
             );
             root.real-element-selected();
         }
@@ -273,7 +272,6 @@ component HoverCanvasFrame inherits MoveResizeFrame {
 
 export component CanvasInteractionLayer inherits Rectangle {
     in property <bool> shift-pressed;
-    private property <Point> hovered-hit-position;
     // Coordinates the selected and hover frames while a hovered item owns the pointer gesture.
     private property <bool> hover-selection-active;
     // Guard on highlight-index >= 0: after Api.unselect(), the backend still populates
@@ -288,7 +286,6 @@ export component CanvasInteractionLayer inherits Rectangle {
         if root.hover-selection-active || selection-area.pressed {
             return;
         }
-        root.hovered-hit-position = position;
         Hover.element = Api.hovered-element-at(position.x, position.y, false);
     }
 
@@ -325,7 +322,6 @@ export component CanvasInteractionLayer inherits Rectangle {
         geometry: geometry;
         gesture-active: root.hover-selection-active;
         selection-area-has-hover: selection-area.has-hover;
-        hovered-hit-position: root.hovered-hit-position;
         gesture-started => {
             root.hover-selection-active = true;
         }

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -9,7 +9,7 @@ import { MoveResizeFrame } from "move-resize-frame.slint";
 component CanvasValueTooltip inherits Rectangle {
     in property <string> label;
     in property <string> value;
-    in property <string> raw-value;
+    in property <string> suffix: "";
     in property <string> value-label;
     in property <Point> pointer-position;
 
@@ -24,10 +24,10 @@ component CanvasValueTooltip inherits Rectangle {
     drop-shadow-color: #33415535;
     accessible-role: AccessibleRole.text;
     accessible-label: root.value-label;
-    accessible-value: root.raw-value;
+    accessible-value: root.value;
 
     tip := Text {
-        text: root.label + " " + root.value;
+        text: root.label + " " + root.value + root.suffix;
         color: white;
         font-size: 12px;
         horizontal-alignment: center;
@@ -87,19 +87,11 @@ component SelectedCanvasFrame inherits Rectangle {
     }
 
     frame := BorderRadiusFrame {
-        x: root.geometry-drag-active && root.primary
-            ? root.geometry-drag-position.x
-            : root.selection.x;
-        y: root.geometry-drag-active && root.primary
-            ? root.geometry-drag-position.y
-            : root.selection.y;
-        width: root.geometry-drag-active && root.primary
-            ? root.geometry-drag-size.width
-            : root.selection.width;
-        height: root.geometry-drag-active && root.primary
-            ? root.geometry-drag-size.height
-            : root.selection.height;
-        rotation: root.rotation-active && root.primary ? root.pending-rotation : root.selection.angle;
+        x: root.selection.x;
+        y: root.selection.y;
+        width: root.selection.width;
+        height: root.selection.height;
+        rotation: root.selection.angle;
         accessible-prefix: Api.current-element.type-name;
         active: !root.interaction-disabled;
         shift-pressed: root.shift-pressed;
@@ -150,10 +142,21 @@ component SelectedCanvasFrame inherits Rectangle {
         }
     }
 
+    states [
+        geometry-dragging when root.geometry-drag-active: {
+            frame.x: root.geometry-drag-position.x;
+            frame.y: root.geometry-drag-position.y;
+            frame.width: root.geometry-drag-size.width;
+            frame.height: root.geometry-drag-size.height;
+        }
+        rotation-dragging when root.rotation-active: {
+            frame.rotation: root.pending-rotation;
+        }
+    ]
+
     if frame.radius-tooltip-visible: CanvasValueTooltip {
         label: "Radius";
         value: (frame.radius-tooltip-value / 1px).to-fixed(0);
-        raw-value: self.value;
         value-label: "Radius value";
         pointer-position: {
             x: frame.x + frame.radius-tooltip-position.x,
@@ -167,8 +170,8 @@ component SelectedCanvasFrame inherits Rectangle {
             normalized < 0deg ? normalized + 360deg : normalized
         };
         label: "Rotation";
-        raw-value: "\{(self.normalized-angle / 1deg).round()}";
-        value: self.raw-value + "°";
+        value: "\{(self.normalized-angle / 1deg).round()}";
+        suffix: "°";
         value-label: "Rotation angle";
         pointer-position: frame.rotation-tooltip-position;
     }
@@ -183,9 +186,7 @@ component HoverCanvasFrame inherits MoveResizeFrame {
     callback pointer-hovered(Point);
     callback real-element-selected();
 
-    private property <bool> geometry-drag-active;
     private property <Point> geometry-drag-position;
-    private property <Size> geometry-drag-size;
 
     visible: Hover.element.valid && !Hover.element.is-selected;
     enabled: root.visible
@@ -203,15 +204,10 @@ component HoverCanvasFrame inherits MoveResizeFrame {
     show-rotation-handles: false;
     accessible-prefix: "Hovered " + Hover.element.type-name;
     accessible-role: AccessibleRole.region;
-    accessible-label: "Hovered " + Hover.element.type-name;
+    accessible-label: root.accessible-prefix;
 
     function preview-geometry(position: Point) {
-        root.geometry-drag-active = true;
         root.geometry-drag-position = position;
-        root.geometry-drag-size = {
-            width: root.geometry.width,
-            height: root.geometry.height,
-        };
         Api.override-selected-element-geometry(
             position.x,
             position.y,
@@ -221,10 +217,9 @@ component HoverCanvasFrame inherits MoveResizeFrame {
     }
 
     function finish-interaction() {
-        if root.geometry-drag-active {
+        if root.move-dragging {
             Api.persist-selected-element-geometry();
         }
-        root.geometry-drag-active = false;
         root.gesture-ended();
         Hover.element = {};
     }
@@ -261,11 +256,9 @@ component HoverCanvasFrame inherits MoveResizeFrame {
     }
 
     states [
-        dragging when root.move-pressed && root.geometry-drag-active: {
+        dragging when root.move-dragging: {
             x: root.geometry-drag-position.x;
             y: root.geometry-drag-position.y;
-            width: root.geometry-drag-size.width;
-            height: root.geometry-drag-size.height;
         }
     ]
 }

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -287,7 +287,7 @@ export component CanvasInteractionLayer inherits Rectangle {
         if root.hover-selection-active || selection-area.pressed {
             return;
         }
-        Hover.element = Api.hovered-element-at(position.x, position.y, false);
+        Hover.element = Hover.element-at(position.x, position.y, false);
     }
 
     // Click to select the real previewed element. This sits on top of the live

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -48,6 +48,7 @@ component SelectedCanvasFrame inherits Rectangle {
     private property <Size> geometry-drag-size;
     private property <bool> rotation-active;
     private property <angle> pending-rotation;
+    private property <bool> radius-drag-active;
 
     function current-corner-radius(property-name: string) -> length {
         let corner = Api.current-property-value-data(property-name);
@@ -70,18 +71,19 @@ component SelectedCanvasFrame inherits Rectangle {
         );
     }
 
-    function finish-interaction(radius-active: bool) {
+    function finish-interaction() {
         if root.geometry-drag-active {
             Api.persist-selected-element-geometry();
         }
         if root.rotation-active {
             Api.selected-element-rotate(root.pending-rotation);
         }
-        if radius-active {
+        if root.radius-drag-active {
             Api.persist-selected-element-border-radius();
         }
         root.geometry-drag-active = false;
         root.rotation-active = false;
+        root.radius-drag-active = false;
     }
 
     frame := BorderRadiusFrame {
@@ -103,7 +105,7 @@ component SelectedCanvasFrame inherits Rectangle {
         shift-pressed: root.shift-pressed;
         show-resize-handles: root.primary;
         show-rotation-handles: root.primary;
-        enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
+        enable-border-radius-edits: root.primary && Api.current-element.type-name == "Rectangle";
         top-left-radius: root.current-corner-radius("border-top-left-radius");
         top-right-radius: root.current-corner-radius("border-top-right-radius");
         bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");
@@ -122,6 +124,7 @@ component SelectedCanvasFrame inherits Rectangle {
         }
         interaction-started => {
             root.rotation-active = false;
+            root.radius-drag-active = false;
             Hover.element = {};
         }
         pointer-moved(position) => {
@@ -130,6 +133,7 @@ component SelectedCanvasFrame inherits Rectangle {
             }
         }
         radius-changed(corner, radius, single-corner) => {
+            root.radius-drag-active = true;
             Api.override-selected-element-border-radius(corner, radius, single-corner);
         }
         resized-to(corner, position, size) => {
@@ -142,7 +146,7 @@ component SelectedCanvasFrame inherits Rectangle {
             });
         }
         interaction-ended => {
-            root.finish-interaction(self.radius-tooltip-visible);
+            root.finish-interaction();
         }
     }
 

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -1,0 +1,335 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Api, CanvasCorner, Hover, SelectionRectangle } from "../api.slint";
+import { EditorCursors, EditorMetrics, StudioTheme } from "common.slint";
+import { BorderRadiusFrame } from "border-radius-frame.slint";
+import { MoveResizeFrame } from "move-resize-frame.slint";
+
+export component CanvasInteractionLayer inherits Rectangle {
+    in property <bool> shift-pressed: false;
+    private property <bool> radius-tooltip-visible: false;
+    private property <Point> radius-tooltip-position: { x: 0px, y: 0px };
+    private property <length> radius-tooltip-value: 0px;
+    private property <bool> rotation-tooltip-visible: false;
+    private property <Point> rotation-tooltip-position: { x: 0px, y: 0px };
+    private property <angle> rotation-tooltip-value: 0deg;
+    // Bounding rectangles of the currently selected element, in phone-content coordinates.
+    // Guard on highlight-index >= 0: after Api.unselect(), the backend still populates
+    // current-element with the component root (for the property panel), which would make
+    // highlight-positions return a component-sized rect. That rect's move-touch would
+    // silently swallow all subsequent clicks, preventing re-selection.
+    property <[SelectionRectangle]> selections: Api.selection.highlight-index >= 0
+        ? Api.highlight-positions(Api.current-element.source-uri, Api.current-element.offset)
+        : [];
+    // Outline-drag state: while dragging a handle the frame follows the pointer locally
+    private property <bool> selection-drag-active: false;
+    private property <Point> selection-drag-position;
+    private property <Size> selection-drag-size;
+    private property <bool> selection-rotation-active: false;
+    private property <angle> selection-rotation;
+    private property <Point> hovered-hit-position: { x: 0px, y: 0px };
+    private property <bool> hover-press-active: false;
+    private property <int> hover-press-index: -1;
+
+    callback real-element-selected();
+
+    function normalized-angle(value: angle) -> angle {
+        let normalized = value.mod(360deg);
+        return normalized < 0deg ? normalized + 360deg : normalized;
+    }
+
+    function current-length-property(property-name: string) -> length {
+        return Api.current-property-value-data(property-name).value-float * 1px;
+    }
+
+    function current-corner-radius(property-name: string) -> length {
+        let corner = Api.current-property-value-data(property-name);
+        return corner.code != "" ? corner.value-float * 1px : root.current-length-property("border-radius");
+    }
+
+    function update-hover(position: Point) {
+        if root.hover-press-active || root.selection-drag-active || selection-area.pressed {
+            return;
+        }
+        root.hovered-hit-position = position;
+        Hover.element = Api.hovered-element-at(position.x, position.y, false);
+    }
+
+    // Click to select the real previewed element. This sits on top of the live
+    // preview so it intercepts clicks. Its pointer positions are in content coordinates.
+    selection-area := TouchArea {
+        x: EditorMetrics.phone-outer-padding;
+        y: EditorMetrics.phone-outer-padding;
+        width: parent.width - 2 * EditorMetrics.phone-outer-padding;
+        height: parent.height - 2 * EditorMetrics.phone-outer-padding;
+        mouse-cursor: EditorCursors.canvas-default;
+        clicked => {
+            Api.unselect();
+            Api.select-at(self.pressed-x, self.pressed-y, false);
+            root.real-element-selected();
+        }
+        pointer-event(event) => {
+            if event.kind == PointerEventKind.move {
+                root.update-hover({ x: self.mouse-x, y: self.mouse-y });
+            }
+        }
+    }
+
+    // Selection frame(s) for the currently selected element. Rendered after
+    // selection-area so the active frame intercepts clicks on the selected element.
+    for selection[idx] in root.selections : BorderRadiusFrame {
+        property <SelectionRectangle> s: selection;
+        property <bool> primary: idx == Api.selection.highlight-index;
+        // During a drag the frame follows the pointer locally (no disk write).
+        // When idle it tracks the backend geometry from selections[].
+        x: root.selection-drag-active && primary
+            ? root.selection-drag-position.x
+            : s.x + EditorMetrics.phone-outer-padding;
+        y: root.selection-drag-active && primary
+            ? root.selection-drag-position.y
+            : s.y + EditorMetrics.phone-outer-padding;
+        width: root.selection-drag-active && primary ? root.selection-drag-size.width : s.width;
+        height: root.selection-drag-active && primary ? root.selection-drag-size.height : s.height;
+        rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
+        accessible-prefix: Api.current-element.type-name;
+        active: !root.hover-press-active;
+        shift-pressed: root.shift-pressed;
+        show-resize-handles: primary;
+        show-rotation-handles: primary;
+        enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
+        top-left-radius: root.current-corner-radius("border-top-left-radius");
+        top-right-radius: root.current-corner-radius("border-top-right-radius");
+        bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");
+        bottom-left-radius: root.current-corner-radius("border-bottom-left-radius");
+        // Only allow move/resize for elements that have geometry outside a layout, and only
+        // when the element is not rotated (we don't support rotating + repositioning at once).
+        resizable: primary && Api.selection.is-resizable && s.angle == 0deg;
+        moveable: primary && Api.selection.is-moveable && s.angle == 0deg;
+        accessible-role: AccessibleRole.region;
+        accessible-label: "Selected " + Api.current-element.type-name;
+
+        rotated-to(rotation) => {
+            root.selection-rotation-active = true;
+            root.selection-rotation = rotation;
+            Api.override-selected-element-rotation(rotation);
+        }
+        interaction-started => {
+            root.selection-rotation-active = false;
+            Hover.element = {};
+        }
+        pointer-moved(position) => {
+            if !self.move-pressed {
+                root.update-hover({
+                    x: position.x - EditorMetrics.phone-outer-padding,
+                    y: position.y - EditorMetrics.phone-outer-padding,
+                });
+            }
+        }
+        changed rotation-tooltip-visible => {
+            root.rotation-tooltip-visible = self.rotation-tooltip-visible;
+        }
+        changed rotation-tooltip-position => {
+            root.rotation-tooltip-position = self.rotation-tooltip-position;
+        }
+        changed rotation-tooltip-value => {
+            root.rotation-tooltip-value = self.rotation-tooltip-value;
+        }
+        changed radius-tooltip-visible => {
+            root.radius-tooltip-visible = self.radius-tooltip-visible;
+        }
+        changed radius-tooltip-position => {
+            root.radius-tooltip-position = {
+                x: self.x + self.radius-tooltip-position.x,
+                y: self.y + self.radius-tooltip-position.y,
+            };
+        }
+        changed radius-tooltip-value => {
+            root.radius-tooltip-value = self.radius-tooltip-value;
+        }
+        radius-changed(corner, radius, single-corner) => {
+            Api.override-selected-element-border-radius(corner, radius, single-corner);
+        }
+
+        resized-to(corner, position, size) => {
+            root.selection-drag-active = true;
+            root.selection-drag-position = position;
+            root.selection-drag-size = size;
+            // Push live geometry (content space) so the previewed element follows the
+            // drag via debug-hook overrides, without writing to disk.
+            Api.override-selected-element-geometry(
+                position.x - EditorMetrics.phone-outer-padding,
+                position.y - EditorMetrics.phone-outer-padding,
+                size.width,
+                size.height,
+            );
+        }
+        moved-to(position) => {
+            let content-position = {
+                x: position.x - EditorMetrics.phone-outer-padding,
+                y: position.y - EditorMetrics.phone-outer-padding,
+            };
+            root.selection-drag-active = true;
+            root.selection-drag-position = position;
+            root.selection-drag-size = { width: s.width, height: s.height };
+            Api.override-selected-element-geometry(
+                content-position.x,
+                content-position.y,
+                s.width,
+                s.height,
+            );
+        }
+        interaction-ended => {
+            if root.selection-drag-active {
+                Api.persist-selected-element-geometry();
+            }
+            if root.selection-rotation-active {
+                Api.selected-element-rotate(root.selection-rotation);
+                root.selection-rotation-active = false;
+            }
+            root.selection-drag-active = false;
+            if self.radius-tooltip-visible {
+                Api.persist-selected-element-border-radius();
+            }
+        }
+    }
+
+    for geometry[geometry-index] in Hover.element.geometry: hover-frame := MoveResizeFrame {
+        private property <bool> pressed-frame: geometry-index == root.hover-press-index;
+        visible: Hover.element.valid && !Hover.element.is-selected;
+        enabled: self.visible
+            && !Hover.element.is-over-selected-element
+            && (!root.hover-press-active || self.pressed-frame);
+        x: geometry.x + EditorMetrics.phone-outer-padding;
+        y: geometry.y + EditorMetrics.phone-outer-padding;
+        width: geometry.width;
+        height: geometry.height;
+        rotation: geometry.angle;
+        active: !root.hover-press-active || self.pressed-frame;
+        moveable: geometry.angle == 0deg;
+        resizable: false;
+        show-resize-handles: false;
+        show-rotation-handles: false;
+        accessible-prefix: "Hovered " + Hover.element.type-name;
+        accessible-role: AccessibleRole.region;
+        accessible-label: "Hovered " + Hover.element.type-name;
+
+        states [
+            pressed when self.pressed-frame && root.hover-press-active && !root.selection-drag-active: {
+                visible: Hover.element.valid;
+            }
+            dragging when self.pressed-frame && root.hover-press-active && root.selection-drag-active: {
+                visible: Hover.element.valid;
+                x: root.selection-drag-position.x;
+                y: root.selection-drag-position.y;
+                width: root.selection-drag-size.width;
+                height: root.selection-drag-size.height;
+            }
+        ]
+
+        changed frame-hover => {
+            if !self.frame-hover && !selection-area.has-hover && !root.hover-press-active {
+                Hover.element = {};
+            }
+        }
+        selected => {
+            if !root.hover-press-active {
+                root.hover-press-index = geometry-index;
+                root.hover-press-active = true;
+                Api.select-element(
+                    Hover.element.element-path,
+                    Hover.element.element-offset,
+                    root.hovered-hit-position.x,
+                    root.hovered-hit-position.y,
+                );
+                root.real-element-selected();
+            }
+        }
+        moved-to(position) => {
+            let content-position = {
+                x: position.x - EditorMetrics.phone-outer-padding,
+                y: position.y - EditorMetrics.phone-outer-padding,
+            };
+            root.selection-drag-active = true;
+            root.selection-drag-position = position;
+            root.selection-drag-size = {
+                width: geometry.width,
+                height: geometry.height,
+            };
+            Api.override-selected-element-geometry(
+                content-position.x,
+                content-position.y,
+                geometry.width,
+                geometry.height,
+            );
+        }
+        move-released => {
+            if root.hover-press-active {
+                if root.selection-drag-active {
+                    Api.persist-selected-element-geometry();
+                }
+                root.selection-drag-active = false;
+                root.hover-press-active = false;
+                root.hover-press-index = -1;
+                Hover.element = {};
+            }
+        }
+        pointer-moved(position) => {
+            if !root.hover-press-active {
+                root.update-hover({
+                    x: position.x - EditorMetrics.phone-outer-padding,
+                    y: position.y - EditorMetrics.phone-outer-padding,
+                });
+            }
+        }
+    }
+
+    if root.radius-tooltip-visible: Rectangle {
+        x: root.radius-tooltip-position.x - self.width - 12px;
+        y: root.radius-tooltip-position.y - self.height - 12px;
+        width: radius-tip.width + 14px;
+        height: radius-tip.height + 8px;
+        border-radius: 6px;
+        background: StudioTheme.accent-strong;
+        drop-shadow-blur: 12px;
+        drop-shadow-offset-y: 4px;
+        drop-shadow-color: #33415535;
+        accessible-role: AccessibleRole.text;
+        accessible-label: "Radius value";
+        accessible-value: (root.radius-tooltip-value / 1px).to-fixed(0);
+
+        radius-tip := Text {
+            text: "Radius \{(root.radius-tooltip-value / 1px).to-fixed(0)}";
+            color: white;
+            font-size: 12px;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+            accessible-role: none;
+        }
+    }
+
+    if root.rotation-tooltip-visible: Rectangle {
+        property <int> display-angle: (root.normalized-angle(root.rotation-tooltip-value) / 1deg).round();
+        x: root.rotation-tooltip-position.x - self.width - 12px;
+        y: root.rotation-tooltip-position.y - self.height - 12px;
+        width: rotation-tip.width + 14px;
+        height: rotation-tip.height + 8px;
+        border-radius: 6px;
+        background: StudioTheme.accent-strong;
+        drop-shadow-blur: 12px;
+        drop-shadow-offset-y: 4px;
+        drop-shadow-color: #33415535;
+        accessible-role: AccessibleRole.text;
+        accessible-label: "Rotation angle";
+        accessible-value: "\{self.display-angle}";
+
+        rotation-tip := Text {
+            text: "Rotation \{parent.display-angle}°";
+            color: white;
+            font-size: 12px;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+            accessible-role: none;
+        }
+    }
+}

--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -32,6 +32,14 @@ export global EditorIcons {
     out property <image> select-chevron: @image-url("../assets/octicons/select-chevron.svg");
 }
 
+export global EditorCursors {
+    out property <MouseCursor> canvas-default: MouseCursor.custom(
+        @image-url("../assets/cursors/default-32.png"),
+        14,
+        14,
+    );
+}
+
 export global EditorMetrics {
     out property <length> left-pane-width: 286px;
     out property <length> inspector-pane-width: 232px;

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -22,27 +22,18 @@ component PhoneChrome inherits Rectangle {
 }
 
 export component EditorCanvas inherits Rectangle {
-    in property <bool> shift-pressed: false;
+    in property <bool> shift-pressed;
+    private property <length> phone-canvas-top: max(
+        40px,
+        (root.height - EditorMetrics.phone-portrait-height) / 2,
+    );
 
     accessible-role: AccessibleRole.main;
     accessible-label: "Editor canvas";
 
     callback real-element-selected();
 
-    horizontal-stretch: 1;
     background: StudioTheme.canvas;
-
-    function phone-width() -> length {
-        return EditorMetrics.phone-portrait-width;
-    }
-
-    function phone-height() -> length {
-        return EditorMetrics.phone-portrait-height;
-    }
-
-    function phone-canvas-top() -> length {
-        return max(40px, (root.height - root.phone-height()) / 2);
-    }
 
     for row in 28: Rectangle {
         y: row * 32px;
@@ -57,8 +48,6 @@ export component EditorCanvas inherits Rectangle {
     }
 
     TouchArea {
-        width: root.width;
-        height: root.height;
         mouse-cursor: EditorCursors.canvas-default;
 
         clicked => {
@@ -68,7 +57,7 @@ export component EditorCanvas inherits Rectangle {
 
     Rectangle {
         x: (parent.width - phone.width) / 2;
-        y: root.phone-canvas-top() + 18px;
+        y: root.phone-canvas-top + 18px;
         width: phone.width;
         height: phone.height;
         border-radius: EditorMetrics.phone-frame-radius;
@@ -79,14 +68,14 @@ export component EditorCanvas inherits Rectangle {
 
     phone := Rectangle {
         x: (parent.width - self.width) / 2;
-        y: root.phone-canvas-top();
-        width: root.phone-width();
-        height: root.phone-height();
+        y: root.phone-canvas-top;
+        width: EditorMetrics.phone-portrait-width;
+        height: EditorMetrics.phone-portrait-height;
         border-radius: EditorMetrics.phone-frame-radius;
         border-width: 1px;
         border-color: StudioTheme.border;
 
-        touch := TouchArea {
+        TouchArea {
             mouse-cursor: EditorCursors.canvas-default;
             clicked => {
                 Api.unselect();
@@ -137,12 +126,10 @@ export component EditorCanvas inherits Rectangle {
                 }
             }
 
-            property <DropMark> drop-mark <=> Api.drop-mark;
+            property <DropMark> drop-mark: Api.drop-mark;
             if drop-mark.x1 >= 0.0 || drop-mark.y1 >= 0.0 || drop-mark.x2 >= 0.0 || drop-mark.y2 >= 0.0: Rectangle {
-                property <length> mark-x: min(drop-mark.x1, drop-mark.x2);
-                property <length> mark-y: min(drop-mark.y1, drop-mark.y2);
-                x: mark-x;
-                y: mark-y;
+                x: min(drop-mark.x1, drop-mark.x2);
+                y: min(drop-mark.y1, drop-mark.y2);
                 width: max((drop-mark.x2 - drop-mark.x1).abs(), 2px);
                 height: max((drop-mark.y2 - drop-mark.y1).abs(), 2px);
                 border-color: StudioTheme.drop-mark-foreground;
@@ -153,6 +140,10 @@ export component EditorCanvas inherits Rectangle {
         }
 
         CanvasInteractionLayer {
+            x: EditorMetrics.phone-outer-padding;
+            y: EditorMetrics.phone-outer-padding;
+            width: parent.width - 2 * EditorMetrics.phone-outer-padding;
+            height: parent.height - 2 * EditorMetrics.phone-outer-padding;
             shift-pressed: root.shift-pressed;
             real-element-selected => {
                 root.real-element-selected();

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -305,7 +305,6 @@ export component EditorCanvas inherits Rectangle {
                 );
             }
             moved-to(position) => {
-                Hover.element = {};
                 let content-position = {
                     x: position.x - EditorMetrics.phone-outer-padding,
                     y: position.y - EditorMetrics.phone-outer-padding,

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -1,9 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Api, CanvasCorner, DropMark, SelectionRectangle } from "../api.slint";
-import { AppState, EditorMetrics, PaletteComponentKind, StudioTheme } from "common.slint";
+import { Api, CanvasCorner, DropMark, HoveredElement, SelectionRectangle } from "../api.slint";
+import { AppState, EditorCursors, EditorMetrics, PaletteComponentKind, StudioTheme } from "common.slint";
 import { BorderRadiusFrame } from "border-radius-frame.slint";
+import { MoveResizeFrame } from "move-resize-frame.slint";
 
 component PhoneChrome inherits Rectangle {
     background: StudioTheme.phone-bg;
@@ -43,6 +44,9 @@ export component EditorCanvas inherits Rectangle {
     private property <Size> selection-drag-size;
     private property <bool> selection-rotation-active: false;
     private property <angle> selection-rotation;
+    private property <HoveredElement> hovered-element: root.empty-hovered-element();
+    private property <Point> hovered-hit-position: { x: 0px, y: 0px };
+    private property <bool> hover-press-active: false;
 
     accessible-role: AccessibleRole.main;
     accessible-label: "Editor canvas";
@@ -78,6 +82,29 @@ export component EditorCanvas inherits Rectangle {
         return corner.code != "" ? corner.value-float * 1px : root.current-length-property("border-radius");
     }
 
+    function update-hover(position: Point) {
+        if root.hover-press-active || root.selection-drag-active || selection-area.pressed {
+            return;
+        }
+        root.hovered-hit-position = position;
+        root.hovered-element = Api.hovered-element-at(position.x, position.y, false);
+    }
+
+    pure function empty-hovered-element() -> HoveredElement {
+        return {
+            valid: false,
+            is-selected: false,
+            element-path: "",
+            element-offset: 0,
+            type-name: "",
+            x: 0px,
+            y: 0px,
+            width: 0px,
+            height: 0px,
+            angle: 0deg,
+        };
+    }
+
     for row in 28: Rectangle {
         y: row * 32px;
         height: 1px;
@@ -93,6 +120,7 @@ export component EditorCanvas inherits Rectangle {
     TouchArea {
         width: root.width;
         height: root.height;
+        mouse-cursor: EditorCursors.canvas-default;
 
         clicked => {
             Api.unselect();
@@ -120,6 +148,7 @@ export component EditorCanvas inherits Rectangle {
         border-color: StudioTheme.border;
 
         touch := TouchArea {
+            mouse-cursor: EditorCursors.canvas-default;
             clicked => {
                 Api.unselect();
             }
@@ -187,18 +216,18 @@ export component EditorCanvas inherits Rectangle {
             // Sits on top of the live preview so it intercepts clicks.
             // pressed-x/y are already in content coordinates, matching what the backend expects.
             selection-area := TouchArea {
-                mouse-cursor: MouseCursor.custom(
-                    @image-url("../assets/cursors/default-32.png"),
-                    14,
-                    14,
-                );
+                mouse-cursor: EditorCursors.canvas-default;
                 clicked => {
                     Api.unselect();
                     Api.select-at(self.pressed-x, self.pressed-y, false);
                     root.real-element-selected();
                 }
+                pointer-event(event) => {
+                    if event.kind == PointerEventKind.move {
+                        root.update-hover({ x: self.mouse-x, y: self.mouse-y });
+                    }
+                }
             }
-
         }
 
         // Selection frame(s) for the currently selected element. Rendered after
@@ -241,6 +270,12 @@ export component EditorCanvas inherits Rectangle {
             }
             interaction-started => {
                 root.selection-rotation-active = false;
+            }
+            pointer-moved(position) => {
+                root.update-hover({
+                    x: position.x - EditorMetrics.phone-outer-padding,
+                    y: position.y - EditorMetrics.phone-outer-padding,
+                });
             }
             changed rotation-tooltip-visible => {
                 root.rotation-tooltip-visible = self.rotation-tooltip-visible;
@@ -306,6 +341,86 @@ export component EditorCanvas inherits Rectangle {
                 root.selection-drag-active = false;
                 if self.radius-tooltip-visible {
                     Api.persist-selected-element-border-radius();
+                }
+            }
+        }
+
+        hover-frame := MoveResizeFrame {
+            visible: root.hovered-element.valid
+                && (!root.hovered-element.is-selected || root.hover-press-active);
+            enabled: self.visible;
+            x: root.hover-press-active && root.selection-drag-active
+                ? root.selection-drag-position.x
+                : root.hovered-element.x + EditorMetrics.phone-outer-padding;
+            y: root.hover-press-active && root.selection-drag-active
+                ? root.selection-drag-position.y
+                : root.hovered-element.y + EditorMetrics.phone-outer-padding;
+            width: root.hover-press-active && root.selection-drag-active
+                ? root.selection-drag-size.width
+                : root.hovered-element.width;
+            height: root.hover-press-active && root.selection-drag-active
+                ? root.selection-drag-size.height
+                : root.hovered-element.height;
+            rotation: root.hovered-element.angle;
+            active: true;
+            moveable: root.hovered-element.angle == 0deg;
+            resizable: false;
+            show-resize-handles: false;
+            show-rotation-handles: false;
+            accessible-prefix: "Hovered " + root.hovered-element.type-name;
+            accessible-role: AccessibleRole.region;
+            accessible-label: "Hovered " + root.hovered-element.type-name;
+            changed frame-hover => {
+                if !self.frame-hover && !selection-area.has-hover && !root.hover-press-active {
+                    root.hovered-element = root.empty-hovered-element();
+                }
+            }
+            selected => {
+                if !root.hover-press-active {
+                    root.hover-press-active = true;
+                    Api.select-element(
+                        root.hovered-element.element-path,
+                        root.hovered-element.element-offset,
+                        root.hovered-hit-position.x,
+                        root.hovered-hit-position.y,
+                    );
+                    root.real-element-selected();
+                }
+            }
+            moved-to(position) => {
+                let content-position = {
+                    x: position.x - EditorMetrics.phone-outer-padding,
+                    y: position.y - EditorMetrics.phone-outer-padding,
+                };
+                root.selection-drag-active = true;
+                root.selection-drag-position = position;
+                root.selection-drag-size = {
+                    width: root.hovered-element.width,
+                    height: root.hovered-element.height,
+                };
+                Api.override-selected-element-geometry(
+                    content-position.x,
+                    content-position.y,
+                    root.hovered-element.width,
+                    root.hovered-element.height,
+                );
+            }
+            move-released => {
+                if root.hover-press-active {
+                    if root.selection-drag-active {
+                        Api.persist-selected-element-geometry();
+                    }
+                    root.selection-drag-active = false;
+                    root.hover-press-active = false;
+                    root.hovered-element = root.empty-hovered-element();
+                }
+            }
+            pointer-moved(position) => {
+                if !root.hover-press-active {
+                    root.update-hover({
+                        x: position.x - EditorMetrics.phone-outer-padding,
+                        y: position.y - EditorMetrics.phone-outer-padding,
+                    });
                 }
             }
         }

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Api, CanvasCorner, DropMark, HoveredElement, SelectionRectangle } from "../api.slint";
+import { Api, CanvasCorner, DropMark, Hover, SelectionRectangle } from "../api.slint";
 import { AppState, EditorCursors, EditorMetrics, PaletteComponentKind, StudioTheme } from "common.slint";
 import { BorderRadiusFrame } from "border-radius-frame.slint";
 import { MoveResizeFrame } from "move-resize-frame.slint";
@@ -44,9 +44,9 @@ export component EditorCanvas inherits Rectangle {
     private property <Size> selection-drag-size;
     private property <bool> selection-rotation-active: false;
     private property <angle> selection-rotation;
-    private property <HoveredElement> hovered-element: root.empty-hovered-element();
     private property <Point> hovered-hit-position: { x: 0px, y: 0px };
     private property <bool> hover-press-active: false;
+    private property <int> hover-press-index: -1;
 
     accessible-role: AccessibleRole.main;
     accessible-label: "Editor canvas";
@@ -87,22 +87,7 @@ export component EditorCanvas inherits Rectangle {
             return;
         }
         root.hovered-hit-position = position;
-        root.hovered-element = Api.hovered-element-at(position.x, position.y, false);
-    }
-
-    pure function empty-hovered-element() -> HoveredElement {
-        return {
-            valid: false,
-            is-selected: false,
-            element-path: "",
-            element-offset: 0,
-            type-name: "",
-            x: 0px,
-            y: 0px,
-            width: 0px,
-            height: 0px,
-            angle: 0deg,
-        };
+        Hover.element = Api.hovered-element-at(position.x, position.y, false);
     }
 
     for row in 28: Rectangle {
@@ -250,6 +235,7 @@ export component EditorCanvas inherits Rectangle {
             accessible-prefix: Api.current-element.type-name;
             active: !root.hover-press-active;
             shift-pressed: root.shift-pressed;
+            show-resize-handles: primary;
             show-rotation-handles: primary;
             enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
             top-left-radius: root.current-corner-radius("border-top-left-radius");
@@ -270,6 +256,7 @@ export component EditorCanvas inherits Rectangle {
             }
             interaction-started => {
                 root.selection-rotation-active = false;
+                Hover.element = {};
             }
             pointer-moved(position) => {
                 if !self.move-pressed {
@@ -318,6 +305,7 @@ export component EditorCanvas inherits Rectangle {
                 );
             }
             moved-to(position) => {
+                Hover.element = {};
                 let content-position = {
                     x: position.x - EditorMetrics.phone-outer-padding,
                     y: position.y - EditorMetrics.phone-outer-padding,
@@ -347,29 +335,32 @@ export component EditorCanvas inherits Rectangle {
             }
         }
 
-        hover-frame := MoveResizeFrame {
-            visible: root.hovered-element.valid && !root.hovered-element.is-selected;
-            enabled: self.visible;
-            x: root.hovered-element.x + EditorMetrics.phone-outer-padding;
-            y: root.hovered-element.y + EditorMetrics.phone-outer-padding;
-            width: root.hovered-element.width;
-            height: root.hovered-element.height;
-            rotation: root.hovered-element.angle;
-            active: true;
-            moveable: root.hovered-element.angle == 0deg;
+        for geometry[geometry-index] in Hover.element.geometry: hover-frame := MoveResizeFrame {
+            private property <bool> pressed-frame: geometry-index == root.hover-press-index;
+            visible: Hover.element.valid && !Hover.element.is-selected;
+            enabled: self.visible
+                && !Hover.element.is-over-selected-element
+                && (!root.hover-press-active || self.pressed-frame);
+            x: geometry.x + EditorMetrics.phone-outer-padding;
+            y: geometry.y + EditorMetrics.phone-outer-padding;
+            width: geometry.width;
+            height: geometry.height;
+            rotation: geometry.angle;
+            active: !root.hover-press-active || self.pressed-frame;
+            moveable: geometry.angle == 0deg;
             resizable: false;
             show-resize-handles: false;
             show-rotation-handles: false;
-            accessible-prefix: "Hovered " + root.hovered-element.type-name;
+            accessible-prefix: "Hovered " + Hover.element.type-name;
             accessible-role: AccessibleRole.region;
-            accessible-label: "Hovered " + root.hovered-element.type-name;
+            accessible-label: "Hovered " + Hover.element.type-name;
 
             states [
-                pressed when root.hover-press-active && !root.selection-drag-active: {
-                    visible: root.hovered-element.valid;
+                pressed when self.pressed-frame && root.hover-press-active && !root.selection-drag-active: {
+                    visible: Hover.element.valid;
                 }
-                dragging when root.hover-press-active && root.selection-drag-active: {
-                    visible: root.hovered-element.valid;
+                dragging when self.pressed-frame && root.hover-press-active && root.selection-drag-active: {
+                    visible: Hover.element.valid;
                     x: root.selection-drag-position.x;
                     y: root.selection-drag-position.y;
                     width: root.selection-drag-size.width;
@@ -379,15 +370,16 @@ export component EditorCanvas inherits Rectangle {
 
             changed frame-hover => {
                 if !self.frame-hover && !selection-area.has-hover && !root.hover-press-active {
-                    root.hovered-element = root.empty-hovered-element();
+                    Hover.element = {};
                 }
             }
             selected => {
                 if !root.hover-press-active {
+                    root.hover-press-index = geometry-index;
                     root.hover-press-active = true;
                     Api.select-element(
-                        root.hovered-element.element-path,
-                        root.hovered-element.element-offset,
+                        Hover.element.element-path,
+                        Hover.element.element-offset,
                         root.hovered-hit-position.x,
                         root.hovered-hit-position.y,
                     );
@@ -402,14 +394,14 @@ export component EditorCanvas inherits Rectangle {
                 root.selection-drag-active = true;
                 root.selection-drag-position = position;
                 root.selection-drag-size = {
-                    width: root.hovered-element.width,
-                    height: root.hovered-element.height,
+                    width: geometry.width,
+                    height: geometry.height,
                 };
                 Api.override-selected-element-geometry(
                     content-position.x,
                     content-position.y,
-                    root.hovered-element.width,
-                    root.hovered-element.height,
+                    geometry.width,
+                    geometry.height,
                 );
             }
             move-released => {
@@ -419,7 +411,8 @@ export component EditorCanvas inherits Rectangle {
                     }
                     root.selection-drag-active = false;
                     root.hover-press-active = false;
-                    root.hovered-element = root.empty-hovered-element();
+                    root.hover-press-index = -1;
+                    Hover.element = {};
                 }
             }
             pointer-moved(position) => {

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -248,7 +248,7 @@ export component EditorCanvas inherits Rectangle {
             height: root.selection-drag-active && primary ? root.selection-drag-size.height : s.height;
             rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
             accessible-prefix: Api.current-element.type-name;
-            active: true;
+            active: !root.hover-press-active;
             shift-pressed: root.shift-pressed;
             show-rotation-handles: primary;
             enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
@@ -272,10 +272,12 @@ export component EditorCanvas inherits Rectangle {
                 root.selection-rotation-active = false;
             }
             pointer-moved(position) => {
-                root.update-hover({
-                    x: position.x - EditorMetrics.phone-outer-padding,
-                    y: position.y - EditorMetrics.phone-outer-padding,
-                });
+                if !self.move-pressed {
+                    root.update-hover({
+                        x: position.x - EditorMetrics.phone-outer-padding,
+                        y: position.y - EditorMetrics.phone-outer-padding,
+                    });
+                }
             }
             changed rotation-tooltip-visible => {
                 root.rotation-tooltip-visible = self.rotation-tooltip-visible;

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -348,21 +348,12 @@ export component EditorCanvas inherits Rectangle {
         }
 
         hover-frame := MoveResizeFrame {
-            visible: root.hovered-element.valid
-                && (!root.hovered-element.is-selected || root.hover-press-active);
+            visible: root.hovered-element.valid && !root.hovered-element.is-selected;
             enabled: self.visible;
-            x: root.hover-press-active && root.selection-drag-active
-                ? root.selection-drag-position.x
-                : root.hovered-element.x + EditorMetrics.phone-outer-padding;
-            y: root.hover-press-active && root.selection-drag-active
-                ? root.selection-drag-position.y
-                : root.hovered-element.y + EditorMetrics.phone-outer-padding;
-            width: root.hover-press-active && root.selection-drag-active
-                ? root.selection-drag-size.width
-                : root.hovered-element.width;
-            height: root.hover-press-active && root.selection-drag-active
-                ? root.selection-drag-size.height
-                : root.hovered-element.height;
+            x: root.hovered-element.x + EditorMetrics.phone-outer-padding;
+            y: root.hovered-element.y + EditorMetrics.phone-outer-padding;
+            width: root.hovered-element.width;
+            height: root.hovered-element.height;
             rotation: root.hovered-element.angle;
             active: true;
             moveable: root.hovered-element.angle == 0deg;
@@ -372,6 +363,20 @@ export component EditorCanvas inherits Rectangle {
             accessible-prefix: "Hovered " + root.hovered-element.type-name;
             accessible-role: AccessibleRole.region;
             accessible-label: "Hovered " + root.hovered-element.type-name;
+
+            states [
+                pressed when root.hover-press-active && !root.selection-drag-active: {
+                    visible: root.hovered-element.valid;
+                }
+                dragging when root.hover-press-active && root.selection-drag-active: {
+                    visible: root.hovered-element.valid;
+                    x: root.selection-drag-position.x;
+                    y: root.selection-drag-position.y;
+                    width: root.selection-drag-size.width;
+                    height: root.selection-drag-size.height;
+                }
+            ]
+
             changed frame-hover => {
                 if !self.frame-hover && !selection-area.has-hover && !root.hover-press-active {
                     root.hovered-element = root.empty-hovered-element();

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -1,10 +1,9 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Api, CanvasCorner, DropMark, Hover, SelectionRectangle } from "../api.slint";
+import { Api, DropMark } from "../api.slint";
 import { AppState, EditorCursors, EditorMetrics, PaletteComponentKind, StudioTheme } from "common.slint";
-import { BorderRadiusFrame } from "border-radius-frame.slint";
-import { MoveResizeFrame } from "move-resize-frame.slint";
+import { CanvasInteractionLayer } from "canvas-interaction-layer.slint";
 
 component PhoneChrome inherits Rectangle {
     background: StudioTheme.phone-bg;
@@ -24,29 +23,6 @@ component PhoneChrome inherits Rectangle {
 
 export component EditorCanvas inherits Rectangle {
     in property <bool> shift-pressed: false;
-    private property <bool> radius-tooltip-visible: false;
-    private property <Point> radius-tooltip-position: { x: 0px, y: 0px };
-    private property <length> radius-tooltip-value: 0px;
-    private property <bool> rotation-tooltip-visible: false;
-    private property <Point> rotation-tooltip-position: { x: 0px, y: 0px };
-    private property <angle> rotation-tooltip-value: 0deg;
-    // Bounding rectangles of the currently selected element, in phone-content coordinates.
-    // Guard on highlight-index >= 0: after Api.unselect(), the backend still populates
-    // current-element with the component root (for the property panel), which would make
-    // highlight-positions return a component-sized rect. That rect's move-touch would
-    // silently swallow all subsequent clicks, preventing re-selection.
-    property <[SelectionRectangle]> selections: Api.selection.highlight-index >= 0
-        ? Api.highlight-positions(Api.current-element.source-uri, Api.current-element.offset)
-        : [];
-    // Outline-drag state: while dragging a handle the frame follows the pointer locally
-    private property <bool> selection-drag-active: false;
-    private property <Point> selection-drag-position;
-    private property <Size> selection-drag-size;
-    private property <bool> selection-rotation-active: false;
-    private property <angle> selection-rotation;
-    private property <Point> hovered-hit-position: { x: 0px, y: 0px };
-    private property <bool> hover-press-active: false;
-    private property <int> hover-press-index: -1;
 
     accessible-role: AccessibleRole.main;
     accessible-label: "Editor canvas";
@@ -66,28 +42,6 @@ export component EditorCanvas inherits Rectangle {
 
     function phone-canvas-top() -> length {
         return max(40px, (root.height - root.phone-height()) / 2);
-    }
-
-    function normalized-angle(value: angle) -> angle {
-        let normalized = value.mod(360deg);
-        return normalized < 0deg ? normalized + 360deg : normalized;
-    }
-
-    function current-length-property(property-name: string) -> length {
-        return Api.current-property-value-data(property-name).value-float * 1px;
-    }
-
-    function current-corner-radius(property-name: string) -> length {
-        let corner = Api.current-property-value-data(property-name);
-        return corner.code != "" ? corner.value-float * 1px : root.current-length-property("border-radius");
-    }
-
-    function update-hover(position: Point) {
-        if root.hover-press-active || root.selection-drag-active || selection-area.pressed {
-            return;
-        }
-        root.hovered-hit-position = position;
-        Hover.element = Api.hovered-element-at(position.x, position.y, false);
     }
 
     for row in 28: Rectangle {
@@ -196,282 +150,13 @@ export component EditorCanvas inherits Rectangle {
                 accessible-role: AccessibleRole.region;
                 accessible-label: "Canvas drop marker";
             }
-
-            // Click to select the real previewed element.
-            // Sits on top of the live preview so it intercepts clicks.
-            // pressed-x/y are already in content coordinates, matching what the backend expects.
-            selection-area := TouchArea {
-                mouse-cursor: EditorCursors.canvas-default;
-                clicked => {
-                    Api.unselect();
-                    Api.select-at(self.pressed-x, self.pressed-y, false);
-                    root.real-element-selected();
-                }
-                pointer-event(event) => {
-                    if event.kind == PointerEventKind.move {
-                        root.update-hover({ x: self.mouse-x, y: self.mouse-y });
-                    }
-                }
-            }
         }
 
-        // Selection frame(s) for the currently selected element. Rendered after
-        // selection-area so the active frame intercepts clicks on the selected element.
-        // Note: This sits outside of the PhoneChrome so it doesn't get clipped.
-        for selection[idx] in root.selections : BorderRadiusFrame {
-            property <SelectionRectangle> s: selection;
-            property <bool> primary: idx == Api.selection.highlight-index;
-            // During a drag the frame follows the pointer locally (no disk write).
-            // When idle it tracks the backend geometry from selections[].
-            x: root.selection-drag-active && primary
-                ? root.selection-drag-position.x
-                : s.x + EditorMetrics.phone-outer-padding;
-            y: root.selection-drag-active && primary
-                ? root.selection-drag-position.y
-                : s.y + EditorMetrics.phone-outer-padding;
-            width: root.selection-drag-active && primary ? root.selection-drag-size.width : s.width;
-            height: root.selection-drag-active && primary ? root.selection-drag-size.height : s.height;
-            rotation: root.selection-rotation-active && primary ? root.selection-rotation : s.angle;
-            accessible-prefix: Api.current-element.type-name;
-            active: !root.hover-press-active;
+        CanvasInteractionLayer {
             shift-pressed: root.shift-pressed;
-            show-resize-handles: primary;
-            show-rotation-handles: primary;
-            enable-border-radius-edits: Api.current-element.type-name == "Rectangle";
-            top-left-radius: root.current-corner-radius("border-top-left-radius");
-            top-right-radius: root.current-corner-radius("border-top-right-radius");
-            bottom-right-radius: root.current-corner-radius("border-bottom-right-radius");
-            bottom-left-radius: root.current-corner-radius("border-bottom-left-radius");
-            // Only allow move/resize for elements that have geometry outside a layout, and only
-            // when the element is not rotated (we don't support rotating + repositioning at once).
-            resizable: primary && Api.selection.is-resizable && s.angle == 0deg;
-            moveable: primary && Api.selection.is-moveable && s.angle == 0deg;
-            accessible-role: AccessibleRole.region;
-            accessible-label: "Selected " + Api.current-element.type-name;
-
-            rotated-to(rotation) => {
-                root.selection-rotation-active = true;
-                root.selection-rotation = rotation;
-                Api.override-selected-element-rotation(rotation);
-            }
-            interaction-started => {
-                root.selection-rotation-active = false;
-                Hover.element = {};
-            }
-            pointer-moved(position) => {
-                if !self.move-pressed {
-                    root.update-hover({
-                        x: position.x - EditorMetrics.phone-outer-padding,
-                        y: position.y - EditorMetrics.phone-outer-padding,
-                    });
-                }
-            }
-            changed rotation-tooltip-visible => {
-                root.rotation-tooltip-visible = self.rotation-tooltip-visible;
-            }
-            changed rotation-tooltip-position => {
-                root.rotation-tooltip-position = self.rotation-tooltip-position;
-            }
-            changed rotation-tooltip-value => {
-                root.rotation-tooltip-value = self.rotation-tooltip-value;
-            }
-            changed radius-tooltip-visible => {
-                root.radius-tooltip-visible = self.radius-tooltip-visible;
-            }
-            changed radius-tooltip-position => {
-                root.radius-tooltip-position = {
-                    x: self.x + self.radius-tooltip-position.x,
-                    y: self.y + self.radius-tooltip-position.y,
-                };
-            }
-            changed radius-tooltip-value => {
-                root.radius-tooltip-value = self.radius-tooltip-value;
-            }
-            radius-changed(corner, radius, single-corner) => {
-                Api.override-selected-element-border-radius(corner, radius, single-corner);
-            }
-
-            resized-to(corner, position, size) => {
-                root.selection-drag-active = true;
-                root.selection-drag-position = position;
-                root.selection-drag-size = size;
-                // Push live geometry (content space) so the previewed element follows the
-                // drag via debug-hook overrides, without writing to disk.
-                Api.override-selected-element-geometry(
-                    position.x - EditorMetrics.phone-outer-padding,
-                    position.y - EditorMetrics.phone-outer-padding,
-                    size.width,
-                    size.height,
-                );
-            }
-            moved-to(position) => {
-                let content-position = {
-                    x: position.x - EditorMetrics.phone-outer-padding,
-                    y: position.y - EditorMetrics.phone-outer-padding,
-                };
-                root.selection-drag-active = true;
-                root.selection-drag-position = position;
-                root.selection-drag-size = { width: s.width, height: s.height };
-                Api.override-selected-element-geometry(
-                    content-position.x,
-                    content-position.y,
-                    s.width,
-                    s.height,
-                );
-            }
-            interaction-ended => {
-                if root.selection-drag-active {
-                    Api.persist-selected-element-geometry();
-                }
-                if root.selection-rotation-active {
-                    Api.selected-element-rotate(root.selection-rotation);
-                    root.selection-rotation-active = false;
-                }
-                root.selection-drag-active = false;
-                if self.radius-tooltip-visible {
-                    Api.persist-selected-element-border-radius();
-                }
-            }
-        }
-
-        for geometry[geometry-index] in Hover.element.geometry: hover-frame := MoveResizeFrame {
-            private property <bool> pressed-frame: geometry-index == root.hover-press-index;
-            visible: Hover.element.valid && !Hover.element.is-selected;
-            enabled: self.visible
-                && !Hover.element.is-over-selected-element
-                && (!root.hover-press-active || self.pressed-frame);
-            x: geometry.x + EditorMetrics.phone-outer-padding;
-            y: geometry.y + EditorMetrics.phone-outer-padding;
-            width: geometry.width;
-            height: geometry.height;
-            rotation: geometry.angle;
-            active: !root.hover-press-active || self.pressed-frame;
-            moveable: geometry.angle == 0deg;
-            resizable: false;
-            show-resize-handles: false;
-            show-rotation-handles: false;
-            accessible-prefix: "Hovered " + Hover.element.type-name;
-            accessible-role: AccessibleRole.region;
-            accessible-label: "Hovered " + Hover.element.type-name;
-
-            states [
-                pressed when self.pressed-frame && root.hover-press-active && !root.selection-drag-active: {
-                    visible: Hover.element.valid;
-                }
-                dragging when self.pressed-frame && root.hover-press-active && root.selection-drag-active: {
-                    visible: Hover.element.valid;
-                    x: root.selection-drag-position.x;
-                    y: root.selection-drag-position.y;
-                    width: root.selection-drag-size.width;
-                    height: root.selection-drag-size.height;
-                }
-            ]
-
-            changed frame-hover => {
-                if !self.frame-hover && !selection-area.has-hover && !root.hover-press-active {
-                    Hover.element = {};
-                }
-            }
-            selected => {
-                if !root.hover-press-active {
-                    root.hover-press-index = geometry-index;
-                    root.hover-press-active = true;
-                    Api.select-element(
-                        Hover.element.element-path,
-                        Hover.element.element-offset,
-                        root.hovered-hit-position.x,
-                        root.hovered-hit-position.y,
-                    );
-                    root.real-element-selected();
-                }
-            }
-            moved-to(position) => {
-                let content-position = {
-                    x: position.x - EditorMetrics.phone-outer-padding,
-                    y: position.y - EditorMetrics.phone-outer-padding,
-                };
-                root.selection-drag-active = true;
-                root.selection-drag-position = position;
-                root.selection-drag-size = {
-                    width: geometry.width,
-                    height: geometry.height,
-                };
-                Api.override-selected-element-geometry(
-                    content-position.x,
-                    content-position.y,
-                    geometry.width,
-                    geometry.height,
-                );
-            }
-            move-released => {
-                if root.hover-press-active {
-                    if root.selection-drag-active {
-                        Api.persist-selected-element-geometry();
-                    }
-                    root.selection-drag-active = false;
-                    root.hover-press-active = false;
-                    root.hover-press-index = -1;
-                    Hover.element = {};
-                }
-            }
-            pointer-moved(position) => {
-                if !root.hover-press-active {
-                    root.update-hover({
-                        x: position.x - EditorMetrics.phone-outer-padding,
-                        y: position.y - EditorMetrics.phone-outer-padding,
-                    });
-                }
-            }
-        }
-
-        if root.radius-tooltip-visible: Rectangle {
-            x: root.radius-tooltip-position.x - self.width - 12px;
-            y: root.radius-tooltip-position.y - self.height - 12px;
-            width: radius-tip.width + 14px;
-            height: radius-tip.height + 8px;
-            border-radius: 6px;
-            background: StudioTheme.accent-strong;
-            drop-shadow-blur: 12px;
-            drop-shadow-offset-y: 4px;
-            drop-shadow-color: #33415535;
-            accessible-role: AccessibleRole.text;
-            accessible-label: "Radius value";
-            accessible-value: (root.radius-tooltip-value / 1px).to-fixed(0);
-
-            radius-tip := Text {
-                text: "Radius \{(root.radius-tooltip-value / 1px).to-fixed(0)}";
-                color: white;
-                font-size: 12px;
-                horizontal-alignment: center;
-                vertical-alignment: center;
-                accessible-role: none;
-            }
-        }
-
-        if root.rotation-tooltip-visible: Rectangle {
-            property <int> display-angle: (root.normalized-angle(root.rotation-tooltip-value) / 1deg).round();
-            x: root.rotation-tooltip-position.x - self.width - 12px;
-            y: root.rotation-tooltip-position.y - self.height - 12px;
-            width: rotation-tip.width + 14px;
-            height: rotation-tip.height + 8px;
-            border-radius: 6px;
-            background: StudioTheme.accent-strong;
-            drop-shadow-blur: 12px;
-            drop-shadow-offset-y: 4px;
-            drop-shadow-color: #33415535;
-            accessible-role: AccessibleRole.text;
-            accessible-label: "Rotation angle";
-            accessible-value: "\{self.display-angle}";
-
-            rotation-tip := Text {
-                text: "Rotation \{parent.display-angle}°";
-                color: white;
-                font-size: 12px;
-                horizontal-alignment: center;
-                vertical-alignment: center;
-                accessible-role: none;
+            real-element-selected => {
+                root.real-element-selected();
             }
         }
     }
-
 }

--- a/tools/editor/ui/components/move-resize-frame.slint
+++ b/tools/editor/ui/components/move-resize-frame.slint
@@ -3,13 +3,15 @@
 
 // cspell:ignore nesw
 import { CanvasCorner } from "../api.slint";
-import { EditorMetrics, StudioTheme } from "common.slint";
+import { EditorCursors, EditorMetrics, StudioTheme } from "common.slint";
 
 export component MoveResizeFrame inherits Rectangle {
+    in property <bool> enabled: true;
     in property <string> accessible-prefix: "Selection";
     in property <bool> active;
     in property <bool> shift-pressed: false;
     in property <angle> rotation: 0deg;
+    in property <bool> show-resize-handles: true;
     in property <bool> show-rotation-handles: true;
     out property <bool> frame-hover: move-touch.has-hover;
     out property <bool> move-pressed: move-touch.pressed;
@@ -35,6 +37,8 @@ export component MoveResizeFrame inherits Rectangle {
     callback selected();
     callback interaction-started();
     callback interaction-ended();
+    callback pointer-moved(Point);
+    callback move-released();
     callback moved-to(Point);
     callback resized-to(CanvasCorner, Point, Size);
     callback rotated-to(angle);
@@ -243,9 +247,10 @@ export component MoveResizeFrame inherits Rectangle {
         transform-rotation: root.rotation;
 
         move-touch := TouchArea {
+            enabled: root.enabled;
             width: root.width;
             height: root.height;
-            mouse-cursor: move;
+            mouse-cursor: EditorCursors.canvas-default;
             accessible-role: AccessibleRole.button;
             accessible-label: root.accessible-prefix + " move handle";
             accessible-enabled: root.moveable;
@@ -262,15 +267,25 @@ export component MoveResizeFrame inherits Rectangle {
                     if root.move-dragging {
                         root.interaction-ended();
                     }
+                    root.move-released();
                     root.move-dragging = false;
                 }
             }
 
+            pointer-event(event) => {
+                if event.kind == PointerEventKind.move {
+                    root.pointer-moved(root.local-point-to-parent({
+                        x: self.mouse-x,
+                        y: self.mouse-y,
+                    }));
+                }
+            }
+
             moved => {
+                let pointer = root.local-point-to-parent({ x: self.mouse-x, y: self.mouse-y });
                 if !root.moveable {
                     return;
                 }
-                let pointer = root.local-point-to-parent({ x: self.mouse-x, y: self.mouse-y });
                 let delta = {
                     x: pointer.x - self.move-start-pointer.x,
                     y: pointer.y - self.move-start-pointer.y,
@@ -408,6 +423,7 @@ export component MoveResizeFrame inherits Rectangle {
                     background: white;
                     border-width: 2px;
                     border-color: StudioTheme.accent-strong;
+                    visible: root.show-resize-handles;
 
                     TouchArea {
                         enabled: root.resizable;

--- a/tools/editor/ui/components/move-resize-frame.slint
+++ b/tools/editor/ui/components/move-resize-frame.slint
@@ -16,7 +16,6 @@ export component MoveResizeFrame inherits Rectangle {
     out property <bool> frame-hover: move-touch.has-hover;
     out property <bool> move-pressed: move-touch.pressed;
     out property <bool> move-dragging;
-    out property <Point> move-pointer-position;
     out property <bool> rotating;
     out property <bool> rotation-tooltip-visible;
     out property <Point> rotation-tooltip-position;
@@ -34,7 +33,7 @@ export component MoveResizeFrame inherits Rectangle {
     private property <Size> free-resize-size;
     in property <bool> resizable: true;
     in property <bool> moveable: true;
-    callback selected();
+    callback move-press-started(Point);
     callback interaction-started();
     callback interaction-ended();
     callback pointer-moved(Point);
@@ -155,18 +154,10 @@ export component MoveResizeFrame inherits Rectangle {
         return (value / 15deg).round() * 15deg;
     }
 
-    pure function corner-local-x-sign(corner: CanvasCorner) -> float {
-        return root.corner-on-left(corner) ? -1 : 1;
-    }
-
-    pure function corner-local-y-sign(corner: CanvasCorner) -> float {
-        return root.corner-on-top(corner) ? -1 : 1;
-    }
-
     pure function corner-local-point(corner: CanvasCorner, size: Size) -> Point {
         return {
-            x: size.width / 2 + root.corner-local-x-sign(corner) * size.width / 2,
-            y: size.height / 2 + root.corner-local-y-sign(corner) * size.height / 2,
+            x: root.corner-on-left(corner) ? 0px : size.width,
+            y: root.corner-on-top(corner) ? 0px : size.height,
         };
     }
 
@@ -202,17 +193,13 @@ export component MoveResizeFrame inherits Rectangle {
         let target-height = root.corner-on-top(root.resize-corner)
             ? root.resize-start-size.height - delta.y
             : root.resize-start-size.height + delta.y;
-        root.store-free-resize-target-from-size({ width: target-width, height: target-height });
-    }
-
-    function store-free-resize-target-from-size(target-size: Size) {
         root.free-resize-position = root.position-for-fixed-corner(
             root.resize-corner,
             root.resize-fixed-corner,
-            target-size,
+            { width: target-width, height: target-height },
             root.resize-start-rotation,
         );
-        root.free-resize-size = target-size;
+        root.free-resize-size = { width: target-width, height: target-height };
     }
 
     function emit-resize-target() {
@@ -240,16 +227,12 @@ export component MoveResizeFrame inherits Rectangle {
         }
     }
 
-    rotated := Rectangle {
-        width: root.width;
-        height: root.height;
+    Rectangle {
         transform-origin: { x: root.width / 2, y: root.height / 2 };
         transform-rotation: root.rotation;
 
         move-touch := TouchArea {
             enabled: root.enabled;
-            width: root.width;
-            height: root.height;
             mouse-cursor: EditorCursors.canvas-default;
             accessible-role: AccessibleRole.button;
             accessible-label: root.accessible-prefix + " move handle";
@@ -261,8 +244,9 @@ export component MoveResizeFrame inherits Rectangle {
                 if self.pressed {
                     root.move-dragging = false;
                     self.move-start-position = { x: root.x, y: root.y };
-                    self.move-start-pointer = root.local-point-to-parent({ x: self.mouse-x, y: self.mouse-y });
-                    root.selected();
+                    let pointer = root.local-point-to-parent({ x: self.mouse-x, y: self.mouse-y });
+                    self.move-start-pointer = pointer;
+                    root.move-press-started(pointer);
                 } else {
                     if root.move-dragging {
                         root.interaction-ended();
@@ -292,7 +276,6 @@ export component MoveResizeFrame inherits Rectangle {
                 };
                 let moved-far-enough = delta.x.abs() >= root.drag-threshold
                     || delta.y.abs() >= root.drag-threshold;
-                root.move-pointer-position = pointer;
                 if self.pressed && !root.move-dragging && moved-far-enough {
                     root.move-dragging = true;
                     root.interaction-started();
@@ -305,16 +288,11 @@ export component MoveResizeFrame inherits Rectangle {
                 }
             }
 
-            clicked => {
-                root.selected();
-            }
         }
 
         @children
 
         if root.active && !root.move-dragging: Rectangle {
-            width: root.width;
-            height: root.height;
             border-width: 1px;
             border-color: StudioTheme.accent-strong;
 
@@ -346,8 +324,6 @@ export component MoveResizeFrame inherits Rectangle {
                 y: root.rotation-zone-y(corner);
                 width: EditorMetrics.rotation-zone-size;
                 height: EditorMetrics.rotation-zone-size;
-                background: transparent;
-
                 TouchArea {
                     mouse-cursor: root.rotation-cursor-is-forward-diagonal(corner) ? nwse-resize : nesw-resize;
                     accessible-role: AccessibleRole.button;
@@ -369,7 +345,6 @@ export component MoveResizeFrame inherits Rectangle {
                                 { x: parent.x, y: parent.y },
                                 { x: self.mouse-x, y: self.mouse-y },
                             );
-                            root.selected();
                             root.interaction-started();
                             root.rotating = true;
                             root.rotation-tooltip-visible = true;
@@ -399,7 +374,6 @@ export component MoveResizeFrame inherits Rectangle {
                         );
                         let angle = self.start-rotation + root.pointer-angle(local-point.x, local-point.y) - self.start-pointer-angle;
                         let target-angle = (root.shift-pressed || self.event-shift-pressed) ? root.snapped-rotation(angle) : angle;
-                        root.rotation-tooltip-visible = true;
                         root.rotation-tooltip-position = root.local-point-to-parent(local-point);
                         root.rotation-tooltip-value = target-angle;
                         root.rotated-to(target-angle);
@@ -408,8 +382,6 @@ export component MoveResizeFrame inherits Rectangle {
             }
 
             if !root.rotating: Rectangle {
-                width: root.width;
-                height: root.height;
                 for corner in [
                     CanvasCorner.top-left,
                     CanvasCorner.top-right,
@@ -449,7 +421,6 @@ export component MoveResizeFrame inherits Rectangle {
                                     { x: self.mouse-x, y: self.mouse-y },
                                 ));
 
-                                root.selected();
                                 root.resize-corner = corner;
                                 root.resize-pressed = true;
                                 root.resize-dragging = false;

--- a/tools/editor/ui/components/move-resize-frame.slint
+++ b/tools/editor/ui/components/move-resize-frame.slint
@@ -9,29 +9,29 @@ export component MoveResizeFrame inherits Rectangle {
     in property <bool> enabled: true;
     in property <string> accessible-prefix: "Selection";
     in property <bool> active;
-    in property <bool> shift-pressed: false;
-    in property <angle> rotation: 0deg;
+    in property <bool> shift-pressed;
+    in property <angle> rotation;
     in property <bool> show-resize-handles: true;
     in property <bool> show-rotation-handles: true;
     out property <bool> frame-hover: move-touch.has-hover;
     out property <bool> move-pressed: move-touch.pressed;
-    out property <bool> move-dragging: false;
-    out property <Point> move-pointer-position: { x: 0px, y: 0px };
-    out property <bool> rotating: false;
-    out property <bool> rotation-tooltip-visible: false;
-    out property <Point> rotation-tooltip-position: { x: 0px, y: 0px };
-    out property <angle> rotation-tooltip-value: 0deg;
+    out property <bool> move-dragging;
+    out property <Point> move-pointer-position;
+    out property <bool> rotating;
+    out property <bool> rotation-tooltip-visible;
+    out property <Point> rotation-tooltip-position;
+    out property <angle> rotation-tooltip-value;
     private property <length> drag-threshold: 2px;
-    private property <bool> resize-pressed: false;
-    private property <bool> resize-dragging: false;
-    private property <bool> resize-shift-pressed: false;
-    private property <CanvasCorner> resize-corner: CanvasCorner.top-left;
-    private property <Size> resize-start-size: { width: 0px, height: 0px };
-    private property <Point> resize-start-pointer: { x: 0px, y: 0px };
-    private property <Point> resize-fixed-corner: { x: 0px, y: 0px };
-    private property <angle> resize-start-rotation: 0deg;
-    private property <Point> free-resize-position: { x: 0px, y: 0px };
-    private property <Size> free-resize-size: { width: 0px, height: 0px };
+    private property <bool> resize-pressed;
+    private property <bool> resize-dragging;
+    private property <bool> resize-shift-pressed;
+    private property <CanvasCorner> resize-corner;
+    private property <Size> resize-start-size;
+    private property <Point> resize-start-pointer;
+    private property <Point> resize-fixed-corner;
+    private property <angle> resize-start-rotation;
+    private property <Point> free-resize-position;
+    private property <Size> free-resize-size;
     in property <bool> resizable: true;
     in property <bool> moveable: true;
     callback selected();
@@ -254,8 +254,8 @@ export component MoveResizeFrame inherits Rectangle {
             accessible-role: AccessibleRole.button;
             accessible-label: root.accessible-prefix + " move handle";
             accessible-enabled: root.moveable;
-            private property <Point> move-start-position: { x: 0px, y: 0px };
-            private property <Point> move-start-pointer: { x: 0px, y: 0px };
+            private property <Point> move-start-position;
+            private property <Point> move-start-pointer;
 
             changed pressed => {
                 if self.pressed {
@@ -293,8 +293,9 @@ export component MoveResizeFrame inherits Rectangle {
                 let moved-far-enough = delta.x.abs() >= root.drag-threshold
                     || delta.y.abs() >= root.drag-threshold;
                 root.move-pointer-position = pointer;
-                if self.pressed && moved-far-enough {
+                if self.pressed && !root.move-dragging && moved-far-enough {
                     root.move-dragging = true;
+                    root.interaction-started();
                 }
                 if root.move-dragging {
                     root.moved-to({
@@ -352,10 +353,10 @@ export component MoveResizeFrame inherits Rectangle {
                     accessible-role: AccessibleRole.button;
                     accessible-label: root.accessible-prefix + " rotate " + root.corner-name(corner);
                     accessible-enabled: root.show-rotation-handles;
-                    private property <bool> event-shift-pressed: false;
+                    private property <bool> event-shift-pressed;
                     private property <angle> start-rotation;
                     private property <angle> start-pointer-angle;
-                    private property <Point> press-position: { x: 0px, y: 0px };
+                    private property <Point> press-position;
 
                     pointer-event(event) => {
                         self.event-shift-pressed = event.modifiers.shift;
@@ -431,7 +432,7 @@ export component MoveResizeFrame inherits Rectangle {
                         accessible-role: AccessibleRole.button;
                         accessible-label: root.accessible-prefix + " resize " + root.corner-name(corner);
                         accessible-enabled: root.resizable;
-                        private property <bool> event-shift-pressed: false;
+                        private property <bool> event-shift-pressed;
 
                         pointer-event(event) => {
                             self.event-shift-pressed = event.modifiers.shift;

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -3,7 +3,7 @@
 
 import "./assets/Inter-VariableFont.ttf";
 
-import { Api, EditorSurfaceMode } from "api.slint";
+import { Api, EditorSurfaceMode, Hover } from "api.slint";
 import { Project } from "project.slint";
 import { StartupWizard } from "startup-wizard.slint";
 import { AppState, PaletteComponentKind, SidebarToggleButton, StudioTheme } from "components/common.slint";
@@ -16,7 +16,7 @@ import { LeftPane } from "components/left-pane.slint";
 import { EditorMetrics } from "components/common.slint";
 import { UpdateStatus, UpdateStatusBar, UpdateStatusPill } from "components/update-status.slint";
 
-export { Api, Project }
+export { Api, Hover, Project }
 
 export component EditorUi inherits Window {
     preferred-width: 1360px;


### PR DESCRIPTION
Previously as you move the cursor items you move over do not gain an indicator they can be selected.
Now on hover they gain a blue outline.

Previously you could not click and drag an item in one move. You had to click once to focus and then
after click and drag.
Now you can click and drag non focussed items in one gesture. Thanks to the above change you also get
a visual indicator of what is going to be dragged.