### PR TITLE
Make spring() without argument a compile error

### DIFF
--- a/docs/astro/src/content/docs/reference/language/animations.mdx
+++ b/docs/astro/src/content/docs/reference/language/animations.mdx
@@ -119,7 +119,9 @@ See [States and Transitions](../states-and-transitions/) for where transitions a
 
 ## Spring Animations
 
-The `spring` easing curve can be defined as `spring`, `spring()`, and `spring(bounce)` where `spring`, `spring()`, and `spring(0)` are equivalent. `bounce` must be a number literal between `-1` and `1`; any other value is a compile error.
+The `spring` easing curve takes an optional bounce argument, for example `spring(0.4)`.
+The bounce must be a number literal between `-1` and `1`; any other argument is a compile error.
+Writing just `spring` is the same as `spring(0)`.
 
 Since `duration` helps define the spring’s [natural frequency](https://en.wikipedia.org/wiki/Natural_frequency), the animation is not guaranteed to be done after `duration` elapses.
 If `bounce` is close to 0, the animation will be nearly done, however the further from 0 `bounce` is, the longer the animation will take.

--- a/internal/compiler/builtin_macros.rs
+++ b/internal/compiler/builtin_macros.rs
@@ -146,70 +146,35 @@ pub fn lower_macro(
 
             expr
         }
-        BuiltinMacroFunction::Spring => {
-            let mut has_error = None;
-            let mut bounce_node = None;
-            let expected_argument_type_error = "Arguments to spring curve must be number literal";
-            let mut a = || match sub_expr.next() {
-                None => 0.,
-                Some((Expression::NumberLiteral(val, Unit::None), n)) => {
-                    bounce_node = n;
-                    val as f32
-                }
-                // handle negative numbers
-                Some((Expression::UnaryOp { sub, op: '-' }, n)) => match *sub {
-                    Expression::NumberLiteral(val, Unit::None) => {
-                        bounce_node = n;
-                        -val as f32
-                    }
-                    _ => {
-                        has_error
-                            .get_or_insert((n.to_source_location(), expected_argument_type_error));
-                        0.
-                    }
-                },
-                // handle positive numbers
-                Some((Expression::UnaryOp { sub, op: '+' }, n)) => match *sub {
-                    Expression::NumberLiteral(val, Unit::None) => {
-                        bounce_node = n;
-                        val as f32
-                    }
-                    _ => {
-                        has_error
-                            .get_or_insert((n.to_source_location(), expected_argument_type_error));
-                        0.
-                    }
-                },
-                Some((_, n)) => {
-                    has_error.get_or_insert((n.to_source_location(), expected_argument_type_error));
-                    0.
-                }
-            };
-            let bounce = a();
-            let bounce = if !(-1.0..=1.0).contains(&bounce) {
-                let loc = bounce_node
-                    .map(|n| n.to_source_location())
-                    .unwrap_or_else(|| n.to_source_location());
-                has_error.get_or_insert((
-                    loc,
-                    "The bounce argument to spring curve must be between -1 and 1",
-                ));
-                0.
-            } else {
-                bounce
-            };
-            let expr = Expression::EasingCurve(EasingCurve::Spring(bounce));
-            if let Some((_, n)) = sub_expr.next() {
-                has_error
-                    .get_or_insert((n.to_source_location(), "Too many argument for spring curve"));
-            }
-            if let Some((n, msg)) = has_error {
-                diag.push_error(msg.into(), &n);
-            }
-
-            expr
-        }
+        BuiltinMacroFunction::Spring => spring_macro(n, sub_expr.collect(), diag),
     }
+}
+
+fn spring_macro(
+    node: &dyn Spanned,
+    args: Vec<(Expression, Option<NodeOrToken>)>,
+    diag: &mut BuildDiagnostics,
+) -> Expression {
+    let literal = |e: &Expression| match e {
+        Expression::NumberLiteral(val, Unit::None) => Some(*val),
+        _ => None,
+    };
+    let bounce = match args.as_slice() {
+        [(Expression::UnaryOp { sub, op: '-' }, _)] => literal(sub).map(|v| -v),
+        [(Expression::UnaryOp { sub, op: '+' }, _)] => literal(sub),
+        [(expr, _)] => literal(expr),
+        _ => None,
+    };
+    let Some(mut bounce) = bounce else {
+        diag.push_error("The spring curve needs a single number literal argument".into(), node);
+        return Expression::EasingCurve(EasingCurve::Spring(0.));
+    };
+    if !(-1.0..=1.0).contains(&bounce) {
+        let loc = args[0].1.as_ref().map_or(node, |n| n as &dyn Spanned);
+        diag.push_error("The bounce argument to spring curve must be between -1 and 1".into(), loc);
+        bounce = 0.;
+    }
+    Expression::EasingCurve(EasingCurve::Spring(bounce as f32))
 }
 
 fn min_max_macro(

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -1716,15 +1716,9 @@ impl Expression {
         };
         match r {
             LookupResult::Expression { expression, .. } => expression,
-            // `spring` used bare (no call parens) is sugar for `spring()`, i.e. bounce 0.
+            // `spring` used bare (no call parens) is a spring curve with the default bounce of 0.
             LookupResult::Callable(LookupResultCallable::Macro(BuiltinMacroFunction::Spring)) => {
-                crate::builtin_macros::lower_macro(
-                    BuiltinMacroFunction::Spring,
-                    node,
-                    std::iter::empty(),
-                    ctx.diag,
-                    &ctx.symbol_counters,
-                )
+                Expression::EasingCurve(crate::expression_tree::EasingCurve::Spring(0.))
             }
             LookupResult::Callable(c) => {
                 let what = match c {

--- a/internal/compiler/tests/syntax/basic/spring_bounce.slint
+++ b/internal/compiler/tests/syntax/basic/spring_bounce.slint
@@ -6,6 +6,7 @@ export component X inherits Rectangle {
     animate a { easing: spring; }
     property <float> b;
     animate b { easing: spring(); }
+//                      >    <error{The spring curve needs a single number literal argument}
     property <float> c;
     animate c { easing: spring(0.0); }
     property <float> d;
@@ -18,4 +19,16 @@ export component X inherits Rectangle {
     property <float> g;
     animate g { easing: spring(-2); }
 //                             ><error{The bounce argument to spring curve must be between -1 and 1}
+    property <float> h;
+    animate h { easing: spring(0, 0); }
+//                      >    <error{The spring curve needs a single number literal argument}
+    property <float> i;
+    animate i { easing: spring(50%); }
+//                      >    <error{The spring curve needs a single number literal argument}
+    property <float> j;
+    animate j { easing: spring(32 * 1); }
+//                      >    <error{The spring curve needs a single number literal argument}
+    property <float> k;
+    animate k { easing: spring("string"); }
+//                      >    <error{The spring curve needs a single number literal argument}
 }


### PR DESCRIPTION
Keep bare `spring` and `spring(bounce)`. Decided in the API review: don't give the same meaning to two spellings.

Bare `spring` no longer goes through the macro; the macro only sees call syntax and requires a single number literal argument.
