### PR TITLE
Skia: Pass memory-mapped font data to Skia instead of copying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ All notable changes to this project are documented in this file.
  - esp-idf: Added `SlintPlatformConfiguration::panel_type` so MIPI-DSI panels no longer use RGB-panel APIs. (#13180)
  - LinuxKMS: Improved software rendering performance, and the `mouse-cursor` property is now honored.
  - Skia: Improved performance when rendering opaque images.
+ - Skia: Font files are no longer copied into the heap when creating typefaces; the memory-mapped
+   file is passed to Skia instead.
  - Skia: Fixed partially drawn frames, Vulkan validation errors, and window transparency when
    rendering with WGPU.
  - Skia: Fixed changes to `Window.background` not triggering a repaint with partial rendering.

--- a/internal/renderers/skia/font_cache.rs
+++ b/internal/renderers/skia/font_cache.rs
@@ -17,11 +17,17 @@ pub struct FontCache {
     // preventing eviction from fontique's shared cache (see commit 30a03cf).
     // The u64 is a hash of variation settings (0 for base typefaces).
     fonts: CLruCache<(HashedBlob, u32, u64), Option<skia_safe::Typeface>>,
+    // Blobs handed to Skia without copying. Typefaces can outlive their LRU entry.
+    shared_blobs: std::collections::HashSet<HashedBlob>,
 }
 
 impl Default for FontCache {
     fn default() -> Self {
-        Self { font_mgr: skia_safe::FontMgr::new(), fonts: CLruCache::new(FONT_CACHE_CAPACITY) }
+        Self {
+            font_mgr: skia_safe::FontMgr::new(),
+            fonts: CLruCache::new(FONT_CACHE_CAPACITY),
+            shared_blobs: Default::default(),
+        }
     }
 }
 
@@ -76,11 +82,13 @@ impl FontCache {
         typeface
     }
 
-    fn load_typeface_internal(&self, font: &parley::FontData) -> Option<skia_safe::Typeface> {
-        let typeface = self.font_mgr.new_from_data(
-            skia_safe::Data::new_copy(font.data.as_ref()),
-            if font.index > 0 { Some(font.index as _) } else { None },
-        );
+    fn load_typeface_internal(&mut self, font: &parley::FontData) -> Option<skia_safe::Typeface> {
+        self.shared_blobs.insert(font.data.clone().into());
+        // SAFETY: the blob is retained in `shared_blobs` for the lifetime of the cache.
+        let data = unsafe { skia_safe::Data::new_bytes(font.data.as_ref()) };
+        let typeface = self
+            .font_mgr
+            .new_from_data(data, if font.index > 0 { Some(font.index as _) } else { None });
 
         // Due to  https://issues.skia.org/issues/310510989, fonts from true type collections
         // with an index > 0 fail to load on macOS. As a workaround, we manually extract the font from the


### PR DESCRIPTION
fontique memory-maps font files, but FontCache handed the bytes to SkFontMgr through Data::new_copy, which copies the whole file into the heap and keeps the copy for the lifetime of the typeface. For a CJK collection that is about 20 MB per file, and reading the whole file also faults in every page of the mapping.

Pass the mapping to Skia with Data::new_bytes and keep the blob alive in the cache, so only the pages Skia actually touches become resident, and those stay in the page cache instead of the heap.

Measured on Linux with Noto Sans CJK as the default font: anonymous memory went from 59 MB to 19 MB, and the resident part of the font file mappings from 41 MB to 3.5 MB.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
