### PR TITLE
esp-idf: don't call the RGB panel API on MIPI-DSI panels

### DIFF
--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -8,6 +8,26 @@
 #include "esp_lcd_types.h"
 
 /**
+ * The type of LCD peripheral that drives the panel.
+ *
+ * Slint can't detect the peripheral from the panel handle, but needs it to select the matching
+ * display synchronization. On chips that support several peripherals, such as the ESP32-P4,
+ * set the type explicitly if the panel doesn't use the one `Auto` selects.
+ */
+enum class SlintPanelType {
+    /// Select the peripheral based on the chip's capabilities: the MIPI-DSI DPI peripheral if
+    /// the chip supports MIPI-DSI, otherwise the parallel RGB LCD peripheral.
+    Auto,
+    /// A panel driven by the parallel RGB LCD peripheral (`esp_lcd_new_rgb_panel`).
+    RgbLcd,
+    /// A DPI panel on the MIPI-DSI peripheral (`esp_lcd_new_panel_dpi`).
+    MipiDsiDpi,
+    /// A panel behind another interface (SPI, I80, ...), without peripheral-specific
+    /// synchronization.
+    Other,
+};
+
+/**
  * This data structure configures the Slint platform for use with ESP-IDF, in particular
  * the esp_lcd component (
  * https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/lcd.html )
@@ -17,16 +37,18 @@
  *
  * * Single-buffering: Allocate one frame-buffer at a location of your choosing in RAM, and
  *                     set the `buffer1` field.
- * * Double-buffering: Call `esp_lcd_rgb_panel_get_frame_buffer` to obtain two frame buffers
+ * * Double-buffering: Call `esp_lcd_rgb_panel_get_frame_buffer` or
+ *                     `esp_lcd_dpi_panel_get_frame_buffer` to obtain two frame buffers
  *                     allocated by the `esp_lcd` driver and set `buffer1` and `buffer2`.
+ *                     On chips that support several LCD peripherals, also set `panel_type`.
  * * Line-by-line rendering: Set neither `buffer1` nor `buffer2` to instruct Slint to allocate
  *                           a buffer (with MALLOC_CAP_INTERNAL) big enough to hold one line,
  *                           render into it, and send it to the display.
  *
  *  Use single-buffering if you can allocate a buffer in a memory region that allows the esp_lcd
- *  driver to efficiently transfer to the display. Use double-buffering if your driver supports
- *  calling `esp_lcd_rgb_panel_get_frame_buffer` and the buffers can be accessed directly by the
- *  display controller. Use line-by-line rendering if you don't have sufficient memory or rendering
+ *  driver to efficiently transfer to the display. Use double-buffering if the driver for your
+ *  panel provides two frame buffers that the display controller can access directly.
+ *  Use line-by-line rendering if you don't have sufficient memory or rendering
  *  to internal memory (MALLOC_CAP_INTERNAL) and flushing to the display is faster than rendering
  *  into memory buffers that may be slower to access for the CPU.
  *
@@ -55,9 +77,9 @@ struct SlintPlatformConfiguration
     /// The buffer Slint will render into. It must have have the size of at least one frame. Slint
     /// calls esp_lcd_panel_draw_bitmap to flush the buffer to the screen.
     std::optional<std::span<PixelType>> buffer1 = {};
-    /// If specified, this is a second buffer that will be used for double-buffering. Use this if
-    /// your LCD panel supports double buffering: Call `esp_lcd_rgb_panel_get_frame_buffer` to
-    /// obtain two buffers and set `buffer` and `buffer2` in this data structure.
+    /// If specified, this is a second buffer that will be used for double-buffering. Call
+    /// `esp_lcd_rgb_panel_get_frame_buffer` or `esp_lcd_dpi_panel_get_frame_buffer` to obtain
+    /// two driver-allocated buffers and set `buffer1` and `buffer2`.
     std::optional<std::span<PixelType>> buffer2 = {};
     slint::platform::SoftwareRenderer::RenderingRotation rotation =
             slint::platform::SoftwareRenderer::RenderingRotation::NoRotation;
@@ -67,6 +89,9 @@ struct SlintPlatformConfiguration
         [[deprecated("Renamed to byte_swap")]] bool color_swap_16;
         bool byte_swap = false;
     };
+    /// The type of LCD peripheral that drives the panel. Only set this on chips that support
+    /// several peripherals, such as the ESP32-P4.
+    SlintPanelType panel_type = SlintPanelType::Auto;
 };
 
 template<typename... Args>

--- a/api/cpp/esp-idf/slint/include/slint-esp.h
+++ b/api/cpp/esp-idf/slint/include/slint-esp.h
@@ -14,7 +14,7 @@
  * display synchronization. On chips that support several peripherals, such as the ESP32-P4,
  * set the type explicitly if the panel doesn't use the one `Auto` selects.
  */
