### PR TITLE
node: Forward Slint log messages to console.log

### DIFF
--- a/api/node/rust/interpreter/component_definition.rs
+++ b/api/node/rust/interpreter/component_definition.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use napi::Result;
+use napi::{Env, Result};
 use slint_interpreter::ComponentDefinition;
 
 use super::{JsComponentInstance, JsProperty};
@@ -68,7 +68,13 @@ impl JsComponentDefinition {
     }
 
     #[napi]
-    pub fn create(&self) -> Result<JsComponentInstance> {
+    pub fn create(&self, env: Env) -> Result<JsComponentInstance> {
+        // Install the log handler before the instantiation, so that `debug()` in an
+        // `init` callback is routed too.
+        i_slint_backend_selector::with_global_context(|ctx| {
+            crate::install_log_message_handler(&env, ctx)
+        })
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
         Ok(self.internal.create().map_err(|e| napi::Error::from_reason(e.to_string()))?.into())
     }
 

--- a/api/node/rust/interpreter/component_instance.rs
+++ b/api/node/rust/interpreter/component_instance.rs
@@ -80,7 +80,10 @@ impl JsComponentInstance {
             } else if let Ok(value) = super::to_value(&env, result, &return_type, &owner) {
                 value
             } else {
-                eprintln!("Node.js: cannot convert return type of callback {callback_name}");
+                crate::console_err!(
+                    env,
+                    "Node.js: cannot convert return type of callback {callback_name}"
+                );
                 slint_interpreter::default_value_for_type(&return_type)
             }
         }

--- a/api/node/rust/lib.rs
+++ b/api/node/rust/lib.rs
@@ -197,3 +197,28 @@ pub fn print_to_console(env: Env, function: &str, arguments: core::fmt::Argument
 macro_rules! console_err {
     ($env:expr, $($t:tt)*) => ($crate::print_to_console($env, "error", format_args!($($t)*)))
 }
+
+/// Route Slint log messages (the `debug()` function in Slint code and runtime warnings)
+/// to `console.log`, like on wasm.
+pub(crate) fn install_log_message_handler(env: &Env, ctx: &i_slint_core::SlintContext) {
+    let env = *env;
+    ctx.set_log_message_handler(Some(Box::new(move |message| {
+        let arguments = message.message_arguments();
+        // A handle scope is needed because a message can arrive outside of any JS frame,
+        // e.g. from a timer dispatched by the integrated event loop.
+        let result = env.run_in_scope(|| {
+            match message.location() {
+                Some(l) => print_to_console(
+                    env,
+                    "log",
+                    format_args!("{}:{}:{}: {arguments}", l.path, l.line, l.column),
+                ),
+                None => print_to_console(env, "log", arguments),
+            }
+            Ok(())
+        });
+        if result.is_err() {
+            i_slint_core::debug_log::default_log_message(arguments);
+        }
+    })));
+}

--- a/api/node/rust/types/model.rs
+++ b/api/node/rust/types/model.rs
@@ -24,11 +24,26 @@ impl core::ops::Deref for SharedModelNotify {
     }
 }
 
+/// Take the pending JavaScript exception off the environment, so that later napi
+/// calls succeed and the exception doesn't surface when the runtime returns to JS.
+fn take_exception(env: &Env) {
+    let mut exception = std::ptr::null_mut();
+    // SAFETY: plain FFI call, napi-rs has no safe wrapper for it. The env is the valid
+    // environment of the calling thread and the out-pointer is a valid local; the
+    // exception value written to it stays owned by the VM and is discarded.
+    unsafe { napi::sys::napi_get_and_clear_last_exception(env.raw(), &mut exception) };
+}
+
 /// An unsupported ModelError naming the JavaScript class of the model, falling
