### PR TITLE
`implement` statements are validated as a compiler pass

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -31,7 +31,7 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
 pub(crate) mod forward_inherited_expression;
-mod interfaces;
+pub(crate) mod interfaces;
 
 macro_rules! unwrap_or_continue {
     ($e:expr ; $diag:expr) => {
@@ -1303,6 +1303,8 @@ pub struct Element {
     pub default_fill_parent: (bool, bool),
 
     pub accessibility_props: AccessibilityProps,
+
+    pub(crate) implement_statements: Vec<interfaces::ImplementedInterface>,
 
     /// Reference to the property.
     /// This is always initialized from the element constructor, but is Option because it references itself
@@ -2746,8 +2748,9 @@ impl Element {
             }
         }
 
-        interfaces::validate_self_implement_statements(&r.borrow(), &implemented_interfaces, diag);
-        interfaces::apply_child_implement_statements(&r, child_implements, diag);
+        interfaces::apply_child_implement_statements(&r, &child_implements, diag);
+        r.borrow_mut().implement_statements =
+            implemented_interfaces.into_iter().chain(child_implements).collect();
 
         r
     }

--- a/internal/compiler/object_tree/interfaces.rs
+++ b/internal/compiler/object_tree/interfaces.rs
@@ -47,7 +47,7 @@ fn check_property_declaration_conflicts(
 const SELF_ID: &str = "self";
 
 #[derive(Debug, PartialEq)]
-pub(super) enum ImplementBinding {
+pub(crate) enum ImplementBinding {
     OnSelf,
     OnChild {
         /// The normalized id of the element.
@@ -77,7 +77,7 @@ impl ImplementBinding {
     }
 }
 
-pub(super) struct ImplementedInterface {
+pub(crate) struct ImplementedInterface {
     node: syntax_nodes::ImplementStatement,
     interface: ElementRc,
     interface_name: SmolStr,
@@ -342,18 +342,29 @@ pub(super) fn disallow_implement_in_non_root(
     }
 }
 
-pub(super) fn validate_self_implement_statements(
-    element: &Element,
-    implemented_interfaces: &[ImplementedInterface],
+/// A two-way binding written without a type only gets one in `infer_aliases_types`.
+/// This runs as a pass after it rather than while the object tree is built.
+pub(crate) fn validate_implement_statements(
+    element: &ElementRc,
     diagnostics: &mut BuildDiagnostics,
 ) {
-    for ImplementedInterface { interface, node, interface_name, binding } in implemented_interfaces
+    let root = element.borrow();
+    for ImplementedInterface { interface, node, interface_name, binding } in
+        &root.implement_statements
     {
+        let (target, source) = match binding {
+            ImplementBinding::OnSelf => (element.clone(), SyntaxNode::from(node.QualifiedName())),
+            ImplementBinding::OnChild { child_id, .. } => {
+                // `apply_child_implement_statements` reports a missing child.
+                let Some(child) = find_element_by_id(element, child_id) else { continue };
+                (child, SyntaxNode::from(node.DeclaredIdentifier()))
+            }
+        };
         validate_interface_implementation(
-            element,
+            &target.borrow(),
             interface,
             interface_name,
-            &node.QualifiedName(),
+            &source,
             binding,
             diagnostics,
         );
@@ -535,13 +546,13 @@ fn validate_interface_member_implementation(
 
 pub(super) fn apply_child_implement_statements(
     element: &ElementRc,
-    child_implements: Vec<ImplementedInterface>,
+    child_implements: &[ImplementedInterface],
     diagnostics: &mut BuildDiagnostics,
 ) {
     let mut applied_members: BTreeMap<SmolStr, ElementRc> = BTreeMap::new();
     for ImplementedInterface { node, interface, interface_name, binding } in child_implements {
-        debug_assert_ne!(binding, ImplementBinding::OnSelf);
-        let ImplementBinding::OnChild { child_id, child_name } = &binding else {
+        debug_assert_ne!(*binding, ImplementBinding::OnSelf);
+        let ImplementBinding::OnChild { child_id, child_name } = binding else {
             continue;
         };
         let Some(child) = find_element_by_id(element, child_id) else {
@@ -550,13 +561,15 @@ pub(super) fn apply_child_implement_statements(
             continue;
         };
 
+        // Later passes read these declarations, so generation cannot wait for
+        // `validate_implement_statements`, which reports what this check finds.
         if !validate_interface_implementation(
             &child.borrow(),
-            &interface,
-            &interface_name,
+            interface,
+            interface_name,
             &node.DeclaredIdentifier(),
-            &binding,
-            diagnostics,
+            binding,
+            &mut BuildDiagnostics::default(),
         ) {
             continue;
         }
@@ -564,7 +577,7 @@ pub(super) fn apply_child_implement_statements(
         let mut conflicts = Vec::new();
         let mut notes = Vec::new();
         for (name, InterfaceMember { declaration: mut prop_decl, declaring_interface }) in
-            declared_members(&interface)
+            declared_members(interface)
         {
             if let Some(applied) = applied_members.get(&name) {
                 debug_assert!(
@@ -587,7 +600,7 @@ pub(super) fn apply_child_implement_statements(
                     notes.push(NoteWithSource {
                         note: declared_here_note(
                             &name,
-                            &interface_name,
+                            interface_name,
                             &syntax_for_declaration(&prop_decl, &name),
                             &source,
                         ),
@@ -629,7 +642,7 @@ pub(super) fn apply_child_implement_statements(
                 );
                 diagnostics.push_note(
                     declares_as_note(
-                        &interface_name,
+                        interface_name,
                         &name,
                         &syntax_for_declaration(&prop_decl, &name),
                     ),
@@ -787,6 +800,11 @@ fn property_matches_interface(
             expected_syntax,
             anchor: DeclarationAnchor::Name,
         }]);
+    }
+
+    // Checked in `validate_implement_statements` once the type has been resolved by `infer_aliases_types`.
+    if matches!(property.property_type, Type::InferredProperty | Type::InferredCallback) {
+        return Ok(());
     }
 
     let mut errors = Vec::new();

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -59,6 +59,7 @@ pub mod resolve_native_classes;
 pub mod resolving;
 mod unique_declared_type_names;
 mod unique_id;
+mod validate_interfaces;
 mod visible;
 mod windows;
 mod z_order;
@@ -386,6 +387,7 @@ pub fn run_import_passes(
     diag: &mut crate::diagnostics::BuildDiagnostics,
 ) {
     infer_aliases_types::resolve_aliases(doc, diag, &type_loader.symbol_counters);
+    validate_interfaces::validate_interfaces(doc, diag);
     resolving::resolve_expressions(doc, type_loader, diag);
     purity_check::purity_check(doc, diag);
     focus_handling::replace_forward_focus_bindings_with_focus_functions(doc, diag);

--- a/internal/compiler/passes/inlining.rs
+++ b/internal/compiler/passes/inlining.rs
@@ -592,6 +592,7 @@ fn duplicate_element_with_mapping(
         is_injected_wrapper_element: elem.is_injected_wrapper_element,
         property_declarations: elem.property_declarations.clone(),
         shadowing_members: elem.shadowing_members.clone(),
+        implement_statements: Default::default(),
         // We will do the fixup of the references in bindings later
         bindings: elem
             .bindings_including_synthetic()

--- a/internal/compiler/passes/repeater_component.rs
+++ b/internal/compiler/passes/repeater_component.rs
@@ -46,6 +46,7 @@ fn create_repeater_components(component: &Rc<Component>) {
                 children: std::mem::take(&mut original_elem.children),
                 property_declarations: std::mem::take(&mut original_elem.property_declarations),
                 shadowing_members: std::mem::take(&mut original_elem.shadowing_members),
+                implement_statements: Default::default(),
                 named_references: Default::default(),
                 repeated: None,
                 is_component_placeholder: false,

--- a/internal/compiler/passes/validate_interfaces.rs
+++ b/internal/compiler/passes/validate_interfaces.rs
@@ -1,0 +1,12 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use crate::diagnostics::BuildDiagnostics;
+use crate::object_tree::Document;
+use crate::object_tree::interfaces::validate_implement_statements;
+
+pub(crate) fn validate_interfaces(doc: &Document, diag: &mut BuildDiagnostics) {
+    for component in doc.inner_components.iter() {
+        validate_implement_statements(&component.root_element, diag);
+    }
+}

--- a/internal/compiler/passes/windows.rs
+++ b/internal/compiler/passes/windows.rs
@@ -49,6 +49,7 @@ pub fn ensure_window(
         enclosing_component: win_elem_mut.enclosing_component.clone(),
         property_declarations: Default::default(),
         shadowing_members: Default::default(),
+        implement_statements: Default::default(),
         named_references: Default::default(),
         repeated: Default::default(),
         states: Default::default(),

--- a/internal/compiler/tests/syntax/interfaces/implement_child.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_child.slint
@@ -207,3 +207,43 @@ export component ChildWithProperties {
 //               >   <note{'child_with_conflicts' declares 'reset' here, 'ValidInterface' expects 'pure public function reset() { }'}
     }
 }
+
+// The child may satisfy a member with a two-way binding written without a type.
+component InferredMemberChild {
+    in-out property value <=> inner.value;
+    callback speak <=> inner.speak;
+    public pure function reset() {
+        inner.reset();
+    }
+
+    inner := ValidBase { }
+}
+
+export component ChildWithInferredMembers {
+    implement ValidInterface <=> base;
+    base := InferredMemberChild { }
+}
+
+component WrongTypeBase {
+    in-out property <float> value;
+    callback speak();
+    public pure function reset() { }
+}
+
+component InferredMemberChildWrongType {
+    in-out property value <=> inner.value;
+//                  >   <note{'InferredMemberChildWrongType' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
+    callback speak <=> inner.speak;
+    public pure function reset() {
+        inner.reset();
+    }
+
+    inner := WrongTypeBase { }
+}
+
+// A member the child's alias types wrongly is still reported.
+export component ChildWithInferredMembersWrongType {
+    implement ValidInterface <=> base;
+//                               >  <error{Cannot implement 'ValidInterface' based on 'base'.↵- 'base.value' must be a 'int' property (found a 'float' property)}
+    base := InferredMemberChildWrongType { }
+}

--- a/internal/compiler/tests/syntax/interfaces/implement_self.slint
+++ b/internal/compiler/tests/syntax/interfaces/implement_self.slint
@@ -302,3 +302,44 @@ export component ConflictsWithBuiltIn inherits Flickable {
     implement Viewport <=> self;
 //            >       <error{Cannot implement 'Viewport'.↵- 'viewport-x' must be a 'float' property (found a 'length' property)↵- 'viewport-y' must be a 'float' property (found a 'length' property)}
 }
+
+// A member may be a two-way binding written without a type, which the language requires for a
+// callback alias. Its type arrives from `infer_aliases_types`, after the object tree is built.
+component ValidSource {
+    in-out property <int> value;
+    callback speak();
+    public function reset() { }
+}
+
+export component InferredMembers {
+    implement ValidInterface <=> self;
+
+    in-out property value <=> source.value;
+    callback speak <=> source.speak;
+    public function reset() {
+        source.reset();
+    }
+
+    source := ValidSource { }
+}
+
+component WrongTypeSource {
+    in-out property <float> value;
+    callback speak();
+    public function reset() { }
+}
+
+// A member the alias types wrongly is still reported.
+export component InferredMembersWrongType {
+    implement ValidInterface <=> self;
+//            >             <error{Cannot implement 'ValidInterface'.↵- 'value' must be a 'int' property (found a 'float' property)}
+
+    in-out property value <=> source.value;
+//                  >   <note{'InferredMembersWrongType' declares 'value' here, 'ValidInterface' expects 'in-out property <int> value;'}
+    callback speak <=> source.speak;
+    public function reset() {
+        source.reset();
+    }
+
+    source := WrongTypeSource { }
+}

--- a/tests/cases/interfaces/inferred_alias.slint
+++ b/tests/cases/interfaces/inferred_alias.slint
@@ -1,0 +1,80 @@
+// Copyright © 2026 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>, author Nathan Collins <nathan.collins@kdab.com>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+interface Counter {
+    in-out property <int> count;
+    callback bump(int);
+}
+
+// A callback can only be aliased without parentheses, so a component satisfying `Counter` this
+// way has no type for either member until `infer_aliases_types` runs.
+component Backing {
+    in-out property count <=> state.count;
+    callback bump <=> state.bump;
+
+    state := Rectangle {
+        in-out property <int> count: 1;
+        callback bump(int);
+        bump(increment) => {
+            self.count += increment;
+        }
+    }
+}
+
+component Delegating {
+    implement Counter <=> backing;
+
+    backing := Backing { }
+}
+
+component SelfImplementing {
+    implement Counter <=> self;
+
+    in-out property count <=> backing.count;
+    callback bump <=> backing.bump;
+
+    backing := Backing { }
+}
+
+export component TestCase {
+    delegating := Delegating { }
+
+    self-implementing := SelfImplementing { }
+
+    out property <bool> test: delegating.count == 1 && self-implementing.count == 1;
+
+    public function bump-both() {
+        delegating.bump(10);
+        self-implementing.bump(10);
+    }
+
+    out property <int> delegating-count: delegating.count;
+    out property <int> self-implementing-count: self-implementing.count;
+}
+
+/*
+```rust
+let instance = TestCase::new().unwrap();
+assert!(instance.get_test());
+instance.invoke_bump_both();
+assert_eq!(instance.get_delegating_count(), 11);
+assert_eq!(instance.get_self_implementing_count(), 11);
+```
+
+```cpp
+auto handle = TestCase::create();
+const TestCase &instance = *handle;
+assert(instance.get_test());
+instance.invoke_bump_both();
+assert_eq(instance.get_delegating_count(), 11);
+assert_eq(instance.get_self_implementing_count(), 11);
+```
+
+```js
+var instance = new slint.TestCase({});
+assert(instance.test);
+instance.bump_both();
+assert.equal(instance.delegating_count, 11);
+assert.equal(instance.self_implementing_count, 11);
+```
+*/


### PR DESCRIPTION
Callback aliases must omit parenthesis, and property aliases are not required to provide a type. These declarations get `Type::InferredCallback` and `Type::InferredProperty` which is not resolved until the `infer_aliases_types` pass.

Store the implemented interfaces in Element, and move the checks that validate an interface implementation into a compiler pass that runs after `infer_aliases_types`. This ensures these declarations have a resolved type that can be checked against the interface.

We still have to perform validation in `interfaces::apply_child_implement_statements` as this generates forwarding declarations required by other passes. In this case we pass a default constructed `BuildDiagnostics` to prevent the diagnostics being emitted twice.

Part of the experimental `interface` work tracked in #1870.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>