### PR TITLE
mcp: hold keyboard modifiers during a pointer gesture

### DIFF
--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -102,6 +102,58 @@ fn ensure_event_tracking() -> Result<(), i_slint_core::api::EventLoopError> {
     })
 }
 
+/// Holds modifier keys down for as long as it lives.
+///
+/// Slint takes the modifiers of a pointer event from the window's key state, not
+/// from the event itself, so a modified gesture is a key press, the gesture, and a
+/// key release. Releasing on drop keeps the window's state clean when the gesture
+/// in between fails.
+#[cfg(feature = "mcp")]
+pub(crate) struct HeldModifiers {
+    window_adapter: Rc<dyn WindowAdapter>,
+    keys: Vec<i_slint_core::input::key_codes::Key>,
+}
+
+#[cfg(feature = "mcp")]
+impl HeldModifiers {
+    pub(crate) fn hold(
+        window_adapter: Rc<dyn WindowAdapter>,
+        modifiers: Option<&proto::KeyboardModifiers>,
+    ) -> Self {
+        use i_slint_core::input::key_codes::Key;
+        let mut keys = Vec::new();
+        if let Some(modifiers) = modifiers {
+            for (pressed, key) in [
+                (modifiers.shift, Key::Shift),
+                (modifiers.control, Key::Control),
+                (modifiers.alt, Key::Alt),
+                (modifiers.meta, Key::Meta),
+            ] {
+                if pressed {
+                    keys.push(key);
+                }
+            }
+        }
+        for key in &keys {
+            window_adapter.window().dispatch_event(
+                i_slint_core::platform::WindowEvent::KeyPressed { text: (*key).into() },
+            );
+        }
+        Self { window_adapter, keys }
+    }
+}
+
+#[cfg(feature = "mcp")]
+impl Drop for HeldModifiers {
+    fn drop(&mut self) {
+        for key in self.keys.iter().rev() {
+            self.window_adapter.window().dispatch_event(
+                i_slint_core::platform::WindowEvent::KeyReleased { text: (*key).into() },
+            );
+        }
+    }
+}
+
 pub(crate) struct RootWrapper<'a>(pub &'a ItemTreeRc);
 
 impl ElementRoot for RootWrapper<'_> {
