### PR TITLE
layout: Keep center/end alignment when a BoxLayout cell overflows

### DIFF
--- a/internal/compiler/passes/lower_layout.rs
+++ b/internal/compiler/passes/lower_layout.rs
@@ -1328,11 +1328,12 @@ fn optimize_single_cell_layout(
         // isn't duplicated.
         let cell_size =
             Expression::PropertyReference(NamedReference::new(cell, SmolStr::new_static(size)));
-        let leftover = min_max(
-            MinMaxOp::Max,
-            Expression::NumberLiteral(0., Unit::Px),
-            bin('-', available(), cell_size),
-        );
+        let leftover = bin('-', available(), cell_size);
+        let leftover = if single_cell.clamps_leftover_to_zero {
+            min_max(MinMaxOp::Max, Expression::NumberLiteral(0., Unit::Px), leftover)
+        } else {
+            leftover
+        };
         let factor = Expression::NumberLiteral(single_cell.pos_factor, Unit::None);
         pos_expr = bin('+', pos_expr, bin('*', leftover, factor));
     }
@@ -1374,6 +1375,15 @@ struct SingleCellBoxLayout {
     /// Fraction of the leftover space placed before the cell:
     /// 0 for stretch/start/space-between, ½ for center/space-around/space-evenly, 1 for end.
     pos_factor: f64,
+    /// Whether `leftover` clamps to zero when the cell doesn't fit (`leftover` would
+    /// otherwise be negative), instead of keeping the negative value. Per the CSS Box
+    /// Alignment spec, `start` and the `space-*` values fall back to start-alignment
+    /// when the leftover space is negative; `center` and `end` don't (`false` here),
+    /// so an oversized cell overflows symmetrically (or past the start edge, for
+    /// `end`) rather than snapping to start-alignment. See the matching case in the
+    /// runtime `solve_box_layout` (`internal/core/layout.rs`), which this must stay
+    /// consistent with.
+    clamps_leftover_to_zero: bool,
     /// The `(min, max, preferred)` expressions clamping the size; the preferred
     /// term is `None` when stretching. The whole option is `None` when the size
     /// is fixed by an explicit binding that stays in place.
@@ -1413,11 +1423,12 @@ fn single_cell_box_layout(layout: &BoxLayout) -> Option<SingleCellBoxLayout> {
             Some(ev.enumeration.values[ev.value].clone())
         }
     };
