### PR TITLE
partial renderer: repaint only the region of destroyed items

### DIFF
--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -330,7 +330,10 @@ fn if_condition() {
             in property <bool> c : true;
             background: black;
             // Static siblings before and after the conditional: toggling the condition
-            // must not repaint them.
+            // must not repaint the one before. The one after currently repaints when the
+            // condition turns false: the disappearance shifts its rank among the visited
+            // siblings, which is indistinguishable from a z-order change (see the
+            // `sibling_index` comment in `CachedItemBoundingBoxAndTransform`).
             Rectangle { x: 5px; y: 5px; width: 8px; height: 8px; background: green; }
             if c: Rectangle {
                 x: 45px;
@@ -354,8 +357,8 @@ fn if_condition() {
     assert!(!window.draw_if_needed(|_| { unreachable!() }));
     ui.set_c(false);
     assert!(window.draw_if_needed(|renderer| {
-        // Currently we redraw when a condition becomes false because we don't track the position otherwise
-        do_test_render_region(renderer, 0, 0, 180, 260);
+        // The vanished conditional plus the sibling after it (see the comment above).
+        do_test_render_region(renderer, 45, 45, 100 + 20, 200 + 20);
     }));
     assert!(!window.draw_if_needed(|_| { unreachable!() }));
     ui.set_c(true);
@@ -422,14 +425,14 @@ fn list_view() {
     assert!(!window.draw_if_needed(|_| { unreachable!() }));
     model.set_vec(vec![0, 0]);
     assert!(window.draw_if_needed(|renderer| {
-        // Currently, when ItemTree are removed, we redraw the whole window.
-        do_test_render_region(renderer, 0, 0, 300, 300);
+        // The model reset drops and recreates both rows.
+        do_test_render_region(renderer, LV_X, LV_Y, LV_X + 25, LV_Y + 20);
     }));
     assert!(!window.draw_if_needed(|_| { unreachable!() }));
     model.remove(1);
     assert!(window.draw_if_needed(|renderer| {
-        // Currently, when ItemTree are removed, we redraw the whole window.
-        do_test_render_region(renderer, 0, 0, 300, 300);
+        // Only the region of the removed row repaints.
+        do_test_render_region(renderer, LV_X, LV_Y + 10, LV_X + 25, LV_Y + 20);
     }));
     assert!(!window.draw_if_needed(|_| { unreachable!() }));
 }

--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -435,6 +435,17 @@ fn list_view() {
         do_test_render_region(renderer, LV_X, LV_Y + 10, LV_X + 25, LV_Y + 20);
     }));
     assert!(!window.draw_if_needed(|_| { unreachable!() }));
+    model.set_vec(vec![1, 0]);
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, LV_X, LV_Y, LV_X + 25, LV_Y + 20);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+    model.remove(0);
+    assert!(window.draw_if_needed(|renderer| {
+        // Removing a leading row repaints the following rows too: they move up.
+        do_test_render_region(renderer, LV_X, LV_Y, LV_X + 25, LV_Y + 20);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
 }
 
 #[test]
@@ -1808,7 +1819,11 @@ fn destroy_never_rendered_item() {
             in property <bool> c : false;
             background: black;
             Rectangle { x: 5px; y: 5px; width: 8px; height: 8px; background: green; }
-            if c: Rectangle { x: 45px; y: 45px; width: 32px; height: 3px; background: pink; }
+            out property <int> instantiated;
+            if c: Rectangle {
+                x: 45px; y: 45px; width: 32px; height: 3px; background: pink;
+                init => { root.instantiated += 1; }
+            }
         }
     }
 
@@ -1828,13 +1843,9 @@ fn destroy_never_rendered_item() {
     window.dispatch_event(slint::platform::WindowEvent::PointerMoved {
         position: slint::LogicalPosition::new(90., 90.),
     });
+    assert_eq!(ui.get_instantiated(), 1);
     ui.set_c(false);
 
     // The instance is destroyed without ever having been rendered: nothing repaints.
-    assert!(window.draw_if_needed(|renderer| {
-        let mut buffer = vec![TestPixel(false); 500 * 500];
-        let r = renderer.render(buffer.as_mut_slice(), 500);
-        assert_eq!(r.bounding_box_size(), PhysicalSize::default());
-        assert!(buffer.iter().all(|p| !p.0), "something was rendered");
-    }));
+    do_test_no_repaint(&window);
 }

--- a/api/rs/slint/tests/partial_renderer.rs
+++ b/api/rs/slint/tests/partial_renderer.rs
@@ -1800,3 +1800,41 @@ fn partial_rendering_popup_position_size_change() {
         }
     }
 }
