### PR TITLE
mcp: instantiate repeaters before serving a tool call

### DIFF
--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -185,6 +185,21 @@ impl IntrospectionState {
             .ok_or_else(|| "Attempting to access deleted window".to_string())
     }
 
+    /// Runs the instantiation pass on every tracked window.
+    ///
+    /// The pass materializes repeaters, conditionals and component containers.
+    /// Introspection reads the item tree between events, where nothing else runs the pass.
+    /// A model changed since the last event would otherwise report its old instances (#13223).
+    /// Call this from a transport entry point, never from within a property evaluation.
+    pub fn ensure_windows_instantiated(&self) {
+        // Collect first: the pass runs change handlers, which may re-enter `add_window`.
+        let adapters: Vec<_> =
+            self.windows.borrow().values().filter_map(|w| w.window_adapter.upgrade()).collect();
+        for adapter in adapters {
+            WindowInner::from_pub(adapter.window()).ensure_tree_instantiated();
+        }
+    }
+
     pub fn root_element_handle(&self, window_index: ArenaIndex) -> Result<ArenaIndex, String> {
         Ok(self
             .windows

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -233,6 +233,9 @@ async fn handle_tool_call(
     name: &str,
     args: &Value,
 ) -> Result<ToolResult, String> {
+    // Report on the current tree: see `IntrospectionState::ensure_windows_instantiated`.
+    state.ensure_windows_instantiated();
+
     match name {
         "list_windows" => {
             let response = dispatch::list_windows(state);
@@ -1057,6 +1060,49 @@ mod tests {
         assert_eq!(find_header_end(b"GET / HTTP/1.1\r\n\r\n"), Some(14));
         assert_eq!(find_header_end(b"no double crlf here"), None);
         assert_eq!(find_header_end(b"\r\n\r\n"), Some(0));
+    }
+
+    #[test]
+    fn test_tool_call_instantiates_pending_repeaters() {
+        use slint::ComponentHandle;
+
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                in property <int> count: 3;
+                probe := VerticalLayout {
+                    for _ in root.count: Rectangle { height: 10px; }
+                }
+                measured := Rectangle {
+                    height: probe.preferred-height;
+                }
+            }
+        }
+
+        let app = App::new().unwrap();
+        let adapter = i_slint_core::window::WindowInner::from_pub(app.window()).window_adapter();
+        let state = make_state();
+        state.add_window(&adapter);
+
+        let measured = crate::ElementHandle::find_by_element_id(&app, "App::measured")
+            .next()
+            .expect("measured element");
+        let element_handle = index_to_handle(state.element_to_handle(measured));
+
+        // The model changes between events,
+        // so the repeater instances stay stale until the next instantiation pass.
+        app.set_count(5);
+
+        let result = block_on(handle_tool_call(
+            &state,
+            "get_element_properties",
+            &serde_json::json!({
+                "elementHandle": serde_json::to_value(element_handle).unwrap()
+            }),
+        ))
+        .expect("get_element_properties failed");
+        let ToolResult::Json(value) = result else { panic!("expected a json result") };
+        assert_eq!(value["size"]["height"], 50.0);
     }
 
     #[test]


### PR DESCRIPTION
`WindowInner::ensure_tree_instantiated` materializes repeater and conditional instances on event dispatch and before rendering, but not while layout info is evaluated.
The tree an introspection request walks therefore reflects the model as of the last event.
An MCP client that changes a model and then reads back element geometry sees the previous instances, and their stale geometry with them.

This runs the pass over the tracked windows at the top of the MCP tool dispatch, [as suggested on the issue](https://github.com/slint-ui/slint/issues/13223#issuecomment-5545827478).
The call sits at a transport boundary, outside any property evaluation, so it doesn't re-enter a tracker mid-pull the way the same pass on the layout-info path would.
It does mean an MCP read can run application change handlers, which the pass loops over together with instantiation.

It goes through the introspection state's tracked `WindowAdapter`s rather than the testing backend's own window list, so it also works when the MCP server runs under winit.
This is the same pattern as `accesskit.rs`, which runs the pass before building its tree for the same reason.

The regression test drives `handle_tool_call` rather than the pass directly, so it fails if the call is dropped: it reports 30px instead of 50px.

## Scope

Addresses #13223 for the MCP transport only, so I'd leave the issue open.

The systest protobuf transport shares the `introspection::dispatch` functions but has its own entry point, and doesn't get the pass.
A plain property read through the generated getters also stays stale.
That one looks deliberate rather than accidental: 7bd380d0f moved instantiation out of the visit pass, and the `Repeater::instance_generation` doc comment states that layout and visit code re-evaluate only after the update pass materializes the change.
The design question is on the issue rather than patched here.
