### PR TITLE
compiler: let components inheriting Path take path elements

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -3536,7 +3536,8 @@ impl Element {
         })
     }
 
-    fn any_in_inheritance_chain(&self, predicate: impl Fn(&Element) -> bool + Copy) -> bool {
+    /// Whether `predicate` holds for this element or the root element of a component it derives from
+    pub fn any_in_inheritance_chain(&self, predicate: impl Fn(&Element) -> bool + Copy) -> bool {
         predicate(self)
             || matches!(
                 &self.base_type,

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -138,7 +138,7 @@ pub async fn run_passes(
         );
         lower_states::lower_states(component, &symbol_counters, &mut forwarded_references, diag);
         lower_text_input_interface::lower_text_input_interface(component);
-        compile_paths::compile_paths(component, &doc.local_registry, diag);
+        compile_paths::check_derived_paths(component, &doc.local_registry, diag);
         repeater_component::process_repeater_components(component);
         lower_popups::lower_popups(component, &doc.local_registry, diag);
         collect_init_code::collect_init_code(component);
@@ -164,6 +164,9 @@ pub async fn run_passes(
     }
 
     doc.visit_all_used_components(|component| {
+        // After inlining, so that path elements added through `@children` or to a
+        // component inheriting `Path` are direct children of the `Path` element
+        compile_paths::compile_paths(component, &doc.local_registry, diag);
         border_radius::handle_border_radius(component, diag);
         check_drag_area::check_drag_area(component, diag);
         deprecated_rotation_origin::handle_rotation_origin(component, diag);

--- a/internal/compiler/passes/compile_paths.rs
+++ b/internal/compiler/passes/compile_paths.rs
@@ -11,7 +11,7 @@
 
 use crate::diagnostics::BuildDiagnostics;
 use crate::expression_tree::*;
-use crate::langtype::{BuiltinStruct, Struct, Type};
+use crate::langtype::{BuiltinElement, BuiltinStruct, ElementType, Struct, Type};
 use crate::object_tree::*;
 use smol_str::SmolStr;
 use std::rc::Rc;
@@ -30,15 +30,15 @@ pub fn compile_paths(
             return;
         }
 
-        let element_types = &path_type.additional_accepted_child_types;
-
         let commands_binding = elem_.borrow_mut().take_binding("commands");
 
         let path_data_binding = if let Some(commands_expr) = commands_binding {
-            if let Some(path_child) = elem_.borrow().children.iter().find(|child| {
-                element_types
-                    .contains_key(&child.borrow().base_type.as_builtin().native_class.class_name)
-            }) {
+            if let Some(path_child) = elem_
+                .borrow()
+                .children
+                .iter()
+                .find(|child| path_element_type(child, path_type).is_some())
+            {
                 diag.push_error(
                     "Path elements cannot be mixed with the use of the SVG commands property"
                         .into(),
@@ -81,10 +81,7 @@ pub fn compile_paths(
             let mut path_data = Vec::new();
 
             for child in old_children {
-                let element_name =
-                    &child.borrow().base_type.as_builtin().native_class.class_name.clone();
-
-                if let Some(element_type) = element_types.get(element_name).cloned() {
+                if let Some(element_type) = path_element_type(&child, path_type).cloned() {
                     if child.borrow().repeated.is_some() {
                         diag.push_error(
                             "Path elements are not supported with `for`-`in` syntax, yet (https://github.com/slint-ui/slint/issues/754)".into(),
@@ -108,19 +105,9 @@ pub fn compile_paths(
                 }
             }
 
-            if elem.is_binding_set("elements", false) {
-                if path_data.is_empty() {
-                    // Just Path subclass that had elements declared earlier, since path_data is empty we should retain the
-                    // existing elements
-                    return;
-                } else {
-                    diag.push_error(
-                        "The Path was already populated in the base type and it can't be re-populated again"
-                            .into(),
-                        &*elem,
-                    );
-                    return;
-                }
+            if path_data.is_empty() {
+                // Keep the elements a base component may have compiled already
+                return;
             }
 
             Expression::PathData(crate::expression_tree::Path::Elements(path_data)).into()
@@ -128,6 +115,69 @@ pub fn compile_paths(
 
         elem_.borrow_mut().set_binding(SmolStr::new_static("elements"), path_data_binding);
     });
+}
+
+/// Reports path elements or `commands` given to an instance of a component whose `Path` base
+/// already declares path elements, and a children placeholder in such a `Path`.
+///
+/// Runs before inlining, while the path elements of the base are still its children.
+/// A `Path` is populated in one place only: a base that declares nothing can be filled by the
+/// instance, but there is no appending to what the base declares.
+pub fn check_derived_paths(
+    component: &Rc<Component>,
+    tr: &crate::typeregister::TypeRegister,
+    diag: &mut BuildDiagnostics,
+) {
+    let path_type = tr.lookup_element("Path").unwrap();
+    let path_type = path_type.as_builtin();
+
+    for (name, cip) in component.child_insertion_points.borrow().iter() {
+        if declares_path_elements(&cip.parent.borrow(), path_type) {
+            diag.push_error(
+                format!(
+                    "{} cannot be placed in a Path that already has path elements",
+                    slot_error_subject(name)
+                ),
+                &cip.node,
+            );
+        }
+    }
+
+    recurse_elem_including_sub_components_no_borrow(component, &(), &mut |elem, _| {
+        let elem = elem.borrow();
+        let ElementType::Component(base) = &elem.base_type else { return };
+        if elem.children.is_empty() && elem.binding("commands").is_none() {
+            return;
+        }
+        if base.child_insertion_points.borrow().contains_key(DEFAULT_SLOT_NAME) {
+            // The children go to the placeholder, which is checked above
+            return;
+        }
+        if declares_path_elements(&base.root_element.borrow(), path_type) {
+            diag.push_error(
+                "The Path was already populated in the base type and it can't be re-populated again"
+                    .into(),
+                &*elem,
+            );
+        }
+    });
+}
+
+/// Whether `elem`, or the root of a component it derives from, has path element children
+fn declares_path_elements(elem: &Element, path_type: &BuiltinElement) -> bool {
+    elem.builtin_type().is_some_and(|builtin| builtin.name == path_type.name)
+        && elem.any_in_inheritance_chain(|e| {
+            e.children.iter().any(|child| path_element_type(child, path_type).is_some())
+        })
+}
+
+/// The path element type of `child` when it is a `MoveTo`, `LineTo`, ... element
+fn path_element_type<'a>(
+    child: &ElementRc,
+    path_type: &'a BuiltinElement,
+) -> Option<&'a Rc<BuiltinElement>> {
+    let builtin = child.borrow().builtin_type()?;
+    path_type.additional_accepted_child_types.get(&builtin.native_class.class_name)
 }
 
 fn compile_path_from_string_literal(

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -149,10 +149,11 @@ fn inline_element(
 
     // Ensure @children CIP exists if it's missing but the component is a builtin that accepts children.
     // This preserves the implicit-children behavior for builtins without explicit placeholders.
+    // Which children a builtin accepts was checked when the object tree was built, so a builtin
+    // restricted to specific child types, such as `Path`, gets the placeholder too.
     if !inlined_insertion_points.contains_key(DEFAULT_SLOT_NAME)
         && let Some(builtin) = inlined_component.root_element.borrow().builtin_type()
         && !builtin.is_non_item_type
-        && !builtin.disallow_global_types_as_child_elements
     {
         let cip_node = inlined_component
             .node

--- a/internal/compiler/tests/syntax/elements/path.slint
+++ b/internal/compiler/tests/syntax/elements/path.slint
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+component Empty inherits Path { }
+
 component Arc inherits Path {
     MoveTo {
         x: 0;
@@ -8,11 +10,87 @@ component Arc inherits Path {
     }
 }
 
+component Arc2 inherits Path {
+    commands: "M 0 0 L 1 1";
+}
+
+component EmptySlot {
+    Path {
+        @children
+    }
+}
+
+component Slotted {
+    Path {
+        MoveTo {
+            x: 0;
+            y: 0;
+        }
+        @children
+//      >       <error{The @children placeholder cannot be placed in a Path that already has path elements}
+    }
+}
+
+component SlottedCommands {
+    Path {
+        commands: "M 0 0 L 1 1";
+        @children
+    }
+}
+
 export component Foo inherits Rectangle {
+    Empty { } // OK!
+    Empty {
+        // OK, the base declares nothing
+        LineTo {
+            x: 1;
+            y: 1;
+        }
+    }
+    Empty {
+        commands: "M 0 0 L 1 1"; // OK
+    }
     Arc { } // OK!
     Arc {
 //  >  <error{The Path was already populated in the base type and it can't be re-populated again}
         LineTo {
+            x: 1;
+            y: 1;
+        }
+    }
+    Arc {
+//  >  <error{The Path was already populated in the base type and it can't be re-populated again}
+        commands: "M 0 0 L 1 1";
+    }
+    Arc2 { } // OK!
+    Arc2 {
+        commands: "M 1 1 L 2 2"; // OK, replaces the commands of the base
+    }
+    Arc2 {
+        LineTo {
+//      >     <error{Path elements cannot be mixed with the use of the SVG commands property}
+            x: 1;
+            y: 1;
+        }
+    }
+    EmptySlot { } // OK!
+    EmptySlot {
+        // OK, the Path declares nothing
+        LineTo {
+            x: 1;
+            y: 1;
+        }
+        Close { }
+    }
+    Slotted {
+        LineTo {
+            x: 1;
+            y: 1;
+        }
+    }
+    SlottedCommands {
+        LineTo {
+//      >     <error{Path elements cannot be mixed with the use of the SVG commands property}
             x: 1;
             y: 1;
         }

--- a/internal/compiler/tests/syntax/elements/path_children.slint
+++ b/internal/compiler/tests/syntax/elements/path_children.slint
@@ -1,0 +1,15 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component EmptySlot {
+    Path {
+        @children
+    }
+}
+
+export component Foo inherits Rectangle {
+    EmptySlot {
+        Rectangle { }
+//      >        <error{Rectangle is not allowed within Path. Only ArcTo Close CubicTo LineTo MoveTo QuadraticTo are valid children}
+    }
+}

--- a/tests/cases/elements/path_inherit.slint
+++ b/tests/cases/elements/path_inherit.slint
@@ -1,0 +1,93 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A component that inherits `Path`, or has a `@children` inside a `Path`, without declaring
+// path elements itself, takes them from its instances.
+// Regression test for #13264 and #13265.
+
+component EmptyBase inherits Path {
+    width: 100px;
+    height: 100px;
+    fit: preserve;
+    stroke-width: 0px;
+}
+
+component EmptySlot {
+    width: 100px;
+    height: 100px;
+    path := Path {
+        width: 100px;
+        height: 100px;
+        fit: preserve;
+        stroke-width: 0px;
+        @children
+    }
+    out property <float> start_x: path.point-at(0).x / 1px;
+    out property <float> start_y: path.point-at(0).y / 1px;
+    out property <float> end_x: path.point-at(1).x / 1px;
+    out property <float> end_y: path.point-at(1).y / 1px;
+    out property <float> mid_x: path.point-at(0.5).x / 1px;
+}
+
+export component TestCase inherits Window {
+    width: 100px;
+    height: 100px;
+
+    in-out property <float> slot_end: 90;
+
+    from-elements := EmptyBase {
+        MoveTo { x: 10; y: 20; }
+        LineTo { x: 90; y: 20; }
+    }
+    from-commands := EmptyBase {
+        commands: "M 10 30 L 90 30";
+    }
+    from-slot := EmptySlot {
+        MoveTo { x: 10; y: 50; }
+        LineTo { x: root.slot_end; y: 50; }
+        Close { }
+    }
+
+    out property <float> from_elements_start_x: from-elements.point-at(0).x / 1px;
+    out property <float> from_elements_start_y: from-elements.point-at(0).y / 1px;
+    out property <float> from_elements_end_x: from-elements.point-at(1).x / 1px;
+    out property <float> from_elements_end_y: from-elements.point-at(1).y / 1px;
+
+    out property <float> from_commands_start_x: from-commands.point-at(0).x / 1px;
+    out property <float> from_commands_start_y: from-commands.point-at(0).y / 1px;
+    out property <float> from_commands_end_x: from-commands.point-at(1).x / 1px;
+    out property <float> from_commands_end_y: from-commands.point-at(1).y / 1px;
+
+    out property <float> from_slot_start_x: from-slot.start_x;
+    out property <float> from_slot_start_y: from-slot.start_y;
+    // The path is closed, so it ends where it started and reaches `slot_end` halfway
+    out property <float> from_slot_end_x: from-slot.end_x;
+    out property <float> from_slot_end_y: from-slot.end_y;
+    out property <float> from_slot_mid_x: from-slot.mid_x;
+
+    out property <bool> test: from_elements_start_x == 10 && from_elements_start_y == 20
+        && from_elements_end_x == 90 && from_elements_end_y == 20
+        && from_commands_start_x == 10 && from_commands_start_y == 30
+        && from_commands_end_x == 90 && from_commands_end_y == 30
+        && from_slot_start_x == 10 && from_slot_start_y == 50
+        && from_slot_end_x == 10 && from_slot_end_y == 50
+        && from_slot_mid_x == slot_end;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/

--- a/tests/screenshots/cases/path/path.slint
+++ b/tests/screenshots/cases/path/path.slint
@@ -4,12 +4,15 @@
 // ROTATION_THRESHOLD=30  - Zeno anti-aliasing is slightly different in different rotation
 // SKIP_LINE_BY_LINE  - Path not implemented in line-by-line mode
 
+// A component inheriting Path takes the commands or path elements from its instance
+component BasePath inherits Path { }
+
 export component TestCase inherits Window {
     width: 64px;
     height: 64px;
     background: transparent;
 
-    Path {
+    BasePath {
         x: 0px;
         y: 0px;
         width: 32px;
@@ -21,7 +24,7 @@ export component TestCase inherits Window {
         opacity: 0.5;
     }
 
-    Path {
+    BasePath {
         x: 32px;
         y: 32px;
         width: 32px;


### PR DESCRIPTION
The compile_paths pass ran before inlining, so path elements written as children of a component never reached the Path element: with `@children` inside the Path they stayed item elements and the interpreter panicked on the non-item `Close` type, and with a component inheriting Path the empty base had already compiled its elements, which triggered the "already populated" error.

Run the pass after inlining instead, and let inlining create the implicit `@children` insertion point for every item builtin: what a builtin accepts as children was checked when the object tree was built, so a Path base gets the placeholder too.

A Path is populated from one place only. An instance of a component inheriting Path may add path elements or commands only when nothing in the base chain declares path elements, and a `@children` placeholder may only sit in a Path without path elements. A check before inlining, while the base's path elements are still its children, reports the "already populated" error otherwise.

The screenshot test draws its paths through a component inheriting Path, which renders the same image.

Fixes: #13264
Fixes: #13265
ChangeLog: Path: A component inheriting `Path` without path elements, or using `@children` inside an empty `Path`, now takes path elements or `commands` from its instances
