### PR TITLE
docs(ai-plugins): note that slint-viewer's mcp feature isn't on by default

### DIFF
--- a/.github/workflows/slint_tool_binary.yaml
+++ b/.github/workflows/slint_tool_binary.yaml
@@ -86,7 +86,7 @@ jobs:
               with:
                   target: ${{ matrix.arch }}
             - name: Build
-              run: cargo build --verbose --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
+              run: cargo build --verbose --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
             - name: Create artifact directory
               run: |
                   mkdir pkg
@@ -97,7 +97,7 @@ jobs:
                   cd ..
                   cd ..
                   cd tools\${{ github.event.inputs.program || inputs.program }}
-                  bash -x ../../scripts/prepare_binary_package.sh ..\..\pkg\slint-${{ github.event.inputs.program || inputs.program }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }}
+                  bash -x ../../scripts/prepare_binary_package.sh ..\..\pkg\slint-${{ github.event.inputs.program || inputs.program }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }}
             - name: Create archive
               shell: powershell
               run: |
@@ -119,13 +119,13 @@ jobs:
               with:
                   target: x86_64-unknown-linux-gnu
             - name: Build
-              run: cargo build --verbose --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
+              run: cargo build --verbose --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
             - name: Create artifact directory
               run: |
                   mkdir -p slint-${{ github.event.inputs.program || inputs.program }}
                   cp target/release/slint-${{ github.event.inputs.program || inputs.program }} slint-${{ github.event.inputs.program || inputs.program }}/
                   cd tools/${{ github.event.inputs.program || inputs.program }}
-                  ../../scripts/prepare_binary_package.sh ../../slint-${{ github.event.inputs.program || inputs.program }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }}
+                  ../../scripts/prepare_binary_package.sh ../../slint-${{ github.event.inputs.program || inputs.program }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }}
             - name: Tar artifacts to preserve permissions
               run: tar czvf slint-${{ github.event.inputs.program || inputs.program }}-x86_64-unknown-linux-gnu.tar.gz slint-${{ github.event.inputs.program || inputs.program }}
             - name: Upload artifact
@@ -150,13 +150,13 @@ jobs:
             with:
                 crate: cross
           - name: Build
-            run: cross build --target=${{ matrix.target }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
+            run: cross build --target=${{ matrix.target }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
           - name: Create artifact directory
             run: |
                 mkdir -p slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }}
                 cp target//${{ matrix.target }}/release/slint-${{ github.event.inputs.program || inputs.program }} slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }}/
                 cd tools/${{ github.event.inputs.program || inputs.program }}
-                ../../scripts/prepare_binary_package.sh ../../slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }}
+                ../../scripts/prepare_binary_package.sh ../../slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }}
           - name: Tar artifacts to preserve permissions
             run: tar czvf slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }}.tar.gz slint-${{ github.event.inputs.program || inputs.program }}-${{ matrix.target }}
           - name: Upload artifact
@@ -176,9 +176,9 @@ jobs:
               with:
                   target: aarch64-apple-darwin
             - name: Build x86-64
-              run: cargo build --verbose --target x86_64-apple-darwin --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
+              run: cargo build --verbose --target x86_64-apple-darwin --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
             - name: Build aarch64
-              run: cargo build --verbose --target aarch64-apple-darwin --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
+              run: cargo build --verbose --target aarch64-apple-darwin --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }} --release -p slint-${{ github.event.inputs.program || inputs.program }}
             - name: Create artifact directory
               run: |
                   mkdir -p slint-${{ github.event.inputs.program || inputs.program }}
@@ -187,7 +187,7 @@ jobs:
                   install_name_tool -add_rpath @executable_path/. ./slint-${{ github.event.inputs.program || inputs.program }}
                   cd ..
                   cd tools/${{ github.event.inputs.program || inputs.program }}
