### PR TITLE
compiler: don't keep a proc_macro::Span in the diagnostics

### DIFF
--- a/api/rs/macros/lib.rs
+++ b/api/rs/macros/lib.rs
@@ -387,6 +387,14 @@ pub fn slint(stream: TokenStream) -> TokenStream {
 
     let mut tokens = Vec::new();
     fill_token_vec(token_iter, &mut tokens);
+    // Position each token in the document the parser will see: the concatenation of the token
+    // texts. A token can still grow while the vector is built, as later tokens are merged into
+    // it, so this can only be done now.
+    let mut offset = 0;
+    for t in &mut tokens {
+        t.offset = offset;
+        offset += t.text.len();
+    }
 
     fn local_file(tokens: &[parser::Token]) -> Option<PathBuf> {
         tokens.first()?.span?.local_file()

--- a/internal/compiler/diagnostics.rs
+++ b/internal/compiler/diagnostics.rs
@@ -11,14 +11,10 @@ use std::collections::BTreeSet;
 /// Span represent an error location within a file.
 ///
 /// Currently, it is just an offset in byte within the file + the corresponding length.
-///
-/// When the `proc_macro_span` feature is enabled, it may also hold a proc_macro span.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Span {
     pub offset: usize,
     pub length: usize,
-    #[cfg(feature = "proc_macro_span")]
-    pub span: Option<proc_macro::Span>,
 }
 
 impl Span {
@@ -26,33 +22,14 @@ impl Span {
         self.offset != usize::MAX
     }
 
-    #[allow(clippy::needless_update)] // needed when `proc_macro_span` is enabled
     pub fn new(offset: usize, length: usize) -> Self {
-        Self { offset, length, ..Default::default() }
+        Self { offset, length }
     }
 }
 
 impl Default for Span {
     fn default() -> Self {
-        Span {
-            offset: usize::MAX,
-            length: 0,
-            #[cfg(feature = "proc_macro_span")]
-            span: Default::default(),
-        }
-    }
-}
-
-impl PartialEq for Span {
-    fn eq(&self, other: &Span) -> bool {
-        self.offset == other.offset && self.length == other.length
-    }
-}
-
-#[cfg(feature = "proc_macro_span")]
-impl From<proc_macro::Span> for Span {
-    fn from(span: proc_macro::Span) -> Self {
-        Self { span: Some(span), ..Default::default() }
+        Span { offset: usize::MAX, length: 0 }
     }
 }
 
@@ -552,28 +529,26 @@ impl BuildDiagnostics {
 
     #[cfg(all(feature = "proc_macro_span", feature = "display-diagnostics"))]
     /// Will convert the diagnostics that only have offsets to the actual proc_macro::Span
+    ///
+    /// `tokens` are the tokens the document was parsed from, in document order.
     pub fn report_macro_diagnostic(
         self,
-        span_map: &[crate::parser::Token],
+        tokens: &[crate::parser::Token],
     ) -> proc_macro::TokenStream {
         let mut result = proc_macro::TokenStream::default();
         let mut needs_error = self.has_errors();
         let output = self.call_diagnostics(
             Some(&mut |diag| {
-                let span = diag.span.span.span.or_else(|| {
-                    //let pos =
-                    //span_map.binary_search_by_key(d.span.offset, |x| x.0).unwrap_or_else(|x| x);
-                    //d.span.span = span_map.get(pos).as_ref().map(|x| x.1);
-                    let mut offset = 0;
-                    span_map.iter().find_map(|t| {
-                        if diag.span.span.offset <= offset {
-                            t.span
-                        } else {
-                            offset += t.text.len();
-                            None
-                        }
-                    })
-                });
+                // A diagnostic only carries an offset into the document, which is the
+                // concatenation of the token texts: find the token that offset lands in.
+                let span = if diag.span.span.is_valid() {
+                    let index = tokens
+                        .binary_search_by_key(&diag.span.span.offset, |t| t.offset)
+                        .unwrap_or_else(|i| i.saturating_sub(1));
+                    tokens.get(index).and_then(|t| t.span)
+                } else {
+                    None
+                };
                 let message = &diag.message;
 
                 let span: proc_macro2::Span = if let Some(span) = span {

--- a/internal/compiler/lexer.rs
+++ b/internal/compiler/lexer.rs
@@ -213,7 +213,6 @@ pub fn lex(mut source: &str) -> Vec<crate::parser::Token> {
             kind: SyntaxKind::Whitespace,
             text: source[..3].into(),
             offset: 0,
-            length: 3,
             ..Default::default()
         });
         source = &source[3..];
@@ -232,7 +231,6 @@ pub fn lex(mut source: &str) -> Vec<crate::parser::Token> {
             kind,
             text: source[..len].into(),
             offset,
-            length: len,
             ..Default::default()
         });
         offset += len;

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -684,10 +684,9 @@ impl<'a> DefaultParser<'a> {
     /// Where a diagnostic reported at the current token points to
     fn current_token_location(&self) -> crate::diagnostics::SourceLocation {
         let token = self.current_token();
-        let length = if token.kind == SyntaxKind::DoubleLess { 1 } else { token.text.len() };
         crate::diagnostics::SourceLocation {
             source_file: Some(self.source_file.clone()),
-            span: crate::diagnostics::Span::new(token.offset, length),
+            span: crate::diagnostics::Span::new(token.offset, token.text.len()),
         }
     }
 

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -503,8 +503,8 @@ impl From<SyntaxKind> for rowan::SyntaxKind {
 pub struct Token {
     pub kind: SyntaxKind,
     pub text: SmolStr,
+    /// Byte offset of `text` in the document, which is the concatenation of every token's text
     pub offset: usize,
-    pub length: usize,
     #[cfg(feature = "proc_macro_span")]
     pub span: Option<proc_macro::Span>,
 }
@@ -515,7 +515,6 @@ impl Default for Token {
             kind: SyntaxKind::Eof,
             text: Default::default(),
             offset: 0,
-            length: 0,
             #[cfg(feature = "proc_macro_span")]
             span: None,
         }
@@ -738,15 +737,10 @@ impl Parser for DefaultParser<'_> {
     /// Reports an error at the current token location
     fn error(&mut self, e: impl Into<String>) {
         let current_token = self.current_token();
-        #[allow(unused_mut)]
-        let mut span = crate::diagnostics::Span::new(
+        let span = crate::diagnostics::Span::new(
             current_token.offset,
-            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.length },
+            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.text.len() },
         );
-        #[cfg(feature = "proc_macro_span")]
-        {
-            span.span = current_token.span;
-        }
 
         self.diags.push_error_with_span(
             e.into(),
@@ -760,15 +754,10 @@ impl Parser for DefaultParser<'_> {
     /// Reports an error at the current token location
     fn warning(&mut self, e: impl Into<String>) {
         let current_token = self.current_token();
-        #[allow(unused_mut)]
-        let mut span = crate::diagnostics::Span::new(
+        let span = crate::diagnostics::Span::new(
             current_token.offset,
-            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.length },
+            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.text.len() },
         );
-        #[cfg(feature = "proc_macro_span")]
-        {
-            span.span = current_token.span;
-        }
 
         self.diags.push_warning_with_span(
             e.into(),

--- a/internal/compiler/parser.rs
+++ b/internal/compiler/parser.rs
@@ -681,6 +681,16 @@ impl<'a> DefaultParser<'a> {
         self.tokens.get(self.cursor).cloned().unwrap_or_default()
     }
 
+    /// Where a diagnostic reported at the current token points to
+    fn current_token_location(&self) -> crate::diagnostics::SourceLocation {
+        let token = self.current_token();
+        let length = if token.kind == SyntaxKind::DoubleLess { 1 } else { token.text.len() };
+        crate::diagnostics::SourceLocation {
+            source_file: Some(self.source_file.clone()),
+            span: crate::diagnostics::Span::new(token.offset, length),
+        }
+    }
+
     /// Consume all the whitespace
     pub fn consume_ws(&mut self) {
         while matches!(self.current_token().kind, SyntaxKind::Whitespace | SyntaxKind::Comment) {
@@ -736,36 +746,14 @@ impl Parser for DefaultParser<'_> {
 
     /// Reports an error at the current token location
     fn error(&mut self, e: impl Into<String>) {
-        let current_token = self.current_token();
-        let span = crate::diagnostics::Span::new(
-            current_token.offset,
-            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.text.len() },
-        );
-
-        self.diags.push_error_with_span(
-            e.into(),
-            crate::diagnostics::SourceLocation {
-                source_file: Some(self.source_file.clone()),
-                span,
-            },
-        );
+        let location = self.current_token_location();
+        self.diags.push_error_with_span(e.into(), location);
     }
 
-    /// Reports an error at the current token location
+    /// Reports a warning at the current token location
     fn warning(&mut self, e: impl Into<String>) {
-        let current_token = self.current_token();
-        let span = crate::diagnostics::Span::new(
-            current_token.offset,
-            if current_token.kind == SyntaxKind::DoubleLess { 1 } else { current_token.text.len() },
-        );
-
-        self.diags.push_warning_with_span(
-            e.into(),
-            crate::diagnostics::SourceLocation {
-                source_file: Some(self.source_file.clone()),
-                span,
-            },
-        );
+        let location = self.current_token_location();
+        self.diags.push_warning_with_span(e.into(), location);
     }
 
     type Checkpoint = rowan::Checkpoint;

--- a/internal/compiler/tests/syntax/parse_error/state1.slint
+++ b/internal/compiler/tests/syntax/parse_error/state1.slint
@@ -9,9 +9,9 @@ export TestCase := Rectangle {
         checked when checked: {
             text.color: red;
             <<<<<    // FIXME: we should only report one error
-//          ^error{Syntax error: expected Identifier}
-//          ^^error{Syntax error: expected ']'}
-//          ^^^error{Parse error}
+//          ><error{Syntax error: expected Identifier}
+//          ><^error{Syntax error: expected ']'}
+//          ><^^error{Parse error}
             border: 42;
         }
     ]


### PR DESCRIPTION
A proc_macro::Span is not Send, and Span is reachable from the LLR and from the interpreter's CompilationResult through SourceLocation. That keeps a compilation from being moved to another thread, also in builds that have nothing to do with the macro:
cargo unifies the proc_macro_span feature as soon as api/rs/macros is a selected workspace member.

The macro pushed its tokens without an offset, so a parse diagnostic had no usable position and had to carry the span of the token instead. Give each token the offset it has in the document, which is the concatenation of the token texts, and let report_macro_diagnostic find the token back from the offset, like it already did for the diagnostics of the passes.

Token::length was always the length of the token's text, so drop it.
