### PR TITLE
C++ platform API: native menus and input method support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7636,6 +7636,7 @@ dependencies = [
  "raw-window-handle",
  "slint-interpreter",
  "unicode-segmentation",
+ "vtable",
 ]
 
 [[package]]

--- a/api/cpp/Cargo.toml
+++ b/api/cpp/Cargo.toml
@@ -77,6 +77,7 @@ i-slint-backend-testing = { workspace = true, optional = true, features = ["ffi"
 i-slint-renderer-skia = { workspace = true, features = ["default", "x11", "wayland"], optional = true }
 i-slint-renderer-software = { workspace = true, optional = true }
 i-slint-core = { workspace = true, features = ["ffi"] }
+vtable = { workspace = true }
 slint-interpreter = { workspace = true, features = ["ffi", "compat-1-2"], optional = true }
 i-slint-live-preview = { workspace = true, optional = true, features = ["ffi"] }
 raw-window-handle = { version = "0.6", optional = true }

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -172,8 +172,8 @@ class WindowAdapter
                 },
                 [](void *wa, const vtable::VRc<cbindgen_private::MenuVTable> *menu,
                    LogicalPosition position) -> bool {
-                    return reinterpret_cast<WindowAdapter *>(wa)->show_native_popup_menu(
-                            *menu, position);
+                    return reinterpret_cast<WindowAdapter *>(wa)->show_native_popup_menu(*menu,
+                                                                                         position);
                 },
                 [](void *wa, cbindgen_private::InputMethodRequestKind kind,
                    const cbindgen_private::InputMethodPropertiesReprC *properties) {
@@ -359,8 +359,9 @@ public:
     ///
     /// The default implementation does nothing, which leaves the platform's input method
     /// uninvolved and limits text entry to whatever arrives as plain key events.
-    virtual void input_method_request(cbindgen_private::InputMethodRequestKind kind,
-                                      const cbindgen_private::InputMethodPropertiesReprC *properties)
+    virtual void
+    input_method_request(cbindgen_private::InputMethodRequestKind kind,
+                         const cbindgen_private::InputMethodPropertiesReprC *properties)
     {
         (void)kind;
         (void)properties;

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -135,7 +135,7 @@ class WindowAdapter
 
     cbindgen_private::WindowAdapterRcOpaque initialize()
     {
-        cbindgen_private::slint_window_adapter_new(
+        cbindgen_private::slint_window_adapter_new2(
                 this, [](void *wa) { delete reinterpret_cast<WindowAdapter *>(wa); },
                 [](void *wa) {
                     return reinterpret_cast<WindowAdapter *>(wa)->renderer().renderer_handle();
@@ -166,6 +166,14 @@ class WindowAdapter
                 [](void *wa, cbindgen_private::Point2D<int32_t> point) {
                     reinterpret_cast<WindowAdapter *>(wa)->set_position(
                             slint::PhysicalPosition({ point.x, point.y }));
+                },
+                [](void *wa) -> bool {
+                    return reinterpret_cast<WindowAdapter *>(wa)->supports_native_menu_bar();
+                },
+                [](void *wa, const vtable::VRc<cbindgen_private::MenuVTable> *menu,
+                   LogicalPosition position) -> bool {
+                    return reinterpret_cast<WindowAdapter *>(wa)->show_native_popup_menu(
+                            *menu, position);
                 },
                 &self);
         was_initialized = true;
@@ -318,6 +326,26 @@ public:
     /// properties that were queried on the last call are changed. If you do not query any
     /// properties, it may not be called again.
     virtual void update_window_properties(const WindowProperties &) { }
+
+    /// Re-implement this function to report that the platform can host a native menu bar.
+    ///
+    /// The default implementation returns false, and Slint renders any menu bar itself.
+    virtual bool supports_native_menu_bar() { return false; }
+
+    /// Re-implement this function to show a context menu using the platform's own menus.
+    ///
+    /// \a menu is the menu tree to display and \a position is where to show it, in
+    /// logical coordinates relative to the window. Walk the menu with
+    /// `cbindgen_private::MenuVTable`'s `sub_menu` and report a selection with `activate`.
+    ///
+    /// Return false — the default — to let Slint draw the menu inside the window instead.
+    virtual bool show_native_popup_menu(const vtable::VRc<cbindgen_private::MenuVTable> &menu,
+                                        LogicalPosition position)
+    {
+        (void)menu;
+        (void)position;
+        return false;
+    }
 
     /// Re-implement this function to provide a reference to the renderer for use with the window
     /// adapter.

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -175,6 +175,10 @@ class WindowAdapter
                     return reinterpret_cast<WindowAdapter *>(wa)->show_native_popup_menu(
                             *menu, position);
                 },
+                [](void *wa, cbindgen_private::InputMethodRequestKind kind,
+                   const cbindgen_private::InputMethodPropertiesReprC *properties) {
+                    reinterpret_cast<WindowAdapter *>(wa)->input_method_request(kind, properties);
+                },
                 &self);
         was_initialized = true;
         return self;
@@ -331,6 +335,25 @@ public:
     ///
     /// The default implementation returns false, and Slint renders any menu bar itself.
     virtual bool supports_native_menu_bar() { return false; }
+
+    /// Re-implement this function to drive the platform's input method.
+    ///
+    /// Slint calls this when a text input gains focus (\a kind Enable), changes while
+    /// composing (Update), or loses focus (Disable). \a properties describes the field
+    /// being edited and is null for Disable.
+    ///
+    /// A platform that implements this is expected to feed composition back with
+    /// slint::Window's input-method events. Offsets in the properties are byte offsets
+    /// into the text, so a platform counting in UTF-16 must convert.
+    ///
+    /// The default implementation does nothing, which leaves the platform's input method
+    /// uninvolved and limits text entry to whatever arrives as plain key events.
+    virtual void input_method_request(cbindgen_private::InputMethodRequestKind kind,
+                                      const cbindgen_private::InputMethodPropertiesReprC *properties)
+    {
+        (void)kind;
+        (void)properties;
+    }
 
     /// Re-implement this function to show a context menu using the platform's own menus.
     ///

--- a/api/cpp/include/slint-platform.h
+++ b/api/cpp/include/slint-platform.h
@@ -336,6 +336,17 @@ public:
     /// The default implementation returns false, and Slint renders any menu bar itself.
     virtual bool supports_native_menu_bar() { return false; }
 
+    /// Dispatch an input method event to the scene, updating or committing composed text.
+    ///
+    /// Call this while driving a platform input method in response to
+    /// input_method_request(): a key press cannot express a pre-edit. Send
+    /// `UpdateComposition` while the text is still being composed, and `CommitComposition`
+    /// once the input method settles on text.
+    void dispatch_composition_event(const cbindgen_private::CompositionEvent &event)
+    {
+        cbindgen_private::slint_windowrc_dispatch_composition_event(&self, &event);
+    }
+
     /// Re-implement this function to drive the platform's input method.
     ///
     /// Slint calls this when a text input gains focus (\a kind Enable), changes while

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -15,6 +15,7 @@ use i_slint_core::graphics::euclid;
 use i_slint_core::platform::{Clipboard, Platform, PlatformError};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::ffi::WindowAdapterRcOpaque;
+use i_slint_core::input::{InternalKeyEvent, KeyEventType};
 use i_slint_core::window::{
     InputMethodRequest, WindowAdapter, WindowAdapterInternal, WindowProperties,
 };
@@ -282,6 +283,80 @@ pub extern "C" fn slint_window_properties_get_layout_constraints(
 ///
 /// Kept for source and ABI compatibility; it is equivalent to
 /// [`slint_window_adapter_new2`] with every optional callback left unset.
+/// The parts of an input method event that a plain key event cannot carry.
+///
+/// `slint_windowrc_dispatch_key_event` builds its event with defaults for everything but
+/// the text, which is enough for a key press and not enough for composition. This is the
+/// composition-shaped counterpart, laid out so it can cross the C++ boundary: each
+/// `Option<Range>` becomes a pair of bounds plus a flag.
+#[repr(C)]
+pub struct CompositionEvent {
+    /// Either `UpdateComposition` while composing or `CommitComposition` when the input
+    /// method settles on text.
+    pub event_type: KeyEventType,
+    /// The committed text. Only meaningful for `CommitComposition`.
+    pub text: SharedString,
+    /// The text being composed: shown, but not committed.
+    pub preedit_text: SharedString,
+    /// Selection within `preedit_text`, when `has_preedit_selection`.
+    pub preedit_selection_start: i32,
+    /// End of that selection.
+    pub preedit_selection_end: i32,
+    /// Whether the pre-edit selection fields mean anything.
+    pub has_preedit_selection: bool,
+    /// The range of existing text this event replaces, when `has_replacement_range`.
+    pub replacement_start: i32,
+    /// End of that range.
+    pub replacement_end: i32,
+    /// Whether the replacement range fields mean anything.
+    pub has_replacement_range: bool,
+    /// Where to leave the cursor, when `has_cursor_position`; otherwise it goes after the
+    /// text that was just inserted.
+    pub cursor_position: i32,
+    /// Whether `cursor_position` means anything.
+    pub has_cursor_position: bool,
+    /// Where to leave the selection anchor, when `has_anchor_position`.
+    pub anchor_position: i32,
+    /// Whether `anchor_position` means anything.
+    pub has_anchor_position: bool,
+}
+
+/// Dispatch an input method event, updating or committing composed text.
+///
+/// This is what a platform driving an input method sends in response to
+/// `WindowAdapter::input_method_request`; a plain key event cannot express a pre-edit.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_windowrc_dispatch_composition_event(
+    handle: *const WindowAdapterRcOpaque,
+    event: &CompositionEvent,
+) {
+    unsafe {
+        let window_adapter = &*(handle as *const Rc<dyn WindowAdapter>);
+
+        //  Both types are #[non_exhaustive], so they are filled in field by field rather
+        //  than with a struct expression.
+        let mut key_event = i_slint_core::items::KeyEvent::default();
+        key_event.text = event.text.clone();
+
+        let mut internal = InternalKeyEvent::default();
+        internal.event_type = event.event_type;
+        internal.key_event = key_event;
+        internal.preedit_text = event.preedit_text.clone();
+        internal.replacement_range = event
+            .has_replacement_range
+            .then(|| event.replacement_start..event.replacement_end);
+        internal.preedit_selection = event
+            .has_preedit_selection
+            .then(|| event.preedit_selection_start..event.preedit_selection_end);
+        internal.cursor_position = event.has_cursor_position.then_some(event.cursor_position);
+        internal.anchor_position = event.has_anchor_position.then_some(event.anchor_position);
+
+        window_adapter
+            .window()
+            .dispatch_event(i_slint_core::platform::WindowEvent::internal(internal));
+    }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_window_adapter_new(
     user_data: WindowAdapterUserData,

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -8,13 +8,16 @@ use i_slint_core::api::{
     LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Window, WindowPosition,
     WindowSize,
 };
+use i_slint_core::items::InputType;
 use i_slint_core::menus::MenuVTable;
 use i_slint_core::graphics::IntSize;
 use i_slint_core::graphics::euclid;
 use i_slint_core::platform::{Clipboard, Platform, PlatformError};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::ffi::WindowAdapterRcOpaque;
-use i_slint_core::window::{WindowAdapter, WindowAdapterInternal, WindowProperties};
+use i_slint_core::window::{
+    InputMethodRequest, WindowAdapter, WindowAdapterInternal, WindowProperties,
+};
 use i_slint_core::{Brush, SharedString};
 
 type WindowAdapterUserData = *mut c_void;
@@ -50,6 +53,14 @@ pub struct CppWindowAdapter {
             &vtable::VRc<MenuVTable>,
             LogicalPosition,
         ) -> bool,
+    >,
+    /// Optional: tells the platform to start, update or stop an input method session.
+    input_method_request: Option<
+        unsafe extern "C" fn(
+            WindowAdapterUserData,
+            InputMethodRequestKind,
+            Option<&InputMethodPropertiesReprC>,
+        ),
     >,
 }
 
@@ -126,6 +137,91 @@ impl WindowAdapterInternal for CppWindowAdapter {
     ) -> bool {
         self.show_native_popup_menu
             .is_some_and(|f| unsafe { f(self.user_data, &context_menu_item, position) })
+    }
+
+    fn input_method_request(&self, request: InputMethodRequest) {
+        let Some(f) = self.input_method_request else { return };
+
+        match request {
+            InputMethodRequest::Enable(p) => unsafe {
+                f(
+                    self.user_data,
+                    InputMethodRequestKind::Enable,
+                    Some(&InputMethodPropertiesReprC::new(&p)),
+                )
+            },
+            InputMethodRequest::Update(p) => unsafe {
+                f(
+                    self.user_data,
+                    InputMethodRequestKind::Update,
+                    Some(&InputMethodPropertiesReprC::new(&p)),
+                )
+            },
+            InputMethodRequest::Disable => unsafe {
+                f(self.user_data, InputMethodRequestKind::Disable, None)
+            },
+            _ => {}
+        }
+    }
+}
+
+/// Which input method transition a text input is asking the platform for.
+///
+/// Mirrors the discriminant of [`i_slint_core::window::InputMethodRequest`], whose payload
+/// is not `repr(C)`.
+#[repr(C)]
+pub enum InputMethodRequestKind {
+    /// Begin composing; the properties describe the field being entered.
+    Enable = 0,
+    /// The field changed while composing; the properties are the new state.
+    Update = 1,
+    /// Stop composing. No properties accompany this.
+    Disable = 2,
+}
+
+/// A `repr(C)` view of [`i_slint_core::window::InputMethodProperties`].
+///
+/// The Rust type is `#[non_exhaustive]` and holds `Option`s, so it cannot cross the FFI
+/// boundary as it stands. Offsets are in bytes into `text`, matching the Rust type; a
+/// platform whose input method counts in UTF-16 has to convert.
+#[repr(C)]
+pub struct InputMethodPropertiesReprC {
+    /// The text around the cursor, excluding any pre-edit.
+    pub text: SharedString,
+    /// Byte offset of the cursor within `text`.
+    pub cursor_position: usize,
+    /// Byte offset of the other end of the selection; only meaningful with `has_anchor`.
+    pub anchor_position: usize,
+    /// Whether there is a selection, i.e. whether `anchor_position` means anything.
+    pub has_anchor: bool,
+    /// The text being composed but not yet committed. Empty when not composing.
+    pub preedit_text: SharedString,
+    /// Byte offset of the pre-edit within `text`.
+    pub preedit_offset: usize,
+    /// Top-left of the cursor rectangle, in window coordinates.
+    pub cursor_rect_origin: LogicalPosition,
+    /// Size of the cursor rectangle.
+    pub cursor_rect_size: LogicalSize,
+    /// Bottom of the anchor; only meaningful with `has_anchor`.
+    pub anchor_point: LogicalPosition,
+    /// What kind of text the field accepts.
+    pub input_type: InputType,
+}
+
+impl InputMethodPropertiesReprC {
+    fn new(p: &i_slint_core::window::InputMethodProperties) -> Self {
+        Self {
+            text: p.text.clone(),
+            cursor_position: p.cursor_position,
+            anchor_position: p.anchor_position.unwrap_or_default(),
+            has_anchor: p.anchor_position.is_some(),
+            preedit_text: p.preedit_text.clone(),
+            preedit_offset: p.preedit_offset,
+            cursor_rect_origin: p.cursor_rect_origin,
+            cursor_rect_size: p.cursor_rect_size,
+            anchor_point: p.anchor_point,
+            input_type: p.input_type,
+        }
     }
 }
 
@@ -217,6 +313,7 @@ pub unsafe extern "C" fn slint_window_adapter_new(
             set_position,
             None,
             None,
+            None,
             target,
         )
     }
@@ -251,6 +348,13 @@ pub unsafe extern "C" fn slint_window_adapter_new2(
             LogicalPosition,
         ) -> bool,
     >,
+    input_method_request: Option<
+        unsafe extern "C" fn(
+            WindowAdapterUserData,
+            InputMethodRequestKind,
+            Option<&InputMethodPropertiesReprC>,
+        ),
+    >,
     target: *mut WindowAdapterRcOpaque,
 ) {
     let window = Rc::<CppWindowAdapter>::new_cyclic(|w| CppWindowAdapter {
@@ -267,6 +371,7 @@ pub unsafe extern "C" fn slint_window_adapter_new2(
         set_position,
         supports_native_menu_bar,
         show_native_popup_menu,
+        input_method_request,
     });
 
     unsafe {

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -8,14 +8,14 @@ use i_slint_core::api::{
     LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Window, WindowPosition,
     WindowSize,
 };
-use i_slint_core::items::InputType;
-use i_slint_core::menus::MenuVTable;
 use i_slint_core::graphics::IntSize;
 use i_slint_core::graphics::euclid;
+use i_slint_core::input::{InternalKeyEvent, KeyEventType};
+use i_slint_core::items::InputType;
+use i_slint_core::menus::MenuVTable;
 use i_slint_core::platform::{Clipboard, Platform, PlatformError};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::ffi::WindowAdapterRcOpaque;
-use i_slint_core::input::{InternalKeyEvent, KeyEventType};
 use i_slint_core::window::{
     InputMethodRequest, WindowAdapter, WindowAdapterInternal, WindowProperties,
 };
@@ -342,9 +342,8 @@ pub unsafe extern "C" fn slint_windowrc_dispatch_composition_event(
         internal.event_type = event.event_type;
         internal.key_event = key_event;
         internal.preedit_text = event.preedit_text.clone();
-        internal.replacement_range = event
-            .has_replacement_range
-            .then(|| event.replacement_start..event.replacement_end);
+        internal.replacement_range =
+            event.has_replacement_range.then(|| event.replacement_start..event.replacement_end);
         internal.preedit_selection = event
             .has_preedit_selection
             .then(|| event.preedit_selection_start..event.preedit_selection_end);

--- a/api/cpp/platform.rs
+++ b/api/cpp/platform.rs
@@ -5,14 +5,16 @@ use alloc::rc::Rc;
 use alloc::{boxed::Box, string::String};
 use core::ffi::c_void;
 use i_slint_core::api::{
-    LogicalSize, PhysicalPosition, PhysicalSize, Window, WindowPosition, WindowSize,
+    LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Window, WindowPosition,
+    WindowSize,
 };
+use i_slint_core::menus::MenuVTable;
 use i_slint_core::graphics::IntSize;
 use i_slint_core::graphics::euclid;
 use i_slint_core::platform::{Clipboard, Platform, PlatformError};
 use i_slint_core::renderer::Renderer;
 use i_slint_core::window::ffi::WindowAdapterRcOpaque;
-use i_slint_core::window::{WindowAdapter, WindowProperties};
+use i_slint_core::window::{WindowAdapter, WindowAdapterInternal, WindowProperties};
 use i_slint_core::{Brush, SharedString};
 
 type WindowAdapterUserData = *mut c_void;
@@ -38,6 +40,17 @@ pub struct CppWindowAdapter {
     position:
         unsafe extern "C" fn(WindowAdapterUserData, &mut euclid::default::Point2D<i32>) -> bool,
     set_position: unsafe extern "C" fn(WindowAdapterUserData, euclid::default::Point2D<i32>),
+    /// Optional: reports whether the platform can host a native menu bar.
+    /// `None` when the adapter was created with `slint_window_adapter_new`.
+    supports_native_menu_bar: Option<unsafe extern "C" fn(WindowAdapterUserData) -> bool>,
+    /// Optional: shows a native context menu, returning false to let Slint draw its own.
+    show_native_popup_menu: Option<
+        unsafe extern "C" fn(
+            WindowAdapterUserData,
+            &vtable::VRc<MenuVTable>,
+            LogicalPosition,
+        ) -> bool,
+    >,
 }
 
 impl Drop for CppWindowAdapter {
@@ -95,6 +108,25 @@ impl WindowAdapter for CppWindowAdapter {
     fn update_window_properties(&self, properties: WindowProperties<'_>) {
         unsafe { (self.update_window_properties)(self.user_data, &properties) }
     }
+
+    fn internal(&self, _: i_slint_core::InternalToken) -> Option<&dyn WindowAdapterInternal> {
+        Some(self)
+    }
+}
+
+impl WindowAdapterInternal for CppWindowAdapter {
+    fn supports_native_menu_bar(&self) -> bool {
+        self.supports_native_menu_bar.is_some_and(|f| unsafe { f(self.user_data) })
+    }
+
+    fn show_native_popup_menu(
+        &self,
+        context_menu_item: vtable::VRc<MenuVTable>,
+        position: LogicalPosition,
+    ) -> bool {
+        self.show_native_popup_menu
+            .is_some_and(|f| unsafe { f(self.user_data, &context_menu_item, position) })
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -150,6 +182,10 @@ pub extern "C" fn slint_window_properties_get_layout_constraints(
     }
 }
 
+/// Creates a window adapter backed by a C++ implementation.
+///
+/// Kept for source and ABI compatibility; it is equivalent to
+/// [`slint_window_adapter_new2`] with every optional callback left unset.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn slint_window_adapter_new(
     user_data: WindowAdapterUserData,
@@ -167,6 +203,56 @@ pub unsafe extern "C" fn slint_window_adapter_new(
     set_position: unsafe extern "C" fn(WindowAdapterUserData, euclid::default::Point2D<i32>),
     target: *mut WindowAdapterRcOpaque,
 ) {
+    unsafe {
+        slint_window_adapter_new2(
+            user_data,
+            drop,
+            get_renderer_ref,
+            set_visible,
+            request_redraw,
+            size,
+            set_size,
+            update_window_properties,
+            position,
+            set_position,
+            None,
+            None,
+            target,
+        )
+    }
+}
+
+/// Creates a window adapter backed by a C++ implementation, including the callbacks a
+/// platform only implements when it can serve them natively.
+///
+/// The trailing callbacks may be null, in which case Slint falls back to the behaviour it
+/// uses for any platform that does not support them: no native menu bar, and a context
+/// menu drawn inside the window.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn slint_window_adapter_new2(
+    user_data: WindowAdapterUserData,
+    drop: unsafe extern "C" fn(WindowAdapterUserData),
+    get_renderer_ref: unsafe extern "C" fn(WindowAdapterUserData) -> RendererPtr,
+    set_visible: unsafe extern "C" fn(WindowAdapterUserData, bool),
+    request_redraw: unsafe extern "C" fn(WindowAdapterUserData),
+    size: unsafe extern "C" fn(WindowAdapterUserData) -> IntSize,
+    set_size: unsafe extern "C" fn(WindowAdapterUserData, IntSize),
+    update_window_properties: unsafe extern "C" fn(WindowAdapterUserData, &WindowProperties),
+    position: unsafe extern "C" fn(
+        WindowAdapterUserData,
+        &mut euclid::default::Point2D<i32>,
+    ) -> bool,
+    set_position: unsafe extern "C" fn(WindowAdapterUserData, euclid::default::Point2D<i32>),
+    supports_native_menu_bar: Option<unsafe extern "C" fn(WindowAdapterUserData) -> bool>,
+    show_native_popup_menu: Option<
+        unsafe extern "C" fn(
+            WindowAdapterUserData,
+            &vtable::VRc<MenuVTable>,
+            LogicalPosition,
+        ) -> bool,
+    >,
+    target: *mut WindowAdapterRcOpaque,
+) {
     let window = Rc::<CppWindowAdapter>::new_cyclic(|w| CppWindowAdapter {
         window: Window::new(w.clone()),
         user_data,
@@ -179,6 +265,8 @@ pub unsafe extern "C" fn slint_window_adapter_new(
         update_window_properties,
         position,
         set_position,
+        supports_native_menu_bar,
+        show_native_popup_menu,
     });
 
     unsafe {

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2285,9 +2285,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2902,9 +2902,9 @@ checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -3236,9 +3236,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -3374,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_algorithms"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8575c0d003ae459399623c4def180c63b77f343b1a7fee64f249b349e7699a31"
+checksum = "cdfa8785f95e57914ddb35e3b59994aeba6f5e79e9cfd03da1c269f010f36009"
 dependencies = [
  "lyon_path",
  "num-traits",
@@ -3474,9 +3474,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -4407,7 +4407,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi 0.5.3",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5230,7 +5230,7 @@ dependencies = [
  "regex",
  "serde_json",
  "tar",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -5309,6 +5309,7 @@ dependencies = [
  "proc-macro2",
  "slint-interpreter",
  "unicode-segmentation",
+ "vtable",
 ]
 
 [[package]]
@@ -5354,9 +5355,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -5905,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -7200,9 +7201,9 @@ checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wuff"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f625c6894838ab68e8c1c6e0f728e67363c9d4391cfa82333e58e6e30bc3a627"
+checksum = "200a7b806377b65f1ff9a985874332f15357c87e5dd7855f35f06dade95b8b3d"
 dependencies = [
  "brotli-decompressor",
  "bytes",


### PR DESCRIPTION
# C++ platform API: native menus and input method support

## Motivation

The C++ `slint::platform::WindowAdapter` exposes 13 virtuals. The Rust `WindowAdapter`
exposes those plus `WindowAdapterInternal`, which is where input methods and native menus
live. A C++ platform therefore cannot compose text or raise a native menu however it is
written — the capability is not reachable, not merely unimplemented.

Two consequences today:

- **Menus.** `WindowInner::show_native_popup_menu` consults
  `WindowAdapterInternal`, and `slint_windowrc_show_native_popup_menu` is already declared
  in `slint_window.h` — but `CppWindowAdapter` never implemented `WindowAdapter::internal()`,
  so the question always resolved to `None`. Every C++ platform silently takes the
  in-window fallback, and `supports_native_menu_bar` is always false.
- **Input methods.** Nothing tells a C++ platform that a text input gained focus, so it
  cannot enable an input method; and `slint_windowrc_dispatch_key_event` fills every
  composition field of `InternalKeyEvent` with defaults, so it could not report a pre-edit
  even if it knew to. Text entry is limited to what arrives as plain key events: dead keys,
  accent composition and any CJK input source are out of reach.

This came out of writing a custom platform for an plug-in of an application, where the host
owns `NSApplication` and the event loop, so the winit backend cannot be used and everything
it provides has to be supplied by hand.

## What this does

Three commits, all within `api/cpp`. Nothing in `internal/core` changes.

1. **`internal()` + `WindowAdapterInternal`** on `CppWindowAdapter`, forwarding
   `supports_native_menu_bar` and `show_native_popup_menu` to callbacks the platform
   supplies. The menu tree crosses as the `VRc<MenuVTable>` already exported to C++, so a
   platform walks it with `sub_menu()` and reports a choice with `activate()` using types
   that were already public.
2. **`input_method_request`**, with `InputMethodPropertiesReprC` — a `repr(C)` mirror,
   because `InputMethodProperties` is `#[non_exhaustive]`, is not `repr(C)` and holds
   `Option`s. It follows the existing `LayoutConstraintsReprC` precedent in the same file.
   `clip_rect` is not mirrored; everything else is, including the caret rectangle needed to
   place a candidate window.
3. **`slint_windowrc_dispatch_composition_event`** and
   `WindowAdapter::dispatch_composition_event` — the way back. `CompositionEvent` is
   `repr(C)` with each `Option<Range>` flattened to a pair of bounds and a flag.

## Compatibility

`slint_window_adapter_new` is unchanged and delegates to a new
`slint_window_adapter_new2` with every new callback unset. The callbacks are nullable and
the new C++ virtuals are defaulted, so a platform implementing none of them behaves exactly
as it does today — verified against a platform that overrides neither.

Offsets stay byte offsets into UTF-8, as in the Rust types, and the doc comments say so: a
platform whose input method counts in UTF-16 converts at its own boundary. Doing it here
would be the wrong place, since not every platform needs it.

## Testing

Built with `SLINT_FEATURE_RENDERER_SKIA=ON`, `BACKEND_WINIT=OFF` and a custom platform.
Against a `TextInput`:

- focusing reports `Enable`, editing reports `Update` with a tracking caret rectangle, and
  blurring reports `Disable`;
- an `UpdateComposition` shows a pre-edit without altering committed text, and a
  `CommitComposition` appends it and reports the new cursor back;
- right-clicking calls `show_native_popup_menu` with a walkable menu, and `activate()`
  performs the item;
- a platform overriding neither still gets the in-window menu and no composition.

Also exercised in the original setting where the callbacks drive
a real `NSMenu` and an `NSTextInputClient`, with Korean 2-Set composing inline.

## Notes for review

- `WindowAdapterInternal` is `#[doc(hidden)]` and documented as not for users to
  re-implement. The argument here is that `CppWindowAdapter` is not a user: it is part of
  Slint, standing in for a backend, and it is the only reason the C++ API is narrower than
  the Rust one.
