### PR TITLE
Fix has-hover getting stuck on a TouchArea under a delayed Flickable/SwipeGestureHandler pan

### DIFF
--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1745,10 +1745,33 @@ pub fn process_mouse_input(
             || Option::zip(result.item_stack.last(), mouse_input_state.item_stack.last())
                 .is_none_or(|(a, b)| a.0 != b.0))
     {
+        // This dispatch is discarded: the delayed press is still pending and either nothing
+        // claimed this event, or something other than the delaying item's own subtree did.
+        // The speculative dispatch above may still have run `input_event_filter_before_children`
+        // on items along `result`'s path (e.g. updating a TouchArea's has-hover) before we knew
+        // it would be thrown away. Queue a compensating Exit for any such item that isn't part
+        // of the retained stack, so it isn't left stuck with stale state once the delayed
+        // dispatch eventually resolves.
+        for (weak, _) in &result.item_stack {
+            if mouse_input_state.item_stack.iter().any(|(w, _)| w == weak)
+                || mouse_input_state.delayed_exit_items.contains(weak)
+            {
+                continue;
+            }
+            mouse_input_state.delayed_exit_items.push(weak.clone());
+        }
         // Keep the delayed event but transfer the just-attempted dispatch's cursor.
         mouse_input_state.cursor = result.cursor;
         return MouseInputResult { state: mouse_input_state, accepted };
     }
+    // Carry forward any Exit events queued by a previous, discarded dispatch (or by the loop
+    // below, on an earlier call) so they finally get delivered now that the ambiguity that
+    // deferred them has been resolved one way or another. An item that ended up back in
+    // `result.item_stack` from this very dispatch (e.g. a delayed press whose resolution just
+    // re-added it for real) was reclaimed, not abandoned, so it needs no compensating Exit.
+    let mut delayed_exit_items = core::mem::take(&mut mouse_input_state.delayed_exit_items);
+    delayed_exit_items.retain(|weak| !result.item_stack.iter().any(|(w, _)| w == weak));
+    result.delayed_exit_items = delayed_exit_items;
     send_exit_events(&mouse_input_state, &mut result, mouse_event.position(), window_adapter);
 
     if let MouseEvent::Wheel { position, .. } = mouse_event

--- a/tests/cases/elements/flickable.slint
+++ b/tests/cases/elements/flickable.slint
@@ -235,6 +235,62 @@ assert!((instance.get_offset_y() - 55.).abs() < 5.);
 ```
 
 ```rust
+// Test 1b
+// Same idea as Test 1's pan, but the pan threshold is crossed by a *gradual* drag
+// (a small move under the 8px threshold, then a bigger one) instead of a single big jump,
+// and entirely within the 100ms DelayForwarding window (no mock_elapsed_time before the pan
+// is detected). A gradual real-world drag routinely produces small moves before crossing the
+// threshold, unlike a single scripted jump. https://github.com/slint-ui/slint/issues/5262
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+let instance = TestCase::new().unwrap();
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(175.0, 175.0) });
+assert!(instance.get_inner_ta_has_hover());
+
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(175.0, 175.0), button: PointerEventButton::Left });
+assert!(instance.get_inner_ta_has_hover());
+
+// Small move, still under the 8px pan threshold: forwarded to inner_ta (hover tracking runs),
+// while the press itself is still held back by the Flickable's DelayForwarding.
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(178.0, 176.0) });
+assert!(instance.get_inner_ta_has_hover());
+
+// Now cross the pan threshold, all still within the 100ms delay: the Flickable intercepts
+// and pans directly, without ever forwarding this event to inner_ta.
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 120.0) });
+assert!(!instance.get_inner_ta_pressed());
+assert!(!instance.get_inner_ta_has_hover(), "inner_ta should no longer be hovered once the Flickable took over the pan");
+```
+
+```rust
+// Test 1c
+// Bounding case for Test 1b: same gradual drag, but the 100ms delay is allowed to resolve
+// (delivering a real Pressed to inner_ta) *before* the drag crosses the pan threshold, matching
+// Test 1's ordering. This was already correct before the Test 1b fix, since the delayed press
+// is no longer pending by the time the Flickable claims the pan, so the ordinary (non-delayed)
+// exit-event path in `send_exit_events` already applies.
+use slint::{platform::WindowEvent, platform::PointerEventButton, LogicalPosition};
+let instance = TestCase::new().unwrap();
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(175.0, 175.0) });
+assert!(instance.get_inner_ta_has_hover());
+
+instance.window().dispatch_event(WindowEvent::PointerPressed { position: LogicalPosition::new(175.0, 175.0), button: PointerEventButton::Left });
+assert!(instance.get_inner_ta_has_hover());
+
+slint_testing::mock_elapsed_time(150);
+assert!(instance.get_inner_ta_pressed()); // the delayed press has resolved for real
+assert!(instance.get_inner_ta_has_hover());
+
+// Small move, still under the 8px pan threshold.
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(178.0, 176.0) });
+assert!(instance.get_inner_ta_has_hover());
+
+// Cross the pan threshold: the Flickable intercepts and pans.
+instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 120.0) });
+assert!(!instance.get_inner_ta_pressed());
+assert!(!instance.get_inner_ta_has_hover());
+```
+
+```rust
 // Test 2
 // Test high-level wheel events stay synchronous
 use slint::{LogicalPosition, platform::{WindowEvent, Key} };

--- a/tests/cases/elements/swipegesturehandler.slint
+++ b/tests/cases/elements/swipegesturehandler.slint
@@ -114,7 +114,9 @@ assert_eq!(instance.get_right_swiping(), false);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(298.0, 452.0) });
 slint_testing::mock_elapsed_time(20);
 assert_eq!(instance.get_ta_pressed(), false);
