### PR TITLE
Experiment: Add Overlay to PopupKind

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -439,35 +439,17 @@ fn generate_public_component(
 
     let experimental = compiler_config.enable_experimental;
 
-    let experimental_window_constructors: Option<TokenStream> = match llr.top_level_type {
+    let new_with_existing_window_impl: Option<TokenStream> = match llr.top_level_type {
         llr::TopLevelComponentType::Window => Some(quote!(
             #[cfg(#experimental)]
             pub fn new_with_existing_window(window: &slint::Window) -> ::core::result::Result<Self, slint::PlatformError> {
                 slint::private_unstable_api::ensure_backend()?;
-                let inner = #inner_component_id::new(sp::None)?;
+                let inner = #inner_component_id::new()?;
                 #init_bundle_translations
                 inner.globals.get().unwrap().create_window_from_existing(window)?;
                 #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
                 #ensure_tree_instantiated
                 ::core::result::Result::Ok(Self(inner))
-            }
-
-            #[cfg(#experimental)]
-            #[doc(hidden)]
-            pub fn new_detached_with_existing_window(window: &slint::Window) -> ::core::result::Result<Self, slint::PlatformError> {
-                slint::private_unstable_api::ensure_backend()?;
-                let window_adapter = sp::WindowInner::from_pub(window).window_adapter();
-                let inner = #inner_component_id::new(sp::Some(window_adapter))?;
-                #init_bundle_translations
-                #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
-                sp::ensure_item_tree_instantiated(&sp::VRc::into_dyn(inner.clone()));
-                ::core::result::Result::Ok(Self(inner))
-            }
-
-            #[cfg(#experimental)]
-            #[doc(hidden)]
-            pub fn as_item_tree(&self) -> sp::ItemTreeRc {
-                sp::VRc::into_dyn(self.0.clone())
             }
         )),
         llr::TopLevelComponentType::SystemTrayIcon => None,
@@ -560,7 +542,7 @@ fn generate_public_component(
         impl #public_component_id {
             pub fn new() -> ::core::result::Result<Self, slint::PlatformError> {
                 slint::private_unstable_api::ensure_backend()?;
-                let inner = #inner_component_id::new(sp::None)?;
+                let inner = #inner_component_id::new()?;
                 #init_bundle_translations
                 #eager_create_window
                 #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
@@ -570,7 +552,7 @@ fn generate_public_component(
 
             #[cfg(#experimental)]
             pub fn new_with_context(ctx: sp::SlintContext) -> ::core::result::Result<Self, slint::PlatformError> {
-                let inner = #inner_component_id::new(sp::None)?;
+                let inner = #inner_component_id::new()?;
                 #init_bundle_translations
 
                 #init_with_context
@@ -580,7 +562,7 @@ fn generate_public_component(
                 ::core::result::Result::Ok(Self(inner))
             }
 
-            #experimental_window_constructors
+            #new_with_existing_window_impl
 
             #property_and_callback_accessors
         }
@@ -717,32 +699,12 @@ fn generate_shared_globals(
             #library_shared_globals_names : sp::Rc<#library_shared_globals_types>,)*
         }
         impl SharedGlobals {
-            #pub_token fn new(root_item_tree_weak: sp::VWeak<sp::ItemTreeVTable>) -> sp::Rc<Self> {
-                Self::new_with_window_adapter(root_item_tree_weak, sp::None)
-            }
-
-            fn new_with_window_adapter(
-                root_item_tree_weak: sp::VWeak<sp::ItemTreeVTable>,
-                window_adapter: sp::Option<sp::WindowAdapterRc>,
-            ) -> sp::Rc<Self> {
-                #(let #library_shared_globals_names = {
-                    let shared_globals = #library_shared_globals_types::new(
-                        root_item_tree_weak.clone(),
-                    );
-                    if let sp::Some(window_adapter) = window_adapter.as_ref() {
-                        shared_globals.clone_with_window_adapter(window_adapter.clone())
-                    } else {
-                        shared_globals
-                    }
-                };)*
-                let window_adapter_cell = sp::OnceCell::new();
-                if let sp::Some(window_adapter) = window_adapter {
-                    window_adapter_cell.set(window_adapter).ok().unwrap();
-                }
+            #pub_token fn new(root_item_tree_weak : sp::VWeak<sp::ItemTreeVTable>) -> sp::Rc<Self> {
+                #(let #library_shared_globals_names = #library_shared_globals_types::new(root_item_tree_weak.clone());)*
                 sp::Rc::new(Self {
                     #(#global_names : #global_types::new(),)*
                     #(#from_library_global_names : #library_global_vars.clone(),)*
-                    window_adapter: window_adapter_cell,
+                    window_adapter : ::core::default::Default::default(),
                     root_item_tree_weak,
                     #(#library_shared_globals_names,)*
                 })
@@ -2369,24 +2331,12 @@ fn generate_item_tree(
         .collect::<Vec<_>>();
 
     let is_root_component = !is_popup && parent_ctx.is_none();
-    let root_window_adapter_arg =
-        is_root_component.then(|| quote!(window_adapter: sp::Option<sp::WindowAdapterRc>));
     let globals = if is_popup {
         quote!(globals)
     } else if parent_ctx.is_some() {
         quote!(parent.upgrade().unwrap().globals.get().unwrap().clone())
     } else {
-        quote!({
-            let root_item_tree_weak = sp::VRc::downgrade(&self_dyn_rc);
-            if let sp::Some(window_adapter) = window_adapter {
-                SharedGlobals::new_with_window_adapter(
-                    root_item_tree_weak,
-                    sp::Some(window_adapter),
-                )
-            } else {
-                SharedGlobals::new(root_item_tree_weak)
-            }
-        })
+        quote!(SharedGlobals::new(sp::VRc::downgrade(&self_dyn_rc)))
     };
     // The root component owns the freshly created `SharedGlobals` and is responsible for running
     // its eager initialization. The root's own `globals` field must be set *before* that init
@@ -2626,11 +2576,7 @@ fn generate_item_tree(
         #sub_comp
 
         impl #inner_component_id {
-            fn new(
-                #(parent: #parent_component_type,)*
-                #globals_arg
-                #root_window_adapter_arg
-            ) -> ::core::result::Result<sp::VRc<sp::ItemTreeVTable, Self>, slint::PlatformError> {
+            fn new(#(parent: #parent_component_type,)* #globals_arg) -> ::core::result::Result<sp::VRc<sp::ItemTreeVTable, Self>, slint::PlatformError> {
                 #![allow(unused)]
                 let mut _self = Self::default();
                 #(_self.parent = parent.clone() as #parent_component_type;)*

--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -439,17 +439,35 @@ fn generate_public_component(
 
     let experimental = compiler_config.enable_experimental;
 
-    let new_with_existing_window_impl: Option<TokenStream> = match llr.top_level_type {
+    let experimental_window_constructors: Option<TokenStream> = match llr.top_level_type {
         llr::TopLevelComponentType::Window => Some(quote!(
             #[cfg(#experimental)]
             pub fn new_with_existing_window(window: &slint::Window) -> ::core::result::Result<Self, slint::PlatformError> {
                 slint::private_unstable_api::ensure_backend()?;
-                let inner = #inner_component_id::new()?;
+                let inner = #inner_component_id::new(sp::None)?;
                 #init_bundle_translations
                 inner.globals.get().unwrap().create_window_from_existing(window)?;
                 #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
                 #ensure_tree_instantiated
                 ::core::result::Result::Ok(Self(inner))
+            }
+
+            #[cfg(#experimental)]
+            #[doc(hidden)]
+            pub fn new_detached_with_existing_window(window: &slint::Window) -> ::core::result::Result<Self, slint::PlatformError> {
+                slint::private_unstable_api::ensure_backend()?;
+                let window_adapter = sp::WindowInner::from_pub(window).window_adapter();
+                let inner = #inner_component_id::new(sp::Some(window_adapter))?;
+                #init_bundle_translations
+                #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
+                sp::ensure_item_tree_instantiated(&sp::VRc::into_dyn(inner.clone()));
+                ::core::result::Result::Ok(Self(inner))
+            }
+
+            #[cfg(#experimental)]
+            #[doc(hidden)]
+            pub fn as_item_tree(&self) -> sp::ItemTreeRc {
+                sp::VRc::into_dyn(self.0.clone())
             }
         )),
         llr::TopLevelComponentType::SystemTrayIcon => None,
@@ -542,7 +560,7 @@ fn generate_public_component(
         impl #public_component_id {
             pub fn new() -> ::core::result::Result<Self, slint::PlatformError> {
                 slint::private_unstable_api::ensure_backend()?;
-                let inner = #inner_component_id::new()?;
+                let inner = #inner_component_id::new(sp::None)?;
                 #init_bundle_translations
                 #eager_create_window
                 #inner_component_id::user_init(sp::VRc::map(inner.clone(), |x| x));
@@ -552,7 +570,7 @@ fn generate_public_component(
 
             #[cfg(#experimental)]
             pub fn new_with_context(ctx: sp::SlintContext) -> ::core::result::Result<Self, slint::PlatformError> {
-                let inner = #inner_component_id::new()?;
+                let inner = #inner_component_id::new(sp::None)?;
                 #init_bundle_translations
 
                 #init_with_context
@@ -562,7 +580,7 @@ fn generate_public_component(
                 ::core::result::Result::Ok(Self(inner))
             }
 
-            #new_with_existing_window_impl
+            #experimental_window_constructors
 
             #property_and_callback_accessors
         }
@@ -699,12 +717,32 @@ fn generate_shared_globals(
             #library_shared_globals_names : sp::Rc<#library_shared_globals_types>,)*
         }
         impl SharedGlobals {
-            #pub_token fn new(root_item_tree_weak : sp::VWeak<sp::ItemTreeVTable>) -> sp::Rc<Self> {
-                #(let #library_shared_globals_names = #library_shared_globals_types::new(root_item_tree_weak.clone());)*
+            #pub_token fn new(root_item_tree_weak: sp::VWeak<sp::ItemTreeVTable>) -> sp::Rc<Self> {
+                Self::new_with_window_adapter(root_item_tree_weak, sp::None)
+            }
+
+            fn new_with_window_adapter(
+                root_item_tree_weak: sp::VWeak<sp::ItemTreeVTable>,
+                window_adapter: sp::Option<sp::WindowAdapterRc>,
+            ) -> sp::Rc<Self> {
+                #(let #library_shared_globals_names = {
+                    let shared_globals = #library_shared_globals_types::new(
+                        root_item_tree_weak.clone(),
+                    );
+                    if let sp::Some(window_adapter) = window_adapter.as_ref() {
+                        shared_globals.clone_with_window_adapter(window_adapter.clone())
+                    } else {
+                        shared_globals
+                    }
+                };)*
+                let window_adapter_cell = sp::OnceCell::new();
+                if let sp::Some(window_adapter) = window_adapter {
+                    window_adapter_cell.set(window_adapter).ok().unwrap();
+                }
                 sp::Rc::new(Self {
                     #(#global_names : #global_types::new(),)*
                     #(#from_library_global_names : #library_global_vars.clone(),)*
-                    window_adapter : ::core::default::Default::default(),
+                    window_adapter: window_adapter_cell,
                     root_item_tree_weak,
                     #(#library_shared_globals_names,)*
                 })
@@ -2331,12 +2369,24 @@ fn generate_item_tree(
         .collect::<Vec<_>>();
 
     let is_root_component = !is_popup && parent_ctx.is_none();
+    let root_window_adapter_arg =
+        is_root_component.then(|| quote!(window_adapter: sp::Option<sp::WindowAdapterRc>));
     let globals = if is_popup {
         quote!(globals)
     } else if parent_ctx.is_some() {
         quote!(parent.upgrade().unwrap().globals.get().unwrap().clone())
     } else {
-        quote!(SharedGlobals::new(sp::VRc::downgrade(&self_dyn_rc)))
+        quote!({
+            let root_item_tree_weak = sp::VRc::downgrade(&self_dyn_rc);
+            if let sp::Some(window_adapter) = window_adapter {
+                SharedGlobals::new_with_window_adapter(
+                    root_item_tree_weak,
+                    sp::Some(window_adapter),
+                )
+            } else {
+                SharedGlobals::new(root_item_tree_weak)
+            }
+        })
     };
     // The root component owns the freshly created `SharedGlobals` and is responsible for running
     // its eager initialization. The root's own `globals` field must be set *before* that init
@@ -2576,7 +2626,11 @@ fn generate_item_tree(
         #sub_comp
 
         impl #inner_component_id {
-            fn new(#(parent: #parent_component_type,)* #globals_arg) -> ::core::result::Result<sp::VRc<sp::ItemTreeVTable, Self>, slint::PlatformError> {
+            fn new(
+                #(parent: #parent_component_type,)*
+                #globals_arg
+                #root_window_adapter_arg
+            ) -> ::core::result::Result<sp::VRc<sp::ItemTreeVTable, Self>, slint::PlatformError> {
                 #![allow(unused)]
                 let mut _self = Self::default();
                 #(_self.parent = parent.clone() as #parent_component_type;)*

--- a/internal/core/input.rs
+++ b/internal/core/input.rs
@@ -1469,6 +1469,22 @@ impl MouseInputState {
         self.delayed_exit_items.last().and_then(|x| x.upgrade()).or_else(|| self.top_item())
     }
 
+    pub(crate) fn tracks_item_tree(&self, item_tree: &crate::item_tree::ItemTreeRc) -> bool {
+        self.top_item_including_delayed().is_some_and(|item| {
+            ItemRc::new_root(item_tree.clone()).is_root_item_of(item.item_tree())
+        })
+    }
+
+    pub(crate) fn dispatch_shell(&self) -> Self {
+        Self {
+            drag_data: self.drag_data.clone(),
+            drag_source: self.drag_source.clone(),
+            drop_target: self.drop_target.clone(),
+            cursor: self.cursor.clone(),
+            ..Default::default()
+        }
+    }
+
     /// Returns true if there is a pending delayed event (e.g. from a Flickable)
     pub fn has_delayed_event(&self) -> bool {
         self.delayed.is_some()
@@ -1718,13 +1734,7 @@ pub fn process_mouse_input(
     window_adapter: &Rc<dyn WindowAdapter>,
     mut mouse_input_state: MouseInputState,
 ) -> MouseInputResult {
-    let mut result = MouseInputState {
-        drag_data: mouse_input_state.drag_data.clone(),
-        drag_source: mouse_input_state.drag_source.clone(),
-        drop_target: mouse_input_state.drop_target.clone(),
-        cursor: mouse_input_state.cursor.clone(),
-        ..Default::default()
-    };
+    let mut result = mouse_input_state.dispatch_shell();
     let r = send_mouse_event_to_item(
         mouse_event,
         root.clone(),

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1682,7 +1682,7 @@ mod tests {
     use crate::Property;
     use crate::api::LogicalPosition;
     use crate::api::Window;
-    use crate::items::{Clip, Transform, WindowItem};
+    use crate::items::{Clip, TouchArea, Transform, WindowItem};
     use crate::lengths::LogicalLength;
     use crate::lengths::LogicalSize;
     use euclid::Point2D;
@@ -2744,6 +2744,151 @@ mod tests {
         )
     }
 
+    struct InputTestItemTree {
+        self_weak: std::cell::OnceCell<ItemTreeWeak>,
+        item_tree: [ItemTreeNode; 2],
+        window_adapter: std::rc::Weak<dyn crate::window::WindowAdapter>,
+        root: WindowItem,
+        touch_area: TouchArea,
+    }
+
+    impl ItemTree for InputTestItemTree {
+        fn visit_children_item(
+            self: Pin<&Self>,
+            index: isize,
+            order: TraversalOrder,
+            visitor: VRefMut<ItemVisitorVTable>,
+        ) -> VisitChildrenResult {
+            let item_tree = self.self_weak.get().unwrap().upgrade().unwrap();
+            visit_item_tree(&item_tree, &self.item_tree, index, order, visitor, &mut |_, _, _| {
+                VisitChildrenResult::CONTINUE
+            })
+        }
+
+        fn get_item_ref(self: Pin<&Self>, index: u32) -> Pin<VRef<'_, ItemVTable>> {
+            let item_tree = self.get_ref();
+            match index {
+                0 => Pin::new(VRef::new(&item_tree.root)),
+                1 => Pin::new(VRef::new(&item_tree.touch_area)),
+                _ => unreachable!(),
+            }
+        }
+
+        fn get_item_tree(self: Pin<&Self>) -> Slice<'_, ItemTreeNode> {
+            Slice::from_slice(&self.get_ref().item_tree)
+        }
+
+        fn parent_node(self: Pin<&Self>, _result: &mut ItemWeak) {}
+
+        fn embed_component(
+            self: Pin<&Self>,
+            _parent_component: &ItemTreeWeak,
+            _item_tree_index: u32,
+        ) -> bool {
+            false
+        }
+
+        fn layout_info(self: Pin<&Self>, _orientation: Orientation) -> LayoutInfo {
+            LayoutInfo { min: 100., max: 100., preferred: 100., ..Default::default() }
+        }
+
+        fn subtree_index(self: Pin<&Self>) -> usize {
+            usize::MAX
+        }
+
+        fn get_subtree_range(self: Pin<&Self>, _subtree_index: u32) -> IndexRange {
+            (0..0).into()
+        }
+
+        fn get_subtree(
+            self: Pin<&Self>,
+            _subtree_index: u32,
+            _component_index: usize,
+            _result: &mut ItemTreeWeak,
+        ) {
+        }
+
+        fn accessible_role(self: Pin<&Self>, _index: u32) -> AccessibleRole {
+            AccessibleRole::None
+        }
+
+        fn accessible_string_property(
+            self: Pin<&Self>,
+            _index: u32,
+            _what: AccessibleStringProperty,
+            _result: &mut SharedString,
+        ) -> bool {
+            false
+        }
+
+        fn item_element_infos(self: Pin<&Self>, _index: u32, _result: &mut SharedString) -> bool {
+            false
+        }
+
+        fn ensure_instantiated(self: Pin<&Self>) -> bool {
+            false
+        }
+
+        fn window_adapter(
+            self: Pin<&Self>,
+            _do_create: bool,
+            result: &mut Option<WindowAdapterRc>,
+        ) {
+            *result = self.window_adapter.upgrade()
+        }
+
+        fn item_geometry(self: Pin<&Self>, _index: u32) -> LogicalRect {
+            LogicalRect::new(LogicalPoint::zero(), LogicalSize::new(100., 100.))
+        }
+
+        fn accessibility_action(self: Pin<&Self>, _index: u32, _action: &AccessibilityAction) {}
+
+        fn supported_accessibility_actions(
+            self: Pin<&Self>,
+            _index: u32,
+        ) -> SupportedAccessibilityAction {
+            SupportedAccessibilityAction::default()
+        }
+    }
+
+    crate::item_tree::ItemTreeVTable_static!(static INPUT_TEST_COMPONENT_VT for InputTestItemTree);
+
+    fn create_input_test_item_tree(
+        window_adapter: &Rc<WindowAdapter>,
+        enabled: bool,
+    ) -> VRc<ItemTreeVTable> {
+        let mut root = WindowItem::default();
+        root.width = Property::new(LogicalLength::new(100.));
+        root.height = Property::new(LogicalLength::new(100.));
+        let mut touch_area = TouchArea::default();
+        touch_area.enabled = Property::new(enabled);
+        let item_tree = VRc::new(InputTestItemTree {
+            self_weak: Default::default(),
+            item_tree: [
+                ItemTreeNode::Item {
+                    is_accessible: false,
+                    children_count: 1,
+                    children_index: 1,
+                    parent_index: 0,
+                    item_array_index: 0,
+                },
+                ItemTreeNode::Item {
+                    is_accessible: false,
+                    children_count: 0,
+                    children_index: 2,
+                    parent_index: 0,
+                    item_array_index: 1,
+                },
+            ],
+            window_adapter: Rc::downgrade(window_adapter) as _,
+            root,
+            touch_area,
+        });
+        let item_tree_dyn = VRc::into_dyn(item_tree.clone());
+        assert!(item_tree.as_pin_ref().self_weak.set(VRc::downgrade(&item_tree_dyn)).is_ok());
+        item_tree_dyn
+    }
+
     struct TransformTestItemTree {
         item_tree: Vec<ItemTreeNode>,
         geometries: Vec<LogicalRect>,
@@ -3074,7 +3219,7 @@ mod tests {
     }
 
     #[test]
-    fn test_window_overlay_renders_above_child_popups_without_joining_popup_stack() {
+    fn test_window_overlay_uses_popup_stack_without_popup_close_behavior() {
         let mut window_item = WindowItem::default();
         window_item.width = Property::new(LogicalLength::new(30.));
         window_item.height = Property::new(LogicalLength::new(30.));
@@ -3100,13 +3245,24 @@ mod tests {
         let unrelated_overlay = create_subsubtree_items(None).1;
         assert!(window_adapter.window.0.add_overlay(&unrelated_overlay).is_err());
 
+        let nested_popup = create_subsubtree_items(Some(window_adapter.clone())).1;
+        window_adapter.window.0.show_popup(
+            &nested_popup,
+            alloc::boxed::Box::new(|| LogicalPosition::new(5., 5.)),
+            crate::items::PopupClosePolicy::NoAutoClose,
+            &ItemRc::new_root(popup.clone()),
+            crate::window::WindowKind::Popup,
+            alloc::boxed::Box::new(|_| {}),
+        );
+
         let resized = LogicalSize::new(75., 65.);
         window_adapter.window.0.set_window_item_geometry(resized);
         let overlay_window = ItemRc::new_root(overlay.clone()).downcast::<WindowItem>().unwrap();
         assert_eq!(overlay_window.as_pin_ref().width().0, resized.width);
         assert_eq!(overlay_window.as_pin_ref().height().0, resized.height);
 
-        assert_eq!(window_adapter.window.0.active_popups().len(), 1);
+        assert_eq!(window_adapter.window.0.active_popups().len(), 2);
+        assert_eq!(window_adapter.window.0.active_popups.borrow().len(), 3);
         let rendered_components = || {
             window_adapter
                 .window
@@ -3119,15 +3275,23 @@ mod tests {
                 })
                 .unwrap()
         };
-        for (actual, expected) in rendered_components().iter().zip([&component, &popup, &overlay]) {
+        for (actual, expected) in
+            rendered_components().iter().zip([&component, &popup, &nested_popup, &overlay])
+        {
             assert!(VRc::ptr_eq(actual, expected));
         }
 
         window_adapter.window.0.close_top_popup();
-        assert!(window_adapter.window.0.active_popups().is_empty());
+        assert_eq!(window_adapter.window.0.active_popups().len(), 1);
         let components_without_popup = rendered_components();
-        assert_eq!(components_without_popup.len(), 2);
-        assert!(VRc::ptr_eq(&components_without_popup[1], &overlay));
+        assert_eq!(components_without_popup.len(), 3);
+        assert!(VRc::ptr_eq(&components_without_popup[2], &overlay));
+
+        window_adapter.window.0.close_all_popups();
+        assert!(window_adapter.window.0.active_popups().is_empty());
+        let components_without_popups = rendered_components();
+        assert_eq!(components_without_popups.len(), 2);
+        assert!(VRc::ptr_eq(&components_without_popups[1], &overlay));
 
         window_adapter.window.0.clear_overlays();
         assert_eq!(rendered_components().len(), 1);
@@ -3138,6 +3302,47 @@ mod tests {
         let components_after_replacement = rendered_components();
         assert_eq!(components_after_replacement.len(), 1);
         assert!(VRc::ptr_eq(&components_after_replacement[0], &replacement));
+    }
+
+    #[test]
+    fn test_window_overlay_input_intercepts_only_when_accepted() {
+        let window_adapter = WindowAdapter::new();
+        let component = create_input_test_item_tree(&window_adapter, true);
+        window_adapter
+            .window
+            .0
+            .set_context(crate::SlintContext::new(Box::new(window_adapter.clone())));
+        window_adapter.window.0.set_component(&component);
+
+        let overlay = create_input_test_item_tree(&window_adapter, false);
+        window_adapter.window.0.add_overlay(&overlay).unwrap();
+        let component_touch_area =
+            ItemRc::new(component.clone(), 1).downcast::<TouchArea>().unwrap();
+        let overlay_touch_area = ItemRc::new(overlay.clone(), 1).downcast::<TouchArea>().unwrap();
+
+        let press = crate::input::MouseEvent::Pressed {
+            position: LogicalPoint::new(10., 10.),
+            button: crate::input::PointerEventButton::Left,
+            click_count: 0,
+            touch_finger_id: 0,
+        };
+        assert!(window_adapter.window.0.process_mouse_input(press.clone()).unwrap().accepted);
+        assert!(component_touch_area.as_pin_ref().pressed());
+        assert!(!overlay_touch_area.as_pin_ref().pressed());
+
+        let release = crate::input::MouseEvent::Released {
+            position: LogicalPoint::new(10., 10.),
+            button: crate::input::PointerEventButton::Left,
+            click_count: 0,
+            touch_finger_id: 0,
+        };
+        window_adapter.window.0.process_mouse_input(release);
+        assert!(!component_touch_area.as_pin_ref().pressed());
+
+        TouchArea::FIELD_OFFSETS.enabled().apply_pin(overlay_touch_area.as_pin_ref()).set(true);
+        assert!(window_adapter.window.0.process_mouse_input(press).unwrap().accepted);
+        assert!(overlay_touch_area.as_pin_ref().pressed());
+        assert!(!component_touch_area.as_pin_ref().pressed());
     }
 
     #[test]

--- a/internal/core/item_tree.rs
+++ b/internal/core/item_tree.rs
@@ -1686,7 +1686,7 @@ mod tests {
     use crate::lengths::LogicalLength;
     use crate::lengths::LogicalSize;
     use euclid::Point2D;
-    use std::{rc::Rc, vec};
+    use std::{boxed::Box, rc::Rc, vec};
 
     const GEOMETRY_POSITION_X: f32 = 6.;
     const GEOMETRY_POSITION_Y: f32 = 27.;
@@ -1727,6 +1727,14 @@ mod tests {
 
         fn renderer(&self) -> &dyn crate::platform::Renderer {
             &self.renderer
+        }
+    }
+
+    impl crate::platform::Platform for Rc<WindowAdapter> {
+        fn create_window_adapter(
+            &self,
+        ) -> Result<Rc<dyn crate::window::WindowAdapter>, crate::api::PlatformError> {
+            Ok(self.clone())
         }
     }
 
@@ -3066,6 +3074,73 @@ mod tests {
     }
 
     #[test]
+    fn test_window_overlay_renders_above_child_popups_without_joining_popup_stack() {
+        let mut window_item = WindowItem::default();
+        window_item.width = Property::new(LogicalLength::new(30.));
+        window_item.height = Property::new(LogicalLength::new(30.));
+        let (window_adapter, component) = create_one_node_component(Some(window_item));
+        window_adapter
+            .window
+            .0
+            .set_context(crate::SlintContext::new(Box::new(window_adapter.clone())));
+        window_adapter.window.0.set_component(&component);
+
+        let popup = create_subsubtree_items(Some(window_adapter.clone())).1;
+        window_adapter.window.0.show_popup(
+            &popup,
+            alloc::boxed::Box::new(|| LogicalPosition::new(10., 20.)),
+            crate::items::PopupClosePolicy::NoAutoClose,
+            &ItemRc::new_root(component.clone()),
+            crate::window::WindowKind::Popup,
+            alloc::boxed::Box::new(|_| {}),
+        );
+
+        let overlay = create_subsubtree_items(Some(window_adapter.clone())).1;
+        window_adapter.window.0.add_overlay(&overlay).unwrap();
+        let unrelated_overlay = create_subsubtree_items(None).1;
+        assert!(window_adapter.window.0.add_overlay(&unrelated_overlay).is_err());
+
+        let resized = LogicalSize::new(75., 65.);
+        window_adapter.window.0.set_window_item_geometry(resized);
+        let overlay_window = ItemRc::new_root(overlay.clone()).downcast::<WindowItem>().unwrap();
+        assert_eq!(overlay_window.as_pin_ref().width().0, resized.width);
+        assert_eq!(overlay_window.as_pin_ref().height().0, resized.height);
+
+        assert_eq!(window_adapter.window.0.active_popups().len(), 1);
+        let rendered_components = || {
+            window_adapter
+                .window
+                .0
+                .draw_contents(|components, _| {
+                    components
+                        .iter()
+                        .map(|(component, _)| component.upgrade().unwrap())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap()
+        };
+        for (actual, expected) in rendered_components().iter().zip([&component, &popup, &overlay]) {
+            assert!(VRc::ptr_eq(actual, expected));
+        }
+
+        window_adapter.window.0.close_top_popup();
+        assert!(window_adapter.window.0.active_popups().is_empty());
+        let components_without_popup = rendered_components();
+        assert_eq!(components_without_popup.len(), 2);
+        assert!(VRc::ptr_eq(&components_without_popup[1], &overlay));
+
+        window_adapter.window.0.clear_overlays();
+        assert_eq!(rendered_components().len(), 1);
+
+        window_adapter.window.0.add_overlay(&overlay).unwrap();
+        let replacement = create_subsubtree_items(Some(window_adapter.clone())).1;
+        window_adapter.window.0.set_component(&replacement);
+        let components_after_replacement = rendered_components();
+        assert_eq!(components_after_replacement.len(), 1);
+        assert!(VRc::ptr_eq(&components_after_replacement[0], &replacement));
+    }
+
+    #[test]
     fn test_map_to_window_popup() {
         const POPUP_LOCATION: LogicalPosition = LogicalPosition::new(20., 33.);
         let (window_adapter, item_tree) = create_subsubtree_items(None);
@@ -3278,7 +3353,6 @@ mod tests {
             &self,
             _window_adapter: &std::rc::Rc<dyn crate::window::WindowAdapter>,
         ) {
-            unimplemented!("Not required in this test");
         }
 
         fn slint_context(&self) -> Option<crate::SlintContext> {

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -613,6 +613,7 @@ pub struct WindowInner {
     /// Stack of currently active popups
     pub active_popups: RefCell<Vec<PopupWindow>>,
     next_popup_id: Cell<NonZeroU32>,
+    overlays: RefCell<Vec<ItemTreeRc>>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
     click_state: ClickState,
@@ -679,6 +680,7 @@ impl WindowInner {
             cursor_blinker: Default::default(),
             active_popups: Default::default(),
             next_popup_id: Cell::new(NonZeroU32::MIN),
+            overlays: Default::default(),
             had_popup_on_press: Default::default(),
             close_requested: Default::default(),
             click_state: ClickState::default(),
@@ -693,6 +695,7 @@ impl WindowInner {
     /// done with that component.
     pub fn set_component(&self, component: &ItemTreeRc) {
         self.close_all_popups();
+        self.clear_overlays();
         self.focus_item_visibility_tracker.clear();
         self.focus_item.replace(Default::default());
         self.mouse_input_state.replace(Default::default());
@@ -743,6 +746,9 @@ impl WindowInner {
             }
             for popup in self.active_popups.borrow().iter() {
                 changed |= crate::item_tree::ensure_item_tree_instantiated(&popup.component);
+            }
+            for overlay in self.overlays.borrow().iter() {
+                changed |= crate::item_tree::ensure_item_tree_instantiated(overlay);
             }
             changed |= crate::properties::ChangeTracker::run_change_handlers_once();
             if !changed {
@@ -1772,18 +1778,20 @@ impl WindowInner {
         };
         Some(self.pinned_fields.as_ref().project_ref().redraw_tracker.evaluate_as_dependency_root(
             || {
-                if !self
-                    .active_popups
-                    .borrow()
-                    .iter()
-                    .any(|p| matches!(p.location, PopupWindowLocation::ChildWindow(..)))
-                {
+                let has_child_popup =
+                    self.active_popups.borrow().iter().any(|popup| {
+                        matches!(popup.location, PopupWindowLocation::ChildWindow(..))
+                    });
+                let has_overlay = !self.overlays.borrow().is_empty();
+                if !has_child_popup && !has_overlay {
                     render_components(&[(component_weak, LogicalPoint::default())], &post_render)
                 } else {
-                    let borrow = self.active_popups.borrow();
-                    let mut item_trees = Vec::with_capacity(borrow.len() + 1);
+                    let active_popups = self.active_popups.borrow();
+                    let overlays = self.overlays.borrow();
+                    let mut item_trees =
+                        Vec::with_capacity(active_popups.len() + overlays.len() + 1);
                     item_trees.push((component_weak, LogicalPoint::default()));
-                    for popup in borrow.iter() {
+                    for popup in active_popups.iter() {
                         // If the popup is not a real window and does not have its own coordinate system.
                         // We have to draw the popup and consider the location for subelements because everything must
                         // be rendered relative to the main window position
@@ -1791,7 +1799,11 @@ impl WindowInner {
                             item_trees.push((ItemTreeRc::downgrade(&popup.component), *location));
                         }
                     }
-                    drop(borrow);
+                    for overlay in overlays.iter() {
+                        item_trees.push((ItemTreeRc::downgrade(overlay), LogicalPoint::zero()));
+                    }
+                    drop(overlays);
+                    drop(active_popups);
                     render_components(&item_trees, &post_render)
                 }
             },
@@ -2204,6 +2216,59 @@ impl WindowInner {
         }
     }
 
+    /// Adds an item tree that renders above the component and embedded popups.
+    ///
+    /// The item tree must have a `Window` root and use this window's adapter.
+    /// Overlays don't participate in input, focus, popup closing, or accessibility.
+    #[doc(hidden)]
+    pub fn add_overlay(&self, component: &ItemTreeRc) -> Result<(), PlatformError> {
+        let mut overlay_window_adapter = None;
+        ItemTreeRc::borrow_pin(component)
+            .as_ref()
+            .window_adapter(false, &mut overlay_window_adapter);
+        let Some(overlay_window_adapter) = overlay_window_adapter else {
+            return Err(PlatformError::Other("The overlay has no window adapter".into()));
+        };
+        if !Rc::ptr_eq(&self.window_adapter(), &overlay_window_adapter) {
+            return Err(PlatformError::Other(
+                "The overlay must use the target window's adapter".into(),
+            ));
+        }
+
+        crate::item_tree::ensure_item_tree_instantiated(component);
+        let overlay_component = ItemTreeRc::borrow_pin(component);
+        let overlay_root = overlay_component.as_ref().get_item_ref(0);
+        let Some(window_item) = ItemRef::downcast_pin::<crate::items::WindowItem>(overlay_root)
+        else {
+            return Err(PlatformError::Other("The overlay root must be a Window".into()));
+        };
+        let size = self.window_adapter().size().to_logical(self.scale_factor()).to_euclid();
+        window_item.width.set(size.width_length());
+        window_item.height.set(size.height_length());
+
+        self.overlays.borrow_mut().push(component.clone());
+        self.window_adapter().request_redraw();
+        Ok(())
+    }
+
+    /// Removes all overlays.
+    #[doc(hidden)]
+    pub fn clear_overlays(&self) {
+        if self.overlays.take().is_empty() {
+            return;
+        }
+        self.mark_overlay_region_dirty();
+    }
+
+    fn mark_overlay_region_dirty(&self) {
+        let window_adapter = self.window_adapter();
+        let size = window_adapter.size().to_logical(self.scale_factor()).to_euclid();
+        if !size.is_empty() {
+            window_adapter.renderer().mark_dirty_region(LogicalRect::from_size(size).into());
+        }
+        window_adapter.request_redraw();
+    }
+
     /// Returns the scale factor set on the window, as provided by the windowing system.
     pub fn scale_factor(&self) -> f32 {
         self.pinned_fields.as_ref().project_ref().scale_factor.get()
@@ -2268,13 +2333,19 @@ impl WindowInner {
     /// window resize event from the windowing system.
     pub(crate) fn set_window_item_geometry(&self, size: crate::lengths::LogicalSize) {
         if let Some(component_rc) = self.try_component() {
-            let component = ItemTreeRc::borrow_pin(&component_rc);
-            let root_item = component.as_ref().get_item_ref(0);
-            if let Some(window_item) = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item)
-            {
-                window_item.width.set(size.width_length());
-                window_item.height.set(size.height_length());
-            }
+            Self::set_item_tree_window_geometry(&component_rc, size);
+        }
+        for overlay in self.overlays.borrow().iter() {
+            Self::set_item_tree_window_geometry(overlay, size);
+        }
+    }
+
+    fn set_item_tree_window_geometry(component: &ItemTreeRc, size: crate::lengths::LogicalSize) {
+        let component = ItemTreeRc::borrow_pin(component);
+        let root_item = component.as_ref().get_item_ref(0);
+        if let Some(window_item) = ItemRef::downcast_pin::<crate::items::WindowItem>(root_item) {
+            window_item.width.set(size.width_length());
+            window_item.height.set(size.height_length());
         }
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -544,6 +544,19 @@ pub struct PopupWindow {
     is_open_setter: Box<dyn Fn(bool)>,
     // tracks all relevant properties and reacts on changes
     properties_tracker: Pin<Box<PropertyTracker<true, PopupWindowPropertiesTracker>>>,
+    role: PopupWindowRole,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum PopupWindowRole {
+    Popup,
+    Overlay,
+}
+
+impl PopupWindow {
+    fn is_overlay(&self) -> bool {
+        self.role == PopupWindowRole::Overlay
+    }
 }
 
 impl Drop for PopupWindow {
@@ -613,7 +626,6 @@ pub struct WindowInner {
     /// Stack of currently active popups
     pub active_popups: RefCell<Vec<PopupWindow>>,
     next_popup_id: Cell<NonZeroU32>,
-    overlays: RefCell<Vec<ItemTreeRc>>,
     had_popup_on_press: Cell<bool>,
     close_requested: Callback<(), CloseRequestResponse>,
     click_state: ClickState,
@@ -680,7 +692,6 @@ impl WindowInner {
             cursor_blinker: Default::default(),
             active_popups: Default::default(),
             next_popup_id: Cell::new(NonZeroU32::MIN),
-            overlays: Default::default(),
             had_popup_on_press: Default::default(),
             close_requested: Default::default(),
             click_state: ClickState::default(),
@@ -747,9 +758,6 @@ impl WindowInner {
             for popup in self.active_popups.borrow().iter() {
                 changed |= crate::item_tree::ensure_item_tree_instantiated(&popup.component);
             }
-            for overlay in self.overlays.borrow().iter() {
-                changed |= crate::item_tree::ensure_item_tree_instantiated(overlay);
-            }
             changed |= crate::properties::ChangeTracker::run_change_handlers_once();
             if !changed {
                 return;
@@ -760,7 +768,71 @@ impl WindowInner {
 
     /// Returns a slice of the active popups.
     pub fn active_popups(&self) -> core::cell::Ref<'_, [PopupWindow]> {
-        core::cell::Ref::map(self.active_popups.borrow(), |v| v.as_slice())
+        let active_popups = self.active_popups.borrow();
+        let popup_count =
+            active_popups.iter().position(PopupWindow::is_overlay).unwrap_or(active_popups.len());
+        core::cell::Ref::map(active_popups, |active_popups| &active_popups[..popup_count])
+    }
+
+    fn dispatch_to_overlay(
+        &self,
+        active_popups: &RefCell<Vec<PopupWindow>>,
+        event: &MouseEvent,
+        window_adapter: &Rc<dyn WindowAdapter>,
+        mouse_input_state: &mut MouseInputState,
+    ) -> Option<MouseInputState> {
+        let overlays = active_popups
+            .borrow()
+            .iter()
+            .rev()
+            .filter(|popup| popup.is_overlay())
+            .filter_map(|popup| match popup.location {
+                PopupWindowLocation::ChildWindow(offset) => Some((popup.component.clone(), offset)),
+                PopupWindowLocation::TopLevel(_) => None,
+            })
+            .collect::<Vec<_>>();
+
+        for (component, offset) in overlays {
+            let geometry = ItemTreeRc::borrow_pin(&component).as_ref().item_geometry(0);
+            if !event
+                .position()
+                .is_none_or(|position| geometry.contains(position - offset.to_vector()))
+            {
+                continue;
+            }
+
+            let tracks_overlay = mouse_input_state.tracks_item_tree(&component);
+            let dispatch_state = if tracks_overlay {
+                core::mem::take(mouse_input_state)
+            } else {
+                mouse_input_state.dispatch_shell()
+            };
+            let mut overlay_event = event.clone();
+            overlay_event.translate(-offset.to_vector());
+            let crate::input::MouseInputResult { mut state, accepted } =
+                crate::input::process_mouse_input(
+                    ItemRc::new_root(component),
+                    &overlay_event,
+                    window_adapter,
+                    dispatch_state,
+                );
+            if accepted {
+                if !tracks_overlay {
+                    crate::input::send_exit_events(
+                        mouse_input_state,
+                        &mut state,
+                        event.position(),
+                        window_adapter,
+                    );
+                }
+                state.offset = offset;
+                return Some(state);
+            }
+            if tracks_overlay {
+                *mouse_input_state = state;
+            }
+        }
+        None
     }
 
     /// Receive a mouse event and pass it to the items of the component to
@@ -904,6 +976,10 @@ impl WindowInner {
             .and_then(|internal| internal.get_parent())
             .unwrap_or_else(|| window_adapter.clone());
         let active_popups = &WindowInner::from_pub(parent_adapter.window()).active_popups;
+        let popup_count = {
+            let active_popups = active_popups.borrow();
+            active_popups.iter().position(PopupWindow::is_overlay).unwrap_or(active_popups.len())
+        };
         let native_popup_index = active_popups.borrow().iter().position(|p| {
             if let PopupWindowLocation::TopLevel(wa) = &p.location {
                 Rc::ptr_eq(wa, &window_adapter)
@@ -913,10 +989,12 @@ impl WindowInner {
         });
 
         if pressed_event {
-            self.had_popup_on_press.set(!active_popups.borrow().is_empty());
+            self.had_popup_on_press.set(popup_count > 0);
         }
 
-        let mut popup_to_close = active_popups.borrow().last().and_then(|popup| {
+        let mut popup_to_close = popup_count.checked_sub(1).and_then(|popup_index| {
+            let active_popups = active_popups.borrow();
+            let popup = &active_popups[popup_index];
             let mouse_inside_popup = || {
                 if let PopupWindowLocation::ChildWindow(coordinates) = &popup.location {
                     event.position().is_none_or(|pos| {
@@ -926,7 +1004,7 @@ impl WindowInner {
                             .contains(pos - coordinates.to_vector())
                     })
                 } else {
-                    native_popup_index.is_some_and(|idx| idx == active_popups.borrow().len() - 1)
+                    native_popup_index.is_some_and(|index| index == popup_count - 1)
                         && event.position().is_none_or(|pos| {
                             ItemTreeRc::borrow_pin(&item_tree)
                                 .as_ref()
@@ -957,74 +1035,89 @@ impl WindowInner {
             // other state, so materialize any pending repeater/conditional
             // changes before hit-testing with the returned event.
             self.ensure_tree_instantiated();
-            let mut item_tree = self.component.borrow().upgrade();
-            let mut offset = LogicalPoint::default();
-            let mut menubar_item = None;
-            for (idx, popup) in active_popups.borrow().iter().enumerate().rev() {
-                if matches!(popup.window_kind, WindowKind::ToolTip) {
-                    continue;
-                }
-                item_tree = None;
-                menubar_item = None;
-                if let PopupWindowLocation::ChildWindow(coordinates) = &popup.location {
-                    let geom = ItemTreeRc::borrow_pin(&popup.component).as_ref().item_geometry(0);
-                    let mouse_inside_popup = event
-                        .position()
-                        .is_none_or(|pos| geom.contains(pos - coordinates.to_vector()));
-                    if mouse_inside_popup {
-                        item_tree = Some(popup.component.clone());
-                        offset = *coordinates;
+            let overlay_state = Rc::ptr_eq(&parent_adapter, &window_adapter).then(|| {
+                self.dispatch_to_overlay(
+                    active_popups,
+                    &event,
+                    &window_adapter,
+                    &mut mouse_input_state,
+                )
+            });
+            if let Some(overlay_state) = overlay_state.flatten() {
+                popup_to_close = None;
+                dispatch_accepted = true;
+                overlay_state
+            } else {
+                let mut item_tree = self.component.borrow().upgrade();
+                let mut offset = LogicalPoint::default();
+                let mut menubar_item = None;
+                for (idx, popup) in active_popups.borrow().iter().enumerate().rev() {
+                    if popup.is_overlay() || matches!(popup.window_kind, WindowKind::ToolTip) {
+                        continue;
+                    }
+                    item_tree = None;
+                    menubar_item = None;
+                    if let PopupWindowLocation::ChildWindow(coordinates) = &popup.location {
+                        let geom =
+                            ItemTreeRc::borrow_pin(&popup.component).as_ref().item_geometry(0);
+                        let mouse_inside_popup = event
+                            .position()
+                            .is_none_or(|pos| geom.contains(pos - coordinates.to_vector()));
+                        if mouse_inside_popup {
+                            item_tree = Some(popup.component.clone());
+                            offset = *coordinates;
+                            break;
+                        }
+                    } else if native_popup_index.is_some_and(|i| i == idx) {
+                        item_tree = self.component.borrow().upgrade();
                         break;
                     }
-                } else if native_popup_index.is_some_and(|i| i == idx) {
-                    item_tree = self.component.borrow().upgrade();
-                    break;
+
+                    if !matches!(popup.window_kind, WindowKind::Menu) {
+                        break;
+                    } else if popup_to_close.is_some() {
+                        // clicking outside of a popup menu should close all the menus
+                        popup_to_close = Some(popup.popup_id);
+                    }
+
+                    menubar_item = popup.parent_item.upgrade();
                 }
 
-                if !matches!(popup.window_kind, WindowKind::Menu) {
-                    break;
-                } else if popup_to_close.is_some() {
-                    // clicking outside of a popup menu should close all the menus
-                    popup_to_close = Some(popup.popup_id);
-                }
+                let root = match menubar_item {
+                    None => item_tree.map(|item_tree| ItemRc::new_root(item_tree.clone())),
+                    Some(menubar_item) => {
+                        event.translate(
+                            menubar_item
+                                .map_to_item_tree(Default::default(), &self.component())
+                                .to_vector(),
+                        );
+                        menubar_item.parent_item(ParentItemTraversalMode::StopAtPopups)
+                    }
+                };
 
-                menubar_item = popup.parent_item.upgrade();
-            }
-
-            let root = match menubar_item {
-                None => item_tree.map(|item_tree| ItemRc::new_root(item_tree.clone())),
-                Some(menubar_item) => {
-                    event.translate(
-                        menubar_item
-                            .map_to_item_tree(Default::default(), &self.component())
-                            .to_vector(),
-                    );
-                    menubar_item.parent_item(ParentItemTraversalMode::StopAtPopups)
-                }
-            };
-
-            if let Some(root) = root {
-                event.translate(-offset.to_vector());
-                let crate::input::MouseInputResult { mut state, accepted } =
-                    crate::input::process_mouse_input(
-                        root,
-                        &event,
+                if let Some(root) = root {
+                    event.translate(-offset.to_vector());
+                    let crate::input::MouseInputResult { mut state, accepted } =
+                        crate::input::process_mouse_input(
+                            root,
+                            &event,
+                            &window_adapter,
+                            mouse_input_state,
+                        );
+                    state.offset = offset;
+                    dispatch_accepted = accepted;
+                    state
+                } else {
+                    // When outside, send exit event
+                    let mut new_input_state = MouseInputState::default();
+                    crate::input::send_exit_events(
+                        &mouse_input_state,
+                        &mut new_input_state,
+                        event.position(),
                         &window_adapter,
-                        mouse_input_state,
                     );
-                state.offset = offset;
-                dispatch_accepted = accepted;
-                state
-            } else {
-                // When outside, send exit event
-                let mut new_input_state = MouseInputState::default();
-                crate::input::send_exit_events(
-                    &mouse_input_state,
-                    &mut new_input_state,
-                    event.position(),
-                    &window_adapter,
-                );
-                new_input_state
+                    new_input_state
+                }
             }
         } else {
             mouse_input_state
@@ -1331,7 +1424,8 @@ impl WindowInner {
             }
             let window = WindowInner::from_pub(adapter.window());
 
-            let close_on_escape = if let Some(popup) = window.active_popups.borrow().last() {
+            let active_popups = window.active_popups();
+            let close_on_escape = if let Some(popup) = active_popups.last() {
                 popup.close_policy == PopupClosePolicy::CloseOnClick
                     || popup.close_policy == PopupClosePolicy::CloseOnClickOutside
             } else {
@@ -1401,7 +1495,7 @@ impl WindowInner {
             return;
         }
 
-        let popup_wa = self.active_popups.borrow().last().and_then(|p| match &p.location {
+        let popup_wa = self.active_popups().last().and_then(|p| match &p.location {
             PopupWindowLocation::TopLevel(wa) => Some(wa.clone()),
             PopupWindowLocation::ChildWindow(..) => None,
         });
@@ -1559,8 +1653,7 @@ impl WindowInner {
             .map(next_focus_item)
             .unwrap_or_else(|| {
                 ItemRc::new(
-                    self.active_popups
-                        .borrow()
+                    self.active_popups()
                         .last()
                         .map_or_else(|| self.component(), |p| p.component.clone()),
                     0,
@@ -1580,8 +1673,7 @@ impl WindowInner {
             self.take_focus_item(&FocusEvent::FocusOut(FocusReason::TabNavigation)).unwrap_or_else(
                 || {
                     ItemRc::new(
-                        self.active_popups
-                            .borrow()
+                        self.active_popups()
                             .last()
                             .map_or_else(|| self.component(), |p| p.component.clone()),
                         0,
@@ -1782,14 +1874,11 @@ impl WindowInner {
                     self.active_popups.borrow().iter().any(|popup| {
                         matches!(popup.location, PopupWindowLocation::ChildWindow(..))
                     });
-                let has_overlay = !self.overlays.borrow().is_empty();
-                if !has_child_popup && !has_overlay {
+                if !has_child_popup {
                     render_components(&[(component_weak, LogicalPoint::default())], &post_render)
                 } else {
                     let active_popups = self.active_popups.borrow();
-                    let overlays = self.overlays.borrow();
-                    let mut item_trees =
-                        Vec::with_capacity(active_popups.len() + overlays.len() + 1);
+                    let mut item_trees = Vec::with_capacity(active_popups.len() + 1);
                     item_trees.push((component_weak, LogicalPoint::default()));
                     for popup in active_popups.iter() {
                         // If the popup is not a real window and does not have its own coordinate system.
@@ -1799,10 +1888,6 @@ impl WindowInner {
                             item_trees.push((ItemTreeRc::downgrade(&popup.component), *location));
                         }
                     }
-                    for overlay in overlays.iter() {
-                        item_trees.push((ItemTreeRc::downgrade(overlay), LogicalPoint::zero()));
-                    }
-                    drop(overlays);
                     drop(active_popups);
                     render_components(&item_trees, &post_render)
                 }
@@ -2009,7 +2094,7 @@ impl WindowInner {
             .active_popups
             .borrow()
             .iter()
-            .filter(|p| p.parent_item == parent_item.downgrade())
+            .filter(|popup| !popup.is_overlay() && popup.parent_item == parent_item.downgrade())
             .map(|p| p.popup_id)
             .collect();
 
@@ -2031,12 +2116,10 @@ impl WindowInner {
         };
 
         let parent_root_item_tree = root_of(parent_item.item_tree().clone());
-        let parent_window_adapter = if let Some(parent_popup) = self
-            .active_popups
-            .borrow()
-            .iter()
-            .find(|p| ItemTreeRc::ptr_eq(&p.component, &parent_root_item_tree))
-        {
+        let parent_window_adapter = if let Some(parent_popup) =
+            self.active_popups.borrow().iter().find(|popup| {
+                !popup.is_overlay() && ItemTreeRc::ptr_eq(&popup.component, &parent_root_item_tree)
+            }) {
             // Popup in a popup
             match &parent_popup.location {
                 PopupWindowLocation::TopLevel(wa) => wa.clone(),
@@ -2109,7 +2192,7 @@ impl WindowInner {
         // `active_popups` while running user-provided code.
         is_open_setter(true);
 
-        self.active_popups.borrow_mut().push(PopupWindow {
+        let popup = PopupWindow {
             popup_id,
             location,
             component: popup_componentrc.clone(),
@@ -2120,7 +2203,13 @@ impl WindowInner {
             position_access: popup_access_position,
             is_open_setter,
             properties_tracker,
-        });
+            role: PopupWindowRole::Popup,
+        };
+        let mut active_popups = self.active_popups.borrow_mut();
+        let insertion_index =
+            active_popups.iter().position(PopupWindow::is_overlay).unwrap_or(active_popups.len());
+        active_popups.insert(insertion_index, popup);
+        drop(active_popups);
 
         self.update_popup_properties(popup_id);
 
@@ -2180,7 +2269,9 @@ impl WindowInner {
     /// Removes the popup matching the given ID.
     pub fn close_popup(&self, popup_id: NonZeroU32) {
         let mut active_popups = self.active_popups.borrow_mut();
-        let maybe_index = active_popups.iter().position(|popup| popup.popup_id == popup_id);
+        let maybe_index = active_popups
+            .iter()
+            .position(|popup| !popup.is_overlay() && popup.popup_id == popup_id);
 
         if let Some(popup_index) = maybe_index {
             let p = active_popups.remove(popup_index);
@@ -2203,14 +2294,30 @@ impl WindowInner {
 
     /// Close all active popups.
     pub fn close_all_popups(&self) {
-        for popup in self.active_popups.take() {
+        let popups = {
+            let mut active_popups = self.active_popups.borrow_mut();
+            let popup_count = active_popups
+                .iter()
+                .position(PopupWindow::is_overlay)
+                .unwrap_or(active_popups.len());
+            active_popups.drain(..popup_count).collect::<Vec<_>>()
+        };
+        for popup in popups {
             self.close_popup_impl(&popup);
         }
     }
 
     /// Close the top-most popup.
     pub fn close_top_popup(&self) {
-        let popup = self.active_popups.borrow_mut().pop();
+        let popup = {
+            let mut active_popups = self.active_popups.borrow_mut();
+            active_popups
+                .iter()
+                .position(PopupWindow::is_overlay)
+                .unwrap_or(active_popups.len())
+                .checked_sub(1)
+                .map(|popup_index| active_popups.remove(popup_index))
+        };
         if let Some(popup) = popup {
             self.close_popup_impl(&popup);
         }
@@ -2219,7 +2326,8 @@ impl WindowInner {
     /// Adds an item tree that renders above the component and embedded popups.
     ///
     /// The item tree must have a `Window` root and use this window's adapter.
-    /// Overlays don't participate in input, focus, popup closing, or accessibility.
+    /// Overlays receive input before popups and the component, with ignored events falling through.
+    /// They don't participate in popup closing, focus navigation, or accessibility.
     #[doc(hidden)]
     pub fn add_overlay(&self, component: &ItemTreeRc) -> Result<(), PlatformError> {
         let mut overlay_window_adapter = None;
@@ -2246,7 +2354,24 @@ impl WindowInner {
         window_item.width.set(size.width_length());
         window_item.height.set(size.height_length());
 
-        self.overlays.borrow_mut().push(component.clone());
+        self.active_popups.borrow_mut().push(PopupWindow {
+            popup_id: NonZeroU32::MAX,
+            location: PopupWindowLocation::ChildWindow(LogicalPoint::zero()),
+            component: component.clone(),
+            close_policy: PopupClosePolicy::NoAutoClose,
+            focus_item_in_parent: ItemWeak::default(),
+            parent_item: ItemWeak::default(),
+            window_kind: WindowKind::Popup,
+            position_access: Box::new(LogicalPosition::default),
+            is_open_setter: Box::new(|_| {}),
+            properties_tracker: Box::pin(PropertyTracker::new_with_dirty_handler(
+                PopupWindowPropertiesTracker {
+                    parent_window_adapter_weak: self.window_adapter_weak.clone(),
+                    popup_id: NonZeroU32::MAX,
+                },
+            )),
+            role: PopupWindowRole::Overlay,
+        });
         self.window_adapter().request_redraw();
         Ok(())
     }
@@ -2254,7 +2379,20 @@ impl WindowInner {
     /// Removes all overlays.
     #[doc(hidden)]
     pub fn clear_overlays(&self) {
-        if self.overlays.take().is_empty() {
+        let removed_overlay = {
+            let mut active_popups = self.active_popups.borrow_mut();
+            let overlay_index = active_popups
+                .iter()
+                .position(PopupWindow::is_overlay)
+                .unwrap_or(active_popups.len());
+            if overlay_index == active_popups.len() {
+                false
+            } else {
+                active_popups.truncate(overlay_index);
+                true
+            }
+        };
+        if !removed_overlay {
             return;
         }
         self.mark_overlay_region_dirty();
@@ -2335,8 +2473,8 @@ impl WindowInner {
         if let Some(component_rc) = self.try_component() {
             Self::set_item_tree_window_geometry(&component_rc, size);
         }
-        for overlay in self.overlays.borrow().iter() {
-            Self::set_item_tree_window_geometry(overlay, size);
+        for overlay in self.active_popups.borrow().iter().filter(|popup| popup.is_overlay()) {
+            Self::set_item_tree_window_geometry(&overlay.component, size);
         }
     }
 

--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -559,6 +559,10 @@ impl PopupWindow {
     }
 }
 
+fn ordinary_popup_count(active_popups: &[PopupWindow]) -> usize {
+    active_popups.partition_point(|popup| !popup.is_overlay())
+}
+
 impl Drop for PopupWindow {
     fn drop(&mut self) {
         // Dropping the `PopupWindow` is the single choke point that every close path funnels through
@@ -769,9 +773,8 @@ impl WindowInner {
     /// Returns a slice of the active popups.
     pub fn active_popups(&self) -> core::cell::Ref<'_, [PopupWindow]> {
         let active_popups = self.active_popups.borrow();
-        let popup_count =
-            active_popups.iter().position(PopupWindow::is_overlay).unwrap_or(active_popups.len());
-        core::cell::Ref::map(active_popups, |active_popups| &active_popups[..popup_count])
+        let popup_count = ordinary_popup_count(&active_popups);
+        core::cell::Ref::map(active_popups, move |active_popups| &active_popups[..popup_count])
     }
 
     fn dispatch_to_overlay(
@@ -978,7 +981,7 @@ impl WindowInner {
         let active_popups = &WindowInner::from_pub(parent_adapter.window()).active_popups;
         let popup_count = {
             let active_popups = active_popups.borrow();
-            active_popups.iter().position(PopupWindow::is_overlay).unwrap_or(active_popups.len())
+            ordinary_popup_count(&active_popups)
         };
         let native_popup_index = active_popups.borrow().iter().position(|p| {
             if let PopupWindowLocation::TopLevel(wa) = &p.location {
@@ -2206,8 +2209,7 @@ impl WindowInner {
             role: PopupWindowRole::Popup,
         };
         let mut active_popups = self.active_popups.borrow_mut();
-        let insertion_index =
-            active_popups.iter().position(PopupWindow::is_overlay).unwrap_or(active_popups.len());
+        let insertion_index = ordinary_popup_count(&active_popups);
         active_popups.insert(insertion_index, popup);
         drop(active_popups);
 
@@ -2296,10 +2298,7 @@ impl WindowInner {
     pub fn close_all_popups(&self) {
         let popups = {
             let mut active_popups = self.active_popups.borrow_mut();
-            let popup_count = active_popups
-                .iter()
-                .position(PopupWindow::is_overlay)
-                .unwrap_or(active_popups.len());
+            let popup_count = ordinary_popup_count(&active_popups);
             active_popups.drain(..popup_count).collect::<Vec<_>>()
         };
         for popup in popups {
@@ -2311,10 +2310,7 @@ impl WindowInner {
     pub fn close_top_popup(&self) {
         let popup = {
             let mut active_popups = self.active_popups.borrow_mut();
-            active_popups
-                .iter()
-                .position(PopupWindow::is_overlay)
-                .unwrap_or(active_popups.len())
+            ordinary_popup_count(&active_popups)
                 .checked_sub(1)
                 .map(|popup_index| active_popups.remove(popup_index))
         };
@@ -2381,10 +2377,7 @@ impl WindowInner {
     pub fn clear_overlays(&self) {
         let removed_overlay = {
             let mut active_popups = self.active_popups.borrow_mut();
-            let overlay_index = active_popups
-                .iter()
-                .position(PopupWindow::is_overlay)
-                .unwrap_or(active_popups.len());
+            let overlay_index = ordinary_popup_count(&active_popups);
             if overlay_index == active_popups.len() {
                 false
             } else {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1205,6 +1205,17 @@ impl ComponentDefinition {
         ))
     }
 
+    /// Instantiate the component using an existing window without replacing its component.
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub fn create_detached_with_existing_window(
+        &self,
+        window: &Window,
+    ) -> Result<ComponentInstance, PlatformError> {
+        let adapter = WindowInner::from_pub(window).window_adapter();
+        Ok(ComponentInstance { inner: self.inner.create_detached_with_existing_window(adapter) })
+    }
+
     /// Private implementation of create
     pub(crate) fn create_with_options(
         &self,
@@ -1435,6 +1446,13 @@ impl ComponentInstance {
     /// Return the [`ComponentDefinition`] that was used to create this instance.
     pub fn definition(&self) -> ComponentDefinition {
         ComponentDefinition { inner: std::rc::Rc::new(self.inner.definition()) }
+    }
+
+    /// Return the item tree without attaching it as the window's component.
+    #[doc(hidden)]
+    #[cfg(feature = "internal")]
+    pub fn as_item_tree(&self) -> i_slint_core::item_tree::ItemTreeRc {
+        vtable::VRc::into_dyn(self.inner.vrc().clone())
     }
 
     fn is_system_tray_rooted(&self) -> bool {

--- a/internal/interpreter/component.rs
+++ b/internal/interpreter/component.rs
@@ -84,6 +84,19 @@ impl ComponentDefinitionInner {
         ComponentInstanceInner(vrc)
     }
 
+    pub fn create_detached_with_existing_window(
+        &self,
+        window_adapter: i_slint_core::window::WindowAdapterRc,
+    ) -> ComponentInstanceInner {
+        let vrc = Instance::new_detached_with_window(
+            self.compilation_unit.clone(),
+            self.public_index,
+            window_adapter,
+            self.type_loaders.clone(),
+        );
+        ComponentInstanceInner(vrc)
+    }
+
     /// Instantiate the component and embed it at `parent_item_tree_index`
     /// in the given outer item tree. Used by the `ComponentFactory` path
     /// to embed an interpreter-built component inside a natively compiled

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -236,6 +236,7 @@ pub struct Instance {
     /// attach idempotent and lets binding-evaluated code paths distinguish
     /// "adapter exists" from "window is fully wired for display".
     pub window_attached: OnceCell<()>,
+    window_attachment_disabled: bool,
     /// Set once `bindings::install_bindings_only` has wired up property
     /// bindings, two-way links and timers. Idempotent on repeated calls.
     pub bindings_installed: OnceCell<()>,
@@ -426,7 +427,10 @@ impl Instance {
     pub fn attach_to_window(&self) {
         // make sure not to attach embedded instances, they would otherwise take over
         // the window of the item tree they are embedded in.
-        if self.window_attached.get().is_some() || self.embedded_in.get().is_some() {
+        if self.window_attached.get().is_some()
+            || self.window_attachment_disabled
+            || self.embedded_in.get().is_some()
+        {
             return;
         }
         let Some(adapter) = self.window_adapter_or_default() else { return };
@@ -656,6 +660,23 @@ impl Instance {
             window_adapter,
             type_loaders,
             None,
+            false,
+        )
+    }
+
+    pub fn new_detached_with_window(
+        compilation_unit: Rc<CompilationUnit>,
+        public_component_index: usize,
+        window_adapter: i_slint_core::window::WindowAdapterRc,
+        type_loaders: crate::component::TypeLoaders,
+    ) -> VRc<ItemTreeVTable, Instance> {
+        Self::new_with_options(
+            compilation_unit,
+            public_component_index,
+            Some(window_adapter),
+            type_loaders,
+            None,
+            true,
         )
     }
 
@@ -676,6 +697,7 @@ impl Instance {
             None,
             type_loaders,
             Some((parent, parent_item_tree_index)),
+            false,
         )
     }
 
@@ -685,6 +707,7 @@ impl Instance {
         window_adapter: Option<i_slint_core::window::WindowAdapterRc>,
         type_loaders: crate::component::TypeLoaders,
         embedded_in: Option<(vtable::VWeak<ItemTreeVTable>, u32)>,
+        disable_window_attachment: bool,
     ) -> VRc<ItemTreeVTable, Instance> {
         let public = &compilation_unit.public_components[public_component_index];
         let globals = Rc::new(GlobalStorage::new(&compilation_unit));
@@ -696,6 +719,7 @@ impl Instance {
             globals,
             Some(public_component_index),
             type_loaders,
+            disable_window_attachment,
         );
         if let Some(adapter) = window_adapter {
             let _ = vrc.window_adapter.set(adapter);
@@ -728,6 +752,7 @@ impl Instance {
             globals,
             None,
             Default::default(),
+            false,
         );
         let _ = vrc.root_sub_component.repeated_in.set((parent, repeater_idx));
         vrc
@@ -742,7 +767,15 @@ impl Instance {
         parent: Weak<SubComponentInstance>,
         globals: Rc<GlobalStorage>,
     ) -> VRc<ItemTreeVTable, Instance> {
-        build_instance(&compilation_unit, item_tree, parent, globals, None, Default::default())
+        build_instance(
+            &compilation_unit,
+            item_tree,
+            parent,
+            globals,
+            None,
+            Default::default(),
+            false,
+        )
     }
 }
 
@@ -760,6 +793,7 @@ fn build_instance(
     globals: Rc<GlobalStorage>,
     public_component_index: Option<usize>,
     type_loaders: crate::component::TypeLoaders,
+    disable_window_attachment: bool,
 ) -> VRc<ItemTreeVTable, Instance> {
     let parent_for_root = parent.clone();
     let root_sub_component =
@@ -779,6 +813,7 @@ fn build_instance(
         window_adapter: OnceCell::new(),
         window_adapter_error: OnceCell::new(),
         window_attached: OnceCell::new(),
+        window_attachment_disabled: disable_window_attachment,
         bindings_installed: OnceCell::new(),
         init_code_run: OnceCell::new(),
         embedded_in: OnceCell::new(),

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -46,6 +46,18 @@ fn reuse_window() {
             instance.get_property("text_alias").unwrap(),
             Value::from(SharedString::from("foo"))
         );
+        let attached_item_tree =
+            i_slint_core::window::WindowInner::from_pub(instance.window()).component();
+        let detached = definition.create_detached_with_existing_window(instance.window()).unwrap();
+        assert!(!i_slint_core::item_tree::ItemTreeRc::ptr_eq(
+            &attached_item_tree,
+            &detached.as_item_tree(),
+        ));
+        let _ = detached.window();
+        assert!(i_slint_core::item_tree::ItemTreeRc::ptr_eq(
+            &attached_item_tree,
+            &i_slint_core::window::WindowInner::from_pub(instance.window()).component(),
+        ));
         instance
     };
 }

--- a/tools/viewer/Cargo.toml
+++ b/tools/viewer/Cargo.toml
@@ -77,7 +77,7 @@ i-slint-core = { workspace = true }
 i-slint-renderer-software = { workspace = true, features = ["std"] }
 i-slint-renderer-skia = { workspace = true, optional = true }
 slint = { workspace = true, features = ["compat-1-2"], optional = true }
-slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "accessibility", "image-default-formats", "internal-json"] }
+slint-interpreter = { workspace = true, features = ["display-diagnostics", "compat-1-2", "internal", "internal-highlight", "accessibility", "image-default-formats", "internal-json"] }
 i-slint-live-preview = { workspace = true, features = ["file-watcher", "live-component"] }
 i-slint-backend-selector = { workspace = true }
 

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -16,6 +16,84 @@ use slint::ComponentHandle as _;
 slint::slint! {
     export { RemoteViewerWindow, RemoteViewerState } from "remote/main.slint";
     export { AttributionItem } from "remote/licenses.slint";
+
+    export struct InspectorHighlight {
+        x: length,
+        y: length,
+        width: length,
+        height: length,
+        angle: angle,
+    }
+
+    export component InspectorOverlay inherits Window {
+        in property <[InspectorHighlight]> highlights;
+
+        background: transparent;
+
+        for highlight in root.highlights: Rectangle {
+            x: highlight.x;
+            y: highlight.y;
+            width: highlight.width;
+            height: highlight.height;
+            transform-rotation: highlight.angle;
+            background: #3584e433;
+            border-color: #3584e4;
+            border-width: 1px;
+        }
+    }
+}
+
+struct Inspector {
+    component: InspectorOverlay,
+    highlights: Rc<slint::VecModel<InspectorHighlight>>,
+}
+
+impl Inspector {
+    fn new(window: &slint::Window) -> anyhow::Result<Self> {
+        let component = InspectorOverlay::new_detached_with_existing_window(window)
+            .map_err(|error| anyhow::anyhow!("Cannot create inspector overlay: {error}"))?;
+        let highlights = Rc::new(slint::VecModel::default());
+        component.set_highlights(slint::ModelRc::new(highlights.clone()));
+        Ok(Self { component, highlights })
+    }
+
+    fn attach(&self) -> anyhow::Result<()> {
+        let window = WindowInner::from_pub(self.component.window());
+        window
+            .add_overlay(&self.component.as_item_tree())
+            .map_err(|error| anyhow::anyhow!("Cannot show inspector overlay: {error}"))
+    }
+
+    fn detach(&self) {
+        WindowInner::from_pub(self.component.window()).clear_overlays();
+        self.highlights.clear();
+    }
+
+    fn update(
+        &self,
+        user_instance: Option<&slint_interpreter::ComponentInstance>,
+        highlight: Option<&(lsp_types::Url, u32)>,
+    ) {
+        let rectangles = user_instance
+            .zip(highlight)
+            .and_then(|(instance, (url, offset))| {
+                url.to_file_path().ok().map(|path| instance.component_positions(&path, *offset))
+            })
+            .unwrap_or_default();
+        self.highlights.set_vec(
+            rectangles
+                .into_iter()
+                .map(|geometry| InspectorHighlight {
+                    x: geometry.rect.origin.x,
+                    y: geometry.rect.origin.y,
+                    width: geometry.rect.size.width,
+                    height: geometry.rect.size.height,
+                    angle: geometry.angle,
+                })
+                .collect::<Vec<_>>(),
+        );
+        self.component.window().request_redraw();
+    }
 }
 
 // CARGO_PKG_VERSION tracks the workspace version, so it is the Slint version.
@@ -133,6 +211,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     })?;
 
     let mut placeholder = RemoteViewerWindow::new()?;
+    let inspector = Inspector::new(placeholder.window())?;
 
     #[cfg(not(target_vendor = "apple"))]
     let mdns = enable_mdns.then(mdns_sd::ServiceDaemon::new).transpose()?;
@@ -176,6 +255,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     let mut last_connection = None;
     let mut user_instance: Option<slint_interpreter::ComponentInstance> = None;
     let mut current_preview: Option<PreviewComponent> = None;
+    let mut current_highlight: Option<(lsp_types::Url, u32)> = None;
     let mut registered_fonts = HashSet::<lsp_types::Url>::new();
     while let Some(event) = event_receiver.recv().await {
         let msg = match event {
@@ -205,6 +285,8 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     &preview_component,
                     &mut placeholder,
                     &mut user_instance,
+                    &inspector,
+                    current_highlight.as_ref(),
                     &connection,
                     &address,
                     &connection.device_name(),
@@ -219,13 +301,18 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                     &preview_component,
                     &mut placeholder,
                     &mut user_instance,
+                    &inspector,
+                    current_highlight.as_ref(),
                     &connection,
                     &address,
                     &connection.device_name(),
                 )
                 .await?;
             }
-            ConnectionMessage::HighlightFromEditor { .. } => {}
+            ConnectionMessage::HighlightFromEditor { url, offset } => {
+                current_highlight = url.map(|url| (url, offset));
+                inspector.update(user_instance.as_ref(), current_highlight.as_ref());
+            }
             ConnectionMessage::RegisterFont { url, contents } => {
                 let len = contents.len();
                 if !registered_fonts.insert(url.clone()) {
@@ -251,10 +338,12 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
                 if last_connection == Some(remote_addr) {
                     last_connection = None;
                     current_preview = None;
+                    current_highlight = None;
                     connection.set_dependencies(Vec::new());
                     swap_to_placeholder(
                         &mut placeholder,
                         &mut user_instance,
+                        &inspector,
                         &address,
                         &connection.device_name(),
                         "",
@@ -284,6 +373,8 @@ async fn build_and_show(
     preview_component: &PreviewComponent,
     placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
+    inspector: &Inspector,
+    current_highlight: Option<&(lsp_types::Url, u32)>,
     connection: &Rc<Connection>,
     address: &str,
     name: &str,
@@ -323,6 +414,7 @@ async fn build_and_show(
         swap_to_placeholder(
             placeholder,
             user_instance,
+            inspector,
             address,
             name,
             &message,
@@ -343,6 +435,7 @@ async fn build_and_show(
         swap_to_placeholder(
             placeholder,
             user_instance,
+            inspector,
             address,
             name,
             "Component not found",
@@ -360,6 +453,8 @@ async fn build_and_show(
 
     new_instance.show().map_err(|err| anyhow::anyhow!("Cannot show component: {err}"))?;
     *user_instance = Some(new_instance);
+    inspector.attach()?;
+    inspector.update(user_instance.as_ref(), current_highlight);
     // The placeholder is hidden now, but keep its state property truthful.
     placeholder.set_state(RemoteViewerState::Previewing);
     Ok(())
@@ -369,11 +464,13 @@ async fn build_and_show(
 fn swap_to_placeholder(
     placeholder: &mut RemoteViewerWindow,
     user_instance: &mut Option<slint_interpreter::ComponentInstance>,
+    inspector: &Inspector,
     address: &str,
     name: &str,
     message: &str,
     state: RemoteViewerState,
 ) -> anyhow::Result<()> {
+    inspector.detach();
     let fresh = RemoteViewerWindow::new_with_existing_window(placeholder.window())
         .map_err(|err| anyhow::anyhow!("Cannot create placeholder: {err}"))?;
     fresh.set_address(SharedString::from(address));
@@ -427,4 +524,87 @@ fn send_diagnostics(
             .collect(),
     };
     connection.send(message).ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use i_slint_renderer_software::{
+        MinimalSoftwareWindow, PremultipliedRgbaColor, RepaintBufferType, TargetPixel,
+    };
+    use slint::platform::{Platform, PlatformError, WindowAdapter};
+
+    slint::slint! {
+        export component TestPreview inherits Window {
+            background: white;
+        }
+    }
+
+    const WIDTH: u32 = 100;
+    const HEIGHT: u32 = 80;
+
+    struct SoftwareRendererPlatform(Rc<MinimalSoftwareWindow>);
+
+    impl Platform for SoftwareRendererPlatform {
+        fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, PlatformError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Clone, Copy, Default)]
+    struct RgbPixel {
+        red: u8,
+        green: u8,
+        blue: u8,
+    }
+
+    impl TargetPixel for RgbPixel {
+        fn blend(&mut self, color: PremultipliedRgbaColor) {
+            let inverse_alpha = 255u32 - color.alpha as u32;
+            self.red = (color.red as u32 + self.red as u32 * inverse_alpha / 255).min(255) as u8;
+            self.green =
+                (color.green as u32 + self.green as u32 * inverse_alpha / 255).min(255) as u8;
+            self.blue = (color.blue as u32 + self.blue as u32 * inverse_alpha / 255).min(255) as u8;
+        }
+
+        fn from_rgb(red: u8, green: u8, blue: u8) -> Self {
+            Self { red, green, blue }
+        }
+    }
+
+    #[test]
+    fn inspector_overlay_renders_highlight_over_preview() {
+        let window_adapter = MinimalSoftwareWindow::new(RepaintBufferType::NewBuffer);
+        slint::platform::set_platform(Box::new(SoftwareRendererPlatform(window_adapter.clone())))
+            .unwrap();
+        window_adapter.set_size(slint::PhysicalSize::new(WIDTH, HEIGHT));
+
+        let preview = TestPreview::new().unwrap();
+        preview.show().unwrap();
+        let inspector = Inspector::new(preview.window()).unwrap();
+        let preview_item_tree = WindowInner::from_pub(preview.window()).component();
+        assert!(!i_slint_core::item_tree::ItemTreeRc::ptr_eq(
+            &preview_item_tree,
+            &inspector.component.as_item_tree(),
+        ));
+        inspector.highlights.set_vec(vec![InspectorHighlight {
+            x: 20.,
+            y: 20.,
+            width: 30.,
+            height: 20.,
+            angle: 0.,
+        }]);
+        inspector.attach().unwrap();
+
+        let mut pixels = vec![RgbPixel::default(); (WIDTH * HEIGHT) as usize];
+        preview.window().request_redraw();
+        window_adapter.draw_if_needed(|renderer| {
+            renderer.render(pixels.as_mut_slice(), WIDTH as usize);
+        });
+
+        let highlighted = pixels[(25 * WIDTH + 25) as usize];
+        let outside = pixels[(5 * WIDTH + 5) as usize];
+        assert!(highlighted.blue > highlighted.red);
+        assert_eq!((outside.red, outside.green, outside.blue), (255, 255, 255));
+    }
 }

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -2,70 +2,68 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::{net::SocketAddr, rc::Rc};
 
 use i_slint_core::InternalToken;
 use i_slint_core::SharedString;
+use i_slint_core::item_tree::ItemTreeRc;
+use i_slint_core::model::{ModelRc, VecModel};
 use i_slint_core::textlayout::sharedparley::fontique;
-use i_slint_core::window::WindowInner;
+use i_slint_core::window::{WindowAdapterRc, WindowInner};
 use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage, lsp_types};
 use i_slint_live_preview::remote::{Connection, ConnectionMessage, init_compiler};
 use slint::ComponentHandle as _;
+use slint_interpreter::{Struct, Value};
 
 slint::slint! {
     export { RemoteViewerWindow, RemoteViewerState } from "remote/main.slint";
     export { AttributionItem } from "remote/licenses.slint";
-
-    export struct InspectorHighlight {
-        x: length,
-        y: length,
-        width: length,
-        height: length,
-        angle: angle,
-    }
-
-    export component InspectorOverlay inherits Window {
-        in property <[InspectorHighlight]> highlights;
-
-        background: transparent;
-
-        for highlight in root.highlights: Rectangle {
-            x: highlight.x;
-            y: highlight.y;
-            width: highlight.width;
-            height: highlight.height;
-            transform-rotation: highlight.angle;
-            background: #3584e433;
-            border-color: #3584e4;
-            border-width: 1px;
-        }
-    }
 }
 
 struct Inspector {
-    component: InspectorOverlay,
-    highlights: Rc<slint::VecModel<InspectorHighlight>>,
+    highlights: Rc<VecModel<Value>>,
+    item_tree: ItemTreeRc,
+    window_adapter: WindowAdapterRc,
 }
 
 impl Inspector {
-    fn new(window: &slint::Window) -> anyhow::Result<Self> {
-        let component = InspectorOverlay::new_detached_with_existing_window(window)
+    async fn new(window: &slint::Window) -> anyhow::Result<Self> {
+        let compiler = slint_interpreter::Compiler::default();
+        let compilation_result = compiler
+            .build_from_source(
+                include_str!("remote/inspector.slint").into(),
+                PathBuf::from("inspector.slint"),
+            )
+            .await;
+        if compilation_result.has_errors() {
+            compilation_result.print_diagnostics();
+            anyhow::bail!("Cannot compile inspector overlay");
+        }
+        let definition = compilation_result
+            .component("InspectorOverlay")
+            .ok_or_else(|| anyhow::anyhow!("Inspector overlay component is missing"))?;
+        let component = definition
+            .create_detached_with_existing_window(window)
             .map_err(|error| anyhow::anyhow!("Cannot create inspector overlay: {error}"))?;
-        let highlights = Rc::new(slint::VecModel::default());
-        component.set_highlights(slint::ModelRc::new(highlights.clone()));
-        Ok(Self { component, highlights })
+        let highlights = Rc::new(VecModel::default());
+        component
+            .set_property("highlights", Value::Model(ModelRc::from(highlights.clone())))
+            .map_err(|error| anyhow::anyhow!("Cannot initialize inspector highlights: {error}"))?;
+        let item_tree = component.as_item_tree();
+        let window_adapter = WindowInner::from_pub(window).window_adapter();
+        Ok(Self { highlights, item_tree, window_adapter })
     }
 
     fn attach(&self) -> anyhow::Result<()> {
-        let window = WindowInner::from_pub(self.component.window());
-        window
-            .add_overlay(&self.component.as_item_tree())
+        WindowInner::from_pub(self.window_adapter.window())
+            .add_overlay(&self.item_tree)
             .map_err(|error| anyhow::anyhow!("Cannot show inspector overlay: {error}"))
     }
 
     fn detach(&self) {
-        WindowInner::from_pub(self.component.window()).clear_overlays();
+        WindowInner::from_pub(self.window_adapter.window()).clear_overlays();
         self.highlights.clear();
     }
 
@@ -83,16 +81,18 @@ impl Inspector {
         self.highlights.set_vec(
             rectangles
                 .into_iter()
-                .map(|geometry| InspectorHighlight {
-                    x: geometry.rect.origin.x,
-                    y: geometry.rect.origin.y,
-                    width: geometry.rect.size.width,
-                    height: geometry.rect.size.height,
-                    angle: geometry.angle,
+                .map(|geometry| {
+                    Value::Struct(Struct::from_iter([
+                        ("x".into(), Value::Number(geometry.rect.origin.x.into())),
+                        ("y".into(), Value::Number(geometry.rect.origin.y.into())),
+                        ("width".into(), Value::Number(geometry.rect.size.width.into())),
+                        ("height".into(), Value::Number(geometry.rect.size.height.into())),
+                        ("angle".into(), Value::Number(geometry.angle.into())),
+                    ]))
                 })
                 .collect::<Vec<_>>(),
         );
-        self.component.window().request_redraw();
+        self.window_adapter.window().request_redraw();
     }
 }
 
@@ -211,7 +211,7 @@ async fn run_async(address: Option<SocketAddr>, enable_mdns: bool) -> anyhow::Re
     })?;
 
     let mut placeholder = RemoteViewerWindow::new()?;
-    let inspector = Inspector::new(placeholder.window())?;
+    let inspector = Inspector::new(placeholder.window()).await?;
 
     #[cfg(not(target_vendor = "apple"))]
     let mdns = enable_mdns.then(mdns_sd::ServiceDaemon::new).transpose()?;
@@ -534,14 +534,20 @@ mod tests {
     };
     use slint::platform::{Platform, PlatformError, WindowAdapter};
 
-    slint::slint! {
-        export component TestPreview inherits Window {
-            background: white;
-        }
-    }
-
     const WIDTH: u32 = 100;
     const HEIGHT: u32 = 80;
+    const TEST_PREVIEW_SOURCE: &str = r#"
+        export component TestPreview inherits Window {
+            background: white;
+
+            Rectangle {
+                x: 20px;
+                y: 20px;
+                width: 30px;
+                height: 20px;
+            }
+        }
+    "#;
 
     struct SoftwareRendererPlatform(Rc<MinimalSoftwareWindow>);
 
@@ -579,21 +585,29 @@ mod tests {
             .unwrap();
         window_adapter.set_size(slint::PhysicalSize::new(WIDTH, HEIGHT));
 
-        let preview = TestPreview::new().unwrap();
+        let preview_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-preview.slint");
+        let compilation_result = crate::poll_ready(
+            slint_interpreter::Compiler::default()
+                .build_from_source(TEST_PREVIEW_SOURCE.into(), preview_path.clone()),
+        );
+        assert!(!compilation_result.has_errors());
+        let preview = compilation_result.component("TestPreview").unwrap().create().unwrap();
         preview.show().unwrap();
-        let inspector = Inspector::new(preview.window()).unwrap();
         let preview_item_tree = WindowInner::from_pub(preview.window()).component();
+        let inspector = crate::poll_ready(Inspector::new(preview.window())).unwrap();
+        assert!(i_slint_core::item_tree::ItemTreeRc::ptr_eq(
+            &preview_item_tree,
+            &WindowInner::from_pub(preview.window()).component(),
+        ));
         assert!(!i_slint_core::item_tree::ItemTreeRc::ptr_eq(
             &preview_item_tree,
-            &inspector.component.as_item_tree(),
+            &inspector.item_tree,
         ));
-        inspector.highlights.set_vec(vec![InspectorHighlight {
-            x: 20.,
-            y: 20.,
-            width: 30.,
-            height: 20.,
-            angle: 0.,
-        }]);
+        let highlight = (
+            lsp_types::Url::from_file_path(&preview_path).unwrap(),
+            TEST_PREVIEW_SOURCE.find("Rectangle").unwrap() as u32,
+        );
+        inspector.update(Some(&preview), Some(&highlight));
         inspector.attach().unwrap();
 
         let mut pixels = vec![RgbPixel::default(); (WIDTH * HEIGHT) as usize];

--- a/tools/viewer/remote/inspector.slint
+++ b/tools/viewer/remote/inspector.slint
@@ -1,0 +1,27 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export struct InspectorHighlight {
+    x: length,
+    y: length,
+    width: length,
+    height: length,
+    angle: angle,
+}
+
+export component InspectorOverlay inherits Window {
+    in property <[InspectorHighlight]> highlights;
+
+    background: transparent;
+
+    for highlight in root.highlights: Rectangle {
+        x: highlight.x;
+        y: highlight.y;
+        width: highlight.width;
+        height: highlight.height;
+        transform-rotation: highlight.angle;
+        background: #3584e433;
+        border-color: #3584e4;
+        border-width: 1px;
+    }
+}


### PR DESCRIPTION
Experimental alternative implementation to the approach in #13215.

Instead of storing the overlays in a different collection, we add them to the PopupKind enum.

This change supports more behavior, but is also more invasive and requires special-casing the Overlay popups in many cases.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
