### PR TITLE
core: Lay out the empty line a trailing line separator opens

### DIFF
--- a/internal/core/textlayout.rs
+++ b/internal/core/textlayout.rs
@@ -732,7 +732,9 @@ fn test_no_line_separators_characters_rendered() {
         )
         .unwrap();
 
-    assert_eq!(lines.len(), 2);
+    // The text ends with a separator, so it ends on an empty line.
+    // That line renders nothing, which is what this test is about.
+    assert_eq!(lines.len(), 3);
     let rendered_text = lines
         .iter()
         .map(|glyphs_per_line| {
@@ -746,7 +748,7 @@ fn test_no_line_separators_characters_rendered() {
                 .collect::<std::string::String>()
         })
         .collect::<Vec<_>>();
-    debug_assert_eq!(rendered_text, std::vec!["Hello", "World"]);
+    debug_assert_eq!(rendered_text, std::vec!["Hello", "World", ""]);
 }
 
 #[test]

--- a/internal/core/textlayout/linebreak_unicode.rs
+++ b/internal/core/textlayout/linebreak_unicode.rs
@@ -14,12 +14,21 @@ pub struct LineBreakIterator<'a> {
     phantom: PhantomData<&'a str>,
 }
 
+/// The characters UAX #14 gives a mandatory break of their own.
+/// These are the BK class, CR, LF and NEL.
+const MANDATORY_BREAK: [char; 7] =
+    ['\n', '\r', '\u{000b}', '\u{000c}', '\u{0085}', '\u{2028}', '\u{2029}'];
+
 impl LineBreakIterator<'_> {
     pub fn new(text: &str) -> Self {
-        let iterator = unicode_linebreak::linebreaks(text).filter(|(offset, opportunity)| {
-            // unicode-linebreaks emits a mandatory break at the end of the text. We're not interested
-            // in that.
-            *offset != text.len() || !matches!(opportunity, BreakOpportunity::Mandatory)
+        // unicode-linebreaks emits a mandatory break at the end of the text, per UAX #14 rule LB3.
+        // That break is a separator's own when the text ends with one, and a line follows it.
+        let ends_on_break = text.ends_with(MANDATORY_BREAK);
+        let text_len = text.len();
+        let iterator = unicode_linebreak::linebreaks(text).filter(move |(offset, opportunity)| {
+            *offset != text_len
+                || !matches!(opportunity, BreakOpportunity::Mandatory)
+                || ends_on_break
         });
 
         Self { breaks: iterator.collect(), pos: 0, phantom: Default::default() }

--- a/internal/core/textlayout/linebreaker.rs
+++ b/internal/core/textlayout/linebreaker.rs
@@ -71,6 +71,10 @@ pub struct TextLineBreaker<'a, Font: TextShaper> {
     current_line: TextLine<Font::Length>,
     num_emitted_lines: usize,
     mandatory_line_break_on_next_iteration: bool,
+    /// Whether the fragment read most recently ends with a mandatory line break.
+    /// A text ending on one ends on an empty line that no fragment reports.
+    /// `TextFragmentIterator` folds a trailing separator into the fragment before it.
+    trailing_mandatory_break: bool,
     max_lines: Option<usize>,
     text_wrap: TextWrap,
     done: bool,
@@ -90,6 +94,7 @@ impl<'a, Font: TextShaper> TextLineBreaker<'a, Font> {
             current_line: Default::default(),
             num_emitted_lines: 0,
             mandatory_line_break_on_next_iteration: false,
+            trailing_mandatory_break: false,
             max_lines,
             text_wrap,
             done: false,
@@ -130,6 +135,10 @@ impl<Font: TextShaper> Iterator for TextLineBreaker<'_, Font> {
                 }
             };
 
+            // Every fragment that is read, not only one that is consumed.
+            // A fragment put back is read again before the iterator runs dry.
+            self.trailing_mandatory_break = fragment.trailing_mandatory_break;
+
             // As trailing_mandatory_break is only set if break_anywhere is false, the fragment must
             // be first processed with break_anywhere = false and if no mandatory break is found, the
             // loop is re-run with break_anywhere = true when using CharWrap.
@@ -161,7 +170,6 @@ impl<Font: TextShaper> Iterator for TextLineBreaker<'_, Font> {
                 }
 
                 let next_line = core::mem::take(&mut self.current_line);
-                self.mandatory_line_break_on_next_iteration = fragment.trailing_mandatory_break;
 
                 if self.text_wrap != TextWrap::CharWrap
                     && !fragments.break_anywhere
@@ -169,6 +177,9 @@ impl<Font: TextShaper> Iterator for TextLineBreaker<'_, Font> {
                 {
                     self.current_line.add_fragment(&fragment);
                     self.fragments = fragments;
+                    // Only for a fragment this branch takes.
+                    // One it puts back is read again, and its break belongs to the next line.
+                    self.mandatory_line_break_on_next_iteration = fragment.trailing_mandatory_break;
                 }
 
                 break Some(next_line);
@@ -189,9 +200,13 @@ impl<Font: TextShaper> Iterator for TextLineBreaker<'_, Font> {
             }
         };
 
