### PR TITLE
Fix races that freeze the Slint language server

### DIFF
--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -668,6 +668,58 @@ fn crossbeam_tokio_adapter(
     }
 }
 
+#[cfg(test)]
+mod outgoing_request_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn fast_client_responses_complete() {
+        let (connection, client) = Connection::memory();
+        let connection = Arc::new(connection);
+        let queue = OutgoingRequestQueue::default();
+        let notifier = ServerNotifier::new(connection.sender.clone(), queue.clone());
+        let (sender, _receiver) = mpsc::unbounded_channel();
+        let adapter = std::thread::spawn(move || {
+            crossbeam_tokio_adapter(connection, sender, queue);
+        });
+        let client = std::thread::spawn(move || {
+            while let Ok(Message::Request(request)) = client.receiver.recv() {
+                client
+                    .sender
+                    .send(Message::Response(lsp_server::Response::new_ok(
+                        request.id,
+                        serde_json::json!([]),
+                    )))
+                    .unwrap();
+            }
+        });
+
+        let mut failed_round = None;
+        for round in 0..10_000 {
+            let response = notifier
+                .send_request::<lsp_types::request::WorkspaceConfiguration>(
+                    lsp_types::ConfigurationParams { items: vec![] },
+                )
+                .unwrap();
+            let result = tokio::time::timeout(std::time::Duration::from_secs(2), response).await;
+            if !matches!(result, Ok(Ok(values)) if values.is_empty()) {
+                failed_round = Some(round);
+                break;
+            }
+        }
+
+        notifier
+            .send_message(Message::Notification(lsp_server::Notification::new(
+                "exit".into(),
+                serde_json::Value::Null,
+            )))
+            .unwrap();
+        client.join().unwrap();
+        adapter.join().unwrap();
+        assert!(failed_round.is_none(), "Client response failed at round {failed_round:?}");
+    }
+}
+
 async fn handle_notification(
     req: lsp_server::Notification,
     ctx: &mut Context,

--- a/tools/lsp/server_notifier.rs
+++ b/tools/lsp/server_notifier.rs
@@ -62,27 +62,105 @@ mod native {
                 T::METHOD.to_string(),
                 request,
             ));
-            self.sender.send(msg)?;
             let queue = self.queue.clone();
             queue.insert(id.clone(), OutgoingRequest::Start);
-            Ok(std::future::poll_fn(move |ctx| match queue.remove(&id).unwrap().1 {
-                OutgoingRequest::Pending(_) | OutgoingRequest::Start => {
-                    queue.insert(id.clone(), OutgoingRequest::Pending(ctx.waker().clone()));
-                    Poll::Pending
+            if let Err(err) = self.sender.send(msg) {
+                queue.remove(&id);
+                return Err(err.into());
+            }
+            Ok(std::future::poll_fn(move |ctx| {
+                let mut entry = queue.get_mut(&id).unwrap();
+                if !matches!(*entry, OutgoingRequest::Done(_)) {
+                    *entry = OutgoingRequest::Pending(ctx.waker().clone());
+                    return Poll::Pending;
                 }
-                OutgoingRequest::Done(d) => match d.response_result {
+                drop(entry);
+                let OutgoingRequest::Done(response) = queue.remove(&id).unwrap().1 else {
+                    unreachable!();
+                };
+                match response.response_result {
                     Err(err) => Poll::Ready(Err(err.message.into())),
                     Ok(result) => Poll::Ready(
                         serde_json::from_value(result)
                             .map_err(|e| format!("cannot deserialize response: {e:?}").into()),
                     ),
-                },
+                }
             }))
         }
 
         #[cfg(test)]
         pub fn dummy() -> Self {
             Self { sender: crossbeam_channel::unbounded().0, queue: Default::default() }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn request_is_registered_before_transport_receives_it() {
+            let (sender, receiver) = crossbeam_channel::bounded(0);
+            let queue = OutgoingRequestQueue::default();
+            let notifier = ServerNotifier::new(sender, queue.clone());
+            let sender_thread = std::thread::spawn(move || {
+                let _request = notifier
+                    .send_request::<lsp_types::request::WorkspaceConfiguration>(
+                        lsp_types::ConfigurationParams { items: vec![] },
+                    )
+                    .unwrap();
+            });
+
+            let mut select = crossbeam_channel::Select::new();
+            select.recv(&receiver);
+            select.ready_timeout(std::time::Duration::from_secs(5)).unwrap();
+            let registered = queue.len();
+            receiver.recv().unwrap();
+            sender_thread.join().unwrap();
+
+            assert_eq!(registered, 1, "The transport can receive an unregistered request");
+        }
+
+        #[test]
+        fn failed_send_removes_request() {
+            let (sender, receiver) = crossbeam_channel::unbounded();
+            let queue = OutgoingRequestQueue::default();
+            let notifier = ServerNotifier::new(sender, queue.clone());
+            drop(receiver);
+
+            assert!(
+                notifier
+                    .send_request::<lsp_types::request::WorkspaceConfiguration>(
+                        lsp_types::ConfigurationParams { items: vec![] },
+                    )
+                    .is_err()
+            );
+            assert!(queue.is_empty());
+        }
+
+        #[test]
+        fn response_before_first_poll_completes() {
+            let (sender, receiver) = crossbeam_channel::unbounded();
+            let queue = OutgoingRequestQueue::default();
+            let notifier = ServerNotifier::new(sender, queue.clone());
+            let response = notifier
+                .send_request::<lsp_types::request::WorkspaceConfiguration>(
+                    lsp_types::ConfigurationParams { items: vec![] },
+                )
+                .unwrap();
+            let Message::Request(request) = receiver.recv().unwrap() else {
+                panic!("Expected a request");
+            };
+            *queue.get_mut(&request.id).unwrap() = OutgoingRequest::Done(
+                lsp_server::Response::new_ok(request.id.clone(), serde_json::json!([])),
+            );
+
+            let mut response = std::pin::pin!(response);
+            let mut context = std::task::Context::from_waker(Waker::noop());
+            assert!(
+                matches!(response.as_mut().poll(&mut context), Poll::Ready(Ok(value)) if value.is_empty())
+            );
+            assert!(queue.is_empty());
         }
     }
 }


### PR DESCRIPTION
A fast editor response can make the native LSP log `Response to unknown request` and stop processing documents.
Semantic highlighting and Show Preview code lenses then become unresponsive.

Register outgoing requests before sending them, and update pending state while holding the map guard.
Previously, sending preceded registration, and polling temporarily removed each entry before reinserting it with an updated waker.
Either window could discard a valid response and leave its future pending forever.
Remove the registration if sending fails.

The unmodified nightly reproduced the failure after 9,016 and 515 configuration exchanges.
After the second failure, fresh code-lens and semantic-token requests received no response.
The in-process adapter test failed on the original code at round 52.
Fixing insertion order alone still failed at round 1,114.

Validation:

- `cargo test -p slint-lsp --bin slint-lsp --no-default-features --features preview-external`: 200 tests passed.
  New tests cover registration before delivery, 10,000 fast replies through the adapter, failed-send cleanup, and a response arriving before the first poll.
- `rustfmt --edition 2024 --check --config skip_children=true tools/lsp/main.rs tools/lsp/server_notifier.rs`.
- The compiled fixed server completed 1,000 configuration exchanges on the affected document.
  Subsequent requests returned the same preview code lens and semantic tokens as before the exchanges.
