### PR TITLE
Scale the drag image based on scale factor

### DIFF
--- a/internal/core/window.rs
+++ b/internal/core/window.rs
@@ -1856,6 +1856,7 @@ impl WindowInner {
 
         item_renderer.save_state();
         item_renderer.translate(top_left.to_vector());
+        item_renderer.scale(self.scale_factor(), self.scale_factor());
         item_renderer.draw_image_direct(image);
         item_renderer.restore_state();
 


### PR DESCRIPTION
This makes it nicer from a user's point-of-view when dragging from an Image that's also scaled.

| Previous | Current |
|--------|--------|
| ![Screencast_20260908_115048.webm](https://github.com/user-attachments/assets/eae29195-f725-4beb-bb18-be95b6f6ec7f) | ![Screencast_20260908_114826.webm](https://github.com/user-attachments/assets/193d499d-f089-434c-ac92-96881273ae2c) |

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