@@ -988,8 +1040,16 @@ pub(crate) mod dispatch {
         element: ArenaIndex,
         action: proto::ClickAction,
         button: proto::PointerEventButton,
+        modifiers: Option<proto::KeyboardModifiers>,
     ) -> Result<(), String> {
         let element = state.element("click", element)?;
+        #[cfg(feature = "mcp")]
+        let _modifiers = super::HeldModifiers::hold(
+            element.window_adapter().ok_or_else(|| "element has no window".to_string())?,
+            modifiers.as_ref(),
+        );
+        #[cfg(not(feature = "mcp"))]
+        let _ = modifiers;
         let button = convert_pointer_event_button(button);
         match action {
             proto::ClickAction::SingleClick => element.single_click(button).await,
@@ -1006,11 +1066,13 @@ pub(crate) mod dispatch {
     pub(crate) fn move_pointer_to_element(
         state: &IntrospectionState,
         element: ArenaIndex,
+        modifiers: Option<&proto::KeyboardModifiers>,
     ) -> Result<(), String> {
         let element = state.element("move_pointer", element)?;
         let position = element.absolute_center();
         let window_adapter =
             element.window_adapter().ok_or_else(|| "element has no window".to_string())?;
+        let _modifiers = super::HeldModifiers::hold(window_adapter.clone(), modifiers);
         window_adapter
             .window()
             .dispatch_event(i_slint_core::platform::WindowEvent::PointerMoved { position });
@@ -1024,8 +1086,13 @@ pub(crate) mod dispatch {
         element: ArenaIndex,
         delta_x: f32,
         delta_y: f32,
+        modifiers: Option<&proto::KeyboardModifiers>,
     ) -> Result<(), String> {
-        state.element("scroll_element", element)?.scroll(delta_x, delta_y);
+        let element = state.element("scroll_element", element)?;
+        let window_adapter =
+            element.window_adapter().ok_or_else(|| "element has no window".to_string())?;
+        let _modifiers = super::HeldModifiers::hold(window_adapter.clone(), modifiers);
+        element.scroll(delta_x, delta_y);
         Ok(())
     }
 
@@ -1034,8 +1101,16 @@ pub(crate) mod dispatch {
         element: ArenaIndex,
         target: proto::LogicalPosition,
         button: proto::PointerEventButton,
+        modifiers: Option<proto::KeyboardModifiers>,
     ) -> Result<(), String> {
         let element = state.element("drag", element)?;
+        #[cfg(feature = "mcp")]
+        let _modifiers = super::HeldModifiers::hold(
+            element.window_adapter().ok_or_else(|| "element has no window".to_string())?,
+            modifiers.as_ref(),
+        );
+        #[cfg(not(feature = "mcp"))]
+        let _ = modifiers;
         let button = convert_pointer_event_button(button);
         let target = i_slint_core::api::LogicalPosition::new(target.x, target.y);
         element.drag(target, button).await;
@@ -1134,6 +1209,7 @@ fn test_dispatch_click_double_click_stale_handle() {
             ArenaIndex::default(),
             proto::ClickAction::DoubleClick,
             proto::PointerEventButton::Left,
+            None,
         )
         .await
         .unwrap_err();
@@ -1145,7 +1221,7 @@ fn test_dispatch_click_double_click_stale_handle() {
 #[cfg(feature = "mcp")]
 fn test_dispatch_move_pointer_stale_handle() {
     let state = IntrospectionState::new();
-    let err = dispatch::move_pointer_to_element(&state, ArenaIndex::default()).unwrap_err();
+    let err = dispatch::move_pointer_to_element(&state, ArenaIndex::default(), None).unwrap_err();
     assert!(err.contains("Invalid element handle"), "got: {err}");
 }
 

--- a/internal/backends/testing/introspection/mod.rs
+++ b/internal/backends/testing/introspection/mod.rs
@@ -111,7 +111,7 @@ fn ensure_event_tracking() -> Result<(), i_slint_core::api::EventLoopError> {
 #[cfg(feature = "mcp")]
 pub(crate) struct HeldModifiers {
     window_adapter: Rc<dyn WindowAdapter>,
-    keys: Vec<i_slint_core::input::key_codes::Key>,
+    modifiers: proto::KeyboardModifiers,
 }
 
 #[cfg(feature = "mcp")]
@@ -120,35 +120,34 @@ impl HeldModifiers {
         window_adapter: Rc<dyn WindowAdapter>,
         modifiers: Option<&proto::KeyboardModifiers>,
     ) -> Self {
-        use i_slint_core::input::key_codes::Key;
-        let mut keys = Vec::new();
-        if let Some(modifiers) = modifiers {
-            for (pressed, key) in [
-                (modifiers.shift, Key::Shift),
-                (modifiers.control, Key::Control),
-                (modifiers.alt, Key::Alt),
-                (modifiers.meta, Key::Meta),
-            ] {
-                if pressed {
-                    keys.push(key);
-                }
-            }
-        }
-        for key in &keys {
-            window_adapter.window().dispatch_event(
-                i_slint_core::platform::WindowEvent::KeyPressed { text: (*key).into() },
+        let this = Self { window_adapter, modifiers: modifiers.copied().unwrap_or_default() };
+        for key in this.keys() {
+            this.window_adapter.window().dispatch_event(
+                i_slint_core::platform::WindowEvent::KeyPressed { text: key.into() },
             );
         }
-        Self { window_adapter, keys }
+        this
+    }
+
+    fn keys(&self) -> impl DoubleEndedIterator<Item = i_slint_core::input::key_codes::Key> {
+        use i_slint_core::input::key_codes::Key;
+        [
+            (self.modifiers.shift, Key::Shift),
+            (self.modifiers.control, Key::Control),
+            (self.modifiers.alt, Key::Alt),
+            (self.modifiers.meta, Key::Meta),
+        ]
+        .into_iter()
+        .filter_map(|(pressed, key)| pressed.then_some(key))
     }
 }
 
 #[cfg(feature = "mcp")]
 impl Drop for HeldModifiers {
     fn drop(&mut self) {
-        for key in self.keys.iter().rev() {
+        for key in self.keys().rev() {
             self.window_adapter.window().dispatch_event(
-                i_slint_core::platform::WindowEvent::KeyReleased { text: (*key).into() },
+                i_slint_core::platform::WindowEvent::KeyReleased { text: key.into() },
             );
         }
     }

--- a/internal/backends/testing/mcp_server.rs
+++ b/internal/backends/testing/mcp_server.rs
@@ -88,19 +88,19 @@ const TOOLS: &[ToolDef] = &[
         name: "click_element",
         description: "Simulate a mouse click at the center of an element. Omit action/button for a left single-click (the most common case).",
         request_type: "RequestElementClick",
-        optional_fields: &["action", "button"],
+        optional_fields: &["action", "button", "modifiers"],
     },
     ToolDef {
         name: "drag_element",
         description: "Simulate a drag gesture from the element's center to a target position (logical coordinates). The pointer is pressed at the element center, moved in interpolated steps to the target, then released. Use for sliders, scrollable areas, drag handles, or any element that responds to pointer movement while pressed.",
         request_type: "RequestElementDrag",
-        optional_fields: &["button"],
+        optional_fields: &["button", "modifiers"],
     },
     ToolDef {
         name: "hover_element",
         description: "Move the mouse pointer to the center of an element without pressing any button. Use this for hover states, tooltips and menu highlighting: click_element and drag_element both press, so they cannot produce a hover on their own. The pointer stays where it is left; move it away with move_pointer to check that a hover is cleared.",
         request_type: "RequestHoverElement",
-        optional_fields: &[],
+        optional_fields: &["modifiers"],
     },
     ToolDef {
         name: "move_pointer",
@@ -112,13 +112,13 @@ const TOOLS: &[ToolDef] = &[
         name: "scroll_element",
         description: "Send a mouse wheel event over the center of an element. deltaX and deltaY are logical pixels: a deltaY of -50 moves a Flickable's viewport up by 50, revealing content further down, which is what a wheel-down does. Use this to scroll a Flickable or ScrollView, and for wheel-driven gestures such as zooming a canvas.",
         request_type: "RequestScrollElement",
-        optional_fields: &["deltaX", "deltaY"],
+        optional_fields: &["deltaX", "deltaY", "modifiers"],
     },
     ToolDef {
         name: "dispatch_pointer_scroll",
         description: "Send a mouse wheel event at a position in the window, in logical coordinates. Use scroll_element to scroll an element by handle; use this for an arbitrary point.",
         request_type: "RequestPointerScroll",
-        optional_fields: &["deltaX", "deltaY"],
+        optional_fields: &["deltaX", "deltaY", "modifiers"],
     },
     ToolDef {
         name: "invoke_accessibility_action",
@@ -395,7 +395,7 @@ async fn handle_tool_call(
                 .map_err(|_| format!("invalid button value: {}", p.button))?;
             let action = proto::ClickAction::try_from(p.action)
                 .map_err(|_| format!("invalid action value: {}", p.action))?;
-            dispatch::click(state, element_index, action, button).await?;
+            dispatch::click(state, element_index, action, button, p.modifiers).await?;
             let response = proto::ElementClickResponse {};
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
@@ -406,7 +406,7 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            dispatch::move_pointer_to_element(state, element_index)?;
+            dispatch::move_pointer_to_element(state, element_index, p.modifiers.as_ref())?;
             Ok(ToolResult::Json(serde_json::json!({})))
         }
         "move_pointer" => {
@@ -428,7 +428,13 @@ async fn handle_tool_call(
             let element_index = handle_to_index(
                 p.element_handle.ok_or_else(|| "missing elementHandle".to_string())?,
             )?;
-            dispatch::scroll_element(state, element_index, p.delta_x, p.delta_y)?;
+            dispatch::scroll_element(
+                state,
+                element_index,
+                p.delta_x,
+                p.delta_y,
+                p.modifiers.as_ref(),
+            )?;
             Ok(ToolResult::Json(serde_json::json!({})))
         }
         "dispatch_pointer_scroll" => {
@@ -437,6 +443,10 @@ async fn handle_tool_call(
                 p.window_handle.ok_or_else(|| "missing windowHandle".to_string())?,
             )?;
             let position = p.position.ok_or_else(|| "missing position".to_string())?;
+            let _modifiers = introspection::HeldModifiers::hold(
+                state.window_adapter(window_index)?,
+                p.modifiers.as_ref(),
+            );
             state.dispatch_window_event(
                 window_index,
                 i_slint_core::platform::WindowEvent::PointerScrolled {
@@ -455,7 +465,7 @@ async fn handle_tool_call(
             let target = p.target.ok_or_else(|| "missing target position".to_string())?;
             let button = proto::PointerEventButton::try_from(p.button)
                 .map_err(|_| format!("invalid button value: {}", p.button))?;
-            dispatch::drag(state, element_index, target, button).await?;
+            dispatch::drag(state, element_index, target, button, p.modifiers).await?;
             let response = proto::ElementDragResponse {};
             Ok(ToolResult::Json(
                 serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?,
@@ -601,6 +611,10 @@ async fn handle_mcp_request(state: &IntrospectionState, body: &str) -> Option<Va
                     "Element type names and ids need the application to be built with `SLINT_EMIT_DEBUG_INFO=1`, ",
                     "or with `with_debug_info` in `slint_build`'s `CompilerConfiguration`. ",
                     "Without it get_element_tree returns the root element alone, unnamed, and find_elements_by_id fails.\n\n",
+
+                    "# Modifiers\n\n",
+                    "click_element, drag_element, hover_element, scroll_element and dispatch_pointer_scroll accept a `modifiers` object with `shift`, `control`, `alt` and `meta`. ",
+                    "The keys are held for the gesture and released after it, which is how a shift-click or a ctrl+wheel zoom is expressed as one call.\n\n",
 
                     "# Handle format\n\n",
                     "All handles are JSON objects with string-valued fields: {\"index\": \"0\", \"generation\": \"0\"}. ",
@@ -1244,6 +1258,72 @@ mod tests {
         assert!(response.get("note").is_none());
         assert_eq!(response["totalCount"], 1);
         assert_eq!(response["truncated"], true);
+    }
+
+    #[test]
+    fn test_pointer_tools_hold_modifiers() {
+        use slint::ComponentHandle;
+
+        crate::init_no_event_loop();
+        slint::slint! {
+            export component App inherits Window {
+                width: 100px;
+                height: 100px;
+                out property <bool> shift-on-move;
+                out property <bool> control-on-scroll;
+                TouchArea {
+                    width: 100%;
+                    height: 100%;
+                    pointer-event(event) => {
+                        if (event.kind == PointerEventKind.move) {
+                            root.shift-on-move = event.modifiers.shift;
+                        }
+                    }
+                    scroll-event(event) => {
+                        root.control-on-scroll = event.modifiers.control;
+                        accept
+                    }
+                }
+            }
+        }
+
+        let app = App::new().unwrap();
+        let adapter = i_slint_core::window::WindowInner::from_pub(app.window()).window_adapter();
+        let state = make_state();
+        state.add_window(&adapter);
+        let root = serde_json::to_value(index_to_handle(
+            state.root_element_handle(state.window_handles()[0]).unwrap(),
+        ))
+        .unwrap();
+
+        block_on(handle_tool_call(
+            &state,
+            "hover_element",
+            &serde_json::json!({ "elementHandle": root, "modifiers": { "shift": true } }),
+        ))
+        .expect("hover_element failed");
+        assert!(app.get_shift_on_move(), "the pointer event didn't carry Shift");
+
+        block_on(handle_tool_call(
+            &state,
+            "scroll_element",
+            &serde_json::json!({
+                "elementHandle": root,
+                "deltaY": -10.0,
+                "modifiers": { "control": true }
+            }),
+        ))
+        .expect("scroll_element failed");
+        assert!(app.get_control_on_scroll(), "the wheel event didn't carry Control");
+
+        // The keys are released with the gesture, so the next one is unmodified.
+        block_on(handle_tool_call(
+            &state,
+            "hover_element",
+            &serde_json::json!({ "elementHandle": root }),
+        ))
+        .expect("hover_element failed");
+        assert!(!app.get_shift_on_move(), "Shift stayed down after the gesture");
     }
 
     #[test]

--- a/internal/backends/testing/slint_systest.proto
+++ b/internal/backends/testing/slint_systest.proto
@@ -212,16 +212,28 @@ message RequestTakeSnapshot {
     string image_mime_type = 2;
 }
 
+// Keyboard modifiers to hold during a pointer gesture. Slint reads modifiers from
+// the window's key state rather than from the pointer event, so these are pressed
+// before the gesture and released after it.
+message KeyboardModifiers {
+    bool shift = 1;
+    bool control = 2;
+    bool alt = 3;
+    bool meta = 4;
+}
+
 message RequestElementClick {
     Handle element_handle = 1;
     ClickAction action = 2;
     PointerEventButton button = 3;
+    KeyboardModifiers modifiers = 4;
 }
 
 message RequestElementDrag {
     Handle element_handle = 1;
     LogicalPosition target = 2;
     PointerEventButton button = 3;
+    KeyboardModifiers modifiers = 4;
 }
 
 message RequestDispatchWindowEvent {
@@ -240,12 +252,14 @@ message RequestMovePointer {
 
 message RequestHoverElement {
     Handle element_handle = 1;
+    KeyboardModifiers modifiers = 2;
 }
 
 message RequestScrollElement {
     Handle element_handle = 1;
     float delta_x = 2;
     float delta_y = 3;
+    KeyboardModifiers modifiers = 4;
 }
 
 message RequestPointerScroll {
@@ -253,6 +267,7 @@ message RequestPointerScroll {
     LogicalPosition position = 2;
     float delta_x = 3;
     float delta_y = 4;
+    KeyboardModifiers modifiers = 5;
 }
 
 message RequestDispatchKeyEvent {

--- a/internal/backends/testing/systest.rs
+++ b/internal/backends/testing/systest.rs
@@ -130,6 +130,7 @@ impl TestingClient {
                 element_handle,
                 action,
                 button,
+                modifiers,
             }) => {
                 let element_index =
                     handle_to_index(element_handle.ok_or_else(|| {
@@ -139,13 +140,14 @@ impl TestingClient {
                     .map_err(|_| format!("invalid PointerEventButton value: {button}"))?;
                 let action = proto::ClickAction::try_from(action)
                     .map_err(|_| format!("invalid ClickAction value: {action}"))?;
-                dispatch::click(&self.state, element_index, action, button).await?;
+                dispatch::click(&self.state, element_index, action, button, modifiers).await?;
                 Resp::ElementClickResponse(proto::ElementClickResponse {})
             }
             Req::RequestElementDrag(proto::RequestElementDrag {
                 element_handle,
                 target,
                 button,
+                modifiers,
             }) => {
                 let element_index =
                     handle_to_index(element_handle.ok_or_else(|| {
@@ -155,7 +157,7 @@ impl TestingClient {
                     .map_err(|_| format!("invalid PointerEventButton value: {button}"))?;
                 let target =
                     target.ok_or_else(|| "element drag request missing target".to_string())?;
-                dispatch::drag(&self.state, element_index, target, button).await?;
+                dispatch::drag(&self.state, element_index, target, button, modifiers).await?;
                 Resp::ElementDragResponse(proto::ElementDragResponse {})
             }
             Req::RequestDispatchWindowEvent(proto::RequestDispatchWindowEvent {


### PR DESCRIPTION
Part of #13244. Stacked on #13253 — review that one first; this branch contains its commit.

A shift-click over MCP was three calls: `dispatch_key_event` pressing `\u{0010}`, the click, then the release.
Every embedder had to rediscover that Shift is that code, which lives in `internal/common/key_codes.rs` and nowhere near the MCP documentation, and a modifier-sensitive gesture couldn't be expressed as one call.

`click_element`, `drag_element`, `hover_element`, `scroll_element` and `dispatch_pointer_scroll` now take an optional `modifiers` object with `shift`, `control`, `alt` and `meta`.

Slint takes the modifiers of a pointer event from the window's key state rather than from the event itself, so this can't be a field on the dispatched event — the keys have to be held around the gesture.
A `HeldModifiers` guard presses them on construction and releases them on drop, which keeps the window's key state clean when the gesture in between returns an error, and composes with the async click and drag paths.

`click_element` and `drag_element` are part of the systest `RequestToAUT` oneof, so the field reaches that transport too; both share the same dispatch functions.

## Test

`hover_element` with Shift, then `scroll_element` with Control, then an unmodified `hover_element` to prove the keys were released.
It asserts on `event.modifiers` inside the `.slint` markup, so it checks what the application actually observes rather than what was dispatched.

The test deliberately avoids `click_element`: `single_click().await` waits on timing that only advances in a running event loop, so under `init_no_event_loop` and `block_on` it hangs. The synchronous tools cover the guard's press and release paths.
