### PR TITLE
Software renderer: leave take_snapshot out of no_std builds

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -411,6 +411,7 @@ mipidsi
 miscompile
 modalnavigationdrawer
 modelprop
+monomorphizes
 MOSI
 msgctx
 msgctxt

--- a/api/cpp/include/private/slint_window.h
+++ b/api/cpp/include/private/slint_window.h
@@ -706,9 +706,12 @@ public:
         return cbindgen_private::slint_windowrc_has_active_animations(&inner.handle());
     }
 
+#if !defined(SLINT_FEATURE_FREESTANDING) || defined(DOXYGEN)
     /// Takes a snapshot of the window contents and returns it as RGBA8 encoded pixel buffer.
     ///
     /// Note that this function may be slow to call as it may need to re-render the scene.
+    ///
+    /// This function is not available in freestanding environments.
     std::optional<SharedPixelBuffer<Rgba8Pixel>> take_snapshot() const
     {
         SharedPixelBuffer<Rgba8Pixel> result;
@@ -719,6 +722,7 @@ public:
             return {};
         }
     }
+#endif
 
 #if (!defined(__APPLE__) && !defined(_WIN32) && !defined(_WIN64)                                   \
      && !defined(SLINT_FEATURE_FREESTANDING))                                                      \

--- a/internal/core/api.rs
+++ b/internal/core/api.rs
@@ -832,6 +832,9 @@ impl Window {
     /// Takes a snapshot of the window contents and returns it as RGBA8 encoded pixel buffer.
     ///
     /// Note that this function may be slow to call as it may need to re-render the scene.
+    ///
+    /// Only available with the `std` feature.
+    #[cfg(feature = "std")]
     pub fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         self.0.window_adapter().renderer().take_snapshot()
     }

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -6,6 +6,7 @@ use alloc::rc::Rc;
 use core::pin::Pin;
 
 use crate::api::PlatformError;
+#[cfg(feature = "std")]
 use crate::graphics::{Rgba8Pixel, SharedPixelBuffer};
 use crate::item_tree::ItemTreeRef;
 use crate::items::{ItemRc, TextWrap};
@@ -367,6 +368,7 @@ pub trait RendererSealed {
 
     /// Re-implement this function to support Window::take_snapshot(), i.e. return
     /// the contents of the window in an image buffer.
+    #[cfg(feature = "std")]
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         Err("WindowAdapter::take_snapshot is not implemented by the platform".into())
     }

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -2457,10 +2457,13 @@ pub mod ffi {
     #![allow(missing_docs)]
 
     use super::*;
+    #[cfg(feature = "std")]
     use crate::SharedVector;
     use crate::api::{RenderingNotifier, RenderingState, SetRenderingNotifierError};
+    use crate::graphics::IntSize;
+    #[cfg(feature = "std")]
+    use crate::graphics::Rgba8Pixel;
     use crate::graphics::Size;
-    use crate::graphics::{IntSize, Rgba8Pixel};
     use crate::items::WindowItem;
     use core::ffi::c_void;
 
@@ -3072,6 +3075,7 @@ pub mod ffi {
     }
 
     /// Takes a snapshot of the window contents and returns it as RGBA8 encoded pixel buffer.
+    #[cfg(feature = "std")]
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn slint_windowrc_take_snapshot(
         handle: *const WindowAdapterRcOpaque,

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -34,9 +34,9 @@ use euclid::Length;
 use fixed::Fixed;
 #[cfg(feature = "std")]
 use i_slint_core::api::PlatformError;
-use i_slint_core::graphics::rendering_metrics_collector::{RefreshMode, RenderingMetricsCollector};
 #[cfg(feature = "std")]
 use i_slint_core::graphics::Rgba8Pixel;
+use i_slint_core::graphics::rendering_metrics_collector::{RefreshMode, RenderingMetricsCollector};
 use i_slint_core::graphics::{BorderRadius, SharedImageBuffer, SharedPixelBuffer};
 use i_slint_core::item_rendering::HasFont;
 use i_slint_core::item_rendering::{

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -32,9 +32,12 @@ use core::cell::{Cell, RefCell};
 use core::pin::Pin;
 use euclid::Length;
 use fixed::Fixed;
+#[cfg(feature = "std")]
 use i_slint_core::api::PlatformError;
 use i_slint_core::graphics::rendering_metrics_collector::{RefreshMode, RenderingMetricsCollector};
-use i_slint_core::graphics::{BorderRadius, Rgba8Pixel, SharedImageBuffer, SharedPixelBuffer};
+#[cfg(feature = "std")]
+use i_slint_core::graphics::Rgba8Pixel;
+use i_slint_core::graphics::{BorderRadius, SharedImageBuffer, SharedPixelBuffer};
 use i_slint_core::item_rendering::HasFont;
 use i_slint_core::item_rendering::{
     CachedRenderingData, ItemRenderer, PlainOrStyledText, RenderBorderRectangle, RenderImage,
@@ -1201,6 +1204,8 @@ impl RendererSealed for SoftwareRenderer {
             .and_then(|window_adapter| window_adapter.upgrade())
     }
 
+    // Rendering to a second pixel format monomorphizes the pipeline twice; keep it out of MCU builds.
+    #[cfg(feature = "std")]
     fn take_snapshot(&self) -> Result<SharedPixelBuffer<Rgba8Pixel>, PlatformError> {
         let Some(window_adapter) =
             self.maybe_window_adapter.borrow().as_ref().and_then(|w| w.upgrade())


### PR DESCRIPTION
The snapshot renders into a second pixel format, which monomorphizes the whole rendering pipeline a second time. Gating it behind the std feature saves 53K (4.1%) of text in the pico printerdemo firmware. The trait's default implementation remains, so Window::take_snapshot returns an error on MCU instead of not compiling.