### PR TITLE
GridLayout: fix panic when a conditional cell's condition folds to constant false

### DIFF
--- a/internal/compiler/passes/remove_constant_conditions.rs
+++ b/internal/compiler/passes/remove_constant_conditions.rs
@@ -20,9 +20,13 @@ pub fn remove_constant_conditions(component: &Rc<Component>) {
         let e = elem.borrow();
         // Grid cells keep their per-child repeater; the ComponentContainer placeholder is a
         // permanent false repeater that must survive as the embed slot.
+        // For a repeated element, the grid_layout_cell sits on the repeater component's root.
+        let is_grid_cell = e.grid_layout_cell.is_some()
+            || matches!(&e.base_type, crate::langtype::ElementType::Component(c)
+                if c.root_element.borrow().grid_layout_cell.is_some());
         if e.repeated.as_ref().is_some_and(|r| {
             r.is_conditional_element && matches!(r.model, Expression::BoolLiteral(false))
-        }) && e.grid_layout_cell.is_none()
+        }) && !is_grid_cell
             && !e.is_component_placeholder
         {
             dead.push(elem.clone());

--- a/tests/cases/layout/grid_constant_condition.slint
+++ b/tests/cases/layout/grid_constant_condition.slint
@@ -1,0 +1,48 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Conditional grid cells whose condition is a compile time constant false
+// used to panic the compiler; they must compile and not occupy a cell.
+
+export component TestCase inherits Rectangle {
+    width: 300phx;
+    height: 300phx;
+
+    property <bool> never: false;
+    property <string> message;
+
+    GridLayout {
+        padding: 0phx;
+        spacing: 0phx;
+        Row {
+            r1 := Rectangle { min-width: 10phx; min-height: 10phx; }
+            if false : Rectangle { min-width: 10phx; min-height: 10phx; }
+            r2 := Rectangle { min-width: 10phx; min-height: 10phx; }
+        }
+        Row {
+            if never : Rectangle { min-width: 10phx; min-height: 10phx; }
+            r3 := Rectangle { min-width: 10phx; min-height: 10phx; }
+        }
+        if message != "" : Rectangle { min-width: 10phx; min-height: 10phx; }
+    }
+
+    out property <bool> test: r1.width == 150phx && r2.x == 150phx && r3.x == 0phx && r3.y == 150phx;
+}
+
+/*
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
The remove_constant_conditions pass intends to keep the repeater of conditional grid cells, but it checked grid_layout_cell on the repeated element while lower_layout attaches it to the repeater component's root element. The check never matched, the cell was removed from the element tree, and the grid layout expression still referenced it, panicking later in the LLR lowering.

Fixes: #13192
