### PR TITLE
widgets: name the argument of RadioGroup's selected callback

### DIFF
--- a/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
+++ b/docs/astro/src/content/docs/reference/std-widgets/basic-widgets/radiogroup.mdx
@@ -60,7 +60,7 @@ Use `Orientation.vertical` (default) to stack options, or `Orientation.horizonta
 
 ## Callbacks
 
-### selected(string)
+### selected(value: string)
 Invoked when the user selects a different option. The argument is the `text` of the newly selected entry.
 
 ```slint {4-6}

--- a/internal/compiler/builtins.slint
+++ b/internal/compiler/builtins.slint
@@ -2683,7 +2683,7 @@ export component RadioGroup {
     in property <Orientation> orientation;
     out property <string> current-value;
     out property <bool> has-focus;
-    callback selected(string);
+    callback selected(value: string);
 
     //-disallow_global_types_as_child_elements
     RadioButton { }


### PR DESCRIPTION
RadioGroup::selected is currently the only callback in builtins.slint not having named argument. 
(this is prerequisit for another change i'm doing where all builtin callback needs named argument)