### PR TITLE
Update the esp crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,11 +2211,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esp-backtrace"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37950e24b2dfd98f1581102d1798281d4d9547af881e6bffc2c2b534c026ec8f"
+checksum = "4fbfed00e884572d620a6958b13456fc2bb8ab75802b5adc8afc224f97cdebad"
 dependencies = [
- "cfg-if",
  "document-features",
  "esp-config",
  "esp-metadata-generated",
@@ -2227,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "esp-config"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9b92fd9cfb0b4f8f1b6219b9763269a335571e307b014903b8201619374b80"
+checksum = "fcd577a122ec917691f6820a3df54388ecebc750f071b060f5e83707bc415512"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -2240,15 +2239,15 @@ dependencies = [
 
 [[package]]
 name = "esp-metadata-generated"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c2ee95b945a4780796e4359e72c033aed3b45073880e8029458f538532db8a"
+checksum = "44d5a63d730b8c56e6b32773e35fcc4988d7d2e5c64d521652317d3ebddf2b52"
 
 [[package]]
 name = "esp-println"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dee1e9ac7c3539bf6464db1707b0edd7557168f98278cf3c84fe70e63c6ce6"
+checksum = "ebf772a41bc642b57399632aa06ab55391de35b2b8fcbb1b270d282fbd0fe5ff"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -6531,7 +6530,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8086,18 +8085,19 @@ dependencies = [
 
 [[package]]
 name = "somni-expr"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed9b7648d5e8b2df6c5e49940c54bcdd2b4dd71eafc6e8f1c714eb4581b0f53"
+checksum = "f024812d1302010ff9227b80650469e58a3ef129ec5fda36c7a0b6b14ce07371"
 dependencies = [
+ "indexmap",
  "somni-parser",
 ]
 
 [[package]]
 name = "somni-parser"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f368519fc6c85fc1afdb769fb5a51123f6158013e143656e25a3485a0d401c"
+checksum = "4ba0fb59df288988d1f80eab8a0a32b18222e87b48d07b065c2f69cfc54d946c"
 
 [[package]]
 name = "spake2"

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -81,8 +81,8 @@ slint-interpreter = { workspace = true, features = ["ffi", "compat-1-2"], option
 i-slint-live-preview = { workspace = true, optional = true, features = ["ffi"] }
 raw-window-handle = { version = "0.6", optional = true }
 
-esp-backtrace = { version = "0.19.0", features = ["panic-handler", "println"], optional = true }
-esp-println = { version = "0.17.0", default-features = false, features = ["auto", "log-04"], optional = true }
+esp-backtrace = { version = "0.20.0", features = ["panic-handler", "println"], optional = true }
+esp-println = { version = "0.18.0", default-features = false, features = ["auto", "log-04"], optional = true }
 unicode-segmentation = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/examples/mcu-board-support/Cargo.toml
+++ b/examples/mcu-board-support/Cargo.toml
@@ -120,7 +120,7 @@ esp32-s3-box-3 = [
   "dep:static_cell",
   "embedded-hal",
   "embedded-hal-bus",
-  "esp-alloc",
+  "esp-alloc/esp32s3",
   "esp-println/esp32s3",
   "esp-backtrace/esp32s3",
   "dep:mipidsi",
@@ -135,7 +135,7 @@ esp32-s3-lcd-ev-board = [
   "esp-hal/unstable",               # required for PSRAM support
   "embedded-hal",
   "embedded-hal-bus",
-  "esp-alloc",
+  "esp-alloc/esp32s3",
   "esp-println/esp32s3",
   "esp-backtrace/esp32s3",
   "dep:mipidsi",
@@ -150,7 +150,7 @@ esope-sld-c-w-s3 = [
   "esp-hal/unstable",               # required for PSRAM support
   "embedded-hal",
   "embedded-hal-bus",
-  "esp-alloc",
+  "esp-alloc/esp32s3",
   "esp-println/esp32s3",
   "esp-backtrace/esp32s3",
   "dep:mipidsi",
@@ -172,7 +172,7 @@ waveshare-esp32-s3-touch-amoled-1-8 = [
   "esp-hal/unstable",               # required for PSRAM support
   "embedded-hal",
   "embedded-hal-bus",
-  "esp-alloc",
+  "esp-alloc/esp32s3",
   "esp-println/esp32s3",
   "esp-backtrace/esp32s3",
   "dep:mipidsi",
@@ -191,7 +191,7 @@ m5stack-cores3 = [
   "esp-hal/unstable",               # required for PSRAM support
   "embedded-hal",
   "embedded-hal-bus",
-  "esp-alloc",
+  "esp-alloc/esp32s3",
   "esp-println/esp32s3",
   "esp-backtrace/esp32s3",
   "dep:mipidsi",
@@ -268,7 +268,11 @@ embedded-time = { version = "0.12.0", optional = true }
 embedded-display-controller = { version = "0.2.0", optional = true }
 ft5336 = { version = "0.2", optional = true }
 
-esp-hal = { version = "1.1.1", optional = true }
+# The whole esp stack is held on the esp-hal 1.1 release line: sh8601-rs (Waveshare AMOLED)
+# activates esp-hal 1.1-line crates and blocks moving to esp-hal 1.2 / esp-sync 0.3.
+# The tilde pin keeps esp-hal from floating to 1.2, which drags in a second esp-sync
+# that fails to build. Move everything to the 1.2 line together once sh8601-rs updates.
+esp-hal = { version = "~1.1.1", optional = true }
 esp-alloc = { version = "0.10.0", optional = true }
 esp-println = { version = "0.17.0", default-features = false, features = ["auto", "log-04"], optional = true }
 esp-backtrace = { version = "0.19.0", optional = true, features = ["esp32s3", "println"] }
@@ -294,7 +298,7 @@ embassy-sync = { version = "0.8.0", optional = true }
 esp-rtos = { version = "0.3.0", optional = true, features = ["esp32s3", "embassy"] }
 gt911 = { version = "0.3.0", optional = true }
 sitronix-touch = { version = "0.0.1", optional = true }
-sh8601-rs = { version = "0.1.6", features = ["waveshare_18_amoled"], optional = true }
+sh8601-rs = { version = "0.1.8", features = ["waveshare_18_amoled"], optional = true }
 ft3x68-rs = { version = "0.1.2", optional = true }
 
 rand_core = { version = "0.6.3", optional = true }

--- a/examples/safe-ui/esp32-s3-box/Cargo.toml
+++ b/examples/safe-ui/esp32-s3-box/Cargo.toml
@@ -15,12 +15,12 @@ path = "src/main.rs"
 [dependencies]
 slint-safeui-app = { path = "../app" }
 
-esp-hal = { version = "1.1.1", features = ["esp32s3", "rt", "unstable"] }
-esp-alloc = "0.10.0"
-esp-backtrace = { version = "0.19.0", features = ["esp32s3", "panic-handler", "println"] }
-esp-bootloader-esp-idf = { version = "0.5.0", features = ["esp32s3"] }
-esp-println = { version = "0.17.0", default-features = false, features = ["esp32s3", "auto", "log-04"] }
-esp-rtos = { version = "0.3.0", features = ["esp32s3", "embassy"] }
+esp-hal = { version = "1.2.0", features = ["esp32s3", "rt", "unstable"] }
+esp-alloc = { version = "0.11.0", features = ["esp32s3"] }
+esp-backtrace = { version = "0.20.0", features = ["esp32s3", "panic-handler", "println"] }
+esp-bootloader-esp-idf = { version = "0.6.0", features = ["esp32s3"] }
+esp-println = { version = "0.18.0", default-features = false, features = ["esp32s3", "auto", "log-04"] }
+esp-rtos = { version = "0.4.0", features = ["esp32s3", "embassy"] }
 
 embassy-executor = { version = "0.10.0", default-features = false }
 embassy-futures = "0.1.2"

--- a/examples/safe-ui/esp32-s3-box/src/board.rs
+++ b/examples/safe-ui/esp32-s3-box/src/board.rs
@@ -11,7 +11,7 @@ use esp_hal::clock::CpuClock;
 use esp_hal::delay::Delay;
 use esp_hal::gpio::{DriveMode, InputConfig, Level, Output, OutputConfig, Pull};
 use esp_hal::i2c::master::I2c;
-use esp_hal::interrupt::software::{SoftwareInterrupt, SoftwareInterruptControl};
+use esp_hal::peripherals::FROM_CPU_INTR0;
 use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::{Config as SpiConfig, Spi};
 use esp_hal::time::Rate;
@@ -47,7 +47,7 @@ pub type BoardDisplay = mipidsi::Display<
 pub struct Board {
     pub platform: Esp32Platform,
     pub timer: Timer<'static>,
-    pub software_interrupt: SoftwareInterrupt<'static, 0>,
+    pub software_interrupt: FROM_CPU_INTR0<'static>,
 }
 
 /// Initialize the chip, the PSRAM heap and the board peripherals.
@@ -151,11 +151,10 @@ pub fn init() -> Board {
     }
 
     let timer_group = TimerGroup::new(peripherals.TIMG0);
-    let software_interrupts = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
     Board {
         platform: Esp32Platform::new(display, touch, i2c, backlight, touch_int),
         timer: timer_group.timer0,
-        software_interrupt: software_interrupts.software_interrupt0,
+        software_interrupt: peripherals.FROM_CPU_INTR0,
     }
 }


### PR DESCRIPTION
esp-hal 1.2 released today satisfies the previous ^1.1.1 requirement, but moved to esp-sync 0.3 while the crates of the 1.1 line use esp-sync 0.2. Mixing the lines duplicates esp-sync, and the copy without a chip feature aborts the build. This broke CI, which re-resolves the esp crates on every run.

- api/cpp: update esp-backtrace to 0.20 and esp-println to 0.18.
- safe-ui esp32-s3-box: move to the 1.2 line (esp-hal 1.2, esp-alloc 0.11, esp-println 0.18, esp-backtrace 0.20, esp-bootloader-esp-idf 0.6, esp-rtos 0.4). esp-rtos 0.4 replaced the SoftwareInterrupt argument of start() with the FROM_CPU_INTR0 singleton, and esp-alloc 0.11 requires the chip feature.
- mcu-board-support: stays on the 1.1 line because sh8601-rs (Waveshare AMOLED board) activates 1.1-line esp crates and blocks the migration; pin esp-hal with a tilde requirement so it no longer floats to 1.2. Update sh8601-rs to 0.1.8 and enable the esp-alloc chip feature, which the 1.2 line will require.
