### PR TITLE
docs: Slint examples that can compile, should compile

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/array-predicates.mdx
@@ -16,7 +16,7 @@ The array function `index-of` looks up a value in an array, and the operations `
 `array.index-of(value)` reads the index of the first element that equals `value`,
 or `-1` if the array contains no such element.
 
-```slint no-test
+```slint
 export component Example {
     in-out property<[string]> names: ["Aardvark", "Beaver"];
     out property <int> beaver-index: names.index-of("Beaver"); // 1
@@ -49,7 +49,7 @@ Reach for `find-index` when the match condition is more than equality against a 
 
 ## Example
 
-```slint no-test
+```slint
 export component Example {
     in-out property<[int]> list-of-int: [1, 2, 3];
 

--- a/docs/astro/src/content/docs/guide/experimental/component-container.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/component-container.mdx
@@ -36,7 +36,7 @@ The embedded component is placed at `(0, 0)` inside the container and its size c
 
 A minimal `.slint` file that exposes the factory as a property of the root component:
 
-```slint no-test
+```slint
 export component MainWindow inherits Window {
     in property <component-factory> plugin <=> container.component-factory;
 

--- a/docs/astro/src/content/docs/guide/experimental/custom-mouse-cursor.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/custom-mouse-cursor.mdx
@@ -13,7 +13,7 @@ that is aligned with the actual pointer position. It is clamped to the image bou
 > A function on a type namespace is a stand-in for an enum variant with data;
 > once the language has such variants, `custom` should become one.
 
-```slint no-test
+```slint
 TouchArea {
     mouse-cursor: MouseCursor.custom(@image-url("cursor.png"), 0, 0);
 }

--- a/docs/astro/src/content/docs/guide/experimental/deprecated.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/deprecated.mdx
@@ -22,7 +22,7 @@ An access to `old-prop` then warns with `Please use 'new-prop' instead`.
 
 Pass a string literal to provide a custom message when there is no single replacement property:
 
-```slint no-test
+```slint
 @deprecated("Compute it from 'new-prop' instead") in-out property <int> older-prop: 42;
 ```
 

