### PR TITLE
core: cache the content widths of a word-wrapping text

### DIFF
--- a/api/rs/slint/tests/text_content_widths_cache.rs
+++ b/api/rs/slint/tests/text_content_widths_cache.rs
@@ -1,0 +1,134 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! The content widths of a word-wrapping text are shaped once and cached, rather than
+//! re-shaped on every horizontal layout pass.
+
+mod common;
+
+use slint::platform::software_renderer::{
+    MinimalSoftwareWindow, PremultipliedRgbaColor, SoftwareRenderer, TargetPixel,
+};
+use std::rc::Rc;
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Default)]
+struct TestPixel(bool);
+
+impl TargetPixel for TestPixel {
+    fn blend(&mut self, _color: PremultipliedRgbaColor) {
+        *self = Self(true);
+    }
+    fn from_rgb(_red: u8, _green: u8, _blue: u8) -> Self {
+        Self(true)
+    }
+}
+
+const WIDTH: usize = 200;
+const HEIGHT: usize = 100;
+
+/// Renders a frame and returns how many times the content widths had to be shaped so far.
+fn render_and_misses(window: &Rc<MinimalSoftwareWindow>) -> u64 {
+    let mut count = 0;
+    window.request_redraw();
+    // The buffer follows the window: a scale factor change resizes it.
+    let size = window.size();
+    let (width, height) = (size.width as usize, size.height as usize);
+    window.draw_if_needed(|renderer: &SoftwareRenderer| {
+        let mut buf = vec![TestPixel(false); width * height];
+        renderer.render(buf.as_mut_slice(), width);
+        count = renderer.text_layout_cache().content_widths_miss_count();
+    });
+    count
+}
+
+slint::slint! {
+    export component TestComponent inherits Window {
+        in property <string> label: "Hello wrapping world";
+        in property <length> size: 16px;
+        in property <int> limit: 0;
+        // Reading a layout property pulls the text's horizontal layout info, which is
+        // what asks for the content widths.
+        out property <length> min-w: t.min-width;
+        t := Text {
+            text: label;
+            font-size: size;
+            max-lines: limit;
+            overflow: clip;
+            wrap: word-wrap;
+        }
+    }
+}
+
+fn setup() -> (Rc<MinimalSoftwareWindow>, TestComponent) {
+    let window = common::setup(WIDTH as u32, HEIGHT as u32);
+    let ui = TestComponent::new().unwrap();
+    ui.show().unwrap();
+    (window, ui)
+}
+
+#[test]
+fn repeated_layout_passes_shape_once() {
+    let (window, ui) = setup();
+
+    let width = ui.get_min_w();
+    assert!(width > 0.);
+    for _ in 0..4 {
+        assert_eq!(render_and_misses(&window), 1, "the content widths were shaped again");
+    }
+    assert_eq!(ui.get_min_w(), width);
+}
+
+#[test]
+fn text_change_invalidates() {
+    let (window, ui) = setup();
+    let width = ui.get_min_w();
+    assert_eq!(render_and_misses(&window), 1);
+
+    ui.set_label("Supercalifragilistic".into());
+
+    assert_eq!(render_and_misses(&window), 2);
+    assert_ne!(ui.get_min_w(), width, "the widths didn't follow the text");
+}
+
+#[test]
+fn font_size_change_invalidates() {
+    let (window, ui) = setup();
+    let width = ui.get_min_w();
+    assert_eq!(render_and_misses(&window), 1);
+
+    ui.set_size(32.);
+
+    assert_eq!(render_and_misses(&window), 2);
+    assert!(ui.get_min_w() > width, "the widths didn't follow the font size");
+}
+
+#[test]
+fn scale_factor_change_invalidates() {
+    let (window, ui) = setup();
+    let width = ui.get_min_w();
+    assert_eq!(render_and_misses(&window), 1);
+
+    window.dispatch_event(slint::platform::WindowEvent::ScaleFactorChanged { scale_factor: 2. });
+    // A real windowing system resizes the surface along with the scale factor.
+    window.set_size(slint::PhysicalSize::new(WIDTH as u32 * 2, HEIGHT as u32 * 2));
+
+    // Shaping is redone because glyph advances are in physical pixels. The reported
+    // width is logical, so the value itself is unchanged.
+    assert_eq!(render_and_misses(&window), 2);
+    assert_eq!(ui.get_min_w(), width);
+}
+
+#[test]
+fn line_limit_change_invalidates() {
+    let (window, ui) = setup();
+    ui.set_label("short\nSupercalifragilistic".into());
+    ui.set_limit(1);
+    let width = ui.get_min_w();
+    let misses = render_and_misses(&window);
+
+    ui.set_limit(2);
+
+    assert_eq!(render_and_misses(&window), misses + 1);
+    assert_ne!(ui.get_min_w(), width, "the widths didn't follow the line limit");
+}