-        // Emit at least one single line
+        // Emit at least one single line, and one more when the text ends on a mandatory break.
+        // "Hello\n" is two lines, the way "Hello\n\nWorld" is four.
+        // Taking the flag emits that line once.
         if next_line.is_none()
-            && (!self.current_line.byte_range.is_empty() || self.num_emitted_lines == 0)
+            && (!self.current_line.byte_range.is_empty()
+                || self.num_emitted_lines == 0
+                || core::mem::take(&mut self.trailing_mandatory_break))
         {
             next_line = Some(core::mem::take(&mut self.current_line));
         }
@@ -367,6 +382,65 @@ fn test_forced_break_multi_char_wrap() {
     assert_eq!(lines[3].line_text(text), "");
     assert_eq!(lines[4].line_text(text), "Wor");
     assert_eq!(lines[5].line_text(text), "ld");
+}
+
+/// A text that ends with a line separator ends on an empty line.
+#[test]
+fn test_forced_break_trailing() {
+    let font = FixedTestFont;
+    let text = "Hello\nWorld\n";
+    let shape_buffer = ShapeBuffer::new(
+        &TextLayout { font: &font, letter_spacing: None, line_height: None },
+        text,
+    );
+    let lines =
+        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None, None, TextWrap::WordWrap)
+            .collect::<std::vec::Vec<_>>();
+    assert_eq!(lines.len(), 3);
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "World");
+    assert_eq!(lines[2].line_text(text), "");
+}
+
+/// A text that is nothing but a separator is two empty lines.
+#[test]
+fn test_forced_break_trailing_only() {
+    let font = FixedTestFont;
+    let text = "\n";
+    let shape_buffer = ShapeBuffer::new(
+        &TextLayout { font: &font, letter_spacing: None, line_height: None },
+        text,
+    );
+    let lines =
+        TextLineBreaker::<FixedTestFont>::new(text, &shape_buffer, None, None, TextWrap::WordWrap)
+            .collect::<std::vec::Vec<_>>();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].line_text(text), "");
+    assert_eq!(lines[1].line_text(text), "");
+}
+
+/// The empty line a trailing separator opens survives a wrap on the line before it.
+/// The fragment that carries the separator is the one the width check puts back.
+#[test]
+fn test_forced_break_trailing_after_wrap() {
+    let font = FixedTestFont;
+    let text = "Hello World\n";
+    let shape_buffer = ShapeBuffer::new(
+        &TextLayout { font: &font, letter_spacing: None, line_height: None },
+        text,
+    );
+    let lines = TextLineBreaker::<FixedTestFont>::new(
+        text,
+        &shape_buffer,
+        Some(50.),
+        None,
+        TextWrap::WordWrap,
+    )
+    .collect::<std::vec::Vec<_>>();
+    assert_eq!(lines.len(), 3);
+    assert_eq!(lines[0].line_text(text), "Hello");
+    assert_eq!(lines[1].line_text(text), "World");
+    assert_eq!(lines[2].line_text(text), "");
 }
 
 #[test]


