### PR TITLE
testing: aim pointer events at the transformed element center

### DIFF
--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -1078,13 +1078,10 @@ impl ElementHandle {
         let Some(item) = self.item.upgrade() else {
             return Default::default();
         };
-        let geometry = item.geometry();
-        let position = i_slint_core::lengths::logical_position_to_api(
-            item.map_to_native_window(geometry.origin),
-        );
-        LogicalPosition::new(
-            position.x + geometry.width() / 2.,
-            position.y + geometry.height() / 2.,
+        // Map the center rather than mapping the origin and adding a local half-extent,
+        // which ignores any scale or rotation an ancestor applies (#13242).
+        i_slint_core::lengths::logical_position_to_api(
+            item.map_to_native_window(item.geometry().center()),
         )
     }
 

--- a/internal/backends/testing/tests/click_transform_scale.rs
+++ b/internal/backends/testing/tests/click_transform_scale.rs
@@ -1,0 +1,42 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use i_slint_backend_testing::ElementHandle;
+use slint::platform::PointerEventButton;
+
+#[test]
+fn test_click_under_transform_scale() {
+    i_slint_backend_testing::init_integration_test_with_system_time();
+
+    slint::spawn_local(async move {
+        slint::slint! {
+            export component App inherits Window {
+                width: 400px;
+                height: 300px;
+                out property <int> click-count: 0;
+                Rectangle {
+                    transform-scale: 0.25;
+                    Rectangle {
+                        x: 0px;
+                        y: 0px;
+                        width: 200px;
+                        height: 100px;
+                        ta := TouchArea {
+                            clicked => { root.click-count += 1; }
+                        }
+                    }
+                }
+            }
+        }
+
+        let app = App::new().unwrap();
+
+        let elem = ElementHandle::find_by_element_id(&app, "App::ta").next().unwrap();
+        elem.single_click(PointerEventButton::Left).await;
+        assert_eq!(app.get_click_count(), 1, "the click aimed outside the scaled element");
+
+        slint::quit_event_loop().unwrap();
+    })
+    .unwrap();
+    slint::run_event_loop().unwrap();
+}


### PR DESCRIPTION
Fixes #13242.

`ElementHandle::absolute_center` mapped the element origin through the item transform, then added the element's untransformed local half-extent.
Under an ancestor `transform-scale` of z the aim is off by (w/2)·(1 - z), and for z < 0.5 it leaves the element entirely.
The event then lands on whatever is behind it.

Mapping the center covers any affine transform, including rotation, where mapped origin plus an axis-aligned half-extent was also wrong.

`click_element`, `hover_element`, `drag_element` and `scroll` all dispatch at `absolute_center`, so all of them missed.
The failure is silent: an event is dispatched and accepted, so the tool reports success while nothing in the UI changes.

The regression test clicks a `TouchArea` under `transform-scale: 0.25` and fails before the fix, with the click landing ~280px away.
It lives in its own integration test file because `init_integration_test_with_system_time` and `run_event_loop` can only run once per process.

## Not covered

`ElementHandle::absolute_position` has the same mapped-origin/unmapped-size mismatch, and `get_element_properties` exports both as `absolutePosition` and `size`.
A client still can't work out an element's rendered extent from the MCP surface.
Exposing the rect in window coordinates is an API addition rather than a fix, so it's filed separately as #13250.

