### PR TITLE
slint-sc: assert a builtin property has no accessor either

### DIFF
--- a/api/slint-sc/tests/cases/component/child_property.slint
+++ b/api/slint-sc/tests/cases/component/child_property.slint
@@ -33,4 +33,11 @@ let mut x = TestCase::new(crate::harness::WINDOW_SIZE);
 x.set_tint(slint_sc::Color::default());
 //~ ERROR no method named `set_tint`
 ```
+
+A builtin property has no accessor either, even set directly on the root:
+```rust compile_fail
+let mut x = TestCase::new(crate::harness::WINDOW_SIZE);
+x.set_background(slint_sc::Color::default());
+//~ ERROR no method named `set_background`
+```
 */


### PR DESCRIPTION
Addresses review: the existing compile_fail block only showed that a child's declared property stays internal. Pin the more general rule next to it: a builtin property (background, set directly on the root here) never gets one either, declared or not, child or root.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