-                  ../../scripts/prepare_binary_package.sh ../../slint-${{ github.event.inputs.program || inputs.program }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote' || '' }}
+                  ../../scripts/prepare_binary_package.sh ../../slint-${{ github.event.inputs.program || inputs.program }} --no-default-features --features ${{ github.event.inputs.features || inputs.features }}${{ (github.event.inputs.program || inputs.program) == 'viewer' && ',remote,mcp' || '' }}
             - uses: ./.github/actions/codesign
               if: ${{ github.event.inputs.codesign == 'true' }}
               with:

--- a/ai-plugins/skills/slint/reference/debugging-and-mcp.md
+++ b/ai-plugins/skills/slint/reference/debugging-and-mcp.md
@@ -85,12 +85,17 @@ SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 cargo run --features slint/mcp
 ```
 
 **slint-viewer** `(1.18+)`: gets MCP access to any `.slint` file without writing app code.
-Neither the prebuilt release binaries nor a plain `cargo install slint-viewer` carry the `mcp` feature — it's opt-in,
-so build/install it explicitly:
+The prebuilt release binaries (see [tools-install.md](../tools-install.md)) ship with the `mcp` feature built in,
+so just set `SLINT_MCP_PORT` at runtime:
+
+```sh
+SLINT_MCP_PORT=9315 slint-viewer ui/main.slint
+```
+
+A plain `cargo install slint-viewer` from crates.io doesn't include `mcp` — pass it explicitly:
 
 ```sh
 cargo install slint-viewer --features mcp
-SLINT_MCP_PORT=9315 slint-viewer ui/main.slint
 ```
 
 (`SLINT_EMIT_DEBUG_INFO` doesn't apply here — the viewer always compiles through the interpreter,

--- a/ai-plugins/skills/slint/reference/debugging-and-mcp.md
+++ b/ai-plugins/skills/slint/reference/debugging-and-mcp.md
@@ -84,6 +84,18 @@ in `Cargo.toml`):
 SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 cargo run --features slint/mcp
 ```
 
+**slint-viewer** `(1.18+)`: gets MCP access to any `.slint` file without writing app code.
+Neither the prebuilt release binaries nor a plain `cargo install slint-viewer` carry the `mcp` feature — it's opt-in,
+so build/install it explicitly:
+
+```sh
+cargo install slint-viewer --features mcp
+SLINT_MCP_PORT=9315 slint-viewer ui/main.slint
+```
+
+(`SLINT_EMIT_DEBUG_INFO` doesn't apply here — the viewer always compiles through the interpreter,
+which keeps debug info regardless.)
+
 **C++:** released packages don't carry the `mcp` feature — build Slint from
 source with `-DSLINT_FEATURE_MCP=ON`.
 

--- a/ai-plugins/skills/slint/reference/debugging-and-mcp.md
+++ b/ai-plugins/skills/slint/reference/debugging-and-mcp.md
@@ -85,21 +85,12 @@ SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 cargo run --features slint/mcp
 ```
 
 **slint-viewer** `(1.18+)`: gets MCP access to any `.slint` file without writing app code.
-The prebuilt release binaries (see [tools-install.md](../tools-install.md)) ship with the `mcp` feature built in,
-so just set `SLINT_MCP_PORT` at runtime:
+The prebuilt release binaries (see [tools-install.md](../tools-install.md)) ship with `mcp` built in; `cargo install` needs `--features mcp` explicitly.
+`SLINT_EMIT_DEBUG_INFO` doesn't apply — the viewer always keeps debug info.
 
 ```sh
 SLINT_MCP_PORT=9315 slint-viewer ui/main.slint
 ```
-
-A plain `cargo install slint-viewer` from crates.io doesn't include `mcp` — pass it explicitly:
-
-```sh
-cargo install slint-viewer --features mcp
-```
-
-(`SLINT_EMIT_DEBUG_INFO` doesn't apply here — the viewer always compiles through the interpreter,
-which keeps debug info regardless.)
 
 **C++:** released packages don't carry the `mcp` feature — build Slint from
 source with `-DSLINT_FEATURE_MCP=ON`.

--- a/ai-plugins/skills/slint/reference/debugging-and-mcp.md
+++ b/ai-plugins/skills/slint/reference/debugging-and-mcp.md
@@ -86,7 +86,6 @@ SLINT_EMIT_DEBUG_INFO=1 SLINT_MCP_PORT=9315 cargo run --features slint/mcp
 
 **slint-viewer** `(1.18+)`: gets MCP access to any `.slint` file without writing app code.
 The prebuilt release binaries (see [tools-install.md](../tools-install.md)) ship with `mcp` built in; `cargo install` needs `--features mcp` explicitly.
-`SLINT_EMIT_DEBUG_INFO` doesn't apply — the viewer always keeps debug info.
 
 ```sh
 SLINT_MCP_PORT=9315 slint-viewer ui/main.slint

--- a/ai-plugins/skills/slint/tools-install.md
+++ b/ai-plugins/skills/slint/tools-install.md
@@ -46,3 +46,10 @@ cargo install slint-viewer
 Cargo places binaries in `$HOME/.cargo/bin`, which is on `PATH` when Rust was
 installed via `rustup`. For builds against unreleased `master`, add
 `--git https://github.com/slint-ui/slint`.
+
+Neither of the above gives you an MCP-enabled `slint-viewer` — the prebuilt binaries and a plain `cargo install slint-viewer` don't carry the `mcp` feature by default `(1.18+)`.
+Pass it explicitly if you need MCP access to a running `.slint` file (see [debugging-and-mcp.md](reference/debugging-and-mcp.md)):
+
+```sh
+cargo install slint-viewer --features mcp
+```

--- a/ai-plugins/skills/slint/tools-install.md
+++ b/ai-plugins/skills/slint/tools-install.md
@@ -47,8 +47,9 @@ Cargo places binaries in `$HOME/.cargo/bin`, which is on `PATH` when Rust was
 installed via `rustup`. For builds against unreleased `master`, add
 `--git https://github.com/slint-ui/slint`.
 
-Neither of the above gives you an MCP-enabled `slint-viewer` — the prebuilt binaries and a plain `cargo install slint-viewer` don't carry the `mcp` feature by default `(1.18+)`.
-Pass it explicitly if you need MCP access to a running `.slint` file (see [debugging-and-mcp.md](reference/debugging-and-mcp.md)):
+The prebuilt binaries above ship with the `mcp` feature built in `(1.18+)` (see [debugging-and-mcp.md](reference/debugging-and-mcp.md)),
+but `cargo install slint-viewer` with no `--features` doesn't include it.
+Pass it explicitly if you're installing from crates.io and need MCP access to a running `.slint` file:
 
 ```sh
 cargo install slint-viewer --features mcp

--- a/ai-plugins/skills/slint/tools-install.md
+++ b/ai-plugins/skills/slint/tools-install.md
@@ -40,17 +40,11 @@ sudo apt install -y libx11-xcb1 libxkbcommon0 libinput10 libgbm1
 
 ```sh
 cargo install slint-lsp
-cargo install slint-viewer
+cargo install slint-viewer --features mcp
 ```
 
 Cargo places binaries in `$HOME/.cargo/bin`, which is on `PATH` when Rust was
 installed via `rustup`. For builds against unreleased `master`, add
 `--git https://github.com/slint-ui/slint`.
-
-The prebuilt binaries above ship with the `mcp` feature built in `(1.18+)` (see [debugging-and-mcp.md](reference/debugging-and-mcp.md)),
-but `cargo install slint-viewer` with no `--features` doesn't include it.
-Pass it explicitly if you're installing from crates.io and need MCP access to a running `.slint` file:
-
-```sh
-cargo install slint-viewer --features mcp
-```
+`--features mcp` `(1.18+)` gives MCP access to a running `.slint` file (see [debugging-and-mcp.md](reference/debugging-and-mcp.md));
+drop it if you don't need that.


### PR DESCRIPTION
## Summary
- Neither the prebuilt release binaries (`slint_tool_binary.yaml`'s default feature list) nor a plain `cargo install slint-viewer` carry the `mcp` feature that #13111 added to the viewer — it's opt-in, same as the `mcp` feature on the other Slint crates.
- Document how to build/install it explicitly, and add a `slint-viewer` entry to the MCP "Enabling" section of the ai-plugins Slint skill, alongside Rust/C++/Node.js/Python.

## Test plan
- [x] Reviewed with `codex exec review` (found and fixed a Markdown style violation — sentences not on their own line, per `docs/internal/writing-style-guide.md`); final pass reports no findings.
- Documentation-only change, no code/build impact.