### PR TITLE
compiler: fix inlining of derived components that override forward-focus or read a popup's is-open

### DIFF
--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -12,6 +12,7 @@ use crate::object_tree::*;
 use by_address::ByAddress;
 use smol_str::SmolStr;
 use std::cell::RefCell;
+use std::collections::btree_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
@@ -97,25 +98,22 @@ fn inline_element(
     let mut elem_mut = elem.borrow_mut();
     let priority_delta = 1 + elem_mut.inline_depth;
     elem_mut.base_type = inlined_component.root_element.borrow().base_type.clone();
-    // Merging is by name, so the two sides must not share one
-    debug_assert!(
-        inlined_component
-            .root_element
-            .borrow()
-            .property_declarations
-            .keys()
-            .all(|name| !elem_mut.property_declarations.contains_key(name)),
-        "inlining {} into {} would merge two declarations of the same name",
-        inlined_component.id,
-        elem_mut.id
-    );
-    elem_mut.property_declarations.extend(
-        inlined_component.root_element.borrow().property_declarations.iter().map(|(name, decl)| {
-            let mut decl = decl.clone();
-            decl.expose_in_public_api = false;
-            (name.clone(), decl)
-        }),
-    );
+    let Element { id: elem_id, property_declarations, .. } = &mut *elem_mut;
+    for (name, decl) in inlined_component.root_element.borrow().property_declarations.iter() {
+        match property_declarations.entry(name.clone()) {
+            // Only the functions lowered from `forward-focus` can be declared on both sides,
+            // as user code can't declare these reserved names. The derived one overrides.
+            Entry::Occupied(_) => debug_assert!(
+                crate::typeregister::reserved_member_function(name).is_some(),
+                "inlining {} into {} would merge two declarations of the same name",
+                inlined_component.id,
+                elem_id
+            ),
+            Entry::Vacant(e) => {
+                e.insert(PropertyDeclaration { expose_in_public_api: false, ..decl.clone() });
+            }
+        }
+    }
     // Merge the shadow index, keeping the element's own shadows.
     for (source_name, internal_name) in &inlined_component.root_element.borrow().shadowing_members {
         elem_mut

--- a/internal/compiler/passes/lower_popups.rs
+++ b/internal/compiler/passes/lower_popups.rs
@@ -187,13 +187,12 @@ fn lower_popup_window(
             }
         });
         if referenced {
-            let name = format_smolstr!("popup-{}-is-open", popup_window_element.borrow().id);
-            parent_component
-                .root_element
-                .borrow_mut()
-                .property_declarations
-                .insert(name.clone(), Type::Bool.into());
-            let is_open_ref = NamedReference::new(&parent_component.root_element, name);
+            // A base component may already have a popup with the same id
+            let is_open_ref = crate::layout::create_new_prop(
+                &parent_component.root_element,
+                format_smolstr!("popup-{}-is-open", popup_window_element.borrow().id),
+                Type::Bool,
+            );
             // The runtime writes this property through a generated setter that the (LLR) optimizer
             // cannot see, so mark it as set to keep it from being constant-folded to its default.
             is_open_ref.mark_as_set();

--- a/internal/compiler/passes/lower_states.rs
+++ b/internal/compiler/passes/lower_states.rs
@@ -40,11 +40,12 @@ fn lower_state_in_element(
         return;
     }
     let has_transitions = !root_element.borrow().transitions.is_empty();
-    let state_property_name = compute_state_property_name(root_element);
-    let state_property = Expression::PropertyReference(NamedReference::new(
+    let state_property_nr = crate::layout::create_new_prop(
         root_element,
-        state_property_name.clone(),
-    ));
+        SmolStr::new_static("state"),
+        if has_transitions { state_info_type.clone() } else { Type::Int32 },
+    );
+    let state_property = Expression::PropertyReference(state_property_nr.clone());
     let state_property_ref = if has_transitions {
         Expression::StructFieldAccess {
             base: Box::new(state_property.clone()),
@@ -108,14 +109,7 @@ fn lower_state_in_element(
         states_id.insert(state.id, idx as i32 + 1);
     }
 
-    root_element.borrow_mut().property_declarations.insert(
-        state_property_name.clone(),
-        PropertyDeclaration {
-            property_type: if has_transitions { state_info_type.clone() } else { Type::Int32 },
-            ..PropertyDeclaration::default()
-        },
-    );
-    root_element.borrow_mut().set_binding(state_property_name, state_value.into());
+    root_element.borrow_mut().set_binding(state_property_nr.name().clone(), state_value.into());
 
     lower_transitions_in_element(
         root_element,
@@ -183,20 +177,6 @@ fn lower_transitions_in_element(
             );
         }
     }
-}
-
-/// Returns a suitable unique name for the "state" property
-fn compute_state_property_name(root_element: &ElementRc) -> SmolStr {
-    let mut property_name = "state".to_owned();
-    while root_element
-        .borrow()
-        .lookup_property(property_name.as_ref(), PropertyLookupMode::InternalName)
-        .property_type
-        != Type::Invalid
-    {
-        property_name += "-";
-    }
-    property_name.into()
 }
 
 enum ExpressionForProperty {

--- a/tests/cases/elements/popupwindow_is_open_derived.slint
+++ b/tests/cases/elements/popupwindow_is_open_derived.slint
@@ -1,0 +1,77 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A base and a derived component each read `is-open` of their own popup, both called `popup`.
+// The two must stay separate properties.
+
+component Base inherits Rectangle {
+    out property <bool> base-open: popup.is-open;
+    public function show-base() { popup.show(); }
+
+    popup := PopupWindow {
+        close-policy: no-auto-close;
+        width: 40px;
+        height: 40px;
+        Rectangle { background: blue; }
+    }
+}
+
+export component TestCase inherits Base {
+    width: 300px;
+    height: 300px;
+
+    out property <bool> derived-open: popup.is-open;
+    out property <bool> base-open-alias: self.base-open;
+    public function show-derived() { popup.show(); }
+    public function show-base-popup() { self.show-base(); }
+
+    popup := PopupWindow {
+        close-policy: no-auto-close;
+        x: 100px;
+        width: 40px;
+        height: 40px;
+        Rectangle { background: red; }
+    }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(!instance.get_derived_open());
+assert!(!instance.get_base_open_alias());
+
+instance.invoke_show_derived();
+assert!(instance.get_derived_open());
+assert!(!instance.get_base_open_alias());
+
+instance.invoke_show_base_popup();
+assert!(instance.get_base_open_alias());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(!instance.get_derived_open());
+assert(!instance.get_base_open_alias());
+
+instance.invoke_show_derived();
+assert(instance.get_derived_open());
+assert(!instance.get_base_open_alias());
+
+instance.invoke_show_base_popup();
+assert(instance.get_base_open_alias());
+```
+
+```js
+var instance = new slint.TestCase();
+assert(!instance.derived_open);
+assert(!instance.base_open_alias);
+
+instance.show_derived();
+assert(instance.derived_open);
+assert(!instance.base_open_alias);
+
+instance.show_base_popup();
+assert(instance.base_open_alias);
+```
+*/

--- a/tests/cases/focus/forward_derived.slint
+++ b/tests/cases/focus/forward_derived.slint
@@ -1,0 +1,84 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A derived component overrides the `forward-focus` of its base
+
+component Base inherits Rectangle {
+    forward-focus: base-input;
+    out property <bool> base-focused: base-input.has-focus;
+    base-input := TextInput { }
+}
+
+component Derived inherits Base {
+    forward-focus: derived-input;
+    out property <bool> derived-focused: derived-input.has-focus;
+    derived-input := TextInput { }
+}
+
+export component TestCase inherits Base {
+    width: 400phx;
+    height: 400phx;
+
+    forward-focus: own-input;
+    out property <bool> own-focused: own-input.has-focus;
+    out property <bool> own-base-focused: self.base-focused;
+    own-input := TextInput { }
+
+    // Also as a child, where `inner.focus()` resolves to the derived function rather than the public API
+    inner := Derived { }
+    out property <bool> inner-base-focused: inner.base-focused;
+    out property <bool> inner-derived-focused: inner.derived-focused;
+
+    public function focus-inner() { inner.focus(); }
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+// The root's forward-focus sets the initial focus
+assert!(instance.get_own_focused());
+assert!(!instance.get_own_base_focused());
+
+instance.invoke_focus_inner();
+assert!(!instance.get_own_focused());
+assert!(instance.get_inner_derived_focused());
+assert!(!instance.get_inner_base_focused());
+
+instance.invoke_focus();
+assert!(instance.get_own_focused());
+assert!(!instance.get_inner_derived_focused());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+// The root's forward-focus sets the initial focus
+assert(instance.get_own_focused());
+assert(!instance.get_own_base_focused());
+
+instance.invoke_focus_inner();
+assert(!instance.get_own_focused());
+assert(instance.get_inner_derived_focused());
+assert(!instance.get_inner_base_focused());
+
+instance.invoke_focus();
+assert(instance.get_own_focused());
+assert(!instance.get_inner_derived_focused());
+```
+
+```js
+var instance = new slint.TestCase();
+// The root's forward-focus sets the initial focus
+assert(instance.own_focused);
+assert(!instance.own_base_focused);
+
+instance.focus_inner();
+assert(!instance.own_focused);
+assert(instance.inner_derived_focused);
+assert(!instance.inner_base_focused);
+
+instance.focus();
+assert(instance.own_focused);
+assert(!instance.inner_derived_focused);
+```
+*/


### PR DESCRIPTION
The assertion added in 2853fc625e (inlining never merges two declarations of the same name) fires on two cases where a pass synthesizes a declaration on the root of both a base and a derived component before inlining:

- forward-focus set in both: the lowered focus/clear-focus functions collide. Before the assertion this was silent but wrong since 1.7: the base's copy replaced the derived one and the exported derived component lost its public focus()/clear-focus(). Found by running master's slint-compiler on heng30/wayshot while investigating the crater run.
- a popup with the same id in both, whose is-open is read: the synthesized popup-<id>-is-open collided, so both popups drove one flag.

