### PR TITLE
Visual Editor: Add TouchArea to the elements palette

### DIFF
--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -961,6 +961,7 @@ enum PaletteComponent {
     Rectangle,
     Text,
     Image,
+    TouchArea,
 }
 
 impl PaletteComponent {
@@ -969,6 +970,7 @@ impl PaletteComponent {
             ui::PaletteComponentKind::Rectangle => Some(Self::Rectangle),
             ui::PaletteComponentKind::Text => Some(Self::Text),
             ui::PaletteComponentKind::Image => Some(Self::Image),
+            ui::PaletteComponentKind::TouchArea => Some(Self::TouchArea),
             ui::PaletteComponentKind::None => None,
         }
     }
@@ -978,6 +980,7 @@ impl PaletteComponent {
             Self::Rectangle => "Rectangle",
             Self::Text => "Text",
             Self::Image => "Image",
+            Self::TouchArea => "TouchArea",
         }
     }
 }

--- a/tools/editor/preview/outline.rs
+++ b/tools/editor/preview/outline.rs
@@ -261,6 +261,7 @@ fn icon_kind_for_type(element_type: &str) -> ui::OutlineNodeIconKind {
         "Rectangle" => ui::OutlineNodeIconKind::Rectangle,
         "Image" => ui::OutlineNodeIconKind::Image,
         "Text" => ui::OutlineNodeIconKind::Text,
+        "TouchArea" => ui::OutlineNodeIconKind::TouchArea,
         _ => ui::OutlineNodeIconKind::Default,
     }
 }

