### PR TITLE
Visual Editor: Enable simple undo / redo

### DIFF
--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -20,15 +20,30 @@ struct EditItem {
 pub fn compute_file_hashes(
     edits: &[i_slint_editor_preview::editing::text_edit::EditedText],
 ) -> FileHashes {
-    edits
-        .iter()
-        .map(|e| {
-            let mut hasher = std::hash::DefaultHasher::new();
-            e.contents.hash(&mut hasher);
-            let hash = hasher.finish();
-            (e.url.clone(), hash)
-        })
-        .collect()
+    edits.iter().map(|e| (e.url.clone(), content_hash(&e.contents))).collect()
+}
+
+fn content_hash(content: &str) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    content.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn prepare_history_edit(
+    document_cache: &i_slint_editor_preview::DocumentCache,
+    item: &EditItem,
+) -> Option<(lsp_types::WorkspaceEdit, FileHashes)> {
+    for (url, expected) in &item.file_hashes {
+        let document = document_cache.get_document(url)?;
+        let cached = document.node.as_ref()?.source_file.source()?;
+        let disk = std::fs::read_to_string(url.to_file_path().ok()?).ok()?;
+        if content_hash(cached) != *expected || content_hash(&disk) != *expected {
+            return None;
+        }
+    }
+    let result = text_edit::apply_workspace_edit(document_cache, &item.edit).ok()?;
+    let reverse = text_edit::reversed_edit(document_cache, &item.edit)?;
+    Some((reverse, compute_file_hashes(&result)))
 }
 
 #[derive(Default)]
@@ -43,14 +58,6 @@ impl UndoRedoStack {
         self.undo_stack.clear();
         self.redo_stack.clear();
     }
-
-    /*/// Redo the last edit
-    pub fn redo(&mut self) -> Option<lsp_types::WorkspaceEdit> {
-        let item = self.redo_stack.pop()?;
-        let edit = item.edit.clone();
-        self.undo_stack.push(item);
-        Some(edit)
-    }*/
 
     pub fn push(
         &mut self,
@@ -69,17 +76,14 @@ impl UndoRedoStack {
         }
     }
 
-    /// When we get contents from the editor, we check that it matches the expected state of the top of the undo stack,
-    /// otherwise, we reset the stack.
     pub fn check_set_contents_valid(&mut self, url: &lsp_types::Url, content: &str) -> bool {
-        let Some(top) = self.undo_stack.last() else {
-            return true;
-        };
-        let ok = top.file_hashes.get(url).is_none_or(|hash| {
-            let mut hasher = std::hash::DefaultHasher::new();
-            content.hash(&mut hasher);
-            *hash == hasher.finish()
-        });
+        let expected = self
+            .undo_stack
+            .iter()
+            .rev()
+            .chain(self.redo_stack.iter().rev())
+            .find_map(|item| item.file_hashes.get(url));
+        let ok = expected.is_none_or(|hash| *hash == content_hash(content));
         if !ok {
             self.clear();
         }
@@ -97,13 +101,16 @@ pub fn setup(api: &ui::Api<'_>) {
             let Some(edit) = state.undo_redo_stack.undo_stack.pop() else {
                 return;
             };
-            if let Some(reverse) = text_edit::reversed_edit(&document_cache, &edit.edit) {
-                state.undo_redo_stack.redo_stack.push(EditItem {
-                    title: edit.title.clone(),
-                    edit: reverse,
-                    file_hashes: edit.file_hashes.clone(),
-                });
-            }
+            let Some((reverse, file_hashes)) = prepare_history_edit(&document_cache, &edit) else {
+                state.undo_redo_stack.clear();
+                set_undo_redo_enabled(state);
+                return;
+            };
+            state.undo_redo_stack.redo_stack.push(EditItem {
+                title: edit.title.clone(),
+                edit: reverse,
+                file_hashes,
+            });
             state
                 .to_lsp
                 .borrow()
@@ -127,13 +134,16 @@ pub fn setup(api: &ui::Api<'_>) {
             let Some(edit) = state.undo_redo_stack.redo_stack.pop() else {
                 return;
             };
-            if let Some(reverse) = text_edit::reversed_edit(&document_cache, &edit.edit) {
-                state.undo_redo_stack.undo_stack.push(EditItem {
-                    title: edit.title.clone(),
-                    edit: reverse,
-                    file_hashes: edit.file_hashes.clone(),
-                });
-            }
+            let Some((reverse, file_hashes)) = prepare_history_edit(&document_cache, &edit) else {
+                state.undo_redo_stack.clear();
+                set_undo_redo_enabled(state);
+                return;
+            };
+            state.undo_redo_stack.undo_stack.push(EditItem {
+                title: edit.title.clone(),
+                edit: reverse,
+                file_hashes,
+            });
             state
                 .to_lsp
                 .borrow()
@@ -154,5 +164,53 @@ pub fn set_undo_redo_enabled(state: &super::PreviewState) {
     if let Some(api) = state.api.upgrade() {
         api.set_undo_enabled(!state.undo_redo_stack.undo_stack.is_empty());
         api.set_redo_enabled(!state.undo_redo_stack.redo_stack.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(url: &lsp_types::Url, content: &str) -> EditItem {
+        EditItem {
+            title: "Edit".into(),
+            edit: Default::default(),
+            file_hashes: HashMap::from([(url.clone(), content_hash(content))]),
+        }
+    }
+
+    #[test]
+    fn external_change_invalidates_redo_without_undo() {
+        let url = lsp_types::Url::parse("file:///rectangle.slint").unwrap();
+        let mut stack = UndoRedoStack::default();
+        stack.redo_stack.push(item(&url, "x: 80px;"));
+        assert!(stack.check_set_contents_valid(&url, "x: 80px;"));
+        assert!(!stack.check_set_contents_valid(&url, "x: 900px;"));
+        assert!(stack.undo_stack.is_empty());
+        assert!(stack.redo_stack.is_empty());
+    }
+
+    #[test]
+    fn validates_each_file_in_history() {
+        let first = lsp_types::Url::parse("file:///first.slint").unwrap();
+        let second = lsp_types::Url::parse("file:///second.slint").unwrap();
+        let mut stack = UndoRedoStack::default();
+        stack.undo_stack.push(item(&first, "first edit"));
+        stack.undo_stack.push(item(&second, "second edit"));
+        assert!(stack.check_set_contents_valid(&first, "first edit"));
+        assert!(!stack.check_set_contents_valid(&first, "external edit"));
+        assert!(stack.undo_stack.is_empty());
+    }
+
+    #[test]
+    fn validates_nearest_redo_state_and_ignores_unrelated_files() {
+        let url = lsp_types::Url::parse("file:///rectangle.slint").unwrap();
+        let unrelated = lsp_types::Url::parse("file:///unrelated.slint").unwrap();
+        let mut stack = UndoRedoStack::default();
+        stack.redo_stack.push(item(&url, "x: 104px;"));
+        stack.redo_stack.push(item(&url, "x: 80px;"));
+        assert!(stack.check_set_contents_valid(&url, "x: 80px;"));
+        assert!(stack.check_set_contents_valid(&unrelated, "external edit"));
+        assert_eq!(stack.redo_stack.len(), 2);
     }
 }

--- a/tools/editor/ui-tests/fixtures/editor-project/UndoRedo.slint
+++ b/tools/editor/ui-tests/fixtures/editor-project/UndoRedo.slint
@@ -1,0 +1,18 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component UndoRedo inherits Window {
+    width: 640px;
+    height: 480px;
+    background: #f8fafc;
+
+    root-rectangle := Rectangle {
+        x: 80px;
+        y: 80px;
+        width: 180px;
+        height: 120px;
+        background: #2563eb;
+        transform-rotation: 0deg;
+        border-radius: 12px;
+    }
+}

--- a/tools/editor/ui-tests/tests/canvas_interactions.py
+++ b/tools/editor/ui-tests/tests/canvas_interactions.py
@@ -134,11 +134,13 @@ def manual_rotation_drag(
     snapshot: SourceSnapshot,
     *,
     crosses_zero: bool = False,
+    kind: str = "Text",
+    target_angle: int = 15,
 ) -> None:
     start = center(handle)
     end = slint_testing.LogicalPosition(x=start.x + dx, y=start.y + dy)
     button = slint_testing.PointerEventButton.Left
-    initial_frame = selection_frame(window, "Text")
+    initial_frame = selection_frame(window, kind)
     window.dispatch_event(slint_testing.PointerPressEvent(start, button))
     window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
     angles = [_rotation_tooltip_value(window)]
@@ -151,11 +153,11 @@ def manual_rotation_drag(
         )
         window.dispatch_event(slint_testing.PointerMoveEvent(position))
         angles.append(_rotation_tooltip_value(window))
-        frames.append(selection_frame(window, "Text"))
+        frames.append(selection_frame(window, kind))
     snapshot.assert_unchanged_now()
 
     assert all(0 <= angle < 360 for angle in angles)
-    assert angles[-1] == 15 or crosses_zero
+    assert angles[-1] == target_angle or crosses_zero
     assert frames[-1] != initial_frame
     if crosses_zero:
         assert any(angle >= 345 for angle in angles)
@@ -168,8 +170,9 @@ def rotation_delta(
     window: slint_testing.Window,
     handle: slint_testing.Element,
     degrees: float,
+    kind: str = "Text",
 ) -> tuple[float, float]:
-    x, y, width, height = selection_frame(window, "Text")
+    x, y, width, height = selection_frame(window, kind)
     frame_center = slint_testing.LogicalPosition(
         x=x + width / 2,
         y=y + height / 2,
@@ -338,3 +341,57 @@ def manual_radius_drag(
     window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
     if shift:
         window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
+def radius_handle(window: slint_testing.Window, corner: str) -> slint_testing.Element:
+    selection = window_element_with_label(
+        window, "Selected Rectangle", slint_testing.AccessibleRole.Region
+    )
+    # A live reload can replace the frame while the pointer remains at the same logical
+    # position. Move away first so the real frame receives a fresh hover transition.
+    window.dispatch_event(
+        slint_testing.PointerMoveEvent(slint_testing.LogicalPosition(x=1, y=1))
+    )
+    window.dispatch_event(slint_testing.PointerMoveEvent(center(selection)))
+    return window_element_with_label(window, f"Rectangle radius {corner}")
+
+
+OrientedFrame = tuple[float, float, float, float, float]
+
+
+def rotated_handle_center(
+    element: slint_testing.Element, angle: float = 0
+) -> tuple[float, float]:
+    midpoint = center(element)
+    size = element.size
+    radians = math.radians(angle)
+    return (
+        midpoint.x
+        + size.width / 2 * (math.cos(radians) - 1)
+        - size.height / 2 * math.sin(radians),
+        midpoint.y
+        + size.width / 2 * math.sin(radians)
+        + size.height / 2 * (math.cos(radians) - 1),
+    )
+
+
+def oriented_selection_frame(
+    window: slint_testing.Window, kind: str
+) -> OrientedFrame | None:
+    handles = []
+    for corner in ("top-left", "top-right", "bottom-right"):
+        matches = elements_with_label(window.root_element, f"{kind} resize {corner}")
+        if len(matches) != 1:
+            return None
+        handles.append(matches[0])
+    a, b, c = (rotated_handle_center(handle) for handle in handles)
+    angle = math.degrees(math.atan2(b[1] - a[1], b[0] - a[0]))
+    corrected_a = rotated_handle_center(handles[0], angle)
+    corrected_c = rotated_handle_center(handles[2], angle)
+    return (
+        (corrected_a[0] + corrected_c[0]) / 2,
+        (corrected_a[1] + corrected_c[1]) / 2,
+        math.dist(a, b),
+        math.dist(b, c),
+        angle,
+    )

--- a/tools/editor/ui-tests/tests/conftest.py
+++ b/tools/editor/ui-tests/tests/conftest.py
@@ -1,6 +1,8 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+# cspell:ignore addoption nodeid
+
 import math
 import os
 import shutil

--- a/tools/editor/ui-tests/tests/conftest.py
+++ b/tools/editor/ui-tests/tests/conftest.py
@@ -1,11 +1,14 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import math
 import os
 import shutil
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from ui_reporting import TestReport, current_report
 
 UI_TEST_ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY_ROOT = UI_TEST_ROOT.parents[2]
@@ -41,3 +44,34 @@ def fixture_project(tmp_path: Path) -> Path:
     destination = tmp_path / "editor-project"
     shutil.copytree(FIXTURE_PROJECT, destination)
     return destination
+
+
+def replay_pause_seconds(value: str) -> float:
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds < 0:
+        raise ValueError("Replay pause must be a finite, nonnegative number")
+    return seconds
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--replay-pause",
+        type=replay_pause_seconds,
+        default=0,
+        help="Pause for this many seconds after replay stages; use -s to see stage names",
+    )
+
+
+@pytest.fixture(autouse=True)
+def ui_test_report(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[None]:
+    token = current_report.set(
+        TestReport(
+            request.node.nodeid,
+            tmp_path / "screenshots",
+            request.config.getoption("--replay-pause"),
+        )
+    )
+    try:
+        yield
+    finally:
+        current_report.reset(token)

--- a/tools/editor/ui-tests/tests/inspector_interactions.py
+++ b/tools/editor/ui-tests/tests/inspector_interactions.py
@@ -1,0 +1,63 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import slint_testing
+from ui_driver import elements_with_label, wait_until, window_element_with_label
+
+FIELDS = {
+    "x": "Position X",
+    "y": "Position Y",
+    "width": "Width",
+    "height": "Height",
+    "rotation": "Rotation",
+    "radius": "Corner radius",
+}
+
+
+def inspector_field(
+    window: slint_testing.Window,
+    label: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> slint_testing.Element:
+    pane = window_element_with_label(
+        window, "Inspector and outline", slint_testing.AccessibleRole.Complementary
+    )
+    position = slint_testing.LogicalPosition(
+        x=pane.absolute_position.x + pane.size.width / 2,
+        y=pane.absolute_position.y + pane.size.height / 4,
+    )
+    for delta in [0, 10000, -180, -180, -180, -180, -180, -180]:
+        if delta:
+            window.dispatch_event(
+                slint_testing.PointerScrolledEvent(position, delta_x=0, delta_y=delta)
+            )
+        fields = elements_with_label(pane, label, role)
+        if len(fields) == 1:
+            return fields[0]
+    return window_element_with_label(window, label, role)
+
+
+def edit_field(
+    window: slint_testing.Window,
+    label: str,
+    value: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> None:
+    inspector_field(window, label, role).accessible_value = value
+
+
+def wait_for_field(
+    window: slint_testing.Window,
+    label: str,
+    value: str,
+    role: slint_testing.AccessibleRole | None = None,
+    timeout: float = 5,
+) -> None:
+    wait_until(
+        lambda: (
+            field
+            if (field := inspector_field(window, label, role)).accessible_value == value
+            else None
+        ),
+        timeout=timeout,
+    )

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -16,6 +16,7 @@ from canvas_interactions import (
     manual_radius_drag,
     manual_rotation_drag,
     position_distance,
+    radius_handle,
     rotation_delta,
     same_state,
     selection_frame,
@@ -804,19 +805,6 @@ def outside_resize_values(
         x + width + OUTSIDE_ARTBOARD_DISTANCE,
         BOUNDS_HEIGHT + OUTSIDE_ARTBOARD_DISTANCE - y,
     )
-
-
-def radius_handle(window: slint_testing.Window, corner: str) -> slint_testing.Element:
-    selection = window_element_with_label(
-        window, "Selected Rectangle", slint_testing.AccessibleRole.Region
-    )
-    # A live reload can replace the frame while the pointer remains at the same logical
-    # position. Move away first so the real frame receives a fresh hover transition.
-    window.dispatch_event(
-        slint_testing.PointerMoveEvent(slint_testing.LogicalPosition(x=1, y=1))
-    )
-    window.dispatch_event(slint_testing.PointerMoveEvent(center(selection)))
-    return window_element_with_label(window, f"Rectangle radius {corner}")
 
 
 def radius_handle_positions(

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from inspector_interactions import FIELDS, edit_field, inspector_field, wait_for_field
 from source_snapshot import SourceSnapshot
 from ui_driver import (
-    elements_with_label,
     first_window,
     launch_editor,
     select_outline_row,
@@ -32,55 +32,6 @@ def select_element(window: slint_testing.Window, kind: str) -> None:
     select_outline_row(window, ELEMENT_ROWS[kind])
     window_element_with_label(
         window, f"Selected {kind}", slint_testing.AccessibleRole.Region
-    )
-
-
-def inspector_field(
-    window: slint_testing.Window,
-    label: str,
-    role: slint_testing.AccessibleRole | None = None,
-) -> slint_testing.Element:
-    pane = window_element_with_label(
-        window, "Inspector and outline", slint_testing.AccessibleRole.Complementary
-    )
-    position = slint_testing.LogicalPosition(
-        x=pane.absolute_position.x + pane.size.width / 2,
-        y=pane.absolute_position.y + pane.size.height / 4,
-    )
-    for delta in [0, 10000, -180, -180, -180, -180, -180, -180]:
-        if delta:
-            window.dispatch_event(
-                slint_testing.PointerScrolledEvent(position, delta_x=0, delta_y=delta)
-            )
-        fields = elements_with_label(pane, label, role)
-        if len(fields) == 1:
-            return fields[0]
-    return window_element_with_label(window, label, role)
-
-
-def edit_field(
-    window: slint_testing.Window,
-    label: str,
-    value: str,
-    role: slint_testing.AccessibleRole | None = None,
-) -> None:
-    inspector_field(window, label, role).accessible_value = value
-
-
-def wait_for_field(
-    window: slint_testing.Window,
-    label: str,
-    value: str,
-    role: slint_testing.AccessibleRole | None = None,
-    timeout: float = 5,
-) -> None:
-    wait_until(
-        lambda: (
-            field
-            if (field := inspector_field(window, label, role)).accessible_value == value
-            else None
-        ),
-        timeout=timeout,
     )
 
 
@@ -126,11 +77,11 @@ def assert_rendered_element(window: slint_testing.Window, element_id: str) -> No
 @pytest.mark.parametrize(
     ("label", "value", "old", "new"),
     [
-        ("Position X", "44", b"        x: 32px;", b"        x: 44px;"),
-        ("Position Y", "48", b"        y: 32px;", b"        y: 48px;"),
-        ("Width", "176", b"        width: 160px;", b"        width: 176px;"),
+        (FIELDS["x"], "44", b"        x: 32px;", b"        x: 44px;"),
+        (FIELDS["y"], "48", b"        y: 32px;", b"        y: 48px;"),
+        (FIELDS["width"], "176", b"        width: 160px;", b"        width: 176px;"),
         (
-            "Height",
+            FIELDS["height"],
             "112",
             b"        width: 160px;\n        height: 96px;",
             b"        width: 160px;\n        height: 112px;",
@@ -799,15 +750,15 @@ def test_rectangle_effect_value_writes_exact_source(
 
 
 INVALID_EDITS = (
-    ("invalid-number", "Rectangle", "Position X", "invalid"),
-    ("empty-number", "Rectangle", "Position X", ""),
+    ("invalid-number", "Rectangle", FIELDS["x"], "invalid"),
+    ("empty-number", "Rectangle", FIELDS["x"], ""),
     ("empty-family", "Text", "Font family", ""),
     ("empty-fit", "Image", "Image fit", ""),
-    ("nonnumeric-y", "Rectangle", "Position Y", "invalid"),
-    ("zero-width", "Rectangle", "Width", "0"),
-    ("negative-width", "Rectangle", "Width", "-1"),
-    ("zero-height", "Rectangle", "Height", "0"),
-    ("negative-height", "Rectangle", "Height", "-1"),
+    ("nonnumeric-y", "Rectangle", FIELDS["y"], "invalid"),
+    ("zero-width", "Rectangle", FIELDS["width"], "0"),
+    ("negative-width", "Rectangle", FIELDS["width"], "-1"),
+    ("zero-height", "Rectangle", FIELDS["height"], "0"),
+    ("negative-height", "Rectangle", FIELDS["height"], "-1"),
 )
 
 

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -7,6 +7,7 @@ import pytest
 import slint_testing
 from source_snapshot import SourceSnapshot
 from ui_driver import (
+    elements_with_label,
     first_window,
     launch_editor,
     select_outline_row,
@@ -39,6 +40,21 @@ def inspector_field(
     label: str,
     role: slint_testing.AccessibleRole | None = None,
 ) -> slint_testing.Element:
+    pane = window_element_with_label(
+        window, "Inspector and outline", slint_testing.AccessibleRole.Complementary
+    )
+    position = slint_testing.LogicalPosition(
+        x=pane.absolute_position.x + pane.size.width / 2,
+        y=pane.absolute_position.y + pane.size.height / 4,
+    )
+    for delta in [0, 10000, -180, -180, -180, -180, -180, -180]:
+        if delta:
+            window.dispatch_event(
+                slint_testing.PointerScrolledEvent(position, delta_x=0, delta_y=delta)
+            )
+        fields = elements_with_label(pane, label, role)
+        if len(fields) == 1:
+            return fields[0]
     return window_element_with_label(window, label, role)
 
 
@@ -104,19 +120,6 @@ def assert_rendered_element(window: slint_testing.Window, element_id: str) -> No
             if (element := next(iter(window.find_elements_by_id(element_id)), None))
             else None
         )
-    )
-
-
-def scroll_to_shadow_details(window: slint_testing.Window) -> None:
-    anchor = inspector_field(
-        window, "Shadow distance", slint_testing.AccessibleRole.Slider
-    )
-    position = slint_testing.LogicalPosition(
-        x=anchor.absolute_position.x + anchor.size.width / 2,
-        y=anchor.absolute_position.y + anchor.size.height / 2,
-    )
-    window.dispatch_event(
-        slint_testing.PointerScrolledEvent(position=position, delta_x=0, delta_y=-320)
     )
 
 
@@ -726,7 +729,6 @@ def test_each_shadow_family_control_writes_exact_source(
         window = first_window(editor)
         select_element(window, "Rectangle")
         if control in {"blur", "spread"}:
-            scroll_to_shadow_details(window)
             inspector_field(
                 window,
                 f"{label} value",
@@ -772,7 +774,6 @@ def test_shadow_control_boundary_writes_exact_source(
         window = first_window(editor)
         select_element(window, "Rectangle")
         if control in {"blur", "spread"}:
-            scroll_to_shadow_details(window)
             inspector_field(
                 window,
                 f"{label} value",

--- a/tools/editor/ui-tests/tests/test_selection.py
+++ b/tools/editor/ui-tests/tests/test_selection.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from inspector_interactions import FIELDS
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
@@ -48,13 +49,13 @@ def test_outline_selection_synchronizes_canvas_and_inspector(
         select_fixture_element(window, "Rectangle")
         assert (
             window_element_with_label(
-                window, "Position X", slint_testing.AccessibleRole.TextInput
+                window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
             ).accessible_value
             == "40"
         )
         assert (
             window_element_with_label(
-                window, "Width", slint_testing.AccessibleRole.TextInput
+                window, FIELDS["width"], slint_testing.AccessibleRole.TextInput
             ).accessible_value
             == "180"
         )
@@ -98,7 +99,7 @@ def test_canvas_selection_synchronizes_outline_and_inspector(
         )
         assert (
             window_element_with_label(
-                window, "Position X", slint_testing.AccessibleRole.TextInput
+                window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
             ).accessible_value
             == "180"
         )
@@ -194,7 +195,7 @@ def test_focused_inspector_field_consumes_delete_key(
         window = first_window(editor)
         select_fixture_element(window, "Rectangle")
         field = window_element_with_label(
-            window, "Position X", slint_testing.AccessibleRole.TextInput
+            window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
         )
         target = slint_testing.LogicalPosition(
             x=field.absolute_position.x + field.size.width / 2,

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from inspector_interactions import FIELDS
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
@@ -142,7 +143,7 @@ def test_stale_selection_commit_is_rejected(
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
         select_outline_row(window, "inspect-rectangle")
-        stage_field_text(window, "Position X", "99")
+        stage_field_text(window, FIELDS["x"], "99")
         snapshot.assert_unchanged_now()
         select_outline_row(window, "inspect-text")
         wait_until(
@@ -150,7 +151,7 @@ def test_stale_selection_commit_is_rejected(
                 field
                 if (
                     field := window_element_with_label(
-                        window, "Position X", slint_testing.AccessibleRole.TextInput
+                        window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
                     )
                 ).accessible_value
                 == "224"
@@ -174,7 +175,7 @@ def test_stale_revision_commit_is_rejected(
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
         select_outline_row(window, "inspect-rectangle")
-        stage_field_text(window, "Position X", "99")
+        stage_field_text(window, FIELDS["x"], "99")
         snapshot.assert_unchanged_now()
         external = baseline.replace(b"        x: 32px;", b"        x: 36px;", 1)
         source_file.write_bytes(external)
@@ -184,7 +185,7 @@ def test_stale_revision_commit_is_rejected(
                 field
                 if (
                     field := window_element_with_label(
-                        window, "Position X", slint_testing.AccessibleRole.TextInput
+                        window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
                     )
                 ).accessible_value
                 == "36"

--- a/tools/editor/ui-tests/tests/test_undo_redo.py
+++ b/tools/editor/ui-tests/tests/test_undo_redo.py
@@ -214,3 +214,44 @@ def test_rectangle_undo_redo(
                 shortcut(window, redo=name == "redo")
                 snapshot.wait_for_exact(content, SOURCE)
                 assert_visual(window, values, origin, case.endswith("radius"))
+
+
+@pytest.mark.parametrize("wait_for_reload", [False, True])
+def test_redo_after_external_edit_preserves_source(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    wait_for_reload: bool,
+) -> None:
+    source = fixture_project / SOURCE
+    baseline = source.read_bytes()
+    edited = baseline.replace(b"x: 80px;", b"x: 104px;", 1)
+    external = baseline.replace(b"x: 80px;", b"x: 900px;", 1)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(editor_binary, editor_environment, source) as editor:
+        window = first_window(editor)
+        select_fixture_element(window, "Rectangle")
+        cx, cy, *_ = wait_until(lambda: oriented_selection_frame(window, "Rectangle"))
+        origin = (
+            cx - INITIAL["x"] - INITIAL["width"] / 2,
+            cy - INITIAL["y"] - INITIAL["height"] / 2,
+        )
+        edit_field(window, FIELDS["x"], "104", slint_testing.AccessibleRole.TextInput)
+        snapshot.wait_for_exact(edited, SOURCE)
+        assert_visual(window, INITIAL | {"x": 104}, origin, False)
+        select_fixture_element(window, "Rectangle")
+        shortcut(window, redo=False)
+        snapshot.wait_for_exact(baseline, SOURCE)
+        wait_for_field(
+            window, FIELDS["x"], "80", slint_testing.AccessibleRole.TextInput
+        )
+        select_fixture_element(window, "Rectangle")
+        source.write_bytes(external)
+        snapshot_after_external = SourceSnapshot.capture(fixture_project)
+        if wait_for_reload:
+            wait_for_field(
+                window, FIELDS["x"], "900", slint_testing.AccessibleRole.TextInput
+            )
+        shortcut(window, redo=True)
+        snapshot.wait_for_exact(external, SOURCE)
+        snapshot_after_external.assert_unchanged()

--- a/tools/editor/ui-tests/tests/test_undo_redo.py
+++ b/tools/editor/ui-tests/tests/test_undo_redo.py
@@ -1,0 +1,273 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import logging
+import math
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import slint_testing
+from canvas_interactions import center, manual_drag, manual_radius_drag
+from slint_testing import keys
+from source_snapshot import SourceSnapshot
+from test_canvas import radius_handle
+from test_inspector import edit_field, wait_for_field
+from ui_driver import (
+    first_window,
+    launch_editor,
+    select_fixture_element,
+    wait_until,
+    window_element_with_label,
+)
+
+SOURCE = "UndoRedo.slint"
+INITIAL = {"x": 80, "y": 80, "width": 180, "height": 120, "rotation": 0, "radius": 12}
+CASES = [
+    ("handle-move", {"x": 104, "y": 96}),
+    ("handle-resize", {"width": 204, "height": 136}),
+    ("handle-rotation", {"rotation": 15}),
+    ("handle-radius", {"radius": 20}),
+    ("inspector-x", {"x": 104}),
+    ("inspector-y", {"y": 96}),
+    ("inspector-width", {"width": 204}),
+    ("inspector-height", {"height": 136}),
+    ("inspector-rotation", {"rotation": 15}),
+    ("inspector-radius", {"radius": 20}),
+]
+FIELDS = {
+    "x": "Position X",
+    "y": "Position Y",
+    "width": "Width",
+    "height": "Height",
+    "rotation": "Rotation",
+    "radius": "Corner radius",
+}
+
+
+def pause(case: str, stage: str) -> None:
+    print(f"{case}: {stage}", flush=True)
+    if os.environ.get("SLINT_UNDO_REDO_REPLAY") == "1":
+        time.sleep(1)
+
+
+def point(
+    window: slint_testing.Window, label: str, angle: float = 0
+) -> tuple[float, float]:
+    element = window_element_with_label(window, label)
+    p, size = element.absolute_position, element.size
+    radians = math.radians(angle)
+    return (
+        p.x + size.width / 2 * math.cos(radians) - size.height / 2 * math.sin(radians),
+        p.y + size.width / 2 * math.sin(radians) + size.height / 2 * math.cos(radians),
+    )
+
+
+def frame(window: slint_testing.Window) -> tuple[float, ...]:
+    a = point(window, "Rectangle resize top-left")
+    b = point(window, "Rectangle resize top-right")
+    c = point(window, "Rectangle resize bottom-right")
+    angle = math.degrees(math.atan2(b[1] - a[1], b[0] - a[0]))
+    corrected_a = point(window, "Rectangle resize top-left", angle)
+    corrected_c = point(window, "Rectangle resize bottom-right", angle)
+    return (
+        (corrected_a[0] + corrected_c[0]) / 2,
+        (corrected_a[1] + corrected_c[1]) / 2,
+        math.dist(a, b),
+        math.dist(b, c),
+        angle,
+    )
+
+
+def assert_visual(
+    window: slint_testing.Window,
+    values: dict[str, int],
+    origin: tuple[float, float],
+    check_radius: bool,
+) -> None:
+    expected = (
+        origin[0] + values["x"] + values["width"] / 2,
+        origin[1] + values["y"] + values["height"] / 2,
+        values["width"],
+        values["height"],
+        values["rotation"],
+    )
+    try:
+        wait_until(
+            lambda: (
+                True
+                if all(abs(a - b) < 1.5 for a, b in zip(frame(window), expected))
+                else None
+            )
+        )
+    except AssertionError as error:
+        raise AssertionError(
+            f"Expected frame {expected}, got {frame(window)}"
+        ) from error
+    for name in ("x", "y", "width", "height"):
+        wait_for_field(
+            window,
+            FIELDS[name],
+            str(values[name]),
+            slint_testing.AccessibleRole.TextInput,
+        )
+    if not check_radius:
+        return
+    radius_handle(window, "top-left")
+
+    def radius_matches() -> bool | None:
+        a = point(window, "Rectangle resize top-left", values["rotation"])
+        r = point(window, "Rectangle radius top-left", values["rotation"])
+        angle = math.radians(values["rotation"])
+        dx, dy = r[0] - a[0], r[1] - a[1]
+        local = (
+            dx * math.cos(angle) + dy * math.sin(angle),
+            -dx * math.sin(angle) + dy * math.cos(angle),
+        )
+        return (
+            True if all(abs(v - (10 + values["radius"])) < 1.5 for v in local) else None
+        )
+
+    wait_until(radius_matches)
+
+
+def shortcut(window: slint_testing.Window, redo: bool) -> None:
+    modifier = keys.Control
+    modifiers = [modifier] + ([keys.Shift] if redo and sys.platform != "win32" else [])
+    for key in modifiers:
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
+    key = "y" if redo and sys.platform == "win32" else "z"
+    try:
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
+    finally:
+        for key in reversed(modifiers):
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
+
+
+def edit(
+    window: slint_testing.Window,
+    case: str,
+    changes: dict[str, int],
+    snapshot: SourceSnapshot,
+) -> None:
+    if case.startswith("inspector-"):
+        name, value = next(iter(changes.items()))
+        edit_field(
+            window, FIELDS[name], str(value), slint_testing.AccessibleRole.TextInput
+        )
+        return
+    if case == "handle-radius":
+        manual_radius_drag(window, radius_handle(window, "top-left"), 8, 8, snapshot)
+        return
+    if case != "handle-rotation":
+        label = (
+            "Rectangle move handle"
+            if case == "handle-move"
+            else "Rectangle resize bottom-right"
+        )
+        manual_drag(window, window_element_with_label(window, label), 24, 16, snapshot)
+        return
+    handle = window_element_with_label(window, "Rectangle rotate top-left")
+    start = center(handle)
+    cx, cy, *_ = frame(window)
+    angle = math.radians(15)
+    dx, dy = start.x - cx, start.y - cy
+    end = slint_testing.LogicalPosition(
+        x=cx + dx * math.cos(angle) - dy * math.sin(angle),
+        y=cy + dx * math.sin(angle) + dy * math.cos(angle),
+    )
+    button = slint_testing.PointerEventButton.Left
+    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+    window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+    window.dispatch_event(slint_testing.PointerMoveEvent(end))
+    wait_until(
+        lambda: (
+            True
+            if window_element_with_label(
+                window, "Rotation angle", slint_testing.AccessibleRole.Text
+            ).accessible_value
+            == "15"
+            else None
+        )
+    )
+    snapshot.assert_unchanged_now()
+    window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+    window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
+@pytest.mark.parametrize(
+    "case,changes",
+    [
+        pytest.param(
+            case,
+            changes,
+            id=case,
+            marks=pytest.mark.skip(reason=reason) if reason else (),
+        )
+        for case, changes in CASES
+        for reason in [
+            {
+                "handle-radius": "Requires a Rust corner-radius persistence fix",
+                "inspector-rotation": "No Rectangle rotation property editor is available",
+                "inspector-radius": "No Rectangle corner-radius property editor is available",
+            }.get(case)
+        ]
+    ],
+)
+def test_rectangle_undo_redo(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    case: str,
+    changes: dict[str, int],
+) -> None:
+    source = fixture_project / SOURCE
+    baseline = source.read_bytes()
+    expected = baseline
+    for name, value in changes.items():
+        prop, unit = {
+            "rotation": ("transform-rotation", "deg"),
+            "radius": ("border-radius", "px"),
+        }.get(name, (name, "px"))
+        old = f"        {prop}: {INITIAL[name]}{unit};".encode()
+        assert expected.count(old) == 1
+        expected = expected.replace(old, f"        {prop}: {value}{unit};".encode())
+    snapshot = SourceSnapshot.capture(fixture_project)
+    stage = "initial"
+    with launch_editor(editor_binary, editor_environment, source) as editor:
+        window = first_window(editor)
+        try:
+            select_fixture_element(window, "Rectangle")
+            cx, cy, *_ = frame(window)
+            origin = (
+                cx - INITIAL["x"] - INITIAL["width"] / 2,
+                cy - INITIAL["y"] - INITIAL["height"] / 2,
+            )
+            assert_visual(window, INITIAL, origin, case.endswith("radius"))
+            snapshot.assert_unchanged_now()
+            pause(case, stage)
+            stage = "initial edit"
+            edit(window, case, changes, snapshot)
+            for stage, content, values in [
+                ("edited", expected, INITIAL | changes),
+                ("undo", baseline, INITIAL),
+                ("redo", expected, INITIAL | changes),
+            ]:
+                if stage != "edited":
+                    if case.startswith("inspector-"):
+                        select_fixture_element(window, "Rectangle")
+                    shortcut(window, redo=stage == "redo")
+                snapshot.wait_for_exact(content, SOURCE)
+                assert_visual(window, values, origin, case.endswith("radius"))
+                pause(case, stage)
+        except Exception as error:
+            artifact = fixture_project.parent / f"{case}-{stage.replace(' ', '-')}.png"
+            try:
+                artifact.write_bytes(window.grab_window_as_png())
+                print(f"Failure screenshot: {artifact}", flush=True)
+            except Exception:
+                logging.getLogger(__name__).exception("Screenshot unavailable")
+            raise AssertionError(f"{case} failed at {stage}: {error}") from error

--- a/tools/editor/ui-tests/tests/test_undo_redo.py
+++ b/tools/editor/ui-tests/tests/test_undo_redo.py
@@ -1,11 +1,8 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import logging
 import math
-import os
 import sys
-import time
 from pathlib import Path
 
 import pytest
@@ -31,6 +28,7 @@ from ui_driver import (
     wait_until,
     window_element_with_label,
 )
+from ui_reporting import replay_stage
 
 SOURCE = "UndoRedo.slint"
 INITIAL = {"x": 80, "y": 80, "width": 180, "height": 120, "rotation": 0, "radius": 12}
@@ -46,12 +44,6 @@ CASES = [
     ("inspector-rotation", {"rotation": 15}),
     ("inspector-radius", {"radius": 20}),
 ]
-
-
-def pause(case: str, stage: str) -> None:
-    print(f"{case}: {stage}", flush=True)
-    if os.environ.get("SLINT_UNDO_REDO_REPLAY") == "1":
-        time.sleep(1)
 
 
 def assert_visual(
@@ -195,10 +187,9 @@ def test_rectangle_undo_redo(
         assert expected.count(old) == 1
         expected = expected.replace(old, f"        {prop}: {value}{unit};".encode())
     snapshot = SourceSnapshot.capture(fixture_project)
-    stage = "initial"
     with launch_editor(editor_binary, editor_environment, source) as editor:
         window = first_window(editor)
-        try:
+        with replay_stage("initial"):
             select_fixture_element(window, "Rectangle")
             cx, cy, *_ = wait_until(
                 lambda: oriented_selection_frame(window, "Rectangle")
@@ -209,26 +200,17 @@ def test_rectangle_undo_redo(
             )
             assert_visual(window, INITIAL, origin, case.endswith("radius"))
             snapshot.assert_unchanged_now()
-            pause(case, stage)
-            stage = "initial edit"
+        with replay_stage("initial edit"):
             edit(window, case, changes, snapshot)
-            for stage, content, values in [
-                ("edited", expected, INITIAL | changes),
-                ("undo", baseline, INITIAL),
-                ("redo", expected, INITIAL | changes),
-            ]:
-                if stage != "edited":
-                    if case.startswith("inspector-"):
-                        select_fixture_element(window, "Rectangle")
-                    shortcut(window, redo=stage == "redo")
+            snapshot.wait_for_exact(expected, SOURCE)
+            assert_visual(window, INITIAL | changes, origin, case.endswith("radius"))
+        for name, content, values in [
+            ("undo", baseline, INITIAL),
+            ("redo", expected, INITIAL | changes),
+        ]:
+            with replay_stage(name):
+                if case.startswith("inspector-"):
+                    select_fixture_element(window, "Rectangle")
+                shortcut(window, redo=name == "redo")
                 snapshot.wait_for_exact(content, SOURCE)
                 assert_visual(window, values, origin, case.endswith("radius"))
-                pause(case, stage)
-        except Exception as error:
-            artifact = fixture_project.parent / f"{case}-{stage.replace(' ', '-')}.png"
-            try:
-                artifact.write_bytes(window.grab_window_as_png())
-                print(f"Failure screenshot: {artifact}", flush=True)
-            except Exception:
-                logging.getLogger(__name__).exception("Screenshot unavailable")
-            raise AssertionError(f"{case} failed at {stage}: {error}") from error

--- a/tools/editor/ui-tests/tests/test_undo_redo.py
+++ b/tools/editor/ui-tests/tests/test_undo_redo.py
@@ -10,14 +10,23 @@ from pathlib import Path
 
 import pytest
 import slint_testing
-from canvas_interactions import center, manual_drag, manual_radius_drag
+from canvas_interactions import (
+    OrientedFrame,
+    manual_drag,
+    manual_radius_drag,
+    manual_rotation_drag,
+    oriented_selection_frame,
+    radius_handle,
+    rotated_handle_center,
+    rotation_delta,
+)
+from inspector_interactions import FIELDS, edit_field, wait_for_field
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
-from test_canvas import radius_handle
-from test_inspector import edit_field, wait_for_field
 from ui_driver import (
     first_window,
     launch_editor,
+    press_shortcut,
     select_fixture_element,
     wait_until,
     window_element_with_label,
@@ -37,48 +46,12 @@ CASES = [
     ("inspector-rotation", {"rotation": 15}),
     ("inspector-radius", {"radius": 20}),
 ]
-FIELDS = {
-    "x": "Position X",
-    "y": "Position Y",
-    "width": "Width",
-    "height": "Height",
-    "rotation": "Rotation",
-    "radius": "Corner radius",
-}
 
 
 def pause(case: str, stage: str) -> None:
     print(f"{case}: {stage}", flush=True)
     if os.environ.get("SLINT_UNDO_REDO_REPLAY") == "1":
         time.sleep(1)
-
-
-def point(
-    window: slint_testing.Window, label: str, angle: float = 0
-) -> tuple[float, float]:
-    element = window_element_with_label(window, label)
-    p, size = element.absolute_position, element.size
-    radians = math.radians(angle)
-    return (
-        p.x + size.width / 2 * math.cos(radians) - size.height / 2 * math.sin(radians),
-        p.y + size.width / 2 * math.sin(radians) + size.height / 2 * math.cos(radians),
-    )
-
-
-def frame(window: slint_testing.Window) -> tuple[float, ...]:
-    a = point(window, "Rectangle resize top-left")
-    b = point(window, "Rectangle resize top-right")
-    c = point(window, "Rectangle resize bottom-right")
-    angle = math.degrees(math.atan2(b[1] - a[1], b[0] - a[0]))
-    corrected_a = point(window, "Rectangle resize top-left", angle)
-    corrected_c = point(window, "Rectangle resize bottom-right", angle)
-    return (
-        (corrected_a[0] + corrected_c[0]) / 2,
-        (corrected_a[1] + corrected_c[1]) / 2,
-        math.dist(a, b),
-        math.dist(b, c),
-        angle,
-    )
 
 
 def assert_visual(
@@ -94,17 +67,23 @@ def assert_visual(
         values["height"],
         values["rotation"],
     )
-    try:
-        wait_until(
-            lambda: (
-                True
-                if all(abs(a - b) < 1.5 for a, b in zip(frame(window), expected))
-                else None
-            )
+    actual: OrientedFrame | None = None
+
+    def matches() -> bool | None:
+        nonlocal actual
+        actual = oriented_selection_frame(window, "Rectangle")
+        return (
+            True
+            if actual is not None
+            and all(abs(a - b) < 1.5 for a, b in zip(actual, expected))
+            else None
         )
+
+    try:
+        wait_until(matches)
     except AssertionError as error:
         raise AssertionError(
-            f"Expected frame {expected}, got {frame(window)}"
+            f"Expected frame {expected}, last observed {actual}"
         ) from error
     for name in ("x", "y", "width", "height"):
         wait_for_field(
@@ -118,8 +97,14 @@ def assert_visual(
     radius_handle(window, "top-left")
 
     def radius_matches() -> bool | None:
-        a = point(window, "Rectangle resize top-left", values["rotation"])
-        r = point(window, "Rectangle radius top-left", values["rotation"])
+        a = rotated_handle_center(
+            window_element_with_label(window, "Rectangle resize top-left"),
+            values["rotation"],
+        )
+        r = rotated_handle_center(
+            window_element_with_label(window, "Rectangle radius top-left"),
+            values["rotation"],
+        )
         angle = math.radians(values["rotation"])
         dx, dy = r[0] - a[0], r[1] - a[1]
         local = (
@@ -134,17 +119,11 @@ def assert_visual(
 
 
 def shortcut(window: slint_testing.Window, redo: bool) -> None:
-    modifier = keys.Control
-    modifiers = [modifier] + ([keys.Shift] if redo and sys.platform != "win32" else [])
-    for key in modifiers:
-        window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
+    modifiers = [keys.Control] + (
+        [keys.Shift] if redo and sys.platform != "win32" else []
+    )
     key = "y" if redo and sys.platform == "win32" else "z"
-    try:
-        window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
-        window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
-    finally:
-        for key in reversed(modifiers):
-            window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
+    press_shortcut(window, *modifiers, key)
 
 
 def edit(
@@ -171,31 +150,18 @@ def edit(
         manual_drag(window, window_element_with_label(window, label), 24, 16, snapshot)
         return
     handle = window_element_with_label(window, "Rectangle rotate top-left")
-    start = center(handle)
-    cx, cy, *_ = frame(window)
-    angle = math.radians(15)
-    dx, dy = start.x - cx, start.y - cy
-    end = slint_testing.LogicalPosition(
-        x=cx + dx * math.cos(angle) - dy * math.sin(angle),
-        y=cy + dx * math.sin(angle) + dy * math.cos(angle),
+    target_angle = changes["rotation"]
+    dx, dy = rotation_delta(window, handle, target_angle, kind="Rectangle")
+    manual_rotation_drag(
+        window, handle, dx, dy, snapshot, kind="Rectangle", target_angle=target_angle
     )
-    button = slint_testing.PointerEventButton.Left
-    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
-    window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
-    window.dispatch_event(slint_testing.PointerMoveEvent(end))
-    wait_until(
-        lambda: (
-            True
-            if window_element_with_label(
-                window, "Rotation angle", slint_testing.AccessibleRole.Text
-            ).accessible_value
-            == "15"
-            else None
-        )
-    )
-    snapshot.assert_unchanged_now()
-    window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
-    window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+
+
+SKIPS = {
+    "handle-radius": "Requires a Rust corner-radius persistence fix",
+    "inspector-rotation": "No Rectangle rotation property editor is available",
+    "inspector-radius": "No Rectangle corner-radius property editor is available",
+}
 
 
 @pytest.mark.parametrize(
@@ -205,16 +171,9 @@ def edit(
             case,
             changes,
             id=case,
-            marks=pytest.mark.skip(reason=reason) if reason else (),
+            marks=pytest.mark.skip(reason=SKIPS[case]) if case in SKIPS else (),
         )
         for case, changes in CASES
-        for reason in [
-            {
-                "handle-radius": "Requires a Rust corner-radius persistence fix",
-                "inspector-rotation": "No Rectangle rotation property editor is available",
-                "inspector-radius": "No Rectangle corner-radius property editor is available",
-            }.get(case)
-        ]
     ],
 )
 def test_rectangle_undo_redo(
@@ -241,7 +200,9 @@ def test_rectangle_undo_redo(
         window = first_window(editor)
         try:
             select_fixture_element(window, "Rectangle")
-            cx, cy, *_ = frame(window)
+            cx, cy, *_ = wait_until(
+                lambda: oriented_selection_frame(window, "Rectangle")
+            )
             origin = (
                 cx - INITIAL["x"] - INITIAL["width"] / 2,
                 cy - INITIAL["y"] - INITIAL["height"] / 2,

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -142,7 +142,8 @@ def file_row(window: slint_testing.Window, path: Path) -> slint_testing.Element:
     from canvas_interactions import center
 
     tree = window_element_with_label(window, "Files", slint_testing.AccessibleRole.Tree)
-    for delta in [0, 10000, -250, -250, -250, -250, -250, -250]:
+    scroll_step = max(1, min(250, tree.size.height / 2))
+    for delta in [0, 10000] + [-scroll_step] * 32:
         if delta:
             window.dispatch_event(
                 slint_testing.PointerScrolledEvent(

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TypeVar
 
 import slint_testing
+from ui_reporting import capture_failure, current_report, replay_stage
 
 PALETTE_KINDS = ("Image", "Rectangle", "Text")
 
@@ -126,7 +127,15 @@ def launch_editor(
     with slint_testing.Application(
         arguments, env=environment, launch_timeout=20
     ) as application:
-        yield application
+        try:
+            yield application
+            report = current_report.get()
+            if report is not None and report.completed_stages == 0:
+                with replay_stage("completed"):
+                    pass
+        except Exception as error:
+            capture_failure(application, error)
+            raise
 
 
 def file_row(window: slint_testing.Window, path: Path) -> slint_testing.Element:

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -148,3 +148,14 @@ def file_row(window: slint_testing.Window, path: Path) -> slint_testing.Element:
     return window_element_with_label(
         window, str(path), slint_testing.AccessibleRole.ListItem
     )
+
+
+def press_shortcut(window: slint_testing.Window, *keys: str) -> None:
+    pressed = []
+    try:
+        for key in keys:
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
+            pressed.append(key)
+    finally:
+        for key in reversed(pressed):
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))

--- a/tools/editor/ui-tests/tests/ui_reporting.py
+++ b/tools/editor/ui-tests/tests/ui_reporting.py
@@ -1,0 +1,59 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import contextlib
+import logging
+import time
+from collections.abc import Iterator
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+
+import slint_testing
+
+
+@dataclass
+class TestReport:
+    name: str
+    artifacts: Path
+    pause_seconds: float
+    completed_stages: int = 0
+    screenshots: int = 0
+
+
+current_report: ContextVar[TestReport | None] = ContextVar(
+    "current_report", default=None
+)
+
+
+@contextlib.contextmanager
+def replay_stage(name: str) -> Iterator[None]:
+    report = current_report.get()
+    try:
+        yield
+    except Exception as error:
+        error.add_note(f"Stage: {name}")
+        raise
+    else:
+        if report is not None:
+            report.completed_stages += 1
+            if report.pause_seconds:
+                print(f"{report.name}: {name}", flush=True)
+                time.sleep(report.pause_seconds)
+
+
+def capture_failure(application: slint_testing.Application, error: Exception) -> None:
+    report = current_report.get()
+    if report is None:
+        return
+    try:
+        window = application.first_window
+        if window is None:
+            return
+        report.artifacts.mkdir(parents=True, exist_ok=True)
+        report.screenshots += 1
+        artifact = report.artifacts / f"failure-{report.screenshots}.png"
+        artifact.write_bytes(window.grab_window_as_png())
+        error.add_note(f"Failure screenshot (pytest temporary directory): {artifact}")
+    except Exception:
+        logging.getLogger(__name__).exception("Screenshot unavailable")

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -27,6 +27,20 @@ export component EditorUi inherits Window {
     background: StudioTheme.app-bg;
     default-font-family: "Inter";
 
+    property <bool> sidebars-collapsed: false;
+    property <length> inspector-scroll-y: 0px;
+
+    function open-startup-wizard() {
+        Api.open-startup-wizard();
+    }
+
+    function close-startup-wizard() {
+        Api.close-startup-wizard();
+    }
+
+    function open-project() {
+        root.close-startup-wizard();
+    }
     MenuBar {
         Menu {
             title: @tr("Edit");
@@ -45,20 +59,6 @@ export component EditorUi inherits Window {
         }
     }
 
-    property <bool> sidebars-collapsed: false;
-    property <length> inspector-scroll-y: 0px;
-
-    function open-startup-wizard() {
-        Api.open-startup-wizard();
-    }
-
-    function close-startup-wizard() {
-        Api.close-startup-wizard();
-    }
-
-    function open-project() {
-        root.close-startup-wizard();
-    }
     Rectangle {
         y: 0;
         height: EditorMetrics.top-bar-height;

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -27,6 +27,24 @@ export component EditorUi inherits Window {
     background: StudioTheme.app-bg;
     default-font-family: "Inter";
 
+    MenuBar {
+        Menu {
+            title: @tr("Edit");
+            MenuItem {
+                title: @tr("Undo");
+                shortcut: @keys(Control + Z);
+                enabled: Api.undo-enabled;
+                activated => { Api.undo(); }
+            }
+            MenuItem {
+                title: @tr("Redo");
+                shortcut: Platform.os == OperatingSystemType.windows ? @keys(Control + Y) : @keys(Control + Shift + Z);
+                enabled: Api.redo-enabled;
+                activated => { Api.redo(); }
+            }
+        }
+    }
+
     property <bool> sidebars-collapsed: false;
     property <length> inspector-scroll-y: 0px;
 


### PR DESCRIPTION
Adds a built-in Slint Edit menu with Undo and Redo, connected to the existing callbacks and `undo-enabled` / `redo-enabled` states. The menu includes the standard platform keyboard shortcuts.

Rectangle undo/redo tests cover move, resize, and rotate through direct manipulation, plus position and size changes through the property editors. The rotation and corner-radius property-editor cases are skipped because those controls are missing; the direct corner-radius case is skipped because the edit is not persisted.

The full-suite CI fixes scroll clipped inspector controls and file-tree rows into view, reacquire virtualized rows, and preserve pending source-reload deadlines across preview messages.

Validation: all 152 editor Rust tests passed. The full Python UI suite passed headlessly with 191 passed and 53 existing skips. Clippy with warnings denied, Rustfmt, Ruff, Python type checking, and diff checks passed.

**Missing Slint feature:** muda supports predefined native Undo/Redo menu items with default keyboard shortcuts and macOS standard actions, which let macOS supply its default menu icons. Slint does not expose those predefined actions through its menu API, so this change uses generic menu items with explicit shortcuts. Exposing native actions would also require routing them to the Slint callbacks. Muda's predefined Undo/Redo items are supported on macOS and Windows, but not Linux.

This is the first PR in a stack of Visual Editor improvements.