-enum class SlintPanelType {
+enum class SlintDisplayPanelType {
     /// Select the peripheral based on the chip's capabilities: the MIPI-DSI DPI peripheral if
     /// the chip supports MIPI-DSI, otherwise the parallel RGB LCD peripheral.
     Auto,
@@ -91,7 +91,7 @@ struct SlintPlatformConfiguration
     };
     /// The type of LCD peripheral that drives the panel. Only set this on chips that support
     /// several peripherals, such as the ESP32-P4.
-    SlintPanelType panel_type = SlintPanelType::Auto;
+    SlintDisplayPanelType panel_type = SlintDisplayPanelType::Auto;
 };
 
 template<typename... Args>

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -47,6 +47,7 @@ struct EspPlatform : public slint::platform::Platform
     EspPlatform(const SlintPlatformConfiguration<PixelType> &config)
         : size(config.size),
           panel_handle(config.panel_handle),
+          panel_type(config.panel_type),
           touch_handle(config.touch_handle),
           buffer1(config.buffer1),
           buffer2(config.buffer2),
@@ -66,6 +67,7 @@ struct EspPlatform : public slint::platform::Platform
 private:
     slint::PhysicalSize size;
     esp_lcd_panel_handle_t panel_handle;
+    SlintPanelType panel_type;
     esp_lcd_touch_handle_t touch_handle;
     std::optional<std::span<PixelType>> buffer1;
     std::optional<std::span<PixelType>> buffer2;
@@ -187,8 +189,21 @@ void EspPlatform<PixelType>::run_event_loop()
             max_ticks_to_wait = pdMS_TO_TICKS(10);
         }
     }
+    // The esp_lcd_rgb_panel_* and esp_lcd_dpi_panel_* APIs write through the opaque panel handle
+    // assuming their own driver's struct layout, without any run-time type check, so they must
+    // only be called on a panel that the matching peripheral drives. The peripheral cannot be
+    // queried from the handle; resolve SlintPanelType::Auto from the chip's capabilities.
+#if SOC_MIPI_DSI_SUPPORTED && ESP_IDF_VERSION_MAJOR >= 5
+    const bool is_dpi_panel =
+            panel_type == SlintPanelType::MipiDsiDpi || panel_type == SlintPanelType::Auto;
+#else
+    [[maybe_unused]] const bool is_dpi_panel = false;
+#endif
+
 #if SOC_LCD_RGB_SUPPORTED && ESP_IDF_VERSION_MAJOR >= 5
