### PR TITLE
lsp: Prospective fix for compilation with musl

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -25,8 +25,9 @@ name = "slint-lsp"
 path = "main.rs"
 
 [lib]
-# lib is there only for the web
-crate-type = ["cdylib"]
+# lib is there only for the web.
+# "rlib" is also needed so cdylib don't cause error on musl (#13169)
+crate-type = ["cdylib", "rlib"]
 path = "wasm_main.rs"
 # On windows building this package creates slint-lsp.exe and slint-lsp.dll.
 # To avoid that both end up trying to create slint-lsp.pdb for their debug


### PR DESCRIPTION
Otherwise compilation on alpine-linux results in

    cannot produce cdylib for `slint-lsp v1.17.1` as the target `x86_64-unknown-linux-musl` does not support these crate types

The library is empty on non-wasm so it should be a no-op

Fixes #13169
