### PR TITLE
cpp: add SLINT_FEATURE_SYSTEM_TRAY

### DIFF
--- a/api/cpp/cmake/SlintFeatures.cmake
+++ b/api/cpp/cmake/SlintFeatures.cmake
@@ -108,6 +108,7 @@ endif()
 
 define_cargo_dependent_feature(gettext "Enable support of translations using gettext" OFF "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_dependent_feature(accessibility "Enable integration with operating system provided accessibility APIs" ON "NOT SLINT_FEATURE_FREESTANDING")
+define_cargo_dependent_feature(system-tray "Enable support for the SystemTrayIcon element" ON "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_dependent_feature(testing "Enable support for testing API (experimental)" ON "NOT SLINT_FEATURE_FREESTANDING")
 define_cargo_feature(experimental "Enable experimental features. (No backward compatibility guarantees)" OFF)
 define_cargo_dependent_feature(system-testing "Enable support for controlling the application from a system testing tool" OFF "NOT SLINT_FEATURE_FREESTANDING")


### PR DESCRIPTION
The CMake build gives cargo an explicit feature list, and system-tray was missing from it. A C++ application would then get the no-op tray backend, and its SystemTrayIcon would never show up.

Fixes: #13236
