### PR TITLE
Introduce interface inheritance

### DIFF
--- a/docs/astro/src/content/docs/guide/experimental/interface.mdx
+++ b/docs/astro/src/content/docs/guide/experimental/interface.mdx
@@ -33,6 +33,25 @@ An interface body may contain:
 An interface body may **not** contain bindings, child elements, layouts, `states`, two-way bindings, `animate` blocks, or private properties.
 An interface can be exported with `export interface`.
 
+## Inheriting an Interface
+
+An interface can extend another with `inherits`:
+
+```slint no-test
+interface Named {
+    in-out property <string> name;
+}
+
+interface Greeter inherits Named {
+    callback greet();
+}
+```
+
+`Greeter`'s contract is `name` and `greet`, so a component implementing `Greeter` must provide both.
+An interface can only inherit another interface.
+
+Redeclaring a member the base already declares is an error.
+
 ## Implementing an interface
 
 A component declares that it implements an interface with an `implement I <=> self;` statement in its body.

--- a/docs/development/type-system.md
+++ b/docs/development/type-system.md
@@ -119,6 +119,7 @@ Elements (components/items) have their own type hierarchy.
 component, `Builtin` for a built-in item such as `Rectangle` or `Text`, `Native` once the
 `resolve_native_classes` pass has run, `Error` when the base type couldn't be looked up, and
 `Global` / `Interface` for the root element of a global or an interface.
+`Interface` carries the interface it inherits, if any.
 
 ### Property Lookup on Elements
 