--- a/internal/backends/testing/testing_backend.rs
+++ b/internal/backends/testing/testing_backend.rs
@@ -571,7 +571,7 @@ impl RendererSealed for TestingWindow {
                 max: LogicalLength::new(longest_line as f32 * pixel_size),
             })
         } else {
-            sharedparley::text_content_widths(self, text_item, item_rc)
+            sharedparley::text_content_widths(self, text_item, item_rc, self.text_layout_cache())
         }
     }
 

--- a/internal/core/renderer.rs
+++ b/internal/core/renderer.rs
@@ -107,7 +107,12 @@ pub trait RendererSealed {
     ) -> Option<ContentWidths> {
         #[cfg(feature = "shared-parley")]
         {
-            crate::textlayout::sharedparley::text_content_widths(self, text_item, item_rc)
+            crate::textlayout::sharedparley::text_content_widths(
+                self,
+                text_item,
+                item_rc,
+                self.text_layout_cache(),
+            )
         }
         #[cfg(not(feature = "shared-parley"))]
         {

--- a/internal/core/textlayout/sharedparley.rs
+++ b/internal/core/textlayout/sharedparley.rs
@@ -486,45 +486,70 @@ pub fn text_content_widths(
     renderer: &(impl RendererSealed + ?Sized),
     text_item: Pin<&dyn crate::item_rendering::RenderString>,
     item_rc: &crate::item_tree::ItemRc,
+    cache: Option<&TextLayoutCache>,
 ) -> Option<crate::renderer::ContentWidths> {
-    text_content_widths_impl(renderer.scale_factor(), renderer.slint_context(), text_item, item_rc)
+    text_content_widths_impl(
+        renderer.scale_factor(),
+        renderer.window_adapter(),
+        renderer.slint_context(),
+        text_item,
+        item_rc,
+        cache,
+    )
 }
 
 fn text_content_widths_impl(
     scale_factor: Option<ScaleFactor>,
+    window_adapter: Option<Rc<dyn WindowAdapter>>,
     ctx: Option<crate::SlintContext>,
     text_item: Pin<&dyn crate::item_rendering::RenderString>,
     item_rc: &crate::item_tree::ItemRc,
+    cache: Option<&TextLayoutCache>,
 ) -> Option<crate::renderer::ContentWidths> {
     let scale_factor = scale_factor?;
 
-    // See text_size(): evaluate properties before borrowing font_context.
-    let font_request = text_item.font_request(item_rc);
-    let text = text_item.text();
+    // See text_size(): evaluate properties before borrowing font_context. Afterwards they are
+    // clean, so `compute` can read them again -- now without re-entering -- inside the cache
+    // entry's dependency tracker.
+    let _ = text_item.font_request(item_rc);
+    let _ = text_item.text();
 
     let ctx = ctx?;
     let mut font_ctx = ctx.font_context().borrow_mut();
 
-    let layout_builder = shaping::content_widths_builder(font_request, scale_factor);
+    // Reads the text, the font request and the line limit, so the cache entry depends on all
+    // three. Nothing else feeds the widths: the wrap mode, the width and the color don't.
+    let compute = |font_ctx: &mut parley::FontContext| {
+        let layout_builder =
+            shaping::content_widths_builder(text_item.font_request(item_rc), scale_factor);
 
-    let paragraphs_without_linebreaks =
-        create_text_paragraphs(&layout_builder, &mut font_ctx, text, Color::default());
+        let paragraphs_without_linebreaks =
+            create_text_paragraphs(&layout_builder, font_ctx, text_item.text(), Color::default());
 
-    // No line breaking needed: parley derives the content widths from the break
-    // opportunities. Paragraphs stack vertically, so both widths are the widest.
-    // Without wrapping each paragraph is one line, so a line limit drops the paragraphs
-    // that are not drawn, from both widths.
-    let (min, max) = paragraphs_without_linebreaks
-        .iter()
-        .take(text_item.line_limit().unwrap_or(usize::MAX))
-        .fold((0., 0.), |(min, max), p| {
-            let w = p.layout.calculate_content_widths();
-            (f32::max(min, w.min), f32::max(max, w.max))
-        });
-    Some(crate::renderer::ContentWidths {
-        min: PhysicalLength::new(min) / scale_factor,
-        max: PhysicalLength::new(max) / scale_factor,
-    })
+        // No line breaking needed: parley derives the content widths from the break
+        // opportunities. Paragraphs stack vertically, so both widths are the widest.
+        // Without wrapping each paragraph is one line, so a line limit drops the paragraphs
+        // that are not drawn, from both widths.
+        let (min, max) = paragraphs_without_linebreaks
+            .iter()
+            .take(text_item.line_limit().unwrap_or(usize::MAX))
+            .fold((0., 0.), |(min, max), p| {
+                let w = p.layout.calculate_content_widths();
+                (f32::max(min, w.min), f32::max(max, w.max))
+            });
+        crate::renderer::ContentWidths {
+            min: PhysicalLength::new(min) / scale_factor,
+            max: PhysicalLength::new(max) / scale_factor,
+        }
+    };
+
+    // Without a window there is no way to notice a scale factor change, and the shaped
+    // advances are in physical pixels, so an entry kept across one would be wrong.
+    let Some((cache, window_adapter)) = cache.zip(window_adapter) else {
+        return Some(compute(&mut font_ctx));
+    };
+    cache.clear_if_scale_factor_changed(window_adapter.window());
+    Some(cache.content_widths(item_rc, || compute(&mut font_ctx)))
 }
 
 pub fn char_size(

--- a/internal/core/textlayout/sharedparley/cache.rs
+++ b/internal/core/textlayout/sharedparley/cache.rs
@@ -45,6 +45,10 @@ const ENTRY_LIMIT: usize = 1024;
 /// Cache for shaped text paragraphs (before line breaking), keyed by ItemRc.
 pub struct TextLayoutCache {
     inner: InnerTextLayoutCache,
+    /// Caches the result of [`super::text_content_widths`]. The widths are two scalars derived from
+    /// paragraphs that no other path can reuse, because they are shaped without
+    /// `OverflowWrap::Anywhere`, so the result is kept instead of the paragraphs.
+    content_widths: crate::item_rendering::ItemCache<crate::renderer::ContentWidths>,
     /// Bumped once per rendered frame; entries are stamped with it when served.
     generation: std::cell::Cell<u32>,
     /// Approximate entry count; a stale-high value just triggers one extra sweep.
@@ -55,6 +59,8 @@ pub struct TextLayoutCache {
     cache_miss_count: std::cell::Cell<u64>,
     #[cfg(feature = "testing")]
     layout_miss_count: std::cell::Cell<u64>,
+    #[cfg(feature = "testing")]
+    content_widths_miss_count: std::cell::Cell<u64>,
 }
 
 #[allow(clippy::derivable_impls)] // clippy doesn't see the feature = "testing" code
@@ -62,6 +68,7 @@ impl Default for TextLayoutCache {
     fn default() -> Self {
         Self {
             inner: Default::default(),
+            content_widths: Default::default(),
             generation: Default::default(),
             entry_count_estimate: Default::default(),
             sweep_threshold: std::cell::Cell::new(ENTRY_LIMIT),
@@ -69,6 +76,8 @@ impl Default for TextLayoutCache {
             cache_miss_count: std::cell::Cell::new(0),
             #[cfg(feature = "testing")]
             layout_miss_count: std::cell::Cell::new(0),
+            #[cfg(feature = "testing")]
+            content_widths_miss_count: std::cell::Cell::new(0),
         }
     }
 }
@@ -78,14 +87,34 @@ impl TextLayoutCache {
     /// pixels, so a new scale factor invalidates every entry at once. Called on the way into the
     /// cache rather than when rendering starts, because the layout pass that follows a scale
     /// factor change measures before anything renders.
-    fn clear_if_scale_factor_changed(&self, window: &crate::api::Window) {
+    pub(super) fn clear_if_scale_factor_changed(&self, window: &crate::api::Window) {
         self.inner.clear_cache_if_scale_factor_changed(window);
+        self.content_widths.clear_cache_if_scale_factor_changed(window);
     }
     pub fn component_destroyed(&self, component: crate::item_tree::ItemTreeRef) {
         self.inner.component_destroyed(component);
+        self.content_widths.component_destroyed(component);
     }
     pub fn clear_all(&self) {
         self.inner.clear_all();
+        self.content_widths.clear_all();
+    }
+
+    /// Returns the cached content widths of `item_rc`, computing them on a miss.
+    ///
+    /// The entry is invalidated by the properties `compute` reads, so it must read the
+    /// text, the font request and the line limit itself. The scale factor is handled by
+    /// [`Self::clear_if_scale_factor_changed`], which the caller runs first.
+    pub(super) fn content_widths(
+        &self,
+        item_rc: &crate::item_tree::ItemRc,
+        compute: impl FnOnce() -> crate::renderer::ContentWidths,
+    ) -> crate::renderer::ContentWidths {
+        self.content_widths.get_or_update_cache_entry(item_rc, || {
+            #[cfg(feature = "testing")]
+            self.content_widths_miss_count.set(self.content_widths_miss_count.get() + 1);
+            compute()
+        })
     }
 
     /// Marks the beginning of a frame; called once per rendered frame.
@@ -122,6 +151,14 @@ impl TextLayoutCache {
     }
     pub fn reset_layout_miss_count(&self) {
         self.layout_miss_count.set(0);
+    }
+    /// How many times the content widths of an item had to be shaped rather than served
+    /// from the cache.
+    pub fn content_widths_miss_count(&self) -> u64 {
+        self.content_widths_miss_count.get()
+    }
+    pub fn reset_content_widths_miss_count(&self) {
+        self.content_widths_miss_count.set(0);
     }
     pub(super) fn count_layout_miss(&self) {
         self.layout_miss_count.set(self.layout_miss_count.get() + 1);

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -882,7 +882,12 @@ impl RendererSealed for SoftwareRenderer {
 
         #[cfg(feature = "systemfonts")]
         if uses_parley(&font) {
-            return sharedparley::text_content_widths(self, text_item, item_rc);
+            return sharedparley::text_content_widths(
+                self,
+                text_item,
+                item_rc,
+                Some(&self.text_layout_cache),
+            );
         }
 
         let max_lines = text_item.line_limit();


### PR DESCRIPTION
`text_content_widths` is the one measurement path that doesn't consult the text layout cache.
It shapes the whole text, folds the paragraphs down to two scalars and throws them away, so a `Text { overflow: clip; wrap: word-wrap; }` re-shapes its content every time its horizontal layout info is pulled.

Wiring it to the existing cache doesn't work.
`content_widths_builder` shapes without `OverflowWrap::Anywhere`, deliberately: with it, parley breaks an overlong word instead of letting it set the minimum width.
Those paragraphs carry different break opportunities from the display ones, and `CachedParagraphs` holds one shaping configuration per item, so there is nowhere to put them.

So this caches the result rather than the paragraphs — two scalars against ~4.7KB per paragraph entry, and no change to the paragraph cache.

## Dependencies

The cache entry is invalidated by everything the widths derive from:

- the text, the font request and the line limit, which the closure reads inside `ItemCache`'s dependency tracker,
- the scale factor, which clears the cache as a whole before the lookup, exactly as `cached_paragraphs` does. Glyph advances are physical, so an entry kept across a scale change would be wrong.

The line limit is easy to miss: it doesn't feed `content_widths_builder`, but it feeds the fold that takes the first N paragraphs, so it belongs in the set.

The pre-reads of the font request and text stay ahead of the `font_context` borrow, for the reason `text_size` documents: those reads can trigger bindings that re-enter text measurement, and a second `borrow_mut()` would panic. They are clean afterwards, so the closure can read them again inside the tracker without re-entering.

Without a window adapter there is no way to notice a scale-factor change, so that case computes uncached rather than caching something it can't invalidate.

## Tests

Five, in `api/rs/slint/tests/text_content_widths_cache.rs`: repeated layout passes shape once, and text, font size, line limit and scale factor each invalidate.

They pull `t.min-width` through an exposed property, because rendering alone doesn't ask for the widths — a `Text` inside a `VerticalLayout` gets its horizontal layout info from the layout, not from the item.

The first test fails without the cache: bypassing it gives 2 misses where the test requires 1.

## Not covered

The `cache: None` path is implemented but untested — under `systemfonts` the software renderer always supplies its cache, so the harness can't reach it.

The profiling check is also outstanding: the miss counter proves the shaping is skipped, but I haven't confirmed the `harfrust` frames disappear from a profile of a scene with several dozen clipped word-wrapping texts.

## Relationship to #13254

Independent. This neither fixes the wrap-keying of `CachedParagraphs` nor depends on it, and it stays worthwhile if #13254 is later fixed by keying entries on the shaping configuration: caching two scalars beats caching and re-deriving the paragraphs they came from.