+
+#[test]
+fn destroy_never_rendered_item() {
+    slint::slint! {
+        export component Ui inherits Window {
+            in property <bool> c : false;
+            background: black;
+            Rectangle { x: 5px; y: 5px; width: 8px; height: 8px; background: green; }
+            if c: Rectangle { x: 45px; y: 45px; width: 32px; height: 3px; background: pink; }
+        }
+    }
+
+    slint::platform::set_platform(Box::new(TestPlatform)).ok();
+    let ui = Ui::new().unwrap();
+    let window = WINDOW.with(|x| x.clone());
+    window.set_size(slint::PhysicalSize::new(180, 260));
+    ui.show().unwrap();
+    assert!(window.draw_if_needed(|renderer| {
+        do_test_render_region(renderer, 0, 0, 180, 260);
+    }));
+    assert!(!window.draw_if_needed(|_| { unreachable!() }));
+
+    // Materialize the conditional between two frames without rendering it: the pointer
+    // event's hit-testing instantiates the repeater's instance.
+    ui.set_c(true);
+    window.dispatch_event(slint::platform::WindowEvent::PointerMoved {
+        position: slint::LogicalPosition::new(90., 90.),
+    });
+    ui.set_c(false);
+
+    // The instance is destroyed without ever having been rendered: nothing repaints.
+    assert!(window.draw_if_needed(|renderer| {
+        let mut buffer = vec![TestPixel(false); 500 * 500];
+        let r = renderer.render(buffer.as_mut_slice(), 500);
+        assert_eq!(r.bounding_box_size(), PhysicalSize::default());
+        assert!(buffer.iter().all(|p| !p.0), "something was rendered");
+    }));
+}

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -510,7 +510,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                     my_sibling_index,
                 );
 
-                // The region the item covers on screen. It is unioned into the owning
+                // The region the item covers on screen. It is merged into the owning
                 // tree's entry in `tree_screen_rects` so that destroying the tree can
                 // repaint that region (see `PartialRenderingState::free_graphics_resources`),
                 // and it doubles as the item's current-position dirty rect in the branches

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -972,8 +972,6 @@ impl PartialRenderingState {
             self.force_dirty.borrow_mut().add_rect(rect);
         }
 
-        // An item without a cache entry was never visited by the dirty-region pass, and
-        // therefore never rendered: there is nothing on screen to erase for it.
         for item in items {
             item.cached_rendering_data_offset().release(&mut cache);
         }

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -205,11 +205,16 @@ struct PartialRenderingCachedData {
 struct PartialRendererCache {
     slab: slab::Slab<PartialRenderingCachedData>,
     generation: usize,
+    /// True when an item may be on screen without a cache entry that records its region:
+    /// an item was rendered without an entry since the last dirty-region pass
+    /// (see [`PartialRenderer::do_rendering`]), or the cache was cleared.
+    /// While set, releasing an item without an entry must fall back to a full refresh.
+    rendered_without_entry: bool,
 }
 
 impl Default for PartialRendererCache {
     fn default() -> Self {
-        Self { slab: Default::default(), generation: 1 }
+        Self { slab: Default::default(), generation: 1, rendered_without_entry: false }
     }
 }
 
@@ -240,6 +245,8 @@ impl PartialRendererCache {
     pub fn clear(&mut self) {
         self.slab.clear();
         self.generation += 1;
+        // Items rendered before the clear are still on screen, but their entries are gone.
+        self.rendered_without_entry = true;
     }
 }
 
@@ -702,6 +709,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
             // This item was created between the computation of the dirty region and the actual rendering.
             // Register a dependency to the geometry since this wasn't done before
             item_rc.geometry();
+            cache.rendered_without_entry = true;
             render_fn();
         }
     }
@@ -905,6 +913,11 @@ impl PartialRenderingState {
 
         let screen_region = LogicalRect::from_size(logical_window_size);
 
+        // Every item now on screen was visited by the dirty-region passes above and has a
+        // cache entry, so from here on a released item without one was never rendered
+        // (until `PartialRenderer::do_rendering` renders another entry-less item).
+        self.partial_cache.borrow_mut().rendered_without_entry = false;
+
         // Items destroyed during `compute_dirty_regions` (a repeater update drops its
         // instances during the traversal) land in `force_dirty` after
         // `create_partial_renderer` already collected it, so collect it again.
@@ -943,11 +956,13 @@ impl PartialRenderingState {
                     force_dirty.add_rect(entry.screen_rect);
                 }
                 None => {
-                    // Without a cache entry the item's screen region is unknown, but the item may
-                    // still be on screen: an item created after the dirty-region pass of a frame
-                    // is rendered without an entry (see `PartialRenderer::do_rendering`).
-                    // As a last resort, refresh everything.
-                    self.force_screen_refresh.set(true);
+                    // Without a cache entry the item was never visited by the dirty-region pass.
+                    // Unless an item was rendered without an entry since then
+                    // (see `PartialRendererCache::rendered_without_entry`), it was never
+                    // rendered either, so there is nothing on screen to erase.
+                    if cache.rendered_without_entry {
+                        self.force_screen_refresh.set(true);
+                    }
                 }
             }
         }
