### PR TITLE
compiler: fix stale property reads across a call that writes the property

### DIFF
--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -1480,7 +1480,7 @@ component ContextMenu inherits Empty {
     callback show(position: Point);
     function close() {
     }
-    function is-open() -> bool {
+    pure function is-open() -> bool {
     }
     in property <bool> enabled: true;
 }
@@ -2562,14 +2562,14 @@ export component Path {
     /// If a `t` outside the bounds of 0 and 1 is passed, it will be converted to its decimal fraction.
     /// Ex: 1.5 -> 0.5 and 2.0 -> 1.0. This allows for N iterations of a loop
     /// by animating t from 0 to N. If `t` is animated from N to 0, it will loop N times backwards.
-    function point-at(t: float) -> Point {
+    pure function point-at(t: float) -> Point {
         BuiltinFunction.PathPointAt
     }
     /// Returns the angle (in degrees) between the x-axis and the path's tangent vector at the given `t`.
     /// The tangent points in the direction the path was defined, so this reflects the path's shape and not
     /// the object's current direction of travel. Returns 0 if the path is empty.
     /// If a `t` outside the bounds of 0 and 1 is passed, the decimal fraction will be passed.
-    function angle-at(t: float) -> angle {
+    pure function angle-at(t: float) -> angle {
         BuiltinFunction.PathAngleAt
     }
     //!

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -403,6 +403,11 @@ pub struct BuiltinPropertyInfo {
     /// unless a compiler pass accesses the member by name, in which case shadowing
     /// would generate wrong code and the member must not be marked.
     pub shadowable: bool,
+    /// For a function or callback: whether it is pure.
+    /// A member implemented natively has no body the compiler could inspect, so this comes from
+    /// the `pure` qualifier in builtins.slint, or from [`BuiltinFunction::is_pure`] when the
+    /// declaration names one.
+    pub pure: bool,
 }
 
 impl BuiltinPropertyInfo {
@@ -413,6 +418,7 @@ impl BuiltinPropertyInfo {
             property_visibility: PropertyVisibility::InOut,
             docs: None,
             shadowable: false,
+            pure: false,
             #[cfg(feature = "slint-sc")]
             slint_sc: false,
         }
@@ -431,16 +437,22 @@ impl BuiltinPropertyInfo {
     pub fn is_native_output(&self) -> bool {
         matches!(self.property_visibility, PropertyVisibility::InOut | PropertyVisibility::Output)
     }
+
+    /// The `pure` declaration of a function or callback, `None` for a property.
+    pub fn declared_pure(&self) -> Option<bool> {
+        matches!(self.ty, Type::Function(_) | Type::Callback(_)).then_some(self.pure)
+    }
 }
 
 impl From<BuiltinFunction> for BuiltinPropertyInfo {
     fn from(function: BuiltinFunction) -> Self {
         Self {
             ty: Type::Function(function.ty()),
-            default_value: BuiltinPropertyDefault::BuiltinFunction(function),
             property_visibility: PropertyVisibility::Public,
             docs: None,
             shadowable: false,
+            pure: function.is_pure(),
+            default_value: BuiltinPropertyDefault::BuiltinFunction(function),
             #[cfg(feature = "slint-sc")]
             slint_sc: false,
         }
@@ -510,7 +522,7 @@ impl ElementType {
                         resolved_name,
                         property_type: p.ty.clone(),
                         property_visibility: p.property_visibility,
-                        declared_pure: None,
+                        declared_pure: p.declared_pure(),
                         is_local_to_component: false,
                         is_in_direct_base: false,
                         is_shadowable: p.shadowable,
@@ -531,13 +543,12 @@ impl ElementType {
                 } else {
                     Cow::Borrowed(name)
                 };
-                let property_type =
-                    n.lookup_property(resolved_name.as_ref()).cloned().unwrap_or_default();
+                let info = n.lookup_property_info(resolved_name.as_ref());
                 PropertyLookupResult {
                     resolved_name,
-                    property_type,
+                    property_type: info.map(|p| p.ty.clone()).unwrap_or_default(),
                     property_visibility: PropertyVisibility::InOut,
-                    declared_pure: None,
+                    declared_pure: info.and_then(|p| p.declared_pure()),
                     is_local_to_component: false,
                     is_in_direct_base: false,
                     is_shadowable: false,
@@ -866,13 +877,14 @@ impl NativeClass {
     }
 
     pub fn lookup_property(&self, name: &str) -> Option<&Type> {
-        if let Some(bty) = self.properties.get(name) {
-            Some(&bty.ty)
-        } else if let Some(parent_class) = &self.parent {
-            parent_class.lookup_property(name)
-        } else {
-            None
-        }
+        self.lookup_property_info(name).map(|info| &info.ty)
+    }
+
+    /// The declaration of `name` on this class or the closest parent that has it.
+    pub fn lookup_property_info(&self, name: &str) -> Option<&BuiltinPropertyInfo> {
+        self.properties
+            .get(name)
+            .or_else(|| self.parent.as_ref().and_then(|parent| parent.lookup_property_info(name)))
     }
 
     pub fn lookup_alias(&self, name: &str) -> Option<&str> {

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -164,6 +164,7 @@ pub(crate) fn load_builtins(
                     })));
                     info.set_docs(docs::doc_comment(&s));
                     info.shadowable = s.ShadowableAttribute().is_some();
+                    info.pure = is_declared_pure(&s);
                     (identifier_text(&s.DeclaredIdentifier()).unwrap(), info)
                 }))
         );
@@ -225,6 +226,7 @@ pub(crate) fn load_builtins(
                 args.push(object_tree::type_from_node(a.Type(), *diag.borrow_mut(), register));
                 arg_names.push(identifier_text(&a.DeclaredIdentifier()).unwrap_or_default());
             }
+            let declared_pure = is_declared_pure(&f);
             let mut info = match builtin_function_body(&f, &id, &name) {
                 Some(function) => {
                     // The BuiltinFunction type prepends implicit ElementReference arguments.
@@ -243,13 +245,23 @@ pub(crate) fn load_builtins(
                     merged.arg_names = std::iter::repeat_n(SmolStr::default(), implicit)
                         .chain(arg_names)
                         .collect();
+                    debug_assert_eq!(
+                        declared_pure,
+                        function.is_pure(),
+                        "the 'pure' qualifier of {id}::{name} doesn't match {function:?}"
+                    );
+                    // `pure` comes from the BuiltinFunction, see BuiltinPropertyInfo::pure.
                     let mut info = BuiltinPropertyInfo::from(function);
                     info.ty = Type::Function(Arc::new(merged));
                     info
                 }
-                None => BuiltinPropertyInfo::new(Type::Function(
-                    Function { return_type, args, arg_names }.into(),
-                )),
+                None => {
+                    let mut info = BuiltinPropertyInfo::new(Type::Function(
+                        Function { return_type, args, arg_names }.into(),
+                    ));
+                    info.pure = declared_pure;
+                    info
+                }
             };
             info.set_docs(docs::doc_comment(&f));
             info.shadowable = f.ShadowableAttribute().is_some();
@@ -381,6 +393,13 @@ fn member_annotation(node: &SyntaxNode, key: &str) -> bool {
         cursor = cur.prev_sibling_or_token();
     }
     false
+}
+
+/// Whether the declaration is qualified `pure`.
+fn is_declared_pure(node: &SyntaxNode) -> bool {
+    node.children_with_tokens()
+        .filter_map(|c| c.into_token())
+        .any(|t| t.kind() == SyntaxKind::Identifier && t.text() == "pure")
 }
 
 /// Return the [`BuiltinFunction`] named by a member function's body, like

--- a/internal/compiler/passes/deduplicate_property_read.rs
+++ b/internal/compiler/passes/deduplicate_property_read.rs
@@ -13,8 +13,12 @@ use std::collections::{BTreeMap, HashMap};
 pub fn deduplicate_property_read(component: &Component) {
     visit_all_expressions(component, |expr, ty| {
         if matches!(ty(), Type::Callback { .. }) {
-            // Callback handler can't be optimizes because they can have side effect.
-            // But that's fine as they also do not register dependencies
+            // Callback handlers don't register dependencies, so there is nothing to gain.
+            return;
+        }
+        // A hoisted read must not cross a write of the same property.
+        // Rather than tracking writes, only optimize expressions that can't write at all.
+        if !super::purity_check::is_pure(expr) {
             return;
         }
         process_expression(expr, &DedupPropState::default());
@@ -31,8 +35,6 @@ struct PropertyReadCounts {
     counts: HashMap<NamedReference, ReadCount>,
     /// If at least one element of the map has duplicates
     has_duplicate: bool,
-    /// if there is an assignment of a property we currently disable this optimization
-    has_set: bool,
 }
 
 #[derive(Default)]
@@ -93,17 +95,10 @@ fn map_nr(nr: &NamedReference) -> SmolStr {
 }
 
 fn process_expression(expr: &mut Expression, old_state: &DedupPropState) {
-    if old_state.counts.borrow().has_set {
-        return;
-    }
     let new_state = DedupPropState { parent_state: Some(old_state), ..DedupPropState::default() };
     collect_unconditional_read_count(expr, &new_state);
     process_conditional_expressions(expr, &new_state);
-    if new_state.counts.borrow().has_set {
-        old_state.counts.borrow_mut().has_set = true;
-    } else {
-        do_replacements(expr, &new_state);
-    }
+    do_replacements(expr, &new_state);
 
     if new_state.counts.borrow().has_duplicate {
         let mut stores = BTreeMap::<SmolStr, NamedReference>::new();
@@ -126,9 +121,6 @@ fn process_expression(expr: &mut Expression, old_state: &DedupPropState) {
 
 // Collect all use of variable and their count, only in non conditional expression
 fn collect_unconditional_read_count(expr: &Expression, result: &DedupPropState) {
-    if result.counts.borrow().has_set {
-        return;
-    }
     match expr {
         Expression::PropertyReference(nr) => {
             result.add(nr);
@@ -141,17 +133,11 @@ fn collect_unconditional_read_count(expr: &Expression, result: &DedupPropState) 
         Expression::Condition { condition, .. } => {
             condition.visit(|sub| collect_unconditional_read_count(sub, result))
         }
-        Expression::SelfAssignment { .. } => {
-            result.counts.borrow_mut().has_set = true;
-        }
         _ => expr.visit(|sub| collect_unconditional_read_count(sub, result)),
     }
 }
 
 fn process_conditional_expressions(expr: &mut Expression, state: &DedupPropState) {
-    if state.counts.borrow().has_set {
-        return;
-    }
     match expr {
         Expression::BinaryExpression { lhs, rhs, op: '|' | '&' } => {
             lhs.visit_mut(|sub| process_conditional_expressions(sub, state));
@@ -161,9 +147,6 @@ fn process_conditional_expressions(expr: &mut Expression, state: &DedupPropState
             condition.visit_mut(|sub| process_conditional_expressions(sub, state));
             process_expression(true_expr, state);
             process_expression(false_expr, state);
-        }
-        Expression::SelfAssignment { .. } => {
-            state.counts.borrow_mut().has_set = true;
         }
         _ => expr.visit_mut(|sub| process_conditional_expressions(sub, state)),
     }

--- a/internal/compiler/passes/purity_check.rs
+++ b/internal/compiler/passes/purity_check.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use crate::diagnostics::BuildDiagnostics;
+use crate::diagnostics::{BuildDiagnostics, DiagnosticLevel};
 use crate::expression_tree::{Callable, Expression, NamedReference};
 use crate::langtype::PropertyLookupMode;
 
@@ -15,8 +15,8 @@ pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnost
             &(),
             &mut |elem, &()| {
                 let level = match elem.borrow().is_legacy_syntax {
-                    true => crate::diagnostics::DiagnosticLevel::Warning,
-                    false => crate::diagnostics::DiagnosticLevel::Error,
+                    true => DiagnosticLevel::Warning,
+                    false => DiagnosticLevel::Error,
                 };
                 crate::object_tree::visit_element_expressions(elem, |expr, name, _| {
                     if let Some(name) = name {
@@ -25,11 +25,11 @@ pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnost
                         if lookup.declared_pure.unwrap_or(false)
                             || lookup.property_type.is_property_type()
                         {
-                            ensure_pure(expr, Some(diag), level, &mut Default::default());
+                            ensure_pure(expr, Some((diag, level)), &mut Default::default());
                         }
                     } else {
                         // model expression must be pure
-                        ensure_pure(expr, Some(diag), level, &mut Default::default());
+                        ensure_pure(expr, Some((diag, level)), &mut Default::default());
                     };
                 })
             },
@@ -37,15 +37,15 @@ pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnost
     }
 }
 
-/// Whether evaluating `expr` has no side effect: it assigns no property and calls only pure functions.
+/// Whether evaluating `expr` has no side effect: it assigns no property and calls nothing impure.
+/// A `pure` declaration is taken at face value, which the legacy syntax only warns about.
 pub(super) fn is_pure(expr: &Expression) -> bool {
-    ensure_pure(expr, None, crate::diagnostics::DiagnosticLevel::Error, &mut Default::default())
+    ensure_pure(expr, None, &mut Default::default())
 }
 
 fn ensure_pure(
     expr: &Expression,
-    mut diag: Option<&mut BuildDiagnostics>,
-    level: crate::diagnostics::DiagnosticLevel,
+    mut diag: Option<(&mut BuildDiagnostics, DiagnosticLevel)>,
     recursion_test: &mut HashSet<NamedReference>,
 ) -> bool {
     let mut r = true;
@@ -58,90 +58,66 @@ fn ensure_pure(
                 .declared_pure
                 .unwrap_or(false) =>
         {
-            if let Some(diag) = diag.as_deref_mut() {
+            if let Some((diag, level)) = diag.as_mut() {
                 diag.push_diagnostic(
                     format!("Call of impure callback '{}'", nr.declared_name()),
                     source_location,
-                    level,
+                    *level,
                 );
             }
             r = false;
         }
-        Expression::FunctionCall { function: Callable::Function(nr), source_location, .. } => {
-            match nr
-                .element()
-                .borrow()
-                .lookup_property(nr.name(), PropertyLookupMode::InternalName)
-                .declared_pure
-            {
-                Some(true) => (),
-                Some(false) => {
-                    if let Some(diag) = diag.as_deref_mut() {
-                        diag.push_diagnostic(
-                            format!("Call of impure function '{}'", nr.declared_name(),),
-                            source_location,
-                            level,
-                        );
-                    }
-                    r = false;
-                }
-                None => {
-                    if recursion_test.insert(nr.clone()) {
-                        let element = nr.element();
-                        let element = element.borrow();
-                        let body = element.binding_cell_including_synthetic(nr.name());
-                        match body.map(|body| body.try_borrow()) {
-                            // A native member function such as 'TextInput.cut()' has no body to inspect,
-                            // so it can't be shown pure.
-                            None => {
-                                if let Some(diag) = diag.as_deref_mut() {
-                                    diag.push_diagnostic(
-                                        format!("Call of impure function '{}'", nr.declared_name()),
-                                        source_location,
-                                        level,
-                                    );
-                                }
-                                r = false;
-                            }
-                            // The expression visitor holds a mutable borrow on the body it is visiting.
-                            // Failing to borrow means the call recursed into the function under analysis,
-                            // a binding loop that is reported elsewhere.
-                            Some(Err(_)) => (),
-                            Some(Ok(body)) => {
-                                if !ensure_pure(&body.expression, None, level, recursion_test) {
-                                    if let Some(diag) = diag.as_deref_mut() {
-                                        diag.push_diagnostic(
-                                            format!(
-                                                "Call of impure function '{}'",
-                                                nr.declared_name()
-                                            ),
-                                            source_location,
-                                            level,
-                                        );
-                                    }
-                                    r = false;
-                                }
-                            }
-                        }
-                    }
-                }
+        Expression::FunctionCall { function: Callable::Function(nr), source_location, .. }
+            if !function_is_pure(nr, recursion_test) =>
+        {
+            if let Some((diag, level)) = diag.as_mut() {
+                diag.push_diagnostic(
+                    format!("Call of impure function '{}'", nr.declared_name()),
+                    source_location,
+                    *level,
+                );
             }
+            r = false;
         }
         Expression::FunctionCall { function: Callable::Builtin(func), source_location, .. }
             if !func.is_pure() =>
         {
-            if let Some(diag) = diag.as_deref_mut() {
-                diag.push_diagnostic("Call of impure function".into(), source_location, level);
+            if let Some((diag, level)) = diag.as_mut() {
+                diag.push_diagnostic("Call of impure function".into(), source_location, *level);
             }
             r = false;
         }
         Expression::SelfAssignment { node, .. } => {
-            if let Some(diag) = diag.as_deref_mut() {
-                diag.push_diagnostic("Assignment in a pure context".into(), node, level);
+            if let Some((diag, level)) = diag.as_mut() {
+                diag.push_diagnostic("Assignment in a pure context".into(), node, *level);
             }
             r = false;
         }
         _ => (),
     });
     r
+}
+
+/// Whether calling the function `nr` is pure.
+/// A private function carries no declaration, so it is judged by its body.
+fn function_is_pure(nr: &NamedReference, recursion_test: &mut HashSet<NamedReference>) -> bool {
+    let element = nr.element();
+    let element = element.borrow();
+    if let Some(declared) =
+        element.lookup_property(nr.name(), PropertyLookupMode::InternalName).declared_pure
+    {
+        return declared;
+    }
+    // A function already under inspection is a cycle, reported as a binding loop elsewhere.
+    if !recursion_test.insert(nr.clone()) {
+        return true;
+    }
+    match element.binding_cell_including_synthetic(nr.name()).map(|body| body.try_borrow()) {
+        Some(Ok(body)) => ensure_pure(&body.expression, None, recursion_test),
+        // The expression visitor holds a mutable borrow on the body it is visiting, and that
+        // function isn't in `recursion_test`. A failed borrow is a call back into it: a cycle too.
+        Some(Err(_)) => true,
+        // Only reached for a lookup that already failed with an error.
+        None => true,
+    }
 }

--- a/internal/compiler/passes/purity_check.rs
+++ b/internal/compiler/passes/purity_check.rs
@@ -37,6 +37,11 @@ pub fn purity_check(doc: &crate::object_tree::Document, diag: &mut BuildDiagnost
     }
 }
 
+/// Whether evaluating `expr` has no side effect: it assigns no property and calls only pure functions.
+pub(super) fn is_pure(expr: &Expression) -> bool {
+    ensure_pure(expr, None, crate::diagnostics::DiagnosticLevel::Error, &mut Default::default())
+}
+
 fn ensure_pure(
     expr: &Expression,
     mut diag: Option<&mut BuildDiagnostics>,
@@ -82,15 +87,28 @@ fn ensure_pure(
                 }
                 None => {
                     if recursion_test.insert(nr.clone()) {
-                        match nr.element().borrow().binding(nr.name()) {
+                        let element = nr.element();
+                        let element = element.borrow();
+                        let body = element.binding_cell_including_synthetic(nr.name());
+                        match body.map(|body| body.try_borrow()) {
+                            // A native member function such as 'TextInput.cut()' has no body to inspect,
+                            // so it can't be shown pure.
                             None => {
-                                debug_assert!(
-                                    diag.as_ref().is_none_or(|d| d.has_errors()),
-                                    "private functions must be local and defined"
-                                );
+                                if let Some(diag) = diag.as_deref_mut() {
+                                    diag.push_diagnostic(
+                                        format!("Call of impure function '{}'", nr.declared_name()),
+                                        source_location,
+                                        level,
+                                    );
+                                }
+                                r = false;
                             }
-                            Some(binding) => {
-                                if !ensure_pure(&binding.expression, None, level, recursion_test) {
+                            // The expression visitor holds a mutable borrow on the body it is visiting.
+                            // Failing to borrow means the call recursed into the function under analysis,
+                            // a binding loop that is reported elsewhere.
+                            Some(Err(_)) => (),
+                            Some(Ok(body)) => {
+                                if !ensure_pure(&body.expression, None, level, recursion_test) {
                                     if let Some(diag) = diag.as_deref_mut() {
                                         diag.push_diagnostic(
                                             format!(

--- a/internal/compiler/tests/syntax/functions/functions_private_base_binding.slint
+++ b/internal/compiler/tests/syntax/functions/functions_private_base_binding.slint
@@ -1,0 +1,12 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Calling a private function of the base from a binding is one error, not also a purity error.
+component Base inherits Rectangle {
+    function f() -> int { 1 }
+}
+
+export component Derived inherits Base {
+    in property <int> p: root.f();
+//                            ^error{The function 'f' is private. Annotate it with 'public' to make it accessible from other components}
+}

--- a/internal/compiler/tests/syntax/functions/functions_purity_native_member.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity_native_member.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// Member functions of native elements have no body to inspect, so they count as impure.
+// Member functions of native elements are impure unless builtins.slint declares them 'pure'.
 export component Foo inherits Window {
     ti := TextInput { }
 

--- a/internal/compiler/tests/syntax/functions/functions_purity_native_member.slint
+++ b/internal/compiler/tests/syntax/functions/functions_purity_native_member.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Member functions of native elements have no body to inspect, so they count as impure.
+export component Foo inherits Window {
+    ti := TextInput { }
+
+    pure function f1() {
+        ti.select-all();
+//         >        <error{Call of impure function 'select-all'}
+    }
+
+    property <int> p1: { ti.cut(); 1 }
+//                          > <error{Call of impure function 'cut'}
+}

--- a/internal/compiler/widgets/common/spinbox-base.slint
+++ b/internal/compiler/widgets/common/spinbox-base.slint
@@ -55,12 +55,9 @@ export component SpinBoxBase {
         text-input.text = root.value;
     }
 
-    private property <int> end-of-text;
-
     function update-text-and-cursor() {
         root.set-text-to-value();
-        root.end-of-text = text-input.text.character-count;
-        text-input.set-selection-offsets(root.end-of-text, root.end-of-text);
+        text-input.set-selection-offsets(text-input.text.character-count, text-input.text.character-count);
     }
 
     TouchArea {

--- a/tests/cases/properties/property_read_across_function_call.slint
+++ b/tests/cases/properties/property_read_across_function_call.slint
@@ -5,6 +5,7 @@
 // into a local variable at the start of the function and uses that twice.
 // Each function below calls something that changes the property and then reads it twice.
 // The reads must see the new value, so the single read can't be moved above the call.
+// A read that already sits before the call must keep the old value.
 
 export component TestCase inherits Window {
     in-out property <string> label: "a";
@@ -28,15 +29,25 @@ export component TestCase inherits Window {
         return (ti.has-focus ? 1 : 0) + (ti.has-focus ? 1 : 0);
     }
 
+    // 1 + 5 = 6. Merging the two reads gives 1 + 1 = 2, moving the first below the call 5 + 5 = 10.
+    function label-length-around-call() -> int {
+        let before = label.character-count;
+        set-label-to-hello();
+        return before + label.character-count;
+    }
+
     out property <int> label-length;
     out property <int> focus-count;
+    out property <int> label-length-around;
 
     init => {
         label-length = label-length-after-call();
         focus-count = focus-count-after-call();
+        label = "a";
+        label-length-around = label-length-around-call();
     }
 
-    out property <bool> test: label-length == 10 && focus-count == 2;
+    out property <bool> test: label-length == 10 && focus-count == 2 && label-length-around == 6;
 }
 
 /*
@@ -44,6 +55,7 @@ export component TestCase inherits Window {
 let instance = TestCase::new().unwrap();
 assert_eq!(instance.get_label_length(), 10);
 assert_eq!(instance.get_focus_count(), 2);
+assert_eq!(instance.get_label_length_around(), 6);
 assert!(instance.get_test());
 ```
 
@@ -52,6 +64,7 @@ auto handle = TestCase::create();
 const TestCase &instance = *handle;
 assert_eq(instance.get_label_length(), 10);
 assert_eq(instance.get_focus_count(), 2);
+assert_eq(instance.get_label_length_around(), 6);
 assert(instance.get_test());
 ```
 
@@ -59,6 +72,7 @@ assert(instance.get_test());
 let instance = new slint.TestCase({});
 assert.equal(instance.label_length, 10);
 assert.equal(instance.focus_count, 2);
+assert.equal(instance.label_length_around, 6);
 assert(instance.test);
 ```
 */

--- a/tests/cases/properties/property_read_across_function_call.slint
+++ b/tests/cases/properties/property_read_across_function_call.slint
@@ -1,0 +1,64 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// When a function reads the same property twice, the compiler reads it once
+// into a local variable at the start of the function and uses that twice.
+// Each function below calls something that changes the property and then reads it twice.
+// The reads must see the new value, so the single read can't be moved above the call.
+
+export component TestCase inherits Window {
+    in-out property <string> label: "a";
+
+    function set-label-to-hello() {
+        label = "hello";
+    }
+
+    // 5 + 5 = 10. A read moved above the call sees "a" and gives 1 + 1 = 2.
+    function label-length-after-call() -> int {
+        set-label-to-hello();
+        return label.character-count + label.character-count;
+    }
+
+    ti := TextInput { }
+
+    // Same with a built-in function: focus() sets ti.has-focus.
+    // 1 + 1 = 2. A read moved above the call sees false and gives 0.
+    function focus-count-after-call() -> int {
+        ti.focus();
+        return (ti.has-focus ? 1 : 0) + (ti.has-focus ? 1 : 0);
+    }
+
+    out property <int> label-length;
+    out property <int> focus-count;
+
+    init => {
+        label-length = label-length-after-call();
+        focus-count = focus-count-after-call();
+    }
+
+    out property <bool> test: label-length == 10 && focus-count == 2;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_label_length(), 10);
+assert_eq!(instance.get_focus_count(), 2);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_label_length(), 10);
+assert_eq(instance.get_focus_count(), 2);
+assert(instance.get_test());
+```
+
+```js
+let instance = new slint.TestCase({});
+assert.equal(instance.label_length, 10);
+assert.equal(instance.focus_count, 2);
+assert(instance.test);
+```
+*/


### PR DESCRIPTION
`SpinBoxBase` had to keep the caret position in a property, because reading the text length right after setting the text gave the old value. That was a compiler bug, found in #13191.

`deduplicate_property_read` merges repeated reads of a property into one read at the top of the block. It stopped at a direct assignment, but not at a call to a function that assigns. The read then ended up above the call and saw the old value.

The pass now only runs on expressions that the purity check finds free of side effects.

Reusing the purity check needed two fixes:

- A native member function such as `TextInput.cut()` has no body to inspect. That case only had a `debug_assert`, so debug builds panicked. Native members now declare `pure` in `builtins.slint`, false by default.
- Inspecting a private function's body can recurse into the binding being visited. A failed `try_borrow` is now treated as a cycle.

The second commit removes the workaround from `SpinBoxBase`.

Not handled: a legacy `pure` function that assigns is still trusted, and so is a `pure callback`. Any impure call disables merging for the whole expression, which takes 353 merged reads to 349 across the widget library, the gallery and four demos.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [x] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [x] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
