### PR TITLE
Visual Editor: Compact inspector with rotation and corner controls

### DIFF
--- a/internal/compiler/passes/border_radius.rs
+++ b/internal/compiler/passes/border_radius.rs
@@ -24,9 +24,13 @@ pub fn handle_border_radius(root_component: &Rc<Component>, _diag: &mut BuildDia
             let bty = if let Some(bty) = elem.borrow().builtin_type() { bty } else { return };
             if bty.name == "Rectangle"
                 && elem.borrow().is_binding_set("border-radius", true)
-                && BORDER_RADIUS_PROPERTIES
-                    .iter()
-                    .any(|property_name| elem.borrow().is_binding_set(property_name, true))
+                && BORDER_RADIUS_PROPERTIES.iter().any(|property_name| {
+                    let elem = elem.borrow();
+                    elem.is_binding_set(property_name, true)
+                        || elem.binding_cell_including_synthetic(property_name).is_some_and(
+                            |binding| binding.borrow().expression.is_synthetic_debug_hook(),
+                        )
+                })
             {
                 let border_radius = NamedReference::new(elem, SmolStr::new_static("border-radius"));
                 for property_name in BORDER_RADIUS_PROPERTIES.iter() {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1707,6 +1707,17 @@ impl ComponentInstance {
         crate::highlight::element_node_at_source_code_position(self.inner.vrc(), path, offset)
     }
 
+    /// Read parent-relative rotation and corner radii (top-left, top-right, bottom-left, bottom-right).
+    ///
+    /// WARNING: this is not part of the public API.
+    #[cfg(feature = "internal-highlight")]
+    pub fn element_rotation_and_radii(
+        &self,
+        element: &i_slint_compiler::object_tree::ElementRc,
+    ) -> Vec<(f32, [f32; 4])> {
+        crate::highlight::element_rotation_and_radii(self.inner.vrc(), element)
+    }
+
     /// Set a callback triggered by `Expression::DebugHook`.
     #[cfg(feature = "internal")]
     pub fn set_debug_hook_callback(&self, callback: Option<crate::debug_hook::DebugHookCallback>) {

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1707,17 +1707,6 @@ impl ComponentInstance {
         crate::highlight::element_node_at_source_code_position(self.inner.vrc(), path, offset)
     }
 
-    /// Read parent-relative rotation and corner radii (top-left, top-right, bottom-left, bottom-right).
-    ///
-    /// WARNING: this is not part of the public API.
-    #[cfg(feature = "internal-highlight")]
-    pub fn element_rotation_and_radii(
-        &self,
-        element: &i_slint_compiler::object_tree::ElementRc,
-    ) -> Vec<(f32, [f32; 4])> {
-        crate::highlight::element_rotation_and_radii(self.inner.vrc(), element)
-    }
-
     /// Set a callback triggered by `Expression::DebugHook`.
     #[cfg(feature = "internal")]
     pub fn set_debug_hook_callback(&self, callback: Option<crate::debug_hook::DebugHookCallback>) {

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -42,9 +42,26 @@ pub struct HighlightedRect {
     /// Absolute rotation (in degrees) of this instance's parent coordinate system.
     ///
     /// `angle - parent_rotation` yields the element's own rotation relative to its parent, which
-    /// matches the `rotation-angle`/`transform-rotation` property written to the source.
+    /// matches `transform-rotation` modulo complete turns. Use `transform_rotation` to retain those turns.
     pub parent_rotation: f32,
+    /// Evaluated parent-relative rotation in degrees, including complete turns.
+    pub transform_rotation: f32,
+    /// Evaluated corner radii in logical pixels.
+    pub corner_radii: CornerRadii,
 }
+/// Evaluated rectangle corner radii in logical pixels.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CornerRadii {
+    /// Top-left radius.
+    pub top_left: f32,
+    /// Top-right radius.
+    pub top_right: f32,
+    /// Bottom-left radius.
+    pub bottom_left: f32,
+    /// Bottom-right radius.
+    pub bottom_right: f32,
+}
+
 impl HighlightedRect {
     /// Returns true if `position` lies inside the (potentially rotated) rectangle.
     pub fn contains(&self, position: LogicalPoint) -> bool {
@@ -340,6 +357,7 @@ fn item_flat_index_to_rect(
     // `lower_property_to_element`) take over the element's geometry and lay the element
     // out at (0,0) inside themselves, so measuring the parent frame from the element
     // directly would collapse `rect.origin - parent_origin` to ~0.
+    let mut transform_rotation = 0.;
     let mut anchor = item_rc.clone();
     while let Some(parent) =
         anchor.parent_item(i_slint_core::item_tree::ParentItemTraversalMode::StopAtPopups)
@@ -349,6 +367,12 @@ fn item_flat_index_to_rect(
         }
         if !is_injected_wrapper_element(instance, parent.index() as usize) {
             break;
+        }
+        if let Some(transform) = i_slint_core::items::ItemRef::downcast_pin::<
+            i_slint_core::items::Transform,
+        >(parent.borrow())
+        {
+            transform_rotation += transform.transform_rotation();
         }
         anchor = parent;
     }
@@ -389,6 +413,8 @@ fn item_flat_index_to_rect(
         angle: angle_rad.to_degrees(),
         parent_origin,
         parent_rotation,
+        transform_rotation,
+        corner_radii: item_corner_radii(item_rc.borrow()),
     })
 }
 
@@ -413,52 +439,26 @@ fn positions_by_source(
         .collect()
 }
 
-pub(crate) fn element_rotation_and_radii(
-    root: &VRc<ItemTreeVTable, Instance>,
-    element: &ElementRc,
-) -> Vec<(f32, [f32; 4])> {
-    use i_slint_core::items::{BasicBorderRectangle, BorderRectangle, ItemRef, Transform};
-    let target = walk_to_native_root(element);
-    let Some((path, offset)) = source_location_of(&target) else { return Vec::new() };
-    let use_site = if Rc::ptr_eq(&target, element) { None } else { source_location_of(element) };
-    items_by_source(root, &path, offset, use_site.as_ref().map(|(p, o)| (p.as_path(), *o)))
-        .into_iter()
-        .filter_map(|(instance, flat_idx)| {
-            let item = ItemRc::new(VRc::into_dyn(instance.clone()), flat_idx as u32);
-            if item.geometry().size.is_empty() {
-                return None;
-            }
-            let item_ref = item.borrow();
-            let radii = if let Some(rect) = ItemRef::downcast_pin::<BorderRectangle>(item_ref) {
-                [
-                    rect.border_top_left_radius().get(),
-                    rect.border_top_right_radius().get(),
-                    rect.border_bottom_left_radius().get(),
-                    rect.border_bottom_right_radius().get(),
-                ]
-            } else if let Some(rect) = ItemRef::downcast_pin::<BasicBorderRectangle>(item_ref) {
-                [rect.border_radius().get(); 4]
-            } else {
-                [0.; 4]
-            };
-            let mut rotation = 0.;
-            let mut anchor = item.clone();
-            while let Some(parent) =
-                anchor.parent_item(i_slint_core::item_tree::ParentItemTraversalMode::StopAtPopups)
-            {
-                if !VRc::ptr_eq(parent.item_tree(), item.item_tree())
-                    || !is_injected_wrapper_element(&instance, parent.index() as usize)
-                {
-                    break;
-                }
-                if let Some(transform) = ItemRef::downcast_pin::<Transform>(parent.borrow()) {
-                    rotation += transform.transform_rotation();
-                }
-                anchor = parent;
-            }
-            Some((rotation, radii))
-        })
-        .collect()
+fn item_corner_radii(item: Pin<i_slint_core::items::ItemRef<'_>>) -> CornerRadii {
+    use i_slint_core::items::{BasicBorderRectangle, BorderRectangle, ItemRef};
+    if let Some(rect) = ItemRef::downcast_pin::<BorderRectangle>(item) {
+        CornerRadii {
+            top_left: rect.border_top_left_radius().get(),
+            top_right: rect.border_top_right_radius().get(),
+            bottom_left: rect.border_bottom_left_radius().get(),
+            bottom_right: rect.border_bottom_right_radius().get(),
+        }
+    } else if let Some(rect) = ItemRef::downcast_pin::<BasicBorderRectangle>(item) {
+        let radius = rect.border_radius().get();
+        CornerRadii {
+            top_left: radius,
+            top_right: radius,
+            bottom_left: radius,
+            bottom_right: radius,
+        }
+    } else {
+        CornerRadii::default()
+    }
 }
 
 fn items_by_source(
@@ -609,5 +609,50 @@ export component Win inherits Window {
 
         check("outer", 30.0);
         check("inner", 15.0);
+    }
+    #[test]
+    fn evaluated_rotation_and_radii_share_geometry_instances() {
+        let code = r#"
+export component Win inherits Window {
+    width: 300px;
+    height: 300px;
+    outer := Rectangle {
+        width: 200px;
+        height: 200px;
+        transform-rotation: 30deg;
+        for angle in [382.25deg, -397.5deg]: Rectangle {
+            width: 40px;
+            height: 40px;
+            transform-rotation: angle;
+            border-top-left-radius: 1.5px;
+            border-top-right-radius: 2.5px;
+            border-bottom-left-radius: 3.5px;
+            border-bottom-right-radius: 4.5px;
+        }
+    }
+}"#;
+        let instance = compile_with_debug_hooks(code);
+        let offset = code
+            .find(
+                "Rectangle {
+            width",
+            )
+            .unwrap();
+        let (element, _) = instance
+            .element_node_at_source_code_position(&test_path(), offset as u32)
+            .first()
+            .cloned()
+            .unwrap();
+        let geometries = instance.element_positions(&element);
+        assert_eq!(geometries.len(), 2);
+        for (geometry, expected) in geometries.iter().zip([382.25, -397.5]) {
+            assert_eq!(geometry.transform_rotation, expected);
+            assert!((geometry.parent_rotation - 30.).abs() < 0.001);
+            let radii = geometry.corner_radii;
+            assert_eq!(
+                [radii.top_left, radii.top_right, radii.bottom_left, radii.bottom_right],
+                [1.5, 2.5, 3.5, 4.5]
+            );
+        }
     }
 }

--- a/internal/interpreter/highlight.rs
+++ b/internal/interpreter/highlight.rs
@@ -399,6 +399,74 @@ fn positions_by_source(
     use_site: Option<(&Path, u32)>,
     filter: ElementPositionFilter,
 ) -> Vec<HighlightedRect> {
+    items_by_source(root, target_path, target_offset, use_site)
+        .into_iter()
+        .filter_map(|(instance, flat_idx)| {
+            if filter == ElementPositionFilter::ExcludeClipped {
+                let item = ItemRc::new(VRc::into_dyn(instance.clone()), flat_idx as u32);
+                if !item.is_visible() {
+                    return None;
+                }
+            }
+            item_flat_index_to_rect(&instance, root, flat_idx)
+        })
+        .collect()
+}
+
+pub(crate) fn element_rotation_and_radii(
+    root: &VRc<ItemTreeVTable, Instance>,
+    element: &ElementRc,
+) -> Vec<(f32, [f32; 4])> {
+    use i_slint_core::items::{BasicBorderRectangle, BorderRectangle, ItemRef, Transform};
+    let target = walk_to_native_root(element);
+    let Some((path, offset)) = source_location_of(&target) else { return Vec::new() };
+    let use_site = if Rc::ptr_eq(&target, element) { None } else { source_location_of(element) };
+    items_by_source(root, &path, offset, use_site.as_ref().map(|(p, o)| (p.as_path(), *o)))
+        .into_iter()
+        .filter_map(|(instance, flat_idx)| {
+            let item = ItemRc::new(VRc::into_dyn(instance.clone()), flat_idx as u32);
+            if item.geometry().size.is_empty() {
+                return None;
+            }
+            let item_ref = item.borrow();
+            let radii = if let Some(rect) = ItemRef::downcast_pin::<BorderRectangle>(item_ref) {
+                [
+                    rect.border_top_left_radius().get(),
+                    rect.border_top_right_radius().get(),
+                    rect.border_bottom_left_radius().get(),
+                    rect.border_bottom_right_radius().get(),
+                ]
+            } else if let Some(rect) = ItemRef::downcast_pin::<BasicBorderRectangle>(item_ref) {
+                [rect.border_radius().get(); 4]
+            } else {
+                [0.; 4]
+            };
+            let mut rotation = 0.;
+            let mut anchor = item.clone();
+            while let Some(parent) =
+                anchor.parent_item(i_slint_core::item_tree::ParentItemTraversalMode::StopAtPopups)
+            {
+                if !VRc::ptr_eq(parent.item_tree(), item.item_tree())
+                    || !is_injected_wrapper_element(&instance, parent.index() as usize)
+                {
+                    break;
+                }
+                if let Some(transform) = ItemRef::downcast_pin::<Transform>(parent.borrow()) {
+                    rotation += transform.transform_rotation();
+                }
+                anchor = parent;
+            }
+            Some((rotation, radii))
+        })
+        .collect()
+}
+
+fn items_by_source(
+    root: &VRc<ItemTreeVTable, Instance>,
+    target_path: &Path,
+    target_offset: u32,
+    use_site: Option<(&Path, u32)>,
+) -> Vec<(VRc<ItemTreeVTable, Instance>, usize)> {
     let cu = root.root_sub_component.compilation_unit.clone();
     let mut results = Vec::new();
     // Repeated / conditional rows are separate instances with their own
@@ -420,16 +488,7 @@ fn positions_by_source(
                     continue;
                 }
                 for flat_idx in find_flat_indices_for_item(&instance, sc_idx, local_idx, use_site) {
-                    if filter == ElementPositionFilter::ExcludeClipped {
-                        let dyn_rc = vtable::VRc::into_dyn(instance.clone());
-                        let item_rc = i_slint_core::items::ItemRc::new(dyn_rc, flat_idx as u32);
-                        if !item_rc.is_visible() {
-                            continue;
-                        }
-                    }
-                    if let Some(rect) = item_flat_index_to_rect(&instance, root, flat_idx) {
-                        results.push(rect);
-                    }
+                    results.push((instance.clone(), flat_idx));
                 }
             }
         }

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -557,11 +557,14 @@ mod tests {
             pending_recompile: Default::default(),
         };
         let (tx, rx) = std::sync::mpsc::channel();
+        let (error_tx, error_rx) = std::sync::mpsc::channel();
         let mut watcher = FileWatcher::start(
             move |event| {
                 let _ = tx.send(event);
             },
-            |_| {},
+            move |error| {
+                let _ = error_tx.send(error);
+            },
         )
         .unwrap();
         spin_on::spin_on(open_initial_preview(
@@ -573,16 +576,21 @@ mod tests {
         .unwrap();
         sync_file_watcher_if_needed(&mut watcher, &session, &root, &mut None).unwrap();
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut seen = Vec::new();
         loop {
             let event = rx
                 .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
-                .expect(
-                    "repair made while publishing the initial preview must produce a watch event",
-                );
-            if event.path == source {
+                .unwrap_or_else(|error| {
+                    let errors = error_rx.try_iter().collect::<Vec<_>>();
+                    panic!(
+                        "repair made while publishing the initial preview must produce a watch event for {url}: {error}; received {seen:?}; watcher errors {errors:?}"
+                    );
+                });
+            if Url::from_file_path(&event.path).ok().as_ref() == Some(&url) {
                 spin_on::spin_on(trigger_editor_file_watcher(&mut session, event)).unwrap();
                 break;
             }
+            seen.push(event);
         }
         assert!(session.pending_recompile.remove(&url));
         spin_on::spin_on(session.reload_document(url.clone())).unwrap();

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -44,6 +44,7 @@ mod drop_location;
 mod element_selection;
 pub mod eval;
 mod ext;
+mod inspector;
 #[cfg(target_os = "macos")]
 pub mod macos_titlebar;
 mod preview_data;
@@ -214,6 +215,7 @@ pub struct PreviewState {
     initial_live_data: preview_data::PreviewDataMap,
     current_live_data: preview_data::PreviewDataMap,
     undo_redo_stack: undo_redo::UndoRedoStack,
+    inspector_edit: Option<inspector::Edit>,
 
     source_code: SourceCodeCache,
     resources: HashSet<Url>,
@@ -425,6 +427,7 @@ fn apply_live_preview_data() {
 }
 
 fn set_contents(url: &VersionedUrl, content: String) {
+    inspector::invalidate();
     if let Some((current, behavior)) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
         if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
             undo_redo::set_undo_redo_enabled(preview_state);
@@ -2394,6 +2397,7 @@ fn set_selected_element(
     selection: Option<element_selection::ElementSelection>,
     editor_notification: SelectionNotification,
 ) {
+    inspector::cancel();
     let (layout_kind, parent_layout_kind, type_name) = {
         let selection_node = selection.as_ref().and_then(|s| s.as_element_node());
         let (layout_kind, parent_layout_kind) = selection_node
@@ -2613,7 +2617,7 @@ fn update_preview_area(
 
         if let Some(compiled) = compiled {
             api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
-            api.set_current_element(Default::default());
+            // Keep the inspector mounted until reselection, so edits retain keyboard focus.
 
             set_preview_factory(
                 editor_ui,
@@ -2670,6 +2674,7 @@ fn update_preview_area(
         Ok(())
     })?;
 
+    inspector::invalidate();
     element_selection::reselect_element();
     Ok(())
 }

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -215,6 +215,7 @@ pub struct PreviewState {
     initial_live_data: preview_data::PreviewDataMap,
     current_live_data: preview_data::PreviewDataMap,
     undo_redo_stack: undo_redo::UndoRedoStack,
+    pending_history: std::collections::VecDeque<bool>,
     inspector_edit: Option<inspector::Edit>,
 
     source_code: SourceCodeCache,
@@ -2689,6 +2690,7 @@ fn update_preview_area(
 
     inspector::invalidate();
     element_selection::reselect_element();
+    undo_redo::apply_pending();
     Ok(())
 }
 

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -427,28 +427,33 @@ fn apply_live_preview_data() {
 }
 
 fn set_contents(url: &VersionedUrl, content: String) {
-    inspector::invalidate();
-    if let Some((current, behavior)) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
+    let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
         if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
             undo_redo::set_undo_redo_enabled(preview_state);
         }
-
         let old = preview_state.source_code.insert(
             url.url().clone(),
             SourceCodeCacheEntry { version: *url.version(), code: content.clone() },
         );
-
-        if Some(content) == old.map(|o| o.code) {
-            return None;
-        }
-
-        if preview_state.dependencies.contains(url.url()) {
-            preview_state.current_component().map(|current| (current, LoadBehavior::Reload))
-        } else {
-            None
-        }
-    }) {
-        load_preview(current, behavior);
+        let changed = old.as_ref().is_none_or(|old| old.code != content);
+        let version_changed = old.as_ref().is_none_or(|old| old.version != *url.version());
+        let selected_document = preview_state
+            .selected
+            .as_ref()
+            .and_then(|selected| Url::from_file_path(&selected.path).ok())
+            .as_ref()
+            == Some(url.url());
+        let dependency = preview_state.dependencies.contains(url.url());
+        let invalidate =
+            (selected_document && (changed || version_changed)) || (dependency && changed);
+        let reload = (dependency && changed).then(|| preview_state.current_component()).flatten();
+        (reload, invalidate)
+    });
+    if invalidate {
+        inspector::invalidate();
+    }
+    if let Some(current) = reload {
+        load_preview(current, LoadBehavior::Reload);
     }
 }
 
@@ -2394,7 +2399,7 @@ pub enum SelectionNotification {
 }
 
 fn set_selected_element(
-    selection: Option<element_selection::ElementSelection>,
+    mut selection: Option<element_selection::ElementSelection>,
     editor_notification: SelectionNotification,
 ) {
     inspector::cancel();
@@ -2498,6 +2503,14 @@ fn set_selected_element(
                         properties::query_properties(&uri, version, &selection, in_layout).ok(),
                     ));
                 }
+            } else if !notify_editor_about_selection_after_update
+                && !preview_state.workspace_edit_sent
+            {
+                api.set_current_element(Default::default());
+                api.set_properties(Default::default());
+                api.set_selection(ui::Selection { highlight_index: -1, ..Default::default() });
+                preview_state.property_range_declarations = None;
+                selection = None;
             }
         }
 
@@ -2765,6 +2778,34 @@ mod tests {
             *state = PreviewState::default();
             state.to_lsp = RefCell::new(Some(Rc::new(CapturePreviewToLsp { messages })));
         });
+    }
+
+    #[test]
+    fn source_push_only_invalidates_relevant_inspector_edits() {
+        i_slint_backend_testing::init_no_event_loop();
+        reset_preview_state(Default::default());
+        let editor = ui::EditorUi::new().unwrap();
+        let api = editor.global::<ui::Api>();
+        let path = std::env::temp_dir().join("inspector-push.slint");
+        let url = Url::from_file_path(&path).unwrap();
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            state.api = <ui::Api as slint::Global<'_, ui::EditorUi>>::as_weak(&api);
+            state.selected = Some(ElementSelection { path, offset: 0.into(), instance_index: 0 });
+            state.dependencies.insert(url.clone());
+            state
+                .source_code
+                .insert(url.clone(), SourceCodeCacheEntry { version: Some(1), code: "old".into() });
+        });
+        set_contents(&VersionedUrl::new(url.clone(), Some(1)), "old".into());
+        assert_eq!(api.get_inspector_generation(), 0);
+        let unrelated = Url::from_file_path(std::env::temp_dir().join("unrelated.slint")).unwrap();
+        set_contents(&VersionedUrl::new(unrelated, Some(2)), "other".into());
+        assert_eq!(api.get_inspector_generation(), 0);
+        set_contents(&VersionedUrl::new(url.clone(), Some(2)), "old".into());
+        assert_eq!(api.get_inspector_generation(), 1);
+        set_contents(&VersionedUrl::new(url, Some(2)), "new".into());
+        assert_eq!(api.get_inspector_generation(), 2);
+        reset_preview_state(Default::default());
     }
 
     fn temp_file(name: &str) -> PathBuf {

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -54,6 +54,8 @@ mod properties;
 #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
 pub mod remote;
 pub(crate) mod settings;
+#[cfg(feature = "system-testing")]
+mod test_sync;
 pub mod ui;
 mod undo_redo;
 
@@ -71,6 +73,9 @@ pub fn initialize(
         preview_state.editor_ui = Some(editor_ui.clone_strong());
         preview_state.settings = settings;
     });
+
+    #[cfg(feature = "system-testing")]
+    test_sync::initialize();
 
     to_lsp
         .send_telemetry(&mut [(

--- a/tools/editor/preview/element_selection.rs
+++ b/tools/editor/preview/element_selection.rs
@@ -158,7 +158,10 @@ struct HighlightPositionsModel {
 
 impl HighlightPositionsModel {
     fn new(component_instance: ComponentInstance, path: PathBuf, offset: u32) -> Rc<Self> {
-        let model = Rc::new(Self { rows: Default::default(), change_tracker: Default::default() });
+        let rows = i_slint_core::properties::evaluate_no_tracking(|| {
+            selection_rectangles(&component_instance, &path, offset)
+        });
+        let model = Rc::new(Self { rows: rows.into(), change_tracker: Default::default() });
         let model_weak = Rc::downgrade(&model);
         let component_instance = component_instance.as_weak();
         model.change_tracker.init_delayed(
@@ -233,6 +236,12 @@ pub fn highlight_positions(
     source_uri: slint::SharedString,
     offset: i32,
 ) -> slint::ModelRc<ui::SelectionRectangle> {
+    // The model holds a preview instance, so bindings must recreate it after a reload.
+    super::PREVIEW_STATE.with_borrow(|state| {
+        if let Some(api) = state.api.upgrade() {
+            api.get_inspector_generation();
+        }
+    });
     let Some(component_instance) = super::component_instance() else {
         return Default::default();
     };

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -1,0 +1,167 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use super::*;
+
+const CORNERS: [&str; 4] = [
+    "border-top-left-radius",
+    "border-top-right-radius",
+    "border-bottom-left-radius",
+    "border-bottom-right-radius",
+];
+
+pub(super) struct Edit {
+    key: String,
+    overrides: Vec<(SmolStr, Option<slint_interpreter::Value>)>,
+}
+
+fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
+    let selected = selected_element()?;
+    let node = selected.as_element_node()?;
+    let (path, offset) = node.path_and_offset();
+    let url = Url::from_file_path(path).ok()?;
+    let version = document_cache()?.document_version(&url);
+    let generation = PREVIEW_STATE
+        .with_borrow(|state| state.api.upgrade().map(|api| api.get_inspector_generation()))?;
+    let expected = format!(
+        "{url}:{}:{}:{}:{generation}",
+        version.unwrap_or(i32::MIN),
+        u32::from(offset),
+        selected.instance_index
+    );
+    (key == expected).then_some((node, url, version))
+}
+
+fn names(name: &str) -> Option<Vec<&str>> {
+    match name {
+        "all-corners" => Some(CORNERS.to_vec()),
+        "transform-rotation" => Some(vec![name]),
+        name if CORNERS.contains(&name) => Some(vec![name]),
+        _ => None,
+    }
+}
+
+pub(super) fn cancel() {
+    PREVIEW_STATE.with_borrow_mut(|state| {
+        if let Some(edit) = state.inspector_edit.take() {
+            let overrides = state.debug_hook_overrides.borrow();
+            for (id, previous) in edit.overrides {
+                if let Some(property) = overrides.get(&id) {
+                    property.as_ref().set(previous);
+                }
+            }
+        }
+    });
+    if let Some(instance) = component_instance() {
+        instance.window().request_redraw();
+    }
+}
+
+pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool {
+    let Some((node, _, _)) = target(&key) else {
+        cancel();
+        return false;
+    };
+    let Some(names) = names(&name) else { return false };
+    if !value.is_finite() || (name != "transform-rotation" && value < 0.) {
+        return false;
+    }
+    let hash = node.with_element_debug(|debug| debug.element_hash);
+    let ids: Vec<_> = names
+        .iter()
+        .map(|name| i_slint_compiler::passes::property_id(hash, &SmolStr::from(*name)))
+        .collect();
+    if PREVIEW_STATE.with_borrow(|state| {
+        state.inspector_edit.as_ref().is_some_and(|edit| edit.key != key.as_str())
+    }) {
+        cancel();
+    }
+    PREVIEW_STATE.with_borrow_mut(|state| {
+        let mut overrides = (*state.debug_hook_overrides).borrow_mut();
+        let edit = state
+            .inspector_edit
+            .get_or_insert_with(|| Edit { key: key.to_string(), overrides: Vec::new() });
+        for id in ids {
+            let property = overrides
+                .entry(id.clone())
+                .or_insert_with(|| Box::pin(i_slint_core::Property::new(None)));
+            if !edit.overrides.iter().any(|(saved, _)| saved == &id) {
+                edit.overrides.push((id, property.as_ref().get()));
+            }
+            property.as_ref().set(Some(slint_interpreter::Value::Number(value as f64)));
+        }
+    });
+    if let Some(instance) = component_instance() {
+        instance.window().request_redraw();
+    }
+    true
+}
+
+pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool {
+    let Some((node, url, version)) = target(&key) else {
+        cancel();
+        return false;
+    };
+    let Some(names) = names(&name) else { return false };
+    if !value.is_finite() || (name != "transform-rotation" && value < 0.) {
+        return false;
+    }
+    let unit = if name == "transform-rotation" { "deg" } else { "px" };
+    let changes = names
+        .iter()
+        .map(|name| {
+            i_slint_editor_preview::editing::PropertyChange::new(*name, format!("{value}{unit}"))
+        })
+        .collect::<Vec<_>>();
+    let Some(cache) = document_cache() else {
+        cancel();
+        return false;
+    };
+    let (_, offset) = node.path_and_offset();
+    let edit = properties::update_element_properties(
+        &cache,
+        i_slint_editor_preview::editing::VersionedPosition::new(
+            VersionedUrl::new(url, version),
+            offset,
+        ),
+        changes,
+    );
+    let accepted = edit.is_some_and(|edit| {
+        send_workspace_edit(
+            if name == "transform-rotation" {
+                "Rotating element"
+            } else {
+                "Changing border radius"
+            }
+            .into(),
+            edit,
+            true,
+        )
+    });
+    cancel();
+    accepted
+}
+
+pub(super) fn values(key: SharedString) -> slint::ModelRc<f32> {
+    let values = (|| {
+        let (node, _, _) = target(&key)?;
+        let selected = selected_element()?;
+        let instance = component_instance()?;
+        let (rotation, radii) = instance
+            .element_rotation_and_radii(&node.element)
+            .get(selected.instance_index)
+            .copied()?;
+        Some(vec![rotation, radii[0], radii[1], radii[2], radii[3]])
+    })()
+    .unwrap_or_else(|| vec![0.; 5]);
+    slint::ModelRc::new(slint::VecModel::from(values))
+}
+
+pub(super) fn invalidate() {
+    cancel();
+    PREVIEW_STATE.with_borrow(|state| {
+        if let Some(api) = state.api.upgrade() {
+            api.set_inspector_generation(api.get_inspector_generation().wrapping_add(1));
+        }
+    });
+}

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -41,6 +41,20 @@ fn names(name: &str) -> Option<Vec<&str>> {
     }
 }
 
+fn validate<'a>(
+    key: &str,
+    name: &'a str,
+    value: f32,
+) -> Option<(ElementRcNode, Url, SourceFileVersion, Vec<&'a str>)> {
+    let Some((node, url, version)) = target(key) else {
+        cancel();
+        return None;
+    };
+    let names = names(name)?;
+    (value.is_finite() && (name == "transform-rotation" || value >= 0.))
+        .then_some((node, url, version, names))
+}
+
 pub(super) fn cancel() {
     PREVIEW_STATE.with_borrow_mut(|state| {
         if let Some(edit) = state.inspector_edit.take() {
@@ -58,14 +72,7 @@ pub(super) fn cancel() {
 }
 
 pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool {
-    let Some((node, _, _)) = target(&key) else {
-        cancel();
-        return false;
-    };
-    let Some(names) = names(&name) else { return false };
-    if !value.is_finite() || (name != "transform-rotation" && value < 0.) {
-        return false;
-    }
+    let Some((node, _, _, names)) = validate(&key, &name, value) else { return false };
     let hash = node.with_element_debug(|debug| debug.element_hash);
     let ids: Vec<_> = names
         .iter()
@@ -98,14 +105,7 @@ pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool
 }
 
 pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool {
-    let Some((node, url, version)) = target(&key) else {
-        cancel();
-        return false;
-    };
-    let Some(names) = names(&name) else { return false };
-    if !value.is_finite() || (name != "transform-rotation" && value < 0.) {
-        return false;
-    }
+    let Some((node, url, version, names)) = validate(&key, &name, value) else { return false };
     let unit = if name == "transform-rotation" { "deg" } else { "px" };
     let changes = names
         .iter()
@@ -138,7 +138,13 @@ pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool 
             true,
         )
     });
-    cancel();
+    if accepted {
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            state.inspector_edit.take();
+        });
+    } else {
+        cancel();
+    }
     accepted
 }
 
@@ -147,11 +153,16 @@ pub(super) fn values(key: SharedString) -> slint::ModelRc<f32> {
         let (node, _, _) = target(&key)?;
         let selected = selected_element()?;
         let instance = component_instance()?;
-        let (rotation, radii) = instance
-            .element_rotation_and_radii(&node.element)
-            .get(selected.instance_index)
-            .copied()?;
-        Some(vec![rotation, radii[0], radii[1], radii[2], radii[3]])
+        let geometry =
+            instance.element_positions(&node.element).get(selected.instance_index).copied()?;
+        let radii = geometry.corner_radii;
+        Some(vec![
+            geometry.transform_rotation,
+            radii.top_left,
+            radii.top_right,
+            radii.bottom_left,
+            radii.bottom_right,
+        ])
     })()
     .unwrap_or_else(|| vec![0.; 5]);
     slint::ModelRc::new(slint::VecModel::from(values))

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -110,7 +110,7 @@ pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool 
     let changes = names
         .iter()
         .map(|name| {
-            i_slint_editor_preview::editing::PropertyChange::new(*name, format!("{value}{unit}"))
+            i_slint_editor_preview::editing::PropertyChange::new(name, format!("{value}{unit}"))
         })
         .collect::<Vec<_>>();
     let Some(cache) = document_cache() else {

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -1,0 +1,104 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Opt-in synchronization for tests whose next action requires an installed source revision.
+//! The system-testing transport exposes accessibility, not the preview's document cache.
+
+use std::collections::BTreeMap;
+
+#[derive(serde::Deserialize)]
+struct Request {
+    id: u64,
+    sources: BTreeMap<lsp_types::Url, String>,
+}
+
+fn response(request: &Request) -> serde_json::Value {
+    super::PREVIEW_STATE.with_borrow(|state| {
+        let busy = state.workspace_edit_sent
+            || !state.pending_history.is_empty()
+            || !matches!(state.loading_state, super::PreviewFutureState::Pending);
+        let cache = super::document_cache_from(state);
+        let mismatches: Vec<_> = request
+            .sources
+            .iter()
+            .filter_map(|(url, expected)| {
+                let actual = cache
+                    .as_ref()
+                    .and_then(|cache| cache.get_document(url))
+                    .and_then(|document| document.node.as_ref())
+                    .and_then(|node| node.source_file.source());
+                (actual != Some(expected.as_str())).then_some(url)
+            })
+            .collect();
+        serde_json::json!({
+            "id": request.id,
+            "ready": !busy && mismatches.is_empty(),
+            "busy": busy,
+            "mismatches": mismatches,
+        })
+    })
+}
+
+pub(super) fn initialize() {
+    let Some(directory) = std::env::var_os("SLINT_EDITOR_TEST_SYNC") else { return };
+    let directory = std::path::PathBuf::from(directory);
+    thread_local! {
+        static TIMER: slint::Timer = slint::Timer::default();
+    }
+    TIMER.with(|timer| {
+        timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(20), move || {
+            let Ok(bytes) = std::fs::read(directory.join("request.json")) else { return };
+            let Ok(request) = serde_json::from_slice::<Request>(&bytes) else { return };
+            let response = response(&request);
+            let temporary = directory.join("response.tmp");
+            if std::fs::write(&temporary, response.to_string()).is_ok() {
+                let _ = std::fs::rename(temporary, directory.join("response.json"));
+            }
+        });
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn waits_for_installed_source_and_pending_work() {
+        use super::super::{PREVIEW_STATE, PreviewFutureState, PreviewState};
+        use i_slint_editor_preview::test::{
+            compile_test_with_sources, main_test_file_name, recompile_test_with_sources,
+        };
+        let url = lsp_types::Url::from_file_path(main_test_file_name()).unwrap();
+        let old = "export component Test inherits Window { width: 100px; }";
+        let new = "export component Test inherits Window { width: 200px; }";
+        let old_cache =
+            compile_test_with_sources("fluent", [(url.clone(), old.into())].into(), false);
+        let new_cache =
+            recompile_test_with_sources("fluent", [(url.clone(), new.into())].into(), false, false);
+        let request = Request { id: 42, sources: [(url, new.into())].into() };
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            *state = PreviewState::default();
+            state.document_cache.replace(Some(std::rc::Rc::new(old_cache)));
+        });
+        assert_eq!(response(&request)["ready"], false);
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            state.document_cache.replace(Some(std::rc::Rc::new(new_cache)));
+            state.loading_state = PreviewFutureState::Loading;
+        });
+        assert_eq!(response(&request)["ready"], false);
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            state.loading_state = PreviewFutureState::Pending;
+            state.workspace_edit_sent = true;
+        });
+        assert_eq!(response(&request)["ready"], false);
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            state.workspace_edit_sent = false;
+            state.pending_history.push_back(false);
+        });
+        assert_eq!(response(&request)["ready"], false);
+        PREVIEW_STATE.with_borrow_mut(|state| state.pending_history.clear());
+        assert_eq!(response(&request)["ready"], true);
+        assert_eq!(response(&request)["id"], 42);
+        PREVIEW_STATE.with_borrow_mut(|state| *state = PreviewState::default());
+    }
+}

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -202,6 +202,10 @@ pub fn initialize_editor(
     api.on_override_selected_element_border_radius(super::override_selected_element_border_radius);
     api.on_persist_selected_element_border_radius(super::persist_selected_element_border_radius);
 
+    api.on_inspector_values(super::inspector::values);
+    api.on_inspector_preview(super::inspector::preview);
+    api.on_inspector_commit(super::inspector::commit);
+    api.on_inspector_cancel(super::inspector::cancel);
     api.on_test_code_binding(super::test_code_binding);
     api.on_set_code_binding(super::set_code_binding);
     api.on_set_color_binding(super::set_color_binding);

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -96,6 +96,7 @@ pub fn setup(api: &ui::Api<'_>) {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
             if state.workspace_edit_sent {
+                state.pending_history.push_back(false);
                 return;
             }
             let Some(edit) = state.undo_redo_stack.undo_stack.pop() else {
@@ -129,6 +130,7 @@ pub fn setup(api: &ui::Api<'_>) {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
             if state.workspace_edit_sent {
+                state.pending_history.push_back(true);
                 return;
             }
             let Some(edit) = state.undo_redo_stack.redo_stack.pop() else {
@@ -158,6 +160,23 @@ pub fn setup(api: &ui::Api<'_>) {
             state.workspace_edit_sent = true;
         })
     });
+}
+
+pub(super) fn apply_pending() {
+    loop {
+        let next = super::PREVIEW_STATE.with_borrow_mut(|state| {
+            if state.workspace_edit_sent {
+                return None;
+            }
+            Some((state.api.upgrade()?, state.pending_history.pop_front()?))
+        });
+        let Some((api, redo)) = next else { return };
+        if redo {
+            api.invoke_redo();
+        } else {
+            api.invoke_undo();
+        }
+    }
 }
 
 pub fn set_undo_redo_enabled(state: &super::PreviewState) {

--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -45,6 +45,21 @@ cd tools/editor/ui-tests
 The runner uses up to four workers and lets pytest report the result and total duration.
 The tests use the headless Skia backend by default, so editor windows do not appear locally or in CI.
 
+## Wait for Edits
+
+Use `snapshot.wait_for_applied(expected, relative_path)` before an action that depends on an edit's completed preview and history update.
+It checks exact project source, then waits for matching source in the installed preview with no compilation, workspace edit, or history request pending.
+For external file writes, use `editor_sync.wait_for_source(path, expected)` to wait for the installed source directly.
+
+`launch_editor` creates a private synchronization directory for each editor process.
+The `system-testing` build answers requests on its UI thread through `SLINT_EDITOR_TEST_SYNC`.
+Request IDs prevent an earlier response from satisfying a later wait; source comparisons prevent an older compilation from satisfying it.
+Timeout failures include the pending-work flag and documents that haven't reached the preview.
+
+Keep `wait_for_exact` for disk-only assertions and tests that deliberately send input while compilation is pending.
+Keyboard helpers dispatch immediately; put completion waits at the call sites that need them.
+Don't use completion waits for invalid source or transient drag previews, which must not become installed document revisions.
+
 ## Watch the Tests on a Desktop
 
 Run the suite with native windows to see each interaction:

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -1,0 +1,56 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import json
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class EditorSync:
+    directory: Path
+    request_id: int = 0
+
+    def wait_for_source(self, path: Path, expected: bytes, timeout: float = 15) -> None:
+        self.request_id += 1
+        request = {
+            "id": self.request_id,
+            "sources": {path.resolve().as_uri(): expected.decode("utf-8")},
+        }
+        temporary = self.directory / "request.tmp"
+        temporary.write_text(json.dumps(request))
+        temporary.replace(self.directory / "request.json")
+        deadline = time.monotonic() + timeout
+        last_response = None
+        try:
+            while True:
+                try:
+                    last_response = json.loads(
+                        (self.directory / "response.json").read_text()
+                    )
+                except FileNotFoundError:
+                    pass
+                if (
+                    last_response is not None
+                    and last_response["id"] == self.request_id
+                    and last_response["ready"]
+                ):
+                    return
+                if time.monotonic() >= deadline:
+                    raise AssertionError(
+                        f"Preview did not apply {path} within {timeout}s: "
+                        f"{last_response!r}. Build with system-testing enabled."
+                    )
+                time.sleep(0.02)
+        finally:
+            (self.directory / "request.json").unlink(missing_ok=True)
+
+
+current_editor_sync: ContextVar[EditorSync] = ContextVar("current_editor_sync")
+
+
+def wait_for_source(path: Path, expected: bytes, timeout: float = 15) -> None:
+    """Wait for the requested source in the installed preview and completed history work."""
+    current_editor_sync.get().wait_for_source(path, expected, timeout)

--- a/tools/editor/ui-tests/tests/source_snapshot.py
+++ b/tools/editor/ui-tests/tests/source_snapshot.py
@@ -79,3 +79,20 @@ class SourceSnapshot:
         assert current == expected_sources, exact_source_mismatch(
             current, expected_sources
         )
+
+    def wait_for_applied(
+        self,
+        expected: bytes,
+        relative_path: Path | str = "Main.slint",
+        timeout: float = 15,
+    ) -> None:
+        """Check exact project source, then wait for this revision in the preview."""
+        from editor_sync import wait_for_source
+
+        self.wait_for_exact(expected, relative_path, timeout=timeout)
+        wait_for_source(self.project / relative_path, expected, timeout=timeout)
+        expected_sources = self.sources | {Path(relative_path): expected}
+        current = slint_sources(self.project)
+        assert current == expected_sources, exact_source_mismatch(
+            current, expected_sources
+        )

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -21,6 +21,7 @@ from canvas_interactions import (
     same_state,
     selection_frame,
 )
+from editor_sync import wait_for_source
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
@@ -549,17 +550,18 @@ def test_repeated_palette_drop_preserves_component_kind(
             expected = (
                 GOLDENS / f"RepeatedPaletteDrops.{kind.lower()}-{step}.slint"
             ).read_bytes()
-            snapshot.wait_for_exact(expected, "RepeatedPaletteDrops.slint")
+            snapshot.wait_for_applied(expected, "RepeatedPaletteDrops.slint")
             reload_label = f"Reload probe {step}"
-            source_file.write_bytes(
-                expected.replace(b"Reload probe", reload_label.encode(), 1)
-            )
+            reloaded = expected.replace(b"Reload probe", reload_label.encode(), 1)
+            source_file.write_bytes(reloaded)
+            wait_for_source(source_file, reloaded)
             window_element_with_label(
-                window, reload_label, slint_testing.AccessibleRole.Text, timeout=10
+                window, reload_label, slint_testing.AccessibleRole.Text
             )
             source_file.write_bytes(expected)
+            wait_for_source(source_file, expected)
             window_element_with_label(
-                window, "Reload probe", slint_testing.AccessibleRole.Text, timeout=10
+                window, "Reload probe", slint_testing.AccessibleRole.Text
             )
             wait_until(
                 lambda: (

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -555,11 +555,11 @@ def test_repeated_palette_drop_preserves_component_kind(
                 expected.replace(b"Reload probe", reload_label.encode(), 1)
             )
             window_element_with_label(
-                window, reload_label, slint_testing.AccessibleRole.Text
+                window, reload_label, slint_testing.AccessibleRole.Text, timeout=10
             )
             source_file.write_bytes(expected)
             window_element_with_label(
-                window, "Reload probe", slint_testing.AccessibleRole.Text
+                window, "Reload probe", slint_testing.AccessibleRole.Text, timeout=10
             )
             wait_until(
                 lambda: (

--- a/tools/editor/ui-tests/tests/test_editor_sync.py
+++ b/tools/editor/ui-tests/tests/test_editor_sync.py
@@ -1,0 +1,42 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import json
+
+import pytest
+from editor_sync import EditorSync
+
+
+def test_wait_rejects_old_response_and_unfinished_edit(tmp_path, monkeypatch):
+    sync = EditorSync(tmp_path)
+    response = tmp_path / "response.json"
+    response.write_text(json.dumps({"id": 0, "ready": True}))
+    replies = iter(
+        [
+            {"id": 1, "ready": False, "busy": True},
+            {"id": 1, "ready": False, "busy": False, "mismatches": ["old source"]},
+            {"id": 1, "ready": True},
+        ]
+    )
+    polls = []
+
+    def advance(_):
+        reply = next(replies)
+        polls.append(reply)
+        response.write_text(json.dumps(reply))
+
+    monkeypatch.setattr("editor_sync.time.sleep", advance)
+    sync.wait_for_source(tmp_path / "Main.slint", b"new source")
+    assert len(polls) == 3
+    assert not (tmp_path / "request.json").exists()
+
+
+def test_wait_timeout_reports_last_state_and_removes_request(tmp_path):
+    (tmp_path / "response.json").write_text(
+        json.dumps({"id": 1, "ready": False, "busy": True})
+    )
+    with pytest.raises(AssertionError, match="'busy': True"):
+        EditorSync(tmp_path).wait_for_source(
+            tmp_path / "Main.slint", b"source", timeout=0
+        )
+    assert not (tmp_path / "request.json").exists()

--- a/tools/editor/ui-tests/tests/test_inspector_transform.py
+++ b/tools/editor/ui-tests/tests/test_inspector_transform.py
@@ -560,3 +560,88 @@ def test_undo_while_dragging_cancels_release(
         time.sleep(0.3)
         snapshot.wait_for_exact(baseline, relative_path=SOURCE)
         wait_for_field(window, "Rotation", "32")
+
+
+def test_separate_corners_survive_rotation_edit(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        action(window, "Separate corners")
+        wait_for_field(window, LABELS[0], "12")
+        edit_field(window, "Rotation", "47.5")
+        snapshot.wait_for_exact(baseline.replace(b"32deg", b"47.5deg"), SOURCE)
+        wait_for_field(window, "Rotation", "47.5")
+        time.sleep(0.5)
+        for label in LABELS:
+            wait_for_field(window, label, "12")
+
+
+def test_deleted_selected_element_clears_inspector(
+    editor_binary, editor_environment, fixture_project
+):
+    from ui_driver import elements_with_label, wait_until
+
+    source = fixture_project / SOURCE
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Image")
+        window_element_with_label(
+            window, "Selected Image", slint_testing.AccessibleRole.Region
+        )
+        original = source.read_text()
+        source.write_text(original[: original.index("    inspect-image :=")] + "}\n")
+        wait_until(
+            lambda: (
+                True
+                if not elements_with_label(
+                    window.root_element,
+                    "Selected Image",
+                    slint_testing.AccessibleRole.Region,
+                )
+                else None
+            )
+        )
+        assert not elements_with_label(window.root_element, "Image fit")
+
+
+def test_rotation_release_keeps_preview_until_reload(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        knob = window_element_with_label(window, "Rotation knob")
+        start, end = point(knob, 90), point(knob, 108)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        wait_for_field(window, "Rotation", "50")
+        snapshot.assert_unchanged()
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                end, slint_testing.PointerEventButton.Left
+            )
+        )
+        deadline = time.monotonic() + 0.5
+        while time.monotonic() < deadline:
+            assert (
+                window_element_with_label(
+                    window, "Rotation", slint_testing.AccessibleRole.TextInput
+                ).accessible_value
+                == "50"
+            )
+            time.sleep(0.01)
+        snapshot.wait_for_exact(baseline.replace(b"32deg", b"50deg"), SOURCE)

--- a/tools/editor/ui-tests/tests/test_inspector_transform.py
+++ b/tools/editor/ui-tests/tests/test_inspector_transform.py
@@ -1,0 +1,492 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import math
+import time
+from pathlib import Path
+
+import pytest
+import slint_testing
+from slint_testing import keys
+from source_snapshot import SourceSnapshot
+from test_inspector import edit_field as edit_inspector_field
+from test_inspector import wait_for_field as wait_for_inspector_field
+from ui_driver import (
+    first_window,
+    launch_editor,
+    select_outline_row,
+    window_element_with_label,
+)
+
+SOURCE = "InspectorCases.slint"
+PROPERTIES = (
+    "border-top-left-radius",
+    "border-top-right-radius",
+    "border-bottom-left-radius",
+    "border-bottom-right-radius",
+)
+LABELS = (
+    "Top left corner radius",
+    "Top right corner radius",
+    "Bottom left corner radius",
+    "Bottom right corner radius",
+)
+
+
+def prepare(project: Path, values=(12, 12, 12, 12), rotation="32deg") -> bytes:
+    source = project / SOURCE
+    original = source.read_text()
+    properties = "".join(
+        f"        {name}: {value}px;\n" for name, value in zip(PROPERTIES, values)
+    )
+    original = original.replace(
+        "        background: #2563eb;",
+        "        background: #2563eb;\n"
+        + properties
+        + f"        transform-rotation: {rotation};",
+    )
+    source.write_text(original)
+    return source.read_bytes()
+
+
+def select_element(window, kind):
+    select_outline_row(window, "inspect-" + kind.lower())
+    window_element_with_label(
+        window, "Rotation", slint_testing.AccessibleRole.TextInput
+    )
+
+
+def edit_field(window, label, value):
+    edit_inspector_field(window, label, value, slint_testing.AccessibleRole.TextInput)
+
+
+def wait_for_field(window, label, value):
+    wait_for_inspector_field(
+        window, label, value, slint_testing.AccessibleRole.TextInput
+    )
+
+
+def action(window, label):
+    window_element_with_label(
+        window, label, slint_testing.AccessibleRole.Button
+    ).invoke_accessible_default_action()
+
+
+def shortcut(window, redo=False):
+    # Source writes precede the replacement preview that re-enables undo/redo.
+    time.sleep(0.5)
+    window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Control))
+    if redo:
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+    window.dispatch_event(slint_testing.KeyPressedEvent(text="z"))
+    window.dispatch_event(slint_testing.KeyReleasedEvent(text="z"))
+    if redo:
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+    window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Control))
+
+
+@pytest.mark.parametrize("value", ["-22.5", "0", "382.25"])
+def test_rotation_numeric_exact_source_and_undo(
+    editor_binary, editor_environment, fixture_project, value
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    expected = baseline.replace(
+        b"transform-rotation: 32deg", f"transform-rotation: {value}deg".encode()
+    )
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        edit_field(window, "Rotation", value)
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        wait_for_field(window, "Rotation", value)
+        shortcut(window)
+        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        wait_for_field(window, "Rotation", "32")
+        shortcut(window, redo=True)
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+
+
+@pytest.mark.parametrize("index", range(4))
+def test_corner_edit_changes_only_one_property(
+    editor_binary, editor_environment, fixture_project, index
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    expected = baseline.replace(
+        f"{PROPERTIES[index]}: 12px".encode(),
+        f"{PROPERTIES[index]}: 30.5px".encode(),
+    )
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        action(window, "Separate corners")
+        snapshot.assert_unchanged()
+        edit_field(window, LABELS[index], "30.5")
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        wait_for_field(window, LABELS[index], "30.5")
+
+
+def test_link_uses_top_left_and_one_undo_restores_expressions(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project, (8, 16, 24, 32))
+    baseline = baseline.replace(
+        b"border-top-left-radius: 8px", b"border-top-left-radius: 4px + 4px"
+    )
+    (fixture_project / SOURCE).write_bytes(baseline)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    expected = baseline
+    for name, value in zip(PROPERTIES, ("4px + 4px", "16px", "24px", "32px")):
+        expected = expected.replace(
+            f"{name}: {value}".encode(), f"{name}: 8px".encode()
+        )
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        wait_for_field(window, LABELS[0], "8")
+        action(window, "All corners")
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        wait_for_field(window, "All corner radii", "8")
+        shortcut(window)
+        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        wait_for_field(window, LABELS[1], "16")
+        shortcut(window, redo=True)
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+
+
+@pytest.mark.parametrize("value", ["0", "30.5", "120"])
+def test_shared_corner_value_is_atomic_and_not_clamped(
+    editor_binary, editor_environment, fixture_project, value
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    expected = baseline
+    for name in PROPERTIES:
+        expected = expected.replace(
+            f"{name}: 12px".encode(), f"{name}: {value}px".encode()
+        )
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        edit_field(window, "All corner radii", value)
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        wait_for_field(window, "All corner radii", value)
+        shortcut(window)
+        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+
+
+@pytest.mark.parametrize(
+    "label,value",
+    [
+        ("Rotation", "invalid"),
+        ("Rotation", ""),
+        ("All corner radii", "-1"),
+        ("All corner radii", "invalid"),
+    ],
+)
+def test_invalid_transform_input_preserves_source(
+    editor_binary, editor_environment, fixture_project, label, value
+):
+    prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        edit_field(window, label, value)
+        snapshot.assert_unchanged()
+
+
+def point(knob, angle):
+    position = knob.absolute_position
+    return slint_testing.LogicalPosition(
+        x=position.x + 16 + 12 * math.sin(math.radians(angle)),
+        y=position.y + 16 - 12 * math.cos(math.radians(angle)),
+    )
+
+
+@pytest.mark.parametrize("cancel", ["release", "escape", "pointer"])
+def test_knob_crosses_zero_with_transient_preview(
+    editor_binary, editor_environment, fixture_project, cancel
+):
+    baseline = prepare(fixture_project, rotation="350deg")
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        knob = window_element_with_label(window, "Rotation knob")
+        assert knob.size.width == 32 and knob.size.height == 32
+        start, end = point(knob, 350), point(knob, 10)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        wait_for_field(window, "Rotation", "350")
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        wait_for_field(window, "Rotation", "370")
+        snapshot.assert_unchanged()
+        if cancel == "escape":
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+        if cancel == "pointer":
+            window.dispatch_event(slint_testing.PointerExitedEvent())
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                end, slint_testing.PointerEventButton.Left
+            )
+        )
+        if cancel != "release":
+            snapshot.assert_unchanged()
+            wait_for_field(window, "Rotation", "350")
+        else:
+            snapshot.wait_for_exact(
+                baseline.replace(b"350deg", b"370deg"), relative_path=SOURCE
+            )
+            shortcut(window)
+            snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+
+
+def test_rotation_under_rotated_parent_is_parent_relative(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project, rotation="20deg")
+    baseline = baseline.replace(
+        b"    inspect-rectangle := Rectangle {",
+        b"    Rectangle {\n        transform-rotation: 45deg;\n        width: 600px; height: 400px;\n    inspect-rectangle := Rectangle {",
+    )
+    baseline = baseline.replace(
+        b"    inspect-text := Text {", b"    }\n\n    inspect-text := Text {"
+    )
+    (fixture_project / SOURCE).write_bytes(baseline)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        wait_for_field(window, "Rotation", "20")
+        edit_field(window, "Rotation", "22.5")
+        snapshot.wait_for_exact(
+            baseline.replace(b"20deg", b"22.5deg"), relative_path=SOURCE
+        )
+
+
+@pytest.mark.parametrize("shift,expected", [(False, "33"), (True, "47")])
+def test_knob_keyboard_step(
+    editor_binary, editor_environment, fixture_project, shift, expected
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        knob = window_element_with_label(window, "Rotation knob")
+        start = point(knob, 32)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        if shift:
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.UpArrow))
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.UpArrow))
+        if shift:
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+        snapshot.wait_for_exact(
+            baseline.replace(b"32deg", f"{expected}deg".encode()), relative_path=SOURCE
+        )
+
+
+def test_selection_change_cancels_knob_drag(
+    editor_binary, editor_environment, fixture_project
+):
+    prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        knob = window_element_with_label(window, "Rotation knob")
+        start, end = point(knob, 32), point(knob, 62)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        wait_for_field(window, "Rotation", "62")
+        select_element(window, "Text")
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                end, slint_testing.PointerEventButton.Left
+            )
+        )
+        snapshot.assert_unchanged()
+        select_element(window, "Rectangle")
+        wait_for_field(window, "Rotation", "32")
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+def test_corner_slider_previews_then_commits_once(
+    editor_binary, editor_environment, fixture_project, cancel
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        slider = window_element_with_label(window, "All corner radii slider")
+        pos, size = slider.absolute_position, slider.size
+        start = slint_testing.LogicalPosition(
+            x=pos.x + 6 + (size.width - 12) / 4, y=pos.y + 12
+        )
+        end = slint_testing.LogicalPosition(x=pos.x + size.width - 6, y=pos.y + 12)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        wait_for_field(window, "All corner radii", "48")
+        snapshot.assert_unchanged()
+        if cancel:
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                end, slint_testing.PointerEventButton.Left
+            )
+        )
+        if cancel:
+            snapshot.assert_unchanged()
+            wait_for_field(window, "All corner radii", "12")
+        else:
+            expected = baseline
+            for name in PROPERTIES:
+                expected = expected.replace(
+                    f"{name}: 12px".encode(), f"{name}: 48px".encode()
+                )
+            snapshot.wait_for_exact(expected, relative_path=SOURCE)
+            wait_for_field(window, "All corner radii", "48")
+            shortcut(window)
+            snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+
+
+@pytest.mark.parametrize("radius", ["0", "30.5"])
+def test_shared_radius_reads_effective_shorthand(
+    editor_binary, editor_environment, fixture_project, radius
+):
+    baseline = prepare(fixture_project)
+    for name in PROPERTIES:
+        baseline = baseline.replace(f"        {name}: 12px;\n".encode(), b"")
+    baseline = baseline.replace(
+        b"        background: #2563eb;",
+        f"        background: #2563eb;\n        border-radius: {radius}px;".encode(),
+    )
+    (fixture_project / SOURCE).write_bytes(baseline)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        wait_for_field(window, "All corner radii", radius)
+
+
+def test_knob_shift_drag_snaps_and_retains_keyboard_focus(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        knob = window_element_with_label(window, "Rotation knob")
+        start, end = point(knob, 90), point(knob, 108)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        wait_for_field(window, "Rotation", "32")
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        wait_for_field(window, "Rotation", "45")
+        snapshot.assert_unchanged()
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                end, slint_testing.PointerEventButton.Left
+            )
+        )
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+        snapshot.wait_for_exact(
+            baseline.replace(b"32deg", b"45deg"), relative_path=SOURCE
+        )
+        wait_for_field(window, "Rotation", "45")
+        time.sleep(0.5)
+        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.UpArrow))
+        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.UpArrow))
+        snapshot.wait_for_exact(
+            baseline.replace(b"32deg", b"46deg"), relative_path=SOURCE
+        )
+        shortcut(window)
+        snapshot.wait_for_exact(
+            baseline.replace(b"32deg", b"45deg"), relative_path=SOURCE
+        )
+        shortcut(window)
+        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+
+
+def test_source_reload_cancels_knob_gesture(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        knob = window_element_with_label(window, "Rotation knob")
+        start, end = point(knob, 32), point(knob, 62)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        wait_for_field(window, "Rotation", "62")
+        updated = baseline.replace(b"32deg", b"17.5deg")
+        (fixture_project / SOURCE).write_bytes(updated)
+        wait_for_field(window, "Rotation", "17.5")
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                end, slint_testing.PointerEventButton.Left
+            )
+        )
+        time.sleep(0.2)
+        assert (fixture_project / SOURCE).read_bytes() == updated

