### PR TITLE
femtovg: fix Path position at scale factors other than 1

### DIFF
--- a/internal/renderers/femtovg/itemrenderer.rs
+++ b/internal/renderers/femtovg/itemrenderer.rs
@@ -356,6 +356,7 @@ impl<'a, R: femtovg::Renderer + TextureImporter> ItemRenderer for GLItemRenderer
                 paint
             });
 
+        let offset = offset * self.scale_factor;
         self.canvas.borrow_mut().save_with(|canvas| {
             canvas.translate(offset.x, offset.y);
             if let Some(fill_paint) = &fill_paint {


### PR DESCRIPTION
The fitted path reserves half the stroke width as an offset, in logical pixels. The femtovg renderer converts all path coordinates to physical pixels but translated by the unscaled offset, so the whole path drifted towards the top left on hidpi screens. Scale the offset like the skia renderer does.