-    let (stretch, pos_factor) = match alignment.as_deref() {
-        None | Some("stretch") => (true, 0.),
-        Some("start" | "space-between") => (false, 0.),
-        Some("center" | "space-around" | "space-evenly") => (false, 0.5),
-        Some("end") => (false, 1.),
+    let (stretch, pos_factor, clamps_leftover_to_zero) = match alignment.as_deref() {
+        None | Some("stretch") => (true, 0., true),
+        Some("start" | "space-between") => (false, 0., true),
+        Some("space-around" | "space-evenly") => (false, 0.5, true),
+        Some("center") => (false, 0.5, false),
+        Some("end") => (false, 1., false),
         _ => return None,
     };
     let c = item.constraints.for_orientation(orientation);
@@ -1426,7 +1437,12 @@ fn single_cell_box_layout(layout: &BoxLayout) -> Option<SingleCellBoxLayout> {
         return None;
     }
     if c.fixed {
-        return Some(SingleCellBoxLayout { stretch, pos_factor, size: None });
+        return Some(SingleCellBoxLayout {
+            stretch,
+            pos_factor,
+            clamps_leftover_to_zero,
+            size: None,
+        });
     }
     let implicit = cell_implicit_info(&item.element, orientation);
     let side = |explicit: &Option<NamedReference>, name: &str| {
@@ -1439,6 +1455,7 @@ fn single_cell_box_layout(layout: &BoxLayout) -> Option<SingleCellBoxLayout> {
     Some(SingleCellBoxLayout {
         stretch,
         pos_factor,
+        clamps_leftover_to_zero,
         size: Some((side(c.min, "min")?, side(c.max, "max")?, pref)),
     })
 }

--- a/internal/core/layout.rs
+++ b/internal/core/layout.rs
@@ -1252,12 +1252,37 @@ pub fn solve_box_layout(data: &BoxLayoutData, repeater_indices: Slice<u32>) -> S
             None
         }
         _ if size_without_padding <= pref_size + spacings => {
+            // Not enough room for every cell's preferred size: shrink the cells toward
+            // their minimum, the same way `Stretch` does. A cell whose minimum equals
+            // its preferred size (a non-wrapping `Text`, for instance) can't shrink at
+            // all and keeps overflowing.
+            //
+            // `Center` and `End` still offset the resulting (possibly still oversized)
+            // block by their alignment formula below, so the overflow spills
+            // symmetrically past both edges (or past the start edge, for `End`)
+            // instead of silently collapsing to start-alignment. This matches the CSS
+            // Box Alignment spec's default ("unsafe") behavior: only `start` and the
+            // `space-*` values fall back to start-alignment when the leftover space is
+            // negative -- `center` and `end` keep applying their offset.
             grid_internal::layout_items(
                 &mut layout_data,
                 data.padding.begin,
                 size_without_padding,
                 data.spacing,
             );
+            if matches!(data.alignment, LayoutAlignment::Center | LayoutAlignment::End) {
+                let actual_size: Coord =
+                    layout_data.iter().map(|it| it.size).fold(0 as Coord, Saturating::add)
+                        + spacings;
+                let offset = match data.alignment {
+                    LayoutAlignment::Center => (size_without_padding - actual_size) / 2 as Coord,
+                    LayoutAlignment::End => size_without_padding - actual_size,
+                    _ => unreachable!(),
+                };
+                for it in &mut layout_data {
+                    it.pos += offset;
+                }
+            }
             None
         }
         LayoutAlignment::Center => Some((

--- a/tests/cases/layout/issue_12603_box_alignment_overflow.slint
+++ b/tests/cases/layout/issue_12603_box_alignment_overflow.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore unpadded
+
 // https://github.com/slint-ui/slint/issues/12603
 //
 // A `HorizontalLayout`/`VerticalLayout` cell that cannot shrink below its preferred

--- a/tests/cases/layout/issue_12603_box_alignment_overflow.slint
+++ b/tests/cases/layout/issue_12603_box_alignment_overflow.slint
@@ -1,0 +1,91 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// https://github.com/slint-ui/slint/issues/12603
+//
+// A `HorizontalLayout`/`VerticalLayout` cell that cannot shrink below its preferred
+// size (a fixed `width`, or a non-wrapping `Text`) and doesn't fit the container used
+// to fall back to start-alignment regardless of the container's `alignment`, silently
+// dropping `center`/`end`. That made a `Button` with an explicit size too small for its
+// text (and padding) render its label anchored to the left padding edge and overflowing
+// to the right, instead of staying centered and overflowing both edges symmetrically --
+// which is what an emoji glyph too large for a small fixed-size `Button` made visible as
+// a rightward shift.
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    // A single 150px-wide rigid cell doesn't fit a 100px-wide, unpadded container: the
+    // free space (100px - 150px = -50px) is negative.
+    centered_row := HorizontalLayout {
+        padding: 0px;
+        alignment: center;
+        c1 := Rectangle { width: 150px; }
+    }
+    end_row := HorizontalLayout {
+        padding: 0px;
+        alignment: end;
+        e1 := Rectangle { width: 150px; }
+    }
+    start_row := HorizontalLayout {
+        padding: 0px;
+        alignment: start;
+        s1 := Rectangle { width: 150px; }
+    }
+
+    // `center`/`end` still apply their offset to the oversized content -- like CSS's
+    // default ("unsafe") box alignment, the content overflows past both edges (or past
+    // the start edge, for `end`) rather than snapping to start-alignment.
+    out property <bool> center_overflows_symmetrically: c1.x == -25px;
+    out property <bool> end_overflows_past_start: e1.x == -50px;
+    // `start` already meant start-alignment; overflow doesn't change that.
+    out property <bool> start_unaffected: s1.x == 0px;
+
+    // Padding shifts the whole (still symmetric) overflow, like the non-overflowing case.
+    padded_center := HorizontalLayout {
+        padding-left: 10px;
+        padding-right: 10px;
+        alignment: center;
+        pc1 := Rectangle { width: 150px; }
+    }
+    out property <bool> padded_center_overflows_symmetrically: pc1.x == -25px;
+
+    // Two rigid cells: the offset is computed from their *summed* size (plus spacing),
+    // not just the first cell's. Sized so the halved leftover (-5px) stays exact
+    // under integer `Coord` builds too (`cfg(slint_int_coord)`), not just float ones.
+    two_cells := HorizontalLayout {
+        padding: 0px;
+        spacing: 10px;
+        alignment: center;
+        t1 := Rectangle { width: 50px; }
+        t2 := Rectangle { width: 50px; }
+    }
+    out property <bool> two_cells_offset: t1.x == -5px;
+    out property <bool> two_cells_spacing_kept: t2.x == t1.x + t1.width + 10px;
+
+    // Unlike `center`/`end`, `space-around` (and `space-evenly`) fall back to
+    // start-alignment on overflow -- for a single cell they're otherwise identical to
+    // `center` (see the non-overflowing case below), so this is the case that tells
+    // them apart.
+    space_around_row := HorizontalLayout {
+        padding: 0px;
+        alignment: space-around;
+        sa1 := Rectangle { width: 150px; }
+    }
+    out property <bool> space_around_falls_back_to_start_on_overflow: sa1.x == 0px;
+
+    // Control: with room to spare, single-cell `space-around` centers exactly like
+    // `center` does (both place all the leftover space as one gap split in half).
+    space_around_fits := HorizontalLayout {
+        width: 100px;
+        padding: 0px;
+        alignment: space-around;
+        saf1 := Rectangle { width: 40px; }
+    }
+    out property <bool> space_around_centers_when_it_fits: saf1.x == 30px;
+
+    out property <bool> test: center_overflows_symmetrically && end_overflows_past_start
+        && start_unaffected && padded_center_overflows_symmetrically && two_cells_offset
+        && two_cells_spacing_kept && space_around_falls_back_to_start_on_overflow
+        && space_around_centers_when_it_fits;
+}


### PR DESCRIPTION
## Summary

Partially fixes #12603 ("Emoji text on Button is off center"). The dominant horizontal offset wasn't emoji-specific at all — it was a general `HorizontalLayout`/`VerticalLayout` overflow-alignment bug.

`solve_box_layout` (`internal/core/layout.rs`) and the matching compile-time single-cell lowering (`internal/compiler/passes/lower_layout.rs`) silently downgraded `alignment: center`/`end` to start-alignment whenever a cell couldn't fit its content. That's the CSS Box Alignment spec's *"safe"* alignment — but `start` and `space-between`/`space-around`/`space-evenly` are the only values that should default to it. `center` and `end` should default to *"unsafe"*, keeping their offset (even negative) so an oversized cell overflows symmetrically instead of snapping to one side.

Button's fluent style puts its label `Text` in a `HorizontalLayout { alignment: center; }` cell. A `Button` sized smaller than its label plus padding can't shrink the `Text` (a non-wrapping `Text`'s minimum equals its preferred width), so the cell overflows — and used to render pinned to the left padding edge instead of centered.

**Verified with a clean A/B**: rendering the exact issue repro at 4x scale, ink-centroid offset from the button center went from 0px (natural, unconstrained size) to +8.0px (32×32 forced size) before the fix; after the fix, the forced-size case measures 0px, matching natural size exactly. A plain-text control (no emoji) reproduces the identical left-anchored overflow pre-fix, confirming this isn't emoji-specific.

**Does not fully close #12603**: a smaller, renderer-dependent *vertical* offset remains (Skia ~4.3px, FemtoVG ~1.4px at DPR2), present even at natural (non-overflowing) size, so it's a separate issue from this bug. It's the same font-metrics-box (not ink-based) vertical centering already on record as a design question on #11589, not something this PR addresses.

`end` alignment gets the same treatment as `center` for the same spec reason, even though the issue is only about `center` — happy to narrow this to `center` only if preferred.

## Test plan

- New test: `tests/cases/layout/issue_12603_box_alignment_overflow.slint` — covers both the runtime solver (multi-cell) and the compile-time single-cell lowering, including a `space-around`/`space-evenly` control that correctly keeps falling back to start-alignment on overflow.
- `test-driver-interpreter` full suite: 866/866 passed.
- `test-driver-screenshots`: 115/115 passed, unchanged.
- `i-slint-compiler` and `i-slint-core --lib` full suites: pass.
- `cargo fmt --check` / `cargo clippy`: clean.
- Codex review: clean.