--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -87,7 +87,7 @@ The named child must satisfy the interface API (directly or through its own dele
 
 ## Full example
 
-```slint no-test
+```slint
 interface Counter {
     in-out property <int> value;
     callback increment();

--- a/docs/astro/src/content/docs/guide/experimental/match-elements.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/match-elements.mdx
@@ -29,7 +29,7 @@ If a wildcard case `*` is present, it renders when none of the explicit cases ma
 
 Every value an `int` can take cannot be listed, so a wildcard `*` case is required.
 
-```slint no-test
+```slint
 export component StatusIndicator {
     in property <int> status: 0;
 
@@ -46,7 +46,7 @@ export component StatusIndicator {
 
 `true` and `false` cover every value a `bool` can take, so no wildcard is needed.
 
-```slint no-test
+```slint
 export component Toggle {
     in-out property <bool> checked: false;
 
@@ -62,7 +62,7 @@ export component Toggle {
 When the subject's type is a known enum, case values may use the enum variant name directly, without qualifying it with the enum name.
 Listing every variant covers the enum exhaustively, so no wildcard is needed.
 
-```slint no-test
+```slint
 enum Mode { View, Edit, Preview }
 
 export component Editor {
@@ -78,7 +78,7 @@ export component Editor {
 
 ### Matching on a string
 
-```slint no-test
+```slint
 export component Greeting {
     in property <string> lang: "en";
 

--- a/docs/astro/src/content/docs/guide/experimental/named-slots.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/named-slots.mdx
@@ -13,7 +13,7 @@ It generalizes the built-in `@children` placeholder: instead of a single anonymo
 
 Use the `slot` keyword inside a component to declare a slot, then render it at the desired location by writing the slot's name as an empty element.
 
-```slint no-test
+```slint
 export component Base inherits Rectangle {
     slot header;
     slot footer;
@@ -65,7 +65,7 @@ export component App inherits Rectangle {
 A component can forward one of its own slots to a slot of a child component, again with the `<<` operator.
 This lets a wrapper expose a nested component's slots as its own.
 
-```slint no-test
+```slint
 export component SlotHost inherits Rectangle {
     slot host-header;
     VerticalLayout {
@@ -85,7 +85,7 @@ export component Outer inherits Rectangle {
 
 ## Full example
 
-```slint no-test
+```slint
 export component Card inherits Rectangle {
     slot header;
     slot footer;

--- a/docs/astro/src/content/docs/guide/experimental/shadowable.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/shadowable.mdx
@@ -26,7 +26,7 @@ so such an addition stays backwards compatible.
 
 Prefix a property, callback or function declaration in the base component with `@shadowable`:
 
-```slint no-test
+```slint
 @shadowable in-out property <string> name: "Hello";
 @shadowable callback activated();
 @shadowable public function describe() -> string { "base" }

--- a/docs/astro/src/content/docs/guide/language/coding/animation.mdx
+++ b/docs/astro/src/content/docs/guide/language/coding/animation.mdx
@@ -26,7 +26,7 @@ This animates the color property for 250ms whenever it changes.
 Fine-tune the animation with `delay`, `duration`, `iteration-count`, `easing`,
 `direction`, and `enabled`, and animate several properties with the same animation:
 
-```slint no-test
+```slint
 animate x, y { duration: 100ms; easing: ease-out-bounce; }
 ```
 

--- a/docs/astro/src/content/docs/guide/language/concepts/slint-language.mdx
+++ b/docs/astro/src/content/docs/guide/language/concepts/slint-language.mdx
@@ -204,7 +204,7 @@ slow or costly to evolve the application.
 
 Slint provides a declarative language to describe an application's user interface
 
-```slint showLineNumbers=true no-test
+```slint showLineNumbers=true
 Rectangle {
     Button {
         text: "Click me!";

--- a/docs/astro/src/content/docs/reference/language/animations.mdx
+++ b/docs/astro/src/content/docs/reference/language/animations.mdx
@@ -57,13 +57,13 @@ Animating a property that cannot be assigned, such as a private property of anot
 
 Listing several comma-separated names applies the same animation to each:
 
-```slint no-test
+```slint
 animate x, y { duration: 100ms; easing: ease-out-bounce; }
 ```
 
 is equivalent to:
 
-```slint no-test
+```slint
 animate x { duration: 100ms; easing: ease-out-bounce; }
 animate y { duration: 100ms; easing: ease-out-bounce; }
 ```

--- a/docs/cpp/src/content/docs/types.mdx
+++ b/docs/cpp/src/content/docs/types.mdx
@@ -37,7 +37,7 @@ code.
 
 For example, this `struct` in a `.slint` file
 
-```slint no-test
+```slint
 export struct MyStruct {
     foo: int,
     bar: string,
@@ -61,7 +61,7 @@ for any user-defined, exported `enum` in the `.slint` code.
 
 For example, this `enum` in a `.slint` file
 
-```slint no-test
+```slint
 export enum MyEnum { alpha, beta-gamma, omicron }
 ```
 

--- a/ui-libraries/material/docs/src/content/docs/components/date_picker.mdx
+++ b/ui-libraries/material/docs/src/content/docs/components/date_picker.mdx
@@ -47,7 +47,7 @@ The text that is displayed at the top of the picker.
 ### date
 <SlintProperty propName="date" typeName="struct" structName="Date">
 Set the initial displayed date.
-```slint "date: { year: 2024, month: 11 };" no-test
+```slint "date: { year: 2024, month: 11 };"
 DatePickerPopup {
     date: { year: 2024, month: 11 };
 }
@@ -64,7 +64,7 @@ By default, a DatePickerPopup closes when the user clicks. Set this to false to 
 ### canceled()
 Invoked when the cancel button is clicked.
 
-```slint no-test
+```slint
 date_picker := DatePickerPopup {
     canceled() => {
         date_picker.close();
@@ -75,7 +75,7 @@ date_picker := DatePickerPopup {
 ### accepted(Date)
 Invoked when the ok button is clicked.
 
-```slint no-test
+```slint
 date_picker := DatePickerPopup {
     accepted(date) => {
         debug("Selected date: ", date);


### PR DESCRIPTION
Remove `no-test` from Slint code blocks in the documentation examples.

Code in documentation should be valid, and we can verify this by compiling it as part of the doc-tests.