--- a/tools/editor/preview/ui/element_library.rs
+++ b/tools/editor/preview/ui/element_library.rs
@@ -10,12 +10,21 @@ fn catalog() -> ModelRc<ElementLibraryGroup> {
         (
             "Visual",
             vec![
-                ElementLibraryEntry { label: "Rectangle".into(), kind: PaletteComponentKind::Rectangle },
+                ElementLibraryEntry {
+                    label: "Rectangle".into(),
+                    kind: PaletteComponentKind::Rectangle,
+                },
                 ElementLibraryEntry { label: "Text".into(), kind: PaletteComponentKind::Text },
                 ElementLibraryEntry { label: "Image".into(), kind: PaletteComponentKind::Image },
             ],
         ),
-        ("Input & interaction", vec![ElementLibraryEntry { label: "TouchArea".into(), kind: PaletteComponentKind::TouchArea }]),
+        (
+            "Input & interaction",
+            vec![ElementLibraryEntry {
+                label: "TouchArea".into(),
+                kind: PaletteComponentKind::TouchArea,
+            }],
+        ),
     ];
     ModelRc::new(slint::VecModel::from(
         groups
@@ -85,11 +94,19 @@ mod tests {
         let interaction = groups.row_data(1).unwrap();
         assert_eq!(interaction.label, "Input & interaction");
         assert_eq!(interaction.entries.row_data(0).unwrap().kind, PaletteComponentKind::TouchArea);
-        for (query, expected) in
-            [("", vec!["TouchArea"]), ("  ", vec!["TouchArea"]), (" tOuCh ", vec!["TouchArea"]), ("AREA", vec!["TouchArea"]), ("image", vec![]), ("missing", vec![])]
-        {
+        for (query, expected) in [
+            ("", vec!["TouchArea"]),
+            ("  ", vec!["TouchArea"]),
+            (" tOuCh ", vec!["TouchArea"]),
+            ("AREA", vec!["TouchArea"]),
+            ("image", vec![]),
+            ("missing", vec![]),
+        ] {
             assert_eq!(
-                filter(interaction.entries.clone(), normalize_query(query.into())).iter().map(|entry| entry.label.to_string()).collect::<Vec<_>>(),
+                filter(interaction.entries.clone(), normalize_query(query.into()))
+                    .iter()
+                    .map(|entry| entry.label.to_string())
+                    .collect::<Vec<_>>(),
                 expected
             );
         }

--- a/tools/editor/preview/ui/element_library.rs
+++ b/tools/editor/preview/ui/element_library.rs
@@ -6,16 +6,29 @@ use slint::{Model, ModelExt, ModelRc, SharedString};
 use super::{Api, ElementLibraryEntry, ElementLibraryGroup, PaletteComponentKind};
 
 fn catalog() -> ModelRc<ElementLibraryGroup> {
-    let mut entries = [
-        ElementLibraryEntry { label: "Rectangle".into(), kind: PaletteComponentKind::Rectangle },
-        ElementLibraryEntry { label: "Text".into(), kind: PaletteComponentKind::Text },
-        ElementLibraryEntry { label: "Image".into(), kind: PaletteComponentKind::Image },
+    let groups = [
+        (
+            "Visual",
+            vec![
+                ElementLibraryEntry { label: "Rectangle".into(), kind: PaletteComponentKind::Rectangle },
+                ElementLibraryEntry { label: "Text".into(), kind: PaletteComponentKind::Text },
+                ElementLibraryEntry { label: "Image".into(), kind: PaletteComponentKind::Image },
+            ],
+        ),
+        ("Input & interaction", vec![ElementLibraryEntry { label: "TouchArea".into(), kind: PaletteComponentKind::TouchArea }]),
     ];
-    entries.sort_by(|a, b| a.label.cmp(&b.label));
-    ModelRc::new(slint::VecModel::from(vec![ElementLibraryGroup {
-        label: "Visual".into(),
-        entries: ModelRc::new(slint::VecModel::from(Vec::from(entries))),
-    }]))
+    ModelRc::new(slint::VecModel::from(
+        groups
+            .into_iter()
+            .map(|(label, mut entries)| {
+                entries.sort_by(|a, b| a.label.cmp(&b.label));
+                ElementLibraryGroup {
+                    label: label.into(),
+                    entries: ModelRc::new(slint::VecModel::from(entries)),
+                }
+            })
+            .collect::<Vec<_>>(),
+    ))
 }
 
 fn normalize_query(query: SharedString) -> SharedString {
@@ -49,9 +62,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn visual_library_is_alphabetical_and_search_preserves_order() {
+    fn library_is_alphabetical_and_search_preserves_order() {
         let groups = catalog();
-        assert_eq!(groups.row_count(), 1);
+        assert_eq!(groups.row_count(), 2);
         let group = groups.row_data(0).unwrap();
         assert_eq!(group.label, "Visual");
         for (query, expected) in [
@@ -67,6 +80,17 @@ mod tests {
                 result.iter().map(|entry| entry.label.to_string()).collect::<Vec<_>>(),
                 expected,
                 "query: {query:?}"
+            );
+        }
+        let interaction = groups.row_data(1).unwrap();
+        assert_eq!(interaction.label, "Input & interaction");
+        assert_eq!(interaction.entries.row_data(0).unwrap().kind, PaletteComponentKind::TouchArea);
+        for (query, expected) in
+            [("", vec!["TouchArea"]), ("  ", vec!["TouchArea"]), (" tOuCh ", vec!["TouchArea"]), ("AREA", vec!["TouchArea"]), ("image", vec![]), ("missing", vec![])]
+        {
+            assert_eq!(
+                filter(interaction.entries.clone(), normalize_query(query.into())).iter().map(|entry| entry.label.to_string()).collect::<Vec<_>>(),
+                expected
             );
         }
     }

--- a/tools/editor/ui-tests/goldens/Palette.insert-toucharea.slint
+++ b/tools/editor/ui-tests/goldens/Palette.insert-toucharea.slint
@@ -1,0 +1,14 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export component Palette inherits Window {
+    width: 640px;
+    height: 480px;
+    background: #f8fafc;
+    TouchArea {
+        x: 115px;
+        y: 312px;
+        width: 160px;
+        height: 96px;
+    }
+}

--- a/tools/editor/ui-tests/tests/test_palette.py
+++ b/tools/editor/ui-tests/tests/test_palette.py
@@ -189,7 +189,7 @@ def test_library_search_and_collapse(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
-        expect_library(window, ["Image", "Rectangle", "Text"])
+        expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
         heading = window_element_with_label(window, "ELEMENTS")
         search = window_element_with_label(window, "Search elements")
         heading_y = heading.absolute_position.y
@@ -197,25 +197,32 @@ def test_library_search_and_collapse(
         rows = library_rows(window)
         assert rows[0].absolute_position.y == rows[1].absolute_position.y
         assert rows[2].absolute_position.y > rows[0].absolute_position.y
+        window_element_with_label(
+            window, "Input & interaction", slint_testing.AccessibleRole.Button
+        )
+        assert rows[3].absolute_position.y > rows[2].absolute_position.y
         group = window_element_with_label(
             window, "Visual", slint_testing.AccessibleRole.Button
         )
         group.invoke_accessible_default_action()
-        expect_library(window, [])
+        expect_library(window, ["TouchArea"])
         assert heading.absolute_position.y == heading_y
         assert search.absolute_position.y == search_y
         search = window_element_with_label(window, "Search elements")
         for query, expected in [
             ("  aG  ", ["Image"]),
-            ("T", ["Rectangle", "Text"]),
-            ("TouchArea", []),
+            ("T", ["Rectangle", "Text", "TouchArea"]),
+            ("  tOuCh  ", ["TouchArea"]),
+            ("AREA", ["TouchArea"]),
+            ("missing", []),
         ]:
             search.accessible_value = query
             expect_library(window, expected)
-            for header in elements_with_label(
-                window.root_element, "Visual", slint_testing.AccessibleRole.Button
-            ):
-                assert not header.accessible_enabled
+            for label in ("Visual", "Input & interaction"):
+                for header in elements_with_label(
+                    window.root_element, label, slint_testing.AccessibleRole.Button
+                ):
+                    assert not header.accessible_enabled
             assert heading.absolute_position.y == heading_y
             assert search.absolute_position.y == search_y
         window_element_with_label(window, "No Results")
@@ -223,13 +230,25 @@ def test_library_search_and_collapse(
             window.root_element, "Visual", slint_testing.AccessibleRole.Button
         )
         search.accessible_value = ""
-        expect_library(window, [])
+        expect_library(window, ["TouchArea"])
         assert heading.absolute_position.y == heading_y
         assert search.absolute_position.y == search_y
         group = window_element_with_label(
             window, "Visual", slint_testing.AccessibleRole.Button
         )
         group.invoke_accessible_default_action()
+        expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
+        interaction = window_element_with_label(
+            window, "Input & interaction", slint_testing.AccessibleRole.Button
+        )
+        interaction.invoke_accessible_default_action()
+        expect_library(window, ["Image", "Rectangle", "Text"])
+        search.accessible_value = "touch"
+        expect_library(window, ["TouchArea"])
+        assert not elements_with_label(
+            window.root_element, "Visual", slint_testing.AccessibleRole.Button
+        )
+        search.accessible_value = ""
         expect_library(window, ["Image", "Rectangle", "Text"])
         snapshot.assert_unchanged()
 
@@ -251,21 +270,53 @@ def test_library_search_keyboard_does_not_delete_selection(
         expect_library(window, ["Text"])
         for _ in range(5):
             press_key(window, keys.Backspace)
-        expect_library(window, ["Image", "Rectangle", "Text"])
+        expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
         window_element_with_label(
             window, "Selected Rectangle", slint_testing.AccessibleRole.Region
         )
         snapshot.assert_unchanged()
 
 
+def test_toucharea_drag_preview(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Palette.slint"
+    ) as editor:
+        window = first_window(editor)
+        target = canvas_drop_position(window)
+        begin_palette_drag(window, "TouchArea", target)
+        preview = window_element_with_label(
+            window, "TouchArea drag preview", slint_testing.AccessibleRole.Region
+        )
+        assert preview.size.width == 160
+        assert preview.size.height == 96
+        assert preview.absolute_position.x == target.x - 80
+        assert preview.absolute_position.y == target.y - 48
+        snapshot.assert_unchanged_now()
+        outside = slint_testing.LogicalPosition(x=10, y=10)
+        release_palette_drag(window, outside)
+        snapshot.assert_unchanged()
+
+
 @pytest.mark.parametrize(
     "activation_key", [keys.Return, keys.Space], ids=["enter", "space"]
+)
+@pytest.mark.parametrize(
+    ("group_label", "tab_count", "remaining"),
+    [("Visual", 1, ["TouchArea"]), ("Input & interaction", 2, ["Image", "Rectangle", "Text"])],
 )
 def test_group_header_keyboard_activation(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
     activation_key: str,
+    group_label: str,
+    tab_count: int,
+    remaining: list[str],
 ) -> None:
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(
@@ -274,10 +325,11 @@ def test_group_header_keyboard_activation(
         window = first_window(editor)
         search = window_element_with_label(window, "Search elements")
         search.single_click(slint_testing.PointerEventButton.Left)
-        press_key(window, keys.Tab)
+        for _ in range(tab_count):
+            press_key(window, keys.Tab)
         press_key(window, activation_key)
-        expect_library(window, [])
-        window_element_with_label(window, "Visual", slint_testing.AccessibleRole.Button)
+        expect_library(window, remaining)
+        window_element_with_label(window, group_label, slint_testing.AccessibleRole.Button)
         press_key(window, activation_key)
         expect_library(window, list(PALETTE_KINDS))
         snapshot.assert_unchanged()

--- a/tools/editor/ui-tests/tests/test_palette.py
+++ b/tools/editor/ui-tests/tests/test_palette.py
@@ -21,6 +21,7 @@ from ui_driver import (
 )
 
 GOLDENS = Path(__file__).resolve().parents[1] / "goldens"
+TOUCHAREA_PREVIEW_SIZE = (160, 96)
 
 
 def begin_palette_drag(
@@ -178,7 +179,7 @@ def expect_library(window: slint_testing.Window, labels: list[str]) -> None:
     )
 
 
-def test_library_search_and_collapse(
+def test_library_search_filters_elements(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
@@ -188,25 +189,7 @@ def test_library_search_and_collapse(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
-        expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
-        heading = window_element_with_label(window, "ELEMENTS")
-        search = window_element_with_label(window, "Search elements")
-        heading_y = heading.absolute_position.y
-        search_y = search.absolute_position.y
-        rows = library_rows(window)
-        assert rows[0].absolute_position.y == rows[1].absolute_position.y
-        assert rows[2].absolute_position.y > rows[0].absolute_position.y
-        window_element_with_label(
-            window, "Input & interaction", slint_testing.AccessibleRole.Button
-        )
-        assert rows[3].absolute_position.y > rows[2].absolute_position.y
-        group = window_element_with_label(
-            window, "Visual", slint_testing.AccessibleRole.Button
-        )
-        group.invoke_accessible_default_action()
-        expect_library(window, ["TouchArea"])
-        assert heading.absolute_position.y == heading_y
-        assert search.absolute_position.y == search_y
+        expect_library(window, list(PALETTE_KINDS))
         search = window_element_with_label(window, "Search elements")
         for query, expected in [
             ("  aG  ", ["Image"]),
@@ -222,25 +205,44 @@ def test_library_search_and_collapse(
                     window.root_element, label, slint_testing.AccessibleRole.Button
                 ):
                     assert not header.accessible_enabled
-            assert heading.absolute_position.y == heading_y
-            assert search.absolute_position.y == search_y
         window_element_with_label(window, "No Results")
-        assert not elements_with_label(
-            window.root_element, "Visual", slint_testing.AccessibleRole.Button
-        )
+        for label in ("Visual", "Input & interaction"):
+            assert not elements_with_label(
+                window.root_element, label, slint_testing.AccessibleRole.Button
+            )
         search.accessible_value = ""
-        expect_library(window, ["TouchArea"])
-        assert heading.absolute_position.y == heading_y
-        assert search.absolute_position.y == search_y
-        group = window_element_with_label(
+        expect_library(window, list(PALETTE_KINDS))
+        snapshot.assert_unchanged()
+
+
+def test_library_search_restores_independent_collapse_states(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Palette.slint"
+    ) as editor:
+        window = first_window(editor)
+        search = window_element_with_label(window, "Search elements")
+        for label, collapsed_labels in [
+            ("Visual", ["TouchArea"]),
+            ("Input & interaction", []),
+        ]:
+            window_element_with_label(
+                window, label, slint_testing.AccessibleRole.Button
+            ).invoke_accessible_default_action()
+            expect_library(window, collapsed_labels)
+            search.accessible_value = "t"
+            expect_library(window, ["Rectangle", "Text", "TouchArea"])
+            search.accessible_value = "missing"
+            expect_library(window, [])
+            search.accessible_value = ""
+            expect_library(window, collapsed_labels)
+        window_element_with_label(
             window, "Visual", slint_testing.AccessibleRole.Button
-        )
-        group.invoke_accessible_default_action()
-        expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
-        interaction = window_element_with_label(
-            window, "Input & interaction", slint_testing.AccessibleRole.Button
-        )
-        interaction.invoke_accessible_default_action()
+        ).invoke_accessible_default_action()
         expect_library(window, ["Image", "Rectangle", "Text"])
         search.accessible_value = "touch"
         expect_library(window, ["TouchArea"])
@@ -250,6 +252,42 @@ def test_library_search_and_collapse(
         search.accessible_value = ""
         expect_library(window, ["Image", "Rectangle", "Text"])
         snapshot.assert_unchanged()
+
+
+def test_library_layout_stays_anchored_during_search_and_collapse(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+) -> None:
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Palette.slint"
+    ) as editor:
+        window = first_window(editor)
+        expect_library(window, list(PALETTE_KINDS))
+        heading = window_element_with_label(window, "ELEMENTS")
+        search = window_element_with_label(window, "Search elements")
+        heading_y = heading.absolute_position.y
+        search_y = search.absolute_position.y
+        rows = library_rows(window)
+        assert rows[0].absolute_position.y == rows[1].absolute_position.y
+        assert rows[0].absolute_position.x < rows[1].absolute_position.x
+        assert rows[2].absolute_position.y > rows[0].absolute_position.y
+        assert rows[3].absolute_position.y > rows[2].absolute_position.y
+        for label, remaining in [
+            ("Visual", ["TouchArea"]),
+            ("Input & interaction", []),
+        ]:
+            window_element_with_label(
+                window, label, slint_testing.AccessibleRole.Button
+            ).invoke_accessible_default_action()
+            expect_library(window, remaining)
+            assert heading.absolute_position.y == heading_y
+            assert search.absolute_position.y == search_y
+        for query, expected in [("image", ["Image"]), ("missing", []), ("", [])]:
+            search.accessible_value = query
+            expect_library(window, expected)
+            assert heading.absolute_position.y == heading_y
+            assert search.absolute_position.y == search_y
 
 
 def test_library_search_keyboard_does_not_delete_selection(
@@ -291,10 +329,11 @@ def test_toucharea_drag_preview(
         preview = window_element_with_label(
             window, "TouchArea drag preview", slint_testing.AccessibleRole.Region
         )
-        assert preview.size.width == 160
-        assert preview.size.height == 96
-        assert preview.absolute_position.x == target.x - 80
-        assert preview.absolute_position.y == target.y - 48
+        expected_width, expected_height = TOUCHAREA_PREVIEW_SIZE
+        assert preview.size.width == expected_width
+        assert preview.size.height == expected_height
+        assert preview.absolute_position.x == target.x - expected_width / 2
+        assert preview.absolute_position.y == target.y - expected_height / 2
         snapshot.assert_unchanged_now()
         outside = slint_testing.LogicalPosition(x=10, y=10)
         release_palette_drag(window, outside)

--- a/tools/editor/ui-tests/tests/test_palette.py
+++ b/tools/editor/ui-tests/tests/test_palette.py
@@ -132,7 +132,6 @@ def test_palette_drop_outside_canvas_does_not_edit_source(
 
 
 @pytest.mark.parametrize("kind", PALETTE_KINDS)
-@pytest.mark.skip(reason="Requires Rust palette drop-marker support")
 def test_escape_cancels_palette_drag_without_source_edit(
     editor_binary: Path,
     editor_environment: dict[str, str],
@@ -146,11 +145,11 @@ def test_escape_cancels_palette_drag_without_source_edit(
         target = canvas_drop_position(window)
         begin_palette_drag(window, kind, target)
         window_element_with_label(
-            window, "Canvas drop marker", slint_testing.AccessibleRole.Region
+            window, f"{kind} drag preview", slint_testing.AccessibleRole.Region
         )
         press_key(window, keys.Escape)
         release_palette_drag(window, target)
-        assert not elements_with_label(window.root_element, "Canvas drop marker")
+        assert not elements_with_label(window.root_element, f"{kind} drag preview")
         snapshot.assert_unchanged()
 
 
@@ -307,7 +306,10 @@ def test_toucharea_drag_preview(
 )
 @pytest.mark.parametrize(
     ("group_label", "tab_count", "remaining"),
-    [("Visual", 1, ["TouchArea"]), ("Input & interaction", 2, ["Image", "Rectangle", "Text"])],
+    [
+        ("Visual", 1, ["TouchArea"]),
+        ("Input & interaction", 2, ["Image", "Rectangle", "Text"]),
+    ],
 )
 def test_group_header_keyboard_activation(
     editor_binary: Path,
@@ -329,7 +331,9 @@ def test_group_header_keyboard_activation(
             press_key(window, keys.Tab)
         press_key(window, activation_key)
         expect_library(window, remaining)
-        window_element_with_label(window, group_label, slint_testing.AccessibleRole.Button)
+        window_element_with_label(
+            window, group_label, slint_testing.AccessibleRole.Button
+        )
         press_key(window, activation_key)
         expect_library(window, list(PALETTE_KINDS))
         snapshot.assert_unchanged()

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -9,7 +9,7 @@ from typing import TypeVar
 
 import slint_testing
 
-PALETTE_KINDS = ("Image", "Rectangle", "Text")
+PALETTE_KINDS = ("Image", "Rectangle", "Text", "TouchArea")
 
 
 def press_key(window: slint_testing.Window, key: str) -> None:

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -13,6 +13,7 @@ export enum PaletteComponentKind {
     rectangle,
     text,
     image,
+    touch-area,
 }
 
 /// A palette item whose kind selects its icon and drag payload.
@@ -344,6 +345,7 @@ export enum OutlineNodeIconKind {
     rectangle,
     image,
     text,
+    touch-area,
 }
 
 /// A node in the outline tree

--- a/tools/editor/ui/assets/lucide/README.md
+++ b/tools/editor/ui/assets/lucide/README.md
@@ -7,6 +7,7 @@ These icons come from Lucide revision `22e6094bb533ac2b0ae3b592d2184da461ec1f4b`
 
 - [image.svg](https://github.com/lucide-icons/lucide/blob/22e6094bb533ac2b0ae3b592d2184da461ec1f4b/icons/image.svg)
 - [panels-top-left.svg](https://github.com/lucide-icons/lucide/blob/22e6094bb533ac2b0ae3b592d2184da461ec1f4b/icons/panels-top-left.svg)
+- [pointer.svg](https://github.com/lucide-icons/lucide/blob/22e6094bb533ac2b0ae3b592d2184da461ec1f4b/icons/pointer.svg)
 - [square.svg](https://github.com/lucide-icons/lucide/blob/22e6094bb533ac2b0ae3b592d2184da461ec1f4b/icons/square.svg)
 - [type.svg](https://github.com/lucide-icons/lucide/blob/22e6094bb533ac2b0ae3b592d2184da461ec1f4b/icons/type.svg)
 
@@ -15,5 +16,5 @@ Preserve this change when updating the files.
 
 The [pinned upstream license](https://github.com/lucide-icons/lucide/blob/22e6094bb533ac2b0ae3b592d2184da461ec1f4b/LICENSE)
 lists `square` and `type` as Feather-derived, with copyright `2013-present Cole Bemis`.
-It does not list `image` or `panels-top-left` as Feather-derived.
+It does not list `image`, `panels-top-left`, or `pointer` as Feather-derived.
 The asset annotations in the repository's `REUSE.toml` follow those copyright notices.

--- a/tools/editor/ui/assets/lucide/pointer.svg
+++ b/tools/editor/ui/assets/lucide/pointer.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 14a8 8 0 0 1-8 8" />
+  <path d="M18 11v-1a2 2 0 0 0-2-2a2 2 0 0 0-2 2" />
+  <path d="M14 10V9a2 2 0 0 0-2-2a2 2 0 0 0-2 2v1" />
+  <path d="M10 9.5V4a2 2 0 0 0-2-2a2 2 0 0 0-2 2v10" />
+  <path d="M18 11a2 2 0 1 1 4 0v3a8 8 0 0 1-8 8h-2c-2.8 0-4.5-.86-5.99-2.34l-3.6-3.6a2 2 0 0 1 2.83-2.82L7 15" />
+</svg>

--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -254,6 +254,7 @@ export component ComponentPaletteRow inherits Rectangle {
             height: 18px;
             source: root.kind == PaletteComponentKind.image ? EditorTreeIcons.image
                 : root.kind == PaletteComponentKind.rectangle ? EditorTreeIcons.rectangle
+                : root.kind == PaletteComponentKind.touch-area ? EditorTreeIcons.touch-area
                 : EditorTreeIcons.text;
             colorize: root.active ? StudioTheme.accent-strong : StudioTheme.text;
             opacity: root.active ? 1 : 0.5;
@@ -310,7 +311,7 @@ export global AppState {
         if kind == PaletteComponentKind.rectangle {
             return { width: 160px, height: 64px };
         }
-        if kind == PaletteComponentKind.image {
+        if kind == PaletteComponentKind.image || kind == PaletteComponentKind.touch-area {
             return { width: 160px, height: 96px };
         }
         if kind == PaletteComponentKind.text {

--- a/tools/editor/ui/components/drag-preview.slint
+++ b/tools/editor/ui/components/drag-preview.slint
@@ -4,13 +4,15 @@
 import { AppState, PaletteComponentKind, StudioTheme } from "common.slint";
 import { EditorTreeTokens } from "editor-tree-tokens.slint";
 
-component PaletteImageDragPreview inherits Rectangle {
-    border-radius: 16px;
+component PalettePlaceholderDragPreview inherits Rectangle {
+    in property <bool> show-thumbnail: true;
+    in property <length> corner-radius;
+    border-radius: root.corner-radius;
     background: StudioTheme.object-subtle;
     border-width: 1px;
     border-color: StudioTheme.object-border;
 
-    Rectangle {
+    if root.show-thumbnail: Rectangle {
         width: 48px;
         height: 36px;
         border-radius: 6px;
@@ -54,6 +56,7 @@ export component DragPreview inherits Rectangle {
         : AppState.palette-drag-preview-position.y;
     border-radius: AppState.outline-drag-active
         ? EditorTreeTokens.row-radius
+        : AppState.palette-drag-kind == PaletteComponentKind.touch-area ? 0px
         : AppState.palette-drag-kind == PaletteComponentKind.image ? 16px : 8px;
     background: transparent;
     opacity: AppState.outline-drag-active ? 0.5 : 1;
@@ -64,6 +67,7 @@ export component DragPreview inherits Rectangle {
     accessible-label: AppState.palette-drag-kind == PaletteComponentKind.rectangle ? "Rectangle drag preview"
         : AppState.palette-drag-kind == PaletteComponentKind.text ? "Text drag preview"
         : AppState.palette-drag-kind == PaletteComponentKind.image ? "Image drag preview"
+        : AppState.palette-drag-kind == PaletteComponentKind.touch-area ? "TouchArea drag preview"
         : "Outline drag preview";
 
     if AppState.outline-drag-active: Rectangle {
@@ -114,5 +118,8 @@ export component DragPreview inherits Rectangle {
         vertical-alignment: center;
     }
 
-    if !AppState.outline-drag-active && AppState.palette-drag-kind == PaletteComponentKind.image: PaletteImageDragPreview { }
+    if !AppState.outline-drag-active && (AppState.palette-drag-kind == PaletteComponentKind.image || AppState.palette-drag-kind == PaletteComponentKind.touch-area): PalettePlaceholderDragPreview {
+        corner-radius: root.border-radius;
+        show-thumbnail: AppState.palette-drag-kind == PaletteComponentKind.image;
+    }
 }

--- a/tools/editor/ui/components/editor-tree-icons.slint
+++ b/tools/editor/ui/components/editor-tree-icons.slint
@@ -7,5 +7,6 @@ export global EditorTreeIcons {
     out property <image> default-item: @image-url("../assets/lucide/panels-top-left.svg");
     out property <image> image: @image-url("../assets/lucide/image.svg");
     out property <image> rectangle: @image-url("../assets/lucide/square.svg");
+    out property <image> touch-area: @image-url("../assets/lucide/pointer.svg");
     out property <image> text: @image-url("../assets/lucide/type.svg");
 }

--- a/tools/editor/ui/components/editor-tree-view.slint
+++ b/tools/editor/ui/components/editor-tree-view.slint
@@ -42,6 +42,8 @@ component EditorTreeRow {
         ? EditorTreeIcons.image
         : node.icon-kind == OutlineNodeIconKind.text
         ? EditorTreeIcons.text
+        : node.icon-kind == OutlineNodeIconKind.touch-area
+        ? EditorTreeIcons.touch-area
         : EditorTreeIcons.default-item;
 
     vertical-stretch: 0;


### PR DESCRIPTION
Add TouchArea under Input & interaction, with a shared Pointer icon in the palette and outline. Its drag preview uses the Image placeholder with square corners and no center decoration.

Stacked on #13295.

Validated locally: Rust catalog test, 19 headless editor tests passed (11 skipped), autofix, lint, REUSE, and push hooks.
