### PR TITLE
Build the wasm demos without slint's default features

### DIFF
--- a/.github/workflows/wasm_demos.yaml
+++ b/.github/workflows/wasm_demos.yaml
@@ -21,6 +21,10 @@ jobs:
             # Workspace [profile.release] uses cargo defaults to keep dev release builds fast.
             CARGO_PROFILE_RELEASE_LTO: "fat"
             CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+            # Minimal slint feature set for the web: winit backend + femtovg renderer.
+            # This omits the software renderer (~450 KB), which is only used as a
+            # fallback when WebGL is unavailable.
+            WASM_SLINT_FEATURES: slint/backend-winit,slint/renderer-femtovg
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v7
@@ -33,36 +37,35 @@ jobs:
             - name: Printerdemo WASM build
               run: |
                   sed -i "s/#wasm# //" Cargo.toml
-                  wasm-pack build ${{ inputs.build_artifacts && '--release' || '--dev' }} --target web
+                  wasm-pack build ${{ inputs.build_artifacts && '--release' || '--dev' }} --target web --no-default-features --features $WASM_SLINT_FEATURES
               working-directory:  demos/printerdemo/rust
             - name: Gallery WASM build
               if: ${{ inputs.build_artifacts }}
               run: |
                   sed -i "s/#wasm# //" Cargo.toml
-                  export SLINT_STYLE=fluent && wasm-pack build --release  --out-dir pkg/fluent --target web
-                  export SLINT_STYLE=material && wasm-pack build --release --out-dir pkg/material --target web
-                  export SLINT_STYLE=cupertino && wasm-pack build --release --out-dir pkg/cupertino --target web
-                  export SLINT_STYLE=cosmic && wasm-pack build --release --out-dir pkg/cosmic --target web
+                  for style in fluent material cupertino cosmic; do
+                      SLINT_STYLE=$style wasm-pack build --release --out-dir pkg/$style --target web --no-default-features --features $WASM_SLINT_FEATURES
+                  done
               working-directory: examples/gallery
             - name: Remaining wasm demos
               if: ${{ inputs.build_artifacts }}
               run: |
-                  for demo in demos/printerdemo/rust demos/usecases/rust examples/todo/rust examples/todo-mvc/rust examples/carousel/rust examples/slide_puzzle examples/memory examples/dnd-kanban examples/imagefilter/rust examples/plotter examples/opengl_underlay demos/home-automation/rust examples/speedometer/rust; do
+                  for demo in demos/usecases/rust examples/todo/rust examples/todo-mvc/rust examples/carousel/rust examples/slide_puzzle examples/memory examples/dnd-kanban examples/imagefilter/rust examples/plotter examples/opengl_underlay demos/home-automation/rust examples/speedometer/rust; do
                       pushd $demo
                       sed -i "s/#wasm# //" Cargo.toml
-                      wasm-pack build ${{ inputs.build_artifacts && '--release' || '--dev' }} --target web
+                      wasm-pack build ${{ inputs.build_artifacts && '--release' || '--dev' }} --target web --no-default-features --features $WASM_SLINT_FEATURES
                       popd
                   done
             - name: Energy Monitor example WASM build
               if: ${{ inputs.build_artifacts }}
               run: |
                   sed -i "s/#wasm# //" Cargo.toml
-                  wasm-pack build --release --target web --no-default-features --features slint/default,chrono
+                  wasm-pack build --release --target web --no-default-features --features $WASM_SLINT_FEATURES,chrono
               working-directory: demos/energy-monitor
             - name: Weather Demo example WASM build
               run: |
                   sed -i "s/#wasm# //" Cargo.toml
-                  wasm-pack build --release --target web --no-default-features --features slint/default,chrono
+                  wasm-pack build --release --target web --no-default-features --features $WASM_SLINT_FEATURES,chrono
               working-directory: demos/weather-demo
             - name: "Upload Demo Artifacts"
               if: ${{ inputs.build_artifacts }}

