### PR TITLE
winit: Add invoke_from_event_loop_with_active_event_loop

### DIFF
--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -722,7 +722,7 @@ pub mod winit_030 {
 
     pub use i_slint_backend_winit::{
         CustomApplicationHandler, EventLoopBuilder, EventResult, SlintEvent, WinitWindowAccessor,
-        winit,
+        invoke_from_event_loop_with_active_event_loop, winit,
     };
 
     #[deprecated(note = "Renamed to `EventResult`")]

--- a/api/rs/slint/lib.rs
+++ b/api/rs/slint/lib.rs
@@ -722,7 +722,7 @@ pub mod winit_030 {
 
     pub use i_slint_backend_winit::{
         CustomApplicationHandler, EventLoopBuilder, EventResult, SlintEvent, WinitWindowAccessor,
-        invoke_from_event_loop_with_active_event_loop, winit,
+        invoke_from_active_event_loop, winit,
     };
 
     #[deprecated(note = "Renamed to `EventResult`")]

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -29,6 +29,8 @@ pub enum CustomEvent {
     WakeEventLoopWorkaround,
     /// Slint internal: Invoke the
     UserEvent(Box<dyn FnOnce() + Send>),
+    /// Invoke the callback with the [`ActiveEventLoop`], for [`crate::invoke_from_event_loop_with_active_event_loop`]
+    UserEventWithEventLoop(Box<dyn FnOnce(&ActiveEventLoop) + Send>),
     /// Emitted from quit_event_loop with the current event loop generation
     Exit(usize),
     #[cfg(enable_accesskit)]
@@ -43,6 +45,7 @@ impl std::fmt::Debug for CustomEvent {
             #[cfg(target_arch = "wasm32")]
             Self::WakeEventLoopWorkaround => write!(f, "WakeEventLoopWorkaround"),
             Self::UserEvent(_) => write!(f, "UserEvent"),
+            Self::UserEventWithEventLoop(_) => write!(f, "UserEventWithEventLoop"),
             Self::Exit(_) => write!(f, "Exit"),
             #[cfg(enable_accesskit)]
             Self::Accesskit(a) => write!(f, "AccessKit({a:?})"),
@@ -150,6 +153,7 @@ impl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: SlintEvent) {
         match event.0 {
             CustomEvent::UserEvent(user_callback) => user_callback(),
+            CustomEvent::UserEventWithEventLoop(user_callback) => user_callback(event_loop),
             CustomEvent::Exit(generation) => {
                 if self
                     .shared_backend_data

--- a/internal/backends/winit/event_loop.rs
+++ b/internal/backends/winit/event_loop.rs
@@ -29,7 +29,7 @@ pub enum CustomEvent {
     WakeEventLoopWorkaround,
     /// Slint internal: Invoke the
     UserEvent(Box<dyn FnOnce() + Send>),
-    /// Invoke the callback with the [`ActiveEventLoop`], for [`crate::invoke_from_event_loop_with_active_event_loop`]
+    /// Invoke the callback with the [`ActiveEventLoop`], for [`crate::invoke_from_active_event_loop`]
     UserEventWithEventLoop(Box<dyn FnOnce(&ActiveEventLoop) + Send>),
     /// Emitted from quit_event_loop with the current event loop generation
     Exit(usize),

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -741,6 +741,30 @@ impl Backend {
     }
 }
 
+/// Proxy of the event loop of the winit backend that was installed as the platform, so
+/// that [`invoke_from_event_loop_with_active_event_loop`] can reach it from any thread.
+static GLOBAL_PROXY: std::sync::Mutex<Option<winit::event_loop::EventLoopProxy<SlintEvent>>> =
+    std::sync::Mutex::new(None);
+
+/// Schedules a callback to be invoked in the winit event loop, and passes winit's
+/// [`ActiveEventLoop`] to it.
+///
+/// This is similar to [`slint::invoke_from_event_loop`](i_slint_core::api::invoke_from_event_loop),
+/// but the callback also receives the [`ActiveEventLoop`], which winit only exposes while the
+/// event loop is running. Use it to call winit APIs that need it, for example to create custom
+/// windows.
+///
+/// This function can be called from any thread. It returns an error if the winit backend hasn't
+/// been installed yet, or if the event loop has terminated.
+pub fn invoke_from_event_loop_with_active_event_loop(
+    func: impl FnOnce(&ActiveEventLoop) + Send + 'static,
+) -> Result<(), EventLoopError> {
+    let proxy = GLOBAL_PROXY.lock().unwrap().clone().ok_or(EventLoopError::NoEventLoopProvider)?;
+    proxy
+        .send_event(SlintEvent(CustomEvent::UserEventWithEventLoop(Box::new(func))))
+        .map_err(|_| EventLoopError::EventLoopTerminated)
+}
+
 #[allow(unused)]
 const DEFAULT_CURSOR_FLASH_CYCLE: core::time::Duration = core::time::Duration::from_millis(1000);
 
@@ -940,6 +964,7 @@ impl i_slint_core::platform::Platform for Backend {
                     .map_err(|_| EventLoopError::EventLoopTerminated)
             }
         }
+        *GLOBAL_PROXY.lock().unwrap() = Some(self.shared_data.event_loop_proxy.clone());
         Some(Box::new(Proxy(
             self.shared_data.event_loop_proxy.clone(),
             Arc::clone(&self.shared_data.event_loop_generation),

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -742,7 +742,7 @@ impl Backend {
 }
 
 /// Proxy of the event loop of the winit backend that was installed as the platform, so
-/// that [`invoke_from_event_loop_with_active_event_loop`] can reach it from any thread.
+/// that [`invoke_from_active_event_loop`] can reach it from any thread.
 static GLOBAL_PROXY: std::sync::Mutex<Option<winit::event_loop::EventLoopProxy<SlintEvent>>> =
     std::sync::Mutex::new(None);
 
@@ -756,7 +756,7 @@ static GLOBAL_PROXY: std::sync::Mutex<Option<winit::event_loop::EventLoopProxy<S
 ///
 /// This function can be called from any thread. It returns an error if the winit backend hasn't
 /// been installed yet, or if the event loop has terminated.
-pub fn invoke_from_event_loop_with_active_event_loop(
+pub fn invoke_from_active_event_loop(
     func: impl FnOnce(&ActiveEventLoop) + Send + 'static,
 ) -> Result<(), EventLoopError> {
     let proxy = GLOBAL_PROXY.lock().unwrap().clone().ok_or(EventLoopError::NoEventLoopProvider)?;


### PR DESCRIPTION
Alternative to #11518 that doesn't change i-slint-core: the winit backend keeps its event loop proxy in a crate-local global, registered when the backend is installed as the platform, and a new CustomEvent variant carries a callback that receives the ActiveEventLoop.