-/// back to the name of the JsModel wrapper.
+/// back to the name of the JsModel wrapper. Clears the exception thrown to signal
+/// the rejection, so the class-name lookup and later napi calls work.
 fn unsupported_error(js_model: &JsModel, model: &Object) -> ModelError {
+    take_exception(&js_model.env);
     let class_name = || -> Option<String> {
-        let constructor: Object = model.get_named_property("constructor").ok()?;
+        // The constructor is a JS function; fetch it untyped and coerce, a typed
+        // `get_named_property::<Object>` rejects functions.
+        let constructor: Unknown = model.get_named_property("constructor").ok()?;
+        let constructor = constructor.coerce_to_object().ok()?;
         let name: String = constructor.get_named_property("name").ok()?;
         (!name.is_empty()).then_some(name)
     };
@@ -136,46 +151,59 @@ pub fn js_model_notify_reset(notify: ExternalRef<SharedModelNotify>) {
     notify.reset();
 }
 
+impl JsModel {
+    /// Report a glue-level error to `console.error`. Clears any pending JS exception
+    /// first, so the console call works and the exception doesn't surface in JS.
+    fn report_error(&self, message: core::fmt::Arguments<'_>) {
+        take_exception(&self.env);
+        crate::print_to_console(self.env, "error", message);
+    }
+}
+
 impl Model for JsModel {
     type Data = slint_interpreter::Value;
 
     fn row_count(&self) -> usize {
         let Some(model_unknown) = self.js_impl.get_unknown() else {
-            eprintln!("Node.js: JavaScript Model<T>'s rowCount threw an exception");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s rowCount threw an exception"
+            ));
             return 0;
         };
 
         let Ok(model) = model_unknown.coerce_to_object() else {
-            eprintln!("Node.js: JavaScript Model<T> is not an object");
+            self.report_error(format_args!("Node.js: JavaScript Model<T> is not an object"));
             return 0;
         };
 
         let row_count_fn: Function<(), Unknown> = match model.get_named_property("rowCount") {
             Ok(f) => f,
             Err(_) => {
-                eprintln!(
+                self.report_error(format_args!(
                     "Node.js: JavaScript Model<T> implementation is missing rowCount property"
-                );
+                ));
                 return 0;
             }
         };
 
         let Ok(row_count_result) = row_count_fn.apply(model, ()) else {
-            eprintln!("Node.js: JavaScript Model<T>'s rowCount implementation call failed");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s rowCount implementation call failed"
+            ));
             return 0;
         };
 
         let Ok(row_count_number) = row_count_result.coerce_to_number() else {
-            eprintln!(
+            self.report_error(format_args!(
                 "Node.js: JavaScript Model<T>'s rowCount function returned a value that cannot be coerced to a number"
-            );
+            ));
             return 0;
         };
 
         let Ok(row_count) = row_count_number.get_uint32() else {
-            eprintln!(
+            self.report_error(format_args!(
                 "Node.js: JavaScript Model<T>'s rowCount function returned a number that cannot be mapped to a uint32"
-            );
+            ));
             return 0;
         };
 
@@ -184,27 +212,31 @@ impl Model for JsModel {
 
     fn row_data(&self, row: usize) -> Option<Self::Data> {
         let Some(model_unknown) = self.js_impl.get_unknown() else {
-            eprintln!("Node.js: JavaScript Model<T>'s rowData threw an exception");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s rowData threw an exception"
+            ));
             return None;
         };
 
         let Ok(model) = model_unknown.coerce_to_object() else {
-            eprintln!("Node.js: JavaScript Model<T> is not an object");
+            self.report_error(format_args!("Node.js: JavaScript Model<T> is not an object"));
             return None;
         };
 
         let row_data_fn: Function<f64, Unknown> = match model.get_named_property("rowData") {
             Ok(f) => f,
             Err(_) => {
-                eprintln!(
+                self.report_error(format_args!(
                     "Node.js: JavaScript Model<T> implementation is missing rowData property"
-                );
+                ));
                 return None;
             }
         };
 
         let Ok(row_data) = row_data_fn.apply(model, row as f64) else {
-            eprintln!("Node.js: JavaScript Model<T>'s rowData function threw an exception");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s rowData function threw an exception"
+            ));
             return None;
         };
 
