### PR TITLE
Skia: update skia-safe to 0.153.3 and drop the textlayout feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7512,9 +7512,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+checksum = "eb325787c91b3f6c34a7c6f2b8a2297b20292d733ca53a08c233e5028aec49af"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -7529,9 +7529,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+checksum = "c61cb643dac43067f3eb76c866635a74377ac0abca0ff2590674e1e295514c3d"
 dependencies = [
  "bitflags 2.13.1",
  "skia-bindings",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -4987,9 +4987,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+checksum = "eb325787c91b3f6c34a7c6f2b8a2297b20292d733ca53a08c233e5028aec49af"
 dependencies = [
  "bindgen",
  "cc",
@@ -5004,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+checksum = "c61cb643dac43067f3eb76c866635a74377ac0abca0ff2590674e1e295514c3d"
 dependencies = [
  "bitflags 2.13.1",
  "skia-bindings",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -7839,9 +7839,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+checksum = "eb325787c91b3f6c34a7c6f2b8a2297b20292d733ca53a08c233e5028aec49af"
 dependencies = [
  "bindgen",
  "cc",
@@ -7856,9 +7856,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+checksum = "c61cb643dac43067f3eb76c866635a74377ac0abca0ff2590674e1e295514c3d"
 dependencies = [
  "bitflags 2.13.1",
  "skia-bindings",

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -57,7 +57,7 @@ scoped-tls-hkt = "0.1"
 raw-window-handle = { version = "0.6", features = ["std"] }
 clru = { workspace = true }
 
-skia-safe = { version = "0.99.0", features = ["gl"] }
+skia-safe = { version = "0.153.3", features = ["gl"] }
 glow = { workspace = true }
 unicode-segmentation = { workspace = true }
 
@@ -78,7 +78,7 @@ bytemuck = { workspace = true }
 [target.'cfg(target_family = "windows")'.dependencies]
 windows = { workspace = true, features = ["Win32", "Win32_Graphics", "Win32_Graphics_Dxgi", "Win32_Graphics_Direct3D12", "Win32_Graphics_Direct3D", "Win32_Foundation", "Win32_Graphics_Dxgi_Common"] }
 windows-core = { workspace = true, optional = true }
-skia-safe = { version = "0.99.0", features = ["d3d"] }
+skia-safe = { version = "0.153.3", features = ["d3d"] }
 wgpu-29 = { workspace = true, optional = true, features = ["dx12"] }
 wgpu-30 = { workspace = true, optional = true, features = ["dx12"] }
 
@@ -89,7 +89,7 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = ["s
 objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["std", "objc2-metal", "CALayer", "CAMetalLayer", "objc2-core-foundation"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSResponder", "NSView"] }
 objc2-core-foundation = { version = "0.3.2", default-features = false, features = ["CFCGTypes"] }
-skia-safe = { version = "0.99.0", features = ["metal"] }
+skia-safe = { version = "0.153.3", features = ["metal"] }
 
 wgpu-29 = { workspace = true, optional = true, features = ["metal"] }
 wgpu-30 = { workspace = true, optional = true, features = ["metal"] }
@@ -104,12 +104,9 @@ read-fonts = { workspace = true }
 write-fonts = { version = "0.50" }
 
 [target.'cfg(not(any(target_vendor = "apple", target_family = "windows")))'.dependencies]
-skia-safe = { version = "0.99.0", features = ["gl", "vulkan"] }
+skia-safe = { version = "0.153.3", features = ["gl", "vulkan"] }
 wgpu-29 = { workspace = true, optional = true, features = ["vulkan"] }
 wgpu-30 = { workspace = true, optional = true, features = ["vulkan"] }
-
-[target.'cfg(all(any(target_os = "ios", target_os="macos", target_os="windows", target_os="android", target_os="linux"), not(target_arch = "arm")))'.dependencies]
-skia-safe = { version = "0.99.0", features = ["textlayout"] }
 
 [target.aarch64-apple-ios-sim.dependencies]
 # Disabling encoding assertions until https://github.com/madsmtm/objc2/issues/795 is fixed.

--- a/internal/renderers/skia/font_cache.rs
+++ b/internal/renderers/skia/font_cache.rs
@@ -78,7 +78,7 @@ impl FontCache {
 
     fn load_typeface_internal(&self, font: &parley::FontData) -> Option<skia_safe::Typeface> {
         let typeface = self.font_mgr.new_from_data(
-            font.data.as_ref(),
+            skia_safe::Data::new_copy(font.data.as_ref()),
             if font.index > 0 { Some(font.index as _) } else { None },
         );
 
@@ -92,7 +92,9 @@ impl FontCache {
                 .ok()
                 .and_then(|ttc| ttc.get(font.index).ok())
                 .map(|ttf| write_fonts::FontBuilder::new().copy_missing_tables(ttf).build())
-                .and_then(|new_ttf| self.font_mgr.new_from_data(&new_ttf, None))
+                .and_then(|new_ttf| {
+                    self.font_mgr.new_from_data(skia_safe::Data::new_copy(&new_ttf), None)
+                })
         {
             return Some(typeface);
         }

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -5218,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
+checksum = "eb325787c91b3f6c34a7c6f2b8a2297b20292d733ca53a08c233e5028aec49af"
 dependencies = [
  "bindgen",
  "cc",
@@ -5235,9 +5235,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.99.0"
+version = "0.153.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
+checksum = "c61cb643dac43067f3eb76c866635a74377ac0abca0ff2590674e1e295514c3d"
 dependencies = [
  "bitflags 2.13.1",
  "skia-bindings",


### PR DESCRIPTION
The Skia renderer lays out and shapes text with parley, so it no longer needs Skia's built-in text layout module. rust-skia now ships prebuilt binaries without it (rust-skia/rust-skia#1316).

`FontMgr::new_from_data` takes an `skia_safe::Data` in this version instead of a byte slice.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
