### PR TITLE
compiler/interpreter: avoid monomorphisation to reduce a bit the size of the wasm-interpreter

### DIFF
--- a/internal/compiler/expression_tree.rs
+++ b/internal/compiler/expression_tree.rs
@@ -1148,6 +1148,10 @@ impl Expression {
 
     /// Call the visitor for each sub-expression.  (note: this function does not recurse)
     pub fn visit(&self, mut visitor: impl FnMut(&Self)) {
+        self.visit_dyn(&mut visitor)
+    }
+
+    fn visit_dyn(&self, visitor: &mut dyn FnMut(&Self)) {
         match self {
             Expression::Invalid => {}
             Expression::Uncompiled(_) => {}
@@ -1290,6 +1294,10 @@ impl Expression {
     }
 
     pub fn visit_mut(&mut self, mut visitor: impl FnMut(&mut Self)) {
+        self.visit_mut_dyn(&mut visitor)
+    }
+
+    fn visit_mut_dyn(&mut self, visitor: &mut dyn FnMut(&mut Self)) {
         match self {
             Expression::Invalid => {}
             Expression::Uncompiled(_) => {}

--- a/internal/compiler/layout.rs
+++ b/internal/compiler/layout.rs
@@ -64,7 +64,7 @@ pub enum Layout {
 
 impl Layout {
     /// Call the visitor for each NamedReference stored in the layout
-    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         match self {
             Layout::GridLayout(grid) => grid.visit_named_references(visitor),
             Layout::BoxLayout(l) => l.visit_named_references(visitor),
@@ -168,7 +168,7 @@ impl LayoutRect {
         }
     }
 
-    fn visit_named_references(&mut self, mut visitor: &mut impl FnMut(&mut NamedReference)) {
+    fn visit_named_references(&mut self, mut visitor: &mut dyn FnMut(&mut NamedReference)) {
         self.width_reference.as_mut().map(&mut visitor);
         self.height_reference.as_mut().map(&mut visitor);
         self.x_reference.as_mut().map(&mut visitor);
@@ -420,7 +420,7 @@ impl LayoutConstraints {
             .chain(c.stretch.as_ref().map(|x| (x, "stretch")))
     }
 
-    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         if let Some(e) = self.max_width.as_mut() {
             visitor(&mut *e);
         }
@@ -473,7 +473,7 @@ pub struct GridLayoutCell {
 }
 
 impl GridLayoutCell {
-    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         if let RowColExpr::Named(ref mut e) = self.col_expr {
             visitor(e);
         }
@@ -521,7 +521,7 @@ pub struct Padding {
 }
 
 impl Padding {
-    fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         if let Some(e) = self.left.as_mut() {
             visitor(&mut *e)
         }
@@ -552,7 +552,7 @@ pub struct Spacing {
 }
 
 impl Spacing {
-    fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         if let Some(e) = self.horizontal.as_mut() {
             visitor(&mut *e);
         }
@@ -578,7 +578,7 @@ pub struct LayoutGeometry {
 }
 
 impl LayoutGeometry {
-    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         self.rect.visit_named_references(visitor);
         if let Some(e) = self.alignment.as_mut() {
             visitor(&mut *e)
@@ -698,7 +698,7 @@ impl GridLayout {
         }
     }
 
-    pub fn visit_rowcol_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_rowcol_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         for elem in &mut self.elems {
             let mut cell = elem.cell.borrow_mut();
             if let RowColExpr::Named(ref mut e) = cell.col_expr {
@@ -716,7 +716,7 @@ impl GridLayout {
         }
     }
 
-    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         self.visit_rowcol_named_references(visitor);
         for layout_elem in &mut self.elems {
             layout_elem.item.constraints.visit_named_references(visitor);
@@ -742,7 +742,7 @@ pub struct BoxLayout {
 }
 
 impl BoxLayout {
-    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         for cell in &mut self.elems {
             cell.constraints.visit_named_references(visitor);
             if let Some(e) = cell.cross_axis_self_alignment.as_mut() {
@@ -837,7 +837,7 @@ impl FlexboxLayout {
         }
     }
 
-    pub fn visit_named_references(&mut self, visitor: &mut impl FnMut(&mut NamedReference)) {
+    pub fn visit_named_references(&mut self, visitor: &mut dyn FnMut(&mut NamedReference)) {
         for cell in &mut self.elems {
             cell.constraints.visit_named_references(visitor);
             if let Some(e) = cell.cross_axis_self_alignment.as_mut() {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -4131,9 +4131,17 @@ pub fn recurse_elem<State>(
     state: &State,
     vis: &mut impl FnMut(&ElementRc, &State) -> State,
 ) {
+    recurse_elem_dyn(elem, state, vis)
+}
+
+fn recurse_elem_dyn<State>(
+    elem: &ElementRc,
+    state: &State,
+    vis: &mut dyn FnMut(&ElementRc, &State) -> State,
+) {
     let state = vis(elem, state);
     for sub in &elem.borrow().children {
-        recurse_elem(sub, &state, vis);
+        recurse_elem_dyn(sub, &state, vis);
     }
 }
 
@@ -4143,7 +4151,15 @@ pub fn recurse_elem_including_sub_components<State>(
     state: &State,
     vis: &mut impl FnMut(&ElementRc, &State) -> State,
 ) {
-    recurse_elem(&component.root_element, state, &mut |elem, state| {
+    recurse_elem_including_sub_components_dyn(component, state, vis)
+}
+
+fn recurse_elem_including_sub_components_dyn<State>(
+    component: &Component,
+    state: &State,
+    vis: &mut dyn FnMut(&ElementRc, &State) -> State,
+) {
+    recurse_elem_dyn(&component.root_element, state, &mut |elem, state| {
         debug_assert!(std::ptr::eq(
             component as *const Component,
             (&*elem.borrow().enclosing_component.upgrade().unwrap()) as *const Component
@@ -4152,7 +4168,7 @@ pub fn recurse_elem_including_sub_components<State>(
             && let ElementType::Component(base) = &elem.borrow().base_type
             && base.parent_element().is_some()
         {
-            recurse_elem_including_sub_components(base, state, vis);
+            recurse_elem_including_sub_components_dyn(base, state, vis);
         }
         vis(elem, state)
     });
@@ -4160,12 +4176,12 @@ pub fn recurse_elem_including_sub_components<State>(
         .popup_windows
         .borrow()
         .iter()
-        .for_each(|p| recurse_elem_including_sub_components(&p.component, state, vis));
+        .for_each(|p| recurse_elem_including_sub_components_dyn(&p.component, state, vis));
     component
         .menu_item_tree
         .borrow()
         .iter()
-        .for_each(|c| recurse_elem_including_sub_components(c, state, vis));
+        .for_each(|c| recurse_elem_including_sub_components_dyn(c, state, vis));
 }
 
 /// Same as recurse_elem, but will take the children from the element as to not keep the element borrow
@@ -4174,10 +4190,18 @@ pub fn recurse_elem_no_borrow<State>(
     state: &State,
     vis: &mut impl FnMut(&ElementRc, &State) -> State,
 ) {
+    recurse_elem_no_borrow_dyn(elem, state, vis)
+}
+
+fn recurse_elem_no_borrow_dyn<State>(
+    elem: &ElementRc,
+    state: &State,
+    vis: &mut dyn FnMut(&ElementRc, &State) -> State,
+) {
     let state = vis(elem, state);
     let children = elem.borrow().children.clone();
     for sub in &children {
-        recurse_elem_no_borrow(sub, &state, vis);
+        recurse_elem_no_borrow_dyn(sub, &state, vis);
     }
 }
 
@@ -4187,7 +4211,15 @@ pub fn recurse_elem_including_sub_components_no_borrow<State>(
     state: &State,
     vis: &mut impl FnMut(&ElementRc, &State) -> State,
 ) {
-    recurse_elem_no_borrow(&component.root_element, state, &mut |elem, state| {
+    recurse_elem_including_sub_components_no_borrow_dyn(component, state, vis)
+}
+
+fn recurse_elem_including_sub_components_no_borrow_dyn<State>(
+    component: &Component,
+    state: &State,
+    vis: &mut dyn FnMut(&ElementRc, &State) -> State,
+) {
+    recurse_elem_no_borrow_dyn(&component.root_element, state, &mut |elem, state| {
         let base = if elem.borrow().repeated.is_some() {
             if let ElementType::Component(base) = &elem.borrow().base_type {
                 if base.parent_element().is_some() {
@@ -4203,20 +4235,18 @@ pub fn recurse_elem_including_sub_components_no_borrow<State>(
             None
         };
         if let Some(base) = base {
-            recurse_elem_including_sub_components_no_borrow(&base, state, vis);
+            recurse_elem_including_sub_components_no_borrow_dyn(&base, state, vis);
         }
         vis(elem, state)
     });
-    component
-        .popup_windows
-        .borrow()
-        .iter()
-        .for_each(|p| recurse_elem_including_sub_components_no_borrow(&p.component, state, vis));
+    component.popup_windows.borrow().iter().for_each(|p| {
+        recurse_elem_including_sub_components_no_borrow_dyn(&p.component, state, vis)
+    });
     component
         .menu_item_tree
         .borrow()
         .iter()
-        .for_each(|c| recurse_elem_including_sub_components_no_borrow(c, state, vis));
+        .for_each(|c| recurse_elem_including_sub_components_no_borrow_dyn(c, state, vis));
 }
 
 /// Visit the model expression of `elem`, if `elem` is the body of a `for`.
@@ -4244,9 +4274,16 @@ pub fn visit_element_expressions_excluding_repeater_model(
     elem: &ElementRc,
     mut vis: impl FnMut(&mut Expression, Option<&str>, &dyn Fn() -> Type),
 ) {
+    visit_element_expressions_excluding_repeater_model_dyn(elem, &mut vis)
+}
+
+fn visit_element_expressions_excluding_repeater_model_dyn(
+    elem: &ElementRc,
+    vis: &mut dyn FnMut(&mut Expression, Option<&str>, &dyn Fn() -> Type),
+) {
     fn visit_element_expressions_simple(
         elem: &ElementRc,
-        vis: &mut impl FnMut(&mut Expression, Option<&str>, &dyn Fn() -> Type),
+        vis: &mut dyn FnMut(&mut Expression, Option<&str>, &dyn Fn() -> Type),
     ) {
         for (name, expr) in elem.borrow().bindings_including_synthetic() {
             vis(&mut expr.borrow_mut(), Some(name.as_str()), &|| {
@@ -4277,7 +4314,7 @@ pub fn visit_element_expressions_excluding_repeater_model(
         }
     }
 
-    visit_element_expressions_simple(elem, &mut vis);
+    visit_element_expressions_simple(elem, vis);
 
     for expr in elem.borrow().change_callbacks.values() {
         for expr in expr.borrow_mut().iter_mut() {
@@ -4304,7 +4341,7 @@ pub fn visit_element_expressions_excluding_repeater_model(
     let mut transitions = std::mem::take(&mut elem.borrow_mut().transitions);
     for t in &mut transitions {
         for (_, _, a) in &mut t.property_animations {
-            visit_element_expressions_simple(a, &mut vis);
+            visit_element_expressions_simple(a, vis);
         }
     }
     elem.borrow_mut().transitions = transitions;
@@ -4329,7 +4366,14 @@ pub fn visit_named_references_in_expression(
     expr: &mut Expression,
     vis: &mut impl FnMut(&mut NamedReference),
 ) {
-    expr.visit_mut(|sub| visit_named_references_in_expression(sub, vis));
+    visit_named_references_in_expression_dyn(expr, vis)
+}
+
+fn visit_named_references_in_expression_dyn(
+    expr: &mut Expression,
+    vis: &mut dyn FnMut(&mut NamedReference),
+) {
+    expr.visit_mut(|sub| visit_named_references_in_expression_dyn(sub, vis));
     match expr {
         Expression::PropertyReference(r) => vis(r),
         Expression::FunctionCall {
@@ -4372,8 +4416,15 @@ pub fn visit_all_named_references_in_element(
     elem: &ElementRc,
     mut vis: impl FnMut(&mut NamedReference),
 ) {
+    visit_all_named_references_in_element_dyn(elem, &mut vis)
+}
+
+fn visit_all_named_references_in_element_dyn(
+    elem: &ElementRc,
+    mut vis: &mut dyn FnMut(&mut NamedReference),
+) {
     visit_element_expressions(elem, |expr, _, _| {
-        visit_named_references_in_expression(expr, &mut vis)
+        visit_named_references_in_expression_dyn(expr, vis)
     });
     let mut states = std::mem::take(&mut elem.borrow_mut().states);
     for s in &mut states {
@@ -4420,7 +4471,7 @@ pub fn visit_all_named_references_in_element(
     let mut debug = std::mem::take(&mut elem.borrow_mut().debug);
     for d in debug.iter_mut() {
         if let Some(l) = d.layout.as_mut() {
-            l.visit_named_references(&mut vis)
+            l.visit_named_references(vis)
         }
     }
     elem.borrow_mut().debug = debug;
@@ -4474,11 +4525,15 @@ pub fn visit_all_named_references(
     component: &Component,
     vis: &mut impl FnMut(&mut NamedReference),
 ) {
-    recurse_elem_including_sub_components_no_borrow(
+    visit_all_named_references_dyn(component, vis)
+}
+
+fn visit_all_named_references_dyn(component: &Component, vis: &mut dyn FnMut(&mut NamedReference)) {
+    recurse_elem_including_sub_components_no_borrow_dyn(
         component,
         &Weak::new(),
         &mut |elem, parent_compo| {
-            visit_all_named_references_in_element(elem, |nr| vis(nr));
+            visit_all_named_references_in_element_dyn(elem, vis);
             let compo = elem.borrow().enclosing_component.clone();
             if !Weak::ptr_eq(parent_compo, &compo) {
                 let compo = compo.upgrade().unwrap();
@@ -4497,7 +4552,7 @@ pub fn visit_all_named_references(
                 });
                 for o in compo.optimized_elements.borrow().iter() {
                     visit_element_expressions(o, |expr, _, _| {
-                        visit_named_references_in_expression(expr, vis)
+                        visit_named_references_in_expression_dyn(expr, vis)
                     });
                 }
             }
@@ -4513,7 +4568,14 @@ pub fn visit_all_expressions(
     component: &Component,
     mut vis: impl FnMut(&mut Expression, &dyn Fn() -> Type),
 ) {
-    recurse_elem_including_sub_components(component, &Weak::new(), &mut |elem, parent_compo| {
+    visit_all_expressions_dyn(component, &mut vis)
+}
+
+fn visit_all_expressions_dyn(
+    component: &Component,
+    vis: &mut dyn FnMut(&mut Expression, &dyn Fn() -> Type),
+) {
+    recurse_elem_including_sub_components_dyn(component, &Weak::new(), &mut |elem, parent_compo| {
         visit_element_expressions(elem, |expr, _, ty| vis(expr, ty));
         let compo = elem.borrow().enclosing_component.clone();
         if !Weak::ptr_eq(parent_compo, &compo) {

--- a/internal/core/rtti.rs
+++ b/internal/core/rtti.rs
@@ -171,6 +171,58 @@ pub trait PropertyInfo<Item, Value> {
     );
 }
 
+// The two helpers below only depend on `Value`, so they are kept out of the
+// generic `PropertyInfo` impl: there they would be instantiated once per
+// item property type instead of once.
+
+/// Returns the common property of `p`, installing a two-way binding on it first if needed.
+///
+/// link_two_way installs a TwoWayBinding on p (moving any
+/// existing binding into the shared common property), which
+/// check_common_property finds on subsequent calls. This keeps
+/// prepare_for_two_way_binding idempotent: when several fields of
+/// the same struct property are two-way bound, they must all share
+/// one common property instead of each creating its own.
+fn common_property<Value: Clone + PartialEq + Default + 'static>(
+    p: Pin<&Property<Value>>,
+) -> Pin<Rc<Property<Value>>> {
+    if let Some(cp) = Property::check_common_property(p) {
+        return cp;
+    }
+    let anchor = Rc::pin(Property::<Value>::default());
+    Property::link_two_way(anchor.as_ref(), p);
+    Property::check_common_property(p).unwrap()
+}
+
+/// Links `prop2` to the common property `prop1`, through `mapper` when given.
+fn link_common_properties<Value: Clone + PartialEq + 'static>(
+    prop1: Pin<Rc<Property<Value>>>,
+    prop2: Pin<Rc<Property<Value>>>,
+    mapper: Option<Rc<dyn TwoWayBindingMapping<Value>>>,
+) {
+    match mapper {
+        Some(m1) => {
+            let m2 = m1.clone();
+            Property::link_two_way_with_map_to_common_property(
+                prop2,
+                prop1.as_ref(),
+                move |value| m1.map_to(value),
+                move |value, value2| m2.map_from(value, value2),
+                true,
+            );
+        }
+        None => {
+            Property::link_two_way_with_map_to_common_property(
+                prop2,
+                prop1.as_ref(),
+                |value| value.clone(),
+                |value, value2| *value = value2.clone(),
+                true,
+            );
+        }
+    }
+}
+
 impl<Item: 'static, T, Value> PropertyInfo<Item, Value> for FieldOffset<Item, Property<T>>
 where
     Value: TryInto<T> + Clone + PartialEq + Default + 'static,
@@ -228,19 +280,7 @@ where
         if let Some(self_) =
             (self as &dyn core::any::Any).downcast_ref::<FieldOffset<Item, Property<Value>>>()
         {
-            let p = self_.apply_pin(item);
-            if let Some(cp) = Property::check_common_property(p) {
-                return cp;
-            }
-            // link_two_way installs a TwoWayBinding on p (moving any
-            // existing binding into the shared common property), which
-            // check_common_property finds on subsequent calls. This keeps
-            // prepare_for_two_way_binding idempotent: when several fields of
-            // the same struct property are two-way bound, they must all share
-            // one common property instead of each creating its own.
-            let anchor = Rc::pin(Property::<Value>::default());
-            Property::link_two_way(anchor.as_ref(), p);
-            return Property::check_common_property(p).unwrap();
+            return common_property(self_.apply_pin(item));
         }
 
         let p1 = self.apply_pin(item);
@@ -263,28 +303,7 @@ where
         mapper: Option<Rc<dyn TwoWayBindingMapping<Value>>>,
     ) {
         let prop1 = self.prepare_for_two_way_binding(item);
-
-        match mapper {
-            Some(m1) => {
-                let m2 = m1.clone();
-                Property::link_two_way_with_map_to_common_property(
-                    prop2,
-                    prop1.as_ref(),
-                    move |value| m1.map_to(value),
-                    move |value, value2| m2.map_from(value, value2),
-                    true,
-                );
-            }
-            None => {
-                Property::link_two_way_with_map_to_common_property(
-                    prop2,
-                    prop1.as_ref(),
-                    |value| value.clone(),
-                    |value, value2| *value = value2.clone(),
-                    true,
-                );
-            }
-        }
+        link_common_properties(prop1, prop2, mapper);
     }
 
     fn link_two_way_to_model_data(


### PR DESCRIPTION
Two commits: save ~440K in the wasm-interpreter