### PR TITLE
lsp: fix the language server freezing after a fast client reply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7751,7 +7751,6 @@ dependencies = [
  "clru",
  "console_error_panic_hook",
  "crossbeam-channel",
- "dashmap",
  "dissimilar",
  "futures-util",
  "i-slint-backend-selector",

--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-# cSpell: ignore dashmap nucleo
+# cSpell: ignore nucleo
 [package]
 name = "slint-lsp"
 description = "A language server protocol implementation for Slint"
@@ -130,7 +130,6 @@ clap = { workspace = true }
 crossbeam-channel = "0.5"                                                                                                # must match the version used by lsp-server
 lsp-server = "0.10"
 tokio = { version = "1.50.0", features = ["rt", "sync", "time", "macros", "io-std", "io-util", "net", "fs", "process"] }
-dashmap = "6.1.0"
 mdns-sd = { version = "0.20.0", default-features = false }
 # Unicode XID property lookup used by the host-language accessor scanner to
 # tokenize identifiers in Rust/C++ source rather than scanning byte-by-byte.

--- a/tools/lsp/language.rs
+++ b/tools/lsp/language.rs
@@ -1844,19 +1844,8 @@ pub mod tests {
         }
 
         fn respond(&self, request: Request, result: impl serde::Serialize) {
-            let mut entry = loop {
-                if let Some(entry) = self.queue.get_mut(&request.id) {
-                    break entry;
-                }
-                std::thread::yield_now();
-            };
-            if let crate::OutgoingRequest::Pending(waker) = &*entry {
-                waker.wake_by_ref();
-            }
-            *entry = crate::OutgoingRequest::Done(Response::new_ok(
-                request.id,
-                serde_json::to_value(result).unwrap(),
-            ));
+            let response = Response::new_ok(request.id, serde_json::to_value(result).unwrap());
+            assert!(crate::complete_request(&self.queue, response), "unknown request");
         }
 
         fn next_show_message(&self) -> lsp_types::ShowMessageParams {

--- a/tools/lsp/main.rs
+++ b/tools/lsp/main.rs
@@ -27,7 +27,7 @@ pub use i_slint_editor_preview::util;
 
 use editor_preview::Result;
 use language::*;
-pub use server_notifier::{OutgoingRequest, OutgoingRequestQueue, ServerNotifier};
+pub use server_notifier::{OutgoingRequestQueue, ServerNotifier, complete_request};
 
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidCloseTextDocumentParams,
@@ -644,19 +644,9 @@ fn crossbeam_tokio_adapter(
     loop {
         match connection.receiver.recv() {
             Ok(Message::Response(resp)) => {
-                let Some(mut q) = request_queue.get_mut(&resp.id) else {
+                if !complete_request(&request_queue, resp) {
                     tracing::error!("Response to unknown request");
-                    continue;
-                };
-                match &*q {
-                    OutgoingRequest::Done(_) => {
-                        tracing::error!("Response to unknown request");
-                        continue;
-                    }
-                    OutgoingRequest::Start => { /* nothing to do */ }
-                    OutgoingRequest::Pending(x) => x.wake_by_ref(),
-                };
-                *q = OutgoingRequest::Done(resp);
+                }
             }
             Ok(msg) => {
                 if from_lsp_sender.send(msg.clone()).is_err() {
@@ -666,6 +656,63 @@ fn crossbeam_tokio_adapter(
             Err(_) => return,
         }
     }
+}
+
+/// Round-trips requests through the adapter thread with an in-memory connection.
+/// The client answers every request twice, so the adapter also sees the duplicate
+/// it must ignore, and answers one request with an error that the future reports.
+/// A response that gets lost shows up as a timeout.
+#[tokio::test]
+async fn fast_client_responses_complete() {
+    let (connection, client) = Connection::memory();
+    let connection = Arc::new(connection);
+    let queue = OutgoingRequestQueue::default();
+    let notifier = ServerNotifier::new(connection.sender.clone(), queue.clone());
+    let (sender, _receiver) = mpsc::unbounded_channel();
+    let adapter = std::thread::spawn(move || {
+        crossbeam_tokio_adapter(connection, sender, queue);
+    });
+    let client = std::thread::spawn(move || {
+        while let Ok(Message::Request(request)) = client.receiver.recv() {
+            let response = if request.method == "window/showMessageRequest" {
+                Response::new_err(request.id, ErrorCode::RequestFailed as i32, "refused".into())
+            } else {
+                Response::new_ok(request.id, serde_json::json!([]))
+            };
+            for _ in 0..2 {
+                client.sender.send(Message::Response(response.clone())).unwrap();
+            }
+        }
+    });
+
+    for round in 0..100 {
+        let response = notifier
+            .send_request::<lsp_types::request::WorkspaceConfiguration>(
+                lsp_types::ConfigurationParams { items: vec![] },
+            )
+            .unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(2), response).await;
+        assert!(
+            matches!(&result, Ok(Ok(values)) if values.is_empty()),
+            "round {round}: {result:?}"
+        );
+    }
+
+    let response = notifier
+        .send_request::<lsp_types::request::ShowMessageRequest>(
+            lsp_types::ShowMessageRequestParams {
+                typ: lsp_types::MessageType::INFO,
+                message: String::new(),
+                actions: None,
+            },
+        )
+        .unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(2), response).await;
+    assert!(matches!(&result, Ok(Err(err)) if err.to_string() == "refused"), "{result:?}");
+
+    notifier.send_notification::<lsp_types::notification::Exit>(()).unwrap();
+    client.join().unwrap();
+    adapter.join().unwrap();
 }
 
 async fn handle_notification(

--- a/tools/lsp/server_notifier.rs
+++ b/tools/lsp/server_notifier.rs
@@ -9,18 +9,23 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
     use crate::editor_preview::Result;
-    use lsp_server::{Message, RequestId};
+    use lsp_server::{Message, RequestId, Response};
     use lsp_types::notification::Notification;
-    use std::sync::{Arc, atomic};
-    use std::task::{Poll, Waker};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex, atomic};
+    use tokio::sync::oneshot;
 
-    pub enum OutgoingRequest {
-        Start,
-        Pending(Waker),
-        Done(lsp_server::Response),
+    /// The requests sent to the client that still wait for their response.
+    pub type OutgoingRequestQueue = Arc<Mutex<HashMap<RequestId, oneshot::Sender<Response>>>>;
+
+    /// Delivers a response from the client to the future waiting for it.
+    /// Returns false if no request with that id is waiting.
+    pub fn complete_request(queue: &OutgoingRequestQueue, response: Response) -> bool {
+        let Some(sender) = queue.lock().unwrap().remove(&response.id) else { return false };
+        // Sending fails when the future was dropped before the response came.
+        let _ = sender.send(response);
+        true
     }
-
-    pub type OutgoingRequestQueue = Arc<dashmap::DashMap<RequestId, OutgoingRequest>>;
 
     /// A handle that can be used to communicate with the client
     #[derive(Clone)]
@@ -54,7 +59,19 @@ mod native {
         pub fn send_request<T: lsp_types::request::Request>(
             &self,
             request: T::Params,
-        ) -> Result<impl Future<Output = Result<T::Result>>> {
+        ) -> Result<impl Future<Output = Result<T::Result>> + use<T>> {
+            /// Forgets the request when its future is dropped before the client answers.
+            struct Registration {
+                queue: OutgoingRequestQueue,
+                id: RequestId,
+            }
+
+            impl Drop for Registration {
+                fn drop(&mut self) {
+                    self.queue.lock().unwrap().remove(&self.id);
+                }
+            }
+
             static REQ_ID: atomic::AtomicI32 = atomic::AtomicI32::new(0);
             let id = RequestId::from(REQ_ID.fetch_add(1, atomic::Ordering::Relaxed));
             let msg = Message::Request(lsp_server::Request::new(
@@ -62,27 +79,73 @@ mod native {
                 T::METHOD.to_string(),
                 request,
             ));
+            let (sender, receiver) = oneshot::channel();
+            // Register before sending: the client may answer before `send` returns.
+            let registration = Registration { queue: self.queue.clone(), id: id.clone() };
+            registration.queue.lock().unwrap().insert(id, sender);
             self.sender.send(msg)?;
-            let queue = self.queue.clone();
-            queue.insert(id.clone(), OutgoingRequest::Start);
-            Ok(std::future::poll_fn(move |ctx| match queue.remove(&id).unwrap().1 {
-                OutgoingRequest::Pending(_) | OutgoingRequest::Start => {
-                    queue.insert(id.clone(), OutgoingRequest::Pending(ctx.waker().clone()));
-                    Poll::Pending
+            Ok(async move {
+                let _registration = registration;
+                let response = receiver.await.map_err(|_| "no response from the client")?;
+                match response.response_result {
+                    Err(err) => Err(err.message.into()),
+                    Ok(result) => serde_json::from_value(result)
+                        .map_err(|e| format!("cannot deserialize response: {e:?}").into()),
                 }
-                OutgoingRequest::Done(d) => match d.response_result {
-                    Err(err) => Poll::Ready(Err(err.message.into())),
-                    Ok(result) => Poll::Ready(
-                        serde_json::from_value(result)
-                            .map_err(|e| format!("cannot deserialize response: {e:?}").into()),
-                    ),
-                },
-            }))
+            })
         }
 
         #[cfg(test)]
         pub fn dummy() -> Self {
             Self { sender: crossbeam_channel::unbounded().0, queue: Default::default() }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn notifier(
+            sender: crossbeam_channel::Sender<Message>,
+        ) -> (ServerNotifier, OutgoingRequestQueue) {
+            let queue = OutgoingRequestQueue::default();
+            (ServerNotifier::new(sender, queue.clone()), queue)
+        }
+
+        fn config_request(
+            notifier: &ServerNotifier,
+        ) -> Result<impl Future<Output = Result<Vec<serde_json::Value>>> + use<>> {
+            notifier.send_request::<lsp_types::request::WorkspaceConfiguration>(
+                lsp_types::ConfigurationParams { items: vec![] },
+            )
+        }
+
+        #[test]
+        fn request_is_registered_before_it_is_sent() {
+            // A zero-capacity channel blocks `send` until the test receives,
+            // so the queue can be inspected while the request is in flight.
+            let (sender, receiver) = crossbeam_channel::bounded(0);
+            let (notifier, queue) = notifier(sender);
+            let sender_thread = std::thread::spawn(move || config_request(&notifier).unwrap());
+
+            let mut select = crossbeam_channel::Select::new();
+            select.recv(&receiver);
+            select.ready_timeout(std::time::Duration::from_secs(5)).unwrap();
+            assert_eq!(queue.lock().unwrap().len(), 1);
+
+            receiver.recv().unwrap();
+            drop(sender_thread.join().unwrap());
+            assert!(queue.lock().unwrap().is_empty());
+        }
+
+        #[test]
+        fn dropped_future_removes_request() {
+            let (sender, _receiver) = crossbeam_channel::unbounded();
+            let (notifier, queue) = notifier(sender);
+            let response = config_request(&notifier).unwrap();
+            assert_eq!(queue.lock().unwrap().len(), 1);
+            drop(response);
+            assert!(queue.lock().unwrap().is_empty());
         }
     }
 }


### PR DESCRIPTION
When the server asked the client something, for example for its configuration, it sent the request before registering its id, and every poll of the waiting future briefly removed the entry again. A reply arriving in either window was logged as "Response to unknown request" and dropped, so the future never resolved. The main loop awaits these futures inline, so the whole server stopped answering: semantic highlighting and the "Show Preview" code lens disappeared.

Each request now owns a oneshot channel that is registered before the request is sent. The adapter thread removes the entry and sends the reply into it. This replaces the Start/Pending/Done state machine, the waker handling, and the dashmap dependency. A guard forgets the request when its future is dropped without an answer.

Tests check that a request is registered before it is sent, that a dropped future removes its entry, and that replies, duplicate replies, and error replies travel through the adapter thread.

Closes #13276, which fixed the same race by reordering the existing state machine. The analysis and the tests come from that PR.

ChangeLog: Fixed the language server intermittently freezing and losing semantic highlighting and Show Preview code lenses

