### PR TITLE
docs: elements like Rectangle fill their parent even with children

### DIFF
--- a/docs/astro/src/content/docs/guide/language/coding/positioning-and-layouts.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/positioning-and-layouts.mdx
@@ -79,7 +79,7 @@ parent.
 
 The default values for `width` and `height` depend on the type of element. Elements such as `Image`,
 `Text`, as well as most widgets are sized automatically based on their content. The following elements
-don't have content and default to fill their parent element when they do not have children:
+don't have content and default to fill their parent element:
 
 -   `Rectangle`
 -   `TouchArea`


### PR DESCRIPTION
The qualifier described a planned behavior that was never implemented: the compiler binds the size to the parent whenever the element is not in a layout, regardless of children.

Fixes: #13202