### PR TITLE
docs: don't edit CHANGELOG.md in a PR, use a changelog trailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,9 @@ When this principle applies: any time you design syntax for a new visual or layo
   track how feedback was incorporated; squash them once the review is complete. See
   [`docs/development.md`](docs/development.md#commit-history--code-reviews) for the full
   fixup-then-squash workflow, and for `mise`-based environment setup.
+- Don't edit `CHANGELOG.md`; it's written later from the git log.
+  Add a `ChangeLog:` trailer to the commit message for a noteworthy change.
+  See [`docs/development.md`](docs/development.md#changelog).
 - When responding to review feedback, put the explanation in the commit message and the
   review reply, not in a new code comment.
   Add a comment only where the code itself is unclear to someone who never saw the review.

--- a/docs/development.md
+++ b/docs/development.md
@@ -202,3 +202,17 @@ If that looks okay and targets the right branch for your PR, push with force:
 ```
 $ git push -f
 ```
+
+## Changelog
+
+Don't edit `CHANGELOG.md` in a pull request.
+It's written later from the git log, in one commit per release cycle that covers a range of commits.
+
+If a change is noteworthy, add a `ChangeLog:` trailer to the commit message:
+
+```
+ChangeLog: Fixed a GridLayout row collapsing to its min-height when a sibling cell had a fixed zero size
+```
+
+The trailer sets the wording of the entry.
+It doesn't decide whether there is one: the whole log is read, so a commit without a trailer can still get an entry.


### PR DESCRIPTION
The changelog is written later from the git log, one commit per release
cycle. Nothing in the docs said so — only an HTML comment in the pull
request template — so contributors hand-edit CHANGELOG.md regularly.

The trailer casing documented here is the one the git log and the pull
request template already use.