### PR TITLE
i-slint-live-preview: fix the flaky file watcher tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "slint-interpreter",
  "spake2",
  "subtle",
+ "tempfile",
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -58,9 +58,8 @@ getifs = { version = "0.6.1", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"], optional = true }
 
-# The cool-down tests move the clock rather than sleeping through a
-# 60-second pairing deadline.
 [dev-dependencies]
+tempfile = "3"
 tokio = { version = "1.48.0", features = ["test-util"] }
 
 [lib]

--- a/internal/live-preview/file_watcher.rs
+++ b/internal/live-preview/file_watcher.rs
@@ -71,7 +71,11 @@ impl FileWatcherImpl for notify::RecommendedWatcher {
             notify::ErrorKind::PathNotFound
             | notify::ErrorKind::WatchNotFound
             | notify::ErrorKind::Generic(_) => true,
-            notify::ErrorKind::Io(e) => e.kind() == std::io::ErrorKind::NotFound,
+            // `InvalidInput` is `inotify_rm_watch` on a watch the kernel already dropped with
+            // the deleted directory, before notify processed that event.
+            notify::ErrorKind::Io(e) => {
+                matches!(e.kind(), std::io::ErrorKind::NotFound | std::io::ErrorKind::InvalidInput)
+            }
             _ => false,
         }
     }

--- a/internal/live-preview/file_watcher.rs
+++ b/internal/live-preview/file_watcher.rs
@@ -578,28 +578,18 @@ mod tests {
     use super::*;
 
     use std::fs;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc::{self, Receiver};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::Duration;
 
     const WATCHER_SETTLE_DELAY: Duration = Duration::from_millis(50);
     const EVENT_TIMEOUT: Duration = Duration::from_secs(1);
     const QUIET_TIMEOUT: Duration = Duration::from_millis(50);
 
-    fn new_test_root() -> PathBuf {
-        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
-
-        let unique_id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        let root = std::env::temp_dir()
-            .join(format!("slint-file-watcher-{timestamp}-{unique_id}-{}", std::process::id()));
-        fs::create_dir_all(&root).unwrap();
-        root
-    }
-
     struct TestContext {
-        root: PathBuf,
+        /// Declared before `root` so that it is dropped first: the watcher must not follow the
+        /// vanished paths up to the shared temp directory.
         watcher: FileWatcher,
+        root: tempfile::TempDir,
         events: Receiver<WatchEvent>,
         errors: Receiver<notify::Error>,
     }
@@ -610,7 +600,7 @@ mod tests {
         }
 
         fn new_with_passthrough(pass_through_unwatched_events: bool) -> Self {
-            let root = new_test_root();
+            let root = tempfile::Builder::new().prefix("slint-file-watcher-").tempdir().unwrap();
             let (event_tx, events) = mpsc::channel();
             let (error_tx, errors) = mpsc::channel();
 
@@ -631,11 +621,11 @@ mod tests {
             )
             .unwrap();
 
-            Self { root, watcher, events, errors }
+            Self { watcher, root, events, errors }
         }
 
         fn path(&self, relative: impl AsRef<Path>) -> PathBuf {
-            self.root.join(relative)
+            self.root.path().join(relative)
         }
 
         fn create_dir_all(&self, relative: impl AsRef<Path>) -> PathBuf {
@@ -737,12 +727,6 @@ mod tests {
             }
 
             self.assert_no_errors();
-        }
-    }
-
-    impl Drop for TestContext {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.root);
         }
     }
 


### PR DESCRIPTION
- `refreshing_watch_set_stops_forwarding_old_paths` hung on CI, likely macOS-only:
the teardown removed the directory while the watcher was alive, so the watcher
fell back to watching the shared temp directory, which is very expensive with
kqueue. Drop the watcher before the directory, which now comes from `tempfile`.

- While stress testing this locally on Linux, a different test,
`removing_watched_directory_does_not_report_spurious_errors`, failed a few
times with an EINVAL from `inotify_rm_watch`: the kernel had already dropped
the watch of the deleted directory. Treat that error as transient.