--- a/tools/editor/ui-tests/tests/test_inspector_transform.py
+++ b/tools/editor/ui-tests/tests/test_inspector_transform.py
@@ -490,3 +490,73 @@ def test_source_reload_cancels_knob_gesture(
         )
         time.sleep(0.2)
         assert (fixture_project / SOURCE).read_bytes() == updated
+
+
+@pytest.mark.parametrize(
+    "label,text", [("Search elements", "Text"), ("Rotation", "99")]
+)
+def test_text_input_undo_does_not_revert_document(
+    editor_binary, editor_environment, fixture_project, label, text
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    expected = baseline.replace(b"32deg", b"40deg")
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        edit_field(window, "Rotation", "40")
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        wait_for_field(window, "Rotation", "40")
+        field = window_element_with_label(
+            window, label, slint_testing.AccessibleRole.TextInput
+        )
+        field.single_click(slint_testing.PointerEventButton.Left)
+        for character in text:
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=character))
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=character))
+        wait_for_field(window, label, text)
+        shortcut(window)
+        assert field.accessible_value != text
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        shortcut(window, redo=True)
+        wait_for_field(window, label, text)
+        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+
+
+@pytest.mark.parametrize("history", [False, True])
+def test_undo_while_dragging_cancels_release(
+    editor_binary, editor_environment, fixture_project, history
+):
+    baseline = prepare(fixture_project)
+    snapshot = SourceSnapshot.capture(fixture_project)
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / SOURCE
+    ) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        if history:
+            edit_field(window, "Rotation", "42")
+            snapshot.wait_for_exact(
+                baseline.replace(b"32deg", b"42deg"), relative_path=SOURCE
+            )
+            wait_for_field(window, "Rotation", "42")
+        knob = window_element_with_label(window, "Rotation knob")
+        start, end = point(knob, 32), point(knob, 62)
+        window.dispatch_event(
+            slint_testing.PointerPressEvent(
+                start, slint_testing.PointerEventButton.Left
+            )
+        )
+        window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        wait_for_field(window, "Rotation", "72" if history else "62")
+        shortcut(window)
+        window.dispatch_event(
+            slint_testing.PointerReleaseEvent(
+                end, slint_testing.PointerEventButton.Left
+            )
+        )
+        time.sleep(0.3)
+        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        wait_for_field(window, "Rotation", "32")