-    if (buffer2) {
+    const bool is_rgb_panel = panel_type == SlintPanelType::RgbLcd
+            || (panel_type == SlintPanelType::Auto && !is_dpi_panel);
+    if (buffer2 && is_rgb_panel) {
         sem_vsync_end = xSemaphoreCreateBinary();
         sem_gui_ready = xSemaphoreCreateBinary();
         esp_lcd_rgb_panel_event_callbacks_t cbs = {};
@@ -198,21 +213,22 @@ void EspPlatform<PixelType>::run_event_loop()
 #endif
 
 #if SOC_MIPI_DSI_SUPPORTED && ESP_IDF_VERSION_MAJOR >= 5
-    // Assumes panel_handle is a MIPI-DSI DPI panel (the case on e.g. ESP32-P4). Register the
-    // completion callbacks that drive the draw and refresh synchronization described above.
-    // sem_dpi_draw_done starts "available" so the first draw isn't blocked.
-    sem_dpi_draw_done = xSemaphoreCreateBinary();
-    xSemaphoreGive(sem_dpi_draw_done);
-    sem_dpi_refresh = xSemaphoreCreateBinary();
-    esp_lcd_dpi_panel_event_callbacks_t dpi_cbs = {};
-    dpi_cbs.on_color_trans_done = on_dpi_color_trans_done;
-    dpi_cbs.on_refresh_done = on_dpi_refresh_done;
-    if (esp_lcd_dpi_panel_register_event_callbacks(panel_handle, &dpi_cbs, nullptr) != ESP_OK) {
-        // Not a DPI panel (or callbacks unsupported): fall back to draws without synchronization.
-        vSemaphoreDelete(sem_dpi_draw_done);
-        sem_dpi_draw_done = nullptr;
-        vSemaphoreDelete(sem_dpi_refresh);
-        sem_dpi_refresh = nullptr;
+    if (is_dpi_panel) {
+        // Register the completion callbacks that drive the draw and refresh synchronization
+        // described above. sem_dpi_draw_done starts "available" so the first draw isn't blocked.
+        sem_dpi_draw_done = xSemaphoreCreateBinary();
+        xSemaphoreGive(sem_dpi_draw_done);
+        sem_dpi_refresh = xSemaphoreCreateBinary();
+        esp_lcd_dpi_panel_event_callbacks_t dpi_cbs = {};
+        dpi_cbs.on_color_trans_done = on_dpi_color_trans_done;
+        dpi_cbs.on_refresh_done = on_dpi_refresh_done;
+        if (esp_lcd_dpi_panel_register_event_callbacks(panel_handle, &dpi_cbs, nullptr) != ESP_OK) {
+            // Callbacks unsupported: fall back to draws without synchronization.
+            vSemaphoreDelete(sem_dpi_draw_done);
+            sem_dpi_draw_done = nullptr;
+            vSemaphoreDelete(sem_dpi_refresh);
+            sem_dpi_refresh = nullptr;
+        }
     }
 #endif
 
@@ -297,7 +313,9 @@ void EspPlatform<PixelType>::run_event_loop()
                 auto stride = rotated ? size.height : size.width;
                 if (buffer1) {
 #if SOC_LCD_RGB_SUPPORTED && ESP_IDF_VERSION_MAJOR >= 5
-                    if (buffer2) {
+                    // Only created for double buffering on an RGB panel; wait for the vsync
+                    // event before rendering into the buffer the panel no longer scans out.
+                    if (sem_gui_ready) {
                         xSemaphoreGive(sem_gui_ready);
                         xSemaphoreTake(sem_vsync_end, portMAX_DELAY);
                     }

--- a/api/cpp/esp-idf/slint/src/slint-esp.cpp
+++ b/api/cpp/esp-idf/slint/src/slint-esp.cpp
@@ -67,7 +67,7 @@ struct EspPlatform : public slint::platform::Platform
 private:
     slint::PhysicalSize size;
     esp_lcd_panel_handle_t panel_handle;
-    SlintPanelType panel_type;
+    SlintDisplayPanelType panel_type;
     esp_lcd_touch_handle_t touch_handle;
     std::optional<std::span<PixelType>> buffer1;
     std::optional<std::span<PixelType>> buffer2;
@@ -192,17 +192,17 @@ void EspPlatform<PixelType>::run_event_loop()
     // The esp_lcd_rgb_panel_* and esp_lcd_dpi_panel_* APIs write through the opaque panel handle
     // assuming their own driver's struct layout, without any run-time type check, so they must
     // only be called on a panel that the matching peripheral drives. The peripheral cannot be
-    // queried from the handle; resolve SlintPanelType::Auto from the chip's capabilities.
+    // queried from the handle; resolve SlintDisplayPanelType::Auto from the chip's capabilities.
 #if SOC_MIPI_DSI_SUPPORTED && ESP_IDF_VERSION_MAJOR >= 5
-    const bool is_dpi_panel =
-            panel_type == SlintPanelType::MipiDsiDpi || panel_type == SlintPanelType::Auto;
+    const bool is_dpi_panel = panel_type == SlintDisplayPanelType::MipiDsiDpi
+            || panel_type == SlintDisplayPanelType::Auto;
 #else
     [[maybe_unused]] const bool is_dpi_panel = false;
 #endif
 
 #if SOC_LCD_RGB_SUPPORTED && ESP_IDF_VERSION_MAJOR >= 5
-    const bool is_rgb_panel = panel_type == SlintPanelType::RgbLcd
-            || (panel_type == SlintPanelType::Auto && !is_dpi_panel);
+    const bool is_rgb_panel = panel_type == SlintDisplayPanelType::RgbLcd
+            || (panel_type == SlintDisplayPanelType::Auto && !is_dpi_panel);
     if (buffer2 && is_rgb_panel) {
         sem_vsync_end = xSemaphoreCreateBinary();
         sem_gui_ready = xSemaphoreCreateBinary();

--- a/demos/home-automation/esp-idf/main/main.cpp
+++ b/demos/home-automation/esp-idf/main/main.cpp
@@ -79,6 +79,7 @@ extern "C" void app_main(void)
             .touch_handle = touch_handle,
             .rotation = slint::platform::SoftwareRenderer::RenderingRotation::Rotate90,
             .byte_swap = false,
+            .panel_type = SlintPanelType::MipiDsiDpi,
     });
 
     auto ui = AppWindow::create();

--- a/demos/home-automation/esp-idf/main/main.cpp
+++ b/demos/home-automation/esp-idf/main/main.cpp
@@ -79,7 +79,7 @@ extern "C" void app_main(void)
             .touch_handle = touch_handle,
             .rotation = slint::platform::SoftwareRenderer::RenderingRotation::Rotate90,
             .byte_swap = false,
-            .panel_type = SlintPanelType::MipiDsiDpi,
+            .panel_type = SlintDisplayPanelType::MipiDsiDpi,
     });
 
     auto ui = AppWindow::create();

--- a/demos/usecases/esp-idf/main/main.cpp
+++ b/demos/usecases/esp-idf/main/main.cpp
@@ -43,7 +43,8 @@ extern "C" void app_main(void)
     slint_esp_init(SlintPlatformConfiguration {
             .size = slint::PhysicalSize({ BSP_LCD_H_RES, BSP_LCD_V_RES }),
             .panel_handle = handles.panel,
-            .touch_handle = touch_handle });
+            .touch_handle = touch_handle,
+            .panel_type = SlintPanelType::MipiDsiDpi });
 
     run();
 }

