### PR TITLE
Preview: Add Highlight Overlay support

### DIFF
--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1686,7 +1686,7 @@ mod tests {
     use crate::lengths::LogicalLength;
     use crate::lengths::LogicalSize;
     use euclid::Point2D;
-    use std::{rc::Rc, vec};
+    use std::{boxed::Box, rc::Rc, vec};
 
     const GEOMETRY_POSITION_X: f32 = 6.;
     const GEOMETRY_POSITION_Y: f32 = 27.;
@@ -1727,6 +1727,14 @@ mod tests {
 
         fn renderer(&self) -> &dyn crate::platform::Renderer {
             &self.renderer
+        }
+    }
+
+    impl crate::platform::Platform for Rc<WindowAdapter> {
+        fn create_window_adapter(
+            &self,
+        ) -> Result<Rc<dyn crate::window::WindowAdapter>, crate::api::PlatformError> {
+            Ok(self.clone())
         }
     }
 
@@ -3066,6 +3074,73 @@ mod tests {
     }
 
     #[test]
+    fn test_window_overlay_renders_above_child_popups_without_joining_popup_stack() {
+        let mut window_item = WindowItem::default();
+        window_item.width = Property::new(LogicalLength::new(30.));
+        window_item.height = Property::new(LogicalLength::new(30.));
+        let (window_adapter, component) = create_one_node_component(Some(window_item));
+        window_adapter
+            .window
+            .0
+            .set_context(crate::SlintContext::new(Box::new(window_adapter.clone())));
+        window_adapter.window.0.set_component(&component);
+
+        let popup = create_subsubtree_items(Some(window_adapter.clone())).1;
+        window_adapter.window.0.show_popup(
+            &popup,
+            alloc::boxed::Box::new(|| LogicalPosition::new(10., 20.)),
+            crate::items::PopupClosePolicy::NoAutoClose,
+            &ItemRc::new_root(component.clone()),
+            crate::window::WindowKind::Popup,
+            alloc::boxed::Box::new(|_| {}),
+        );
+
+        let overlay = create_subsubtree_items(Some(window_adapter.clone())).1;
+        window_adapter.window.0.add_overlay(&overlay).unwrap();
+        let unrelated_overlay = create_subsubtree_items(None).1;
+        assert!(window_adapter.window.0.add_overlay(&unrelated_overlay).is_err());
+
+        let resized = LogicalSize::new(75., 65.);
+        window_adapter.window.0.set_window_item_geometry(resized);
+        let overlay_window = ItemRc::new_root(overlay.clone()).downcast::<WindowItem>().unwrap();
+        assert_eq!(overlay_window.as_pin_ref().width().0, resized.width);
+        assert_eq!(overlay_window.as_pin_ref().height().0, resized.height);
+
+        assert_eq!(window_adapter.window.0.active_popups().len(), 1);
+        let rendered_components = || {
+            window_adapter
+                .window
+                .0
+                .draw_contents(|components, _| {
+                    components
+                        .iter()
+                        .map(|(component, _)| component.upgrade().unwrap())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap()
+        };
+        for (actual, expected) in rendered_components().iter().zip([&component, &popup, &overlay]) {
+            assert!(VRc::ptr_eq(actual, expected));
+        }
+
+        window_adapter.window.0.close_top_popup();
+        assert!(window_adapter.window.0.active_popups().is_empty());
+        let components_without_popup = rendered_components();
+        assert_eq!(components_without_popup.len(), 2);
+        assert!(VRc::ptr_eq(&components_without_popup[1], &overlay));
+
+        window_adapter.window.0.clear_overlays();
+        assert_eq!(rendered_components().len(), 1);
+
+        window_adapter.window.0.add_overlay(&overlay).unwrap();
+        let replacement = create_subsubtree_items(Some(window_adapter.clone())).1;
+        window_adapter.window.0.set_component(&replacement);
+        let components_after_replacement = rendered_components();
+        assert_eq!(components_after_replacement.len(), 1);
+        assert!(VRc::ptr_eq(&components_after_replacement[0], &replacement));
+    }
+
+    #[test]
     fn test_map_to_window_popup() {
         const POPUP_LOCATION: LogicalPosition = LogicalPosition::new(20., 33.);
         let (window_adapter, item_tree) = create_subsubtree_items(None);
@@ -3278,7 +3353,6 @@ mod tests {
             &self,
             _window_adapter: &std::rc::Rc<dyn crate::window::WindowAdapter>,
         ) {
-            unimplemented!("Not required in this test");
         }
 
         fn slint_context(&self) -> Option<crate::SlintContext> {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -613,6 +613,7 @@ pub struct WindowInner {
     /// Stack of currently active popups
     pub active_popups: RefCell<Vec<PopupWindow>>,
     next_popup_id: Cell<NonZeroU32>,
+    overlays: RefCell<Vec<ItemTreeRc>>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
     click_state: ClickState,
@@ -679,6 +680,7 @@ impl WindowInner {
             cursor_blinker: Default::default(),
             active_popups: Default::default(),
             next_popup_id: Cell::new(NonZeroU32::MIN),
+            overlays: Default::default(),
             had_popup_on_press: Default::default(),
             close_requested: Default::default(),
             click_state: ClickState::default(),
@@ -693,6 +695,7 @@ impl WindowInner {
     /// done with that component.
     pub fn set_component(&self, component: &ItemTreeRc) {
         self.close_all_popups();
+        self.clear_overlays();
         self.focus_item_visibility_tracker.clear();
         self.focus_item.replace(Default::default());
         self.mouse_input_state.replace(Default::default());
@@ -743,6 +746,9 @@ impl WindowInner {
             }
             for popup in self.active_popups.borrow().iter() {
                 changed |= crate::item_tree::ensure_item_tree_instantiated(&popup.component);
+            }
+            for overlay in self.overlays.borrow().iter() {
+                changed |= crate::item_tree::ensure_item_tree_instantiated(overlay);
             }
             changed |= crate::properties::ChangeTracker::run_change_handlers_once();
             if !changed {
@@ -1772,18 +1778,20 @@ impl WindowInner {
         };
         Some(self.pinned_fields.as_ref().project_ref().redraw_tracker.evaluate_as_dependency_root(
             || {
-                if !self
-                    .active_popups
-                    .borrow()
-                    .iter()
-                    .any(|p| matches!(p.location, PopupWindowLocation::ChildWindow(..)))
-                {
+                let has_child_popup =
+                    self.active_popups.borrow().iter().any(|popup| {
+                        matches!(popup.location, PopupWindowLocation::ChildWindow(..))
+                    });
+                let has_overlay = !self.overlays.borrow().is_empty();
+                if !has_child_popup && !has_overlay {
                     render_components(&[(component_weak, LogicalPoint::default())], &post_render)
                 } else {
-                    let borrow = self.active_popups.borrow();
-                    let mut item_trees = Vec::with_capacity(borrow.len() + 1);
+                    let active_popups = self.active_popups.borrow();
+                    let overlays = self.overlays.borrow();
+                    let mut item_trees =
+                        Vec::with_capacity(active_popups.len() + overlays.len() + 1);
                     item_trees.push((component_weak, LogicalPoint::default()));
-                    for popup in borrow.iter() {
+                    for popup in active_popups.iter() {
                         // If the popup is not a real window and does not have its own coordinate system.
                         // We have to draw the popup and consider the location for subelements because everything must
                         // be rendered relative to the main window position
@@ -1791,7 +1799,11 @@ impl WindowInner {
                             item_trees.push((ItemTreeRc::downgrade(&popup.component), *location));
                         }
                     }
-                    drop(borrow);
+                    for overlay in overlays.iter() {
+                        item_trees.push((ItemTreeRc::downgrade(overlay), LogicalPoint::zero()));
+                    }
+                    drop(overlays);
+                    drop(active_popups);
                     render_components(&item_trees, &post_render)
                 }
             },
@@ -2204,6 +2216,59 @@ impl WindowInner {
         }
     }
 
+    /// Adds an item tree that renders above the component and embedded popups.
+    ///
+    /// The item tree must have a `Window` root and use this window's adapter.
+    /// Overlays don't participate in input, focus, popup closing, or accessibility.
+    #[doc(hidden)]
+    pub fn add_overlay(&self, component: &ItemTreeRc) -> Result<(), PlatformError> {
+        let mut overlay_window_adapter = None;
+        ItemTreeRc::borrow_pin(component)
+            .as_ref()
+            .window_adapter(false, &mut overlay_window_adapter);
+        let Some(overlay_window_adapter) = overlay_window_adapter else {
+            return Err(PlatformError::Other("The overlay has no window adapter".into()));
+        };
+        if !Rc::ptr_eq(&self.window_adapter(), &overlay_window_adapter) {
+            return Err(PlatformError::Other(
+                "The overlay must use the target window's adapter".into(),
+            ));
+        }
+
+        crate::item_tree::ensure_item_tree_instantiated(component);
+        let overlay_component = ItemTreeRc::borrow_pin(component);
+        let overlay_root = overlay_component.as_ref().get_item_ref(0);
+        let Some(window_item) = ItemRef::downcast_pin::<crate::items::WindowItem>(overlay_root)
+        else {
+            return Err(PlatformError::Other("The overlay root must be a Window".into()));
+        };
+        let size = self.window_adapter().size().to_logical(self.scale_factor()).to_euclid();
+        window_item.width.set(size.width_length());
+        window_item.height.set(size.height_length());
+
+        self.overlays.borrow_mut().push(component.clone());
+        self.window_adapter().request_redraw();
+        Ok(())
+    }
+
+    /// Removes all overlays.
+    #[doc(hidden)]
+    pub fn clear_overlays(&self) {
+        if self.overlays.take().is_empty() {
+            return;
+        }
+        self.mark_overlay_region_dirty();
+    }
+
+    fn mark_overlay_region_dirty(&self) {
+        let window_adapter = self.window_adapter();
+        let size = window_adapter.size().to_logical(self.scale_factor()).to_euclid();
+        if !size.is_empty() {
+            window_adapter.renderer().mark_dirty_region(LogicalRect::from_size(size).into());
+        }
+        window_adapter.request_redraw();
+    }
+
     /// Returns the scale factor set on the window, as provided by the windowing system.
     pub fn scale_factor(&self) -> f32 {
         self.pinned_fields.as_ref().project_ref().scale_factor.get()
@@ -2268,13 +2333,19 @@ impl WindowInner {
     /// window resize event from the windowing system.
     pub(crate) fn set_window_item_geometry(&self, size: crate::lengths::LogicalSize) {
         if let Some(component_rc) = self.try_component() {
-            let component = ItemTreeRc::borrow_pin(&component_rc);
-            let root_item = component.as_ref().get_item_ref(0);
-            if let Some(window_item) = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
-            {
-                window_item.width.set(size.width_length());
-                window_item.height.set(size.height_length());
-            }
+            Self::set_item_tree_window_geometry(&component_rc, size);
+        }
+        for overlay in self.overlays.borrow().iter() {
+            Self::set_item_tree_window_geometry(overlay, size);
+        }
+    }
+
+    fn set_item_tree_window_geometry(component: &ItemTreeRc, size: crate::lengths::LogicalSize) {
+        let component = ItemTreeRc::borrow_pin(component);
+        let root_item = component.as_ref().get_item_ref(0);
+        if let Some(window_item) = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item) {
+            window_item.width.set(size.width_length());
+            window_item.height.set(size.height_length());
         }
     }
 

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1242,6 +1242,18 @@ impl ComponentDefinition {
         ))
     }
 
+    /// Instantiate the component using an existing window without replacing its component.
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub fn create_detached_with_existing_window(
+        &self,
+        window: &Window,
+        _: i_slint_core::InternalToken,
+    ) -> Result<ComponentInstance, PlatformError> {
+        let adapter = WindowInner::from_pub(window).window_adapter();
+        Ok(ComponentInstance { inner: self.inner.create_detached_with_existing_window(adapter) })
+    }
+
     /// Private implementation of create
     pub(crate) fn create_with_options(
         &self,
@@ -1472,6 +1484,16 @@ impl ComponentInstance {
     /// Return the [`ComponentDefinition`] that was used to create this instance.
     pub fn definition(&self) -> ComponentDefinition {
         ComponentDefinition { inner: std::rc::Rc::new(self.inner.definition()) }
+    }
+
+    /// Return the item tree without attaching it as the window's component.
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub fn as_item_tree(
+        &self,
+        _: i_slint_core::InternalToken,
+    ) -> i_slint_core::item_tree::ItemTreeRc {
+        vtable::VRc::into_dyn(self.inner.vrc().clone())
     }
 
     fn is_system_tray_rooted(&self) -> bool {

--- a/internal/interpreter/component.rs
+++ b/internal/interpreter/component.rs
@@ -85,6 +85,19 @@ impl ComponentDefinitionInner {
         ComponentInstanceInner(vrc)
     }
 
+    pub fn create_detached_with_existing_window(
+        &self,
+        window_adapter: i_slint_core::window::WindowAdapterRc,
+    ) -> ComponentInstanceInner {
+        let vrc = Instance::new_detached_with_window(
+            self.compilation_unit.clone(),
+            self.public_index,
+            window_adapter,
+            self.type_loaders.clone(),
+        );
+        ComponentInstanceInner(vrc)
+    }
+
     /// Instantiate the component and embed it at `parent_item_tree_index`
     /// in the given outer item tree. Used by the `ComponentFactory` path
     /// to embed an interpreter-built component inside a natively compiled

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -236,6 +236,7 @@ pub struct Instance {
     /// attach idempotent and lets binding-evaluated code paths distinguish
     /// "adapter exists" from "window is fully wired for display".
     pub window_attached: OnceCell<()>,
+    window_attachment_disabled: bool,
     /// Set once `bindings::install_bindings_only` has wired up property
     /// bindings, two-way links and timers. Idempotent on repeated calls.
     pub bindings_installed: OnceCell<()>,
@@ -426,7 +427,10 @@ impl Instance {
     pub fn attach_to_window(&self) {
         // make sure not to attach embedded instances, they would otherwise take over
         // the window of the item tree they are embedded in.
-        if self.window_attached.get().is_some() || self.embedded_in.get().is_some() {
+        if self.window_attached.get().is_some()
+            || self.window_attachment_disabled
+            || self.embedded_in.get().is_some()
+        {
             return;
         }
         let Some(adapter) = self.window_adapter_or_default() else { return };
@@ -656,6 +660,23 @@ impl Instance {
             window_adapter,
             type_loaders,
             None,
+            false,
+        )
+    }
+
+    pub fn new_detached_with_window(
+        compilation_unit: Rc<CompilationUnit>,
+        public_component_index: usize,
+        window_adapter: i_slint_core::window::WindowAdapterRc,
+        type_loaders: crate::component::TypeLoaders,
+    ) -> VRc<ItemTreeVTable, Instance> {
+        Self::new_with_options(
+            compilation_unit,
+            public_component_index,
+            Some(window_adapter),
+            type_loaders,
+            None,
+            true,
         )
     }
 
@@ -676,6 +697,7 @@ impl Instance {
             None,
             type_loaders,
             Some((parent, parent_item_tree_index)),
+            false,
         )
     }
 
@@ -685,6 +707,7 @@ impl Instance {
         window_adapter: Option<i_slint_core::window::WindowAdapterRc>,
         type_loaders: crate::component::TypeLoaders,
         embedded_in: Option<(vtable::VWeak<ItemTreeVTable>, u32)>,
+        disable_window_attachment: bool,
     ) -> VRc<ItemTreeVTable, Instance> {
         let public = &compilation_unit.public_components[public_component_index];
         let globals = Rc::new(GlobalStorage::new(&compilation_unit));
@@ -696,6 +719,7 @@ impl Instance {
             globals,
             Some(public_component_index),
             type_loaders,
+            disable_window_attachment,
         );
         if let Some(adapter) = window_adapter {
             let _ = vrc.window_adapter.set(adapter);
@@ -728,6 +752,7 @@ impl Instance {
             globals,
             None,
             Default::default(),
+            false,
         );
         let _ = vrc.root_sub_component.repeated_in.set((parent, repeater_idx));
         vrc
@@ -742,7 +767,15 @@ impl Instance {
         parent: Weak<SubComponentInstance>,
         globals: Rc<GlobalStorage>,
     ) -> VRc<ItemTreeVTable, Instance> {
-        build_instance(&compilation_unit, item_tree, parent, globals, None, Default::default())
+        build_instance(
+            &compilation_unit,
+            item_tree,
+            parent,
+            globals,
+            None,
+            Default::default(),
+            false,
+        )
     }
 }
 
@@ -760,6 +793,7 @@ fn build_instance(
     globals: Rc<GlobalStorage>,
     public_component_index: Option<usize>,
     type_loaders: crate::component::TypeLoaders,
+    disable_window_attachment: bool,
 ) -> VRc<ItemTreeVTable, Instance> {
     let parent_for_root = parent.clone();
     let root_sub_component =
@@ -779,6 +813,7 @@ fn build_instance(
         window_adapter: OnceCell::new(),
         window_adapter_error: OnceCell::new(),
         window_attached: OnceCell::new(),
+        window_attachment_disabled: disable_window_attachment,
         bindings_installed: OnceCell::new(),
         init_code_run: OnceCell::new(),
         embedded_in: OnceCell::new(),

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -46,6 +46,20 @@ fn reuse_window() {
             instance.get_property("text_alias").unwrap(),
             Value::from(SharedString::from("foo"))
         );
+        let attached_item_tree =
+            i_slint_core::window::WindowInner::from_pub(instance.window()).component();
+        let detached = definition
+            .create_detached_with_existing_window(instance.window(), i_slint_core::InternalToken)
+            .unwrap();
+        assert!(!i_slint_core::item_tree::ItemTreeRc::ptr_eq(
+            &attached_item_tree,
+            &detached.as_item_tree(i_slint_core::InternalToken),
+        ));
+        let _ = detached.window();
+        assert!(i_slint_core::item_tree::ItemTreeRc::ptr_eq(
+            &attached_item_tree,
+            &i_slint_core::window::WindowInner::from_pub(instance.window()).component(),
+        ));
         instance
     };
 }

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -95,6 +95,7 @@ preview-session = [
   "dep:anyhow",
   "slint-interpreter/accessibility",
   "slint-interpreter/image-default-formats",
+  "slint-interpreter/internal-highlight",
 ]
 remote = [
   "preview-session",

--- a/internal/live-preview/inspector.rs
+++ b/internal/live-preview/inspector.rs
@@ -1,16 +1,16 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use std::{path::PathBuf, rc::Rc};
+use std::path::PathBuf;
 
 use i_slint_core::InternalToken;
 use i_slint_core::item_tree::ItemTreeRc;
 use i_slint_core::model::{ModelRc, VecModel};
 use i_slint_core::window::{WindowAdapterRc, WindowInner};
-use slint_interpreter::{Struct, Value};
+use slint_interpreter::{ComponentHandle as _, Struct, Value};
 
 pub struct InspectorOverlay {
-    highlights: Rc<VecModel<Value>>,
+    component: slint_interpreter::ComponentInstance,
     item_tree: ItemTreeRc,
     window_adapter: WindowAdapterRc,
 }
@@ -34,13 +34,9 @@ impl InspectorOverlay {
         let component = definition
             .create_detached_with_existing_window(window, InternalToken)
             .map_err(|error| anyhow::anyhow!("Cannot create inspector overlay: {error}"))?;
-        let highlights = Rc::new(VecModel::default());
-        component
-            .set_property("highlights", Value::Model(ModelRc::from(highlights.clone())))
-            .map_err(|error| anyhow::anyhow!("Cannot initialize inspector highlights: {error}"))?;
         let item_tree = component.as_item_tree(InternalToken);
         let window_adapter = WindowInner::from_pub(window).window_adapter();
-        Ok(Self { highlights, item_tree, window_adapter })
+        Ok(Self { component, item_tree, window_adapter })
     }
 
     pub fn attach(&self) -> anyhow::Result<()> {
@@ -51,7 +47,6 @@ impl InspectorOverlay {
 
     pub fn detach(&self) {
         WindowInner::from_pub(self.window_adapter.window()).clear_overlays();
-        self.highlights.clear();
     }
 
     pub fn update(
@@ -59,26 +54,30 @@ impl InspectorOverlay {
         user_instance: Option<&slint_interpreter::ComponentInstance>,
         highlight: Option<&(lsp_types::Url, u32)>,
     ) {
-        let rectangles = user_instance
-            .zip(highlight)
-            .and_then(|(instance, (url, offset))| {
-                url.to_file_path().ok().map(|path| instance.component_positions(&path, *offset))
+        let highlight = user_instance.zip(highlight).and_then(|(instance, (url, offset))| {
+            url.to_file_path().ok().map(|path| (instance.as_weak(), path, *offset))
+        });
+        self.component
+            .set_callback("highlight-positions", move |_| {
+                let highlights: Vec<Value> = highlight
+                    .as_ref()
+                    .and_then(|(instance, path, offset)| {
+                        instance.upgrade().map(|instance| (instance, path, *offset))
+                    })
+                    .into_iter()
+                    .flat_map(|(instance, path, offset)| instance.component_positions(path, offset))
+                    .map(|geometry| {
+                        Value::Struct(Struct::from_iter([
+                            ("x".into(), Value::Number(geometry.rect.origin.x.into())),
+                            ("y".into(), Value::Number(geometry.rect.origin.y.into())),
+                            ("width".into(), Value::Number(geometry.rect.size.width.into())),
+                            ("height".into(), Value::Number(geometry.rect.size.height.into())),
+                            ("angle".into(), Value::Number(geometry.angle.into())),
+                        ]))
+                    })
+                    .collect();
+                Value::Model(ModelRc::new(VecModel::from(highlights)))
             })
-            .unwrap_or_default();
-        self.highlights.set_vec(
-            rectangles
-                .into_iter()
-                .map(|geometry| {
-                    Value::Struct(Struct::from_iter([
-                        ("x".into(), Value::Number(geometry.rect.origin.x.into())),
-                        ("y".into(), Value::Number(geometry.rect.origin.y.into())),
-                        ("width".into(), Value::Number(geometry.rect.size.width.into())),
-                        ("height".into(), Value::Number(geometry.rect.size.height.into())),
-                        ("angle".into(), Value::Number(geometry.angle.into())),
-                    ]))
-                })
-                .collect::<Vec<_>>(),
-        );
-        self.window_adapter.window().request_redraw();
+            .unwrap();
     }
 }

--- a/internal/live-preview/inspector.rs
+++ b/internal/live-preview/inspector.rs
@@ -1,0 +1,84 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::{path::PathBuf, rc::Rc};
+
+use i_slint_core::InternalToken;
+use i_slint_core::item_tree::ItemTreeRc;
+use i_slint_core::model::{ModelRc, VecModel};
+use i_slint_core::window::{WindowAdapterRc, WindowInner};
+use slint_interpreter::{Struct, Value};
+
+pub struct InspectorOverlay {
+    highlights: Rc<VecModel<Value>>,
+    item_tree: ItemTreeRc,
+    window_adapter: WindowAdapterRc,
+}
+
+impl InspectorOverlay {
+    pub async fn new(window: &i_slint_core::api::Window) -> anyhow::Result<Self> {
+        let compiler = slint_interpreter::Compiler::default();
+        let compilation_result = compiler
+            .build_from_source(
+                include_str!("inspector.slint").into(),
+                PathBuf::from("inspector.slint"),
+            )
+            .await;
+        if compilation_result.has_errors() {
+            compilation_result.print_diagnostics();
+            anyhow::bail!("Cannot compile inspector overlay");
+        }
+        let definition = compilation_result
+            .component("InspectorOverlay")
+            .ok_or_else(|| anyhow::anyhow!("Inspector overlay component is missing"))?;
+        let component = definition
+            .create_detached_with_existing_window(window, InternalToken)
+            .map_err(|error| anyhow::anyhow!("Cannot create inspector overlay: {error}"))?;
+        let highlights = Rc::new(VecModel::default());
+        component
+            .set_property("highlights", Value::Model(ModelRc::from(highlights.clone())))
+            .map_err(|error| anyhow::anyhow!("Cannot initialize inspector highlights: {error}"))?;
+        let item_tree = component.as_item_tree(InternalToken);
+        let window_adapter = WindowInner::from_pub(window).window_adapter();
+        Ok(Self { highlights, item_tree, window_adapter })
+    }
+
+    pub fn attach(&self) -> anyhow::Result<()> {
+        WindowInner::from_pub(self.window_adapter.window())
+            .add_overlay(&self.item_tree)
+            .map_err(|error| anyhow::anyhow!("Cannot show inspector overlay: {error}"))
+    }
+
+    pub fn detach(&self) {
+        WindowInner::from_pub(self.window_adapter.window()).clear_overlays();
+        self.highlights.clear();
+    }
+
+    pub fn update(
+        &self,
+        user_instance: Option<&slint_interpreter::ComponentInstance>,
+        highlight: Option<&(lsp_types::Url, u32)>,
+    ) {
+        let rectangles = user_instance
+            .zip(highlight)
+            .and_then(|(instance, (url, offset))| {
+                url.to_file_path().ok().map(|path| instance.component_positions(&path, *offset))
+            })
+            .unwrap_or_default();
+        self.highlights.set_vec(
+            rectangles
+                .into_iter()
+                .map(|geometry| {
+                    Value::Struct(Struct::from_iter([
+                        ("x".into(), Value::Number(geometry.rect.origin.x.into())),
+                        ("y".into(), Value::Number(geometry.rect.origin.y.into())),
+                        ("width".into(), Value::Number(geometry.rect.size.width.into())),
+                        ("height".into(), Value::Number(geometry.rect.size.height.into())),
+                        ("angle".into(), Value::Number(geometry.angle.into())),
+                    ]))
+                })
+                .collect::<Vec<_>>(),
+        );
+        self.window_adapter.window().request_redraw();
+    }
+}

--- a/internal/live-preview/inspector.slint
+++ b/internal/live-preview/inspector.slint
@@ -10,11 +10,11 @@ export struct InspectorHighlight {
 }
 
 export component InspectorOverlay inherits Window {
-    in property <[InspectorHighlight]> highlights;
+    pure callback highlight-positions() -> [InspectorHighlight];
 
     background: transparent;
 
-    for highlight in root.highlights: Rectangle {
+    for highlight in root.highlight-positions(): Rectangle {
         x: highlight.x;
         y: highlight.y;
         width: highlight.width;

--- a/internal/live-preview/inspector.slint
+++ b/internal/live-preview/inspector.slint
@@ -1,0 +1,27 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export struct InspectorHighlight {
+    x: length,
+    y: length,
+    width: length,
+    height: length,
+    angle: angle,
+}
+
+export component InspectorOverlay inherits Window {
+    in property <[InspectorHighlight]> highlights;
+
+    background: transparent;
+
+    for highlight in root.highlights: Rectangle {
+        x: highlight.x;
+        y: highlight.y;
+        width: highlight.width;
+        height: highlight.height;
+        transform-rotation: highlight.angle;
+        background: #3584e433;
+        border-color: #3584e4;
+        border-width: 1px;
+    }
+}

--- a/internal/live-preview/lib.rs
+++ b/internal/live-preview/lib.rs
@@ -20,5 +20,8 @@ pub mod live_component;
 #[cfg(feature = "preview-session")]
 pub mod preview_sessions;
 
+#[cfg(feature = "preview-session")]
+pub mod inspector;
+
 #[cfg(feature = "remote")]
 pub mod remote;

--- a/internal/live-preview/preview_sessions.rs
+++ b/internal/live-preview/preview_sessions.rs
@@ -17,6 +17,7 @@ use slint_interpreter::ComponentHandle as _;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::REBUILD_DEBOUNCE;
+use crate::inspector::InspectorOverlay;
 #[cfg(target_arch = "wasm32")]
 use crate::protocol::wasm_prelude::*;
 use crate::protocol::{
@@ -472,7 +473,9 @@ pub async fn run_with_channels(
     install_debug_handler(Rc::downgrade(&to_editor))?;
 
     let mut current_component = None;
+    let mut current_highlight = None;
     let mut component_instance = None;
+    let mut inspector = None;
     let mut registered_fonts = HashSet::new();
     let mut pending_fonts = Vec::new();
 
@@ -484,6 +487,8 @@ pub async fn run_with_channels(
                     &preview_session,
                     &component,
                     &mut component_instance,
+                    &mut inspector,
+                    current_highlight.as_ref(),
                     &mut pending_fonts,
                 )
                 .await?;
@@ -495,11 +500,18 @@ pub async fn run_with_channels(
                     &preview_session,
                     component,
                     &mut component_instance,
+                    &mut inspector,
+                    current_highlight.as_ref(),
                     &mut pending_fonts,
                 )
                 .await?;
             }
-            PreviewSessionEvent::HighlightFromEditor { .. } => {}
+            PreviewSessionEvent::HighlightFromEditor { url, offset } => {
+                current_highlight = url.map(|url| (url, offset));
+                if let Some(inspector) = inspector.as_ref() {
+                    inspector.update(component_instance.as_ref(), current_highlight.as_ref());
+                }
+            }
             PreviewSessionEvent::RegisterFont { url, contents } => {
                 if !registered_fonts.insert(url.clone()) {
                     tracing::debug!("Font {url} already registered, skipping");
@@ -521,6 +533,8 @@ async fn show_component(
     preview_session: &PreviewSession,
     component: &PreviewComponent,
     component_instance: &mut Option<slint_interpreter::ComponentInstance>,
+    inspector: &mut Option<InspectorOverlay>,
+    current_highlight: Option<&(Url, u32)>,
     pending_fonts: &mut Vec<Arc<[u8]>>,
 ) -> anyhow::Result<()> {
     let PreviewCompilation::Ready(component_definition) =
@@ -537,8 +551,14 @@ async fn show_component(
     for contents in pending_fonts.drain(..) {
         register_font(new_instance.window(), contents);
     }
+    if inspector.is_none() {
+        *inspector = Some(InspectorOverlay::new(new_instance.window()).await?);
+    }
     new_instance.show()?;
     *component_instance = Some(new_instance);
+    let inspector = inspector.as_ref().unwrap();
+    inspector.attach()?;
+    inspector.update(component_instance.as_ref(), current_highlight);
     Ok(())
 }
 

--- a/internal/live-preview/preview_sessions.rs
+++ b/internal/live-preview/preview_sessions.rs
@@ -24,8 +24,11 @@ use crate::protocol::{
     SourceFileVersion,
 };
 
+/// Small wrapper around tokio::spawn_local to silence the clippy warning that
+/// you should just use `spawn_local`.
+/// spawn_local is shadowed by `slint::spawn_local`, so make this explicit here.
 #[allow(clippy::disallowed_methods)]
-fn spawn_local<Future>(future: Future) -> tokio::task::JoinHandle<Future::Output>
+fn tokio_spawn_local<Future>(future: Future) -> tokio::task::JoinHandle<Future::Output>
 where
     Future: std::future::Future + 'static,
     Future::Output: 'static,
@@ -92,7 +95,7 @@ impl PreviewSession {
         });
         session.compiler.replace(Some(session.create_compiler()));
         let (command_sender, command_receiver) = mpsc::unbounded_channel();
-        spawn_local(session.clone().process_messages(command_receiver, event_handler));
+        tokio_spawn_local(session.clone().process_messages(command_receiver, event_handler));
         (session, PreviewSessionHandle { command_sender })
     }
 
@@ -457,7 +460,7 @@ pub async fn run_with_channels(
         })
         .map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
-    spawn_local(async move {
+    tokio_spawn_local(async move {
         while let Some(message) = from_editor.recv().await {
             let should_quit = matches!(message, LspToPreviewMessage::Quit);
             if session_handle.handle_message(message).is_err() || should_quit {

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -542,9 +542,10 @@ mod tests {
     const TEST_PREVIEW_SOURCE: &str = r#"
         export component TestPreview inherits Window {
             background: white;
+            in property <length> rectangle-x: 20px;
 
             Rectangle {
-                x: 20px;
+                x: root.rectangle-x;
                 y: 20px;
                 width: 30px;
                 height: 20px;
@@ -620,5 +621,16 @@ mod tests {
         let outside = pixels[(5 * WIDTH + 5) as usize];
         assert!(highlighted.blue > highlighted.red);
         assert_eq!((outside.red, outside.green, outside.blue), (255, 255, 255));
+
+        preview.set_property("rectangle-x", slint_interpreter::Value::Number(60.)).unwrap();
+        let mut moved_pixels = vec![RgbPixel::default(); (WIDTH * HEIGHT) as usize];
+        assert!(window_adapter.draw_if_needed(|renderer| {
+            renderer.render(moved_pixels.as_mut_slice(), WIDTH as usize);
+        }));
+
+        let old_position = moved_pixels[(25 * WIDTH + 25) as usize];
+        let new_position = moved_pixels[(25 * WIDTH + 65) as usize];
+        assert_eq!((old_position.red, old_position.green, old_position.blue), (255, 255, 255));
+        assert!(new_position.blue > new_position.red);
     }
 }

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -8,6 +8,7 @@ use std::{net::SocketAddr, rc::Rc};
 use i_slint_core::SharedString;
 use i_slint_core::textlayout::sharedparley::fontique;
 use i_slint_core::window::WindowInner;
+use i_slint_live_preview::inspector::InspectorOverlay;
 use i_slint_live_preview::preview_sessions::{
     PreviewCompilation, PreviewSession, PreviewSessionEvent,
 };
@@ -163,6 +164,7 @@ async fn run_async(
     })?;
 
     let mut placeholder = RemoteViewerWindow::new()?;
+    let inspector = InspectorOverlay::new(placeholder.window()).await?;
 
     #[cfg(not(target_vendor = "apple"))]
     let mdns = enable_mdns.then(mdns_sd::ServiceDaemon::new).transpose()?;
@@ -214,6 +216,7 @@ async fn run_async(
     let mut last_connection = None;
     let mut user_instance: Option<slint_interpreter::ComponentInstance> = None;
     let mut current_preview: Option<PreviewComponent> = None;
+    let mut current_highlight: Option<(lsp_types::Url, u32)> = None;
     let mut registered_fonts = HashSet::<lsp_types::Url>::new();
     while let Some(event) = event_receiver.recv().await {
         match event {
@@ -238,6 +241,8 @@ async fn run_async(
                             &current_preview,
                             &mut placeholder,
                             &mut user_instance,
+                            &inspector,
+                            current_highlight.as_ref(),
                             &preview_session,
                             &chrome,
                         )
@@ -250,13 +255,18 @@ async fn run_async(
                             &current_preview,
                             &mut placeholder,
                             &mut user_instance,
+                            &inspector,
+                            current_highlight.as_ref(),
                             &preview_session,
                             &chrome,
                         )
                         .await?;
                     }
                 }
-                PreviewSessionEvent::HighlightFromEditor { .. } => {}
+                PreviewSessionEvent::HighlightFromEditor { url, offset } => {
+                    current_highlight = url.map(|url| (url, offset));
+                    inspector.update(user_instance.as_ref(), current_highlight.as_ref());
+                }
                 PreviewSessionEvent::RegisterFont { url, contents } => {
                     let len = contents.len();
                     if !registered_fonts.insert(url.clone()) {
@@ -285,10 +295,12 @@ async fn run_async(
                 if last_connection == Some(remote_addr) {
                     last_connection = None;
                     current_preview = None;
+                    current_highlight = None;
                     if !prompt_on_screen {
                         swap_to_placeholder(
                             &mut placeholder,
                             &mut user_instance,
+                            &inspector,
                             &chrome,
                             "",
                             RemoteViewerState::WaitingForConnection,
@@ -308,6 +320,7 @@ async fn run_async(
                 swap_to_placeholder(
                     &mut placeholder,
                     &mut user_instance,
+                    &inspector,
                     &chrome,
                     "",
                     RemoteViewerState::Pairing,
@@ -331,6 +344,8 @@ async fn run_async(
                     &current_preview,
                     &mut placeholder,
                     &mut user_instance,
+                    &inspector,
+                    current_highlight.as_ref(),
                     &preview_session,
                     &chrome,
                 )
@@ -341,7 +356,14 @@ async fn run_async(
                     } else {
                         RemoteViewerState::WaitingForConnection
                     };
-                    swap_to_placeholder(&mut placeholder, &mut user_instance, &chrome, "", state)?;
+                    swap_to_placeholder(
+                        &mut placeholder,
+                        &mut user_instance,
+                        &inspector,
+                        &chrome,
+                        "",
+                        state,
+                    )?;
                 }
             }
         }
@@ -367,11 +389,22 @@ async fn show_current(
     current_preview: &Option<PreviewComponent>,
     placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
+    inspector: &InspectorOverlay,
+    current_highlight: Option<&(lsp_types::Url, u32)>,
     preview_session: &PreviewSession,
     chrome: &Chrome,
 ) -> anyhow::Result<bool> {
     let Some(preview_component) = current_preview.clone() else { return Ok(false) };
-    build_and_show(&preview_component, placeholder, user_instance, preview_session, chrome).await?;
+    build_and_show(
+        &preview_component,
+        placeholder,
+        user_instance,
+        inspector,
+        current_highlight,
+        preview_session,
+        chrome,
+    )
+    .await?;
     Ok(true)
 }
 
@@ -381,6 +414,8 @@ async fn build_and_show(
     preview_component: &PreviewComponent,
     placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
+    inspector: &InspectorOverlay,
+    current_highlight: Option<&(lsp_types::Url, u32)>,
     preview_session: &PreviewSession,
     chrome: &Chrome,
 ) -> anyhow::Result<()> {
@@ -392,6 +427,7 @@ async fn build_and_show(
             swap_to_placeholder(
                 placeholder,
                 user_instance,
+                inspector,
                 chrome,
                 &message,
                 RemoteViewerState::PreviewError,
@@ -402,6 +438,7 @@ async fn build_and_show(
             swap_to_placeholder(
                 placeholder,
                 user_instance,
+                inspector,
                 chrome,
                 "Component not found",
                 RemoteViewerState::PreviewError,
@@ -417,6 +454,8 @@ async fn build_and_show(
 
     new_instance.show().map_err(|err| anyhow::anyhow!("Cannot show component: {err}"))?;
     *user_instance = Some(new_instance);
+    inspector.attach()?;
+    inspector.update(user_instance.as_ref(), current_highlight);
     // The placeholder is hidden now, but keep its state property truthful.
     placeholder.set_state(RemoteViewerState::Previewing);
     Ok(())
@@ -453,10 +492,12 @@ impl Chrome {
 fn swap_to_placeholder(
     placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
+    inspector: &InspectorOverlay,
     chrome: &Chrome,
     message: &str,
     state: RemoteViewerState,
 ) -> anyhow::Result<()> {
+    inspector.detach();
     let fresh = RemoteViewerWindow::new_with_existing_window(placeholder.window())
         .map_err(|err| anyhow::anyhow!("Cannot create placeholder: {err}"))?;
     chrome.apply(&fresh);
@@ -487,3 +528,97 @@ fn device_name_override() -> Option<String> {
 #[cfg(target_os = "android")]
 pub(crate) static ANDROID_DEVICE_NAME: std::sync::Mutex<Option<String>> =
     std::sync::Mutex::new(None);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use i_slint_renderer_software::{
+        MinimalSoftwareWindow, PremultipliedRgbaColor, RepaintBufferType, TargetPixel,
+    };
+    use slint::platform::{Platform, PlatformError, WindowAdapter};
+
+    const WIDTH: u32 = 100;
+    const HEIGHT: u32 = 80;
+    const TEST_PREVIEW_SOURCE: &str = r#"
+        export component TestPreview inherits Window {
+            background: white;
+
+            Rectangle {
+                x: 20px;
+                y: 20px;
+                width: 30px;
+                height: 20px;
+            }
+        }
+    "#;
+
+    struct SoftwareRendererPlatform(Rc<MinimalSoftwareWindow>);
+
+    impl Platform for SoftwareRendererPlatform {
+        fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Clone, Copy, Default)]
+    struct RgbPixel {
+        red: u8,
+        green: u8,
+        blue: u8,
+    }
+
+    impl TargetPixel for RgbPixel {
+        fn blend(&mut self, color: PremultipliedRgbaColor) {
+            let inverse_alpha = 255u32 - color.alpha as u32;
+            self.red = (color.red as u32 + self.red as u32 * inverse_alpha / 255).min(255) as u8;
+            self.green =
+                (color.green as u32 + self.green as u32 * inverse_alpha / 255).min(255) as u8;
+            self.blue = (color.blue as u32 + self.blue as u32 * inverse_alpha / 255).min(255) as u8;
+        }
+
+        fn from_rgb(red: u8, green: u8, blue: u8) -> Self {
+            Self { red, green, blue }
+        }
+    }
+
+    #[test]
+    fn inspector_overlay_renders_highlight_over_preview() {
+        let window_adapter = MinimalSoftwareWindow::new(RepaintBufferType::NewBuffer);
+        slint::platform::set_platform(Box::new(SoftwareRendererPlatform(window_adapter.clone())))
+            .unwrap();
+        window_adapter.set_size(slint::PhysicalSize::new(WIDTH, HEIGHT));
+
+        let preview_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-preview.slint");
+        let compilation_result = crate::poll_ready(
+            slint_interpreter::Compiler::default()
+                .build_from_source(TEST_PREVIEW_SOURCE.into(), preview_path.clone()),
+        );
+        assert!(!compilation_result.has_errors());
+        let preview = compilation_result.component("TestPreview").unwrap().create().unwrap();
+        preview.show().unwrap();
+        let preview_item_tree = WindowInner::from_pub(preview.window()).component();
+        let inspector = crate::poll_ready(InspectorOverlay::new(preview.window())).unwrap();
+        assert!(i_slint_core::item_tree::ItemTreeRc::ptr_eq(
+            &preview_item_tree,
+            &WindowInner::from_pub(preview.window()).component(),
+        ));
+        let highlight = (
+            lsp_types::Url::from_file_path(&preview_path).unwrap(),
+            TEST_PREVIEW_SOURCE.find("Rectangle").unwrap() as u32,
+        );
+        inspector.update(Some(&preview), Some(&highlight));
+        inspector.attach().unwrap();
+
+        let mut pixels = vec![RgbPixel::default(); (WIDTH * HEIGHT) as usize];
+        preview.window().request_redraw();
+        window_adapter.draw_if_needed(|renderer| {
+            renderer.render(pixels.as_mut_slice(), WIDTH as usize);
+        });
+
+        let highlighted = pixels[(25 * WIDTH + 25) as usize];
+        let outside = pixels[(5 * WIDTH + 5) as usize];
+        assert!(highlighted.blue > highlighted.red);
+        assert_eq!((outside.red, outside.green, outside.blue), (255, 255, 255));
+    }
+}


### PR DESCRIPTION
This adds support for highlighting the selected elements in both Slint Viewer, and the Visual Editors "Run" preview.

In core, this is implemented similar to popups, as an additional list of
item trees that can be added to a Window, which then renders them on top.

The viewer then injects an appropriate overlay item tree.

<img width="2784" height="1813" alt="image" src="https://github.com/user-attachments/assets/110f5cec-6b7c-4992-b0e7-710e0f5b055c" />

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