-assert_eq!(instance.get_ta_hover(), true);
+// The down-gesture just claimed the pan, taking over from `ta`: `ta` is no longer part of
+// the dispatch path, so it correctly loses hover here rather than staying stuck.
+assert_eq!(instance.get_ta_hover(), false);
 assert_eq!(instance.get_down_swiping(), true);
 assert_eq!(instance.get_left_swiping(), false);
 assert_eq!(instance.get_right_swiping(), false);
@@ -123,7 +125,7 @@ slint_testing::mock_elapsed_time(220);
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(350.0, 482.0) });
 slint_testing::mock_elapsed_time(20);
 assert_eq!(instance.get_ta_pressed(), false);
-assert_eq!(instance.get_ta_hover(), true);
+assert_eq!(instance.get_ta_hover(), false);
 assert_eq!(instance.get_down_swiping(), true);
 assert_eq!(instance.get_left_swiping(), false);
 assert_eq!(instance.get_right_swiping(), false);
@@ -133,14 +135,14 @@ instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPo
 instance.window().dispatch_event(WindowEvent::PointerReleased { position: LogicalPosition::new(316.0, 463.0), button: PointerEventButton::Left });
 assert_eq!(instance.get_r(), "S1(65)");
 assert_eq!(instance.get_ta_pressed(), false);
+// The release ends the gesture (clearing `swiping`/`pressed`) and the grab-release
+// synthesizes a Moved at the release position, which is still over `ta`: hover resyncs
+// to true for real, no workaround move needed anymore.
 assert_eq!(instance.get_ta_hover(), true);
 assert_eq!(instance.get_down_swiping(), false);
 assert_eq!(instance.get_left_swiping(), false);
 assert_eq!(instance.get_right_swiping(), false);
 instance.set_r("".into());
-
-// FIXME: this shouldn't be necessary, but otherwise we don't send exit event to the toucharea
-instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(316.0, 463.0) });
 
 // Left
 instance.window().dispatch_event(WindowEvent::PointerMoved { position: LogicalPosition::new(100.0, 100.0) });


### PR DESCRIPTION
## Summary

A `Flickable`/`SwipeGestureHandler` press is held back via `DelayForwarding` so a potential pan/swipe has a chance to start. While that press is still pending, `process_mouse_input` speculatively re-dispatches each incoming `Moved` event from the root; if the delaying item's own subtree doesn't end up claiming it (or something else does), the speculative result is discarded and the previous state is kept instead.

That speculative dispatch already ran `input_event_filter_before_children` on every item it reached before the decision to discard was made — and that filter has real side effects. `TouchArea` sets `has-hover` as a side effect of merely being filtered, independent of whether its own `input_event` runs afterwards. So a small, sub-threshold move forwarded into a `TouchArea` nested under the delaying item flips `has-hover` to `true` for real, even though the dispatch carrying that flip is about to be thrown away. If a later event then lets the delaying item claim the pan directly (`Intercept`, without visiting children again), that `TouchArea` never appears in any `item_stack` that ever gets committed, so `send_exit_events` has no way to find it and send the compensating `Exit`. `has-hover` is then stuck `true` until something else happens to touch the same item.

This reproduces with a gradual, real-world-shaped drag: a first move under the 8px pan threshold (forwarded, sets `has-hover`) followed by a second move that crosses it (the delaying item intercepts directly) — both still within the 100ms delay window. A single big jump, or a drag that only crosses the threshold after the 100ms timer has already resolved the delay for real, does not hit this path.

This is distinct from #13120, which is about the delayed press itself being lost (a dropped click) when a dispatch in the same discard branch resolves against nothing. This fix is about that discarded dispatch's mutations on unrelated items never being unwound — same branch in `process_mouse_input`, different failure.

## Fix

When a dispatch is discarded, walk the just-discarded result's `item_stack` and queue any item that isn't part of the retained stack into `delayed_exit_items` — the same deferred-`Exit` mechanism `send_exit_events` already uses elsewhere in this file for an item that falls out of the stack while a delay is pending. Once a later dispatch actually commits, carry that queue into the committed result (minus anything that ended up back in its `item_stack`, which was reclaimed rather than abandoned) so `send_exit_events`'s existing drain delivers the real `Exit`.

Also fixes an existing `swipegesturehandler.slint` test that carried a `// FIXME: this shouldn't be necessary, but otherwise we don't send exit event to the toucharea` workaround for the same bug from a different angle — hover tracks dispatch-path membership, not raw geometric containment (see `send_exit_events`'s own pre-existing comment), so a nested `TouchArea` correctly loses hover once an ancestor gesture recognizer claims the interaction.

## Test plan

- [x] New test `Test 1b` in `flickable.slint`: reproduces the reported gradual-drag scenario (fails without the fix, passes with it)
- [x] New test `Test 1c` in `flickable.slint`: bounding case showing the "100ms timer resolves before the pan" ordering was already correct
- [x] Updated `swipegesturehandler.slint`'s existing test to match corrected (no-longer-buggy) hover behavior, removing the FIXME workaround
- [x] `elements` (129), `input` (4), `properties` (34), `layout` (148), `focus` (33) test binaries pass
- [x] `widgets-fluent`, `widgets-cupertino`, `widgets-cosmic`, `widgets-material` (26 each) pass
- [x] `cargo clippy -p i-slint-core` clean
- [x] `codex exec review` against master: no actionable findings

Fixes #5262

changelog: Fix has-hover getting stuck on a TouchArea under a Flickable or SwipeGestureHandler after a gradual drag crosses the pan threshold while the press is still delayed