@@ -962,6 +977,19 @@ impl PartialRenderingState {
     pub fn force_screen_refresh(&self) {
         self.force_screen_refresh.set(true);
     }
+}
+
+#[test]
+fn dirty_region_ignores_empty_rects() {
+    // A released item that was never visible stores an empty `screen_rect`;
+    // adding it must not drag the region towards the empty rect's origin.
+    let mut region = DirtyRegion::default();
+    region.add_rect(LogicalRect::default());
+    assert_eq!(region.iter().count(), 0);
+    let real = LogicalRect::new(LogicalPoint::new(10., 10.), LogicalSize::new(16., 16.));
+    region.add_rect(real);
+    region.add_rect(LogicalRect::default());
+    assert_eq!(region.bounding_rect(), real);
 }
 
 #[test]

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -52,14 +52,11 @@ impl CachedRenderingData {
     /// This function can be used to remove an entry from the rendering cache for a given item, if it
     /// exists, i.e. if any data was ever cached. This is typically called by the graphics backend's
     /// implementation of the release_item_graphics_cache function.
-    fn release(
-        &self,
-        cache: &mut PartialRendererCache,
-    ) -> Option<CachedItemBoundingBoxAndTransform> {
+    fn release(&self, cache: &mut PartialRendererCache) -> Option<PartialRenderingCachedData> {
         if self.cache_generation.get() == cache.generation() {
             let index = self.cache_index.get();
             self.cache_generation.set(0);
-            Some(cache.remove(index).data)
+            Some(cache.remove(index))
         } else {
             None
         }
@@ -197,11 +194,11 @@ struct PartialRenderingCachedData {
     pub data: CachedItemBoundingBoxAndTransform,
     /// The property tracker that should be used to evaluate whether the item needs to be re-rendered
     pub tracker: Option<core::pin::Pin<Box<PropertyTracker>>>,
-}
-impl PartialRenderingCachedData {
-    fn new(data: CachedItemBoundingBoxAndTransform) -> Self {
-        Self { data, tracker: None }
-    }
+    /// The clipped screen-space region the item covered when it was last visited by
+    /// [`PartialRenderer::compute_dirty_regions`]. When the item is destroyed, this is
+    /// the region that needs to be repainted
+    /// (see [`PartialRenderingState::free_graphics_resources`]).
+    pub screen_rect: LogicalRect,
 }
 
 /// The cache that needs to be held by the Window for the partial rendering
@@ -386,6 +383,25 @@ pub enum RepaintBufferType {
     SwappedBuffers,
 }
 
+/// Map `rect` (relative to its parent) to screen space through `transform` and clip it
+/// to `clip_rect`. Returns `None` when nothing of the rectangle is visible.
+fn clipped_screen_rect(
+    rect: &LogicalRect,
+    transform: &ItemTransform,
+    clip_rect: &LogicalRect,
+) -> Option<LogicalRect> {
+    #[cfg(not(slint_int_coord))]
+    if !rect.origin.is_finite() {
+        // Account for NaN
+        return None;
+    }
+
+    if rect.is_empty() {
+        return None;
+    }
+    transform.outer_transformed_rect(&rect.cast()).cast().intersection(clip_rect)
+}
+
 /// Put this structure in the renderer to help with partial rendering
 ///
 /// This is constructed from a [`PartialRenderingState`]
@@ -477,10 +493,26 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                     my_sibling_index,
                 );
 
+                // The region the item covers on screen. It is stored in the cache entry so
+                // that destroying the item can repaint exactly that region
+                // (see `PartialRenderingState::free_graphics_resources`), and it doubles as
+                // the item's current-position dirty rect in the branches below.
+                let new_screen_rect = clipped_screen_rect(
+                    new_geom.bounding_rect(),
+                    &state.transform_to_screen,
+                    &state.clipped,
+                )
+                .unwrap_or_default();
+
                 let rendering_data = item.cached_rendering_data_offset();
                 let mut cache = self.cache.borrow_mut();
                 match rendering_data.get_entry(&mut cache) {
-                    Some(PartialRenderingCachedData { data: cached_geom, tracker }) => {
+                    Some(PartialRenderingCachedData {
+                        data: cached_geom,
+                        tracker,
+                        screen_rect,
+                    }) => {
+                        *screen_rect = new_screen_rect;
                         let rendering_dirty = tracker.as_ref().is_some_and(|tr| tr.is_dirty());
 
                         // Repaint when the rank among the previously known siblings changed,
@@ -523,11 +555,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                                 state.old_transform_to_screen,
                                 &state.clipped,
                             );
-                            self.mark_dirty_rect(
-                                new_geom.bounding_rect(),
-                                state.transform_to_screen,
-                                &state.clipped,
-                            );
+                            self.dirty_region.add_rect(new_screen_rect);
 
                             new_state
                                 .adjust_transforms_for_child(&new_geom.transform(), &old_transform);
@@ -547,11 +575,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                             || new_state.transform_to_screen != new_state.old_transform_to_screen;
 
                         if rendering_dirty {
-                            self.mark_dirty_rect(
-                                cached_geom.bounding_rect(),
-                                state.transform_to_screen,
-                                &state.clipped,
-                            );
+                            self.dirty_region.add_rect(new_screen_rect);
                             if moved {
                                 self.mark_dirty_rect(
                                     cached_geom.bounding_rect(),
@@ -568,11 +592,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                                     state.old_transform_to_screen,
                                     &state.clipped,
                                 );
-                                self.mark_dirty_rect(
-                                    cached_geom.bounding_rect(),
-                                    state.transform_to_screen,
-                                    &state.clipped,
-                                );
+                                self.dirty_region.add_rect(new_screen_rect);
                             } else if let Some(tr) = &tracker {
                                 tr.as_ref().register_as_dependency_to_current_binding();
                             }
@@ -604,7 +624,11 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                         }
                     }
                     None => {
-                        let cache_entry = PartialRenderingCachedData::new(new_geom.clone());
+                        let cache_entry = PartialRenderingCachedData {
+                            data: new_geom.clone(),
+                            tracker: None,
+                            screen_rect: new_screen_rect,
+                        };
                         rendering_data.cache_index.set(cache.insert(cache_entry));
                         rendering_data.cache_generation.set(cache.generation());
 
@@ -627,11 +651,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                                 .unwrap_or_default();
                         }
 
-                        self.mark_dirty_rect(
-                            new_geom.bounding_rect(),
-                            state.transform_to_screen,
-                            &state.clipped,
-                        );
+                        self.dirty_region.add_rect(new_screen_rect);
                         if new_state.clipped.is_empty() {
                             ItemVisitorResult::SkipChildren
                         } else {
@@ -660,16 +680,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
         transform: ItemTransform,
         clip_rect: &LogicalRect,
     ) {
-        #[cfg(not(slint_int_coord))]
-        if !rect.origin.is_finite() {
-            // Account for NaN
-            return;
-        }
-
-        if !rect.is_empty()
-            && let Some(rect) =
-                transform.outer_transformed_rect(&rect.cast()).cast().intersection(clip_rect)
-        {
+        if let Some(rect) = clipped_screen_rect(rect, &transform, clip_rect) {
             self.dirty_region.add_rect(rect);
         }
     }
@@ -894,6 +905,12 @@ impl PartialRenderingState {
 
         let screen_region = LogicalRect::from_size(logical_window_size);
 
+        // Items destroyed during `compute_dirty_regions` (a repeater update drops its
+        // instances during the traversal) land in `force_dirty` after
+        // `create_partial_renderer` already collected it, so collect it again.
+        partial_renderer.dirty_region =
+            partial_renderer.dirty_region.union(&self.force_dirty.take());
+
         if self.force_screen_refresh.take() {
             partial_renderer.dirty_region = screen_region.into();
         }
@@ -915,15 +932,25 @@ impl PartialRenderingState {
     }
 
     /// Call this from your renderer's `free_graphics_resources` function to ensure that the cached item geometries
-    /// are cleared for the destroyed items in the item tree.
+    /// are cleared for the destroyed items in the item tree, and that the screen regions the items
+    /// covered are repainted in the next frame.
     pub fn free_graphics_resources(&self, items: &mut dyn Iterator<Item = Pin<ItemRef<'_>>>) {
+        let mut cache = self.partial_cache.borrow_mut();
+        let mut force_dirty = self.force_dirty.borrow_mut();
         for item in items {
-            item.cached_rendering_data_offset().release(&mut self.partial_cache.borrow_mut());
+            match item.cached_rendering_data_offset().release(&mut cache) {
+                Some(entry) => {
+                    force_dirty.add_rect(entry.screen_rect);
+                }
+                None => {
+                    // Without a cache entry the item's screen region is unknown, but the item may
+                    // still be on screen: an item created after the dirty-region pass of a frame
+                    // is rendered without an entry (see `PartialRenderer::do_rendering`).
+                    // As a last resort, refresh everything.
+                    self.force_screen_refresh.set(true);
+                }
+            }
         }
-
-        // We don't have a way to determine the screen region of the delete items, what's in the cache is relative. So
-        // as a last resort, refresh everything.
-        self.force_screen_refresh.set(true)
     }
 
     /// Clears the partial rendering cache. Use this for example when the entire underlying window surface changes.

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -409,7 +409,16 @@ fn clipped_screen_rect(
     if rect.is_empty() {
         return None;
     }
-    transform.outer_transformed_rect(&rect.cast()).cast().intersection(clip_rect)
+    let rect = rect.cast();
+    // Fast path for the common case of a pure translation, so that the per-item,
+    // per-frame calls of `compute_dirty_regions` skip the four-corner transform.
+    let transformed =
+        if (transform.m11, transform.m12, transform.m21, transform.m22) == (1., 0., 0., 1.) {
+            rect.translate(euclid::vec2(transform.m31, transform.m32))
+        } else {
+            transform.outer_transformed_rect(&rect)
+        };
+    transformed.cast().intersection(clip_rect)
 }
 
 /// Put this structure in the renderer to help with partial rendering
@@ -520,16 +529,15 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
 
                 let tree_key = vtable::VRef::as_ptr(crate::item_tree::ItemTreeRc::borrow(component))
                     .as_ptr() as usize;
-                if index == 0 {
+                if index == 0
+                    && let Some(acc) = cache.tree_screen_rects.get_mut(&tree_key)
+                {
                     // Entering the tree: rebuild its screen region from this pass's visits.
-                    cache.tree_screen_rects.remove(&tree_key);
+                    *acc = LogicalRect::default();
                 }
                 if !new_screen_rect.is_empty() {
                     let acc = cache.tree_screen_rects.entry(tree_key).or_default();
-                    // Not `Rect::union`, which would extend an empty accumulator's rect
-                    // towards the origin.
-                    *acc =
-                        if acc.is_empty() { new_screen_rect } else { acc.union(&new_screen_rect) };
+                    *acc = acc.union(&new_screen_rect);
                 }
 
                 match rendering_data.get_entry(&mut cache) {
@@ -900,7 +908,7 @@ impl PartialRenderingState {
         &self,
         renderer: T,
     ) -> PartialRenderer<'_, T> {
-        PartialRenderer::new(&self.partial_cache, self.force_dirty.take(), renderer)
+        PartialRenderer::new(&self.partial_cache, DirtyRegion::default(), renderer)
     }
 
     /// Compute the correct partial rendering region based on the components to be drawn, the bounding rectangles of
@@ -922,9 +930,10 @@ impl PartialRenderingState {
 
         let screen_region = LogicalRect::from_size(logical_window_size);
 
-        // Items destroyed during `compute_dirty_regions` (a repeater update drops its
-        // instances during the traversal) land in `force_dirty` after
-        // `create_partial_renderer` already collected it, so collect it again.
+        // Collect the regions accumulated in `force_dirty` (destroyed item trees,
+        // `mark_dirty_region` calls) only now: repeater instances are dropped by
+        // `ensure_tree_instantiated` inside `draw_contents`, after the partial renderer
+        // for the frame was already created.
         partial_renderer.dirty_region =
             partial_renderer.dirty_region.union(&self.force_dirty.take());
 
@@ -983,8 +992,8 @@ impl PartialRenderingState {
 
 #[test]
 fn dirty_region_ignores_empty_rects() {
-    // A released item that was never visible stores an empty `screen_rect`;
-    // adding it must not drag the region towards the empty rect's origin.
+    // `compute_dirty_regions` feeds the empty rect of an invisible item into
+    // `add_rect`; it must not drag the region towards the empty rect's origin.
     let mut region = DirtyRegion::default();
     region.add_rect(LogicalRect::default());
     assert_eq!(region.iter().count(), 0);

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -198,6 +198,11 @@ struct PartialRenderingCachedData {
     /// The property tracker that should be used to evaluate whether the item needs to be re-rendered
     pub tracker: Option<core::pin::Pin<Box<PropertyTracker>>>,
 }
+impl PartialRenderingCachedData {
+    fn new(data: CachedItemBoundingBoxAndTransform) -> Self {
+        Self { data, tracker: None }
+    }
+}
 
 /// The cache that needs to be held by the Window for the partial rendering
 struct PartialRendererCache {
@@ -652,8 +657,7 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                         }
                     }
                     None => {
-                        let cache_entry =
-                            PartialRenderingCachedData { data: new_geom.clone(), tracker: None };
+                        let cache_entry = PartialRenderingCachedData::new(new_geom.clone());
                         rendering_data.cache_index.set(cache.insert(cache_entry));
                         rendering_data.cache_generation.set(cache.generation());
 
@@ -977,18 +981,20 @@ impl PartialRenderingState {
             self.force_dirty.borrow_mut().add_rect(rect);
         }
 
+        let mut released_without_entry = false;
         for item in items {
-            if item.cached_rendering_data_offset().release(&mut cache).is_none()
-                && cache.rendered_without_entry
-            {
-                // Without a cache entry the item was never visited by the dirty-region pass,
-                // so the tree's screen region above does not cover it. Unless an item was
-                // rendered without an entry since that pass
-                // (see `PartialRendererCache::rendered_without_entry`), it was never rendered
-                // either and there is nothing on screen to erase; otherwise refresh
-                // everything as a last resort.
-                self.force_screen_refresh.set(true);
+            if item.cached_rendering_data_offset().release(&mut cache).is_none() {
+                released_without_entry = true;
             }
+        }
+
+        // An item without a cache entry was never visited by the dirty-region pass, so the
+        // tree's screen region above does not cover it. Unless an item was rendered without
+        // an entry since that pass (see `PartialRendererCache::rendered_without_entry`), it
+        // was never rendered either and there is nothing on screen to erase; otherwise
+        // refresh everything as a last resort.
+        if released_without_entry && cache.rendered_without_entry {
+            self.force_screen_refresh.set(true);
         }
     }
 

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -52,11 +52,14 @@ impl CachedRenderingData {
     /// This function can be used to remove an entry from the rendering cache for a given item, if it
     /// exists, i.e. if any data was ever cached. This is typically called by the graphics backend's
     /// implementation of the release_item_graphics_cache function.
-    fn release(&self, cache: &mut PartialRendererCache) -> Option<PartialRenderingCachedData> {
+    fn release(
+        &self,
+        cache: &mut PartialRendererCache,
+    ) -> Option<CachedItemBoundingBoxAndTransform> {
         if self.cache_generation.get() == cache.generation() {
             let index = self.cache_index.get();
             self.cache_generation.set(0);
-            Some(cache.remove(index))
+            Some(cache.remove(index).data)
         } else {
             None
         }
@@ -194,17 +197,18 @@ struct PartialRenderingCachedData {
     pub data: CachedItemBoundingBoxAndTransform,
     /// The property tracker that should be used to evaluate whether the item needs to be re-rendered
     pub tracker: Option<core::pin::Pin<Box<PropertyTracker>>>,
-    /// The clipped screen-space region the item covered when it was last visited by
-    /// [`PartialRenderer::compute_dirty_regions`]. When the item is destroyed, this is
-    /// the region that needs to be repainted
-    /// (see [`PartialRenderingState::free_graphics_resources`]).
-    pub screen_rect: LogicalRect,
 }
 
 /// The cache that needs to be held by the Window for the partial rendering
 struct PartialRendererCache {
     slab: slab::Slab<PartialRenderingCachedData>,
     generation: usize,
+    /// Per ItemTree (keyed by its instance pointer), the union of the clipped screen-space
+    /// regions of the tree's own items, as of the tree's last visit by
+    /// [`PartialRenderer::compute_dirty_regions`]. Nested trees have their own entry.
+    /// When a tree is destroyed, this is the region that needs to be repainted
+    /// (see [`PartialRenderingState::free_graphics_resources`]).
+    tree_screen_rects: alloc::collections::BTreeMap<usize, LogicalRect>,
     /// True when an item may be on screen without a cache entry that records its region:
     /// an item was rendered without an entry since the last dirty-region pass
     /// (see [`PartialRenderer::do_rendering`]), or the cache was cleared.
@@ -214,7 +218,12 @@ struct PartialRendererCache {
 
 impl Default for PartialRendererCache {
     fn default() -> Self {
-        Self { slab: Default::default(), generation: 1, rendered_without_entry: false }
+        Self {
+            slab: Default::default(),
+            generation: 1,
+            tree_screen_rects: Default::default(),
+            rendered_without_entry: false,
+        }
     }
 }
 
@@ -245,6 +254,7 @@ impl PartialRendererCache {
     pub fn clear(&mut self) {
         self.slab.clear();
         self.generation += 1;
+        self.tree_screen_rects.clear();
         // Items rendered before the clear are still on screen, but their entries are gone.
         self.rendered_without_entry = true;
     }
@@ -500,10 +510,11 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                     my_sibling_index,
                 );
 
-                // The region the item covers on screen. It is stored in the cache entry so
-                // that destroying the item can repaint exactly that region
-                // (see `PartialRenderingState::free_graphics_resources`), and it doubles as
-                // the item's current-position dirty rect in the branches below.
+                // The region the item covers on screen. It is unioned into the owning
+                // tree's entry in `tree_screen_rects` so that destroying the tree can
+                // repaint that region (see `PartialRenderingState::free_graphics_resources`),
+                // and it doubles as the item's current-position dirty rect in the branches
+                // below.
                 let new_screen_rect = clipped_screen_rect(
                     new_geom.bounding_rect(),
                     &state.transform_to_screen,
@@ -513,13 +524,23 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
 
                 let rendering_data = item.cached_rendering_data_offset();
                 let mut cache = self.cache.borrow_mut();
+
+                let tree_key = vtable::VRef::as_ptr(crate::item_tree::ItemTreeRc::borrow(component))
+                    .as_ptr() as usize;
+                if index == 0 {
+                    // Entering the tree: rebuild its screen region from this pass's visits.
+                    cache.tree_screen_rects.remove(&tree_key);
+                }
+                if !new_screen_rect.is_empty() {
+                    let acc = cache.tree_screen_rects.entry(tree_key).or_default();
+                    // Not `Rect::union`, which would extend an empty accumulator's rect
+                    // towards the origin.
+                    *acc =
+                        if acc.is_empty() { new_screen_rect } else { acc.union(&new_screen_rect) };
+                }
+
                 match rendering_data.get_entry(&mut cache) {
-                    Some(PartialRenderingCachedData {
-                        data: cached_geom,
-                        tracker,
-                        screen_rect,
-                    }) => {
-                        *screen_rect = new_screen_rect;
+                    Some(PartialRenderingCachedData { data: cached_geom, tracker }) => {
                         let rendering_dirty = tracker.as_ref().is_some_and(|tr| tr.is_dirty());
 
                         // Repaint when the rank among the previously known siblings changed,
@@ -631,11 +652,8 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
                         }
                     }
                     None => {
-                        let cache_entry = PartialRenderingCachedData {
-                            data: new_geom.clone(),
-                            tracker: None,
-                            screen_rect: new_screen_rect,
-                        };
+                        let cache_entry =
+                            PartialRenderingCachedData { data: new_geom.clone(), tracker: None };
                         rendering_data.cache_index.set(cache.insert(cache_entry));
                         rendering_data.cache_generation.set(cache.generation());
 
@@ -945,25 +963,31 @@ impl PartialRenderingState {
     }
 
     /// Call this from your renderer's `free_graphics_resources` function to ensure that the cached item geometries
-    /// are cleared for the destroyed items in the item tree, and that the screen regions the items
-    /// covered are repainted in the next frame.
-    pub fn free_graphics_resources(&self, items: &mut dyn Iterator<Item = Pin<ItemRef<'_>>>) {
+    /// are cleared for the destroyed items in the item tree, and that the screen region the tree
+    /// covered is repainted in the next frame.
+    pub fn free_graphics_resources(
+        &self,
+        component: crate::item_tree::ItemTreeRef,
+        items: &mut dyn Iterator<Item = Pin<ItemRef<'_>>>,
+    ) {
         let mut cache = self.partial_cache.borrow_mut();
-        let mut force_dirty = self.force_dirty.borrow_mut();
+
+        let tree_key = vtable::VRef::as_ptr(component).as_ptr() as usize;
+        if let Some(rect) = cache.tree_screen_rects.remove(&tree_key) {
+            self.force_dirty.borrow_mut().add_rect(rect);
+        }
+
         for item in items {
-            match item.cached_rendering_data_offset().release(&mut cache) {
-                Some(entry) => {
-                    force_dirty.add_rect(entry.screen_rect);
-                }
-                None => {
-                    // Without a cache entry the item was never visited by the dirty-region pass.
-                    // Unless an item was rendered without an entry since then
-                    // (see `PartialRendererCache::rendered_without_entry`), it was never
-                    // rendered either, so there is nothing on screen to erase.
-                    if cache.rendered_without_entry {
-                        self.force_screen_refresh.set(true);
-                    }
-                }
+            if item.cached_rendering_data_offset().release(&mut cache).is_none()
+                && cache.rendered_without_entry
+            {
+                // Without a cache entry the item was never visited by the dirty-region pass,
+                // so the tree's screen region above does not cover it. Unless an item was
+                // rendered without an entry since that pass
+                // (see `PartialRendererCache::rendered_without_entry`), it was never rendered
+                // either and there is nothing on screen to erase; otherwise refresh
+                // everything as a last resort.
+                self.force_screen_refresh.set(true);
             }
         }
     }

--- a/internal/core/partial_renderer.rs
+++ b/internal/core/partial_renderer.rs
@@ -214,21 +214,11 @@ struct PartialRendererCache {
     /// When a tree is destroyed, this is the region that needs to be repainted
     /// (see [`PartialRenderingState::free_graphics_resources`]).
     tree_screen_rects: alloc::collections::BTreeMap<usize, LogicalRect>,
-    /// True when an item may be on screen without a cache entry that records its region:
-    /// an item was rendered without an entry since the last dirty-region pass
-    /// (see [`PartialRenderer::do_rendering`]), or the cache was cleared.
-    /// While set, releasing an item without an entry must fall back to a full refresh.
-    rendered_without_entry: bool,
 }
 
 impl Default for PartialRendererCache {
     fn default() -> Self {
-        Self {
-            slab: Default::default(),
-            generation: 1,
-            tree_screen_rects: Default::default(),
-            rendered_without_entry: false,
-        }
+        Self { slab: Default::default(), generation: 1, tree_screen_rects: Default::default() }
     }
 }
 
@@ -260,8 +250,6 @@ impl PartialRendererCache {
         self.slab.clear();
         self.generation += 1;
         self.tree_screen_rects.clear();
-        // Items rendered before the clear are still on screen, but their entries are gone.
-        self.rendered_without_entry = true;
     }
 }
 
@@ -731,7 +719,6 @@ impl<'a, T: ItemRenderer + ItemRendererFeatures> PartialRenderer<'a, T> {
             // This item was created between the computation of the dirty region and the actual rendering.
             // Register a dependency to the geometry since this wasn't done before
             item_rc.geometry();
-            cache.rendered_without_entry = true;
             render_fn();
         }
     }
@@ -935,11 +922,6 @@ impl PartialRenderingState {
 
         let screen_region = LogicalRect::from_size(logical_window_size);
 
-        // Every item now on screen was visited by the dirty-region passes above and has a
-        // cache entry, so from here on a released item without one was never rendered
-        // (until `PartialRenderer::do_rendering` renders another entry-less item).
-        self.partial_cache.borrow_mut().rendered_without_entry = false;
-
         // Items destroyed during `compute_dirty_regions` (a repeater update drops its
         // instances during the traversal) land in `force_dirty` after
         // `create_partial_renderer` already collected it, so collect it again.
@@ -981,20 +963,10 @@ impl PartialRenderingState {
             self.force_dirty.borrow_mut().add_rect(rect);
         }
 
-        let mut released_without_entry = false;
+        // An item without a cache entry was never visited by the dirty-region pass, and
+        // therefore never rendered: there is nothing on screen to erase for it.
         for item in items {
-            if item.cached_rendering_data_offset().release(&mut cache).is_none() {
-                released_without_entry = true;
-            }
-        }
-
-        // An item without a cache entry was never visited by the dirty-region pass, so the
-        // tree's screen region above does not cover it. Unless an item was rendered without
-        // an entry since that pass (see `PartialRendererCache::rendered_without_entry`), it
-        // was never rendered either and there is nothing on screen to erase; otherwise
-        // refresh everything as a last resort.
-        if released_without_entry && cache.rendered_without_entry {
-            self.force_screen_refresh.set(true);
+            item.cached_rendering_data_offset().release(&mut cache);
         }
     }
 

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -939,7 +939,7 @@ impl i_slint_core::renderer::RendererSealed for SkiaRenderer {
         self.text_layout_cache.component_destroyed(component);
 
         if let Some(partial_rendering_state) = self.partial_rendering_state() {
-            partial_rendering_state.free_graphics_resources(items);
+            partial_rendering_state.free_graphics_resources(component, items);
         }
 
         Ok(())

--- a/internal/renderers/software/lib.rs
+++ b/internal/renderers/software/lib.rs
@@ -1151,12 +1151,12 @@ impl RendererSealed for SoftwareRenderer {
 
     fn free_graphics_resources(
         &self,
-        _component: i_slint_core::item_tree::ItemTreeRef,
+        component: i_slint_core::item_tree::ItemTreeRef,
         items: &mut dyn Iterator<Item = Pin<i_slint_core::items::ItemRef<'_>>>,
     ) -> Result<(), i_slint_core::platform::PlatformError> {
         #[cfg(feature = "systemfonts")]
-        self.text_layout_cache.component_destroyed(_component);
-        self.partial_rendering_state.free_graphics_resources(items);
+        self.text_layout_cache.component_destroyed(component);
+        self.partial_rendering_state.free_graphics_resources(component, items);
         Ok(())
     }
 


### PR DESCRIPTION
Destroying any element — an `if` whose condition turns false, a shrinking repeater, a closing popup — forced a full-window repaint, because `free_graphics_resources` had no way to know the destroyed items' screen regions.

This change stores each item's clipped screen-space rect in its partial-rendering cache entry on every dirty-region pass (the one place where the transform and clip chain is known). `free_graphics_resources` then dirties those stored rects instead of setting `force_screen_refresh`. The full refresh remains as a fallback for items without a cache entry, which can be rendered between the dirty-region pass and the frame that destroys them.

`apply_dirty_region` collects `force_dirty` a second time after the compute pass: a repeater dropping instances during the traversal happens after `create_partial_renderer` already collected it, and without the second collection the teardown frame would under-repaint.

Cost: one `LogicalRect` (16 bytes) per cache entry. The rect doubles as the item's current-position dirty rect in `compute_dirty_regions`, so the per-visit transform work is unchanged on the branches that mark it.

Known limitation: a destroyed item's later siblings still repaint. The disappearance shifts their rank among the visited siblings, which is indistinguishable from a z-order change with the rank comparison alone (see the `sibling_index` comment). For the common cases — tooltips and overlays that are topmost, or an `if` inside a widget such as Button's focus border — there are no or only local later siblings, so the repaint stays bounded. A removal-exact refinement is possible by recording released ranks against the parent entry, at the cost of extra per-entry bookkeeping; left for a follow-up.

The previously pinned full-window expectations in `api/rs/slint/tests/partial_renderer.rs` now assert the bounded regions: the `if` teardown repaints only the vanished rect (plus the later sibling), a model reset only the recreated rows, and `model.remove` only the removed row.

Fixes #7432
