### PR TITLE
Add mismatched literal tests for match elements

### DIFF
--- a/internal/compiler/tests/syntax/match_element/cast.slint
+++ b/internal/compiler/tests/syntax/match_element/cast.slint
@@ -39,17 +39,25 @@ enum MyEnum{
     val2
 }
 
-export component Baz {
+export component MismatchedLiterals {
 
     in property <string> str: "string";
     match str {
         #123 : Rectangle { }
 //      >   <error{Cannot convert color to string}
+        red: { }
+//      > <error{Unknown unqualified identifier 'red'. Did you mean 'Colors.red'?}
+//      > <^error{Cases must be literal values}
+        Colors.lightsteelblue: { }
+//      >                   <error{Cannot convert color to string}
         @markdown("hello"): Rectangle {}
 //      >                <error{Cannot convert styled-text to string}
 //      >                <^error{Cases must be literal values}
         MyEnum.val2 : Rectangle {}
 //      >          <error{Cannot convert MyEnum to string}
+        val1: { }
+//      >  <error{Unknown unqualified identifier 'val1'. Did you mean 'MyEnum.val1'?}
+//      >  <^error{Cases must be literal values}
     }
 }
 

--- a/internal/compiler/tests/syntax/match_element/cast.slint
+++ b/internal/compiler/tests/syntax/match_element/cast.slint
@@ -68,3 +68,14 @@ export component CastWithWildcard {
         *: Rectangle { }
     }
 }
+
+export component ColorCast {
+    in property <color> chosen-color: Colors.lightsteelblue;
+
+    match chosen-color {
+        #ff0000: Text { text: "red literal"; }
+        Colors.lightsteelblue: Text { text: "fully-qualified named color"; }
+        black: Text { text: "type-based lookup named color"; }
+        *: {}
+    }
+}

--- a/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
+++ b/internal/compiler/tests/syntax/match_element/duplicate_cases.slint
@@ -44,6 +44,11 @@ export component DuplicateCaseWithColor {
         #456: Rectangle { }
         #123: Rectangle { }
 //      >  <error{Duplicate case value}
+        #ff0000: Text { text: "red literal"; }
+        red: Text { text: "named color red"; }
+//      > <error{Duplicate case value}
+        Colors.red: Text { text: "fully-qualified named color red"; }
+//      >        <error{Duplicate case value}
         *: Rectangle { }
     }
 }

--- a/internal/compiler/tests/syntax/match_element/literals.slint
+++ b/internal/compiler/tests/syntax/match_element/literals.slint
@@ -53,3 +53,20 @@ export component FooBar {
         "hello": Rectangle { }
     }
 }
+
+enum Fruit {
+    apple,
+    pear,
+    orange,
+    tomato,
+}
+
+export component TypeBasedLookupOfEnumCases {
+    in property <Fruit> fruit: Fruit.tomato;
+
+    match fruit {
+        apple: Text { text: "unqualified Fruit"; }
+        Fruit.pear: Text { text: "fully qualified Fruit"; }
+        * : { }
+    }
+}


### PR DESCRIPTION
Checks off the following from #1307:

> Tests that mismatched literal kinds are rejected (e.g. a color or enum value as a case for a string match)

Add syntax tests to verify that:
- casts between the different colour types (literals, fully-qualified named colours, and unqualified named colours) work as match cases;
- duplicates are detected between these different colour types.

Verify that colour and enum kinds (in their various forms) cannot be matched against a match element expecting a string.

Add an explicit test to verify that the both fully-qualified and unqualified enums are valid cases in match elements.