### PR TITLE
Fix missing space in import/export from statements

### DIFF
--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2204,23 +2204,23 @@ fn format_import_specifier(
 ) -> Result<(), std::io::Error> {
     let is_too_long = node.text().len() > 80.into();
 
-    let mut after_identifier_list = false;
+    let mut in_module_clause = node.child_node(SyntaxKind::ImportIdentifierList).is_none();
     for n in node.children_with_tokens() {
         match n.kind() {
             SyntaxKind::ImportIdentifierList => {
                 if let NodeOrToken::Node(n) = n {
                     format_import_identifier(&n, writer, state, is_too_long)?
                 };
-                after_identifier_list = true;
+                in_module_clause = true;
                 state.insert_whitespace(" ");
             }
-            // `from`
-            SyntaxKind::Identifier if after_identifier_list => {
+            // `from`, or `import` for a font
+            SyntaxKind::Identifier if in_module_clause => {
                 fold(n, writer, state)?;
                 state.insert_whitespace(" ");
             }
             // the module path
-            SyntaxKind::StringLiteral if after_identifier_list => {
+            SyntaxKind::StringLiteral if in_module_clause => {
                 fold(n, writer, state)?;
                 state.skip_all_whitespace = true;
             }
@@ -3762,6 +3762,16 @@ export component MainWindow2 inherits Rectangle {
     }
 
     // cspell:enable
+
+    #[test]
+    fn import_font() {
+        assert_formatting(r#"import "some/font.ttf";"#, r#"import "some/font.ttf";"#);
+        assert_formatting(r#"import   "some/font.ttf"  ;"#, r#"import "some/font.ttf";"#);
+        assert_formatting(
+            "import   \"some/font.ttf\"  ;\nimport {Foo}from \"./here.slint\";\n",
+            "import \"some/font.ttf\";\nimport { Foo } from \"./here.slint\";\n",
+        );
+    }
 
     #[test]
     fn import_from() {

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2204,12 +2204,25 @@ fn format_import_specifier(
 ) -> Result<(), std::io::Error> {
     let is_too_long = node.text().len() > 80.into();
 
+    let mut after_identifier_list = false;
     for n in node.children_with_tokens() {
         match n.kind() {
             SyntaxKind::ImportIdentifierList => {
                 if let NodeOrToken::Node(n) = n {
                     format_import_identifier(&n, writer, state, is_too_long)?
                 };
+                after_identifier_list = true;
+                state.insert_whitespace(" ");
+            }
+            // `from`
+            SyntaxKind::Identifier if after_identifier_list => {
+                fold(n, writer, state)?;
+                state.insert_whitespace(" ");
+            }
+            // the module path
+            SyntaxKind::StringLiteral if after_identifier_list => {
+                fold(n, writer, state)?;
+                state.skip_all_whitespace = true;
             }
             _ => {
                 fold(n, writer, state)?;
@@ -3749,6 +3762,30 @@ export component MainWindow2 inherits Rectangle {
     }
 
     // cspell:enable
+
+    #[test]
+    fn import_from() {
+        assert_formatting(
+            r#"import {Foo,Bar}from "./here.slint";"#,
+            r#"import { Foo, Bar } from "./here.slint";"#,
+        );
+        assert_formatting(
+            r#"import {Foo  as   Bar}from "./here.slint";"#,
+            r#"import { Foo as Bar } from "./here.slint";"#,
+        );
+        assert_formatting(
+            "import { Foo }\nfrom \"./here.slint\";",
+            r#"import { Foo } from "./here.slint";"#,
+        );
+        assert_formatting(
+            r#"import {Foo}from   "./here.slint"  ;"#,
+            r#"import { Foo } from "./here.slint";"#,
+        );
+        assert_formatting(
+            r#"import { Foo, }from "./here.slint";"#,
+            "import {\n    Foo,\n} from \"./here.slint\";",
+        );
+    }
 
     #[test]
     /// format_import_identifier

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -3289,6 +3289,18 @@ export struct LineEditData {
             "export { Foo, }from \"some/path.slint\";\n",
             "export {\n    Foo,\n} from \"some/path.slint\";\n",
         );
+        assert_formatting(
+            "export { Foo }\nfrom \"some/path.slint\";\n",
+            "export { Foo } from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export { Foo, /* keep me */    Bar }    from \"some/path.slint\";\n",
+            "export { Foo, /* keep me */    Bar } from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export {Foo}from   \"some/path.slint\"  ;\n",
+            "export { Foo } from \"some/path.slint\";\n",
+        );
     }
 
     #[test]

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -197,6 +197,9 @@ fn format_node(
         SyntaxKind::ExportSpecifier => {
             return format_export_specifier(node, writer, state);
         }
+        SyntaxKind::ExportModule => {
+            return format_export_module(node, writer, state);
+        }
         SyntaxKind::ObjectType => {
             return format_object_type(node, writer, state);
         }
@@ -1853,6 +1856,16 @@ fn format_exports_list(
     // Only handle the brace-list case specially; otherwise fall through.
     let has_lbrace = node.children_with_tokens().any(|n| n.kind() == SyntaxKind::LBrace);
     if !has_lbrace {
+        if node.child_node(SyntaxKind::ExportModule).is_some() {
+            // `export * from "..."`
+            let mut sub = node.children_with_tokens();
+            whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?;
+            whitespace_to(&mut sub, SyntaxKind::ExportModule, writer, state, " ")?;
+            state.skip_all_whitespace = true;
+            finish_node(sub, writer, state)?;
+            state.new_line();
+            return Ok(());
+        }
         // `export component ...` or `export struct ...` — delegate to default
         for n in node.children_with_tokens() {
             fold(n, writer, state)?;
@@ -1983,6 +1996,25 @@ fn format_exports_list(
     state.skip_all_whitespace = true;
     finish_node(sub, writer, state)?;
     state.new_line();
+    Ok(())
+}
+
+fn format_export_module(
+    node: &SyntaxNode,
+    writer: &mut impl TokenWriter,
+    state: &mut FormatState,
+) -> Result<(), std::io::Error> {
+    let mut sub = node.children_with_tokens();
+    if node.child_token(SyntaxKind::Star).is_some() {
+        whitespace_to(&mut sub, SyntaxKind::Star, writer, state, "")?;
+        whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, " ")?;
+    } else {
+        whitespace_to(&mut sub, SyntaxKind::Identifier, writer, state, "")?;
+    }
+    whitespace_to(&mut sub, SyntaxKind::StringLiteral, writer, state, " ")?;
+    whitespace_to(&mut sub, SyntaxKind::Semicolon, writer, state, "")?;
+    state.skip_all_whitespace = true;
+    finish_node(sub, writer, state)?;
     Ok(())
 }
 
@@ -3256,6 +3288,22 @@ export struct LineEditData {
         assert_formatting(
             "export { Foo, }from \"some/path.slint\";\n",
             "export {\n    Foo,\n} from \"some/path.slint\";\n",
+        );
+    }
+
+    #[test]
+    fn export_star_from() {
+        assert_formatting(
+            "export * from \"some/path.slint\";\n",
+            "export * from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export *    from   \"some/path.slint\";\n",
+            "export * from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export  *  from   \"some/path.slint\"  ;\n",
+            "export * from \"some/path.slint\";\n",
         );
     }
 

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -1977,6 +1977,9 @@ fn format_exports_list(
             _ => break,
         }
     }
+    if node.child_node(SyntaxKind::ExportModule).is_some() {
+        whitespace_to(&mut sub, SyntaxKind::ExportModule, writer, state, " ")?;
+    }
     state.skip_all_whitespace = true;
     finish_node(sub, writer, state)?;
     state.new_line();
@@ -3230,6 +3233,30 @@ export struct LineEditData {
             "export {\n    SuperLongTypeName,\n    AnotherVeryLongTypeName,\n    YetAnotherExtremelyLongTypeName,\n}\n",
         );
         assert_formatting("export { Foo, }\n", "export {\n    Foo,\n}\n");
+    }
+
+    #[test]
+    fn export_from() {
+        assert_formatting(
+            "export {Foo,Bar}from \"some/path.slint\";",
+            "export { Foo, Bar } from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export {Foo  as   Bar}from \"some/path.slint\";\n",
+            "export { Foo as Bar } from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export { SuperLongTypeName, AnotherVeryLongTypeName, YetAnotherExtremelyLongTypeName }from \"some/path.slint\";\n",
+            "export {\n    SuperLongTypeName,\n    AnotherVeryLongTypeName,\n    YetAnotherExtremelyLongTypeName,\n} from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export { Foo, }from \"some/path.slint\";\n",
+            "export {\n    Foo,\n} from \"some/path.slint\";\n",
+        );
+        assert_formatting(
+            "export { Foo, }from \"some/path.slint\";\n",
+            "export {\n    Foo,\n} from \"some/path.slint\";\n",
+        );
     }
 
     #[test]


### PR DESCRIPTION
"export from" formatting has been broken:

```slint
export { Foo } from "bar.slint"; // Typed correctly
export { Foo }from "bar.slint";  // LSP-formated to this
```

Add tests for this case (both `import` and `export`), and fix the broken formatting.

Additionally add tests for other missing import/export statements, and fix the formatting behaviour of font imports.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>