--- a/demos/README.md
+++ b/demos/README.md
@@ -37,12 +37,14 @@ files to uncomment the line starting with `#wasm#` (or use the `sed` line bellow
 You can then use wasm-pack (which you may need to obtain with `cargo install wasm-pack`).
 This will generate the wasm in the `./pkg` directory, which the `index.html` file will open.
 Since wasm files cannot be served from `file://` URL, you need to open a wab server to serve
-the content
+the content.
+The `--features` flags select only the winit backend and the femtovg renderer,
+which keeps the software renderer out of the binary.
 
 ```sh
 cd demos/printerdemo/rust
 sed -i "s/^#wasm# //" Cargo.toml
-wasm-pack build --release --target web
+wasm-pack build --release --target web --no-default-features --features slint/backend-winit,slint/renderer-femtovg
 python3 -m http.server
 ```
 

--- a/demos/energy-monitor/Cargo.toml
+++ b/demos/energy-monitor/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18"] }
 mcu-board-support = { path = "../../examples/mcu-board-support", optional = true }
 chrono = { version = "0.4.34", optional = true, default-features = false, features = ["clock", "std", "wasmbind"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"], optional = true }

--- a/demos/energy-monitor/README.md
+++ b/demos/energy-monitor/README.md
@@ -51,7 +51,7 @@ Set `WEATHER_LAT` and `WEATHER_LONG` to change the location (defaults to Berlin)
 ```sh
 cargo install wasm-pack
 cd demos/energy-monitor/
-wasm-pack build --release --target web --no-default-features --features slint/default,chrono
+wasm-pack build --release --target web --no-default-features --features slint/backend-winit,slint/renderer-femtovg,chrono
 python3 -m http.server
 ```
 

--- a/demos/home-automation/rust/Cargo.toml
+++ b/demos/home-automation/rust/Cargo.toml
@@ -19,10 +19,11 @@ path = "lib.rs"
 name = "home_automation_lib"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", features = ["backend-android-activity-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18", "std", "backend-android-activity-06"] }
 chrono = "0.4"
 
 [features]
+default = ["slint/default"]
 sw-renderer = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/demos/printerdemo/rust/Cargo.toml
+++ b/demos/printerdemo/rust/Cargo.toml
@@ -20,14 +20,17 @@ crate-type = ["lib", "cdylib"]
 name = "printerdemo_lib"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", features = ["backend-android-activity-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18", "std", "backend-android-activity-06"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 
 [target.'cfg(not(any(target_os = "android", target_arch = "wasm32")))'.dependencies]
-slint = { path = "../../../api/rs/slint", features = ["gettext"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["gettext"] }
 
 [build-dependencies]
 slint-build = { path = "../../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/demos/usecases/rust/Cargo.toml
+++ b/demos/usecases/rust/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 name = "usecases"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", features = ["serde", "backend-android-activity-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18", "std", "serde", "backend-android-activity-06"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
@@ -30,3 +30,6 @@ console_error_panic_hook = "0.1.5"
 
 [build-dependencies]
 slint-build = { path = "../../../api/rs/build" }
+
+[features]
+default = ["slint/default"]

--- a/demos/weather-demo/Cargo.toml
+++ b/demos/weather-demo/Cargo.toml
@@ -18,7 +18,7 @@ directories = "6.0"
 log = "0.4.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.115"
-slint = { path = "../../api/rs/slint", features = ["backend-android-activity-06"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18", "std", "backend-android-activity-06"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
 env_logger = "0.11.3"
@@ -42,7 +42,7 @@ wasm-bindgen-futures = "0.4"
 slint-build = { path = "../../api/rs/build" }
 
 [features]
-default = ["chrono", "open_meteo"]
+default = ["slint/default", "chrono", "open_meteo"]
 open_meteo = ["dep:futures", "dep:reqwest", "dep:urlencoding"]
 
 # Android-activity / wasm support

--- a/examples/README.md
+++ b/examples/README.md
@@ -99,12 +99,14 @@ files to uncomment the line starting with `#wasm#` (or use the `sed` line bellow
 You can then use wasm-pack (which you may need to obtain with `cargo install wasm-pack`).
 This will generate the wasm in the `./pkg` directory, which the `index.html` file will open.
 Since wasm files cannot be served from `file://` URL, you need to open a wab server to serve
-the content
+the content.
+The `--features` flags select only the winit backend and the femtovg renderer,
+which keeps the software renderer out of the binary.
 
 ```sh
 cd examples/imagefilter/rust
 sed -i "s/^#wasm# //" Cargo.toml
-wasm-pack build --release --target web
+wasm-pack build --release --target web --no-default-features --features slint/backend-winit,slint/renderer-femtovg
 python3 -m http.server
 ```
 

--- a/examples/carousel/rust/Cargo.toml
+++ b/examples/carousel/rust/Cargo.toml
@@ -15,7 +15,7 @@ path = "main.rs"
 name = "carousel"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18"] }
 mcu-board-support = { path = "../../mcu-board-support", optional = true }
 
 [build-dependencies]

--- a/examples/dnd-kanban/Cargo.toml
+++ b/examples/dnd-kanban/Cargo.toml
@@ -15,10 +15,13 @@ path = "main.rs"
 name = "dnd-kanban"
 
 [dependencies]
-slint = { path = "../../api/rs/slint" }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18", "std"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 # Remove the `#wasm#` to uncomment the wasm build.
 # This is commented out by default because we don't want to build it as a library by default

--- a/examples/gallery/Cargo.toml
+++ b/examples/gallery/Cargo.toml
@@ -16,10 +16,13 @@ path = "main.rs"
 name = "gallery"
 
 [dependencies]
-slint = { path = "../../api/rs/slint", features = ["gettext"] }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18", "std", "gettext"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 # Remove the `#wasm#` to uncomment the wasm build.
 # This is commented out by default because we don't want to build it as a library by default
@@ -34,7 +37,7 @@ slint-build = { path = "../../api/rs/build" }
 #wasm# web-sys = { version = "0.3", features = ["console", "Window", "Navigator"] }
 #wasm# js-sys = { version = "0.3.57" }
 #wasm# console_error_panic_hook = "0.1.5"
-#wasm# slint = { path = "../../api/rs/slint", features = ["unstable-fontique-011"] }
+#wasm# slint = { path = "../../api/rs/slint", default-features = false, features = ["unstable-fontique-011"] }
 #wasm# icu_locale_core = { version = "2.1.1" }
 
 [package.metadata.bundle]

--- a/examples/imagefilter/rust/Cargo.toml
+++ b/examples/imagefilter/rust/Cargo.toml
@@ -15,11 +15,14 @@ path = "main.rs"
 name = "imagefilter"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint" }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18", "std"] }
 image = { workspace = true }
 
 [build-dependencies]
 slint-build = { path = "../../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 # Remove the `#wasm#` to uncomment the wasm build.
 # This is commented out by default because we don't want to build it as a library by default

--- a/examples/memory/Cargo.toml
+++ b/examples/memory/Cargo.toml
@@ -15,10 +15,13 @@ name = "memory"
 
 [dependencies]
 rand = "0.10"
-slint = { path = "../../api/rs/slint" }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18", "std"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 # Remove the `#wasm#` to uncomment the wasm build.
 # This is commented out by default because we don't want to build it as a library by default

--- a/examples/opengl_underlay/Cargo.toml
+++ b/examples/opengl_underlay/Cargo.toml
@@ -15,12 +15,15 @@ path = "main.rs"
 name = "opengl_underlay"
 
 [dependencies]
-slint = { path = "../../api/rs/slint" }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18", "std"] }
 glow = { workspace = true }
 web-time = { version = "1.0" }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 # Remove the `#wasm#` to uncomment the wasm build.
 # This is commented out by default because we don't want to build it as a library by default

--- a/examples/plotter/Cargo.toml
+++ b/examples/plotter/Cargo.toml
@@ -14,11 +14,14 @@ path = "main.rs"
 name = "plotter"
 
 [dependencies]
-slint = { path = "../../api/rs/slint" }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18", "std"] }
 plotters = { version = "0.3.5", default-features = false, features = ["bitmap_backend", "surface_series", "ttf"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 # Remove the `#wasm#` to uncomment the wasm build.
 # This is commented out by default because we don't want to build it as a library by default

--- a/examples/slide_puzzle/Cargo.toml
+++ b/examples/slide_puzzle/Cargo.toml
@@ -15,10 +15,13 @@ name = "slide_puzzle"
 
 [dependencies]
 rand = "0.10"
-slint = { path = "../../api/rs/slint" }
+slint = { path = "../../api/rs/slint", default-features = false, features = ["compat-1-18", "std"] }
 
 [build-dependencies]
 slint-build = { path = "../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 # Remove the `#wasm#` to uncomment the wasm build.
 # This is commented out by default because we don't want to build it as a library by default

--- a/examples/speedometer/rust/Cargo.toml
+++ b/examples/speedometer/rust/Cargo.toml
@@ -19,10 +19,11 @@ path = "lib.rs"
 name = "speedometer_lib"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint" }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18", "std"] }
 chrono = "0.4"
 
 [features]
+default = ["slint/default"]
 sw-renderer = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/todo-mvc/rust/Cargo.toml
+++ b/examples/todo-mvc/rust/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 name = "todo-mvc"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", features = ["serde", "backend-android-activity-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18", "std", "serde", "backend-android-activity-06"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4" }
@@ -31,6 +31,9 @@ console_error_panic_hook = "0.1.5"
 
 [build-dependencies]
 slint-build = { path = "../../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 [dev-dependencies]
 i-slint-backend-testing = { workspace = true }

--- a/examples/todo/rust/Cargo.toml
+++ b/examples/todo/rust/Cargo.toml
@@ -20,7 +20,7 @@ path = "main.rs"
 name = "todo"
 
 [dependencies]
-slint = { path = "../../../api/rs/slint", features = ["serde", "backend-android-activity-06"] }
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-18", "std", "serde", "backend-android-activity-06"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
@@ -30,6 +30,9 @@ console_error_panic_hook = "0.1.5"
 
 [build-dependencies]
 slint-build = { path = "../../../api/rs/build" }
+
+[features]
+default = ["slint/default"]
 
 [dev-dependencies]
 i-slint-backend-testing = { workspace = true }


### PR DESCRIPTION
The demos now declare slint with default-features = false and forward the defaults through their own default cargo feature. The wasm CI builds enable only the winit backend and the femtovg renderer, so the software renderer no longer ships in binaries where it only serves as a fallback when WebGL is unavailable (about 450 KB per demo).
