### PR TITLE
testing: Rename set_accessible_selection() to set_accessible_selectio…

### DIFF
--- a/api/cpp/include/slint-testing.h
+++ b/api/cpp/include/slint-testing.h
@@ -410,7 +410,7 @@ public:
     /// Selects the text between two UTF-8 offsets.
     ///
     /// This will invoke the `accessible-action-set-selection-offsets` callback.
-    void set_accessible_selection(int anchor, int focus) const
+    void set_accessible_selection_offsets(int anchor, int focus) const
     {
         if (inner.element_index != 0)
             return;

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -646,7 +646,7 @@ impl ElementHandle {
     /// Selects the text between two UTF-8 offsets, by invoking the element's
     /// `accessible-action-set-selection-offsets` callback. Note that you can only do this if that callback
     /// is declared in your Slint code.
-    pub fn set_accessible_selection(&self, anchor: i32, focus: i32) {
+    pub fn set_accessible_selection_offsets(&self, anchor: i32, focus: i32) {
         if self.element_index != 0 {
             return;
         }

--- a/tests/cases/accessibility/set_selection.slint
+++ b/tests/cases/accessibility/set_selection.slint
@@ -22,17 +22,17 @@ let instance = TestCase::new().unwrap();
 let text_input =
     slint_testing::ElementHandle::find_by_element_id(&instance, "TestCase::ti").next().unwrap();
 
-text_input.set_accessible_selection(2, 7);
+text_input.set_accessible_selection_offsets(2, 7);
 assert_eq!(instance.get_anchor(), 2);
 assert_eq!(instance.get_cursor(), 7);
 
 // A backwards selection keeps the focus before the anchor.
-text_input.set_accessible_selection(9, 4);
+text_input.set_accessible_selection_offsets(9, 4);
 assert_eq!(instance.get_anchor(), 9);
 assert_eq!(instance.get_cursor(), 4);
 
 // Equal offsets move the cursor without selecting anything.
-text_input.set_accessible_selection(5, 5);
+text_input.set_accessible_selection_offsets(5, 5);
 assert_eq!(instance.get_anchor(), 5);
 assert_eq!(instance.get_cursor(), 5);
 ```
@@ -45,17 +45,17 @@ auto search = slint::testing::ElementHandle::find_by_element_id(handle, "TestCas
 assert_eq(search.size(), 1);
 auto text_input = search[0];
 
-text_input.set_accessible_selection(2, 7);
+text_input.set_accessible_selection_offsets(2, 7);
 assert_eq(instance.get_anchor(), 2);
 assert_eq(instance.get_cursor(), 7);
 
 // A backwards selection keeps the focus before the anchor.
-text_input.set_accessible_selection(9, 4);
+text_input.set_accessible_selection_offsets(9, 4);
 assert_eq(instance.get_anchor(), 9);
 assert_eq(instance.get_cursor(), 4);
 
 // Equal offsets move the cursor without selecting anything.
-text_input.set_accessible_selection(5, 5);
+text_input.set_accessible_selection_offsets(5, 5);
 assert_eq(instance.get_anchor(), 5);
 assert_eq(instance.get_cursor(), 5);
 ```


### PR DESCRIPTION
…n_offsets()

The Rust and C++ ui-testing wrappers follow the earlier rename of the `accessible-action-set-selection-offsets` callback, where the suffix emphasizes that the arguments are utf-8 byte offsets.

cc #13066

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
