### PR TITLE
compiler: Fix an inherited TabWidget Tab being silently dropped

### DIFF
--- a/internal/compiler/passes/lower_tabwidget.rs
+++ b/internal/compiler/passes/lower_tabwidget.rs
@@ -41,6 +41,37 @@ pub async fn lower_tabwidget(
         return;
     }
 
+    // If an element's base is itself a collected TabWidget that already has its own Tab
+    // children (e.g. `component Xyz inherits TabWidget { Tab { ... } }`), it's just
+    // instantiating Xyz rather than defining new Tabs, so skip lowering it here. Lowering it
+    // too would overwrite its base_type and lose the Tabs already lowered on Xyz (issue
+    // #8394); leaving it alone lets inlining pull Xyz's own Tabs in later.
+    //
+    // Any Tab children or an `orientation` override set directly at such an instantiation
+    // site can't be folded into the base, since that would mean moving elements across
+    // component boundaries. Diagnose both cases instead of silently dropping or ignoring them.
+    let tab_widgets: Vec<_> = tab_widgets
+        .into_iter()
+        .filter(|elem| {
+            if !base_chain_declares_tabs(&elem.borrow().base_type, &seen) {
+                return true;
+            }
+            if !elem.borrow().children.is_empty() {
+                diag.push_error(
+                    "Cannot add Tab elements when instantiating a TabWidget subclass that already declares its own Tab; declare them on the subclass instead".to_owned(),
+                    &*elem.borrow(),
+                );
+            }
+            if let Some(orientation) = elem.borrow().binding("orientation") {
+                diag.push_error(
+                    "Cannot set orientation when instantiating a TabWidget subclass that already declares its own Tab; declare it on the subclass instead".to_owned(),
+                    &orientation.span,
+                );
+            }
+            false
+        })
+        .collect();
+
     // Ignore import errors
     let mut build_diags_to_ignore = BuildDiagnostics::default();
     let tabwidget_impl = type_loader
@@ -79,6 +110,29 @@ pub async fn lower_tabwidget(
             &empty_type,
             diag,
         );
+    }
+}
+
+/// Walks a chain of `component Sub inherits Base { ... }` steps (as `base_type`s of
+/// components collected as TabWidgets), skipping empty pass-through subclasses, to check
+/// whether some component along the way already declares its own Tab children. Stops (and
+/// returns `false`) as soon as the chain leaves the collected TabWidgets, e.g. at the
+/// style-selected builtin TabWidget itself.
+fn base_chain_declares_tabs(
+    base_type: &ElementType,
+    tab_widget_roots: &HashSet<*const std::cell::RefCell<Element>>,
+) -> bool {
+    let mut base_type = base_type.clone();
+    loop {
+        let ElementType::Component(c) = &base_type else { return false };
+        if !tab_widget_roots.contains(&Rc::as_ptr(&c.root_element)) {
+            return false;
+        }
+        if !c.root_element.borrow().children.is_empty() {
+            return true;
+        }
+        let next = c.root_element.borrow().base_type.clone();
+        base_type = next;
     }
 }
 

--- a/internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_extra_tab.slint
+++ b/internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_extra_tab.slint
@@ -1,0 +1,19 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A TabWidget subclass that already declares its own Tab can't also take extra
+// Tab elements at its instantiation site: nothing lowers them there without
+// risking silently dropping the subclass's own Tab (see issue #8394).
+
+import { TabWidget } from "std-widgets.slint";
+
+component Xyz inherits TabWidget {
+    Tab { title: "Tab 1"; }
+}
+
+export component Test inherits Window {
+    Xyz {
+//  >  <error{Cannot add Tab elements when instantiating a TabWidget subclass that already declares its own Tab; declare them on the subclass instead}
+        Tab { title: "Tab 2"; }
+    }
+}

