### PR TITLE
Set the macOS bundle identifier for Slint Live Preview

### DIFF
--- a/tools/lsp/Cargo.toml
+++ b/tools/lsp/Cargo.toml
@@ -18,6 +18,7 @@ default-run = "slint-lsp"
 
 [package.metadata.bundle]
 name = "Slint Live Preview"
+identifier = "dev.slint.lsp"
 icon = ["../../logo/slint-logo.icns"]
 
 [[bin]]


### PR DESCRIPTION
The macOS Slint Live Preview bundle currently has an empty `CFBundleIdentifier`.
Set `identifier = "dev.slint.lsp"` in the LSP's cargo-bundle metadata so packaged previews have a stable application identifier.

Validation: `cargo metadata --no-deps --format-version 1 --offline` reports the identifier, and `git diff --check` passes.
The app bundle was not rebuilt; this does not establish whether the identifier fixes repeated Computer Use approval prompts.
Repository pre-push checks passed: CSpell and visual editor Python formatting, lint, and type checks.
