### PR TITLE
Visual Editor: Unify element kinds and preview metadata

### DIFF
--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -41,6 +41,7 @@ use std::rc::Rc;
 use i_slint_editor_preview::wasm_prelude::*;
 
 mod drop_location;
+mod element_catalog;
 mod element_selection;
 pub mod eval;
 mod ext;
@@ -967,36 +968,14 @@ enum DragItem {
     /// An existing element instance to be moved.
     MoveElementInstance { uri: SharedString, offset: u32 },
     /// A new component from the palette to be instantiated.
-    NewComponent { kind: PaletteComponent },
+    NewComponent { kind: ui::ElementKind },
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
-enum PaletteComponent {
-    Rectangle,
-    Text,
-    Image,
-    TouchArea,
-}
-
-impl PaletteComponent {
-    fn from_ui(kind: ui::PaletteComponentKind) -> Option<Self> {
-        match kind {
-            ui::PaletteComponentKind::Rectangle => Some(Self::Rectangle),
-            ui::PaletteComponentKind::Text => Some(Self::Text),
-            ui::PaletteComponentKind::Image => Some(Self::Image),
-            ui::PaletteComponentKind::TouchArea => Some(Self::TouchArea),
-            ui::PaletteComponentKind::None => None,
-        }
+fn new_component_data_for_kind(kind: ui::ElementKind) -> DataTransfer {
+    if element_catalog::primitive(kind).is_none() {
+        return Default::default();
     }
-
-    fn name(self) -> &'static str {
-        match self {
-            Self::Rectangle => "Rectangle",
-            Self::Text => "Text",
-            Self::Image => "Image",
-            Self::TouchArea => "TouchArea",
-        }
-    }
+    DragItem::NewComponent { kind }.into()
 }
 
 /// Tried to convert a [`DataTransfer`] to a `DragItem`, but the data transfer's user data
@@ -1052,12 +1031,13 @@ fn can_drop_component(data: DataTransfer, x: f32, y: f32, on_drop_area: bool) ->
     drop_location::can_drop_at(&document_cache, position, &component)
 }
 
-fn palette_component(kind: PaletteComponent) -> Option<ComponentInformation> {
+fn palette_component(kind: ui::ElementKind) -> Option<ComponentInformation> {
+    let primitive = element_catalog::primitive(kind)?;
     PREVIEW_STATE.with_borrow(|preview_state| {
         preview_state
             .known_components
             .iter()
-            .find(|component| component.name == kind.name() && component.is_builtin)
+            .find(|component| component.name == primitive.type_name && component.is_builtin)
             .cloned()
     })
 }

--- a/tools/editor/preview/element_catalog.rs
+++ b/tools/editor/preview/element_catalog.rs
@@ -1,6 +1,10 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// This catalog owns primitive identity and grouping. Presentation belongs in
+// ui/components/element-presentation.slint. Add each primitive to both sources;
+// metadata_is_complete checks every ElementKind except none and component.
+
 use super::ui::ElementKind;
 use std::hash::{Hash, Hasher};
 
@@ -60,6 +64,65 @@ pub(super) fn kind_for_type(type_name: &str) -> ElementKind {
 mod tests {
     use super::*;
     use crate::preview::{DragItem, new_component_data_for_kind};
+
+    #[test]
+    fn metadata_is_complete() {
+        use i_slint_compiler::langtype::Type;
+        use slint_interpreter::{Compiler, Value};
+
+        i_slint_backend_testing::init_no_event_loop();
+        let source = r#"
+            import { ElementKind } from "api.slint";
+            import { ElementVisuals } from "components/element-presentation.slint";
+            export { ElementKind }
+            export component MetadataProbe inherits Window {
+                public pure function label(kind: ElementKind) -> string {
+                    return ElementVisuals.for-kind(kind).drag-label;
+                }
+            }
+        "#;
+        let result = spin_on::spin_on(Compiler::default().build_from_source(
+            source.into(),
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("ui/metadata-probe.slint"),
+        ));
+        let definition = result.component("MetadataProbe").expect("metadata probe must compile");
+        let instance = definition.create().unwrap();
+        let enumeration = result
+            .structs_and_enums(i_slint_core::InternalToken)
+            .find_map(|ty| match ty {
+                Type::Enumeration(enumeration) if enumeration.name == "ElementKind" => {
+                    Some(enumeration)
+                }
+                _ => None,
+            })
+            .expect("ElementKind must be exported");
+        let mut count = 0;
+        for variant in &enumeration.values {
+            if matches!(variant.as_str(), "none" | "component") {
+                continue;
+            }
+            count += 1;
+            let entries: Vec<_> = PRIMITIVES
+                .iter()
+                .filter(|entry| {
+                    format!("{:?}", entry.kind).to_lowercase() == variant.replace('-', "")
+                })
+                .collect();
+            assert_eq!(entries.len(), 1, "{variant} must have exactly one catalog entry");
+            let label = instance
+                .invoke(
+                    "label",
+                    &[Value::EnumerationValue("ElementKind".into(), variant.to_string())],
+                )
+                .unwrap();
+            assert_eq!(
+                label,
+                Value::String(format!("{} drag preview", entries[0].type_name).into()),
+                "{variant} must have presentation metadata",
+            );
+        }
+        assert_eq!(count, PRIMITIVES.len(), "catalog must contain only primitive kinds");
+    }
 
     #[test]
     fn primitive_names_and_drop_payloads_share_the_catalog() {

--- a/tools/editor/preview/element_catalog.rs
+++ b/tools/editor/preview/element_catalog.rs
@@ -81,11 +81,15 @@ mod tests {
                 }
             }
         "#;
-        let result = spin_on::spin_on(Compiler::default().build_from_source(
+        let mut compiler = Compiler::default();
+        compiler.compiler_configuration(i_slint_core::InternalToken).enable_experimental = true;
+        let result = spin_on::spin_on(compiler.build_from_source(
             source.into(),
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("ui/metadata-probe.slint"),
         ));
-        let definition = result.component("MetadataProbe").expect("metadata probe must compile");
+        let definition = result.component("MetadataProbe").unwrap_or_else(|| {
+            panic!("metadata probe must compile: {:?}", result.diagnostics().collect::<Vec<_>>())
+        });
         let instance = definition.create().unwrap();
         let enumeration = result
             .structs_and_enums(i_slint_core::InternalToken)

--- a/tools/editor/preview/element_catalog.rs
+++ b/tools/editor/preview/element_catalog.rs
@@ -1,0 +1,93 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use super::ui::ElementKind;
+use std::hash::{Hash, Hasher};
+
+impl Eq for ElementKind {}
+impl Hash for ElementKind {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum Group {
+    Visual,
+    InputInteraction,
+}
+
+impl Group {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Visual => "Visual",
+            Self::InputInteraction => "Input & interaction",
+        }
+    }
+}
+
+pub(super) const GROUPS: [Group; 2] = [Group::Visual, Group::InputInteraction];
+
+pub(super) struct Primitive {
+    pub kind: ElementKind,
+    pub type_name: &'static str,
+    pub group: Group,
+}
+
+pub(super) const PRIMITIVES: [Primitive; 4] = [
+    Primitive { kind: ElementKind::Rectangle, type_name: "Rectangle", group: Group::Visual },
+    Primitive { kind: ElementKind::Text, type_name: "Text", group: Group::Visual },
+    Primitive { kind: ElementKind::Image, type_name: "Image", group: Group::Visual },
+    Primitive {
+        kind: ElementKind::TouchArea,
+        type_name: "TouchArea",
+        group: Group::InputInteraction,
+    },
+];
+
+pub(super) fn primitive(kind: ElementKind) -> Option<&'static Primitive> {
+    PRIMITIVES.iter().find(|entry| entry.kind == kind)
+}
+
+pub(super) fn kind_for_type(type_name: &str) -> ElementKind {
+    PRIMITIVES
+        .iter()
+        .find(|entry| entry.type_name == type_name.trim())
+        .map_or(ElementKind::Component, |entry| entry.kind)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preview::{DragItem, new_component_data_for_kind};
+
+    #[test]
+    fn primitive_names_and_drop_payloads_share_the_catalog() {
+        for (kind, name, group) in [
+            (ElementKind::Image, "Image", "Visual"),
+            (ElementKind::Rectangle, "Rectangle", "Visual"),
+            (ElementKind::Text, "Text", "Visual"),
+            (ElementKind::TouchArea, "TouchArea", "Input & interaction"),
+        ] {
+            let entry = primitive(kind).unwrap();
+            assert_eq!(entry.type_name, name);
+            assert_eq!(entry.group.label(), group);
+            assert_eq!(kind_for_type(&format!(" {name} ")), kind);
+            assert_eq!(
+                DragItem::try_from(new_component_data_for_kind(kind)).unwrap(),
+                DragItem::NewComponent { kind }
+            );
+        }
+    }
+
+    #[test]
+    fn fallback_kinds_cannot_create_palette_drops() {
+        for name in ["", "Window", "CustomComponent"] {
+            assert_eq!(kind_for_type(name), ElementKind::Component);
+        }
+        for kind in [ElementKind::None, ElementKind::Component] {
+            assert!(primitive(kind).is_none());
+            assert!(DragItem::try_from(new_component_data_for_kind(kind)).is_err());
+        }
+    }
+}

--- a/tools/editor/preview/outline.rs
+++ b/tools/editor/preview/outline.rs
@@ -160,7 +160,9 @@ impl Tree for OutlineModel {
                             base.text()
                         ),
                     };
-                    let icon_kind = icon_kind_for_type(base_type.as_deref().unwrap_or_default());
+                    let icon_kind = super::element_catalog::kind_for_type(
+                        base_type.as_deref().unwrap_or_default(),
+                    );
                     let data = create_node(&elem, 0, name, Default::default(), icon_kind);
                     (elem, data)
                 });
@@ -194,7 +196,7 @@ impl Tree for OutlineModel {
                             .child_text(parser::SyntaxKind::Identifier)
                             .map(|x| x.to_shared_string())
                             .unwrap_or_default();
-                        let icon_kind = icon_kind_for_type(base.as_str());
+                        let icon_kind = super::element_catalog::kind_for_type(base.as_str());
                         let node = create_node(&elem, indent_level, base, id, icon_kind);
                         Some((elem, node))
                     })