--- a/tools/editor/ui-tests/tests/test_inspector_transform.py
+++ b/tools/editor/ui-tests/tests/test_inspector_transform.py
@@ -73,8 +73,6 @@ def action(window, label):
 
 
 def shortcut(window, redo=False):
-    # Source writes precede the replacement preview that re-enables undo/redo.
-    time.sleep(0.5)
     window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Control))
     if redo:
         window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
@@ -100,13 +98,13 @@ def test_rotation_numeric_exact_source_and_undo(
         window = first_window(app)
         select_element(window, "Rectangle")
         edit_field(window, "Rotation", value)
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
         wait_for_field(window, "Rotation", value)
         shortcut(window)
-        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        snapshot.wait_for_applied(baseline, relative_path=SOURCE)
         wait_for_field(window, "Rotation", "32")
         shortcut(window, redo=True)
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
 
 
 @pytest.mark.parametrize("index", range(4))
@@ -127,7 +125,7 @@ def test_corner_edit_changes_only_one_property(
         action(window, "Separate corners")
         snapshot.assert_unchanged()
         edit_field(window, LABELS[index], "30.5")
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
         wait_for_field(window, LABELS[index], "30.5")
 
 
@@ -152,13 +150,13 @@ def test_link_uses_top_left_and_one_undo_restores_expressions(
         select_element(window, "Rectangle")
         wait_for_field(window, LABELS[0], "8")
         action(window, "All corners")
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
         wait_for_field(window, "All corner radii", "8")
         shortcut(window)
-        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        snapshot.wait_for_applied(baseline, relative_path=SOURCE)
         wait_for_field(window, LABELS[1], "16")
         shortcut(window, redo=True)
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
 
 
 @pytest.mark.parametrize("value", ["0", "30.5", "120"])
@@ -178,10 +176,10 @@ def test_shared_corner_value_is_atomic_and_not_clamped(
         window = first_window(app)
         select_element(window, "Rectangle")
         edit_field(window, "All corner radii", value)
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
         wait_for_field(window, "All corner radii", value)
         shortcut(window)
-        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        snapshot.wait_for_applied(baseline, relative_path=SOURCE)
 
 
 @pytest.mark.parametrize(
@@ -252,11 +250,11 @@ def test_knob_crosses_zero_with_transient_preview(
             snapshot.assert_unchanged()
             wait_for_field(window, "Rotation", "350")
         else:
-            snapshot.wait_for_exact(
+            snapshot.wait_for_applied(
                 baseline.replace(b"350deg", b"370deg"), relative_path=SOURCE
             )
             shortcut(window)
-            snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+            snapshot.wait_for_applied(baseline, relative_path=SOURCE)
 
 
 def test_rotation_under_rotated_parent_is_parent_relative(
@@ -279,7 +277,7 @@ def test_rotation_under_rotated_parent_is_parent_relative(
         select_element(window, "Rectangle")
         wait_for_field(window, "Rotation", "20")
         edit_field(window, "Rotation", "22.5")
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             baseline.replace(b"20deg", b"22.5deg"), relative_path=SOURCE
         )
 
@@ -313,7 +311,7 @@ def test_knob_keyboard_step(
         window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.UpArrow))
         if shift:
             window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             baseline.replace(b"32deg", f"{expected}deg".encode()), relative_path=SOURCE
         )
 
@@ -390,10 +388,10 @@ def test_corner_slider_previews_then_commits_once(
                 expected = expected.replace(
                     f"{name}: 12px".encode(), f"{name}: 48px".encode()
                 )
-            snapshot.wait_for_exact(expected, relative_path=SOURCE)
+            snapshot.wait_for_applied(expected, relative_path=SOURCE)
             wait_for_field(window, "All corner radii", "48")
             shortcut(window)
-            snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+            snapshot.wait_for_applied(baseline, relative_path=SOURCE)
 
 
 @pytest.mark.parametrize("radius", ["0", "30.5"])
@@ -444,22 +442,21 @@ def test_knob_shift_drag_snaps_and_retains_keyboard_focus(
             )
         )
         window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             baseline.replace(b"32deg", b"45deg"), relative_path=SOURCE
         )
         wait_for_field(window, "Rotation", "45")
-        time.sleep(0.5)
         window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.UpArrow))
         window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.UpArrow))
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             baseline.replace(b"32deg", b"46deg"), relative_path=SOURCE
         )
         shortcut(window)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             baseline.replace(b"32deg", b"45deg"), relative_path=SOURCE
         )
         shortcut(window)
