### PR TITLE
docs: require comments to carry information not in the repository

### DIFF
--- a/docs/internal/writing-style-guide.md
+++ b/docs/internal/writing-style-guide.md
@@ -45,10 +45,14 @@ Concretely:
 
 For comments in source code — both internal implementation notes and public API documentation comments:
 
-1. Describe what the code *is* and why, in the present tense.
+1. Where a comment earns its place (see rule 6), describe what the code *is*, in the present tense.
    - Rationale: The comment should make sense to whoever reads the code next; what changed belongs in the commit message, not the source.
-2. For public items, document the interface, not the implementation.
-   - A comment above a property, function, or type says what it does and why for the caller, not how it works inside.
+2. A public item's documentation is its contract, and the one exception to rule 6.
+   - It says what the item does and when to use it, not how it works inside.
+   - It may restate the signature,
+     because it's published apart from the code and callers read it instead of the body.
+   - "Public" means an item that appears in published API documentation, not merely one marked `pub`.
+     Everything else falls under rule 6, where a name and signature are the documentation.
    - Rationale: Callers shouldn't have to read the implementation, and implementation details in the comment go stale as the code evolves.
 3. Explain a thing once, then cross-reference it.
    - Avoid: repeating the same rationale on the trait, on each implementation, and again at the call site.
@@ -62,6 +66,15 @@ For comments in source code — both internal implementation notes and public AP
 5. A comment shouldn't be longer than the item it describes, and rarely needs more than fifteen lines.
    - Use: a page under `docs/development/` for anything longer, linked from the comment.
    - Rationale: A comment that outgrows the code it describes stops being read.
+6. A comment must carry information that isn't in this repository.
+   - Avoid: restating a name, a signature, or the lines below it;
+     justifying why the code does what it plainly does.
+   - Use: an external constraint the code can't show, such as an editor's behavior,
+     a specification, or a platform quirk.
+     A bare issue reference such as `#6739` also qualifies.
+   - Test: if a reader could learn it by reading the code, delete the comment.
+   - Rationale: Anything the code already says will drift out of sync with it,
+     and costs a read either way.
 
 ## Diagnostics
 


### PR DESCRIPTION
Further attempt to reduce unnecessary comments in code.

---

The guide had no rule against a comment that restates a name or justifies the line below it, so both kept getting written and passing review. Rule 1 arguably invited them by asking for "what the code is and why".

Add rule 6 with a single test: if a reader could learn it from the code, delete the comment.
What survives is an external constraint the code can't show, or an issue reference.

Reword rule 1 to govern how a comment is written rather than whether to write one, and drop the "why" that rule 6 now scopes.

Rewrite rule 2 to make a public item's documentation the one exception, since it legitimately restates a signature that callers read instead of the body.
Define "public" as appearing in published API documentation rather than as the `pub` keyword, matching what we already do: internal/compiler documents half its `pub fn` and tools/lsp under a fifth, with no missing_docs lint in either.
