### PR TITLE
docs: Small reorganisations of some paragraphs.

### DIFF
--- a/api/slint-sc/tests/cases/component/image_element.slint
+++ b/api/slint-sc/tests/cases/component/image_element.slint
@@ -9,7 +9,7 @@ export component TestCase inherits Window {
     background: #123456;
     in property <image> pic;
     // The dimensions of an image value are read as .width and .height.
-    //#sls.expr.image.dimensions
+    //#sls.type.image.properties
     //#sls.type.image.width
     //#sls.type.image.height
     //#sls.ref.image.source.dimensions

--- a/docs/astro/src/content/docs/reference/language/callbacks.mdx
+++ b/docs/astro/src/content/docs/reference/language/callbacks.mdx
@@ -21,13 +21,11 @@ export component Example inherits Window {
     }
 }
 ```
-</SC>
 
 <NotInSC>
 A callback may be declared in a component, on any element within a component, or in a [global](../globals/).
 </NotInSC>
 
-<SC>
 ## Declaration
 
 A *callback declaration* adds a callback to the element in whose body it appears.
@@ -47,7 +45,6 @@ A callback name shall not collide with another member of the same element:
 a declaration whose name matches an existing property, function, or callback is an error. \{#sls.callback.decl.unique}
 </SC>
 
-<NotInSC>
 Between the name and the `;`, a declaration may also carry the callback's parameter types and its
 return type:
 
@@ -76,7 +73,6 @@ A `pure` callback may be called from a pure context, and its handler must itself
 Calling an impure callback from a pure context is a compile error.
 
 A duplicate callback declaration is a compile error.
-</NotInSC>
 
 <SC>
 ## Calling
@@ -95,7 +91,6 @@ export component Example inherits Window {
     }
 }
 ```
-</SC>
 
 <NotInSC>
 The number of arguments must match the declaration,