-        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        snapshot.wait_for_applied(baseline, relative_path=SOURCE)
 
 
 def test_source_reload_cancels_knob_gesture(
@@ -507,7 +504,7 @@ def test_text_input_undo_does_not_revert_document(
         window = first_window(app)
         select_element(window, "Rectangle")
         edit_field(window, "Rotation", "40")
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
         wait_for_field(window, "Rotation", "40")
         field = window_element_with_label(
             window, label, slint_testing.AccessibleRole.TextInput
@@ -519,10 +516,10 @@ def test_text_input_undo_does_not_revert_document(
         wait_for_field(window, label, text)
         shortcut(window)
         assert field.accessible_value != text
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
         shortcut(window, redo=True)
         wait_for_field(window, label, text)
-        snapshot.wait_for_exact(expected, relative_path=SOURCE)
+        snapshot.wait_for_applied(expected, relative_path=SOURCE)
 
 
 @pytest.mark.parametrize("history", [False, True])
@@ -538,7 +535,7 @@ def test_undo_while_dragging_cancels_release(
         select_element(window, "Rectangle")
         if history:
             edit_field(window, "Rotation", "42")
-            snapshot.wait_for_exact(
+            snapshot.wait_for_applied(
                 baseline.replace(b"32deg", b"42deg"), relative_path=SOURCE
             )
             wait_for_field(window, "Rotation", "42")
@@ -558,7 +555,7 @@ def test_undo_while_dragging_cancels_release(
             )
         )
         time.sleep(0.3)
-        snapshot.wait_for_exact(baseline, relative_path=SOURCE)
+        snapshot.wait_for_applied(baseline, relative_path=SOURCE)
         wait_for_field(window, "Rotation", "32")
 
 
@@ -575,9 +572,8 @@ def test_separate_corners_survive_rotation_edit(
         action(window, "Separate corners")
         wait_for_field(window, LABELS[0], "12")
         edit_field(window, "Rotation", "47.5")
-        snapshot.wait_for_exact(baseline.replace(b"32deg", b"47.5deg"), SOURCE)
+        snapshot.wait_for_applied(baseline.replace(b"32deg", b"47.5deg"), SOURCE)
         wait_for_field(window, "Rotation", "47.5")
-        time.sleep(0.5)
         for label in LABELS:
             wait_for_field(window, label, "12")
 
@@ -644,4 +640,4 @@ def test_rotation_release_keeps_preview_until_reload(
                 == "50"
             )
             time.sleep(0.01)
-        snapshot.wait_for_exact(baseline.replace(b"32deg", b"50deg"), SOURCE)
+        snapshot.wait_for_applied(baseline.replace(b"32deg", b"50deg"), SOURCE)

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -163,10 +163,23 @@ def test_stale_selection_commit_is_rejected(
         snapshot.assert_unchanged()
 
 
+@pytest.mark.parametrize(
+    ("label", "property_name", "original", "updated"),
+    [
+        (FIELDS["x"], "x", "32", "36"),
+        (FIELDS["y"], "y", "32", "40"),
+        (FIELDS["width"], "width", "160", "180"),
+        (FIELDS["height"], "height", "96", "120"),
+    ],
+)
 def test_stale_revision_commit_is_rejected(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
+    label: str,
+    property_name: str,
+    original: str,
+    updated: str,
 ) -> None:
     source_file = fixture_project / "InspectorCases.slint"
     baseline = source_file.read_bytes()
@@ -175,26 +188,32 @@ def test_stale_revision_commit_is_rejected(
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
         select_outline_row(window, "inspect-rectangle")
-        stage_field_text(window, FIELDS["x"], "99")
+        stage_field_text(window, label, "99")
         snapshot.assert_unchanged_now()
-        external = baseline.replace(b"        x: 32px;", b"        x: 36px;", 1)
+        external = baseline.replace(
+            f"        {property_name}: {original}px;".encode(),
+            f"        {property_name}: {updated}px;".encode(),
+            1,
+        )
+        assert external != baseline
         source_file.write_bytes(external)
         snapshot.wait_for_exact(external, relative_path="InspectorCases.slint")
+        snapshot = SourceSnapshot.capture(fixture_project)
         wait_until(
             lambda: (
                 field
                 if (
                     field := window_element_with_label(
-                        window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
+                        window, label, slint_testing.AccessibleRole.TextInput
                     )
                 ).accessible_value
-                == "36"
+                == updated
                 else None
             ),
             timeout=15,
         )
         press_key(window, keys.Return)
-        SourceSnapshot.capture(fixture_project).assert_unchanged()
+        snapshot.assert_unchanged()
 
 
 @pytest.mark.skip(reason="Requires a Rust source-watcher recovery fix")

--- a/tools/editor/ui-tests/tests/test_undo_redo.py
+++ b/tools/editor/ui-tests/tests/test_undo_redo.py
@@ -202,7 +202,7 @@ def test_rectangle_undo_redo(
             snapshot.assert_unchanged_now()
         with replay_stage("initial edit"):
             edit(window, case, changes, snapshot)
-            snapshot.wait_for_exact(expected, SOURCE)
+            snapshot.wait_for_applied(expected, SOURCE)
             assert_visual(window, INITIAL | changes, origin, case.endswith("radius"))
         for name, content, values in [
             ("undo", baseline, INITIAL),
@@ -212,7 +212,7 @@ def test_rectangle_undo_redo(
                 if case.startswith("inspector-"):
                     select_fixture_element(window, "Rectangle")
                 shortcut(window, redo=name == "redo")
-                snapshot.wait_for_exact(content, SOURCE)
+                snapshot.wait_for_applied(content, SOURCE)
                 assert_visual(window, values, origin, case.endswith("radius"))
 
 
@@ -237,11 +237,11 @@ def test_redo_after_external_edit_preserves_source(
             cy - INITIAL["y"] - INITIAL["height"] / 2,
         )
         edit_field(window, FIELDS["x"], "104", slint_testing.AccessibleRole.TextInput)
-        snapshot.wait_for_exact(edited, SOURCE)
+        snapshot.wait_for_applied(edited, SOURCE)
         assert_visual(window, INITIAL | {"x": 104}, origin, False)
         select_fixture_element(window, "Rectangle")
         shortcut(window, redo=False)
-        snapshot.wait_for_exact(baseline, SOURCE)
+        snapshot.wait_for_applied(baseline, SOURCE)
         wait_for_field(
             window, FIELDS["x"], "80", slint_testing.AccessibleRole.TextInput
         )
@@ -253,5 +253,5 @@ def test_redo_after_external_edit_preserves_source(
                 window, FIELDS["x"], "900", slint_testing.AccessibleRole.TextInput
             )
         shortcut(window, redo=True)
-        snapshot.wait_for_exact(external, SOURCE)
+        snapshot.wait_for_applied(external, SOURCE)
         snapshot_after_external.assert_unchanged()

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -5,9 +5,11 @@ import contextlib
 import time
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TypeVar
 
 import slint_testing
+from editor_sync import EditorSync, current_editor_sync
 from ui_reporting import capture_failure, current_report, replay_stage
 
 PALETTE_KINDS = ("Image", "Rectangle", "Text", "TouchArea")
@@ -124,18 +126,27 @@ def launch_editor(
     arguments = [str(binary)]
     if file is not None:
         arguments.append(str(file))
-    with slint_testing.Application(
-        arguments, env=environment, launch_timeout=20
-    ) as application:
+    with TemporaryDirectory(prefix="slint-editor-sync-") as directory:
+        sync = EditorSync(Path(directory))
+        token = current_editor_sync.set(sync)
         try:
-            yield application
-            report = current_report.get()
-            if report is not None and report.completed_stages == 0:
-                with replay_stage("completed"):
-                    pass
-        except Exception as error:
-            capture_failure(application, error)
-            raise
+            with slint_testing.Application(
+                arguments,
+                env=environment | {"SLINT_EDITOR_TEST_SYNC": directory},
+                launch_timeout=20,
+            ) as application:
+                try:
+                    yield application
+                    report = current_report.get()
+                    if report is not None and report.completed_stages == 0:
+                        with replay_stage("completed"):
+                            pass
+                except Exception as error:
+                    capture_failure(application, error)
+                    raise
+
+        finally:
+            current_editor_sync.reset(token)
 
 
 def file_row(window: slint_testing.Window, path: Path) -> slint_testing.Element:

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -702,6 +702,12 @@ export global Api {
     callback show-preview-for(name: string, url: string);
     callback reload-preview();
 
+    in property <int> inspector-generation;
+    pure callback inspector-values(key: string) -> [float];
+    callback inspector-preview(key: string, name: string, value: float) -> bool;
+    callback inspector-commit(key: string, name: string, value: float) -> bool;
+    callback inspector-cancel();
+
     // ## Property Editor
     pure callback test-code-binding(element-url: string, element-version: int, element-offset: int, property-name: string, property-value: string) -> bool;
     pure callback set-code-binding(element-url: string, element-version: int, element-offset: int, property-name: string, property-value: string);

--- a/tools/editor/ui/components/drag-preview.slint
+++ b/tools/editor/ui/components/drag-preview.slint
@@ -40,6 +40,7 @@ component PalettePlaceholderDragPreview inherits Rectangle {
 }
 
 export component DragPreview inherits Rectangle {
+    in property <Point> parent-origin;
     private property <bool> palette-drag-active: AppState.palette-drag-kind != PaletteComponentKind.none;
     visible: AppState.outline-drag-active || root.palette-drag-active;
     width: AppState.outline-drag-active
@@ -48,12 +49,12 @@ export component DragPreview inherits Rectangle {
     height: AppState.outline-drag-active
         ? AppState.outline-drag-preview-size.height
         : AppState.palette-drag-size.height;
-    x: AppState.outline-drag-active
+    x: (AppState.outline-drag-active
         ? AppState.outline-drag-position.x
-        : AppState.palette-drag-preview-position.x;
-    y: AppState.outline-drag-active
+        : AppState.palette-drag-preview-position.x) - root.parent-origin.x;
+    y: (AppState.outline-drag-active
         ? AppState.outline-drag-position.y
-        : AppState.palette-drag-preview-position.y;
+        : AppState.palette-drag-preview-position.y) - root.parent-origin.y;
     border-radius: AppState.outline-drag-active
         ? EditorTreeTokens.row-radius
         : AppState.palette-drag-kind == PaletteComponentKind.touch-area ? 0px

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -17,6 +17,9 @@ import { InspectorSyntaxField } from "inspector/syntax-field.slint";
 import { InspectorSection } from "inspector/section.slint";
 import { InspectorEffectDial } from "inspector/effect-dial.slint";
 import { InspectorEffectSlider } from "inspector/effect-slider.slint";
+import { InspectorPropertyRow } from "inspector/property-row.slint";
+import { InspectorRotationKnob } from "inspector/rotation-knob.slint";
+import { InspectorCornerEditor } from "inspector/corner-editor.slint";
 import { ScrollView } from "std-widgets.slint";
 
 
@@ -73,6 +76,12 @@ export component InspectorPane inherits Rectangle {
         { value: "drop", label: "Drop Shadow" },
         { value: "inner", label: "Inner Shadow" },
     ];
+
+    property <string> inspector-key: root.element-information.source-uri + ":" + root.element-information.source-version + ":" + root.element-information.offset + ":" + Api.selection.highlight-index + ":" + Api.inspector-generation;
+    property <[float]> control-values: Api.inspector-values(root.inspector-key);
+    function commit-inspector(name: string, value: float) -> bool {
+        return Api.inspector-commit(root.inspector-key, name, value);
+    }
 
     function has-backend-rect() -> bool {
         return Api.selection.highlight-index >= 0 && root.selection-rects.length > Api.selection.highlight-index;
@@ -560,7 +569,7 @@ export component InspectorPane inherits Rectangle {
 
                     VerticalLayout {
                         padding-left: InspectorTokens.side-padding;
-                        spacing: 8px;
+                        spacing: 6px;
 
                         InspectorReadOnlyField {
                             prefix: "File";
@@ -595,7 +604,7 @@ export component InspectorPane inherits Rectangle {
                     VerticalLayout {
                         padding-left: InspectorTokens.side-padding;
                         padding-right: InspectorTokens.side-padding;
-                        spacing: 8px;
+                        spacing: 6px;
 
                         InspectorSyntaxField {
                             value: root.image-nine-slice-expression();
@@ -614,59 +623,53 @@ export component InspectorPane inherits Rectangle {
                 }
 
                 if !root.image-mode && (root.is-rectangle-selection() || root.is-text-selection() || root.is-image-selection()): InspectorSection {
-                    title: "Position";
-
-                    HorizontalLayout {
-                        padding-left: InspectorTokens.side-padding;
-                        spacing: InspectorTokens.column-gap;
-
+                    title: "Geometry";
+                    InspectorPropertyRow {
+                        label: "Position";
                         InspectorValueField {
-                            accessible-name: "Position X";
-                            prefix: "X";
-                            value: root.selected-x-label();
-                            commit-key: root.field-key("x");
-                            accepted(text) => {
-                                return root.commit-geometry(text, root.selected-y-label(), root.selected-width-label(), root.selected-height-label());
-                            }
+                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            accessible-name: "Position X"; prefix: "X";
+                            value: root.selected-x-label(); commit-key: root.field-key("x");
+                            accepted(text) => { return root.commit-geometry(text, root.selected-y-label(), root.selected-width-label(), root.selected-height-label()); }
                         }
-
                         InspectorValueField {
-                            accessible-name: "Position Y";
-                            prefix: "Y";
-                            value: root.selected-y-label();
-                            commit-key: root.field-key("y");
-                            accepted(text) => {
-                                return root.commit-geometry(root.selected-x-label(), text, root.selected-width-label(), root.selected-height-label());
-                            }
+                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            accessible-name: "Position Y"; prefix: "Y";
+                            value: root.selected-y-label(); commit-key: root.field-key("y");
+                            accepted(text) => { return root.commit-geometry(root.selected-x-label(), text, root.selected-width-label(), root.selected-height-label()); }
                         }
                     }
-                }
-
-                if !root.image-mode && (root.is-rectangle-selection() || root.is-text-selection() || root.is-image-selection()): InspectorSection {
-                    title: "Layout";
-
-                    HorizontalLayout {
-                        padding-left: InspectorTokens.side-padding;
-                        spacing: InspectorTokens.column-gap;
-
+                    InspectorPropertyRow {
+                        label: "Size";
                         InspectorValueField {
-                            accessible-name: "Width";
-                            prefix: "W";
-                            value: root.selected-width-label();
-                            commit-key: root.field-key("width");
-                            accepted(text) => {
-                                return root.commit-geometry(root.selected-x-label(), root.selected-y-label(), text, root.selected-height-label());
-                            }
+                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            accessible-name: "Width"; prefix: "W";
+                            value: root.selected-width-label(); commit-key: root.field-key("width");
+                            accepted(text) => { return root.commit-geometry(root.selected-x-label(), root.selected-y-label(), text, root.selected-height-label()); }
                         }
-
                         InspectorValueField {
-                            accessible-name: "Height";
-                            prefix: "H";
-                            value: root.selected-height-label();
-                            commit-key: root.field-key("height");
-                            accepted(text) => {
-                                return root.commit-geometry(root.selected-x-label(), root.selected-y-label(), root.selected-width-label(), text);
-                            }
+                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            accessible-name: "Height"; prefix: "H";
+                            value: root.selected-height-label(); commit-key: root.field-key("height");
+                            accepted(text) => { return root.commit-geometry(root.selected-x-label(), root.selected-y-label(), root.selected-width-label(), text); }
+                        }
+                    }
+                    InspectorPropertyRow {
+                        label: "Rotation";
+                        height: 36px;
+                        knob := InspectorRotationKnob {
+                            value: root.control-values[0];
+                            commit-key: root.inspector-key;
+                            preview(value) => { return Api.inspector-preview(root.inspector-key, "transform-rotation", value); }
+                            accepted(value) => { return root.commit-inspector("transform-rotation", value); }
+                            canceled => { Api.inspector-cancel(); }
+                        }
+                        InspectorValueField {
+                            width: parent.width - 58px - 24px - 38px;
+                            accessible-name: "Rotation"; prefix: "°";
+                            value: "\{knob.visual-value}";
+                            commit-key: root.inspector-key;
+                            accepted(text) => { return text.is-float() && root.commit-inspector("transform-rotation", text.to-float()); }
                         }
                     }
                 }
@@ -674,16 +677,15 @@ export component InspectorPane inherits Rectangle {
                 if !root.image-mode && (root.is-root-selection() || root.is-rectangle-selection() || root.is-text-selection()): InspectorSection {
                     title: "Appearance";
 
-                    HorizontalLayout {
-                        padding-left: InspectorTokens.side-padding;
-                        spacing: InspectorTokens.column-gap;
+                    InspectorPropertyRow {
+                        label: root.is-text-selection() ? "Color" : "Fill";
 
                         if root.is-root-selection(): InspectorColorField {
                             accessible-name: "Root background";
                             value: root.phone-background-label;
                             swatch: root.phone-background;
                             commit-key: root.field-key("background");
-                            wide: true;
+                            width: root.width - 2 * InspectorTokens.side-padding - 59px;
                             accepted(text) => {
                                 return root.commit-code("background", text);
                             }
@@ -694,7 +696,7 @@ export component InspectorPane inherits Rectangle {
                             value: root.rectangle-background-code();
                             swatch: root.rectangle-background-swatch();
                             commit-key: root.field-key("background");
-                            wide: true;
+                            width: root.width - 2 * InspectorTokens.side-padding - 59px;
                             accepted(text) => {
                                 return root.commit-code("background", text);
                             }
@@ -705,10 +707,25 @@ export component InspectorPane inherits Rectangle {
                             value: root.text-color-code();
                             swatch: root.text-color-swatch();
                             commit-key: root.field-key("color");
-                            wide: true;
+                            width: root.width - 2 * InspectorTokens.side-padding - 59px;
                             accepted(text) => {
                                 return root.commit-code("color", text);
                             }
+                        }
+                    }
+                    if root.is-rectangle-selection(): HorizontalLayout {
+                        padding-left: InspectorTokens.side-padding;
+                        padding-right: InspectorTokens.side-padding;
+                        InspectorCornerEditor {
+                            width: root.width - 2 * InspectorTokens.side-padding - 1px;
+                            values: [root.control-values[1], root.control-values[2], root.control-values[3], root.control-values[4]];
+                            maximum: min(root.selected-width(), root.selected-height()) / 2px;
+                            commit-key: root.inspector-key;
+                            preview(value) => { return Api.inspector-preview(root.inspector-key, "all-corners", value); }
+                            accepted(index, value) => {
+                                return root.commit-inspector(index < 0 ? "all-corners" : index == 0 ? "border-top-left-radius" : index == 1 ? "border-top-right-radius" : index == 2 ? "border-bottom-left-radius" : "border-bottom-right-radius", value);
+                            }
+                            canceled => { Api.inspector-cancel(); }
                         }
                     }
                 }
@@ -719,7 +736,7 @@ export component InspectorPane inherits Rectangle {
                     VerticalLayout {
                         padding-left: InspectorTokens.side-padding;
                         padding-right: InspectorTokens.side-padding;
-                        spacing: 8px;
+                        spacing: 6px;
 
                         InspectorComboBox {
                             accessible-name: "Rectangle effect";
@@ -813,7 +830,7 @@ export component InspectorPane inherits Rectangle {
                     VerticalLayout {
                         padding-left: InspectorTokens.side-padding;
                         padding-right: InspectorTokens.side-padding;
-                        spacing: 8px;
+                        spacing: 6px;
 
                         InspectorCodeField {
                             accessible-name: "Image source";
@@ -914,7 +931,7 @@ export component InspectorPane inherits Rectangle {
 
                     VerticalLayout {
                         padding-left: InspectorTokens.side-padding;
-                        spacing: 8px;
+                        spacing: 6px;
 
                         InspectorEditableField {
                             accessible-name: "Font family";

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -756,6 +756,7 @@ export component InspectorPane inherits Rectangle {
 
                             InspectorEffectDial {
                                 accessible-name: "Shadow angle";
+                                commit-key: root.inspector-key + ":" + root.current-shadow-prefix();
                                 value: root.shadow-angle();
                                 accepted(angle) => {
                                     return root.commit-shadow-offsets(angle, root.shadow-distance());

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -77,6 +77,7 @@ export component InspectorPane inherits Rectangle {
         { value: "inner", label: "Inner Shadow" },
     ];
 
+    property <string> selection-key: root.element-information.source-uri + ":" + root.element-information.offset + ":" + Api.selection.highlight-index;
     property <string> inspector-key: root.element-information.source-uri + ":" + root.element-information.source-version + ":" + root.element-information.offset + ":" + Api.selection.highlight-index + ":" + Api.inspector-generation;
     property <[float]> control-values: Api.inspector-values(root.inspector-key);
     function commit-inspector(name: string, value: float) -> bool {
@@ -621,13 +622,13 @@ export component InspectorPane inherits Rectangle {
                     InspectorPropertyRow {
                         label: "Position";
                         InspectorValueField {
-                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            width: (parent.width - InspectorTokens.label-width - 2 * InspectorTokens.side-padding - 2 * InspectorTokens.row-gap) / 2;
                             accessible-name: "Position X"; prefix: "X";
                             value: root.selected-x-label(); commit-key: root.field-key("x");
                             accepted(text) => { return root.commit-geometry(text, root.selected-y-label(), root.selected-width-label(), root.selected-height-label()); }
                         }
                         InspectorValueField {
-                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            width: (parent.width - InspectorTokens.label-width - 2 * InspectorTokens.side-padding - 2 * InspectorTokens.row-gap) / 2;
                             accessible-name: "Position Y"; prefix: "Y";
                             value: root.selected-y-label(); commit-key: root.field-key("y");
                             accepted(text) => { return root.commit-geometry(root.selected-x-label(), text, root.selected-width-label(), root.selected-height-label()); }
@@ -636,13 +637,13 @@ export component InspectorPane inherits Rectangle {
                     InspectorPropertyRow {
                         label: "Size";
                         InspectorValueField {
-                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            width: (parent.width - InspectorTokens.label-width - 2 * InspectorTokens.side-padding - 2 * InspectorTokens.row-gap) / 2;
                             accessible-name: "Width"; prefix: "W";
                             value: root.selected-width-label(); commit-key: root.field-key("width");
                             accepted(text) => { return root.commit-geometry(root.selected-x-label(), root.selected-y-label(), text, root.selected-height-label()); }
                         }
                         InspectorValueField {
-                            width: (parent.width - 58px - 24px - 6px) / 2;
+                            width: (parent.width - InspectorTokens.label-width - 2 * InspectorTokens.side-padding - 2 * InspectorTokens.row-gap) / 2;
                             accessible-name: "Height"; prefix: "H";
                             value: root.selected-height-label(); commit-key: root.field-key("height");
                             accepted(text) => { return root.commit-geometry(root.selected-x-label(), root.selected-y-label(), root.selected-width-label(), text); }
@@ -659,7 +660,7 @@ export component InspectorPane inherits Rectangle {
                             canceled => { Api.inspector-cancel(); }
                         }
                         InspectorValueField {
-                            width: parent.width - 58px - 24px - 38px;
+                            width: parent.width - InspectorTokens.label-width - 2 * InspectorTokens.side-padding - 2 * InspectorTokens.row-gap - knob.width;
                             accessible-name: "Rotation"; prefix: "°";
                             value: "\{knob.visual-value}";
                             commit-key: root.inspector-key;
@@ -679,7 +680,7 @@ export component InspectorPane inherits Rectangle {
                             value: root.phone-background-label;
                             swatch: root.phone-background;
                             commit-key: root.field-key("background");
-                            width: root.width - 2 * InspectorTokens.side-padding - 59px;
+                            width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("background", text);
                             }
@@ -690,7 +691,7 @@ export component InspectorPane inherits Rectangle {
                             value: root.rectangle-background-code();
                             swatch: root.rectangle-background-swatch();
                             commit-key: root.field-key("background");
-                            width: root.width - 2 * InspectorTokens.side-padding - 59px;
+                            width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("background", text);
                             }
@@ -701,7 +702,7 @@ export component InspectorPane inherits Rectangle {
                             value: root.text-color-code();
                             swatch: root.text-color-swatch();
                             commit-key: root.field-key("color");
-                            width: root.width - 2 * InspectorTokens.side-padding - 59px;
+                            width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("color", text);
                             }
@@ -714,6 +715,7 @@ export component InspectorPane inherits Rectangle {
                             width: root.width - 2 * InspectorTokens.side-padding - 1px;
                             values: [root.control-values[1], root.control-values[2], root.control-values[3], root.control-values[4]];
                             maximum: min(root.selected-width(), root.selected-height()) / 2px;
+                            selection-key: root.selection-key;
                             commit-key: root.inspector-key;
                             preview(value) => { return Api.inspector-preview(root.inspector-key, "all-corners", value); }
                             accepted(index, value) => {

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -206,13 +206,7 @@ export component InspectorPane inherits Rectangle {
     }
 
     function field-key(property-name: string) -> string {
-        return root.element-information.source-uri
-            + ":"
-            + root.element-information.source-version
-            + ":"
-            + root.element-information.offset
-            + ":"
-            + property-name;
+        return root.inspector-key + ":" + property-name;
     }
 
     function property-brush(property-name: string, fallback: brush) -> brush {

--- a/tools/editor/ui/components/inspector/corner-editor.slint
+++ b/tools/editor/ui/components/inspector/corner-editor.slint
@@ -1,0 +1,106 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0 OR LicenseRef-Slint-Royalty-free-2.0
+
+import { InspectorTokens } from "tokens.slint";
+import { InspectorValueField } from "value-field.slint";
+import { InspectorRadiusSlider } from "radius-slider.slint";
+
+component CornerMode inherits FocusScope {
+    in property <bool> selected;
+    in property <bool> separate;
+    callback activated();
+    width: 28px;
+    height: 24px;
+    accessible-role: AccessibleRole.button;
+    accessible-label: root.separate ? "Separate corners" : "All corners";
+    accessible-value: root.selected ? "selected" : "";
+    accessible-action-default => { root.activated(); }
+    key-pressed(event) => {
+        if event.text == " " || event.text == Key.Return { root.activated(); return accept; }
+        return reject;
+    }
+    Rectangle {
+        border-radius: 4px;
+        background: root.selected ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg;
+        border-width: root.has-focus ? 1px : 0px;
+        border-color: InspectorTokens.accent;
+        Rectangle {
+            x: 7px; y: 5px; width: 14px; height: 14px;
+            border-radius: 4px; border-width: 1px;
+            border-color: root.selected ? InspectorTokens.text : InspectorTokens.muted;
+            if root.separate: Rectangle { x: 5px; y: -1px; width: 4px; height: 16px; background: root.selected ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg; }
+            if root.separate: Rectangle { x: -1px; y: 5px; width: 16px; height: 4px; background: root.selected ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg; }
+        }
+    }
+    TouchArea { clicked => { root.focus(); root.activated(); } }
+}
+
+export component InspectorCornerEditor inherits Rectangle {
+    in property <[float]> values;
+    in property <float> maximum;
+    in property <string> commit-key;
+    callback preview(float) -> bool;
+    callback accepted(int, float) -> bool;
+    callback canceled();
+    private property <bool> unequal: root.values[0] != root.values[1] || root.values[0] != root.values[2] || root.values[0] != root.values[3];
+    private property <bool> separate: root.unequal;
+    changed commit-key => { root.separate = root.unequal; }
+    changed unequal => { if root.unequal { root.separate = true; } }
+    height: layout.preferred-height;
+    horizontal-stretch: 1;
+    layout := VerticalLayout {
+        spacing: 6px;
+        HorizontalLayout {
+            spacing: 2px;
+            Text {
+                text: "Corner Radius";
+                color: InspectorTokens.text;
+                font-size: 12px;
+                vertical-alignment: center;
+                horizontal-stretch: 1;
+            }
+            CornerMode {
+                selected: !root.separate;
+                activated => {
+                    if root.separate {
+                        root.canceled();
+                        if root.accepted(-1, root.values[0]) { root.separate = false; }
+                    }
+                }
+            }
+            CornerMode { separate: true; selected: root.separate; activated => { root.canceled(); root.separate = true; } }
+        }
+        if !root.separate: HorizontalLayout {
+            spacing: 8px;
+            slider := InspectorRadiusSlider {
+                value: root.values[0]; maximum: root.maximum; commit-key: root.commit-key;
+                preview(value) => { return root.preview(value); }
+                accepted(value) => { return root.accepted(-1, value); }
+                canceled => { root.canceled(); }
+            }
+            InspectorValueField {
+                width: 72px;
+                accessible-name: "All corner radii";
+                prefix: "px";
+                value: "\{slider.visual-value}";
+                commit-key: root.commit-key;
+                accepted(text) => { return text.is-float() && text.to-float() >= 0 && root.accepted(-1, text.to-float()); }
+            }
+        }
+        if root.separate: VerticalLayout {
+            spacing: 6px;
+            for row in 2: HorizontalLayout {
+                spacing: 6px;
+                for column in 2: InspectorValueField {
+                    property <int> index: row * 2 + column;
+                    width: (root.width - 6px) / 2;
+                    accessible-name: index == 0 ? "Top left corner radius" : index == 1 ? "Top right corner radius" : index == 2 ? "Bottom left corner radius" : "Bottom right corner radius";
+                    corner-index: self.index;
+                    value: "\{root.values[index]}";
+                    commit-key: root.commit-key;
+                    accepted(text) => { return text.is-float() && text.to-float() >= 0 && root.accepted(self.index, text.to-float()); }
+                }
+            }
+        }
+    }
+}

--- a/tools/editor/ui/components/inspector/corner-editor.slint
+++ b/tools/editor/ui/components/inspector/corner-editor.slint
@@ -1,5 +1,5 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0 OR LicenseRef-Slint-Royalty-free-2.0
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { InspectorTokens } from "tokens.slint";
 import { InspectorValueField } from "value-field.slint";

--- a/tools/editor/ui/components/inspector/corner-editor.slint
+++ b/tools/editor/ui/components/inspector/corner-editor.slint
@@ -39,12 +39,13 @@ export component InspectorCornerEditor inherits Rectangle {
     in property <[float]> values;
     in property <float> maximum;
     in property <string> commit-key;
+    in property <string> selection-key;
     callback preview(float) -> bool;
     callback accepted(int, float) -> bool;
     callback canceled();
     private property <bool> unequal: root.values[0] != root.values[1] || root.values[0] != root.values[2] || root.values[0] != root.values[3];
     private property <bool> separate: root.unequal;
-    changed commit-key => { root.separate = root.unequal; }
+    changed selection-key => { root.separate = root.unequal; }
     changed unequal => { if root.unequal { root.separate = true; } }
     height: layout.preferred-height;
     horizontal-stretch: 1;

--- a/tools/editor/ui/components/inspector/effect-dial.slint
+++ b/tools/editor/ui/components/inspector/effect-dial.slint
@@ -1,125 +1,24 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { InspectorTokens } from "tokens.slint";
+
+import { InspectorRotationKnob } from "rotation-knob.slint";
 
 export component InspectorEffectDial inherits Rectangle {
     in property <string> accessible-name: "";
     in property <angle> value: 90deg;
+    in property <string> commit-key;
     callback accepted(angle) -> bool;
 
-    property <bool> dragging: false;
-    property <angle> drag-value: 90deg;
+    width: 32px;
+    height: 32px;
 
-    width: 44px;
-    height: 44px;
-    border-radius: 22px;
-    background: touch.has-hover || touch.pressed ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg;
-    border-width: touch.pressed ? 1px : 0px;
-    border-color: InspectorTokens.accent;
-    animate background { duration: 120ms; }
-    accessible-role: AccessibleRole.slider;
-    accessible-label: root.accessible-name;
-    accessible-value: "\{root.normalized-angle(root.visual-value()) / 1deg}";
-    accessible-value-minimum: 0;
-    accessible-value-maximum: 359;
-    accessible-action-set-value(value) => {
-        if value.is-float() {
-            root.accepted(value.to-float() * 1deg);
-        }
-    }
-
-    pure function normalized-angle(angle: angle) -> angle {
-        let value = angle.mod(360deg);
-        return value < 0deg ? value + 360deg : value;
-    }
-
-    pure function angle-from-pointer(x: length, y: length) -> angle {
-        return root.normalized-angle(atan2((y - root.height / 2) / 1px, (x - root.width / 2) / 1px));
-    }
-
-    pure function visual-value() -> angle {
-        return root.dragging ? root.drag-value : root.value;
-    }
-
-    pure function knob-x() -> length {
-        return root.width / 2 + root.visual-value().cos() * 13px;
-    }
-
-    pure function knob-y() -> length {
-        return root.height / 2 + root.visual-value().sin() * 13px;
-    }
-
-    function update-drag(x: length, y: length) {
-        root.drag-value = root.angle-from-pointer(x, y);
-    }
-
-    Rectangle {
-        x: 7px;
-        y: 7px;
-        width: parent.width - 14px;
-        height: parent.height - 14px;
-        border-radius: self.width / 2;
-        border-width: 1px;
-        border-color: InspectorTokens.divider;
-        background: InspectorTokens.panel-bg;
-    }
-
-    Rectangle {
-        x: root.width / 2 + root.visual-value().cos() * 6.5px - 6.5px;
-        y: root.height / 2 + root.visual-value().sin() * 6.5px - 0.5px;
-        width: 13px;
-        height: 1px;
-        background: InspectorTokens.accent;
-        transform-rotation: root.visual-value();
-    }
-
-    Rectangle {
-        x: root.knob-x() - 4px;
-        y: root.knob-y() - 4px;
-        width: 8px;
-        height: 8px;
-        border-radius: 4px;
-        border-width: 1px;
-        border-color: InspectorTokens.panel-bg;
-        background: InspectorTokens.accent;
-        drop-shadow-blur: 6px;
-        drop-shadow-offset-y: 2px;
-        drop-shadow-color: #00000035;
-    }
-
-    Text {
-        x: 0px;
-        y: parent.height - 11px;
-        width: parent.width;
-        height: 10px;
-        text: "\{(root.normalized-angle(root.visual-value()) / 1deg).round()}°";
-        color: InspectorTokens.muted;
-        font-size: 9px;
-        horizontal-alignment: center;
-        vertical-alignment: center;
-    }
-
-    touch := TouchArea {
-        mouse-cursor: pointer;
-
-        pointer-event(event) => {
-            if event.kind == PointerEventKind.down {
-                root.dragging = true;
-                root.update-drag(self.mouse-x, self.mouse-y);
-            } else if event.kind == PointerEventKind.move {
-                if root.dragging {
-                    root.update-drag(self.mouse-x, self.mouse-y);
-                }
-            } else if event.kind == PointerEventKind.up {
-                if root.dragging {
-                    let value = root.drag-value;
-                    root.dragging = false;
-                    root.accepted(value);
-                }
-            } else if event.kind == PointerEventKind.cancel {
-                root.dragging = false;
-            }
-        }
+    InspectorRotationKnob {
+        accessible-name: root.accessible-name;
+        value: root.value / 1deg;
+        angle-offset: 90deg;
+        commit-key: root.commit-key;
+        preview(value) => { return true; }
+        accepted(value) => { return root.accepted(value * 1deg); }
     }
 }

--- a/tools/editor/ui/components/inspector/property-row.slint
+++ b/tools/editor/ui/components/inspector/property-row.slint
@@ -5,12 +5,12 @@ import { InspectorTokens } from "tokens.slint";
 
 export component InspectorPropertyRow inherits HorizontalLayout {
     in property <string> label;
-    spacing: 6px;
+    spacing: InspectorTokens.row-gap;
     padding-left: InspectorTokens.side-padding;
     padding-right: InspectorTokens.side-padding;
     cross-axis-alignment: center;
     Text {
-        width: 52px;
+        width: InspectorTokens.label-width;
         text: root.label;
         color: InspectorTokens.muted;
         font-size: 12px;

--- a/tools/editor/ui/components/inspector/property-row.slint
+++ b/tools/editor/ui/components/inspector/property-row.slint
@@ -1,0 +1,20 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { InspectorTokens } from "tokens.slint";
+
+export component InspectorPropertyRow inherits HorizontalLayout {
+    in property <string> label;
+    spacing: 6px;
+    padding-left: InspectorTokens.side-padding;
+    padding-right: InspectorTokens.side-padding;
+    cross-axis-alignment: center;
+    Text {
+        width: 52px;
+        text: root.label;
+        color: InspectorTokens.muted;
+        font-size: 12px;
+        vertical-alignment: center;
+    }
+    @children
+}

--- a/tools/editor/ui/components/inspector/radius-slider.slint
+++ b/tools/editor/ui/components/inspector/radius-slider.slint
@@ -1,0 +1,61 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { InspectorTokens } from "tokens.slint";
+
+export component InspectorRadiusSlider inherits FocusScope {
+    in property <float> value;
+    in property <float> maximum;
+    in property <string> commit-key;
+    callback preview(float) -> bool;
+    callback accepted(float) -> bool;
+    callback canceled();
+    out property <float> visual-value: root.dragging ? root.drag-value : root.value;
+    private property <bool> dragging;
+    private property <float> drag-value;
+    private property <float> progress: root.maximum > 0 ? (root.visual-value / root.maximum).clamp(0, 1) : 0;
+    height: 24px;
+    min-width: 32px;
+    horizontal-stretch: 1;
+    accessible-role: AccessibleRole.slider;
+    accessible-label: "All corner radii slider";
+    accessible-value: "\{root.visual-value}";
+    accessible-value-minimum: 0;
+    accessible-value-maximum: root.maximum;
+    accessible-action-set-value(value) => {
+        if value.is-float() { root.accepted(value.to-float().clamp(0, root.maximum)); }
+    }
+    changed commit-key => { root.cancel(); }
+    function cancel() {
+        if root.dragging { root.dragging = false; root.canceled(); }
+    }
+    function update() {
+        root.drag-value = (((touch.mouse-x - 6px) / max(1px, root.width - 12px)).clamp(0, 1) * root.maximum).round();
+        if !root.preview(root.drag-value) { root.cancel(); }
+    }
+    key-pressed(event) => {
+        if event.text == Key.Escape && root.dragging { root.cancel(); return accept; }
+        if event.text == Key.LeftArrow || event.text == Key.DownArrow { root.accepted(max(0, root.value - 1)); return accept; }
+        if event.text == Key.RightArrow || event.text == Key.UpArrow { root.accepted(min(root.maximum, root.value + 1)); return accept; }
+        return reject;
+    }
+    Rectangle { x: 6px; y: 11px; width: parent.width - 12px; height: 2px; background: InspectorTokens.divider; }
+    Rectangle {
+        x: 1px + (parent.width - 12px) * root.progress;
+        y: 7px; width: 10px; height: 10px; border-radius: 5px;
+        background: InspectorTokens.muted;
+        border-width: root.has-focus ? 1px : 0px;
+        border-color: InspectorTokens.accent;
+    }
+    touch := TouchArea {
+        mouse-cursor: pointer;
+        pointer-event(event) => {
+            if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
+                root.focus(); root.dragging = true; root.update();
+            } else if event.kind == PointerEventKind.move && root.dragging { root.update();
+            } else if event.kind == PointerEventKind.up && root.dragging {
+                let value = root.drag-value; root.dragging = false; root.accepted(value);
+            } else if event.kind == PointerEventKind.cancel { root.cancel(); }
+        }
+    }
+}

--- a/tools/editor/ui/components/inspector/rotation-knob.slint
+++ b/tools/editor/ui/components/inspector/rotation-knob.slint
@@ -6,6 +6,8 @@ import { InspectorTokens } from "tokens.slint";
 
 export component InspectorRotationKnob inherits FocusScope {
     in property <float> value;
+    in property <string> accessible-name: "Rotation knob";
+    in property <angle> angle-offset: 0deg;
     in property <string> commit-key;
     out property <float> visual-value: root.dragging ? root.drag-value : root.value;
     callback preview(float) -> bool;
@@ -20,7 +22,7 @@ export component InspectorRotationKnob inherits FocusScope {
     width: 32px;
     height: 32px;
     accessible-role: AccessibleRole.slider;
-    accessible-label: "Rotation knob";
+    accessible-label: root.accessible-name;
     accessible-value: "\{root.visual-value}";
     accessible-action-set-value(value) => {
         if value.is-float() { root.accepted(value.to-float()); }
@@ -33,7 +35,7 @@ export component InspectorRotationKnob inherits FocusScope {
         }
     }
     function pointer-angle() -> angle {
-        return atan2((touch.mouse-x - 16px) / 1px, (16px - touch.mouse-y) / 1px);
+        return atan2((touch.mouse-x - 16px) / 1px, (16px - touch.mouse-y) / 1px) - root.angle-offset;
     }
     function update(shift: bool) {
         let angle = root.pointer-angle();
@@ -79,8 +81,8 @@ export component InspectorRotationKnob inherits FocusScope {
             drop-shadow-offset-y: 1px;
         }
         Rectangle {
-            x: 14px + (root.visual-value.mod(360) * 1deg).sin() * 9px;
-            y: 14px - (root.visual-value.mod(360) * 1deg).cos() * 9px;
+            x: 14px + (root.visual-value.mod(360) * 1deg + root.angle-offset).sin() * 9px;
+            y: 14px - (root.visual-value.mod(360) * 1deg + root.angle-offset).cos() * 9px;
             width: 4px; height: 4px; border-radius: 2px;
             background: @linear-gradient(180deg, #0879b7, #38b9fa);
             border-width: 0.5px;

--- a/tools/editor/ui/components/inspector/rotation-knob.slint
+++ b/tools/editor/ui/components/inspector/rotation-knob.slint
@@ -1,0 +1,110 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { StudioTheme } from "../common.slint";
+import { InspectorTokens } from "tokens.slint";
+
+export component InspectorRotationKnob inherits FocusScope {
+    in property <float> value;
+    in property <string> commit-key;
+    out property <float> visual-value: root.dragging ? root.drag-value : root.value;
+    callback preview(float) -> bool;
+    callback accepted(float) -> bool;
+    callback canceled();
+    private property <bool> dragging;
+    private property <float> drag-value;
+    private property <float> initial-value;
+    private property <float> accumulated;
+    private property <angle> last-angle;
+    private property <bool> shift-pressed;
+    width: 32px;
+    height: 32px;
+    accessible-role: AccessibleRole.slider;
+    accessible-label: "Rotation knob";
+    accessible-value: "\{root.visual-value}";
+    accessible-action-set-value(value) => {
+        if value.is-float() { root.accepted(value.to-float()); }
+    }
+    changed commit-key => { root.cancel(); }
+    function cancel() {
+        if root.dragging {
+            root.dragging = false;
+            root.canceled();
+        }
+    }
+    function pointer-angle() -> angle {
+        return atan2((touch.mouse-x - 16px) / 1px, (16px - touch.mouse-y) / 1px);
+    }
+    function update(shift: bool) {
+        let angle = root.pointer-angle();
+        let difference = (angle - root.last-angle + 540deg).mod(360deg) - 180deg;
+        root.accumulated += difference / 1deg;
+        root.last-angle = angle;
+        root.drag-value = shift ? (root.accumulated / 15).round() * 15 : root.accumulated.round();
+        if !root.preview(root.drag-value) { root.cancel(); }
+    }
+    key-pressed(event) => {
+        if event.text == Key.Escape && root.dragging { root.cancel(); return accept; }
+        if event.text == Key.Shift || event.text == Key.ShiftR {
+            root.shift-pressed = true;
+            return accept;
+        }
+        if event.text == Key.UpArrow || event.text == Key.RightArrow {
+            root.accepted(root.value + (event.modifiers.shift ? 15 : 1));
+            return accept;
+        }
+        if event.text == Key.DownArrow || event.text == Key.LeftArrow {
+            root.accepted(root.value - (event.modifiers.shift ? 15 : 1));
+            return accept;
+        }
+        return reject;
+    }
+    key-released(event) => {
+        if event.text == Key.Shift || event.text == Key.ShiftR { root.shift-pressed = false; return accept; }
+        return reject;
+    }
+    Rectangle {
+        border-radius: 16px;
+        background: @linear-gradient(145deg, StudioTheme.dark ? #262a30 : #bdc3cc, StudioTheme.dark ? #737c87 : #ffffff);
+        border-width: 1px;
+        border-color: root.has-focus ? InspectorTokens.accent : StudioTheme.dark ? #454b55 : #cbd0d8;
+        Rectangle {
+            x: 2px; y: 2px; width: 28px; height: 28px;
+            border-radius: 14px;
+            background: @radial-gradient(circle at 10px 7px, StudioTheme.dark ? #89919b : #ffffff, StudioTheme.dark ? #5b626d : #f4f6f9 55%, StudioTheme.dark ? #343a43 : #d8dde5);
+            border-width: 0.5px;
+            border-color: StudioTheme.dark ? #858e99 : #ffffff;
+            drop-shadow-color: #00000025;
+            drop-shadow-blur: 2px;
+            drop-shadow-offset-y: 1px;
+        }
+        Rectangle {
+            x: 14px + (root.visual-value.mod(360) * 1deg).sin() * 9px;
+            y: 14px - (root.visual-value.mod(360) * 1deg).cos() * 9px;
+            width: 4px; height: 4px; border-radius: 2px;
+            background: @linear-gradient(180deg, #0879b7, #38b9fa);
+            border-width: 0.5px;
+            border-color: StudioTheme.dark ? #343e4a : #b9cbd9;
+        }
+    }
+    touch := TouchArea {
+        mouse-cursor: pointer;
+        pointer-event(event) => {
+            if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
+                root.focus();
+                root.dragging = true;
+                root.drag-value = root.value;
+                root.initial-value = root.value;
+                root.accumulated = root.value;
+                root.last-angle = root.pointer-angle();
+                root.shift-pressed = event.modifiers.shift;
+            } else if event.kind == PointerEventKind.move && root.dragging {
+                root.update(root.shift-pressed || event.modifiers.shift);
+            } else if event.kind == PointerEventKind.up && root.dragging {
+                let value = root.drag-value;
+                root.dragging = false;
+                if value != root.initial-value { root.accepted(value); } else { root.canceled(); }
+            } else if event.kind == PointerEventKind.cancel { root.cancel(); }
+        }
+    }
+}

--- a/tools/editor/ui/components/inspector/section.slint
+++ b/tools/editor/ui/components/inspector/section.slint
@@ -14,12 +14,12 @@ export component InspectorSection inherits Rectangle {
 
     section-layout := VerticalLayout {
         width: root.width;
-        padding-top: 12px;
-        padding-bottom: 16px;
-        spacing: 11px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+        spacing: 6px;
 
         Rectangle {
-            height: 19px;
+            height: 16px;
 
             Text {
                 x: InspectorTokens.side-padding;

--- a/tools/editor/ui/components/inspector/text-field-base.slint
+++ b/tools/editor/ui/components/inspector/text-field-base.slint
@@ -14,6 +14,7 @@ export component InspectorTextFieldBase inherits Rectangle {
     in property <color> input-color: root.enabled ? InspectorTokens.text : InspectorTokens.muted;
     in property <string> commit-key: "";
     private property <string> active-commit-key: root.commit-key;
+    private property <bool> edited: false;
     callback accepted(string) -> bool;
 
     height: InspectorTokens.field-height;
@@ -37,12 +38,13 @@ export component InspectorTextFieldBase inherits Rectangle {
     }
 
     changed value => {
-        if !input.has-focus {
+        if !input.has-focus || !root.edited {
             input.text = root.value;
         }
     }
 
     changed commit-key => {
+        root.edited = false;
         input.text = root.value;
         root.active-commit-key = root.commit-key;
     }
@@ -80,6 +82,8 @@ export component InspectorTextFieldBase inherits Rectangle {
                 vertical-alignment: center;
                 selection-background-color: InspectorTokens.accent.with-alpha(0.28);
                 text-cursor-width: 1px;
+
+                edited => { root.edited = true; }
 
                 accepted => {
                     if !root.accept-input(self.text) {

--- a/tools/editor/ui/components/inspector/tokens.slint
+++ b/tools/editor/ui/components/inspector/tokens.slint
@@ -12,13 +12,13 @@ export global InspectorTokens {
     out property <color> text: StudioTheme.dark ? #f4f4f4 : #1e1e1e;
     out property <color> muted: StudioTheme.dark ? #9a9a9a : #8c8c8c;
     out property <color> accent: #0d99ff;
-    out property <length> side-padding: 15px;
+    out property <length> side-padding: 12px;
     out property <length> section-title-size: 12px;
     out property <length> field-height: 24px;
     out property <length> field-radius: 4px;
     out property <length> column-width: 88px;
     out property <length> column-gap: 8px;
-    out property <length> wide-width: 184px;
+    out property <length> wide-width: 207px;
 }
 
 export struct InspectorComboOption {

--- a/tools/editor/ui/components/inspector/tokens.slint
+++ b/tools/editor/ui/components/inspector/tokens.slint
@@ -12,6 +12,8 @@ export global InspectorTokens {
     out property <color> text: StudioTheme.dark ? #f4f4f4 : #1e1e1e;
     out property <color> muted: StudioTheme.dark ? #9a9a9a : #8c8c8c;
     out property <color> accent: #0d99ff;
+    out property <length> label-width: 52px;
+    out property <length> row-gap: 6px;
     out property <length> side-padding: 12px;
     out property <length> section-title-size: 12px;
     out property <length> field-height: 24px;

--- a/tools/editor/ui/components/inspector/value-field.slint
+++ b/tools/editor/ui/components/inspector/value-field.slint
@@ -29,6 +29,7 @@ export component InspectorValueField inherits Rectangle {
         if root.corner-index >= 0: Path {
             width: 12px;
             height: 12px;
+            // Top-left, top-right, bottom-left, and bottom-right corner outlines.
             commands: root.corner-index == 0 ? "M 2 11 L 2 6 Q 2 2 6 2 L 11 2"
                 : root.corner-index == 1 ? "M 1 2 L 6 2 Q 10 2 10 6 L 10 11"
                 : root.corner-index == 2 ? "M 2 1 L 2 6 Q 2 10 6 10 L 11 10"

--- a/tools/editor/ui/components/inspector/value-field.slint
+++ b/tools/editor/ui/components/inspector/value-field.slint
@@ -7,6 +7,7 @@ import { InspectorTextFieldBase } from "text-field-base.slint";
 export component InspectorValueField inherits Rectangle {
     in property <string> accessible-name: "";
     in property <string> prefix;
+    in property <int> corner-index: -1;
     in property <string> value;
     in property <bool> enabled: true;
     in property <string> commit-key: "";
@@ -25,7 +26,17 @@ export component InspectorValueField inherits Rectangle {
             return root.accepted(text);
         }
 
-        Text {
+        if root.corner-index >= 0: Path {
+            width: 12px;
+            height: 12px;
+            commands: root.corner-index == 0 ? "M 2 11 L 2 6 Q 2 2 6 2 L 11 2"
+                : root.corner-index == 1 ? "M 1 2 L 6 2 Q 10 2 10 6 L 10 11"
+                : root.corner-index == 2 ? "M 2 1 L 2 6 Q 2 10 6 10 L 11 10"
+                : "M 1 10 L 6 10 Q 10 10 10 6 L 10 1";
+            stroke: InspectorTokens.muted;
+            stroke-width: 1px;
+        }
+        if root.corner-index < 0: Text {
             text: root.prefix;
             color: root.enabled ? InspectorTokens.text : InspectorTokens.muted;
             font-size: 11px;

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -74,15 +74,6 @@ export component EditorUi inherits Window {
             }
 
             capture-key-pressed(event) => {
-                if (event.modifiers.control || event.modifiers.meta) && (event.text == "z" || event.text == "Z") {
-                    Api.inspector-cancel();
-                    if event.modifiers.shift {
-                        if Api.redo-enabled { Api.redo(); }
-                    } else {
-                        if Api.undo-enabled { Api.undo(); }
-                    }
-                    return accept;
-                }
                 if event.text == Key.Shift || event.text == Key.ShiftR {
                     self.shift-pressed = true;
                     return reject;
@@ -99,6 +90,17 @@ export component EditorUi inherits Window {
             }
 
             key-pressed(event) => {
+                if (event.modifiers.control || event.modifiers.meta) && (event.text == "z" || event.text == "Z") {
+                    Api.inspector-cancel();
+                    // Cancel the gesture even when there is no document edit to undo.
+                    Api.inspector-generation += 1;
+                    if event.modifiers.shift {
+                        if Api.redo-enabled { Api.redo(); }
+                    } else {
+                        if Api.undo-enabled { Api.undo(); }
+                    }
+                    return accept;
+                }
                 if event.text == Key.Escape && AppState.has-active-drag() {
                     AppState.cancel-active-drags();
                     return accept;

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -74,9 +74,18 @@ export component EditorUi inherits Window {
             }
 
             capture-key-pressed(event) => {
+                if (event.modifiers.control || event.modifiers.meta) && (event.text == "z" || event.text == "Z") {
+                    Api.inspector-cancel();
+                    if event.modifiers.shift {
+                        if Api.redo-enabled { Api.redo(); }
+                    } else {
+                        if Api.undo-enabled { Api.undo(); }
+                    }
+                    return accept;
+                }
                 if event.text == Key.Shift || event.text == Key.ShiftR {
                     self.shift-pressed = true;
-                    return accept;
+                    return reject;
                 }
                 reject
             }
@@ -84,7 +93,7 @@ export component EditorUi inherits Window {
             capture-key-released(event) => {
                 if event.text == Key.Shift || event.text == Key.ShiftR {
                     self.shift-pressed = false;
-                    return accept;
+                    return reject;
                 }
                 reject
             }

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -41,20 +41,28 @@ export component EditorUi inherits Window {
     function open-project() {
         root.close-startup-wizard();
     }
+    function apply-history(redo: bool) {
+        Api.inspector-cancel();
+        Api.inspector-generation += 1;
+        if redo {
+            if Api.redo-enabled { Api.redo(); }
+        } else {
+            if Api.undo-enabled { Api.undo(); }
+        }
+    }
+
     MenuBar {
         Menu {
             title: @tr("Edit");
             MenuItem {
                 title: @tr("Undo");
-                shortcut: @keys(Control + Z);
                 enabled: Api.undo-enabled;
-                activated => { Api.undo(); }
+                activated => { root.apply-history(false); }
             }
             MenuItem {
                 title: @tr("Redo");
-                shortcut: Platform.os == OperatingSystemType.windows ? @keys(Control + Y) : @keys(Control + Shift + Z);
                 enabled: Api.redo-enabled;
-                activated => { Api.redo(); }
+                activated => { root.apply-history(true); }
             }
         }
     }
@@ -90,15 +98,9 @@ export component EditorUi inherits Window {
             }
 
             key-pressed(event) => {
-                if (event.modifiers.control || event.modifiers.meta) && (event.text == "z" || event.text == "Z") {
-                    Api.inspector-cancel();
-                    // Cancel the gesture even when there is no document edit to undo.
-                    Api.inspector-generation += 1;
-                    if event.modifiers.shift {
-                        if Api.redo-enabled { Api.redo(); }
-                    } else {
-                        if Api.undo-enabled { Api.undo(); }
-                    }
+                let redo-y = Platform.os == OperatingSystemType.windows && (event.text == "y" || event.text == "Y");
+                if (event.modifiers.control || event.modifiers.meta) && (event.text == "z" || event.text == "Z" || redo-y) {
+                    root.apply-history(event.modifiers.shift || redo-y);
                     return accept;
                 }
                 if event.text == Key.Escape && AppState.has-active-drag() {
@@ -120,7 +122,7 @@ export component EditorUi inherits Window {
             DropArea {
                 can-drop(event) => {
                     if AppState.palette-drag-kind != PaletteComponentKind.none {
-                        AppState.update-palette-drag(AppState.palette-drag-kind, event.position);
+                        AppState.update-palette-drag(AppState.palette-drag-kind, { x: event.position.x + self.absolute-position.x, y: event.position.y + self.absolute-position.y });
                     }
                     return DragAction.none;
                 }
@@ -167,7 +169,7 @@ export component EditorUi inherits Window {
                     }
                 }
 
-                DragPreview { }
+                DragPreview { parent-origin: parent.absolute-position; }
 
                 if root.sidebars-collapsed: Rectangle {
                     x: 18px;


### PR DESCRIPTION

<img width="278" height="386" alt="Screenshot 2026-09-09 at 10 51 06" src="https://github.com/user-attachments/assets/34a893e1-1473-4bf1-b84e-e7201146043f" />

Items have many properties and the prototype UI had large margins around all items resulting in a large area only having a handful of property editors. This change increases the visual density and also introduces new editors for rounded corners and angle based properties.

Codex then made quite some extra changes because changing the corner radius has been broken in the visual editor. Please check that carefully. The problem was real. The fix??