@@ -235,7 +237,7 @@ fn create_node(
     indent_level: i32,
     element_type: SharedString,
     element_id: SharedString,
-    icon_kind: ui::OutlineNodeIconKind,
+    icon_kind: ui::ElementKind,
 ) -> ui::OutlineTreeNode {
     ui::OutlineTreeNode {
         has_children: element
@@ -253,16 +255,6 @@ fn create_node(
             .to_shared_string(),
         offset: usize::from(element.text_range().start()) as i32,
         is_last_child: true,
-    }
-}
-
-fn icon_kind_for_type(element_type: &str) -> ui::OutlineNodeIconKind {
-    match element_type.trim() {
-        "Rectangle" => ui::OutlineNodeIconKind::Rectangle,
-        "Image" => ui::OutlineNodeIconKind::Image,
-        "Text" => ui::OutlineNodeIconKind::Text,
-        "TouchArea" => ui::OutlineNodeIconKind::TouchArea,
-        _ => ui::OutlineNodeIconKind::Default,
     }
 }
 

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -155,14 +155,7 @@ pub fn initialize_editor(
     api.on_highlight_positions(super::element_selection::highlight_positions);
     let lsp = to_lsp.clone();
     api.on_can_drop(super::can_drop_component);
-    api.on_new_component_data_for_kind(|kind| -> DataTransfer {
-        let Some(kind) = super::PaletteComponent::from_ui(kind) else {
-            return Default::default();
-        };
-        let mut transfer = DataTransfer::default();
-        transfer.set_user_data(Rc::new(DragItem::NewComponent { kind }));
-        transfer
-    });
+    api.on_new_component_data_for_kind(super::new_component_data_for_kind);
     api.on_move_element_instance_data(|uri: SharedString, offset: i32| -> DataTransfer {
         let Ok(offset) = offset.try_into() else {
             return Default::default();

--- a/tools/editor/preview/ui/element_library.rs
+++ b/tools/editor/preview/ui/element_library.rs
@@ -3,36 +3,25 @@
 
 use slint::{Model, ModelExt, ModelRc, SharedString};
 
-use super::{Api, ElementLibraryEntry, ElementLibraryGroup, PaletteComponentKind};
+use super::{Api, ElementLibraryEntry, ElementLibraryGroup};
 
 fn catalog() -> ModelRc<ElementLibraryGroup> {
-    let groups = [
-        (
-            "Visual",
-            vec![
-                ElementLibraryEntry {
-                    label: "Rectangle".into(),
-                    kind: PaletteComponentKind::Rectangle,
-                },
-                ElementLibraryEntry { label: "Text".into(), kind: PaletteComponentKind::Text },
-                ElementLibraryEntry { label: "Image".into(), kind: PaletteComponentKind::Image },
-            ],
-        ),
-        (
-            "Input & interaction",
-            vec![ElementLibraryEntry {
-                label: "TouchArea".into(),
-                kind: PaletteComponentKind::TouchArea,
-            }],
-        ),
-    ];
+    use super::super::element_catalog::{GROUPS, PRIMITIVES};
     ModelRc::new(slint::VecModel::from(
-        groups
-            .into_iter()
-            .map(|(label, mut entries)| {
+        GROUPS
+            .iter()
+            .map(|group| {
+                let mut entries: Vec<_> = PRIMITIVES
+                    .iter()
+                    .filter(|entry| entry.group == *group)
+                    .map(|entry| ElementLibraryEntry {
+                        label: entry.type_name.into(),
+                        kind: entry.kind,
+                    })
+                    .collect();
                 entries.sort_by(|a, b| a.label.cmp(&b.label));
                 ElementLibraryGroup {
-                    label: label.into(),
+                    label: group.label().into(),
                     entries: ModelRc::new(slint::VecModel::from(entries)),
                 }
             })
@@ -69,6 +58,7 @@ pub(super) fn setup(api: &Api<'_>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::preview::ui::ElementKind;
 
     #[test]
     fn library_is_alphabetical_and_search_preserves_order() {
@@ -93,7 +83,7 @@ mod tests {
         }
         let interaction = groups.row_data(1).unwrap();
         assert_eq!(interaction.label, "Input & interaction");
-        assert_eq!(interaction.entries.row_data(0).unwrap().kind, PaletteComponentKind::TouchArea);
+        assert_eq!(interaction.entries.row_data(0).unwrap().kind, ElementKind::TouchArea);
         for (query, expected) in [
             ("", vec!["TouchArea"]),
             ("  ", vec!["TouchArea"]),
@@ -127,12 +117,11 @@ mod tests {
     fn filtered_entries_follow_catalog_changes() {
         let entries = std::rc::Rc::new(slint::VecModel::from(vec![ElementLibraryEntry {
             label: "Rectangle".into(),
-            kind: PaletteComponentKind::Rectangle,
+            kind: ElementKind::Rectangle,
         }]));
         let filtered = filter(entries.clone().into(), "text".into());
         assert_eq!(filtered.row_count(), 0);
-        entries
-            .push(ElementLibraryEntry { label: "Text".into(), kind: PaletteComponentKind::Text });
+        entries.push(ElementLibraryEntry { label: "Text".into(), kind: ElementKind::Text });
         assert_eq!(filtered.row_data(0).unwrap().label, "Text");
         entries.remove(1);
         assert_eq!(filtered.row_count(), 0);

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -8,8 +8,9 @@ export enum CanvasCorner {
     bottom-left,
 }
 
-export enum PaletteComponentKind {
+export enum ElementKind {
     none,
+    component,
     rectangle,
     text,
     image,
@@ -19,7 +20,7 @@ export enum PaletteComponentKind {
 /// A palette item whose kind selects its icon and drag payload.
 export struct ElementLibraryEntry {
     label: string,
-    kind: PaletteComponentKind,
+    kind: ElementKind,
 }
 
 /// A named palette group with entries sorted by label.
@@ -340,13 +341,7 @@ export struct LogMessage {
     level: LogMessageLevel,
 }
 
-export enum OutlineNodeIconKind {
-    default,
-    rectangle,
-    image,
-    text,
-    touch-area,
-}
+
 
 /// A node in the outline tree
 export struct OutlineTreeNode {
@@ -354,7 +349,7 @@ export struct OutlineTreeNode {
     has-children: bool,
     is-expanded: bool,
     is-last-child: bool,
-    icon-kind: OutlineNodeIconKind,
+    icon-kind: ElementKind,
     element-type: string,
     element-id: string,
     uri: string,
@@ -448,7 +443,7 @@ export global Api {
     // The actual preview
     in-out property <component-factory> preview-area;
 
-    pure callback new-component-data-for-kind(kind: PaletteComponentKind) -> data-transfer;
+    pure callback new-component-data-for-kind(kind: ElementKind) -> data-transfer;
     pure callback move-element-instance-data(component-uri: string, offset: int) -> data-transfer;
 
     // set to true to resize

--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -3,9 +3,9 @@
 
 import { Palette } from "std-widgets.slint";
 import { EditorTreeIcons } from "editor-tree-icons.slint";
-import { Api, CanvasCorner, PaletteComponentKind } from "../api.slint";
+import { Api, CanvasCorner, ElementKind } from "../api.slint";
 
-export { CanvasCorner, PaletteComponentKind }
+export { CanvasCorner, ElementKind }
 
 export global StudioTheme {
     out property <bool> dark: Palette.color-scheme == ColorScheme.dark;
@@ -216,7 +216,7 @@ export component PrimerNavRow inherits Rectangle {
 }
 
 export component ComponentPaletteRow inherits Rectangle {
-    in property <PaletteComponentKind> kind;
+    in property <ElementKind> kind;
     in property <string> label;
     in property <bool> enabled: true;
     in property <bool> drag-enabled: true;
@@ -252,9 +252,9 @@ export component ComponentPaletteRow inherits Rectangle {
         Image {
             width: 18px;
             height: 18px;
-            source: root.kind == PaletteComponentKind.image ? EditorTreeIcons.image
-                : root.kind == PaletteComponentKind.rectangle ? EditorTreeIcons.rectangle
-                : root.kind == PaletteComponentKind.touch-area ? EditorTreeIcons.touch-area
+            source: root.kind == ElementKind.image ? EditorTreeIcons.image
+                : root.kind == ElementKind.rectangle ? EditorTreeIcons.rectangle
+                : root.kind == ElementKind.touch-area ? EditorTreeIcons.touch-area
                 : EditorTreeIcons.text;
             colorize: root.active ? StudioTheme.accent-strong : StudioTheme.text;
             opacity: root.active ? 1 : 0.5;
@@ -292,7 +292,7 @@ export component ComponentPaletteRow inherits Rectangle {
 }
 
 export global AppState {
-    in-out property <PaletteComponentKind> palette-drag-kind: PaletteComponentKind.none;
+    in-out property <ElementKind> palette-drag-kind: ElementKind.none;
     in-out property <Point> palette-drag-preview-position: { x: 0px, y: 0px };
     in-out property <Size> palette-drag-size: { width: 96px, height: 48px };
     in-out property <bool> palette-drag-cancelled: false;
@@ -304,23 +304,23 @@ export global AppState {
     in-out property <Size> outline-drag-preview-size: { width: 216px, height: 32px };
 
     public pure function has-active-drag() -> bool {
-        return self.palette-drag-kind != PaletteComponentKind.none || self.outline-drag-active;
+        return self.palette-drag-kind != ElementKind.none || self.outline-drag-active;
     }
 
-    pure function palette-drag-size-for-kind(kind: PaletteComponentKind) -> Size {
-        if kind == PaletteComponentKind.rectangle {
+    pure function palette-drag-size-for-kind(kind: ElementKind) -> Size {
+        if kind == ElementKind.rectangle {
             return { width: 160px, height: 64px };
         }
-        if kind == PaletteComponentKind.image || kind == PaletteComponentKind.touch-area {
+        if kind == ElementKind.image || kind == ElementKind.touch-area {
             return { width: 160px, height: 96px };
         }
-        if kind == PaletteComponentKind.text {
+        if kind == ElementKind.text {
             return { width: 220px, height: 40px };
         }
         return { width: 96px, height: 48px };
     }
 
-    public function update-palette-drag(kind: PaletteComponentKind, window-position: Point) {
+    public function update-palette-drag(kind: ElementKind, window-position: Point) {
         if !self.palette-drag-cancelled {
             self.palette-drag-kind = kind;
             self.palette-drag-size = self.palette-drag-size-for-kind(kind);
@@ -332,14 +332,14 @@ export global AppState {
     }
 
     public function finish-palette-drag() {
-        self.palette-drag-kind = PaletteComponentKind.none;
+        self.palette-drag-kind = ElementKind.none;
         self.palette-drag-cancelled = false;
     }
 
     public function cancel-palette-drag() {
-        if self.palette-drag-kind != PaletteComponentKind.none {
+        if self.palette-drag-kind != ElementKind.none {
             self.palette-drag-cancelled = true;
-            self.palette-drag-kind = PaletteComponentKind.none;
+            self.palette-drag-kind = ElementKind.none;
         }
     }
 

--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { Palette } from "std-widgets.slint";
-import { EditorTreeIcons } from "editor-tree-icons.slint";
+import { ElementVisuals } from "element-presentation.slint";
 import { Api, CanvasCorner, ElementKind } from "../api.slint";
 
 export { CanvasCorner, ElementKind }
@@ -252,10 +252,7 @@ export component ComponentPaletteRow inherits Rectangle {
         Image {
             width: 18px;
             height: 18px;
-            source: root.kind == ElementKind.image ? EditorTreeIcons.image
-                : root.kind == ElementKind.rectangle ? EditorTreeIcons.rectangle
-                : root.kind == ElementKind.touch-area ? EditorTreeIcons.touch-area
-                : EditorTreeIcons.text;
+            source: ElementVisuals.for-kind(root.kind).icon;
             colorize: root.active ? StudioTheme.accent-strong : StudioTheme.text;
             opacity: root.active ? 1 : 0.5;
         }
@@ -294,7 +291,7 @@ export component ComponentPaletteRow inherits Rectangle {
 export global AppState {
     in-out property <ElementKind> palette-drag-kind: ElementKind.none;
     in-out property <Point> palette-drag-preview-position: { x: 0px, y: 0px };
-    in-out property <Size> palette-drag-size: { width: 96px, height: 48px };
+    in-out property <Size> palette-drag-size: ElementVisuals.for-kind(ElementKind.none).preview-size;
     in-out property <bool> palette-drag-cancelled: false;
     in-out property <bool> outline-drag-active: false;
     in-out property <bool> outline-drag-cancelled: false;
@@ -307,23 +304,10 @@ export global AppState {
         return self.palette-drag-kind != ElementKind.none || self.outline-drag-active;
     }
 
-    pure function palette-drag-size-for-kind(kind: ElementKind) -> Size {
-        if kind == ElementKind.rectangle {
-            return { width: 160px, height: 64px };
-        }
-        if kind == ElementKind.image || kind == ElementKind.touch-area {
-            return { width: 160px, height: 96px };
-        }
-        if kind == ElementKind.text {
-            return { width: 220px, height: 40px };
-        }
-        return { width: 96px, height: 48px };
-    }
-
     public function update-palette-drag(kind: ElementKind, window-position: Point) {
         if !self.palette-drag-cancelled {
             self.palette-drag-kind = kind;
-            self.palette-drag-size = self.palette-drag-size-for-kind(kind);
+            self.palette-drag-size = ElementVisuals.for-kind(kind).preview-size;
             self.palette-drag-preview-position = {
                 x: window-position.x - self.palette-drag-size.width / 2,
                 y: window-position.y - self.palette-drag-size.height / 2,

--- a/tools/editor/ui/components/drag-preview.slint
+++ b/tools/editor/ui/components/drag-preview.slint
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { AppState, ElementKind, StudioTheme } from "common.slint";
+import { ElementPresentation, ElementVisuals } from "element-presentation.slint";
 import { EditorTreeTokens } from "editor-tree-tokens.slint";
 
 component PalettePlaceholderDragPreview inherits Rectangle {
@@ -41,6 +42,7 @@ component PalettePlaceholderDragPreview inherits Rectangle {
 
 export component DragPreview inherits Rectangle {
     in property <Point> parent-origin;
+    private property <ElementPresentation> presentation: ElementVisuals.for-kind(AppState.palette-drag-kind);
     private property <bool> palette-drag-active: AppState.palette-drag-kind != ElementKind.none;
     visible: AppState.outline-drag-active || root.palette-drag-active;
     width: AppState.outline-drag-active
@@ -57,19 +59,14 @@ export component DragPreview inherits Rectangle {
         : AppState.palette-drag-preview-position.y) - root.parent-origin.y;
     border-radius: AppState.outline-drag-active
         ? EditorTreeTokens.row-radius
-        : AppState.palette-drag-kind == ElementKind.touch-area ? 0px
-        : AppState.palette-drag-kind == ElementKind.image ? 16px : 8px;
+        : root.presentation.corner-radius;
     background: transparent;
     opacity: AppState.outline-drag-active ? 0.5 : 1;
     drop-shadow-blur: 18px;
     drop-shadow-offset-y: 8px;
     drop-shadow-color: StudioTheme.dark ? #00000055 : #33415535;
     accessible-role: AccessibleRole.region;
-    accessible-label: AppState.palette-drag-kind == ElementKind.rectangle ? "Rectangle drag preview"
-        : AppState.palette-drag-kind == ElementKind.text ? "Text drag preview"
-        : AppState.palette-drag-kind == ElementKind.image ? "Image drag preview"
-        : AppState.palette-drag-kind == ElementKind.touch-area ? "TouchArea drag preview"
-        : "Outline drag preview";
+    accessible-label: root.presentation.drag-label;
 
     if AppState.outline-drag-active: Rectangle {
         border-radius: EditorTreeTokens.row-radius;
@@ -105,7 +102,7 @@ export component DragPreview inherits Rectangle {
     }
 
     if !AppState.outline-drag-active && AppState.palette-drag-kind == ElementKind.rectangle: Rectangle {
-        border-radius: 8px;
+        border-radius: root.presentation.corner-radius;
         background: StudioTheme.object-bg;
         border-width: 1px;
         border-color: StudioTheme.object-border;
@@ -121,6 +118,6 @@ export component DragPreview inherits Rectangle {
 
     if !AppState.outline-drag-active && (AppState.palette-drag-kind == ElementKind.image || AppState.palette-drag-kind == ElementKind.touch-area): PalettePlaceholderDragPreview {
         corner-radius: root.border-radius;
-        show-thumbnail: AppState.palette-drag-kind == ElementKind.image;
+        show-thumbnail: root.presentation.show-thumbnail;
     }
 }

--- a/tools/editor/ui/components/drag-preview.slint
+++ b/tools/editor/ui/components/drag-preview.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { AppState, PaletteComponentKind, StudioTheme } from "common.slint";
+import { AppState, ElementKind, StudioTheme } from "common.slint";
 import { EditorTreeTokens } from "editor-tree-tokens.slint";
 
 component PalettePlaceholderDragPreview inherits Rectangle {
@@ -41,7 +41,7 @@ component PalettePlaceholderDragPreview inherits Rectangle {
 
 export component DragPreview inherits Rectangle {
     in property <Point> parent-origin;
-    private property <bool> palette-drag-active: AppState.palette-drag-kind != PaletteComponentKind.none;
+    private property <bool> palette-drag-active: AppState.palette-drag-kind != ElementKind.none;
     visible: AppState.outline-drag-active || root.palette-drag-active;
     width: AppState.outline-drag-active
         ? AppState.outline-drag-preview-size.width
@@ -57,18 +57,18 @@ export component DragPreview inherits Rectangle {
         : AppState.palette-drag-preview-position.y) - root.parent-origin.y;
     border-radius: AppState.outline-drag-active
         ? EditorTreeTokens.row-radius
-        : AppState.palette-drag-kind == PaletteComponentKind.touch-area ? 0px
-        : AppState.palette-drag-kind == PaletteComponentKind.image ? 16px : 8px;
+        : AppState.palette-drag-kind == ElementKind.touch-area ? 0px
+        : AppState.palette-drag-kind == ElementKind.image ? 16px : 8px;
     background: transparent;
     opacity: AppState.outline-drag-active ? 0.5 : 1;
     drop-shadow-blur: 18px;
     drop-shadow-offset-y: 8px;
     drop-shadow-color: StudioTheme.dark ? #00000055 : #33415535;
     accessible-role: AccessibleRole.region;
-    accessible-label: AppState.palette-drag-kind == PaletteComponentKind.rectangle ? "Rectangle drag preview"
-        : AppState.palette-drag-kind == PaletteComponentKind.text ? "Text drag preview"
-        : AppState.palette-drag-kind == PaletteComponentKind.image ? "Image drag preview"
-        : AppState.palette-drag-kind == PaletteComponentKind.touch-area ? "TouchArea drag preview"
+    accessible-label: AppState.palette-drag-kind == ElementKind.rectangle ? "Rectangle drag preview"
+        : AppState.palette-drag-kind == ElementKind.text ? "Text drag preview"
+        : AppState.palette-drag-kind == ElementKind.image ? "Image drag preview"
+        : AppState.palette-drag-kind == ElementKind.touch-area ? "TouchArea drag preview"
         : "Outline drag preview";
 
     if AppState.outline-drag-active: Rectangle {
@@ -104,14 +104,14 @@ export component DragPreview inherits Rectangle {
         }
     }
 
-    if !AppState.outline-drag-active && AppState.palette-drag-kind == PaletteComponentKind.rectangle: Rectangle {
+    if !AppState.outline-drag-active && AppState.palette-drag-kind == ElementKind.rectangle: Rectangle {
         border-radius: 8px;
         background: StudioTheme.object-bg;
         border-width: 1px;
         border-color: StudioTheme.object-border;
     }
 
-    if !AppState.outline-drag-active && AppState.palette-drag-kind == PaletteComponentKind.text: Text {
+    if !AppState.outline-drag-active && AppState.palette-drag-kind == ElementKind.text: Text {
         text: "Text";
         color: StudioTheme.phone-text;
         font-size: 24px;
@@ -119,8 +119,8 @@ export component DragPreview inherits Rectangle {
         vertical-alignment: center;
     }
 
-    if !AppState.outline-drag-active && (AppState.palette-drag-kind == PaletteComponentKind.image || AppState.palette-drag-kind == PaletteComponentKind.touch-area): PalettePlaceholderDragPreview {
+    if !AppState.outline-drag-active && (AppState.palette-drag-kind == ElementKind.image || AppState.palette-drag-kind == ElementKind.touch-area): PalettePlaceholderDragPreview {
         corner-radius: root.border-radius;
-        show-thumbnail: AppState.palette-drag-kind == PaletteComponentKind.image;
+        show-thumbnail: AppState.palette-drag-kind == ElementKind.image;
     }
 }

--- a/tools/editor/ui/components/drag-preview.slint
+++ b/tools/editor/ui/components/drag-preview.slint
@@ -66,7 +66,7 @@ export component DragPreview inherits Rectangle {
     drop-shadow-offset-y: 8px;
     drop-shadow-color: StudioTheme.dark ? #00000055 : #33415535;
     accessible-role: AccessibleRole.region;
-    accessible-label: root.presentation.drag-label;
+    accessible-label: AppState.outline-drag-active ? "Outline drag preview" : root.presentation.drag-label;
 
     if AppState.outline-drag-active: Rectangle {
         border-radius: EditorTreeTokens.row-radius;

--- a/tools/editor/ui/components/editor-canvas.slint
+++ b/tools/editor/ui/components/editor-canvas.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { Api, DropMark } from "../api.slint";
-import { AppState, EditorCursors, EditorMetrics, PaletteComponentKind, StudioTheme } from "common.slint";
+import { AppState, EditorCursors, EditorMetrics, ElementKind, StudioTheme } from "common.slint";
 import { CanvasInteractionLayer } from "canvas-interaction-layer.slint";
 
 component PhoneChrome inherits Rectangle {
@@ -94,7 +94,7 @@ export component EditorCanvas inherits Rectangle {
                     if AppState.palette-drag-cancelled {
                         return DragAction.none;
                     }
-                    if AppState.palette-drag-kind != PaletteComponentKind.none {
+                    if AppState.palette-drag-kind != ElementKind.none {
                         AppState.update-palette-drag(
                             AppState.palette-drag-kind,
                             {
@@ -108,7 +108,7 @@ export component EditorCanvas inherits Rectangle {
                         ? DragAction.copy : DragAction.none;
                 }
                 dropped(event) => {
-                    if AppState.palette-drag-kind != PaletteComponentKind.none {
+                    if AppState.palette-drag-kind != ElementKind.none {
                         let size = AppState.palette-drag-size;
                         Api.drop-with-geometry(
                             event.data,

--- a/tools/editor/ui/components/editor-tree-view.slint
+++ b/tools/editor/ui/components/editor-tree-view.slint
@@ -3,10 +3,10 @@
 
 import {
     DropLocation,
-    ElementKind,
     OutlineTreeNode,
 } from "../api.slint";
 import { AppState } from "common.slint";
+import { ElementVisuals } from "element-presentation.slint";
 import { EditorTreeIcons } from "editor-tree-icons.slint";
 import { EditorTreeTokens } from "editor-tree-tokens.slint";
 import { ListView } from "std-widgets.slint";
@@ -36,15 +36,7 @@ component EditorTreeRow {
     property <length> row-chrome-inset: EditorTreeTokens.disclosure-hit-size;
     property <DropLocation> active-drop-location: DropLocation.onto;
     property <bool> drop-allowed: false;
-    property <image> row-icon: node.icon-kind == ElementKind.rectangle
-        ? EditorTreeIcons.rectangle
-        : node.icon-kind == ElementKind.image
-        ? EditorTreeIcons.image
-        : node.icon-kind == ElementKind.text
-        ? EditorTreeIcons.text
-        : node.icon-kind == ElementKind.touch-area
-        ? EditorTreeIcons.touch-area
-        : EditorTreeIcons.default-item;
+    property <image> row-icon: ElementVisuals.for-kind(node.icon-kind).icon;
 
     vertical-stretch: 0;
     horizontal-stretch: 1;

--- a/tools/editor/ui/components/editor-tree-view.slint
+++ b/tools/editor/ui/components/editor-tree-view.slint
@@ -3,7 +3,7 @@
 
 import {
     DropLocation,
-    OutlineNodeIconKind,
+    ElementKind,
     OutlineTreeNode,
 } from "../api.slint";
 import { AppState } from "common.slint";
@@ -36,13 +36,13 @@ component EditorTreeRow {
     property <length> row-chrome-inset: EditorTreeTokens.disclosure-hit-size;
     property <DropLocation> active-drop-location: DropLocation.onto;
     property <bool> drop-allowed: false;
-    property <image> row-icon: node.icon-kind == OutlineNodeIconKind.rectangle
+    property <image> row-icon: node.icon-kind == ElementKind.rectangle
         ? EditorTreeIcons.rectangle
-        : node.icon-kind == OutlineNodeIconKind.image
+        : node.icon-kind == ElementKind.image
         ? EditorTreeIcons.image
-        : node.icon-kind == OutlineNodeIconKind.text
+        : node.icon-kind == ElementKind.text
         ? EditorTreeIcons.text
-        : node.icon-kind == OutlineNodeIconKind.touch-area
+        : node.icon-kind == ElementKind.touch-area
         ? EditorTreeIcons.touch-area
         : EditorTreeIcons.default-item;
 

--- a/tools/editor/ui/components/element-presentation.slint
+++ b/tools/editor/ui/components/element-presentation.slint
@@ -1,0 +1,61 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { ElementKind } from "../api.slint";
+import { EditorTreeIcons } from "editor-tree-icons.slint";
+
+export struct ElementPresentation {
+    icon: image,
+    preview-size: Size,
+    corner-radius: length,
+    show-thumbnail: bool,
+    drag-label: string,
+}
+
+export global ElementVisuals {
+    public pure function for-kind(kind: ElementKind) -> ElementPresentation {
+        if kind == ElementKind.rectangle {
+            return {
+                icon: EditorTreeIcons.rectangle,
+                preview-size: { width: 160px, height: 64px },
+                corner-radius: 8px,
+                show-thumbnail: false,
+                drag-label: "Rectangle drag preview",
+            };
+        }
+        if kind == ElementKind.text {
+            return {
+                icon: EditorTreeIcons.text,
+                preview-size: { width: 220px, height: 40px },
+                corner-radius: 8px,
+                show-thumbnail: false,
+                drag-label: "Text drag preview",
+            };
+        }
+        if kind == ElementKind.image {
+            return {
+                icon: EditorTreeIcons.image,
+                preview-size: { width: 160px, height: 96px },
+                corner-radius: 16px,
+                show-thumbnail: true,
+                drag-label: "Image drag preview",
+            };
+        }
+        if kind == ElementKind.touch-area {
+            return {
+                icon: EditorTreeIcons.touch-area,
+                preview-size: { width: 160px, height: 96px },
+                corner-radius: 0px,
+                show-thumbnail: false,
+                drag-label: "TouchArea drag preview",
+            };
+        }
+        return {
+            icon: EditorTreeIcons.default-item,
+            preview-size: { width: 96px, height: 48px },
+            corner-radius: 8px,
+            show-thumbnail: false,
+            drag-label: "Outline drag preview",
+        };
+    }
+}

--- a/tools/editor/ui/components/element-presentation.slint
+++ b/tools/editor/ui/components/element-presentation.slint
@@ -12,6 +12,7 @@ export struct ElementPresentation {
     drag-label: string,
 }
 
+// Primitive identity and grouping are defined in preview/element_catalog.rs.
 export global ElementVisuals {
     public pure function for-kind(kind: ElementKind) -> ElementPresentation {
         if kind == ElementKind.rectangle {
@@ -55,7 +56,7 @@ export global ElementVisuals {
             preview-size: { width: 96px, height: 48px },
             corner-radius: 8px,
             show-thumbnail: false,
-            drag-label: "Outline drag preview",
+            drag-label: "",
         };
     }
 }

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -6,7 +6,7 @@ import "./assets/Inter-VariableFont.ttf";
 import { Api, EditorSurfaceMode, Hover } from "api.slint";
 import { Project } from "project.slint";
 import { StartupWizard } from "startup-wizard.slint";
-import { AppState, PaletteComponentKind, SidebarToggleButton, StudioTheme } from "components/common.slint";
+import { AppState, ElementKind, SidebarToggleButton, StudioTheme } from "components/common.slint";
 import { DragPreview } from "components/drag-preview.slint";
 import { EditorCanvas } from "components/editor-canvas.slint";
 import { EditorTopBar } from "components/top-bar.slint";
@@ -121,7 +121,7 @@ export component EditorUi inherits Window {
 
             DropArea {
                 can-drop(event) => {
-                    if AppState.palette-drag-kind != PaletteComponentKind.none {
+                    if AppState.palette-drag-kind != ElementKind.none {
                         AppState.update-palette-drag(AppState.palette-drag-kind, { x: event.position.x + self.absolute-position.x, y: event.position.y + self.absolute-position.y });
                     }
                     return DragAction.none;


### PR DESCRIPTION
Palette, outline, and drag-preview metadata now share one element kind. Rust owns primitive identity and grouping; Slint owns icons and preview presentation. A completeness test checks every primitive kind, and outline drag labels are set explicitly.

Stacked on #13304. The base is `nigel/visual-editor-compact-inspector`.

Validation after rebasing onto the updated inspector PR: 163 Rust tests and 249 headless UI tests passed, with 47 existing skips. Autofix, lint, and Clippy passed. The conflict resolution preserves the parent’s drag-coordinate corrections. Headless captures verified the Image and TouchArea previews and live insertion. Goldens are unchanged.