--- a/internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_orientation.slint
+++ b/internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_orientation.slint
@@ -1,0 +1,25 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore nonconstant
+
+// `orientation` picks the tab bar's implementation, a structural choice baked
+// once into a TabWidget subclass's own, already-lowered tab bar when it
+// already declares its own Tab. Overriding it at an instantiation site of
+// such a subclass can't take effect (there's no separate tab bar to pick an
+// implementation for) and used to be silently ignored; it must be rejected.
+// See issue_8394_tabwidget_subclass_orientation_nonconstant.slint for the
+// nonconstant-expression variant.
+
+import { TabWidget } from "std-widgets.slint";
+
+component Xyz inherits TabWidget {
+    Tab { title: "Tab 1"; }
+}
+
+export component Test inherits Window {
+    Xyz {
+        orientation: vertical;
+//                   >       <error{Cannot set orientation when instantiating a TabWidget subclass that already declares its own Tab; declare it on the subclass instead}
+    }
+}

--- a/internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_orientation_nonconstant.slint
+++ b/internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_orientation_nonconstant.slint
@@ -1,0 +1,26 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore nonconstant
+
+// A nonconstant `orientation` on an instantiation site of a TabWidget
+// subclass that already declares its own Tab used to be rejected at compile
+// time for a plain TabWidget, but went unchecked here once the instantiation
+// site's own lowering was skipped (see issue_8394_tabwidget_subclass_orientation.slint
+// for the constant-override variant, rejected for a different reason: such
+// an override can't take effect at all, constant or not).
+
+import { TabWidget } from "std-widgets.slint";
+
+component Xyz inherits TabWidget {
+    Tab { title: "Tab 1"; }
+}
+
+export component Test inherits Window {
+    in property <Orientation> requested-orientation: Orientation.horizontal;
+
+    Xyz {
+        orientation: root.requested-orientation;
+//                   >                         <error{Cannot set orientation when instantiating a TabWidget subclass that already declares its own Tab; declare it on the subclass instead}
+    }
+}

