### PR TITLE
docs: make the order of sub-element deterministic

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -188,6 +188,10 @@ jobs:
                   EXTRA_FLAGS="--experimental"
                 fi
                 cargo run --release -p slint-doc-generator -- $EXTRA_FLAGS
+                # Make a second run to double check that the output is deterministic
+                cp -r docs/astro/src/content/docs/generated "$RUNNER_TEMP/generated-first-run"
+                cargo run --release -p slint-doc-generator -- $EXTRA_FLAGS generate-mdx
+                diff -r "$RUNNER_TEMP/generated-first-run" docs/astro/src/content/docs/generated
             - name: "Run the slint-sc test suites and measure coverage"
               if: ${{ inputs['slint-sc-coverage'] }}
               run: scripts/slint_sc_test_suite.sh coverage

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -919,7 +919,7 @@ pub struct BuiltinElement {
     pub properties: BTreeMap<SmolStr, BuiltinPropertyInfo>,
     /// Additional builtin element that can be accepted as child of this element
     /// (example `Tab` in `TabWidget`, `Row` in `GridLayout` and the path elements in `Path`)
-    pub additional_accepted_child_types: HashMap<SmolStr, Rc<BuiltinElement>>,
+    pub additional_accepted_child_types: BTreeMap<SmolStr, Rc<BuiltinElement>>,
     /// `Self` is conceptually in `additional_accepted_child_types` (which it can't otherwise that'd make a Rc loop)
     pub additional_accept_self: bool,
     pub disallow_global_types_as_child_elements: bool,


### PR DESCRIPTION
For rexample, the sub-element in the `Path` docs were changed at every run

Now, they are sorted alphabetically.


(Alternative could be to try to respect the order in the builtins.slint, but that's a bit more work)