--- a/demos/usecases/esp-idf/main/main.cpp
+++ b/demos/usecases/esp-idf/main/main.cpp
@@ -44,7 +44,7 @@ extern "C" void app_main(void)
             .size = slint::PhysicalSize({ BSP_LCD_H_RES, BSP_LCD_V_RES }),
             .panel_handle = handles.panel,
             .touch_handle = touch_handle,
-            .panel_type = SlintPanelType::MipiDsiDpi });
+            .panel_type = SlintDisplayPanelType::MipiDsiDpi });
 
     run();
 }

--- a/docs/cpp/src/content/docs/mcu/esp-idf/troubleshoot.md
+++ b/docs/cpp/src/content/docs/mcu/esp-idf/troubleshoot.md
@@ -38,7 +38,7 @@ If your display controller expects little endian, set the `byte_swap` field in `
 Double buffering synchronizes rendering with the LCD peripheral, so Slint needs to know which peripheral
 drives the panel. On chips that support several, such as the ESP32-P4, Slint assumes MIPI-DSI.
 If your panel uses a different interface, set the `panel_type` field in `SlintPlatformConfiguration`,
-for example to `SlintPanelType::RgbLcd` for a parallel RGB panel.
+for example to `SlintDisplayPanelType::RgbLcd` for a parallel RGB panel.
 
 ## Errors about multiple symbol definitions when linking
 

--- a/docs/cpp/src/content/docs/mcu/esp-idf/troubleshoot.md
+++ b/docs/cpp/src/content/docs/mcu/esp-idf/troubleshoot.md
@@ -33,6 +33,13 @@ and your display expecting a different byte order. Typically, esp32 devices are 
 expect big-endian or `esp_lcd` configures them accordingly. Therefore, by default Slint converts pixels to big-endian.
 If your display controller expects little endian, set the `byte_swap` field in `SlintPlatformConfiguration` to `false`.
 
+## Black screen or crash when using double buffering
+
+Double buffering synchronizes rendering with the LCD peripheral, so Slint needs to know which peripheral
+drives the panel. On chips that support several, such as the ESP32-P4, Slint assumes MIPI-DSI.
+If your panel uses a different interface, set the `panel_type` field in `SlintPlatformConfiguration`,
+for example to `SlintPanelType::RgbLcd` for a parallel RGB panel.
+
 ## Errors about multiple symbol definitions when linking
 
 You see errors at application link time such as these:


### PR DESCRIPTION
Double buffering registered the RGB LCD vsync callback whenever the chip supports the RGB LCD peripheral. On chips that also support MIPI-DSI, such as the ESP32-P4, this called an RGB-panel-only API on a DSI panel handle, corrupting the driver state.

The esp_lcd API cannot tell which peripheral drives a panel handle, so add a panel_type field to SlintPlatformConfiguration. The default infers the type from the chip's capabilities: DSI-capable chips now take the DPI path instead of the RGB one, and a board that drives an RGB panel with a DSI-capable chip can set the type explicitly.

Set the new field explicitly in the ESP32-P4 demos and document it in the troubleshooting guide.

Fixes: #13180