--- a/tests/cases/issues/issue_8394_tabwidget_inherited_tab.slint
+++ b/tests/cases/issues/issue_8394_tabwidget_inherited_tab.slint
@@ -1,0 +1,66 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore xyzxyz
+
+// A TabWidget subclass that declares a Tab of its own used to have that Tab
+// silently disappear wherever the subclass was instantiated: the pass that
+// lowers TabWidget also matched the instantiation site (it "looks like" a
+// TabWidget too, through the subclass's base_type), and lowering it there
+// discarded the link to the subclass, orphaning its already-lowered Tab.
+// Instantiate the subclass twice to also cover the pass's deduplication.
+//
+// https://github.com/slint-ui/slint/issues/8394
+import { TabWidget } from "std-widgets.slint";
+
+component Xyz inherits TabWidget {
+    Tab { title: "Tab 1"; }
+}
+
+// An empty subclass of Xyz: its own Tab must also survive being reached
+// through one more level of inheritance.
+component XyzXyz inherits Xyz { }
+
+// A subclass that also sets its own `orientation`: that must still be picked
+// up (it's declared on the same element as the Tab, so this element is never
+// skipped) even though instantiation sites of *other* already-tabbed
+// subclasses now skip their own orientation handling (see the syntax tests
+// for that skip).
+component VerticalXyz inherits TabWidget {
+    orientation: vertical;
+    Tab { title: "Vertical Tab"; }
+}
+
+export component TestCase inherits Window {
+    width: 300px;
+    height: 300px;
+
+    VerticalLayout {
+        xyz1 := Xyz { }
+        Xyz { }
+        xyzxyz1 := XyzXyz { }
+        VerticalXyz { }
+    }
+
+    // A basic sanity check for drivers that don't run the accessibility-based
+    // assertions below: both instances must still behave like working
+    // TabWidgets (current-index in range, not stuck because the Tab it
+    // pointed at was silently dropped).
+    out property <bool> test: xyz1.current-index == 0 && xyzxyz1.current-index == 0;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+
+// Every instance (direct or through the empty XyzXyz subclass) must keep
+// showing the inherited Tab: each contributes two matches (the tab bar entry
+// and its, by default active, panel).
+assert_eq!(slint_testing::ElementHandle::find_by_accessible_label(&instance, "Tab 1").count(), 6);
+
+// A subclass with its own `orientation` (set alongside its own Tab, so it's
+// never skipped by the fix above) must still get its own, vertical tab bar.
+assert!(slint_testing::ElementHandle::find_by_element_id(&instance, "TabBarVerticalImpl::root").next().is_some());
+```
+*/


### PR DESCRIPTION
## Summary

Fixes #8394. `lower_tabwidget` collects every element whose `base_type` resolves (through any chain of `ElementType::Component` wrappers) to the builtin `TabWidget`, then lowers each independently. For a subclass such as `component Xyz inherits TabWidget { Tab { title: "Tab 1"; } }`, that walk matches both `Xyz`'s own root (which correctly lowers Tab 1) *and* every element that merely instantiates `Xyz` elsewhere (e.g. `Xyz { }` in another component). Lowering the instantiation site independently overwrites its `base_type` from `Component(Xyz)` to the TabWidget implementation directly, severing the link to `Xyz` and orphaning its already-lowered Tab 1 — which then silently never appears anywhere, with no diagnostic.

(This regressed a fix for #12332, which made the collection unconditional so a *style's* re-export wrapper — previously skipped as "the wrapper, no need to process" — would still be lowered when instantiated directly. That earlier skip check didn't distinguish "a re-export wrapper with nothing of its own" from "a subclass whose own Tab must not be orphaned"; #12332's fix removed the check but processing every match independently reintroduced the same conflation from the other side.)

**Fix:** for each collected element, check whether its `base_type` chain leads to another collected TabWidget that already has children of its own (skipping empty pass-through subclasses and the style's re-export wrapper, which never have any). If so, leave that element's `base_type` untouched — inlining then pulls in the base's own, correctly-lowered Tabs.

**Two things this deliberately doesn't do**, diagnosed as compile errors instead:
- **An extra `Tab` at the instantiation site** of a subclass (the issue's own repro: `Xyz { Tab { title: "Tab 2"; } }`) — folding it into the base pre-inlining requires moving elements across a component boundary, which breaks the `enclosing_component == component` invariant `recurse_elem_including_sub_components` asserts and severs id-based `NamedReference`s (verified empirically against `text-input-focused-tabwidget.slint`). Now raises a clear diagnostic instead of silently dropping Tab 1 (today's bug) or panicking (the original, pre-#12332 bug).
- **An `orientation` override at such an instantiation site** (found by Codex review, second commit) — `orientation` picks the tab bar's implementation as a structural, compile-time choice baked once into the base's already-lowered tab bar; applying it per-instantiation-site would need the same unsound cross-component move. Now diagnosed rather than silently ignored (previously: wrong rendering with no error for a constant override, or a nonconstant expression compiling when it should be rejected).

Neither makes both tabs (or a per-instance orientation) actually render — that would need the cross-component merge ruled out above. Flagging as a design question for maintainers rather than deciding unilaterally.

Also found, not fixed here (out of scope): `lower_radiogroup.rs` has the identical structural bug for a `RadioGroup` subclass with its own `RadioButton`s. Worth a follow-up issue.

## Test plan

- `tests/cases/issues/issue_8394_tabwidget_inherited_tab.slint` — two `Xyz` instances plus a two-level-deep `XyzXyz inherits Xyz`, all keep their inherited Tab; extended with a `VerticalXyz` subclass setting `orientation: vertical` on itself (not at an instantiation site), confirming that still-supported case keeps working.
- `internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_extra_tab.slint` — extra Tab at instantiation site is diagnosed.
- `internal/compiler/tests/syntax/elements/issue_8394_tabwidget_subclass_orientation{,_nonconstant}.slint` — orientation override at instantiation site is diagnosed, both constant and nonconstant.
- `test-driver-interpreter` full suite: 866 passed.
- `i-slint-compiler --test syntax_tests`: full suite passes.
- Targeted `test-driver-rust`: `issue_8394`, `issue_12332_subclass`, `widgets-reexport`, `focus_text_input_focused_tabwidget`, `widgets_tabwidget_{fluent,material,cosmic,cupertino,qt}` all pass.
- `cargo fmt --check`: clean.
- Codex review: 2 rounds, clean on the second (first round caught the orientation-bypass gap, fixed in the second commit).