@@ -109,7 +104,6 @@ export component Example {
 ```
 </NotInSC>
 
-<SC>
 ## Handlers
 
 A *handler* reacts to a callback's invocation.
@@ -145,7 +139,6 @@ export component Example inherits Window {
 ```
 </SC>
 
-<NotInSC>
 - The handler names its parameters in parentheses.
   These names are local to the handler body and are independent of any names in the declaration.
   Parentheses may be omitted when the callback has no parameters.
@@ -231,4 +224,3 @@ A change callback forces the property to be evaluated eagerly rather than [lazil
 and its side effects make the surrounding bindings impure.
 A declarative [binding](../bindings/) tracks its dependencies automatically and evaluates on demand,
 so a relationship that a binding can express should be expressed as a binding rather than a change callback.
-</NotInSC>

--- a/docs/astro/src/content/docs/reference/language/expressions.mdx
+++ b/docs/astro/src/content/docs/reference/language/expressions.mdx
@@ -17,7 +17,7 @@ a property reference, or a field access. \{#sls.expr.forms}
 
 An expression produces a value.
 A literal is the simplest form: a number such as `42` or `3.14`, a number with a unit such as `100px` or `250ms`,
-the boolean `true` or `false`, a [string](../../property-types/builtin-types/) with `\{ }` interpolation,
+the boolean `true` or `false`, a [string](../../property-types/strings/#string) with `\{ }` interpolation,
 or a [color](#color-literals).
 The other forms are a [reference](#references), an [operator or conditional expression](../operators/),
 a [member access or index](../operators/#member-access-and-indexing), a function or callback call,
@@ -151,4 +151,4 @@ and has that property's type. \{#sls.expr.ref.value}
 
 Without an element reference, a name may also resolve to a local variable, a callback, or a function.
 
-A reference may also name an [enumeration](../../property-types/) value or a [global](../globals/)'s property.
+A reference may also name an [enumeration](../structs-and-enums/#enums) value or a [global](../globals/)'s property.

--- a/docs/astro/src/content/docs/reference/language/expressions.mdx
+++ b/docs/astro/src/content/docs/reference/language/expressions.mdx
@@ -121,22 +121,6 @@ The `nine-slice` argument of full Slint is an
 error. \{#sls.expr.image.no-nine-slice}
 </OnlyInSC>
 
-<SC>
-## Image Dimensions
-
-Reading the field `width` or `height` of an expression of type `image`
-yields the dimensions of the image as an `int`: the number of pixels in each
-row, and the number of rows.
-Both are 0 for no image. \{#sls.expr.image.dimensions}
-
-```slint
-export component Example inherits Window {
-    in property <image> logo;
-    out property <int> logo-width: logo.width;
-}
-```
-</SC>
-
 ## References
 
 ```slint

--- a/docs/astro/src/content/docs/reference/language/expressions.mdx
+++ b/docs/astro/src/content/docs/reference/language/expressions.mdx
@@ -149,8 +149,6 @@ When reading, a property reference evaluates to the value of the referenced prop
 and has that property's type. \{#sls.expr.ref.value}
 </SC>
 
-<NotInSC>
 Without an element reference, a name may also resolve to a local variable, a callback, or a function.
-</NotInSC>
 
 A reference may also name an [enumeration](../../property-types/) value or a [global](../globals/)'s property.

--- a/docs/astro/src/content/docs/reference/language/file-structure.mdx
+++ b/docs/astro/src/content/docs/reference/language/file-structure.mdx
@@ -6,6 +6,7 @@ SC: true
 
 import SC from '@slint/common-files/src/components/SC.astro';
 import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
+import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
 
 <SC>
 ## A Slint Source File
@@ -73,7 +74,28 @@ An instantiation may be preceded by an *id* and `:=`, as in `foo := Rectangle { 
 naming the element within the component,
 so that a [reference](../expressions/#references) can reach its properties. \{#sls.file.element.id}
 
+```slint
+export component Example inherits Window {
+    frame := Rectangle {
+        background: #2a6e3f;
+        width: 120px;
+    }
+    Rectangle {
+        background: #1a4f2c;
+        width: frame.width;
+    }
+}
+```
+
+An id is an [identifier](../lexical-structure/#sls.lex.identifier.classes),
+so two ids are the same id when their
+[normalized forms](../lexical-structure/#sls.lex.identifier.normalization) are equal. \{#sls.file.element.id.identifier}
+
 An id shall be unique within the component. \{#sls.file.element.id.unique}
+
+<NotInSC>
+The uniqueness rule covers the whole component, the elements inside `for` and `if` subtrees included.
+</NotInSC>
 
 The names `self`, `parent`, and `root` are reserved and shall not be used as an id. \{#sls.file.element.id.reserved}
 

--- a/docs/astro/src/content/docs/reference/language/name-resolution.mdx
+++ b/docs/astro/src/content/docs/reference/language/name-resolution.mdx
@@ -1,6 +1,6 @@
 ---
 title: Name Resolution
-description: Element names, pre-defined names, and lookup rules.
+description: Pre-defined names and the lookup rules for identifiers.
 SC: true
 ---
 
@@ -9,25 +9,7 @@ import OnlyInSC from '@slint/common-files/src/components/OnlyInSC.astro';
 
 Name resolution decides which declaration an identifier in an expression refers to.
 Properties, callbacks, and functions share the same rules.
-
-## Element Names
-
-The `:=` syntax gives an element a name, also called its *id*:
-
-```slint
-export component MyApp inherits Window {
-    hello := Text {
-        text: "hello";
-    }
-}
-```
-
-An element name must be a valid [identifier](../lexical-structure/#sls.lex.identifier.classes).
-As with all identifiers, `-` and `_` are interchangeable.
-
-Element names must be unique within a component.
-Two elements in the same component with the same id are a compile error, including elements inside `for` and `if` subtrees.
-The names `self`, `parent`, and `root` are reserved and can't be used as an element name.
+An identifier may also name an element, through the [id](../file-structure/#sls.file.element.id) that `:=` gives it.
 
 ## Pre-Defined Names
 

--- a/docs/astro/src/content/docs/reference/language/operators.mdx
+++ b/docs/astro/src/content/docs/reference/language/operators.mdx
@@ -147,13 +147,11 @@ export component Example inherits Window {
     out property <bool> neither: !a && !b;
 }
 ```
-</SC>
 
 <NotInSC>
 `&&` and `||` short-circuit: the right operand is evaluated only when the left does not already determine the result.
 </NotInSC>
 
-<SC>
 ## Unary operators
 
 The prefix operators are `+`, `-`, and `!`. \{#sls.op.prefix}

--- a/docs/astro/src/content/docs/reference/language/type-conversions.mdx
+++ b/docs/astro/src/content/docs/reference/language/type-conversions.mdx
@@ -5,8 +5,6 @@ description: Implicit and explicit conversions between Slint types.
 
 import Link from '@slint/common-files/src/components/Link.astro';
 
-## Type Conversions
-
 Slint supports conversions between different types. Explicit
 conversions are required to make the UI description more robust, but implicit
 conversions are allowed between some types for convenience.
@@ -46,7 +44,7 @@ export component Example {
 }
 ```
 
-### Converting Between Numbers and Strings
+## Converting Between Numbers and Strings
 
 `int` and `float` convert implicitly to `string`.
 To control how many digits appear in the result, use the [`to-fixed()` and `to-precision()`](../../property-types/numeric-types/#to-fixeddigits-int---string)

--- a/docs/astro/src/content/docs/reference/property-types/images.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/images.mdx
@@ -13,7 +13,6 @@ import SC from '@slint/common-files/src/components/SC.astro';
 import NotInSC from '@slint/common-files/src/components/NotInSC.astro';
 
 <SC>
-## Images
 ### image
 <SlintProperty propName="image" typeName="image" defaultValue='empty image'>
 

--- a/docs/astro/src/content/docs/reference/property-types/images.mdx
+++ b/docs/astro/src/content/docs/reference/property-types/images.mdx
@@ -98,7 +98,8 @@ See also the <Link type="Image" label="Image element"/>.
 
 </SlintProperty>
 
-Images have the following properties: \{#sls.type.image.properties.meta}
+An image has the fields `width` and `height`, read with the `.` operator
+as in `logo.width`: \{#sls.type.image.properties}
 
 #### width
 
@@ -109,6 +110,13 @@ An image without pixels has a width of 0. \{#sls.type.image.width}
 
 The height of the image in pixels, as an `int`.
 An image without pixels has a height of 0. \{#sls.type.image.height}
+
+```slint
+export component Example inherits Window {
+    in property <image> logo;
+    out property <int> logo-width: logo.width;
+}
+```
 
 <NotInSC>
 ```slint

--- a/docs/common/src/utils/rehype-sls-ids.mjs
+++ b/docs/common/src/utils/rehype-sls-ids.mjs
@@ -65,7 +65,10 @@ const MANUAL_REFERENCE_PATH = /[\\/]content[\\/]docs[\\/]reference[\\/]/;
 
 // A feature outside the certified subset is wrapped in the `<NotInSC>`
 // component: the safety manual renders nothing for it, but rehype runs before
-// any component does, so the paragraphs are still here to be skipped.
+// any component does, so the paragraphs are still here to be skipped. It opts
+// a part of a certified block back out, so it belongs inside one; a stray one
+// fails the build, since outside a block the content is uncertified already
+// and the tag would suggest the opposite.
 const NOT_IN_SC = "NotInSC";
 // Certified content is wrapped in <SC>. Inside it, <OnlyInSC> marks wording
 // that holds for Slint SC alone (shown only in the safety manual); it is the
@@ -75,7 +78,9 @@ const NOT_IN_SC = "NotInSC";
 const SC_TAGS = new Set(["SC", "OnlyInSC"]);
 
 function walk(node, fn, depth = 0, inNotInSc = false, scDepth = null) {
-    if (node.type === "element") fn(node, depth, inNotInSc, scDepth);
+    if (node.type === "element" || node.type === "mdxJsxFlowElement") {
+        fn(node, depth, inNotInSc, scDepth);
+    }
     let childNotInSc = inNotInSc;
     let childScDepth = scDepth;
     if (node.type === "mdxJsxFlowElement") {
@@ -153,8 +158,19 @@ export default function rehypeSlsIds({
         // intra-file duplicates still fail.
         const claimedHere = new Set();
         const missing = [];
+        const strayNotInSc = [];
 
         walk(tree, (node, depth, inNotInSc, scDepth) => {
+            if (node.type === "mdxJsxFlowElement") {
+                // <NotInSC> opts a part of a certified block back out, so it
+                // belongs inside one. Outside, the content is uncertified
+                // already and the tag reads as if the prose around it were
+                // certified.
+                if (isSC && node.name === NOT_IN_SC && scDepth === null) {
+                    strayNotInSc.push(node.position?.start?.line);
+                }
+                return;
+            }
             if (node.tagName !== "p") return;
             // Such a paragraph documents what Slint SC leaves out, so it
             // states no requirement and carries no identifier.
@@ -219,6 +235,14 @@ export default function rehypeSlsIds({
                 children: [{ type: "text", value: `[${id}]` }],
             });
         });
+
+        if (strayNotInSc.length > 0) {
+            throw new Error(
+                `rehype-sls-ids: <NotInSC> outside an <SC> block in ${sourcePath}\n` +
+                    strayNotInSc.map((line) => `  line ${line}\n`).join("") +
+                    "<NotInSC> shall be nested in the <SC> block whose content it opts out of.",
+            );
+        }
 
         if (missing.length > 0) {
             throw new Error(

--- a/internal/compiler/tests/syntax/slint-sc/identifier_normalization_collision.slint
+++ b/internal/compiler/tests/syntax/slint-sc/identifier_normalization_collision.slint
@@ -14,6 +14,7 @@ export component Foo_Bar inherits Window {}
 export component Foo-Bar inherits Window {
 //               >     <warning{Component 'Foo-Bar' is replacing a previously defined component with the same name}
 //               >     <^error{Duplicated export 'Foo-Bar'}
+    //#sls.file.element.id.identifier
     a_b := Rectangle {}
 //         >        <error{duplicated element id 'a-b'}
     a-b := Rectangle {}

--- a/internal/compiler/tests/syntax/slint-sc/image.slint
+++ b/internal/compiler/tests/syntax/slint-sc/image.slint
@@ -11,7 +11,7 @@ export component Test inherits Window {
     // A raster image on disk is accepted
     in property <image> ok: @image-url("image_2x2.png");
     // The dimensions of an image are read as `.width` and `.height`
-    //#sls.expr.image.dimensions
+    //#sls.type.image.properties
     out property <int> ok-width: ok.width;
     out property <int> ok-height: ok.height;
     // An SVG image can't be decoded into static pixels


### PR DESCRIPTION
4 commits:
                                                                                                                                                                   
  - The `width` and `height` of an `image` are fields of the type, so they move from the Expressions chapter to the image type page, which already specified both.
  - File Structure and Name Resolution both defined an element id, its uniqueness, and the reserved names. File Structure keeps them.
  - `<NotInSC>` outside an `<SC>` block does nothing, and it suggests that the prose around it is certified which it is not. The doc generator now reports it.
  - fix some links

