### PR TITLE
layout: Fix GridLayout row/col collapsing to min-height when a sibling cell has a fixed zero size

### DIFF
--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -430,19 +430,12 @@ mod grid_internal {
             if cdata.stretch == marker_for_empty {
                 cdata.stretch = 0.;
             }
-            // A row/col's max is the intersection (min) of its cells' own max,
-            // while its min is the union (max) of its cells' own min.
-            // A cell with a fixed zero size (e.g. collapsed via `height: 0px`)
-            // therefore pulls max down to 0, even when another cell sharing the
-            // same row/col has a larger, unrelated minimum.
-            // That leaves max < min, and a later `preferred.min(max).max(min)`
-            // clamp elsewhere silently resolves the inconsistency by favoring
-            // whatever min happens to win downstream (issue #9724), instead of
-            // the real minimum computed here.
-            // The minimum is the hard constraint, so raise max to meet it.
-            if cdata.max < cdata.min {
-                cdata.max = cdata.min;
-            }
+            // A cell collapsed to a fixed zero size can pull the row/col's
+            // max below its min (#9724). Mirror box_layout_info_ortho: the
+            // minimum is the hard constraint, so raise max to meet it, and
+            // keep pref in range now that max may have moved.
+            cdata.max = cdata.max.max(cdata.min);
+            cdata.pref = cdata.pref.clamp(cdata.min, cdata.max);
         }
         layout_data
     }
