### PR TITLE
compiler: keep builtin property defaults as constant expressions

### DIFF
--- a/docs/slint-doc-generator/element_docs.rs
+++ b/docs/slint-doc-generator/element_docs.rs
@@ -508,7 +508,7 @@ fn write_slint_property(
     let raw_doc = info.docs.as_deref().unwrap_or("");
     let (description, doc_default) = extract_default(raw_doc);
     let mut default_value = match &info.default_value {
-        BuiltinPropertyDefault::Expr(expr) => format_default_expr(expr),
+        BuiltinPropertyDefault::Expr(expr) => format_default_expr(&expr.to_expression()),
         _ => String::new(),
     };
     if default_value.is_empty()

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -362,7 +362,7 @@ impl Type {
 #[derive(Debug, Clone)]
 pub enum BuiltinPropertyDefault {
     None,
-    Expr(Expression),
+    Expr(ConstantExpression),
     /// When materializing a property of this type, it will be initialized with an Expression that depends on the ElementRc
     WithElement(fn(&crate::object_tree::ElementRc) -> Expression),
     /// The property is actually not a property but a builtin function
@@ -373,7 +373,7 @@ impl BuiltinPropertyDefault {
     pub fn expr(&self, elem: &crate::object_tree::ElementRc) -> Option<Expression> {
         match self {
             BuiltinPropertyDefault::None => None,
-            BuiltinPropertyDefault::Expr(expression) => Some(expression.clone()),
+            BuiltinPropertyDefault::Expr(constant) => Some(constant.to_expression()),
             BuiltinPropertyDefault::WithElement(init_expr) => Some(init_expr(elem)),
             BuiltinPropertyDefault::BuiltinFunction(..) => {
                 unreachable!("can't get an expression for functions")

--- a/internal/compiler/llr/debug_info.rs
+++ b/internal/compiler/llr/debug_info.rs
@@ -6,9 +6,6 @@
 //!
 //! Populated only when [`crate::CompilerConfiguration::debug_info`] is set.
 //! Treat entries as advisory and tolerate missing data.
-//!
-//! These types hold a [`crate::diagnostics::SourceLocation`] which isn't `Send`.
-//! Making LLR `Send` will require replacing it with a path + offset.
 
 use crate::diagnostics::SourceLocation;
 use smol_str::SmolStr;

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -777,6 +777,12 @@ pub struct CompilationUnit {
     pub translations: Option<crate::translations::Translations>,
 }
 
+// The code generators may run on another thread, so the LLR must not reference the object tree.
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<CompilationUnit>();
+};
+
 impl CompilationUnit {
     pub fn needs_window_adapter(&self) -> bool {
         self.public_components.iter().any(|p| p.top_level_type == TopLevelComponentType::Window)

--- a/internal/compiler/load_builtins.rs
+++ b/internal/compiler/load_builtins.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 
 use crate::expression_tree::{BuiltinFunction, Expression};
 use crate::langtype::{
-    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, BuiltinStruct, DefaultSizeBinding,
-    ElementType, Function, NativeClass, Type,
+    BuiltinElement, BuiltinPropertyDefault, BuiltinPropertyInfo, BuiltinStruct, ConstantExpression,
+    DefaultSizeBinding, ElementType, Function, NativeClass, Type,
 };
 use crate::object_tree::{self, *};
 use crate::parser::{SyntaxKind, SyntaxNode, identifier_text, syntax_nodes};
@@ -268,8 +268,6 @@ pub(crate) fn load_builtins(
             (name, info)
         }));
 
-        // NativeClass is not Send yet; the Arc is for the shared langtype graph.
-        #[allow(clippy::arc_with_non_send_sync)]
         let mut builtin = BuiltinElement::new(Arc::new(n));
         builtin.is_global = matches!(base, Base::Global);
         let properties = &mut builtin.properties;
@@ -354,13 +352,13 @@ pub(crate) fn load_builtins(
     }
 }
 
-/// Compile an expression, knowing that the expression is basic (does not have lookup to other things)
+/// Compile a default value, knowing that the expression is a constant (does not have lookup to other things)
 fn compiled(
     node: syntax_nodes::BindingExpression,
     type_register: &TypeRegister,
     ty: Type,
     symbol_counters: &Rc<crate::symbol_counters::SymbolCounters>,
-) -> Expression {
+) -> ConstantExpression {
     let mut diag = crate::diagnostics::BuildDiagnostics::default();
     let mut ctx =
         crate::lookup::LookupCtx::empty_context(type_register, &mut diag, symbol_counters.clone());
@@ -374,7 +372,9 @@ fn compiled(
         diag.print();
         panic!("Error parsing the builtin elements: {vec:?}");
     }
-    e
+    ConstantExpression::from_expression(&e).unwrap_or_else(|| {
+        panic!("the default value of a builtin property must be a constant expression: {e:?}")
+    })
 }
 
 /// Return true when the member declaration is preceded by a `//-key` comment.

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3776,7 +3776,7 @@ pub(crate) fn apply_default_type_properties(element: &mut Element) {
         for (prop, info) in &builtin_base.properties {
             if let BuiltinPropertyDefault::Expr(expr) = &info.default_value {
                 element.bindings.0.entry(prop.clone()).or_insert_with(|| {
-                    let mut binding = BindingExpression::from(expr.clone());
+                    let mut binding = BindingExpression::from(expr.to_expression());
                     binding.priority = i32::MAX;
                     RefCell::new(binding)
                 });

--- a/internal/compiler/passes/resolve_native_classes.rs
+++ b/internal/compiler/passes/resolve_native_classes.rs
@@ -88,7 +88,7 @@ fn is_default_value(base_type: &BuiltinElement, name: &str, binding: &BindingExp
     };
     binding.animation.is_none()
         && binding.two_way_bindings.is_empty()
-        && same_literal(binding.value_expression(), default)
+        && same_literal(binding.value_expression(), &default.to_expression())
 }
 
 /// Anything that isn't a literal compares as different, so a computed binding counts as a use.
@@ -188,8 +188,9 @@ fn builtin_defaults_are_comparable() {
         let ElementType::Builtin(element) = element else { continue };
         for (property, info) in &element.properties {
             if let BuiltinPropertyDefault::Expr(default) = &info.default_value {
+                let default = default.to_expression();
                 assert!(
-                    same_literal(default, &default.clone()),
+                    same_literal(&default, &default),
                     "the default of {name}::{property} is a shape same_literal doesn't compare, \
                      so the property always counts as used: {default:?}"
                 );


### PR DESCRIPTION
The default value of a builtin property was stored as an Expression, which holds Rc and syntax nodes. It was the only thing reachable from the LLR that isn't Send, since the LLR items share the NativeClass. Every default is a literal, so store it as a ConstantExpression, the form struct field defaults already use, and assert that NativeClass and the LLR compilation unit are Send.
