### PR TITLE
Visual Editor: Improve edge-case hover behavior

### DIFF
--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -339,7 +339,7 @@ def test_overlapping_elements_update_hover_outline_to_topmost_item(
         snapshot.assert_unchanged()
 
 
-def test_overlapping_hover_does_not_intercept_selected_element_drag(
+def test_selected_element_drag_takes_precedence_over_overlapping_element(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
@@ -357,7 +357,7 @@ def test_overlapping_hover_does_not_intercept_selected_element_drag(
             y=artboard.absolute_position.y + 80,
         )
         window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
-        window_element_with_label(window, "Hovered Text")
+        assert not elements_with_label(window.root_element, "Hovered Text")
         initial_frame = selection_frame(window, "Rectangle")
         target = slint_testing.LogicalPosition(
             x=overlapping.x + 20,

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -115,22 +115,6 @@ export struct SelectionRectangle {
     angle: angle,
 }
 
-/// The topmost selectable element under a canvas position.
-export struct HoveredElement {
-    valid: bool,
-    is-selected: bool,
-    is-over-selected-element: bool,
-    element-path: string,
-    element-offset: int,
-    type-name: string,
-    geometry: [SelectionRectangle],
-}
-
-export global Hover {
-    in-out property <HoveredElement> element;
-    pure callback element-at(x: length, y: length, enter-component: bool) -> HoveredElement;
-}
-
 /// A `Selection`
 export struct Selection {
     highlight-index: int,

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -307,34 +307,41 @@ export component CanvasInteractionLayer inherits Rectangle {
                 root.update-hover({ x: self.mouse-x, y: self.mouse-y });
             }
         }
-    }
+        changed has-hover => {
+            if !self.has-hover {
+                Hover.clear();
+            }
+        }
 
-    // Selected frames precede hover frames so an enabled hover frame receives input.
-    for selection[idx] in root.selections: SelectedCanvasFrame {
-        selection: selection;
-        primary: idx == Api.selection.highlight-index;
-        shift-pressed: root.shift-pressed;
-        interaction-disabled: root.hover-selection-active;
-        pointer-hovered(position) => {
-            root.update-hover(position);
+        for geometry in Hover.element.geometry: HoverCanvasFrame {
+            geometry: geometry;
+            gesture-active: root.hover-selection-active;
+            selection-area-has-hover: selection-area.has-hover;
+            gesture-started => {
+                root.hover-selection-active = true;
+            }
+            gesture-ended => {
+                root.hover-selection-active = false;
+            }
+            pointer-hovered(position) => {
+                root.update-hover(position);
+            }
+            real-element-selected => {
+                root.real-element-selected();
+            }
         }
-    }
 
-    for geometry in Hover.element.geometry: HoverCanvasFrame {
-        geometry: geometry;
-        gesture-active: root.hover-selection-active;
-        selection-area-has-hover: selection-area.has-hover;
-        gesture-started => {
-            root.hover-selection-active = true;
-        }
-        gesture-ended => {
-            root.hover-selection-active = false;
-        }
-        pointer-hovered(position) => {
-            root.update-hover(position);
-        }
-        real-element-selected => {
-            root.real-element-selected();
+        // Selected frames come after hover frames so a selection has higher precedence.
+        for selection[idx] in root.selections: SelectedCanvasFrame {
+            selection: selection;
+            primary: idx == Api.selection.highlight-index;
+            shift-pressed: root.shift-pressed;
+            interaction-disabled: root.hover-selection-active;
+            pointer-hovered(position) => {
+                // do not hover inside the selection, a hover would be misleading, as
+                // clicking still reaches the selection, not the hover.
+                Hover.clear();
+            }
         }
     }
 }

--- a/tools/editor/ui/components/canvas-interaction-layer.slint
+++ b/tools/editor/ui/components/canvas-interaction-layer.slint
@@ -1,10 +1,11 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Api, Hover, SelectionRectangle } from "../api.slint";
+import { Api, SelectionRectangle } from "../api.slint";
 import { EditorCursors, StudioTheme } from "common.slint";
 import { BorderRadiusFrame } from "border-radius-frame.slint";
 import { MoveResizeFrame } from "move-resize-frame.slint";
+import { Hover, HoveredElement } from "../hover.slint";
 
 component CanvasValueTooltip inherits Rectangle {
     in property <string> label;

--- a/tools/editor/ui/hover.slint
+++ b/tools/editor/ui/hover.slint
@@ -17,4 +17,7 @@ export struct HoveredElement {
 export global Hover {
     in-out property <HoveredElement> element;
     pure callback element-at(x: length, y: length, enter-component: bool) -> HoveredElement;
+    public function clear() {
+        self.element = {};
+    }
 }

--- a/tools/editor/ui/hover.slint
+++ b/tools/editor/ui/hover.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { SelectionRectangle } from "api.slint";
+
+/// The topmost selectable element under a canvas position.
+export struct HoveredElement {
+    valid: bool,
+    is-selected: bool,
+    is-over-selected-element: bool,
+    element-path: string,
+    element-offset: int,
+    type-name: string,
+    geometry: [SelectionRectangle],
+}
+
+export global Hover {
+    in-out property <HoveredElement> element;
+    pure callback element-at(x: length, y: length, enter-component: bool) -> HoveredElement;
+}

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -3,7 +3,8 @@
 
 import "./assets/Inter-VariableFont.ttf";
 
-import { Api, EditorSurfaceMode, Hover } from "api.slint";
+import { Api, EditorSurfaceMode } from "api.slint";
+import { Hover } from "hover.slint";
 import { Project } from "project.slint";
 import { StartupWizard } from "startup-wizard.slint";
 import { AppState, PaletteComponentKind, SidebarToggleButton, StudioTheme } from "components/common.slint";


### PR DESCRIPTION
This fixes two separate issues:

1. When the cursor moves outside the canvas, the hover is now
   consistently cleared, even if the hovered element extends to the edge
   of the canvas, and if the mouse moves outside the canvas quickly.
2. Elements inside the current selection do not receive a hover outline
   anymore, as they cannot be selected by clicking to prevent
   accidentally changing the selection.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
