### PR TITLE
demos: add an analog clock for round displays

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -14,6 +14,7 @@ alsa
 amdgpu
 amet
 Amoled
+analogclock
 androideabi
 anyrender
 Appbar

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -179,6 +179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "analogclock"
+version = "1.18.0"
+dependencies = [
+ "mcu-board-support",
+ "slint",
+ "slint-build",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -9,6 +9,7 @@
 # as the root workspace so common library artifacts are reused.
 [workspace]
 members = [
+  'analogclock/rust',
   'energy-monitor',
   'home-automation/rust',
   'launcher',

--- a/demos/analogclock/README.md
+++ b/demos/analogclock/README.md
@@ -1,0 +1,35 @@
+<!-- Copyright © SixtyFPS GmbH <info@slint.dev> ; SPDX-License-Identifier: MIT -->
+
+# Analog Clock Demo
+
+An analog clock designed for round displays, such as smartwatch-style MCU
+dev kits with a circular screen.
+
+The window background is transparent and the face is an explicit circle, so
+the UI reads as round everywhere: on round hardware the corners lie outside
+the glass, and in a rectangular window (desktop, SlintPad) you see a round
+clock. The face is black, so a round AMOLED only lights the pixels it needs.
+The software renderer cannot rotate items, so the ticks and hands are chains
+of dots placed with sin/cos.
+
+| `.slint` Design | Rust Source | Online wasm Preview |
+| --- | --- | --- |
+| [`ui/clock.slint`](./ui/clock.slint) | [`rust/main.rs`](./rust/main.rs) | [Online simulation](https://slintpad.com/?load_url=https://raw.githubusercontent.com/slint-ui/slint/master/demos/analogclock/ui/clock.slint) |
+
+Run on the desktop (simulator):
+
+```sh
+cargo run --manifest-path demos/Cargo.toml -p analogclock --release
+```
+
+To run on a microcontroller, the demo builds against the
+[MCU backend](../../examples/mcu-board-support). Its README walks through
+the build and flashing steps for every supported board; use those commands
+with `--features=mcu-board-support/<board>` and this package, for example:
+
+```sh
+cargo build --manifest-path demos/Cargo.toml -p analogclock --no-default-features --features=mcu-board-support/pico-st7789 --target=thumbv6m-none-eabi --release
+```
+
+(The demo was developed on a smartwatch-style dev kit with a 466x466 round
+AMOLED.)

--- a/demos/analogclock/rust/Cargo.toml
+++ b/demos/analogclock/rust/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "analogclock"
+version = "1.18.0"
+authors = ["Slint Developers <info@slint.dev>"]
+edition.workspace = true
+build = "build.rs"
+publish = false
+license = "MIT"
+description = "An analog clock demo for round displays, such as the M5Stack StopWatch"
+
+[[bin]]
+path = "main.rs"
+name = "analogclock"
+
+[features]
+simulator = ["slint/renderer-software", "slint/backend-winit", "slint/std"]
+default = ["simulator"]
+
+[dependencies]
+slint = { path = "../../../api/rs/slint", default-features = false, features = ["compat-1-2"] }
+mcu-board-support = { path = "../../../examples/mcu-board-support" }
+
+[build-dependencies]
+slint-build = { path = "../../../api/rs/build" }

--- a/demos/analogclock/rust/build.rs
+++ b/demos/analogclock/rust/build.rs
@@ -1,0 +1,9 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    let config = slint_build::CompilerConfiguration::new()
+        .embed_resources(slint_build::EmbedResourcesKind::EmbedForSoftwareRenderer);
+    slint_build::compile_with_config("../ui/clock.slint", config).unwrap();
+    slint_build::print_rustc_flags().unwrap();
+}

--- a/demos/analogclock/rust/main.rs
+++ b/demos/analogclock/rust/main.rs
@@ -1,0 +1,39 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+#![no_std]
+#![cfg_attr(not(feature = "simulator"), no_main)]
+
+extern crate alloc;
+
+use core::cell::Cell;
+
+#[allow(unused_imports)]
+use mcu_board_support::prelude::*;
+
+slint::include_modules!();
+
+#[mcu_board_support::entry]
+fn main() -> ! {
+    mcu_board_support::init();
+    let main_window = MainWindow::new().unwrap();
+
+    // Bare metal has no wall clock, so the demo starts from the classic
+    // watch-face pose and counts up from there.
+    let total_seconds = Cell::new((10 * 60 + 8) * 60 + 37u32);
+
+    let timer = slint::Timer::default();
+    let weak = main_window.as_weak();
+    timer.start(slint::TimerMode::Repeated, core::time::Duration::from_secs(1), move || {
+        let Some(window) = weak.upgrade() else { return };
+        let now = (total_seconds.get() + 1) % (24 * 60 * 60);
+        total_seconds.set(now);
+        window.set_seconds((now % 60) as i32);
+        window.set_minutes((now / 60 % 60) as i32);
+        window.set_hours((now / 3600 % 12) as i32);
+    });
+
+    main_window.run().unwrap();
+
+    panic!("The demo should not quit")
+}

--- a/demos/analogclock/ui/clock.slint
+++ b/demos/analogclock/ui/clock.slint
@@ -1,0 +1,105 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+// An analog clock for round displays. The software renderer cannot rotate
+// rectangles, so ticks and hands are built from dots placed with sin/cos -
+// which also gives the face a distinctive look on a round AMOLED, where an
+// unlit black background draws no current.
+
+component Dot inherits Rectangle {
+    in property <angle> a;
+    in property <length> r;
+    in property <length> size;
+    x: 233px + self.r * sin(self.a) - self.size / 2;
+    y: 233px - self.r * cos(self.a) - self.size / 2;
+    width: self.size;
+    height: self.size;
+    border-radius: self.size / 2;
+}
+
+export component MainWindow inherits Window {
+    width: 466px;
+    height: 466px;
+    // Everything outside the circular face: nothing on the round panel,
+    // and see-through in a rectangular window (SlintPad, the simulator).
+    background: transparent;
+
+    in property <int> hours: 10;
+    in property <int> minutes: 8;
+    in property <int> seconds: 37;
+
+    property <angle> second-angle: root.seconds * 6deg;
+    property <angle> minute-angle: root.minutes * 6deg + root.seconds * 0.1deg;
+    property <angle> hour-angle: root.hours * 30deg + root.minutes * 0.5deg;
+
+    // The face itself: an explicit circle, so the UI reads as round even
+    // inside a rectangular window. Black, so the round AMOLED leaves these
+    // pixels unlit.
+    Rectangle {
+        x: 0;
+        y: 0;
+        width: 466px;
+        height: 466px;
+        border-radius: 233px;
+        background: #000000;
+    }
+
+    // Hour marks: larger at 12, 3, 6 and 9.
+    for index in 12: Dot {
+        a: index * 30deg;
+        r: 210px;
+        size: mod(index, 3) == 0 ? 14px : 7px;
+        background: mod(index, 3) == 0 ? #e0e0e0 : #606060;
+    }
+
+    // Minute marks.
+    for index in 60: Dot {
+        a: index * 6deg;
+        r: 222px;
+        size: 3px;
+        background: #303030;
+    }
+
+    // Hour hand.
+    for step in 6: Dot {
+        a: root.hour-angle;
+        r: 24px + step * 18px;
+        size: 18px - step * 1px;
+        background: #e0e0e0;
+    }
+
+    // Minute hand.
+    for step in 10: Dot {
+        a: root.minute-angle;
+        r: 24px + step * 17px;
+        size: 11px;
+        background: #a0a0a0;
+    }
+
+    // Second hand.
+    for step in 14: Dot {
+        a: root.second-angle;
+        r: 12px + step * 14px;
+        size: 5px;
+        background: #e04040;
+    }
+
+    // Centre cap.
+    Rectangle {
+        x: 233px - 12px;
+        y: 233px - 12px;
+        width: 24px;
+        height: 24px;
+        border-radius: 12px;
+        background: #e04040;
+    }
+
+    // Small digital readout under the centre.
+    Text {
+        x: 233px - self.width / 2;
+        y: 320px;
+        text: (root.hours < 10 ? "0" : "") + root.hours + ":" + (root.minutes < 10 ? "0" : "") + root.minutes;
+        color: #505050;
+        font-size: 28px;
+    }
+}


### PR DESCRIPTION
More and more MCU dev kits come with a circular screen, and every existing demo assumes a rectangle. This clock is shaped for the circle: the window background is transparent and the face is an explicit round Rectangle, so it reads as round on the device, in the simulator and on SlintPad alike. The face is black so a round AMOLED only lights what it needs, and since the software renderer cannot rotate items, the ticks and hands are chains of dots placed with sin/cos - a workaround that turned into the design.

Runs on the desktop via the default simulator feature and on any mcu-board-support board; with no wall clock on bare metal it starts at the classic 10:08 pose and counts up.

Fixes #13125

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