@@ -3436,5 +3429,96 @@ mod tests {
         // Without the fix the dropped `50% * MAX` makes this the f32 sentinel
         // (or panics under i32); with it the item just takes its natural size.
         assert!(w.is_finite() && w < Coord::MAX, "item main-axis size was {w}");
+    }
+
+    /// Builds the organized_data for a single row of `num_cells` unspanned,
+    /// side-by-side cells, for use with `grid_internal::to_layout_data`.
+    fn single_row_organized_data(num_cells: usize) -> GridLayoutOrganizedData {
+        let mut result = GridLayoutOrganizedData::default();
+        let mut generator = OrganizedDataGenerator::new(&[], &[], num_cells, 0, 0, &mut result);
+        for col in 0..num_cells {
+            generator.add(col as u16, 1, 0, 1);
+        }
+        result
+    }
+
+    #[test]
+    fn grid_row_collapsed_cell_raises_max_and_clamps_pref() {
+        // Row with a cell collapsed to a fixed zero size (the `height: cond ?
+        // x : 0px` idiom, #9724) next to a cell with an explicit min/preferred
+        // and no max (e.g. `min-height: 5px; preferred-height: 50px;`).
+        let organized_data = single_row_organized_data(2);
+        let constraints = [
+            LayoutItemInfo {
+                constraint: LayoutInfo {
+                    min: 0 as _,
+                    max: 0 as _,
+                    preferred: 0 as _,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            LayoutItemInfo {
+                constraint: LayoutInfo { min: 5 as _, preferred: 50 as _, ..Default::default() },
+                ..Default::default()
+            },
+        ];
+        let layout_data = grid_internal::to_layout_data(
+            &organized_data,
+            Slice::from_slice(&constraints),
+            Orientation::Vertical,
+            Slice::from_slice(&[]),
+            Slice::from_slice(&[]),
+            0 as _,
+            None,
+        );
+        assert_eq!(layout_data.len(), 1);
+        // The collapsed cell's fixed zero pulls the row's max down to 0 while
+        // its sibling's min pulls the row's min up to 5: max must be raised
+        // to meet min, and the sibling's now out-of-range preferred (50) must
+        // be clamped down with it, not summed into the row's LayoutInfo as-is.
+        assert_eq!(layout_data[0].min, 5 as Coord);
+        assert_eq!(layout_data[0].max, 5 as Coord);
+        assert_eq!(layout_data[0].pref, 5 as Coord);
+    }
+
+    #[test]
+    fn grid_row_without_conflicting_constraints_keeps_its_max() {
+        // No cell forces max below min here, so the row's own intersection
+        // (10) must hold as-is -- the fix must not widen a legitimate cap.
+        let organized_data = single_row_organized_data(2);
+        let constraints = [
+            LayoutItemInfo {
+                constraint: LayoutInfo {
+                    min: 0 as _,
+                    max: 10 as _,
+                    preferred: 5 as _,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            LayoutItemInfo {
+                constraint: LayoutInfo {
+                    min: 0 as _,
+                    max: 20 as _,
+                    preferred: 10 as _,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ];
+        let layout_data = grid_internal::to_layout_data(
+            &organized_data,
+            Slice::from_slice(&constraints),
+            Orientation::Vertical,
+            Slice::from_slice(&[]),
+            Slice::from_slice(&[]),
+            0 as _,
+            None,
+        );
+        assert_eq!(layout_data.len(), 1);
+        assert_eq!(layout_data[0].min, 0 as Coord);
+        assert_eq!(layout_data[0].max, 10 as Coord);
+        assert_eq!(layout_data[0].pref, 10 as Coord);
     }
 }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -431,11 +431,15 @@ mod grid_internal {
                 cdata.stretch = 0.;
             }
             // A cell collapsed to a fixed zero size can pull the row/col's
-            // max below its min (#9724). Mirror box_layout_info_ortho: the
-            // minimum is the hard constraint, so raise max to meet it, and
-            // keep pref in range now that max may have moved.
-            cdata.max = cdata.max.max(cdata.min);
-            cdata.pref = cdata.pref.clamp(cdata.min, cdata.max);
+            // max below its min (#9724). The minimum is the hard constraint,
+            // so raise max to meet it, and pull pref down with it -- it was
+            // computed against the old, broken max and can now overshoot.
+            // Guarded: this must not touch rows without a min/max conflict,
+            // since to_layout_data's output also drives solve_grid_layout.
+            if cdata.max < cdata.min {
+                cdata.max = cdata.min;
+                cdata.pref = cdata.pref.min(cdata.max).max(cdata.min);
+            }
         }
         layout_data
     }
@@ -3431,94 +3435,67 @@ mod tests {
         assert!(w.is_finite() && w < Coord::MAX, "item main-axis size was {w}");
     }
 
-    /// Builds the organized_data for a single row of `num_cells` unspanned,
-    /// side-by-side cells, for use with `grid_internal::to_layout_data`.
-    fn single_row_organized_data(num_cells: usize) -> GridLayoutOrganizedData {
-        let mut result = GridLayoutOrganizedData::default();
-        let mut generator = OrganizedDataGenerator::new(&[], &[], num_cells, 0, 0, &mut result);
-        for col in 0..num_cells {
+    /// Runs `grid_internal::to_layout_data` for a single row made of one
+    /// unspanned cell per constraint, and returns that row's combined
+    /// LayoutData (min/max/pref), for testing the row/col aggregation in
+    /// isolation from the rest of GridLayout.
+    fn row_layout_data(constraints: &[LayoutInfo]) -> grid_internal::LayoutData {
+        let mut organized_data = GridLayoutOrganizedData::default();
+        let mut generator =
+            OrganizedDataGenerator::new(&[], &[], constraints.len(), 0, 0, &mut organized_data);
+        for col in 0..constraints.len() {
             generator.add(col as u16, 1, 0, 1);
         }
-        result
+        let items: Vec<LayoutItemInfo> = constraints
+            .iter()
+            .map(|constraint| LayoutItemInfo { constraint: *constraint, ..Default::default() })
+            .collect();
+        let mut layout_data = grid_internal::to_layout_data(
+            &organized_data,
+            Slice::from_slice(&items),
+            Orientation::Vertical,
+            Slice::from_slice(&[]),
+            Slice::from_slice(&[]),
+            0 as _,
+            None,
+        );
+        assert_eq!(layout_data.len(), 1);
+        layout_data.remove(0)
     }
 
     #[test]
-    fn grid_row_collapsed_cell_raises_max_and_clamps_pref() {
+    fn test_grid_row_collapsed_cell_raises_max_and_pulls_pref_down_with_it() {
         // Row with a cell collapsed to a fixed zero size (the `height: cond ?
         // x : 0px` idiom, #9724) next to a cell with an explicit min/preferred
         // and no max (e.g. `min-height: 5px; preferred-height: 50px;`).
-        let organized_data = single_row_organized_data(2);
-        let constraints = [
-            LayoutItemInfo {
-                constraint: LayoutInfo {
-                    min: 0 as _,
-                    max: 0 as _,
-                    preferred: 0 as _,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            LayoutItemInfo {
-                constraint: LayoutInfo { min: 5 as _, preferred: 50 as _, ..Default::default() },
-                ..Default::default()
-            },
-        ];
-        let layout_data = grid_internal::to_layout_data(
-            &organized_data,
-            Slice::from_slice(&constraints),
-            Orientation::Vertical,
-            Slice::from_slice(&[]),
-            Slice::from_slice(&[]),
-            0 as _,
-            None,
-        );
-        assert_eq!(layout_data.len(), 1);
+        let row = row_layout_data(&[
+            LayoutInfo { min: 0 as _, max: 0 as _, preferred: 0 as _, ..Default::default() },
+            LayoutInfo { min: 5 as _, preferred: 50 as _, ..Default::default() },
+        ]);
         // The collapsed cell's fixed zero pulls the row's max down to 0 while
-        // its sibling's min pulls the row's min up to 5: max must be raised
-        // to meet min, and the sibling's now out-of-range preferred (50) must
-        // be clamped down with it, not summed into the row's LayoutInfo as-is.
-        assert_eq!(layout_data[0].min, 5 as Coord);
-        assert_eq!(layout_data[0].max, 5 as Coord);
-        assert_eq!(layout_data[0].pref, 5 as Coord);
+        // its sibling's min pulls the row's min up to 5: a real conflict, so
+        // max must be raised to meet min, and the sibling's now out-of-range
+        // preferred (50) must be pulled down with it, not summed into the
+        // row's LayoutInfo as-is.
+        assert_eq!(row.min, 5 as Coord);
+        assert_eq!(row.max, 5 as Coord);
+        assert_eq!(row.pref, 5 as Coord);
     }
 
     #[test]
-    fn grid_row_without_conflicting_constraints_keeps_its_max() {
-        // No cell forces max below min here, so the row's own intersection
-        // (10) must hold as-is -- the fix must not widen a legitimate cap.
-        let organized_data = single_row_organized_data(2);
-        let constraints = [
-            LayoutItemInfo {
-                constraint: LayoutInfo {
-                    min: 0 as _,
-                    max: 10 as _,
-                    preferred: 5 as _,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            LayoutItemInfo {
-                constraint: LayoutInfo {
-                    min: 0 as _,
-                    max: 20 as _,
-                    preferred: 10 as _,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ];
-        let layout_data = grid_internal::to_layout_data(
-            &organized_data,
-            Slice::from_slice(&constraints),
-            Orientation::Vertical,
-            Slice::from_slice(&[]),
-            Slice::from_slice(&[]),
-            0 as _,
-            None,
-        );
-        assert_eq!(layout_data.len(), 1);
-        assert_eq!(layout_data[0].min, 0 as Coord);
-        assert_eq!(layout_data[0].max, 10 as Coord);
-        assert_eq!(layout_data[0].pref, 10 as Coord);
+    fn test_grid_row_without_conflicting_constraints_keeps_its_own_pref() {
+        // No cell forces max below min here (max 10 >= min 0): not a #9724
+        // conflict, so the fix must leave this row untouched. The second
+        // cell's preferred (50) legitimately exceeds the row's own max (10)
+        // already on master; to_layout_data's output also drives
+        // solve_grid_layout, so clamping pref here would silently shrink
+        // rows that never had a min/max conflict in the first place.
+        let row = row_layout_data(&[
+            LayoutInfo { min: 0 as _, max: 10 as _, preferred: 5 as _, ..Default::default() },
+            LayoutInfo { min: 0 as _, preferred: 50 as _, ..Default::default() },
+        ]);
+        assert_eq!(row.min, 0 as Coord);
+        assert_eq!(row.max, 10 as Coord);
+        assert_eq!(row.pref, 50 as Coord);
     }
 }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -430,6 +430,19 @@ mod grid_internal {
             if cdata.stretch == marker_for_empty {
                 cdata.stretch = 0.;
             }
+            // A row/col's max is the intersection (min) of its cells' own max,
+            // while its min is the union (max) of its cells' own min.
+            // A cell with a fixed zero size (e.g. collapsed via `height: 0px`)
+            // therefore pulls max down to 0, even when another cell sharing the
+            // same row/col has a larger, unrelated minimum.
+            // That leaves max < min, and a later `preferred.min(max).max(min)`
+            // clamp elsewhere silently resolves the inconsistency by favoring
+            // whatever min happens to win downstream (issue #9724), instead of
+            // the real minimum computed here.
+            // The minimum is the hard constraint, so raise max to meet it.
+            if cdata.max < cdata.min {
+                cdata.max = cdata.min;
+            }
         }
         layout_data
     }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -432,13 +432,13 @@ mod grid_internal {
             }
             // A cell collapsed to a fixed zero size can pull the row/col's
             // max below its min (#9724). The minimum is the hard constraint,
-            // so raise max to meet it, and pull pref down with it -- it was
-            // computed against the old, broken max and can now overshoot.
-            // Guarded: this must not touch rows without a min/max conflict,
-            // since to_layout_data's output also drives solve_grid_layout.
+            // so raise max to meet it; min == max now, so that's pref's only
+            // legal value too. Guarded: this must not touch rows without a
+            // min/max conflict, since to_layout_data's output also drives
+            // solve_grid_layout.
             if cdata.max < cdata.min {
                 cdata.max = cdata.min;
-                cdata.pref = cdata.pref.min(cdata.max).max(cdata.min);
+                cdata.pref = cdata.min;
             }
         }
         layout_data

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -3436,7 +3436,7 @@ mod tests {
     }
 
     /// Runs `grid_internal::to_layout_data` for a single row made of one
-    /// unspanned cell per constraint, and returns that row's combined
+    /// non-spanning cell per constraint, and returns that row's combined
     /// LayoutData (min/max/pref), for testing the row/col aggregation in
     /// isolation from the rest of GridLayout.
     fn row_layout_data(constraints: &[LayoutInfo]) -> grid_internal::LayoutData {

--- a/tests/cases/issues/issue_9724_grid_row_collapse.slint
+++ b/tests/cases/issues/issue_9724_grid_row_collapse.slint
@@ -1,0 +1,132 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Regression test for #9724: a GridLayout row containing a cell collapsed to
+// a fixed zero size (the common `height: self.visible ? x : 0px` idiom used
+// to hide a column/cell) pulled the row's derived `max` layout constraint
+// down to 0, even though a sibling cell in the same row stayed visible (or
+// unconditionally sized) and needed more height. That left the row's
+// aggregate LayoutInfo with `max < min` -- an "impossible" constraint --
+// which a later `preferred.min(max).max(min)` clamp silently resolved to
+// whatever an outer `min-height` override happened to be, instead of the
+// sibling's real height requirement, collapsing the whole GridLayout down to
+// its minimum.
+
+component Frame {
+    // Mirrors the report's wrapper component: a plain component whose
+    // layout-info is forwarded through a single child GridLayout, with an
+    // explicit min-height override so it stays visible while empty.
+    min-height: 2px;
+
+    layout := GridLayout {
+        @children
+    }
+}
+
+component Cell {
+    // Collapses to a hard zero size when hidden -- the idiom from the report
+    // used to fully hide a GridLayout column.
+    height: self.visible ? layout.preferred-height : 0px;
+    width: self.visible ? layout.preferred-width : 0px;
+
+    layout := HorizontalLayout {
+        @children
+    }
+}
+
+export component TestCase inherits Window {
+    width: 100phx;
+    height: 100phx;
+
+    in-out property <bool> show-col-0: false;
+
+    VerticalLayout {
+        alignment: start;
+
+        // Reduced repro: min-height directly on the GridLayout that solves
+        // the row, with plain Rectangles instead of the report's widgets.
+        direct := GridLayout {
+            min-height: 2px;
+            Row {
+                Rectangle {
+                    height: show-col-0 ? 20px : 0px;
+                    width: 20px;
+                }
+                Rectangle {
+                    // Always occupies the row, regardless of column 0.
+                    height: 20px;
+                    width: 20px;
+                }
+            }
+        }
+
+        // The report's original shape: min-height on a wrapping *component*
+        // (Frame), whose layout-info is forwarded through a nested
+        // GridLayout, with the column collapsed via Cell's `visible`.
+        frame := Frame {
+            Row {
+                Cell {
+                    visible: show-col-0;
+                    Text { text: "Col 0"; }
+                }
+                Text { text: "Col 1"; }
+            }
+        }
+    }
+
+    out property <length> direct-height: direct.height;
+    out property <length> frame-height: frame.height;
+
+    // Both must reflect the still-visible sibling's real height, not the
+    // (much smaller) explicit min-height override -- whether column 0 starts
+    // out hidden (as tested here by default) or is hidden at runtime (as
+    // tested by the code blocks below).
+    out property <bool> direct-ok: direct-height == 20px;
+    out property <bool> frame-ok: frame-height > 5px;
+    out property <bool> test: direct-ok && frame-ok;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+// Starts with column 0 already hidden: reproduces without any interaction.
+assert(instance.get_test());
+
+// Showing and re-hiding the column must not leave either GridLayout collapsed.
+instance.set_show_col_0(true);
+assert(instance.get_direct_ok());
+assert(instance.get_frame_ok());
+instance.set_show_col_0(false);
+assert(instance.get_direct_ok());
+assert(instance.get_frame_ok());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+// Starts with column 0 already hidden: reproduces without any interaction.
+assert!(instance.get_test());
+
+// Showing and re-hiding the column must not leave either GridLayout collapsed.
+instance.set_show_col_0(true);
+assert!(instance.get_direct_ok());
+assert!(instance.get_frame_ok());
+instance.set_show_col_0(false);
+assert!(instance.get_direct_ok());
+assert!(instance.get_frame_ok());
+```
+
+```js
+var instance = new slint.TestCase({});
+// Starts with column 0 already hidden: reproduces without any interaction.
+assert(instance.test);
+
+// Showing and re-hiding the column must not leave either GridLayout collapsed.
+instance.show_col_0 = true;
+assert(instance.direct_ok);
+assert(instance.frame_ok);
+instance.show_col_0 = false;
+assert(instance.direct_ok);
+assert(instance.frame_ok);
+```
+*/

--- a/tests/cases/issues/issue_9724_grid_row_collapse.slint
+++ b/tests/cases/issues/issue_9724_grid_row_collapse.slint
@@ -72,18 +72,58 @@ export component TestCase inherits Window {
                 Text { text: "Col 1"; }
             }
         }
+
+        // Column analog of `direct`: two rows sharing column 0, where row 0's
+        // cell collapses to a fixed zero width while row 1's cell keeps an
+        // unrelated, unconditional width the column must still fit. Nested in
+        // its own HorizontalLayout so width is the main axis (sized to
+        // content) rather than the VerticalLayout's stretched cross axis.
+        HorizontalLayout {
+            alignment: start;
+            direct-col := GridLayout {
+                min-width: 2px;
+                Row {
+                    Rectangle {
+                        width: show-col-0 ? 20px : 0px;
+                        height: 20px;
+                    }
+                    Rectangle {
+                        width: 20px;
+                        height: 20px;
+                    }
+                }
+                Row {
+                    Rectangle {
+                        // Always occupies column 0, regardless of row 0's cell.
+                        width: 20px;
+                        height: 20px;
+                    }
+                    Rectangle {
+                        width: 20px;
+                        height: 20px;
+                    }
+                }
+            }
+        }
+
+        // Reference for `frame-ok` below: the same content, sized outside
+        // any collapsed GridLayout, so the expected height doesn't need a
+        // magic pixel value that could drift with the font.
+        reference := Text { text: "Col 1"; }
     }
 
     out property <length> direct-height: direct.height;
+    out property <length> direct-col-width: direct-col.width;
     out property <length> frame-height: frame.height;
 
-    // Both must reflect the still-visible sibling's real height, not the
-    // (much smaller) explicit min-height override -- whether column 0 starts
-    // out hidden (as tested here by default) or is hidden at runtime (as
-    // tested by the code blocks below).
+    // All must reflect the still-visible sibling's real size, not the
+    // (much smaller) explicit min-height/min-width override -- whether
+    // column 0 starts out hidden (as tested here by default) or is hidden
+    // at runtime (as tested by the code blocks below).
     out property <bool> direct-ok: direct-height == 20px;
-    out property <bool> frame-ok: frame-height > 5px;
-    out property <bool> test: direct-ok && frame-ok;
+    out property <bool> direct-col-ok: direct-col-width == 40px;
+    out property <bool> frame-ok: frame-height == reference.height;
+    out property <bool> test: direct-ok && direct-col-ok && frame-ok;
 }
 
 /*
@@ -93,12 +133,14 @@ const TestCase &instance = *handle;
 // Starts with column 0 already hidden: reproduces without any interaction.
 assert(instance.get_test());
 
-// Showing and re-hiding the column must not leave either GridLayout collapsed.
+// Showing and re-hiding the column must not leave any GridLayout collapsed.
 instance.set_show_col_0(true);
 assert(instance.get_direct_ok());
+assert(instance.get_direct_col_ok());
 assert(instance.get_frame_ok());
 instance.set_show_col_0(false);
 assert(instance.get_direct_ok());
+assert(instance.get_direct_col_ok());
 assert(instance.get_frame_ok());
 ```
 
@@ -107,12 +149,14 @@ let instance = TestCase::new().unwrap();
 // Starts with column 0 already hidden: reproduces without any interaction.
 assert!(instance.get_test());
 
-// Showing and re-hiding the column must not leave either GridLayout collapsed.
+// Showing and re-hiding the column must not leave any GridLayout collapsed.
 instance.set_show_col_0(true);
 assert!(instance.get_direct_ok());
+assert!(instance.get_direct_col_ok());
 assert!(instance.get_frame_ok());
 instance.set_show_col_0(false);
 assert!(instance.get_direct_ok());
+assert!(instance.get_direct_col_ok());
 assert!(instance.get_frame_ok());
 ```
 
@@ -121,12 +165,14 @@ var instance = new slint.TestCase({});
 // Starts with column 0 already hidden: reproduces without any interaction.
 assert(instance.test);
 
-// Showing and re-hiding the column must not leave either GridLayout collapsed.
+// Showing and re-hiding the column must not leave any GridLayout collapsed.
 instance.show_col_0 = true;
 assert(instance.direct_ok);
+assert(instance.direct_col_ok);
 assert(instance.frame_ok);
 instance.show_col_0 = false;
 assert(instance.direct_ok);
+assert(instance.direct_col_ok);
 assert(instance.frame_ok);
 ```
 */


### PR DESCRIPTION
## Summary

Fixes #9724. Reported as "toggling a Switch collapses an enclosing Frame" -- that's misleading; Switch is a red herring. It's a general `GridLayout` row/column aggregation bug: any property change that toggles a cell's fixed height reproduces it, with plain `Rectangle`s and no widgets at all.

A `GridLayout` row (or column) combines its cells' `max` via intersection (min-of-maxes) and its `min` via union (max-of-mins) -- both correct in isolation. But a cell collapsed to a fixed zero size (the common `height: self.visible ? x : 0px` idiom for hiding a column) pulls the row's `max` down to 0, even when another cell sharing that row is a fixed, unconditional size needing more height. That leaves the row with `max < min` -- an inconsistent `LayoutInfo` that's silently masked almost everywhere by a later `preferred.min(max).max(min)` clamp, *except* when an outer element has its own explicit `min-height` override: that override replaces the row-derived (correct) `min`, and the broken `max` then wins, clamping the whole layout down to the arbitrary `min-height` regardless of what a still-visible sibling actually needs.

Fix: when a row/col's `max` ends up below its `min`, raise `max` to meet it, and pull `pref` down with it since it was computed against the old, broken `max` and can now overshoot. The pref adjustment is guarded to only fire on an actual `max < min` conflict -- `to_layout_data`'s output also drives `solve_grid_layout` directly, so an unconditional clamp would silently shrink unrelated rows whose per-cell `preferred` legitimately exceeds the row's own intersected `max` (a separate, pre-existing inconsistency between reported and solved size, unrelated to #9724 and left as-is here).

Known, pre-existing, out-of-scope issue *not* touched by this PR: this is now the third spot independently encoding a "min wins over max" resolution policy (here, `box_layout_info_ortho`, and `min_max_size_for_layout_constraints`), and two consumers already disagree on the opposite question -- `window.rs` popup sizing resolves `max` wins, `solve_box_layout`'s per-cell preferred resolves `min` wins. Unifying that touches every layout kind's size resolution, not just `GridLayout`, and neither disagreeing consumer has been audited to say which is correct. Left as a follow-up.

## Test plan

- New/extended test: `tests/cases/issues/issue_9724_grid_row_collapse.slint` -- a reduced row repro (`direct`), a column repro (`direct-col`), and the original report's shape (`Frame`-like wrapper forwarding layout-info through a nested `GridLayout`), all both statically (creation-time) and dynamically (toggling visibility at runtime via `rust`/`cpp`/`js` blocks). The Text-height assertion compares against a reference element instead of a magic pixel value.
- Two new unit tests on `grid_internal::to_layout_data` directly (`internal/core/layout.rs`): one pinning the collapsed-cell conflict case (max raised, pref pulled down with it), one pinning that a row *without* a conflict is left untouched, including a per-cell `preferred` that legitimately exceeds the row's own `max`.
- `cargo test --lib` (`i-slint-core`): 318 passed.
- `test-driver-interpreter`, filtered on `issue_9724`: passed. Filtered on `layout` (regression check): 164 passed.
- `test-driver-rust`, filtered on `issue_9724` (exercises the `rust` toggle block): passed.
- `test-driver-cpp`, filtered on `issue_9724` (exercises the `cpp` toggle block): passed.
- `test-driver-nodejs`, filtered on `issue_9724` (exercises the `js` toggle block): passed.
- No screenshot test case exists for this issue.
