### PR TITLE
WGPU: skip unused GL backends when creating a wgpu instance

### DIFF
--- a/internal/backends/selector/api.rs
+++ b/internal/backends/selector/api.rs
@@ -313,6 +313,7 @@ impl BackendSelector {
         if matches!(self.requested_graphics_api, Some(RequestedGraphicsAPI::WGPU30(_)))
             && !i_slint_core::graphics::wgpu_30::any_wgpu30_adapters_with_gpu(
                 self.requested_graphics_api.clone(),
+                i_slint_core::graphics::wgpu_30::default_backends_to_avoid(),
             )
         {
             return Err(
@@ -325,6 +326,7 @@ impl BackendSelector {
         if matches!(self.requested_graphics_api, Some(RequestedGraphicsAPI::WGPU29(_)))
             && !i_slint_core::graphics::wgpu_29::any_wgpu29_adapters_with_gpu(
                 self.requested_graphics_api.clone(),
+                i_slint_core::graphics::wgpu_29::default_backends_to_avoid(),
             )
         {
             return Err(

--- a/internal/backends/winit/renderer/femtovg.rs
+++ b/internal/backends/winit/renderer/femtovg.rs
@@ -169,6 +169,19 @@ impl GlutinFemtoVGRenderer {
 }
 
 #[cfg(feature = "renderer-femtovg-wgpu")]
+fn wgpu_backends_to_avoid() -> i_slint_core::graphics::wgpu_30::wgpu::Backends {
+    // On WASM keep GL so wgpu can fall through to WebGL when WebGPU is missing.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        i_slint_core::graphics::wgpu_30::default_backends_to_avoid()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        i_slint_core::graphics::wgpu_30::wgpu::Backends::empty()
+    }
+}
+
+#[cfg(feature = "renderer-femtovg-wgpu")]
 pub struct WGPUFemtoVGRenderer {
     renderer: FemtoVGRenderer<i_slint_renderer_femtovg::wgpu::WGPUBackend>,
     requested_graphics_api: Option<RequestedGraphicsAPI>,
@@ -181,6 +194,7 @@ impl WGPUFemtoVGRenderer {
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
         if !i_slint_core::graphics::wgpu_30::any_wgpu30_adapters_with_gpu(
             shared_backend_data.requested_graphics_api.clone(),
+            wgpu_backends_to_avoid(),
         ) {
             return Err(PlatformError::from("WGPU: No GPU adapters found"));
         }
@@ -237,21 +251,11 @@ impl WinitCompatibleRenderer for WGPUFemtoVGRenderer {
             i_slint_core::window::WindowInner::from_pub(window_adapter.window()).context().clone()
         };
 
-        // On native we want a real GPU adapter, not an ANGLE/GL one (the WGPU
-        // FemtoVG renderer is meant to use modern backends). On WASM we *want*
-        // the GL backend to be available, so wgpu's
-        // `new_instance_with_webgpu_detection` can fall through to WebGL when no
-        // WebGPU adapter is reachable (e.g. headless Chromium on CI).
-        #[cfg(not(target_arch = "wasm32"))]
-        let backends_to_avoid = i_slint_core::graphics::wgpu_30::wgpu::Backends::GL;
-        #[cfg(target_arch = "wasm32")]
-        let backends_to_avoid = i_slint_core::graphics::wgpu_30::wgpu::Backends::empty();
-
         i_slint_core::graphics::wgpu_30::init_instance_adapter_device_queue_surface_then(
             &context,
             window_handle,
             requested_graphics_api,
-            backends_to_avoid,
+            wgpu_backends_to_avoid(),
             move |instance, adapter, device, queue, surface| {
                 finalize_wgpu_init(
                     &window_adapter_weak,

--- a/internal/backends/winit/renderer/vello.rs
+++ b/internal/backends/winit/renderer/vello.rs
@@ -26,6 +26,7 @@ impl WinitVelloRenderer {
     ) -> Result<Box<dyn WinitCompatibleRenderer>, PlatformError> {
         if !i_slint_core::graphics::wgpu_29::any_wgpu29_adapters_with_gpu(
             shared_backend_data.requested_graphics_api.clone(),
+            i_slint_core::graphics::wgpu_29::default_backends_to_avoid(),
         ) {
             return Err(PlatformError::from("WGPU: No GPU adapters found"));
         }

--- a/internal/core/graphics/wgpu_29.rs
+++ b/internal/core/graphics/wgpu_29.rs
@@ -146,10 +146,41 @@ pub mod api {
 
 use super::RequestedGraphicsAPI;
 
-/// Internal helper function see if there are any GPU adapters for hardware accelerated rendering.
+/// Backends the WGPU renderers do not use on this platform.
+/// Subtracted at instance creation so unused driver stacks are not loaded.
+#[doc(hidden)]
+pub fn default_backends_to_avoid() -> wgpu::Backends {
+    let mut avoid = wgpu::Backends::GL;
+    #[cfg(not(target_vendor = "apple"))]
+    avoid.insert(wgpu::Backends::METAL);
+    #[cfg(not(target_family = "windows"))]
+    avoid.insert(wgpu::Backends::DX12);
+    avoid
+}
+
+/// Subtract `backends_to_avoid` from `requested`.
+/// If that would leave no backends, keep `requested`.
+/// That honors an explicit choice such as `WGPU_BACKEND=gl`.
+#[doc(hidden)]
+pub fn mask_backends(
+    requested: wgpu::Backends,
+    backends_to_avoid: wgpu::Backends,
+) -> wgpu::Backends {
+    let masked = requested & !backends_to_avoid;
+    if masked.is_empty() { requested } else { masked }
+}
+
+/// Internal helper to see if there are any GPU adapters for hardware accelerated rendering.
 /// This is used to determine if we should fall back to software rendering (instead of using WGPU
-/// software rendering, such as DX12's Warp adapter)
-pub fn any_wgpu29_adapters_with_gpu(requested_graphics_api: Option<RequestedGraphicsAPI>) -> bool {
+/// software rendering, such as DX12's Warp adapter).
+///
+/// `backends_to_avoid` is subtracted from the instance backends the same way as in
+/// [`init_instance_adapter_device_queue_surface`].
+/// The throwaway probe then does not load stacks the renderer will not use.
+pub fn any_wgpu29_adapters_with_gpu(
+    requested_graphics_api: Option<RequestedGraphicsAPI>,
+    backends_to_avoid: wgpu::Backends,
+) -> bool {
     // On WASM the wgpu init path uses
     // `wgpu::util::new_instance_with_webgpu_detection`, which probes
     // `navigator.gpu.requestAdapter()` asynchronously and falls through
@@ -170,18 +201,22 @@ pub fn any_wgpu29_adapters_with_gpu(requested_graphics_api: Option<RequestedGrap
             (instance, wgpu::Backends::all())
         }
         #[cfg(feature = "unstable-wgpu-29")]
-        Some(RequestedGraphicsAPI::WGPU29(api::WGPUConfiguration::Automatic(wgpu29_settings))) => (
-            wgpu::Instance::new(wgpu::InstanceDescriptor {
-                backends: wgpu29_settings.backends,
-                flags: wgpu29_settings.instance_flags,
-                backend_options: wgpu29_settings.backend_options,
-                memory_budget_thresholds: wgpu29_settings.instance_memory_budget_thresholds,
-                display: None,
-            }),
-            wgpu29_settings.backends,
-        ),
+        Some(RequestedGraphicsAPI::WGPU29(api::WGPUConfiguration::Automatic(wgpu29_settings))) => {
+            let backends = mask_backends(wgpu29_settings.backends, backends_to_avoid);
+            (
+                wgpu::Instance::new(wgpu::InstanceDescriptor {
+                    backends,
+                    flags: wgpu29_settings.instance_flags,
+                    backend_options: wgpu29_settings.backend_options,
+                    memory_budget_thresholds: wgpu29_settings.instance_memory_budget_thresholds,
+                    display: None,
+                }),
+                backends,
+            )
+        }
         None => {
-            let backends = wgpu::Backends::from_env().unwrap_or_default();
+            let backends =
+                mask_backends(wgpu::Backends::from_env().unwrap_or_default(), backends_to_avoid);
 
             (
                 wgpu::Instance::new(wgpu::InstanceDescriptor {
@@ -196,6 +231,9 @@ pub fn any_wgpu29_adapters_with_gpu(requested_graphics_api: Option<RequestedGrap
         }
         Some(_) => return false,
     };
+    if backends.is_empty() {
+        return false;
+    }
     poll_once(instance.enumerate_adapters(backends))
         .unwrap()
         .into_iter()
@@ -295,7 +333,7 @@ pub async fn async_init_instance_adapter_device_queue_surface(
         Some(RequestedGraphicsAPI::WGPU29(api::WGPUConfiguration::Automatic(wgpu29_settings))) => {
             let instance =
                 wgpu::util::new_instance_with_webgpu_detection(wgpu::InstanceDescriptor {
-                    backends: wgpu29_settings.backends & !backends_to_avoid,
+                    backends: mask_backends(wgpu29_settings.backends, backends_to_avoid),
                     flags: wgpu29_settings.instance_flags,
                     backend_options: wgpu29_settings.backend_options.clone(),
                     memory_budget_thresholds: wgpu29_settings.instance_memory_budget_thresholds,
@@ -344,7 +382,11 @@ pub async fn async_init_instance_adapter_device_queue_surface(
                 Some(RequestedGraphicsAPI::Direct3D) => wgpu::Backends::DX12,
                 _ => wgpu::Backends::from_env().unwrap_or_default(),
             };
-            let backends = requested_backends & !backends_to_avoid;
+            let backends = if maybe_native_api.is_none() {
+                mask_backends(requested_backends, backends_to_avoid)
+            } else {
+                requested_backends & !backends_to_avoid
+            };
             if backends.is_empty() {
                 return Err(alloc::format!(
                     "The requested graphics API ({maybe_native_api:?}) is not supported under wgpu on this platform"
@@ -480,5 +522,25 @@ fn poll_once<F: std::future::Future>(future: F) -> Option<F::Output> {
     match future.poll(&mut ctx) {
         std::task::Poll::Ready(result) => Some(result),
         std::task::Poll::Pending => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_backends_keeps_explicit_choice_when_empty() {
+        let avoid = wgpu::Backends::GL | wgpu::Backends::METAL | wgpu::Backends::DX12;
+        assert_eq!(mask_backends(wgpu::Backends::GL, avoid), wgpu::Backends::GL);
+        assert!(mask_backends(wgpu::Backends::all(), avoid).contains(wgpu::Backends::VULKAN));
+        assert!(!mask_backends(wgpu::Backends::all(), avoid).contains(wgpu::Backends::GL));
+        assert_eq!(mask_backends(wgpu::Backends::empty(), avoid), wgpu::Backends::empty());
+        assert_eq!(mask_backends(wgpu::Backends::VULKAN, avoid), wgpu::Backends::VULKAN);
+    }
+
+    #[test]
+    fn default_avoid_includes_gl() {
+        assert!(default_backends_to_avoid().contains(wgpu::Backends::GL));
     }
 }

--- a/internal/core/graphics/wgpu_30.rs
+++ b/internal/core/graphics/wgpu_30.rs
@@ -146,10 +146,41 @@ pub mod api {
 
 use super::RequestedGraphicsAPI;
 
-/// Internal helper function see if there are any GPU adapters for hardware accelerated rendering.
+/// Backends the WGPU renderers do not use on this platform.
+/// Subtracted at instance creation so unused driver stacks are not loaded.
+#[doc(hidden)]
+pub fn default_backends_to_avoid() -> wgpu::Backends {
+    let mut avoid = wgpu::Backends::GL;
+    #[cfg(not(target_vendor = "apple"))]
+    avoid.insert(wgpu::Backends::METAL);
+    #[cfg(not(target_family = "windows"))]
+    avoid.insert(wgpu::Backends::DX12);
+    avoid
+}
+
+/// Subtract `backends_to_avoid` from `requested`.
+/// If that would leave no backends, keep `requested`.
+/// That honors an explicit choice such as `WGPU_BACKEND=gl`.
+#[doc(hidden)]
+pub fn mask_backends(
+    requested: wgpu::Backends,
+    backends_to_avoid: wgpu::Backends,
+) -> wgpu::Backends {
+    let masked = requested & !backends_to_avoid;
+    if masked.is_empty() { requested } else { masked }
+}
+
+/// Internal helper to see if there are any GPU adapters for hardware accelerated rendering.
 /// This is used to determine if we should fall back to software rendering (instead of using WGPU
-/// software rendering, such as DX12's Warp adapter)
-pub fn any_wgpu30_adapters_with_gpu(requested_graphics_api: Option<RequestedGraphicsAPI>) -> bool {
+/// software rendering, such as DX12's Warp adapter).
+///
+/// `backends_to_avoid` is subtracted from the instance backends the same way as in
+/// [`init_instance_adapter_device_queue_surface`].
+/// The throwaway probe then does not load stacks the renderer will not use.
+pub fn any_wgpu30_adapters_with_gpu(
+    requested_graphics_api: Option<RequestedGraphicsAPI>,
+    backends_to_avoid: wgpu::Backends,
+) -> bool {
     // On WASM the wgpu init path uses
     // `wgpu::util::new_instance_with_webgpu_detection`, which probes
     // `navigator.gpu.requestAdapter()` asynchronously and falls through
@@ -170,18 +201,22 @@ pub fn any_wgpu30_adapters_with_gpu(requested_graphics_api: Option<RequestedGrap
             (instance, wgpu::Backends::all())
         }
         #[cfg(feature = "unstable-wgpu-30")]
-        Some(RequestedGraphicsAPI::WGPU30(api::WGPUConfiguration::Automatic(wgpu30_settings))) => (
-            wgpu::Instance::new(wgpu::InstanceDescriptor {
-                backends: wgpu30_settings.backends,
-                flags: wgpu30_settings.instance_flags,
-                backend_options: wgpu30_settings.backend_options,
-                memory_budget_thresholds: wgpu30_settings.instance_memory_budget_thresholds,
-                display: None,
-            }),
-            wgpu30_settings.backends,
-        ),
+        Some(RequestedGraphicsAPI::WGPU30(api::WGPUConfiguration::Automatic(wgpu30_settings))) => {
+            let backends = mask_backends(wgpu30_settings.backends, backends_to_avoid);
+            (
+                wgpu::Instance::new(wgpu::InstanceDescriptor {
+                    backends,
+                    flags: wgpu30_settings.instance_flags,
+                    backend_options: wgpu30_settings.backend_options,
+                    memory_budget_thresholds: wgpu30_settings.instance_memory_budget_thresholds,
+                    display: None,
+                }),
+                backends,
+            )
+        }
         None => {
-            let backends = wgpu::Backends::from_env().unwrap_or_default();
+            let backends =
+                mask_backends(wgpu::Backends::from_env().unwrap_or_default(), backends_to_avoid);
 
             (
                 wgpu::Instance::new(wgpu::InstanceDescriptor {
@@ -196,6 +231,9 @@ pub fn any_wgpu30_adapters_with_gpu(requested_graphics_api: Option<RequestedGrap
         }
         Some(_) => return false,
     };
+    if backends.is_empty() {
+        return false;
+    }
     poll_once(instance.enumerate_adapters(backends))
         .unwrap()
         .into_iter()
@@ -295,7 +333,7 @@ pub async fn async_init_instance_adapter_device_queue_surface(
         Some(RequestedGraphicsAPI::WGPU30(api::WGPUConfiguration::Automatic(wgpu30_settings))) => {
             let instance =
                 wgpu::util::new_instance_with_webgpu_detection(wgpu::InstanceDescriptor {
-                    backends: wgpu30_settings.backends & !backends_to_avoid,
+                    backends: mask_backends(wgpu30_settings.backends, backends_to_avoid),
                     flags: wgpu30_settings.instance_flags,
                     backend_options: wgpu30_settings.backend_options.clone(),
                     memory_budget_thresholds: wgpu30_settings.instance_memory_budget_thresholds,
@@ -345,7 +383,11 @@ pub async fn async_init_instance_adapter_device_queue_surface(
                 Some(RequestedGraphicsAPI::Direct3D) => wgpu::Backends::DX12,
                 _ => wgpu::Backends::from_env().unwrap_or_default(),
             };
-            let backends = requested_backends & !backends_to_avoid;
+            let backends = if maybe_native_api.is_none() {
+                mask_backends(requested_backends, backends_to_avoid)
+            } else {
+                requested_backends & !backends_to_avoid
+            };
             if backends.is_empty() {
                 return Err(alloc::format!(
                     "The requested graphics API ({maybe_native_api:?}) is not supported under wgpu on this platform"
@@ -481,5 +523,25 @@ fn poll_once<F: std::future::Future>(future: F) -> Option<F::Output> {
     match future.poll(&mut ctx) {
         std::task::Poll::Ready(result) => Some(result),
         std::task::Poll::Pending => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_backends_keeps_explicit_choice_when_empty() {
+        let avoid = wgpu::Backends::GL | wgpu::Backends::METAL | wgpu::Backends::DX12;
+        assert_eq!(mask_backends(wgpu::Backends::GL, avoid), wgpu::Backends::GL);
+        assert!(mask_backends(wgpu::Backends::all(), avoid).contains(wgpu::Backends::VULKAN));
+        assert!(!mask_backends(wgpu::Backends::all(), avoid).contains(wgpu::Backends::GL));
+        assert_eq!(mask_backends(wgpu::Backends::empty(), avoid), wgpu::Backends::empty());
+        assert_eq!(mask_backends(wgpu::Backends::VULKAN, avoid), wgpu::Backends::VULKAN);
+    }
+
+    #[test]
+    fn default_avoid_includes_gl() {
+        assert!(default_backends_to_avoid().contains(wgpu::Backends::GL));
     }
 }

--- a/internal/renderers/anyrender/vello.rs
+++ b/internal/renderers/anyrender/vello.rs
@@ -159,7 +159,7 @@ impl VelloWindowRenderer {
             i_slint_core::graphics::wgpu_29::init_instance_adapter_device_queue_surface(
                 surface_target,
                 self.requested_graphics_api.clone(),
-                wgpu::Backends::empty(),
+                i_slint_core::graphics::wgpu_29::default_backends_to_avoid(),
             )
             .map_err(|e| format!("Error initializing WGPU for vello rendering: {e}"))?;
 

--- a/internal/renderers/skia/wgpu_29_surface.rs
+++ b/internal/renderers/skia/wgpu_29_surface.rs
@@ -51,15 +51,6 @@ pub struct WGPUSurface {
     alpha_modes: Vec<wgpu::CompositeAlphaMode>,
 }
 
-fn backends_to_avoid() -> wgpu::Backends {
-    let mut avoid = wgpu::Backends::GL; /* we're not mapping that to skia because we can't save/restore state */
-    #[cfg(not(target_vendor = "apple"))]
-    avoid.insert(wgpu::Backends::METAL);
-    #[cfg(not(target_family = "windows"))]
-    avoid.insert(wgpu::Backends::DX12);
-    avoid
-}
-
 impl WGPUSurface {
     pub fn new_with_surface(
         surface_target: impl Into<i_slint_core::graphics::wgpu_29::SurfaceTarget>,
@@ -70,7 +61,7 @@ impl WGPUSurface {
             i_slint_core::graphics::wgpu_29::init_instance_adapter_device_queue_surface(
                 surface_target,
                 requested_graphics_api,
-                backends_to_avoid(),
+                i_slint_core::graphics::wgpu_29::default_backends_to_avoid(),
             )?;
         Self::init_with_parts(
             Rc::new(SharedWgpuState { instance, adapter, device, queue }),
@@ -304,7 +295,7 @@ impl crate::Surface for WGPUSurface {
             i_slint_core::graphics::wgpu_29::init_instance_adapter_device_queue_surface(
                 make_target(),
                 requested_graphics_api,
-                backends_to_avoid(),
+                i_slint_core::graphics::wgpu_29::default_backends_to_avoid(),
             )?;
         let wgpu = Rc::new(SharedWgpuState { instance, adapter, device, queue });
         let new_surface = Self::init_with_parts(wgpu.clone(), surface, size)?;

--- a/internal/renderers/skia/wgpu_30_surface.rs
+++ b/internal/renderers/skia/wgpu_30_surface.rs
@@ -51,15 +51,6 @@ pub struct WGPUSurface {
     alpha_modes: Vec<wgpu::CompositeAlphaMode>,
 }
 
-fn backends_to_avoid() -> wgpu::Backends {
-    let mut avoid = wgpu::Backends::GL; /* we're not mapping that to skia because we can't save/restore state */
-    #[cfg(not(target_vendor = "apple"))]
-    avoid.insert(wgpu::Backends::METAL);
-    #[cfg(not(target_family = "windows"))]
-    avoid.insert(wgpu::Backends::DX12);
-    avoid
-}
-
 impl WGPUSurface {
     pub fn new_with_surface(
         surface_target: impl Into<i_slint_core::graphics::wgpu_30::SurfaceTarget>,
@@ -70,7 +61,7 @@ impl WGPUSurface {
             i_slint_core::graphics::wgpu_30::init_instance_adapter_device_queue_surface(
                 surface_target,
                 requested_graphics_api,
-                backends_to_avoid(),
+                i_slint_core::graphics::wgpu_30::default_backends_to_avoid(),
             )?;
         Self::init_with_parts(
             Rc::new(SharedWgpuState { instance, adapter, device, queue }),
@@ -304,7 +295,7 @@ impl crate::Surface for WGPUSurface {
             i_slint_core::graphics::wgpu_30::init_instance_adapter_device_queue_surface(
                 make_target(),
                 requested_graphics_api,
-                backends_to_avoid(),
+                i_slint_core::graphics::wgpu_30::default_backends_to_avoid(),
             )?;
         let wgpu = Rc::new(SharedWgpuState { instance, adapter, device, queue });
         let new_surface = Self::init_with_parts(wgpu.clone(), surface, size)?;


### PR DESCRIPTION
#13260 wgpu's default instance backends are `Backends::all()`. On Linux that maps the Mesa GLES stack even when the session is Vulkan-only. The GPU probe used the same defaults, so a throwaway instance paid the cost before the window existed. 

This centralises the "backends to avoid" logic (GL, plus Metal/DX12 on platforms that don't use them) so the unused Mesa GLES stack is not loaded and also honors an explicit `WGPU_BACKEND` choice if masking out the avoided backends would leave none, the requested set is kept as-is.

On `Fedora 44 / Mesa 26.1.8` the unused GL stack cost about `8.5 MB RSS` and a blocking probe on the order of `80–100 ms`.

ChangeLog: WGPU - skip unused GL backends when creating a wgpu instance

- [x] I license this and all my future contributions to Slint under the [MIT-0 license](https://opensource.org/license/mit-0). They are my own work, and no third party (such as my employer) holds rights to them.