--- a/editors/tree-sitter-slint/grammar.js
+++ b/editors/tree-sitter-slint/grammar.js
@@ -214,7 +214,12 @@ module.exports = grammar({
       ),
 
     interface_definition: ($) =>
-      seq("interface", field("name", $.user_type_identifier), $.interface_block),
+      seq(
+        "interface",
+        field("name", $.user_type_identifier),
+        optional($.component_modifier),
+        $.interface_block,
+      ),
 
     struct_field_definition: ($) =>
       seq(

--- a/internal/compiler/generator.rs
+++ b/internal/compiler/generator.rs
@@ -477,7 +477,7 @@ pub fn for_each_const_properties(
                 ElementType::Builtin(_) => {
                     unreachable!("builtin element should have been resolved")
                 }
-                ElementType::Global | ElementType::Interface | ElementType::Error => break,
+                ElementType::Global | ElementType::Interface(_) | ElementType::Error => break,
             }
         }
         for c in all_prop {

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -488,15 +488,17 @@ impl PartialEq for ElementType {
 impl ElementType {
     /// Resolve a name written in `.slint` source.
     /// Resolve `name` in the given [`PropertyLookupMode`]. See
-    /// [`crate::object_tree::Element::lookup_property`]. Only a component can have shadowed members,
-    /// so the other bases ignore the mode.
+    /// [`crate::object_tree::Element::lookup_property`]. Only a component or an interface can have
+    /// shadowed members, so the other bases ignore the mode.
     pub fn lookup_property<'a>(
         &self,
         name: &'a str,
         mode: PropertyLookupMode,
     ) -> PropertyLookupResult<'a> {
         match self {
-            Self::Component(c) => c.root_element.borrow().lookup_property(name, mode),
+            Self::Component(c) | Self::Interface(Some(c)) => {
+                c.root_element.borrow().lookup_property(name, mode)
+            }
             Self::Builtin(b) => {
                 let resolved_name =
                     if let Some(alias_name) = b.native_class.lookup_alias(name.as_ref()) {
@@ -558,7 +560,9 @@ impl ElementType {
     /// Return the node declaring `name` in this type or one of its bases, if there is one.
     pub fn property_declaration_node(&self, name: &str) -> Option<SyntaxNode> {
         match self {
-            Self::Component(c) => c.root_element.borrow().property_declaration_node(name),
+            Self::Component(c) | Self::Interface(Some(c)) => {
+                c.root_element.borrow().property_declaration_node(name)
+            }
             _ => None,
         }
     }
@@ -566,7 +570,7 @@ impl ElementType {
     /// List of sub properties valid for the auto completion
     pub fn property_list(&self) -> Vec<(SmolStr, Type)> {
         match self {
-            Self::Component(c) => {
+            Self::Component(c) | Self::Interface(Some(c)) => {
                 let root = c.root_element.borrow();
                 let mut r = root.base_type.property_list();
                 // A visible shadowing declaration replaces the inherited entry of the same name.

--- a/internal/compiler/langtype.rs
+++ b/internal/compiler/langtype.rs
@@ -465,8 +465,9 @@ pub enum ElementType {
     Error,
     /// This should be the base type of the root element of a global component
     Global,
-    /// This should be the base type of the root element of an interface
-    Interface,
+    /// This should be the base type of the root element of an interface.
+    /// The payload is the interface this one inherits, if any.
+    Interface(Option<Rc<Component>>),
 }
 
 impl PartialEq for ElementType {
@@ -475,9 +476,10 @@ impl PartialEq for ElementType {
             (Self::Component(a), Self::Component(b)) => Rc::ptr_eq(a, b),
             (Self::Builtin(a), Self::Builtin(b)) => Rc::ptr_eq(a, b),
             (Self::Native(a), Self::Native(b)) => Arc::ptr_eq(a, b),
-            (Self::Error, Self::Error)
-            | (Self::Global, Self::Global)
-            | (Self::Interface, Self::Interface) => true,
+            (Self::Interface(a), Self::Interface(b)) => {
+                a.as_ref().map(Rc::as_ptr) == b.as_ref().map(Rc::as_ptr)
+            }
+            (Self::Error, Self::Error) | (Self::Global, Self::Global) => true,
             _ => false,
         }
     }
@@ -719,7 +721,7 @@ impl ElementType {
             ElementType::Native(_) => None, // Too late, caller should call this function before the native class lowering
             ElementType::Error => None,
             ElementType::Global => None,
-            ElementType::Interface => None,
+            ElementType::Interface(_) => None,
         }
     }
 }
@@ -732,7 +734,7 @@ impl Display for ElementType {
             Self::Native(b) => b.class_name.fmt(f),
             Self::Error => write!(f, "<error>"),
             Self::Global => Ok(()),
-            Self::Interface => Ok(()),
+            Self::Interface(_) => Ok(()),
         }
     }
 }

--- a/internal/compiler/namedreference.rs
+++ b/internal/compiler/namedreference.rs
@@ -141,7 +141,7 @@ impl NamedReference {
                 }
                 crate::langtype::ElementType::Error
                 | crate::langtype::ElementType::Global
-                | crate::langtype::ElementType::Interface => {
+                | crate::langtype::ElementType::Interface(_) => {
                     return true;
                 }
             }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1586,7 +1586,6 @@ impl Element {
     ) -> ElementRc {
         // A child element's parent_type is the type of its parent; the root
         // gets a sentinel from Component::from_node
-        #[cfg(feature = "slint-sc")]
         let is_component_root =
             !matches!(parent_type, ElementType::Builtin(_) | ElementType::Component(_));
         let base_type = if let Some(base_node) = node.QualifiedName() {
@@ -1598,6 +1597,15 @@ impl Element {
                         "Cannot create an instance of a global component".into(),
                         &base_node,
                     );
+                    ElementType::Error
+                }
+                Ok(ElementType::Component(c)) if c.is_interface() && is_component_root => {
+                    let message = if parent_type == ElementType::Interface {
+                        "Interface inheritance is not supported yet"
+                    } else {
+                        "Components cannot inherit from interfaces"
+                    };
+                    diag.push_error(message.into(), &base_node);
                     ElementType::Error
                 }
                 Ok(ty) => {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -1599,13 +1599,18 @@ impl Element {
                     );
                     ElementType::Error
                 }
-                Ok(ElementType::Component(c)) if c.is_interface() && is_component_root => {
-                    let message = if parent_type == ElementType::Interface {
-                        "Interface inheritance is not supported yet"
+                Ok(ElementType::Component(c)) if c.is_interface() => {
+                    let message = if !is_component_root {
+                        format!(
+                            "Cannot create an instance of an interface; write 'implement {} <=> self;' to implement it",
+                            c.id
+                        )
+                    } else if parent_type == ElementType::Interface {
+                        "Interface inheritance is not supported yet".into()
                     } else {
-                        "Components cannot inherit from interfaces"
+                        "Components cannot inherit from interfaces".into()
                     };
-                    diag.push_error(message.into(), &base_node);
+                    diag.push_error(message, &base_node);
                     ElementType::Error
                 }
                 Ok(ty) => {

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -564,7 +564,7 @@ impl Component {
                         if reject_experimental_feature(diag, tr, "interface", &node) {
                             ElementType::Error
                         } else {
-                            ElementType::Interface
+                            ElementType::Interface(None)
                         }
                     }
                     _ => ElementType::Error,
@@ -686,7 +686,7 @@ impl Component {
 
     /// This is an interface introduced with the "interface" keyword
     pub fn is_interface(&self) -> bool {
-        matches!(&self.root_element.borrow().base_type, ElementType::Interface)
+        matches!(&self.root_element.borrow().base_type, ElementType::Interface(_))
     }
 
     /// True if this component's root resolves to the `SystemTrayIcon` native
@@ -1605,7 +1605,7 @@ impl Element {
                             "Cannot create an instance of an interface; write 'implement {} <=> self;' to implement it",
                             c.id
                         )
-                    } else if parent_type == ElementType::Interface {
+                    } else if matches!(parent_type, ElementType::Interface(_)) {
                         "Interface inheritance is not supported yet".into()
                     } else {
                         "Components cannot inherit from interfaces".into()
@@ -1632,12 +1632,12 @@ impl Element {
                     ElementType::Error
                 }
             }
-        } else if parent_type == ElementType::Global || parent_type == ElementType::Interface {
+        } else if matches!(parent_type, ElementType::Global | ElementType::Interface(_)) {
             // This must be a global component or interface. It can only have properties and callbacks
             let mut error_on = |node: &dyn Spanned, what: &str| {
                 let element_type = match parent_type {
                     ElementType::Global => "A global component",
-                    ElementType::Interface => "An interface",
+                    ElementType::Interface(_) => "An interface",
                     _ => "An unexpected type",
                 };
                 diag.push_error(format!("{element_type} cannot have {what}"), node);
@@ -1663,7 +1663,7 @@ impl Element {
             node.MatchElement().for_each(|n| error_on(&n, "match elements"));
             node.SlotDeclaration().for_each(|n| error_on(&n, "slots"));
 
-            if parent_type == ElementType::Interface {
+            if matches!(parent_type, ElementType::Interface(_)) {
                 node.Binding().for_each(|n| error_on(&n, "bindings"));
                 node.TwoWayBinding().for_each(|n| error_on(&n, "two-way bindings"));
 
@@ -1684,7 +1684,7 @@ impl Element {
         } else {
             tr.empty_type()
         };
-        let is_interface = base_type == ElementType::Interface;
+        let is_interface = matches!(base_type, ElementType::Interface(_));
         // This isn't truly qualified yet, the enclosing component is added at the end of Component::from_node
         let qualified_id = (!id.is_empty()).then(|| id.clone());
         if let ElementType::Component(c) = &base_type {
@@ -1847,7 +1847,7 @@ impl Element {
         }
 
         let (implemented_interfaces, child_implements) =
-            if matches!(r.base_type, ElementType::Global | ElementType::Interface) {
+            if matches!(r.base_type, ElementType::Global | ElementType::Interface(_)) {
                 // Already rejected above with a more specific diagnostic.
                 (Vec::new(), Vec::new())
             } else if r.id == "root" {
@@ -2110,14 +2110,14 @@ impl Element {
             };
 
             match (base_type.clone(), func.CodeBlock()) {
-                (ElementType::Interface, Some(code_block)) => {
+                (ElementType::Interface(_), Some(code_block)) => {
                     diag.push_error(
                         "Function declarations in interfaces must not have a body".into(),
                         &code_block,
                     );
                     continue;
                 }
-                (ElementType::Interface, None) => {
+                (ElementType::Interface(_), None) => {
                     // Do not create a binding for this function, as it is just a declaration without body. It will be
                     // implemented by the component that implements the interface.
                     r.property_declarations.insert(name, declaration);

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -895,6 +895,57 @@ fn from_base(mut r: PropertyLookupResult<'_>) -> PropertyLookupResult<'_> {
     r
 }
 
+fn disallow_non_member_content(
+    node: &syntax_nodes::Element,
+    declaration: &ElementType,
+    diag: &mut BuildDiagnostics,
+) {
+    let mut error_on = |node: &dyn Spanned, what: &str| {
+        let element_type = match declaration {
+            ElementType::Global => "A global component",
+            ElementType::Interface(_) => "An interface",
+            _ => "An unexpected type",
+        };
+        diag.push_error(format!("{element_type} cannot have {what}"), node);
+    };
+    node.SubElement().for_each(|n| error_on(&n, "sub elements"));
+    node.RepeatedElement().for_each(|n| error_on(&n, "sub elements"));
+    if let Some(n) = node.ChildrenPlaceholder() {
+        error_on(&n, "sub elements");
+    }
+    node.PropertyAnimation().for_each(|n| error_on(&n, "animations"));
+    node.States().for_each(|n| error_on(&n, "states"));
+    node.Transitions().for_each(|n| error_on(&n, "transitions"));
+    node.CallbackDeclaration().for_each(|cb| {
+        if parser::identifier_text(&cb.DeclaredIdentifier()).is_some_and(|s| s == "init") {
+            error_on(&cb, "an 'init' callback")
+        }
+    });
+    node.CallbackConnection().for_each(|cb| {
+        if parser::identifier_text(&cb).is_some_and(|s| s == "init") {
+            error_on(&cb, "an 'init' callback")
+        }
+    });
+    node.MatchElement().for_each(|n| error_on(&n, "match elements"));
+    node.SlotDeclaration().for_each(|n| error_on(&n, "slots"));
+
+    if matches!(declaration, ElementType::Interface(_)) {
+        node.Binding().for_each(|n| error_on(&n, "bindings"));
+        node.TwoWayBinding().for_each(|n| error_on(&n, "two-way bindings"));
+
+        node.ImplementStatement().for_each(|stmt| {
+            diag.push_error(
+                "Interfaces cannot implement another interface, use 'inherits' instead".into(),
+                &stmt,
+            );
+        });
+    } else {
+        node.ImplementStatement().for_each(|stmt| {
+            diag.push_error("Globals cannot implement an interface".into(), &stmt);
+        });
+    }
+}
+
 /// The error for a declaration that collides with a member it may not shadow.
 /// `kind` is `None` for a function.
 fn cannot_override_message(
@@ -1584,11 +1635,35 @@ impl Element {
         diag: &mut BuildDiagnostics,
         tr: &TypeRegister,
     ) -> ElementRc {
-        // A child element's parent_type is the type of its parent; the root
-        // gets a sentinel from Component::from_node
-        let is_component_root =
-            !matches!(parent_type, ElementType::Builtin(_) | ElementType::Component(_));
-        let base_type = if let Some(base_node) = node.QualifiedName() {
+        // Every element but a declaration's root sits inside a SubElement.
+        let is_component_root = node.parent().is_some_and(|n| n.kind() == SyntaxKind::Component);
+        let is_interface_declaration =
+            is_component_root && matches!(parent_type, ElementType::Interface(_));
+        let base_type = if is_interface_declaration {
+            disallow_non_member_content(&node, &parent_type, diag);
+            match node.QualifiedName() {
+                None => ElementType::Interface(None),
+                Some(base_node) => {
+                    let base = QualifiedTypeName::from_node(base_node.clone());
+                    match parent_type.lookup_type_for_child_element(&base.to_smolstr(), tr) {
+                        Ok(ElementType::Component(c)) if c.is_interface() => {
+                            ElementType::Interface(Some(c))
+                        }
+                        Ok(_) => {
+                            diag.push_error(
+                                "An interface can only inherit another interface".into(),
+                                &base_node,
+                            );
+                            ElementType::Interface(None)
+                        }
+                        Err(err) => {
+                            diag.push_error(err, &base_node);
+                            ElementType::Interface(None)
+                        }
+                    }
+                }
+            }
+        } else if let Some(base_node) = node.QualifiedName() {
             let base = QualifiedTypeName::from_node(base_node.clone());
             let base_string = base.to_smolstr();
             match parent_type.lookup_type_for_child_element(&base_string, tr) {
@@ -1600,15 +1675,13 @@ impl Element {
                     ElementType::Error
                 }
                 Ok(ElementType::Component(c)) if c.is_interface() => {
-                    let message = if !is_component_root {
+                    let message = if is_component_root {
+                        "Components cannot inherit from interfaces".into()
+                    } else {
                         format!(
                             "Cannot create an instance of an interface; write 'implement {} <=> self;' to implement it",
                             c.id
                         )
-                    } else if matches!(parent_type, ElementType::Interface(_)) {
-                        "Interface inheritance is not supported yet".into()
-                    } else {
-                        "Components cannot inherit from interfaces".into()
                     };
                     diag.push_error(message, &base_node);
                     ElementType::Error
@@ -1632,50 +1705,8 @@ impl Element {
                     ElementType::Error
                 }
             }
-        } else if matches!(parent_type, ElementType::Global | ElementType::Interface(_)) {
-            // This must be a global component or interface. It can only have properties and callbacks
-            let mut error_on = |node: &dyn Spanned, what: &str| {
-                let element_type = match parent_type {
-                    ElementType::Global => "A global component",
-                    ElementType::Interface(_) => "An interface",
-                    _ => "An unexpected type",
-                };
-                diag.push_error(format!("{element_type} cannot have {what}"), node);
-            };
-            node.SubElement().for_each(|n| error_on(&n, "sub elements"));
-            node.RepeatedElement().for_each(|n| error_on(&n, "sub elements"));
-            if let Some(n) = node.ChildrenPlaceholder() {
-                error_on(&n, "sub elements");
-            }
-            node.PropertyAnimation().for_each(|n| error_on(&n, "animations"));
-            node.States().for_each(|n| error_on(&n, "states"));
-            node.Transitions().for_each(|n| error_on(&n, "transitions"));
-            node.CallbackDeclaration().for_each(|cb| {
-                if parser::identifier_text(&cb.DeclaredIdentifier()).is_some_and(|s| s == "init") {
-                    error_on(&cb, "an 'init' callback")
-                }
-            });
-            node.CallbackConnection().for_each(|cb| {
-                if parser::identifier_text(&cb).is_some_and(|s| s == "init") {
-                    error_on(&cb, "an 'init' callback")
-                }
-            });
-            node.MatchElement().for_each(|n| error_on(&n, "match elements"));
-            node.SlotDeclaration().for_each(|n| error_on(&n, "slots"));
-
-            if matches!(parent_type, ElementType::Interface(_)) {
-                node.Binding().for_each(|n| error_on(&n, "bindings"));
-                node.TwoWayBinding().for_each(|n| error_on(&n, "two-way bindings"));
-
-                node.ImplementStatement().for_each(|stmt| {
-                    diag.push_error("Interfaces cannot implement another interface".into(), &stmt);
-                });
-            } else {
-                node.ImplementStatement().for_each(|stmt| {
-                    diag.push_error("Globals cannot implement an interface".into(), &stmt);
-                });
-            }
-
+        } else if parent_type == ElementType::Global {
+            disallow_non_member_content(&node, &parent_type, diag);
             parent_type
         } else if parent_type != ElementType::Error {
             // This should normally never happen because the parser does not allow for this
@@ -1687,7 +1718,7 @@ impl Element {
         let is_interface = matches!(base_type, ElementType::Interface(_));
         // This isn't truly qualified yet, the enclosing component is added at the end of Component::from_node
         let qualified_id = (!id.is_empty()).then(|| id.clone());
-        if let ElementType::Component(c) = &base_type {
+        if let ElementType::Component(c) | ElementType::Interface(Some(c)) = &base_type {
             c.used.set(true);
         }
         let type_name = base_type
@@ -3158,7 +3189,9 @@ impl Element {
     fn declaring_base_component(&self, name: &str) -> Option<Rc<Component>> {
         let mut base = self.base_type.clone();
         loop {
-            let ElementType::Component(c) = base else { return None };
+            let (ElementType::Component(c) | ElementType::Interface(Some(c))) = base else {
+                return None;
+            };
             let declares = {
                 let root = c.root_element.borrow();
                 root.shadowing_members.contains_key(name)

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -144,6 +144,26 @@ fn resolve_implement_statement(
     }
 }
 
+/// The members an interface declares under their source names, including inherited ones.
+/// A derived declaration hides the inherited member of the same name.
+/// A shadowing declaration counts as derived, too.
+fn declared_members(interface: &ElementRc) -> BTreeMap<SmolStr, PropertyDeclaration> {
+    let mut members = BTreeMap::new();
+    let mut next = Some(interface.clone());
+    while let Some(element) = next.take() {
+        let element = element.borrow();
+        for (internal_name, declaration) in &element.property_declarations {
+            members.entry(declaration.declared_name(internal_name).clone()).or_insert_with(|| {
+                PropertyDeclaration { shadowed_name: None, ..declaration.clone() }
+            });
+        }
+        if let ElementType::Interface(Some(base)) = &element.base_type {
+            next = Some(base.root_element.clone());
+        }
+    }
+    members
+}
+
 fn filter_conflicting_implement_statements(
     diagnostics: &mut BuildDiagnostics,
     statements: Vec<ImplementedInterface>,
@@ -165,8 +185,8 @@ fn filter_conflicting_implement_statements(
             seen_interfaces.push(stmt.interface.clone());
 
             let mut valid = true;
-            for prop_name in stmt.interface.borrow().property_declarations.keys() {
-                if let Some(existing_interface) = seen_interface_api.get(prop_name) {
+            for prop_name in declared_members(&stmt.interface).into_keys() {
+                if let Some(existing_interface) = seen_interface_api.get(&prop_name) {
                     diagnostics.push_error(
                         format!(
                             "'{}' occurs in '{}' and '{}'",
@@ -176,7 +196,7 @@ fn filter_conflicting_implement_statements(
                     );
                     valid = false;
                 } else {
-                    seen_interface_api.insert(prop_name.clone(), stmt.interface_name.clone());
+                    seen_interface_api.insert(prop_name, stmt.interface_name.clone());
                 }
             }
             valid
@@ -332,11 +352,11 @@ fn validate_interface_implementation(
 ) -> bool {
     let mut errors = Vec::new();
     let mut notes = Vec::new();
-    for (member_name, member_declaration) in interface.borrow().property_declarations.iter() {
+    for (member_name, member_declaration) in declared_members(interface) {
         if let Some(mut conflict) = validate_interface_member_implementation(
             element,
-            member_name,
-            member_declaration,
+            &member_name,
+            &member_declaration,
             interface_name,
             binding,
         ) {
@@ -442,21 +462,21 @@ pub(super) fn apply_child_implement_statements(
 
         let mut conflicts = Vec::new();
         let mut notes = Vec::new();
-        for (name, prop_decl) in interface.borrow().property_declarations.iter() {
+        for (name, mut prop_decl) in declared_members(&interface) {
             let lookup_result = element
                 .borrow()
                 .base_type
-                .lookup_property(name, PropertyLookupMode::ComponentLocal);
+                .lookup_property(&name, PropertyLookupMode::ComponentLocal);
             if let Err(message) =
                 check_property_declaration_conflicts(&lookup_result, &element.borrow().base_type)
             {
                 conflicts.push(message);
-                if let Some(source) = element.borrow().property_declaration_node(name) {
+                if let Some(source) = element.borrow().property_declaration_node(&name) {
                     notes.push(NoteWithSource {
                         note: declared_here_note(
-                            name,
+                            &name,
                             &interface_name,
-                            &syntax_for_declaration(prop_decl, name),
+                            &syntax_for_declaration(&prop_decl, &name),
                             &source,
                         ),
                         source: DeclarationAnchor::Name.source_location(&source),
@@ -467,12 +487,13 @@ pub(super) fn apply_child_implement_statements(
 
             // Replace the node with the interface name for better diagnostics later, since the declaration won't have a
             // node in this element.
-            let mut prop_decl = prop_decl.clone();
             prop_decl.node = Some(node.QualifiedName().into());
 
             // A shadowing declaration also occupies the name, though stored under a different one
-            let shadowing =
-                element.borrow().declaration(name).map(|(_, declaration)| declaration.node.clone());
+            let shadowing = element
+                .borrow()
+                .declaration(&name)
+                .map(|(_, declaration)| declaration.node.clone());
             let existing_node = shadowing.or_else(|| {
                 element
                     .borrow_mut()
@@ -497,8 +518,8 @@ pub(super) fn apply_child_implement_statements(
                 diagnostics.push_note(
                     declares_as_note(
                         &interface_name,
-                        name,
-                        &syntax_for_declaration(&prop_decl, name),
+                        &name,
+                        &syntax_for_declaration(&prop_decl, &name),
                     ),
                     &node.QualifiedName(),
                 );
@@ -507,11 +528,11 @@ pub(super) fn apply_child_implement_statements(
 
             let existing_binding = match &prop_decl.property_type {
                 Type::Function(func) => {
-                    apply_uses_statement_function_binding(element, &child, name, func)
+                    apply_uses_statement_function_binding(element, &child, &name, func)
                 }
                 _ => element.borrow_mut().set_binding(
                     name.clone(),
-                    BindingExpression::new_two_way(member_reference(&child, name).into()),
+                    BindingExpression::new_two_way(member_reference(&child, &name).into()),
                 ),
             };
             debug_assert!(

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -224,6 +224,12 @@ fn filter_inherited_implement_statements(
         .collect()
 }
 
+struct SeenInterface {
+    interface: ElementRc,
+    interface_name: SmolStr,
+    node: syntax_nodes::ImplementStatement,
+}
+
 struct SeenMember {
     interface_name: SmolStr,
     declaring_interface: ElementRc,
@@ -234,21 +240,36 @@ fn filter_conflicting_implement_statements(
     diagnostics: &mut BuildDiagnostics,
     statements: Vec<ImplementedInterface>,
 ) -> Vec<ImplementedInterface> {
-    let mut seen_interfaces: Vec<ElementRc> = Vec::new();
+    let mut seen_interfaces: Vec<SeenInterface> = Vec::new();
     let mut seen_interface_api: BTreeMap<SmolStr, SeenMember> = BTreeMap::new();
     statements
         .into_iter()
         .filter(|stmt| {
-            // Interface identity is the resolved interface's root element, not the syntactic name,
-            // so this also catches the same interface implemented twice under different aliases.
-            if seen_interfaces.iter().any(|seen| Rc::ptr_eq(seen, &stmt.interface)) {
+            if let Some(seen) =
+                seen_interfaces.iter().find(|seen| Rc::ptr_eq(&seen.interface, &stmt.interface))
+            {
                 diagnostics.push_error(
                     format!("'{}' is implemented multiple times", stmt.interface_name),
                     &stmt.node,
                 );
+                diagnostics.push_note(
+                    if seen.interface_name == stmt.interface_name {
+                        format!("'{}' is implemented here", seen.interface_name)
+                    } else {
+                        format!(
+                            "'{}' names the same interface as '{}'",
+                            seen.interface_name, stmt.interface_name
+                        )
+                    },
+                    &seen.node,
+                );
                 return false;
             }
-            seen_interfaces.push(stmt.interface.clone());
+            seen_interfaces.push(SeenInterface {
+                interface: stmt.interface.clone(),
+                interface_name: stmt.interface_name.clone(),
+                node: stmt.node.clone(),
+            });
 
             let target_id = stmt.binding.target_id();
             let mut valid = true;

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -44,6 +44,8 @@ fn check_property_declaration_conflicts(
     }
 }
 
+const SELF_ID: &str = "self";
+
 #[derive(Debug, PartialEq)]
 pub(super) enum ImplementBinding {
     OnSelf,
@@ -57,13 +59,20 @@ pub(super) enum ImplementBinding {
 
 impl ImplementBinding {
     fn from_target(target_id: &SmolStr, target_name: &SmolStr) -> ImplementBinding {
-        if target_id.as_str() == "self" {
+        if target_id.as_str() == SELF_ID {
             ImplementBinding::OnSelf
         } else {
             ImplementBinding::OnChild {
                 child_id: target_id.clone(),
                 child_name: target_name.clone(),
             }
+        }
+    }
+
+    fn target_id(&self) -> SmolStr {
+        match self {
+            ImplementBinding::OnSelf => SmolStr::new_static(SELF_ID),
+            ImplementBinding::OnChild { child_id, .. } => child_id.clone(),
         }
     }
 }
@@ -151,15 +160,23 @@ fn interface_chain(interface: &ElementRc) -> impl Iterator<Item = ElementRc> {
     })
 }
 
+struct InterfaceMember {
+    declaration: PropertyDeclaration,
+    declaring_interface: ElementRc,
+}
+
 /// The members an interface declares under their source names, including inherited ones.
 /// A derived declaration hides the inherited member of the same name.
 /// A shadowing declaration counts as derived, too.
-fn declared_members(interface: &ElementRc) -> BTreeMap<SmolStr, PropertyDeclaration> {
+fn declared_members(interface: &ElementRc) -> BTreeMap<SmolStr, InterfaceMember> {
     let mut members = BTreeMap::new();
     for element in interface_chain(interface) {
         for (internal_name, declaration) in &element.borrow().property_declarations {
             members.entry(declaration.declared_name(internal_name).clone()).or_insert_with(|| {
-                PropertyDeclaration { shadowed_name: None, ..declaration.clone() }
+                InterfaceMember {
+                    declaration: PropertyDeclaration { shadowed_name: None, ..declaration.clone() },
+                    declaring_interface: element.clone(),
+                }
             });
         }
     }
@@ -207,12 +224,18 @@ fn filter_inherited_implement_statements(
         .collect()
 }
 
+struct SeenMember {
+    interface_name: SmolStr,
+    declaring_interface: ElementRc,
+    target_id: SmolStr,
+}
+
 fn filter_conflicting_implement_statements(
     diagnostics: &mut BuildDiagnostics,
     statements: Vec<ImplementedInterface>,
 ) -> Vec<ImplementedInterface> {
     let mut seen_interfaces: Vec<ElementRc> = Vec::new();
-    let mut seen_interface_api: BTreeMap<SmolStr, SmolStr> = BTreeMap::new();
+    let mut seen_interface_api: BTreeMap<SmolStr, SeenMember> = BTreeMap::new();
     statements
         .into_iter()
         .filter(|stmt| {
@@ -227,19 +250,31 @@ fn filter_conflicting_implement_statements(
             }
             seen_interfaces.push(stmt.interface.clone());
 
+            let target_id = stmt.binding.target_id();
             let mut valid = true;
-            for prop_name in declared_members(&stmt.interface).into_keys() {
-                if let Some(existing_interface) = seen_interface_api.get(&prop_name) {
-                    diagnostics.push_error(
-                        format!(
-                            "'{}' occurs in '{}' and '{}'",
-                            prop_name, stmt.interface_name, existing_interface
-                        ),
-                        &stmt.node.QualifiedName(),
-                    );
-                    valid = false;
+            for (prop_name, member) in declared_members(&stmt.interface) {
+                if let Some(seen) = seen_interface_api.get(&prop_name) {
+                    if !Rc::ptr_eq(&seen.declaring_interface, &member.declaring_interface)
+                        || seen.target_id != target_id
+                    {
+                        diagnostics.push_error(
+                            format!(
+                                "'{}' occurs in '{}' and '{}'",
+                                prop_name, stmt.interface_name, seen.interface_name
+                            ),
+                            &stmt.node.QualifiedName(),
+                        );
+                        valid = false;
+                    }
                 } else {
-                    seen_interface_api.insert(prop_name, stmt.interface_name.clone());
+                    seen_interface_api.insert(
+                        prop_name,
+                        SeenMember {
+                            interface_name: stmt.interface_name.clone(),
+                            declaring_interface: member.declaring_interface,
+                            target_id: target_id.clone(),
+                        },
+                    );
                 }
             }
             valid
@@ -396,11 +431,11 @@ fn validate_interface_implementation(
 ) -> bool {
     let mut errors = Vec::new();
     let mut notes = Vec::new();
-    for (member_name, member_declaration) in declared_members(interface) {
+    for (member_name, member) in declared_members(interface) {
         if let Some(mut conflict) = validate_interface_member_implementation(
             element,
             &member_name,
-            &member_declaration,
+            &member.declaration,
             interface_name,
             binding,
         ) {
@@ -482,6 +517,7 @@ pub(super) fn apply_child_implement_statements(
     child_implements: Vec<ImplementedInterface>,
     diagnostics: &mut BuildDiagnostics,
 ) {
+    let mut applied_members: BTreeMap<SmolStr, ElementRc> = BTreeMap::new();
     for ImplementedInterface { node, interface, interface_name, binding } in child_implements {
         debug_assert_ne!(binding, ImplementBinding::OnSelf);
         let ImplementBinding::OnChild { child_id, child_name } = &binding else {
@@ -506,7 +542,18 @@ pub(super) fn apply_child_implement_statements(
 
         let mut conflicts = Vec::new();
         let mut notes = Vec::new();
-        for (name, mut prop_decl) in declared_members(&interface) {
+        for (name, InterfaceMember { declaration: mut prop_decl, declaring_interface }) in
+            declared_members(&interface)
+        {
+            if let Some(applied) = applied_members.get(&name) {
+                debug_assert!(
+                    Rc::ptr_eq(applied, &declaring_interface),
+                    "Conflicting members should have been caught earlier"
+                );
+                continue;
+            }
+            applied_members.insert(name.clone(), declaring_interface);
+
             let lookup_result = element
                 .borrow()
                 .base_type

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -144,24 +144,67 @@ fn resolve_implement_statement(
     }
 }
 
+fn interface_chain(interface: &ElementRc) -> impl Iterator<Item = ElementRc> {
+    std::iter::successors(Some(interface.clone()), |element| match &element.borrow().base_type {
+        ElementType::Interface(Some(base)) => Some(base.root_element.clone()),
+        _ => None,
+    })
+}
+
 /// The members an interface declares under their source names, including inherited ones.
 /// A derived declaration hides the inherited member of the same name.
 /// A shadowing declaration counts as derived, too.
 fn declared_members(interface: &ElementRc) -> BTreeMap<SmolStr, PropertyDeclaration> {
     let mut members = BTreeMap::new();
-    let mut next = Some(interface.clone());
-    while let Some(element) = next.take() {
-        let element = element.borrow();
-        for (internal_name, declaration) in &element.property_declarations {
+    for element in interface_chain(interface) {
+        for (internal_name, declaration) in &element.borrow().property_declarations {
             members.entry(declaration.declared_name(internal_name).clone()).or_insert_with(|| {
                 PropertyDeclaration { shadowed_name: None, ..declaration.clone() }
             });
         }
-        if let ElementType::Interface(Some(base)) = &element.base_type {
-            next = Some(base.root_element.clone());
-        }
     }
     members
+}
+
+fn inherits_from(derived: &ElementRc, base: &ElementRc) -> bool {
+    interface_chain(derived).skip(1).any(|element| Rc::ptr_eq(&element, base))
+}
+
+fn filter_inherited_implement_statements(
+    diagnostics: &mut BuildDiagnostics,
+    statements: Vec<ImplementedInterface>,
+) -> Vec<ImplementedInterface> {
+    let covering: Vec<Option<(SmolStr, syntax_nodes::ImplementStatement)>> = statements
+        .iter()
+        .map(|stmt| {
+            statements
+                .iter()
+                .find(|other| inherits_from(&other.interface, &stmt.interface))
+                .map(|other| (other.interface_name.clone(), other.node.clone()))
+        })
+        .collect();
+
+    statements
+        .into_iter()
+        .zip(covering)
+        .filter_map(|(stmt, covering)| match covering {
+            Some((derived_name, derived_node)) => {
+                diagnostics.push_error(
+                    format!(
+                        "'{}' is already implemented through '{}'",
+                        stmt.interface_name, derived_name
+                    ),
+                    &stmt.node,
+                );
+                diagnostics.push_note(
+                    format!("'{}' inherits '{}'", derived_name, stmt.interface_name),
+                    &derived_node,
+                );
+                None
+            }
+            None => Some(stmt),
+        })
+        .collect()
 }
 
 fn filter_conflicting_implement_statements(
@@ -215,6 +258,7 @@ pub(super) fn get_implemented_interfaces(
         .filter_map(|stmt| resolve_implement_statement(element, stmt, type_register, diagnostics))
         .collect();
 
+    let resolved = filter_inherited_implement_statements(diagnostics, resolved);
     let filtered = filter_conflicting_implement_statements(diagnostics, resolved);
 
     let mut self_interfaces = Vec::new();

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -104,6 +104,7 @@ pub fn parse_document(p: &mut impl Parser) -> bool {
 /// component C { property<int> xx; }
 /// component C inherits D { }
 /// interface I { property<int> xx; }
+/// interface I inherits J { property<int> xx; }
 /// ```
 pub fn parse_component(p: &mut impl Parser) -> bool {
     let simple_component = p.nth(1).kind() == SyntaxKind::ColonEqual;
@@ -135,9 +136,7 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
             p.consume();
         }
         if p.peek().as_str() == "inherits" {
-            p.error("Interface inheritance is not supported");
-            drop(p.start_node(SyntaxKind::Element));
-            return false;
+            p.consume();
         }
     } else if !is_new_component {
         if p.peek().kind() == SyntaxKind::ColonEqual {

--- a/internal/compiler/parser/document.rs
+++ b/internal/compiler/parser/document.rs
@@ -125,6 +125,7 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
         drop(p.start_node(SyntaxKind::Element));
         return false;
     }
+    let mut interface_inherits = false;
     if is_global {
         if p.peek().kind() == SyntaxKind::ColonEqual {
             p.warning("':=' to declare a global is deprecated. Remove the ':='");
@@ -137,6 +138,7 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
         }
         if p.peek().as_str() == "inherits" {
             p.consume();
+            interface_inherits = true;
         }
     } else if !is_new_component {
         if p.peek().kind() == SyntaxKind::ColonEqual {
@@ -159,7 +161,8 @@ pub fn parse_component(p: &mut impl Parser) -> bool {
         return false;
     }
 
-    if (is_global || is_interface) && p.peek().kind() == SyntaxKind::LBrace {
+    if (is_global || (is_interface && !interface_inherits)) && p.peek().kind() == SyntaxKind::LBrace
+    {
         let mut p = p.start_node(SyntaxKind::Element);
         p.consume();
         parse_element_content(&mut *p);

--- a/internal/compiler/passes/materialize_fake_properties.rs
+++ b/internal/compiler/passes/materialize_fake_properties.rs
@@ -113,7 +113,7 @@ pub(crate) fn should_materialize(
         ElementType::Component(c) => has_declared_property(&c.root_element.borrow(), prop),
         ElementType::Builtin(b) => b.native_class.lookup_property(prop).is_some(),
         ElementType::Native(n) => n.lookup_property(prop).is_some(),
-        ElementType::Global | ElementType::Interface | ElementType::Error => false,
+        ElementType::Global | ElementType::Interface(_) | ElementType::Error => false,
     };
 
     if !has_declared_property {
@@ -149,7 +149,7 @@ pub fn has_declared_property(elem: &Element, prop: &str) -> bool {
         ElementType::Component(c) => has_declared_property(&c.root_element.borrow(), prop),
         ElementType::Builtin(b) => b.native_class.lookup_property(prop).is_some(),
         ElementType::Native(n) => n.lookup_property(prop).is_some(),
-        ElementType::Global | ElementType::Interface | ElementType::Error => false,
+        ElementType::Global | ElementType::Interface(_) | ElementType::Error => false,
     }
 }
 

--- a/internal/compiler/passes/resolve_native_classes.rs
+++ b/internal/compiler/passes/resolve_native_classes.rs
@@ -28,7 +28,7 @@ pub fn resolve_native_classes(component: &Component) {
                     // already native
                     return;
                 }
-                ElementType::Interface | ElementType::Global | ElementType::Error => {
+                ElementType::Interface(_) | ElementType::Global | ElementType::Error => {
                     panic!("This should not happen")
                 }
             };

--- a/internal/compiler/passes/resolving.rs
+++ b/internal/compiler/passes/resolving.rs
@@ -2820,7 +2820,7 @@ fn continue_lookup_within_element(
     } else {
         let mut err = |extra: &str| {
             let what = match &elem.borrow().base_type {
-                ElementType::Global | ElementType::Interface => {
+                ElementType::Global | ElementType::Interface(_) => {
                     let enclosing_type = elem.borrow().enclosing_component.upgrade().unwrap();
                     assert!(enclosing_type.is_global() || enclosing_type.is_interface());
                     format!("'{}'", enclosing_type.id)

--- a/internal/compiler/tests/consistent_styles.rs
+++ b/internal/compiler/tests/consistent_styles.rs
@@ -131,7 +131,7 @@ fn load_component(component: &Rc<i_slint_compiler::object_tree::Component>) -> C
             i_slint_compiler::langtype::ElementType::Native(_) => unreachable!(),
             i_slint_compiler::langtype::ElementType::Error => unreachable!(),
             i_slint_compiler::langtype::ElementType::Global => break,
-            i_slint_compiler::langtype::ElementType::Interface => break,
+            i_slint_compiler::langtype::ElementType::Interface(_) => break,
         };
         elem = e;
     }

--- a/internal/compiler/tests/syntax/interfaces/implement_conflicts.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_conflicts.slint
@@ -16,6 +16,7 @@ component ChildA { }
 
 export component SelfChildSameInterface {
     implement I <=> self;
+//  >                   <note{'I' is implemented here}
     implement I <=> child;
 //  >                    <error{'I' is implemented multiple times}
 
@@ -26,6 +27,7 @@ export component SelfChildSameInterface {
 
 export component SelfSelfSameInterface {
     implement I <=> self;
+//  >                   <note{'I' is implemented here}
     implement I <=> self;
 //  >                   <error{'I' is implemented multiple times}
 

--- a/internal/compiler/tests/syntax/interfaces/implement_inherited.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_inherited.slint
@@ -101,3 +101,90 @@ export component RedundantAcrossBindings {
     in-out property <string> text;
     child := ChildBase { }
 }
+
+// Two interfaces that inherit the same member from a common base can be implemented together.
+interface Sibling inherits Base {
+    out property <int> other;
+}
+
+component ChildAll {
+    in-out property <string> text;
+    out property <int> count;
+    out property <int> other;
+}
+
+// Both interfaces forward to `self`.
+export component SharedBaseSelf {
+    implement Derived <=> self;
+    implement Sibling <=> self;
+
+    in-out property <string> text;
+    out property <int> count;
+    out property <int> other;
+}
+
+// Both interfaces forward to the same child.
+// Installing the shared member twice would trip the `Cannot override` path.
+export component SharedBaseChild {
+    implement Derived <=> child;
+    implement Sibling <=> child;
+
+    child := ChildAll { }
+}
+
+// A shared member still conflicts once the two statements target different elements.
+// One member cannot be forwarded to two places.
+export component SharedBaseSelfAndChild {
+    implement Derived <=> self;
+    implement Sibling <=> child;
+//            >      <error{'text' occurs in 'Sibling' and 'Derived'}
+
+    in-out property <string> text;
+    out property <int> count;
+    child := ChildAll { }
+}
+
+// Same as above with two children, proving the check is target-based rather than self-vs-child.
+export component SharedBaseDifferentChildren {
+    implement Derived <=> child-a;
+    implement Sibling <=> child-b;
+//            >      <error{'text' occurs in 'Sibling' and 'Derived'}
+
+    child-a := ChildAll { }
+    child-b := ChildAll { }
+}
+
+// A shared member that's missing is reported once per interface, not deduplicated.
+export component SharedBaseMissingMember {
+    implement Derived <=> self;
+//            >      <error{Cannot implement 'Derived'.↵- missing 'in-out property <string> text;'}
+    implement Sibling <=> self;
+//            >      <error{Cannot implement 'Sibling'.↵- missing 'in-out property <string> text;'}
+
+    out property <int> count;
+    out property <int> other;
+}
+
+// `@shadowable` lets a derived interface redeclare the member.
+// The redeclaration is a different declaration, so implementing both interfaces still conflicts.
+interface ShadowableBase {
+    @shadowable in-out property <string> text;
+}
+
+interface DerivedFromShadowable inherits ShadowableBase {
+    out property <int> count;
+}
+
+interface ShadowsBase inherits ShadowableBase {
+    in-out property <string> text;
+//                           >  <warning{'text' shadows the inherited property of the same name}
+}
+
+export component ShadowedMemberIsADifferentDeclaration {
+    implement DerivedFromShadowable <=> self;
+    implement ShadowsBase <=> self;
+//            >          <error{'text' occurs in 'ShadowsBase' and 'DerivedFromShadowable'}
+
+    in-out property <string> text;
+    out property <int> count;
+}

--- a/internal/compiler/tests/syntax/interfaces/implement_inherited.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_inherited.slint
@@ -1,0 +1,56 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// `implement` must be satisfied against an interface's full member set: its own declarations
+// plus the ones it inherits.
+
+interface Base {
+    in-out property <string> text;
+}
+
+interface Derived inherits Base {
+    out property <int> count;
+}
+
+// A component that provides only the derived members is missing the inherited one.
+export component MissingInheritedMember {
+    implement Derived <=> self;
+//            >      <error{Cannot implement 'Derived'.↵- missing 'in-out property <string> text;'}
+
+    out property <int> count;
+}
+
+// An inherited member with the wrong type still names the interface that declared it.
+export component MismatchedInheritedMember {
+    implement Derived <=> self;
+//            >      <error{Cannot implement 'Derived'.↵- 'text' must be a 'string' property (found a 'int' property)}
+
+    out property <int> count;
+    in-out property <int> text;
+//                   > <note{'MismatchedInheritedMember' declares 'text' here, 'Derived' expects 'in-out property <string> text;'}
+}
+
+interface Other {
+    in-out property <string> text;
+}
+
+// Two unrelated interfaces still conflict when one's own member matches a name the other inherits.
+export component OverlapViaInheritance {
+    implement Derived <=> self;
+    implement Other <=> self;
+//            >    <error{'text' occurs in 'Other' and 'Derived'}
+
+    out property <int> count;
+    in-out property <string> text;
+}
+
+component ChildBase {
+    out property <int> count;
+}
+
+// A delegated child must carry the inherited members too, not just the derived ones.
+export component MissingInheritedMemberChild {
+    implement Derived <=> child;
+//                        >   <error{Cannot implement 'Derived' based on 'child'.↵- missing 'in-out property <string> text;'}
+    child := ChildBase { }
+}

--- a/internal/compiler/tests/syntax/interfaces/implement_inherited.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_inherited.slint
@@ -12,6 +12,8 @@ interface Derived inherits Base {
     out property <int> count;
 }
 
+interface MostDerived inherits Derived { }
+
 // A component that provides only the derived members is missing the inherited one.
 export component MissingInheritedMember {
     implement Derived <=> self;
@@ -52,5 +54,50 @@ component ChildBase {
 export component MissingInheritedMemberChild {
     implement Derived <=> child;
 //                        >   <error{Cannot implement 'Derived' based on 'child'.↵- missing 'in-out property <string> text;'}
+    child := ChildBase { }
+}
+
+// Implementing Base is redundant once Derived, which inherits it, is implemented too.
+export component RedundantAfterInherited {
+    implement Derived <=> self;
+//  >                         <note{'Derived' inherits 'Base'}
+    implement Base <=> self;
+//  >                      <error{'Base' is already implemented through 'Derived'}
+
+    out property <int> count;
+    in-out property <string> text;
+}
+
+// The same redundancy, reported the same way regardless of which statement comes first.
+export component RedundantBeforeInherited {
+    implement Base <=> self;
+//  >                      <error{'Base' is already implemented through 'Derived'}
+    implement Derived <=> self;
+//  >                         <note{'Derived' inherits 'Base'}
+
+    out property <int> count;
+    in-out property <string> text;
+}
+
+// The inheritance chain walk goes past the immediate parent.
+export component RedundantAcrossTwoLevels {
+    implement Base <=> self;
+//  >                      <error{'Base' is already implemented through 'MostDerived'}
+    implement MostDerived <=> self;
+//  >                             <note{'MostDerived' inherits 'Base'}
+
+    out property <int> count;
+    in-out property <string> text;
+}
+
+// Redundancy doesn't depend on both statements binding to the same target.
+export component RedundantAcrossBindings {
+    implement Base <=> child;
+//  >                       <error{'Base' is already implemented through 'Derived'}
+    implement Derived <=> self;
+//  >                         <note{'Derived' inherits 'Base'}
+
+    out property <int> count;
+    in-out property <string> text;
     child := ChildBase { }
 }

--- a/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
@@ -114,3 +114,9 @@ export interface CannotInheritInterface inherits Other {
 export component ComponentInheritsInterface inherits Other {
 //                                                   >    <error{Components cannot inherit from interfaces}
 }
+
+// An interface is not an element, so it cannot be instantiated as a child.
+export component ComponentInstantiatesInterface {
+    Other { }
+//  >    <error{Cannot create an instance of an interface; write 'implement Other <=> self;' to implement it}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
@@ -102,12 +102,7 @@ export interface Other {
 
 export interface CannotImplementInterface {
     implement Other <=> self;
-//  >                       <error{Interfaces cannot implement another interface}
-}
-
-// An interface may not yet inherit another interface.
-export interface CannotInheritInterface inherits Other {
-//                                               >    <error{Interface inheritance is not supported yet}
+//  >                       <error{Interfaces cannot implement another interface, use 'inherits' instead}
 }
 
 // A component cannot inherit an interface; it implements one instead.

--- a/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
@@ -104,3 +104,13 @@ export interface CannotImplementInterface {
     implement Other <=> self;
 //  >                       <error{Interfaces cannot implement another interface}
 }
+
+// An interface may not yet inherit another interface.
+export interface CannotInheritInterface inherits Other {
+//                                               >    <error{Interface inheritance is not supported yet}
+}
+
+// A component cannot inherit an interface; it implements one instead.
+export component ComponentInheritsInterface inherits Other {
+//                                                   >    <error{Components cannot inherit from interfaces}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_grammar.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_grammar.slint
@@ -9,3 +9,7 @@
 interface ColonEqual := {
 //                   ><error{':=' to declare an interface is not supported. Remove the ':='}
 }
+
+interface DanglingInherits inherits {
+//                                  ^error{Syntax error: expected Identifier}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_grammar.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_grammar.slint
@@ -5,16 +5,7 @@
 // Kept apart from the semantic tests (a syntax error suppresses semantic analysis of the file) and
 // from the `implement`-statement syntax errors (declaration-level parse recovery breaks them).
 
-interface Base {
-    out property <bool> test;
-}
-
 // `:=` is not valid to declare an interface.
 interface ColonEqual := {
 //                   ><error{':=' to declare an interface is not supported. Remove the ':='}
-}
-
-// Interface inheritance is not supported.
-export interface Inherits inherits Base {
-//                        >      <error{Interface inheritance is not supported}
 }

--- a/internal/compiler/tests/syntax/interfaces/interface_grammar_inherits_eof.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_grammar_inherits_eof.slint
@@ -1,0 +1,8 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+//|^<<error{Syntax error: expected Identifier}
+
+// A dangling `inherits` at the end of the file reports at offset 0,
+// so the marker can't sit next to the declaration.
+// Kept apart from the other declaration syntax errors for that reason.
+interface DanglingInherits inherits

--- a/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
@@ -1,0 +1,129 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// A derived interface gains the base's members, and may only redeclare one the base marked
+// `@shadowable`. Inheriting an interface counts as a use of it, so a base needs no export.
+
+interface Base {
+    in-out property <string> text;
+    callback base-callback();
+    public pure function base-function() -> int;
+}
+
+export interface Derived inherits Base {
+    out property <int> foo;
+    callback derived-callback();
+    public pure function derived-function() -> int;
+}
+
+export component Implementer {
+    implement Derived <=> self;
+
+    in-out property <string> text;
+    out property <int> foo;
+    callback base-callback();
+    callback derived-callback();
+    public pure function base-function() -> int {
+        1
+    }
+    public pure function derived-function() -> int {
+        2
+    }
+}
+
+// Redeclaring an inherited member is an error, whatever its kind.
+export interface Redeclares inherits Base {
+    in-out property <string> text;
+//                           >  <error{Cannot override property 'text' declared in 'Base'}
+    callback base-callback();
+//           >           <error{Cannot override callback 'base-callback' declared in 'Base'}
+    public pure function base-function() -> int;
+//                       >           <error{Cannot override 'base-function' declared in 'Base'}
+}
+
+// `@shadowable` on the base declaration opts into shadowing, which warns instead.
+interface Shadowable {
+    @shadowable in-out property <string> text;
+}
+
+export interface Shadows inherits Shadowable {
+    in-out property <string> text;
+//                           >  <warning{'text' shadows the inherited property of the same name}
+}
+
+// Through three levels, the message names the interface that declares the member.
+interface Level1 {
+    in-out property <string> text;
+}
+
+interface Level2 inherits Level1 {
+    out property <int> two;
+}
+
+export interface Level3 inherits Level2 {
+    in-out property <string> text;
+//                           >  <error{Cannot override property 'text' declared in 'Level1'}
+}
+
+// An interface can only inherit another interface.
+export component SomeComponent { }
+
+export interface InheritsBuiltin inherits Rectangle { }
+//                                        >        <error{An interface can only inherit another interface}
+
+export interface InheritsComponent inherits SomeComponent { }
+//                                          >            <error{An interface can only inherit another interface}
+
+export interface InheritsUnknown inherits NoSuchThing { }
+//                                        >          <error{Unknown element 'NoSuchThing'}
+
+// An inheriting interface is policed like any other: its body may only list members.
+export interface InheritingBody inherits Base {
+    out property <int> bound;
+    bound: 1;
+//  >       <error{An interface cannot have bindings}
+
+    Rectangle { }
+//  >           <error{An interface cannot have sub elements}
+
+    states [
+//  >error{An interface cannot have states}
+    ]
+//  <error{An interface cannot have states}
+
+    implement Base <=> self;
+//  >                      <error{Interfaces cannot implement another interface, use 'inherits' instead}
+}
+
+// The member rules apply on the inherits path too, where the base type used to be an error.
+export interface InheritingMembers inherits Base {
+    in property <int> with-default: 42;
+//                                  > <error{Interface properties cannot have default values}
+    out property <int> with-binding <=> self.with-default;
+//                                  >                    <error{Interface properties cannot have default bindings}
+    private property <int> private-property;
+//  >                                      <error{'private' properties are inaccessible in an interface}
+    function not-public();
+//  >                    <error{Function declarations in an interface must be public}
+    public function with-body() {
+//                              >error{Function declarations in interfaces must not have a body}
+    }
+//  <error{Function declarations in interfaces must not have a body}
+}
+
+// An interface cannot inherit itself.
+export interface SelfInherits inherits SelfInherits { }
+//                                     >           <error{Unknown element 'SelfInherits'}
+
+// An interface a cannot inherit an interface not declared yet.
+export interface InheritsLater inherits DeclaredLater { }
+//                                      >            <error{Unknown element 'DeclaredLater'}
+
+export interface DeclaredLater { }
+
+// An interface is not an element, inside another interface no more than anywhere else.
+export interface InstantiatesInterface {
+    Base { }
+//  >      <error{An interface cannot have sub elements}
+//  >   <^error{Cannot create an instance of an interface; write 'implement Base <=> self;' to implement it}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_inheritance_import.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_inheritance_import.slint
@@ -1,0 +1,66 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import {
+    ImportedBase,
+    ImportedDerived,
+} from "../../typeloader/interfaces.slint";
+import { ImportedBase as AliasedBase } from "../../typeloader/interfaces.slint";
+
+interface LocalDerived inherits ImportedBase {
+    in-out property <string> label;
+}
+
+// A local interface inheriting an imported one gains the imported members.
+export component ImplementsLocalDerived {
+    implement LocalDerived <=> self;
+
+    in-out property <float> value;
+    in-out property <string> label;
+}
+
+// The chain walk follows the local interface into the other document.
+export component RedundantThroughLocalDerived {
+    implement LocalDerived <=> self;
+//  >                              <note{'LocalDerived' inherits 'ImportedBase'}
+    implement ImportedBase <=> self;
+//  >                              <error{'ImportedBase' is already implemented through 'LocalDerived'}
+
+    in-out property <float> value;
+    in-out property <string> label;
+}
+
+// A chain built entirely in the other document is walked the same way.
+export component RedundantThroughImportedDerived {
+    implement ImportedDerived <=> self;
+//  >                                 <note{'ImportedDerived' inherits 'ImportedBase'}
+    implement ImportedBase <=> self;
+//  >                              <error{'ImportedBase' is already implemented through 'ImportedDerived'}
+
+    in-out property <float> value;
+    in-out property <string> label;
+}
+
+// The same interface imported twice under two names is one interface, not two.
+export component AliasIsTheSameInterface {
+    implement ImportedBase <=> self;
+    implement AliasedBase <=> self;
+//  >                             <error{'AliasedBase' is implemented multiple times}
+
+    in-out property <float> value;
+}
+
+// `inherits` on an alias builds the same chain, so the original base is already covered.
+interface DerivedFromAlias inherits AliasedBase {
+    in-out property <int> count;
+}
+
+export component RedundantThroughAlias {
+    implement ImportedBase <=> self;
+//  >                              <error{'ImportedBase' is already implemented through 'DerivedFromAlias'}
+    implement DerivedFromAlias <=> self;
+//  >                                  <note{'DerivedFromAlias' inherits 'ImportedBase'}
+
+    in-out property <float> value;
+    in-out property <int> count;
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_inheritance_import.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_inheritance_import.slint
@@ -44,6 +44,7 @@ export component RedundantThroughImportedDerived {
 // The same interface imported twice under two names is one interface, not two.
 export component AliasIsTheSameInterface {
     implement ImportedBase <=> self;
+//  >                              <note{'ImportedBase' names the same interface as 'AliasedBase'}
     implement AliasedBase <=> self;
 //  >                             <error{'AliasedBase' is implemented multiple times}
 

--- a/internal/compiler/tests/typeloader/interfaces.slint
+++ b/internal/compiler/tests/typeloader/interfaces.slint
@@ -1,0 +1,10 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+export interface ImportedBase {
+    in-out property <float> value;
+}
+
+export interface ImportedDerived inherits ImportedBase {
+    in-out property <string> label;
+}

--- a/internal/compiler/typeloader.rs
+++ b/internal/compiler/typeloader.rs
@@ -643,6 +643,12 @@ impl Snapshotter {
                         .expect("I can unwrap at this point"),
                 )
             }
+            langtype::ElementType::Interface(base) => {
+                langtype::ElementType::Interface(base.as_ref().map(|component| {
+                    Weak::upgrade(&self.use_component(component))
+                        .expect("I can unwrap at this point")
+                }))
+            }
             _ => element_type.clone(),
         }
     }

--- a/internal/editor-preview/token_info.rs
+++ b/internal/editor-preview/token_info.rs
@@ -84,7 +84,9 @@ impl TokenInfo {
             TokenInfo::LocalFunction(x) => Some(x.clone().into()),
             TokenInfo::IncompleteNamedReference(element_type, prop_name) => {
                 let mut element_type = element_type.clone();
-                while let ElementType::Component(com) = element_type {
+                while let ElementType::Component(com) | ElementType::Interface(Some(com)) =
+                    element_type
+                {
                     if let Some((_, p)) = com.root_element.borrow().declaration(prop_name) {
                         return p.node.clone();
                     }

--- a/tests/cases/imports/external_derived_interface.slint
+++ b/tests/cases/imports/external_derived_interface.slint
@@ -1,0 +1,43 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>, Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Python is ignored because include paths aren't forwarded in the generated stubs.
+//ignore: pyi
+
+//include_path: ../../helper_components
+import { ExportedBase, ExportedDerived } from "export_interfaces.slint";
+
+component Child inherits ExportedBase {
+    in-out property <string> label: "derived";
+}
+
+export component TestCase {
+    implement ExportedDerived <=> child;
+    child := Child { }
+
+    out property <bool> test: self.value == 2.71 && self.label == "derived";
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(instance.get_value(), 2.71);
+assert_eq!(instance.get_label(), "derived");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+assert_eq(instance.get_value(), 2.71);
+assert_eq(instance.get_label(), "derived");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+assert.equal(instance.value, 2.71);
+assert.equal(instance.label, "derived");
+```
+*/

--- a/tests/cases/imports/external_interface_inheritance.slint
+++ b/tests/cases/imports/external_interface_inheritance.slint
@@ -1,0 +1,45 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>, Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// Python is ignored because include paths aren't forwarded in the generated stubs.
+//ignore: pyi
+
+//include_path: ../../helper_components
+import { ExportedInterface } from "export_interfaces.slint";
+
+interface Local inherits ExportedInterface {
+    in-out property <string> label;
+}
+
+export component TestCase {
+    implement Local <=> self;
+
+    in-out property <float> value: 2.71;
+    in-out property <string> label: "local";
+
+    out property <bool> test: self.value == 2.71 && self.label == "local";
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+assert_eq!(instance.get_value(), 2.71);
+assert_eq!(instance.get_label(), "local");
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+assert_eq(instance.get_value(), 2.71);
+assert_eq(instance.get_label(), "local");
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+assert.equal(instance.value, 2.71);
+assert.equal(instance.label, "local");
+```
+*/

--- a/tests/cases/interfaces/inheritance.slint
+++ b/tests/cases/interfaces/inheritance.slint
@@ -1,0 +1,81 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface A {
+    out property <int> speed;
+    in-out property <string> greeting;
+    pure callback callback-a() -> int;
+    public pure function function-a() -> int;
+}
+
+interface B inherits A {
+    out property <float> direction;
+    pure callback callback-b() -> int;
+    public pure function function-b() -> int;
+}
+
+export component TestCase {
+    implement B <=> self;
+
+    out property <int> speed: 42;
+    in-out property <string> greeting: "hello";
+    pure callback callback-a() -> int;
+    callback-a() => { 1 }
+    public pure function function-a() -> int {
+        2
+    }
+
+    out property <float> direction: 1.5;
+    pure callback callback-b() -> int;
+    callback-b() => { 3 }
+    public pure function function-b() -> int {
+        4
+    }
+
+    out property <bool> test: self.speed == 42
+        && self.greeting == "hello"
+        && self.callback-a() == 1
+        && self.function-a() == 2
+        && self.direction == 1.5
+        && self.callback-b() == 3
+        && self.function-b() == 4;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_speed(), 42);
+assert_eq!(instance.get_greeting(), "hello");
+assert_eq!(instance.invoke_callback_a(), 1);
+assert_eq!(instance.invoke_function_a(), 2);
+assert_eq!(instance.get_direction(), 1.5);
+assert_eq!(instance.invoke_callback_b(), 3);
+assert_eq!(instance.invoke_function_b(), 4);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_speed(), 42);
+assert_eq(instance.get_greeting(), "hello");
+assert_eq(instance.invoke_callback_a(), 1);
+assert_eq(instance.invoke_function_a(), 2);
+assert_eq(instance.get_direction(), 1.5);
+assert_eq(instance.invoke_callback_b(), 3);
+assert_eq(instance.invoke_function_b(), 4);
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.speed, 42);
+assert.equal(instance.greeting, "hello");
+assert.equal(instance.callback_a(), 1);
+assert.equal(instance.function_a(), 2);
+assert.equal(instance.direction, 1.5);
+assert.equal(instance.callback_b(), 3);
+assert.equal(instance.function_b(), 4);
+assert(instance.test);
+```
+*/

--- a/tests/cases/interfaces/inheritance_child.slint
+++ b/tests/cases/interfaces/inheritance_child.slint
@@ -1,0 +1,61 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface A {
+    in-out property <string> text;
+    out property <bool> enabled;
+    public pure function length(text: string) -> int;
+}
+
+interface B inherits A {
+    in property <int> precision;
+}
+
+component Base {
+    in-out property <string> text: "Hello";
+    out property <bool> enabled: true;
+    in property <int> precision;
+
+    public pure function length(text: string) -> int {
+        text.character-count
+    }
+}
+
+export component TestCase {
+    implement B <=> child;
+
+    child := Base {
+        // Base does not explicitly implement B, but satisfies the API.
+        precision: 3;
+    }
+
+    // We expect the child values for both the inherited and the derived members.
+    out property <bool> test: self.text == "Hello" && self.enabled && self.precision == 3 && self.length("abc") == 3;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_text(), "Hello");
+assert!(instance.get_enabled());
+assert_eq!(instance.get_precision(), 3);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_text(), "Hello");
+assert_eq(instance.get_enabled(), true);
+assert_eq(instance.get_precision(), 3);
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.text, "Hello");
+assert.equal(instance.enabled, true);
+assert.equal(instance.precision, 3);
+assert(instance.test);
+```
+*/

--- a/tests/cases/interfaces/inheritance_shadowed.slint
+++ b/tests/cases/interfaces/inheritance_shadowed.slint
@@ -1,0 +1,42 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface A {
+    @shadowable in-out property <string> text;
+}
+
+interface B inherits A {
+    in-out property <string> text;
+}
+
+component Base {
+    in-out property <string> text: "Hello";
+}
+
+export component TestCase {
+    implement B <=> child;
+
+    child := Base { }
+
+    // Only resolves because `declared_members` clears `shadowed_name` on the forwarded clone.
+    // Otherwise the clone would stay reachable only under its mangled internal name.
+    out property <bool> test: self.text == "Hello";
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+```
+*/

--- a/tests/cases/interfaces/shared_base.slint
+++ b/tests/cases/interfaces/shared_base.slint
@@ -1,0 +1,52 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface Base {
+    in-out property <string> text;
+}
+
+interface Left inherits Base {
+    out property <int> l;
+}
+
+interface Right inherits Base {
+    out property <int> r;
+}
+
+export component TestCase {
+    implement Left <=> self;
+    implement Right <=> self;
+
+    in-out property <string> text: "hello";
+    out property <int> l: 1;
+    out property <int> r: 2;
+
+    out property <bool> test: self.text == "hello" && self.l == 1 && self.r == 2;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.get_text(), "hello");
+assert_eq!(instance.get_l(), 1);
+assert_eq!(instance.get_r(), 2);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.get_text(), "hello");
+assert_eq(instance.get_l(), 1);
+assert_eq(instance.get_r(), 2);
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.text, "hello");
+assert.equal(instance.l, 1);
+assert.equal(instance.r, 2);
+assert(instance.test);
+```
+*/

--- a/tests/cases/interfaces/shared_base_child.slint
+++ b/tests/cases/interfaces/shared_base_child.slint
@@ -1,0 +1,59 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface Base {
+    public pure function greet() -> string;
+}
+
+interface Left inherits Base {
+    out property <int> l;
+}
+
+interface Right inherits Base {
+    out property <int> r;
+}
+
+component ChildImpl {
+    public pure function greet() -> string {
+        "hi"
+    }
+
+    out property <int> l: 1;
+    out property <int> r: 2;
+}
+
+export component TestCase {
+    implement Left <=> child;
+    implement Right <=> child;
+
+    child := ChildImpl { }
+
+    out property <bool> test: self.greet() == "hi" && self.l == 1 && self.r == 2;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert_eq!(instance.invoke_greet(), "hi");
+assert_eq!(instance.get_l(), 1);
+assert_eq!(instance.get_r(), 2);
+assert!(instance.get_test());
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert_eq(instance.invoke_greet(), "hi");
+assert_eq(instance.get_l(), 1);
+assert_eq(instance.get_r(), 2);
+assert(instance.get_test());
+```
+
+```js
+var instance = new slint.TestCase({});
+assert.equal(instance.greet(), "hi");
+assert.equal(instance.l, 1);
+assert.equal(instance.r, 2);
+assert(instance.test);
+```
+*/

--- a/tests/helper_components/export_interfaces.slint
+++ b/tests/helper_components/export_interfaces.slint
@@ -15,3 +15,7 @@ export interface ComboBoxInterface {
     in-out property <int> current-index;
     in-out property <string> current-value;
 }
+
+export interface ExportedDerived inherits ExportedInterface {
+    in-out property <string> label;
+}

--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2411,6 +2411,14 @@ mod tests {
     }
 
     #[test]
+    fn interfaces() {
+        assert_formatting(
+            "interface   A   {}  export interface  B  inherits  A {  }",
+            "interface A { }\n\nexport interface B inherits A { }\n",
+        );
+    }
+
+    #[test]
     fn with_comments() {
         assert_formatting(
             r#"component /* */ Foo // aaa

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -15,7 +15,9 @@ use i_slint_compiler::expression_tree::{Callable, Expression};
 use i_slint_compiler::langtype::{ElementType, PropertyLookupMode, Type};
 use i_slint_compiler::lookup::{LookupCtx, LookupObject, LookupResult, LookupResultCallable};
 use i_slint_compiler::object_tree::ElementRc;
-use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken, TextSize, syntax_nodes};
+use i_slint_compiler::parser::{
+    SyntaxKind, SyntaxNode, SyntaxToken, TextSize, identifier_text, syntax_nodes,
+};
 use i_slint_compiler::typeregister::TypeRegister;
 use itertools::Itertools;
 use lsp_types::{
@@ -301,6 +303,30 @@ pub(crate) fn completion_at(
     } else if let Some(q) = syntax_nodes::QualifiedName::new(node.clone()) {
         match q.parent()?.kind() {
             SyntaxKind::Element => {
+                let element = q.parent()?;
+                if is_interface_root_element(&element) {
+                    if !enable_experimental {
+                        return None;
+                    }
+
+                    let component = element.parent()?;
+                    if !component
+                        .children_with_tokens()
+                        .any(|c| c.as_token().is_some_and(|t| t.text() == "inherits"))
+                    {
+                        return Some(vec![
+                            CompletionItem::new_simple("inherits".into(), String::new())
+                                .with_kind(CompletionItemKind::KEYWORD),
+                        ]);
+                    }
+                    return resolve_implement_interface_name_scope(
+                        &q,
+                        &token,
+                        document_cache,
+                        snippet_support,
+                    );
+                }
+
                 // auto-complete the components
                 let global_tr = document_cache.global_type_registry();
                 let tr = q
@@ -1095,6 +1121,24 @@ fn complete_path_in_string(
     )
 }
 
+fn is_interface_root_element(element: &SyntaxNode) -> bool {
+    element.parent().is_some_and(|component| {
+        component.kind() == SyntaxKind::Component
+            && component.child_text(SyntaxKind::Identifier).is_some_and(|k| k == "interface")
+    })
+}
+
+fn enclosing_declaration_name(node: &SyntaxNode) -> Option<SmolStr> {
+    let mut candidate = node.clone();
+    let component = loop {
+        if candidate.kind() == SyntaxKind::Component {
+            break candidate;
+        }
+        candidate = candidate.parent()?;
+    };
+    identifier_text(&component.child_node(SyntaxKind::DeclaredIdentifier)?)
+}
+
 fn resolve_implement_interface_name_scope(
     node: &SyntaxNode,
     token: &SyntaxToken,
@@ -1108,17 +1152,20 @@ fn resolve_implement_interface_name_scope(
         .map(|document| &document.local_registry)
         .unwrap_or(&global_type_register);
 
+    let own_name = enclosing_declaration_name(node);
+
     let mut result = type_register
         .all_elements()
         .into_iter()
         .filter_map(|(key, element_type)| {
-            matches!(&element_type, ElementType::Component(component) if component.is_interface())
-                .then(|| {
-                    let mut completion =
-                        CompletionItem::new_simple(key.to_string(), "interface".into());
-                    completion.kind = Some(CompletionItemKind::INTERFACE);
-                    completion
-                })
+            (matches!(&element_type, ElementType::Component(component) if component.is_interface())
+                && Some(&key) != own_name.as_ref())
+            .then(|| {
+                let mut completion =
+                    CompletionItem::new_simple(key.to_string(), "interface".into());
+                completion.kind = Some(CompletionItemKind::INTERFACE);
+                completion
+            })
         })
         .collect::<Vec<_>>();
 
@@ -2390,7 +2437,7 @@ mod tests {
     }
 
     #[test]
-    fn inherits() {
+    fn component_inherits() {
         let sources = [
             "component Bar 🔺",
             "component Bar in🔺",
@@ -2402,14 +2449,48 @@ mod tests {
             "export component Bar in🔺 Window {}",
         ];
         for source in sources {
-            tracing::debug!("Test for inherits in {source:?}");
+            tracing::debug!("Test for component inherits in {source:?}");
             let res = get_completions(source).unwrap();
-            res.iter().find(|ci| ci.label == "inherits").unwrap();
+            assert!(
+                res.iter().any(|ci| ci.label == "inherits"),
+                "completion for {source:?} lacks 'inherits'"
+            );
         }
 
         let sources = ["component 🔺", "component Bar {}🔺", "component Bar inherits 🔺 {}", "🔺"];
         for source in sources {
             let Some(res) = get_completions(source) else { continue };
+            assert!(
+                !res.iter().any(|ci| ci.label == "inherits"),
+                "completion for {source:?} contains 'inherits'"
+            );
+        }
+    }
+
+    #[test]
+    fn interface_inherits() {
+        let sources = [
+            "interface Bar 🔺",
+            "interface Bar in🔺",
+            "interface Bar 🔺 {}",
+            "interface Bar in🔺 Window {}",
+            "export interface Bar 🔺",
+            "export interface Bar in🔺",
+            "export interface Bar 🔺 {}",
+            "export interface Bar in🔺 Window {}",
+        ];
+        for source in sources {
+            tracing::debug!("Test for interface inherits in {source:?}");
+            let res = get_completions_experimental(source).unwrap();
+            assert!(
+                res.iter().any(|ci| ci.label == "inherits"),
+                "completion for {source:?} lacks 'inherits'"
+            );
+        }
+
+        let sources = ["interface 🔺", "interface Bar {}🔺", "interface Bar inherits 🔺 {}", "🔺"];
+        for source in sources {
+            let Some(res) = get_completions_experimental(source) else { continue };
             assert!(
                 !res.iter().any(|ci| ci.label == "inherits"),
                 "completion for {source:?} contains 'inherits'"
@@ -2810,6 +2891,83 @@ export component TestWindow inherits Window {
         let results = get_completions_experimental(source).unwrap();
         let count = results.iter().filter(|c| c.label == "prop").count();
         assert_eq!(count, 1, "'prop' should be completed exactly once");
+    }
+
+    #[test]
+    fn interface_inherits_base_name() {
+        let source = r#"
+            interface MyInterface { property <int> x; }
+            component NotAnInterface { }
+            interface Foo inherits M🔺
+        "#;
+        let results = get_completions_experimental(source).unwrap();
+        let completion =
+            results.iter().find(|completion| completion.label == "MyInterface").unwrap();
+        assert_eq!(completion.kind, Some(CompletionItemKind::INTERFACE));
+        assert!(!results.iter().any(|completion| completion.label == "NotAnInterface"));
+        assert!(!results.iter().any(|completion| completion.label == "Rectangle"));
+    }
+
+    #[test]
+    fn interface_inherits_does_not_offer_itself() {
+        let source = r#"
+            interface Other { property <int> x; }
+            interface Foo inherits F🔺
+        "#;
+        let results = get_completions_experimental(source).unwrap();
+        assert_completion_found(
+            &CompletionItem { label: "Other".into(), ..Default::default() },
+            &results,
+        );
+        assert!(!results.iter().any(|completion| completion.label == "Foo"));
+    }
+
+    #[test]
+    fn component_inherits_offers_elements_not_interfaces() {
+        let source = r#"
+            interface MyInterface { property <int> x; }
+            component Foo inherits M🔺
+        "#;
+        let results = get_completions_experimental(source).unwrap();
+        assert_completion_found(
+            &CompletionItem { label: "Rectangle".into(), ..Default::default() },
+            &results,
+        );
+        assert!(!results.iter().any(|completion| completion.label == "MyInterface"));
+    }
+
+    #[test]
+    fn interface_inherits_base_name_requires_experimental() {
+        assert!(get_completions("interface Foo inherits M🔺").is_none());
+    }
+
+    #[test]
+    fn interface_inherits_base_name_suggests_import() {
+        let types_content = r#"export interface MyInterface { property <int> x; }
+"#;
+        let main_content = r#"interface Foo inherits M🔺
+"#;
+        let results = get_completions_multi_file_experimental(
+            "types.slint",
+            types_content,
+            "main.slint",
+            main_content,
+        )
+        .unwrap();
+
+        assert_completion_found(
+            &CompletionItem {
+                label: "MyInterface (import from \"types.slint\")".into(),
+                insert_text: Some("MyInterface".into()),
+                filter_text: Some("MyInterface".into()),
+                additional_text_edits: Some(vec![TextEdit {
+                    range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                    new_text: "import { MyInterface } from \"types.slint\";\n".into(),
+                }]),
+                ..Default::default()
+            },
+            &results,
+        );
     }
 
     #[test]


### PR DESCRIPTION
An `interface` can now extend another with `inherits`, so a contract can be
built from a shared base instead of being repeated.

```slint
interface Named {
    in-out property <string> name;
}

interface Greeter inherits Named {
    callback greet();
}

export component Hello {
    implement Greeter <=> self;

    in-out property <string> name;
    callback greet();
}
```

`Greeter`'s contract is `name` plus `greet`, and `implement` is satisfied
against that full set.
An interface can only inherit another interface.
Redeclaring a member the base declares is an error, unless the base marked it
`@shadowable`, which warns instead.

Part of the experimental `interface` / `implement` work tracked in #1870.

## How It Works

`ElementType::Interface` gains the base interface as a payload, so a derived
interface's root element resolves the base's members through the same lookup a
component uses.
The existing component machinery then covers inheritance for free: conflict
detection, `@shadowable` shadowing, and the "declared in 'X'" notes all work
without an interface-specific diagnostic.

`declared_members` walks the base chain and reports each member together with
the interface that declares it.
Carrying the declaring interface, rather than the member name alone, is what
lets the conflict check tell a member shared through a common base apart from a
genuine name collision.

## Diagnostics

Cases that used to compile silently, or reported something misleading:

| Code | Before | Now |
|---|---|---|
| `interface B inherits Rectangle` | accepted, then no interface rule applied at all | `An interface can only inherit another interface` |
| `interface B inherits A { Rectangle { } }` | accepted | `An interface cannot have sub elements` |
| `interface A inherits { }` | accepted | `Syntax error: expected Identifier` |
| `component C inherits SomeInterface` | accepted | `Components cannot inherit from interfaces` |
| `SomeInterface { }` inside a component | resolved to the interface | `Cannot create an instance of an interface; write 'implement I <=> self;' to implement it` |
| `implement Base` next to `implement Derived` | `'x' occurs in 'Derived' and 'Base'` for every shared member | `'Base' is already implemented through 'Derived'`, with a note on the covering statement |
| `implement Left` and `implement Right` sharing a base | `'text' occurs in 'Right' and 'Left'`, with no workaround | compiles |
| duplicate `implement` under an import alias | named one statement only | notes the statement that already claimed the interface, and says when the two names mean one interface |

## Tooling

- The parser and the tree-sitter grammar accept the clause, so format-on-save
  stops mangling it.
  The grammar reuses `component_modifier`, so Zed's existing highlight query
  covers interfaces with no `.scm` change.
- The LSP completes interfaces after `inherits`, offers the `inherits` keyword
  from the base-type position, and no longer offers the enclosing declaration
  to itself.

## Tests

- `internal/compiler/tests/syntax/interfaces/` — `interface_inheritance.slint`
  for the declaration rules, `implement_inherited.slint` for `implement`
  against an inherited member set, `interface_inheritance_import.slint` for
  chains crossing a document boundary, including import aliases.
- `tests/cases/interfaces/` — runtime cases for a plain chain, a chain resolved
  through a child, a `@shadowable` member, and two interfaces sharing a base.
- `tests/cases/imports/` — the same across a file boundary, built both locally
  and in the imported document.
  Run under the Rust driver too, since a forwarded inherited member appears in
  the generated public API.
- `tools/lsp/fmt/fmt.rs` — formatting an interface with a base.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>