@@ -214,9 +246,9 @@ impl Model for JsModel {
         } else {
             let Ok(js_value) = to_value(&self.env, row_data, &self.row_data_type, &self.owner)
             else {
-                eprintln!(
+                self.report_error(format_args!(
                     "Node.js: JavaScript Model<T>'s rowData function returned data type that cannot be represented in Rust"
-                );
+                ));
                 return None;
             };
             Some(js_value)
@@ -225,12 +257,14 @@ impl Model for JsModel {
 
     fn set_row_data(&self, row: usize, data: Self::Data) {
         let Some(model_unknown) = self.js_impl.get_unknown() else {
-            eprintln!("Node.js: JavaScript Model<T>'s setRowData threw an exception");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s setRowData threw an exception"
+            ));
             return;
         };
 
         let Ok(model) = model_unknown.coerce_to_object() else {
-            eprintln!("Node.js: JavaScript Model<T> is not an object");
+            self.report_error(format_args!("Node.js: JavaScript Model<T> is not an object"));
             return;
         };
 
@@ -238,35 +272,37 @@ impl Model for JsModel {
             match model.get_named_property("setRowData") {
                 Ok(f) => f,
                 Err(_) => {
-                    eprintln!(
+                    self.report_error(format_args!(
                         "Node.js: JavaScript Model<T> implementation is missing setRowData property"
-                    );
+                    ));
                     return;
                 }
             };
 
         let Ok(js_data) = to_js_unknown(&self.env, &data) else {
-            eprintln!(
+            self.report_error(format_args!(
                 "Node.js: Model<T>'s set_row_data called by Rust with data type that can't be represented in JavaScript"
-            );
+            ));
             return;
         };
 
-        if let Err(exception) = set_row_data_fn.apply(model, FnArgs::from((row as f64, js_data))) {
-            eprintln!(
-                "Node.js: JavaScript Model<T>'s setRowData function threw an exception: {exception}"
-            );
+        // A rejected modification is reported by throwing.
+        if set_row_data_fn.apply(model, FnArgs::from((row as f64, js_data))).is_err() {
+            let error = unsupported_error(self, &model);
+            i_slint_core::debug_log!("setRowData(): {error}");
         }
     }
 
     fn push_row(&self, data: Self::Data) -> CoreResult<(), ModelError> {
         let Some(model_unknown) = self.js_impl.get_unknown() else {
-            eprintln!("Node.js: JavaScript Model<T>'s pushRow threw an exception");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s pushRow threw an exception"
+            ));
             return Err(ModelError::unsupported(self));
         };
 
         let Ok(model) = model_unknown.coerce_to_object() else {
-            eprintln!("Node.js: JavaScript Model<T> is not an object");
+            self.report_error(format_args!("Node.js: JavaScript Model<T> is not an object"));
             return Err(ModelError::unsupported(self));
         };
 
@@ -274,18 +310,17 @@ impl Model for JsModel {
         {
             Ok(f) => f,
             Err(e) => {
-                eprintln!("{}", e.to_string());
-                eprintln!(
-                    "Node.js: JavaScript Model<T> implementation is missing pushRow property"
-                );
+                self.report_error(format_args!(
+                    "Node.js: JavaScript Model<T> implementation is missing pushRow property: {e}"
+                ));
                 return Err(ModelError::unsupported(self));
             }
         };
 
         let Ok(js_data) = to_js_unknown(&self.env, &data) else {
-            eprintln!(
+            self.report_error(format_args!(
                 "Node.js: Model<T>'s push_row called by Rust with data type that can't be represented in JavaScript"
-            );
+            ));
             return Err(ModelError::unsupported(self));
         };
 
@@ -303,22 +338,23 @@ impl Model for JsModel {
         }
 
         let Some(model_unknown) = self.js_impl.get_unknown() else {
-            eprintln!("Node.js: JavaScript Model<T>'s removeRow threw an exception");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s removeRow threw an exception"
+            ));
             return Err(ModelError::unsupported(self));
         };
 
         let Ok(model) = model_unknown.coerce_to_object() else {
-            eprintln!("Node.js: JavaScript Model<T> is not an object");
+            self.report_error(format_args!("Node.js: JavaScript Model<T> is not an object"));
             return Err(ModelError::unsupported(self));
         };
 
         let remove_row_fn: Function<f64, Unknown> = match model.get_named_property("removeRow") {
             Ok(f) => f,
             Err(e) => {
-                eprintln!("{}", e.to_string());
-                eprintln!(
-                    "Node.js: JavaScript Model<T> implementation is missing removeRow property"
-                );
+                self.report_error(format_args!(
+                    "Node.js: JavaScript Model<T> implementation is missing removeRow property: {e}"
+                ));
                 return Err(ModelError::unsupported(self));
             }
         };
