### PR TITLE
compiler: use a SourceLocation for a type declaration 

### DIFF
--- a/internal/compiler/generator/rust.rs
+++ b/internal/compiler/generator/rust.rs
@@ -14,8 +14,9 @@ Some convention used in the generated code:
 
 use super::accessor_names::{self, AccessorKind};
 use crate::CompilerConfiguration;
+use crate::diagnostics::SourceLocation;
 use crate::expression_tree::{BuiltinFunction, EasingCurve, MinMaxOp, OperatorClass};
-use crate::langtype::{DeclNode, Enumeration, EnumerationValue, Struct, StructName, Type};
+use crate::langtype::{Enumeration, EnumerationValue, Struct, StructName, Type};
 use crate::layout::Orientation;
 use crate::llr::lower_expression::lower_constant_expression;
 use crate::llr::lower_layout_expression::{
@@ -758,12 +759,12 @@ fn rust_attributes_tokens(
     attributes: &[SmolStr],
     kind: &str,
     name: &SmolStr,
-    node: Option<&DeclNode>,
+    node: Option<&SourceLocation>,
 ) -> TokenStream {
     let attrs = attributes.iter().map(|attr| match TokenStream::from_str(attr) {
         Ok(t) => quote!(#[#t]),
         Err(_) => {
-            let source_location = node.map(|n| n.to_source_location()).unwrap_or_default();
+            let source_location = node.cloned().unwrap_or_default();
             let error = format!(
                 "Error parsing @rust-attr for {kind} '{name}' declared at {source_location}"
             );

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 
 use smol_str::SmolStr;
 
+use crate::diagnostics::SourceLocation;
 use crate::expression_tree::{BuiltinFunction, Expression, Unit};
 use crate::object_tree::{Component, DEFAULT_SLOT_NAME, PropertyVisibility};
 use crate::parser::SyntaxNode;
@@ -1057,45 +1058,6 @@ impl Display for Function {
     }
 }
 
-/// A `Send` + `Sync` reference to *where* a user-declared struct or enum was
-/// written: the source file and the text range of its declaration node.
-///
-/// It deliberately carries no syntax tree, so the langtype graph (and therefore
-/// the LLR) stays compact and `Send` without pinning parsed documents at
-/// runtime. Everything the code generators need from the declaration is captured
-/// into the type at build time (e.g. `@rust-attr` in `rust_attributes`); the
-/// language server, which keeps every open document, resolves the actual syntax
-/// node from its own `DocumentCache` using [`Self::text_range`].
-#[derive(Debug, Clone)]
-pub struct DeclNode {
-    source_file: crate::diagnostics::SourceFile,
-    range: rowan::TextRange,
-}
-
-impl DeclNode {
-    pub fn new(node: &crate::parser::SyntaxNode) -> Self {
-        Self { source_file: node.source_file.clone(), range: node.node.text_range() }
-    }
-
-    /// The absolute text range of the declaration node within its document.
-    pub fn text_range(&self) -> rowan::TextRange {
-        self.range
-    }
-
-    /// The source file the declaration was parsed from.
-    pub fn source_file(&self) -> &crate::diagnostics::SourceFile {
-        &self.source_file
-    }
-
-    /// The source location (file + span) of the declaration.
-    pub fn to_source_location(&self) -> crate::diagnostics::SourceLocation {
-        crate::diagnostics::SourceLocation {
-            source_file: Some(self.source_file.clone()),
-            span: crate::diagnostics::Span::new(self.range.start().into(), self.range.len().into()),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum StructName {
     /// Anonymous structs
@@ -1104,7 +1066,7 @@ pub enum StructName {
     User {
         name: SmolStr,
         /// Where the declaration was written (for the language server).
-        node: DeclNode,
+        node: SourceLocation,
         /// The raw text of each `@rust-attr(...)` on the declaration, captured
         /// at build time so the Rust generator does not need the syntax tree.
         rust_attributes: Vec<SmolStr>,
@@ -1176,7 +1138,7 @@ impl Struct {
     }
 
     /// Where a user-declared struct was written (for the language server).
-    pub fn node(&self) -> Option<&DeclNode> {
+    pub fn node(&self) -> Option<&SourceLocation> {
         match &self.name {
             StructName::User { node, .. } => Some(node),
             _ => None,
@@ -1355,7 +1317,7 @@ pub struct Enumeration {
     pub values: Vec<SmolStr>,
     pub default_value: usize, // index in values
     // For non-builtins enums, this is where the declaration was written.
-    pub node: Option<DeclNode>,
+    pub node: Option<SourceLocation>,
     /// The raw text of each `@rust-attr(...)` on the declaration, captured at
     /// build time so the Rust generator does not need the syntax tree.
     pub rust_attributes: Vec<SmolStr>,

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -1290,9 +1290,7 @@ impl Display for Struct {
 pub(crate) fn visit_declared_types(ty: &Type, visitor: &mut impl FnMut(&SmolStr, &Type)) {
     match ty {
         Type::Struct(s) => {
-            if s.node().is_some()
-                && let StructName::User { name, .. } = &s.name
-            {
+            if let StructName::User { name, .. } = &s.name {
                 visitor(name, ty);
             }
             for sub_ty in s.fields.values() {

--- a/internal/compiler/llr/debug_info.rs
+++ b/internal/compiler/llr/debug_info.rs
@@ -6,9 +6,6 @@
 //!
 //! Populated only when [`crate::CompilerConfiguration::debug_info`] is set.
 //! Treat entries as advisory and tolerate missing data.
-//!
-//! These types hold a [`crate::diagnostics::SourceLocation`] which isn't `Send`.
-//! Making LLR `Send` will require replacing it with a path + offset.
 
 use crate::diagnostics::SourceLocation;
 use smol_str::SmolStr;

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -175,7 +175,7 @@ impl Document {
                 name: name.clone(),
                 values,
                 default_value: 0,
-                node: Some(crate::langtype::DeclNode::new(&n)),
+                node: Some(n.to_source_location()),
                 rust_attributes: n
                     .AtRustAttr()
                     .map(|a| SmolStr::from(a.text().to_string()))
@@ -3875,7 +3875,7 @@ pub fn type_struct_from_node(
                 .and_then(|p| syntax_nodes::StructDeclaration::new(p.clone()))
                 .map(|d| d.AtRustAttr().map(|a| SmolStr::from(a.text().to_string())).collect())
                 .unwrap_or_default();
-            let node = crate::langtype::DeclNode::new(struct_decl.as_ref().unwrap_or(&object_node));
+            let node = struct_decl.as_ref().unwrap_or(&object_node).to_source_location();
             StructName::User { name, node, rust_attributes, field_order }
         }),
     }))

--- a/internal/compiler/passes/unique_declared_type_names.rs
+++ b/internal/compiler/passes/unique_declared_type_names.rs
@@ -9,8 +9,9 @@
 //! into one type, so a value of one silently becomes a value of the other (see #6880, #9358).
 //! Renaming the extra declarations here keeps each one distinct.
 
+use crate::diagnostics::SourceLocation;
 use crate::expression_tree::Expression;
-use crate::langtype::{DeclNode, Struct, StructName, Type, visit_declared_types};
+use crate::langtype::{Struct, StructName, Type, visit_declared_types};
 use crate::object_tree::*;
 use smol_str::{SmolStr, format_smolstr};
 use std::cell::RefCell;
@@ -19,11 +20,11 @@ use std::sync::Arc;
 
 /// Identifies a declaration by its source location, so two references to the same declared type
 /// share an identity while two same-named declarations in different places do not.
-type Identity = (SmolStr, u32, u32);
+type Identity = (SmolStr, usize);
 
-fn identity(node: &DeclNode) -> Identity {
-    let range = node.text_range();
-    (node.source_file().path().to_string_lossy().into(), range.start().into(), range.end().into())
+fn identity(node: &SourceLocation) -> Identity {
+    let file = node.source_file.as_ref().map(|f| f.path().to_string_lossy().into());
+    (file.unwrap_or_default(), node.span.offset)
 }
 
 type Renames = HashMap<Identity, SmolStr>;

--- a/internal/editor-preview/token_info.rs
+++ b/internal/editor-preview/token_info.rs
@@ -1,13 +1,13 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use i_slint_compiler::diagnostics::Spanned;
+use i_slint_compiler::diagnostics::{SourceLocation, Spanned};
 use i_slint_compiler::expression_tree::{Callable, Expression};
 use i_slint_compiler::langtype::{ElementType, EnumerationValue, Type};
 use i_slint_compiler::lookup::{LookupObject, LookupResult, LookupResultCallable};
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
-use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken, syntax_nodes};
+use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken, TextRange, syntax_nodes};
 use i_slint_compiler::pathutils::clean_path;
 use smol_str::{SmolStr, ToSmolStr};
 use std::path::Path;
@@ -34,11 +34,16 @@ pub enum TokenInfo {
 /// not need to carry a syntax tree.
 pub fn node_for_decl(
     document_cache: &crate::DocumentCache,
-    decl: &i_slint_compiler::langtype::DeclNode,
+    decl: &SourceLocation,
 ) -> Option<SyntaxNode> {
-    let doc = document_cache.get_document_for_source_file(decl.source_file())?;
-    let node = doc.node.as_ref()?.covering_element(decl.text_range()).into_node()?;
-    Some(SyntaxNode { node, source_file: decl.source_file().clone() })
+    let source_file = decl.source_file.as_ref()?;
+    let doc = document_cache.get_document_for_source_file(source_file)?;
+    let node = doc.node.as_ref()?.covering_element(decl_range(decl)).into_node()?;
+    Some(SyntaxNode { node, source_file: source_file.clone() })
+}
+
+fn decl_range(decl: &SourceLocation) -> TextRange {
+    TextRange::at((decl.span.offset as u32).into(), (decl.span.length as u32).into())
 }
 
 impl TokenInfo {
@@ -307,8 +312,7 @@ pub fn token_info(document_cache: &crate::DocumentCache, token: SyntaxToken) -> 
                 match &ty {
                     Type::Struct(s)
                         if s.node()
-                            .map(|n| n.text_range().contains_range(token.text_range()))
-                            .unwrap_or_default() =>
+                            .is_some_and(|n| decl_range(n).contains_range(token.text_range())) =>
                     {
                         return Some(TokenInfo::Type(ty));
                     }
@@ -324,8 +328,7 @@ pub fn token_info(document_cache: &crate::DocumentCache, token: SyntaxToken) -> 
                     Type::Enumeration(e)
                         if e.node
                             .as_ref()
-                            .map(|n| n.text_range().contains_range(token.text_range()))
-                            .unwrap_or_default() =>
+                            .is_some_and(|n| decl_range(n).contains_range(token.text_range())) =>
                     {
                         return Some(TokenInfo::Type(ty));
                     }


### PR DESCRIPTION
DeclNode was a source file and a text range, which is what a SourceLocation
already is. It only existed as its own type because SourceLocation used to
hold a proc_macro::Span and was therefore not Send.

Now that SourceLocation is Send we can simplify the code