### PR TITLE
mcp: tell the client when the app has no element debug info

### DIFF
--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -309,8 +309,13 @@ impl IntrospectionState {
         let adapter = self.window_adapter(window_index)?;
         let window = adapter.window();
         let item_tree = WindowInner::from_pub(window).component();
-        Ok(ElementHandle::find_by_element_id(&RootWrapper(&item_tree), elements_id)
-            .collect::<Vec<_>>())
+        let root = RootWrapper(&item_tree);
+        // Without debug info there are no ids to match, so report that rather than
+        // an empty result that reads like "no such element" (#13225).
+        if !root.root_element().has_debug_info() {
+            return Err(crate::search_api::MISSING_DEBUG_INFO_MESSAGE.into());
+        }
+        Ok(ElementHandle::find_by_element_id(&root, elements_id).collect::<Vec<_>>())
     }
 
     pub fn take_snapshot(

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -196,6 +196,7 @@ impl IntrospectionState {
     /// Introspection reads the item tree between events, where nothing else runs the pass.
     /// A model changed since the last event would otherwise report its old instances (#13223).
     /// Call this from a transport entry point, never from within a property evaluation.
+    #[cfg(feature = "mcp")]
     pub fn ensure_windows_instantiated(&self) {
         // Collect first: the pass runs change handlers, which may re-enter `add_window`.
         let adapters: Vec<_> =

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -240,6 +240,30 @@ enum ToolResult {
     Image { png_data: Vec<u8>, meta: Value },
 }
 
+/// Assembles the `get_element_tree` response.
+///
+/// Without debug info the walk yields no descendants and no names, so the response
+/// says so rather than looking like a UI with one unnamed element (#13225).
+fn element_tree_response(elements: Vec<Value>, truncated: bool, has_debug_info: bool) -> Value {
+    let total_count = elements.len();
+    let mut response = serde_json::json!({
+        "elements": elements,
+        "totalCount": total_count,
+        "truncated": truncated
+    });
+    if !has_debug_info && let Some(object) = response.as_object_mut() {
+        object.insert("debugInfoMissing".into(), Value::Bool(true));
+        object.insert(
+            "note".into(),
+            Value::String(format!(
+                "No descendants, type names or ids are available. {}",
+                crate::search_api::MISSING_DEBUG_INFO_MESSAGE
+            )),
+        );
+    }
+    response
+}
+
 async fn handle_tool_call(
     state: &IntrospectionState,
     name: &str,
@@ -344,11 +368,11 @@ async fn handle_tool_call(
                 std::ops::ControlFlow::<()>::Continue(())
             });
 
-            Ok(ToolResult::Json(serde_json::json!({
-                "elements": elements,
-                "totalCount": elements.len(),
-                "truncated": truncated
-            })))
+            Ok(ToolResult::Json(element_tree_response(
+                elements,
+                truncated,
+                root_element.has_debug_info(),
+            )))
         }
         "take_screenshot" => {
             let p: proto::RequestTakeSnapshot = deserialize_params(args)?;
@@ -572,6 +596,11 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "The pointer stays where it is left, so clear a hover with move_pointer to a point away from the element.\n",
                     "8. start_event_recording → then interact → stop_event_recording to verify the runtime received and processed expected input/window events\n",
                     "9. take_screenshot again to verify the visual effect\n\n",
+
+                    "# Requirements\n\n",
+                    "Element type names and ids need the application to be built with `SLINT_EMIT_DEBUG_INFO=1`, ",
+                    "or with `with_debug_info` in `slint_build`'s `CompilerConfiguration`. ",
+                    "Without it get_element_tree returns the root element alone, unnamed, and find_elements_by_id fails.\n\n",
 
                     "# Handle format\n\n",
                     "All handles are JSON objects with string-valued fields: {\"index\": \"0\", \"generation\": \"0\"}. ",
@@ -1198,6 +1227,23 @@ mod tests {
         ))
         .expect("dispatch_pointer_scroll failed");
         assert_eq!(app.get_scrolled(), -100., "the second wheel event had no effect");
+    }
+
+    #[test]
+    fn test_element_tree_response_reports_missing_debug_info() {
+        let response = element_tree_response(vec![], false, false);
+        assert_eq!(response["debugInfoMissing"], true);
+        assert!(response["note"].as_str().unwrap().contains("SLINT_EMIT_DEBUG_INFO"));
+        assert_eq!(response["totalCount"], 0);
+    }
+
+    #[test]
+    fn test_element_tree_response_omits_the_note_with_debug_info() {
+        let response = element_tree_response(vec![serde_json::json!({})], true, true);
+        assert!(response.get("debugInfoMissing").is_none());
+        assert!(response.get("note").is_none());
+        assert_eq!(response["totalCount"], 1);
+        assert_eq!(response["truncated"], true);
     }
 
     #[test]

--- a/internal/backends/testing/search_api.rs
+++ b/internal/backends/testing/search_api.rs
@@ -58,10 +58,11 @@ pub(crate) fn mock_drag_window(
     window.dispatch_event(WindowEvent::PointerReleased { position: end, button });
 }
 
+/// Shown when the application was built without element debug info.
+pub(crate) const MISSING_DEBUG_INFO_MESSAGE: &str = "The use of the ElementHandle API requires the presence of debug info in Slint compiler generated code. Set the `SLINT_EMIT_DEBUG_INFO=1` environment variable at application build time or use `compile_with_config` and `with_debug_info` with `slint_build`'s `CompilerConfiguration`";
+
 fn warn_missing_debug_info() {
-    i_slint_core::debug_log!(
-        "The use of the ElementHandle API requires the presence of debug info in Slint compiler generated code. Set the `SLINT_EMIT_DEBUG_INFO=1` environment variable at application build time or use `compile_with_config` and `with_debug_info` with `slint_build`'s `CompilerConfiguration`"
-    )
+    i_slint_core::debug_log!("{}", MISSING_DEBUG_INFO_MESSAGE)
 }
 
 mod internal {
@@ -402,6 +403,13 @@ impl ElementHandle {
     #[cfg(any(feature = "system-testing", feature = "mcp"))]
     pub(crate) fn identity_hint(&self) -> Option<(u32, usize)> {
         self.item.upgrade().map(|item| (item.index(), self.element_index))
+    }
+
+    /// Returns whether the compiler emitted the debug info that type names, ids and
+    /// descendant traversal need. See `MISSING_DEBUG_INFO_MESSAGE`.
+    #[cfg(any(feature = "system-testing", feature = "mcp"))]
+    pub(crate) fn has_debug_info(&self) -> bool {
+        self.item.upgrade().is_some_and(|item| item.element_count().is_some())
     }
 
     /// Creates a new [`ElementQuery`] to match any descendants of this element.


### PR DESCRIPTION
Fixes #13225.

Element introspection needs the compiler to emit debug info, which is off unless the application sets `SLINT_EMIT_DEBUG_INFO=1` or uses `with_debug_info`.
The existing warning goes to the application's stderr, which an MCP client never sees.

## Correction to the issue

The issue says the tree comes back with "the right shape and element count" and empty names.
Measured, it is worse than that.
`ItemRc::element_count` returns `None` without debug info, and `ElementHandle::collect_elements` turns that into zero handles per item, so the descendant walk yields nothing.

Same UI, `get_element_tree` on the root:

| build | totalCount | find_elements_by_id |
| --- | --- | --- |
| without debug info | 1 (root only, empty type name) | empty match |
| with debug info | 4 | matches |

So the client sees an application that appears to have no UI, not one whose elements are unnamed.

## Change

- `get_element_tree` carries `debugInfoMissing: true` and a note naming the flag.
- `find_elements_by_id` fails with that message rather than reporting an empty match, since without debug info there are no ids it could ever match.
- The `initialize` instructions state the requirement, so a client can recognize the symptom from the handshake.

`query_element_descendants` is left alone: it accepts accessible-role matchers that work without debug info, so gating it would need to inspect the query stack.

The response assembly moved into `element_tree_response`, which the tests drive both ways.
That keeps the tests independent of how the test binary itself was built — CI sets `SLINT_EMIT_DEBUG_INFO=1` job-wide, so a test asserting the missing case end to end could never fail there.
Both paths were verified by hand against a real window, which is where the table above comes from.