@@ -337,30 +373,32 @@ impl Model for JsModel {
         }
 
         let Some(model_unknown) = self.js_impl.get_unknown() else {
-            eprintln!("Node.js: JavaScript Model<T>'s insertRow threw an exception");
+            self.report_error(format_args!(
+                "Node.js: JavaScript Model<T>'s insertRow threw an exception"
+            ));
             return Err(ModelError::unsupported(self));
         };
 
         let Ok(model) = model_unknown.coerce_to_object() else {
-            eprintln!("Node.js: JavaScript Model<T> is not an object");
+            self.report_error(format_args!("Node.js: JavaScript Model<T> is not an object"));
             return Err(ModelError::unsupported(self));
         };
 
         let insert_row_fn: Function<FnArgs<(f64, Unknown<'_>)>, Unknown> =
             match model.get_named_property("insertRow") {
                 Ok(f) => f,
-                Err(_) => {
-                    eprintln!(
-                        "Node.js: JavaScript Model<T> implementation is missing insertRow property"
-                    );
+                Err(e) => {
+                    self.report_error(format_args!(
+                    "Node.js: JavaScript Model<T> implementation is missing insertRow property: {e}"
+                ));
                     return Err(ModelError::unsupported(self));
                 }
             };
 
         let Ok(js_data) = to_js_unknown(&self.env, &data) else {
-            eprintln!(
+            self.report_error(format_args!(
                 "Node.js: Model<T>'s insert_row called by Rust with data type that can't be represented in JavaScript"
-            );
+            ));
             return Err(ModelError::unsupported(self));
         };
 
@@ -406,8 +444,9 @@ impl ReadOnlyRustModel {
     }
 
     #[napi]
-    pub fn set_row_data(&self, _env: &Env, _row: u32, _data: Unknown<'_>) {
-        eprintln!(
+    pub fn set_row_data(&self, env: &Env, _row: u32, _data: Unknown<'_>) {
+        crate::console_err!(
+            *env,
             "setRowData called on a model which does not re-implement this method. This happens when trying to modify a read-only model"
         )
     }

--- a/api/node/typescript/models.ts
+++ b/api/node/typescript/models.ts
@@ -126,13 +126,12 @@ export abstract class Model<T> implements Iterable<T> {
     /**
      * Implementations of this function must store the provided data parameter
      * in the model at the specified row.
+     * The default implementation throws, rejecting the modification.
      * @param _row index in range 0..(rowCount() - 1).
      * @param _data new data item to store on the given row index
      */
     setRowData(_row: number, _data: T): void {
-        console.log(
-            "setRowData called on a model which does not re-implement this method. This happens when trying to modify a read-only model",
-        );
+        throw new TypeError("setRowData is not implemented on this model");
     }
 
     /**

--- a/tests/cases/expr/debug.slint
+++ b/tests/cases/expr/debug.slint
@@ -42,6 +42,8 @@ export component TestCase inherits Window {
 
     im := Image {x:0;y:0;}
 
+    init => { debug("init"); }
+
     pure public function do-debug() {
         debug();
         debug("a string");
@@ -66,6 +68,8 @@ export component TestCase inherits Window {
 /*
 ```rust
 let instance = TestCase::new().unwrap();
+let init_logs = slint_testing::access_testing_window(instance.window(), |w| w.take_debug_log());
+assert_eq!(init_logs, ["init"]);
 assert!(instance.get_test());
 // The test binding called do-debug()
 let binding_logs = slint_testing::access_testing_window(instance.window(), |w| w.take_debug_log());
@@ -96,5 +100,34 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 assert(instance.get_test());
 instance.invoke_do_debug();
+```
+
+```js
+// debug() prints to console.log, prefixed with the .slint source location
+const log = require("node:test").mock.method(console, "log", () => {});
+var instance = new slint.TestCase({});
+assert.equal(log.mock.calls.length, 1);
+// The line number of `init => { debug("init"); }` above
+assert(log.mock.calls[0].arguments[0].endsWith("debug.slint:45:15: init"), log.mock.calls[0].arguments[0]);
+// The test binding called do-debug()
+assert(instance.test);
+assert.equal(log.mock.calls.length, 16);
+instance.do_debug();
+log.mock.restore();
+const logs = log.mock.calls.map((call) => call.arguments[0]);
+assert.equal(logs.length, 31);
+const location = /^.*debug\.slint:\d+:\d+: /;
+const messages = logs.map((message) => {
+    assert.match(message, location);
+    return message.replace(location, "");
+});
+assert.equal(messages[16], "");
+assert.equal(messages[17], "a string");
+assert.equal(messages[18], "42");
+assert.equal(messages[21], "beta");
+assert.equal(messages[22], "{ flag: true, name: test, value: 7 }");
+assert.equal(messages[26], "multi 1 true");
+assert.equal(messages[27], "{ active: true, inner: { dir: gamma, pos: { px: 3.5, py: 4.5 }, x: 1, y: 2 }, label: outer }");
+assert.equal(messages[30], "0.1(px×ms⁻¹)");
 ```
 */

--- a/tests/cases/models/array.slint
+++ b/tests/cases/models/array.slint
@@ -44,6 +44,7 @@ export component TestCase {
     public function push_one(val: int) { ints.push(val) }
     public function remove_one(index: int) { ints.remove(index) }
     public function insert_one(index: int, value: int) { ints.insert(index, value) }
+    public function set_one(index: int, value: int) { ints[index] = value }
 
     public function push_one_empty(val: int) { empty_ints.push(val) }
     public function remove_one_empty() { empty_ints.remove(0) }
@@ -305,6 +306,31 @@ instance.remove_one_empty();
 assert.equal(model.rowCount(), 0);
 instance.insert_one_empty();
 assert.equal(model.rowCount(), 0);
+
+// A read-only model: it doesn't re-implement pushRow/insertRow/removeRow,
+// so mutating operations coming from .slint are rejected and logged.
+class ReadOnlyModel extends slintlib.Model {
+    rowCount() { return 3; }
+    rowData(row) { return [10, 20, 30][row]; }
+}
+instance.ints = new ReadOnlyModel();
+assert.equal(instance.num_ints, 3);
+assert.equal(instance.third_int, 30);
+
+const log = require("node:test").mock.method(console, "log", () => {});
+instance.push_one(40);
+instance.remove_one(0);
+instance.insert_one(1, 40);
+instance.set_one(0, 99);
+log.mock.restore();
+const logs = log.mock.calls.map((call) => call.arguments[0]);
+assert.equal(instance.num_ints, 3);
+assert.equal(instance.third_int, 30);
+assert.equal(logs.length, 4);
+assert.match(logs[0], /array\.slint:\d+:\d+: array\.push\(\): the model ReadOnlyModel does not support this modification$/);
+assert.match(logs[1], /array\.slint:\d+:\d+: array\.remove\(\): the model ReadOnlyModel does not support this modification$/);
+assert.match(logs[2], /array\.slint:\d+:\d+: array\.insert\(\): the model ReadOnlyModel does not support this modification$/);
+assert.equal(logs[3], "setRowData(): the model ReadOnlyModel does not support this modification");
 ```
 
 ////////// Test with read-only model and check for logs.


### PR DESCRIPTION
The debug() function in Slint code and the runtime warnings used to go to stderr. They now go to console.log, like on wasm, prefixed with the .slint source location. The handler is installed before a component is created, so messages from init callbacks are covered too.

This made it possible to test the rejected model modifications from JavaScript, which found several problems in the model glue:
 - The exception thrown to signal a rejection was left pending on the environment. It broke the napi calls that print the warning, and surfaced as an uncaught exception in the application.
 - The model's JavaScript class name never appeared in the warning, because napi's typed getter rejects the constructor for being a function.
 - The setRowData default now throws like the other row functions, and the rejection is logged in the same format. Note that a direct call to the default setRowData used to log a warning; now it throws.
 - The remaining stderr diagnostics in the glue now go to console.error.                                                                                        
                                                                     
Both are tested through the js blocks of the debug and array test cases.           