### PR DESCRIPTION
`LineBreakIterator::new` filters away the mandatory break at the end of the text. That is right for the artificial one UAX #14 rule LB3 gives every string, and wrong for a string that ends with a separator, whose own break sits at the same offset — the two are indistinguishable by position. The last fragment then carries `trailing_mandatory_break: false` and the newline is gone before anything downstream can count it. `test_no_linebreak_opportunity_at_eot`, which is the test that filter exists for, asks about a text with no separator at its end, and passes unchanged.

`TextLineBreaker` is the second half: it emits a final line only when the current line is non-empty or nothing has been emitted at all, so even with the break reported there is no line after it. `TextFragmentIterator` folds a trailing separator into the fragment before it, and makes a fragment of its own only for a separator that directly follows another, which is why `"Hello\n\nWorld"` was already four lines and `"Hello\n"` was one.

The visible fault is in a multi-line `TextInput`. The caret can be moved onto the last line and there is no line box to draw it in, so `cursor_rect_for_byte_offset` returns the end of the line above and `cursor-position-changed` reports that position. A box sized from `preferred-height` does not grow until a character lands on the new line, so Return reads as doing nothing and the line appears a keystroke late. That is #3590 word for word — "sometimes you need to press enter twice to insert a new line; once you type in the next character, the extra line break appears" — which was fixed for Skia in #3593.

Restoring the break exposes a third fault in the same function, and the third change is for it: `mandatory_line_break_on_next_iteration` was set from a fragment that the width-overflow branch may put back rather than take. Read again on the next call, that fragment opened an empty line before itself.

**Regression tests.** Three in `linebreaker.rs`: `test_forced_break_trailing` (`"Hello\nWorld\n"` is three lines), `test_forced_break_trailing_only` (`"\n"` is two), and `test_forced_break_trailing_after_wrap`, which puts the separator on a fragment the width check puts back and so covers the third change. Reverting the first two changes fails the first two tests with `left: 2, right: 3` and `left: 1, right: 2`. Reverting only the third turns the wrapped case into `["Hello", "", "World", ""]`.

**Measured.** A `TextInput`'s `preferred-height`, read through `MinimalSoftwareWindow` so the numbers need no windowing system. The line count is what matters: the pixel heights move with the font and with which engine measured them, and the counts do not.

| text | 1.17.1 | this change | parley | correct |
| --- | --- | --- | --- | --- |
| `"a"` | 1 | 1 | 1 | 1 |
| `"a\n"` | **1** | 2 | 2 | 2 |
| `"a\nb"` | 2 | 2 | 2 | 2 |
| `"a\nb\n"` | **2** | 3 | 3 | 3 |
| `"a\n\nb"` | 3 | 3 | 3 | 3 |
| `"a\n\n"` | **1** | 3 | 3 | 3 |

Every empty line at the end of a text is lost, not only the last: the filter takes the break that would have ended the second-to-last line as well.

**Scope.** `TextParagraphLayout` is reached from one crate: `i-slint-renderer-software`. Nothing else in the tree names it or `TextLineBreaker`. The software renderer takes it when the `systemfonts` feature is off, when the matched font is a `PixelFont`, or when `SLINT_SOFTWARE_RENDERER_PARLEY_DISABLED` is set. Otherwise it delegates to `sharedparley`, which lays these strings out correctly. FemtoVG and Skia call `sharedparley::text_size` and `sharedparley::text_input_cursor_rect_for_byte_offset` unconditionally, with no branch and no fallback, so they are not affected. Confirmed by running one application against unpatched 1.17.1 both ways: the caret lands on the line Return opens under FemtoVG and stays at the end of the line above under the software renderer.

**One existing assertion changes.** `test_no_line_separators_characters_rendered` counted the lines of `"Hello\nWorld\n"` as two, and it is three now. The third line renders no glyphs, which is what that test is about. The count was incidental to it.

Fixes #13297