### PR TITLE
Attempt to bring Claude comments under control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ When this principle applies: any time you design syntax for a new visual or layo
 - When responding to review feedback, put the explanation in the commit message and the
   review reply, not in a new code comment.
   Add a comment only where the code itself is unclear to someone who never saw the review.
-  See rule 4 of the [Writing Style Guide](docs/internal/writing-style-guide.md).
+  See Code Comments rule 4 of the [Writing Style Guide](docs/internal/writing-style-guide.md).
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,10 @@ When this principle applies: any time you design syntax for a new visual or layo
   track how feedback was incorporated; squash them once the review is complete. See
   [`docs/development.md`](docs/development.md#commit-history--code-reviews) for the full
   fixup-then-squash workflow, and for `mise`-based environment setup.
+- When responding to review feedback, put the explanation in the commit message and the
+  review reply, not in a new code comment.
+  Add a comment only where the code itself is unclear to someone who never saw the review.
+  See rule 4 of the [Writing Style Guide](docs/internal/writing-style-guide.md).
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+@AGENTS.md
+@docs/internal/writing-style-guide.md

--- a/docs/internal/writing-style-guide.md
+++ b/docs/internal/writing-style-guide.md
@@ -33,6 +33,7 @@ Concretely:
    - Rationale: Use exclamation points sparingly and save them for when they really count; we already have the reader's attention.
 4. In Markdown and doc comments, put each sentence on its own line, or break after a comma when a line gets long.
    - Rationale: Just like a newline after `;` in code, this keeps diffs readable and avoids reflowing a whole paragraph for one edit.
+     It also makes an overlong sentence obvious: one that fills three lines on its own needs splitting, not rewrapping.
 5. Use American English spelling.
    - Rationale: Slint's API uses American spelling (such as `color`), so the rest of our writing matches.
 

--- a/docs/internal/writing-style-guide.md
+++ b/docs/internal/writing-style-guide.md
@@ -36,6 +36,10 @@ Concretely:
      It also makes an overlong sentence obvious: one that fills three lines on its own needs splitting, not rewrapping.
 5. Use American English spelling.
    - Rationale: Slint's API uses American spelling (such as `color`), so the rest of our writing matches.
+6. Keep sentences under about 25 words.
+   - Avoid: reaching for a third clause, a dash, or a parenthetical aside.
+   - Use: a split at the first "and" or ";".
+   - Rationale: A sentence the reader has to take twice costs more than the two sentences it replaces.
 
 ## Code Comments
 

--- a/docs/internal/writing-style-guide.md
+++ b/docs/internal/writing-style-guide.md
@@ -57,6 +57,7 @@ For comments in source code — both internal implementation notes and public AP
 4. Never write what the code used to be, or what a review said about it.
    - Avoid: "the review found this wrong", "this used to be unrounded", "round 3", "see the commit message".
    - Use: a bare issue reference such as `#6739` when the background is worth chasing.
+   - Exception: a regression test may state the old, wrong behavior, since pinning it is why the test exists.
    - Rationale: The next reader needs the code's current contract, not the discussion that produced it; `git log` and `git blame` already keep the discussion.
 5. Keep a doc comment under about ten lines.
    - Use: a page under `docs/development/` for anything longer, linked from the comment.

--- a/docs/internal/writing-style-guide.md
+++ b/docs/internal/writing-style-guide.md
@@ -59,9 +59,9 @@ For comments in source code — both internal implementation notes and public AP
    - Use: a bare issue reference such as `#6739` when the background is worth chasing.
    - Exception: a regression test may state the old, wrong behavior, since pinning it is why the test exists.
    - Rationale: The next reader needs the code's current contract, not the discussion that produced it; `git log` and `git blame` already keep the discussion.
-5. Keep a doc comment under about ten lines.
+5. A comment shouldn't be longer than the item it describes, and rarely needs more than fifteen lines.
    - Use: a page under `docs/development/` for anything longer, linked from the comment.
-   - Rationale: A comment that outgrows the item it describes stops being read.
+   - Rationale: A comment that outgrows the code it describes stops being read.
 
 ## Diagnostics
 

--- a/docs/internal/writing-style-guide.md
+++ b/docs/internal/writing-style-guide.md
@@ -45,6 +45,17 @@ For comments in source code — both internal implementation notes and public AP
 2. For public items, document the interface, not the implementation.
    - A comment above a property, function, or type says what it does and why for the caller, not how it works inside.
    - Rationale: Callers shouldn't have to read the implementation, and implementation details in the comment go stale as the code evolves.
+3. Explain a thing once, then cross-reference it.
+   - Avoid: repeating the same rationale on the trait, on each implementation, and again at the call site.
+   - Use: the full explanation where the thing is defined, and "see `foo`" everywhere else.
+   - Rationale: One copy can't drift out of sync with the other three, and a reader who already knows the rationale skips a reference faster than a paragraph.
+4. Never write what the code used to be, or what a review said about it.
+   - Avoid: "the review found this wrong", "this used to be unrounded", "round 3", "see the commit message".
+   - Use: a bare issue reference such as `#6739` when the background is worth chasing.
+   - Rationale: The next reader needs the code's current contract, not the discussion that produced it; `git log` and `git blame` already keep the discussion.
+5. Keep a doc comment under about ten lines.
+   - Use: a page under `docs/development/` for anything longer, linked from the comment.
+   - Rationale: A comment that outgrows the item it describes stops being read.
 
 ## Diagnostics
 


### PR DESCRIPTION
Reviewing the session context in Claude code using the `/memory` command shows that Claude does not include `AGENTS.md` as part of the session context. Resolve this by adding a `CLAUDE.md` that at-includes the `AGENTS.md` file.

Additionally inline the writing style guide because the markdown link in `AGENTS.md` is not sufficient to pull it into Claude's context. The agent sees the link as inert text and has to make a decision as to whether it is worth including in the context or not.

The writing style guide and `AGENTS.md` changes were produced following a discussion with Claude about another PR and whether the comments there followed the writing style guide (and why not). I welcome discussion on these rules (is ten lines still too many?) and maybe it is worth a slightly wider study of PRs to see how the rules would apply to them.