### PR TITLE
Improve interface diagnostics

### DIFF
--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -924,6 +924,7 @@ fn disallow_non_member_content(
     };
     node.SubElement().for_each(|n| error_on(&n, "sub elements"));
     node.RepeatedElement().for_each(|n| error_on(&n, "sub elements"));
+    node.ConditionalElement().for_each(|n| error_on(&n, "sub elements"));
     if let Some(n) = node.ChildrenPlaceholder() {
         error_on(&n, "sub elements");
     }

--- a/internal/compiler/object_tree.rs
+++ b/internal/compiler/object_tree.rs
@@ -895,6 +895,20 @@ fn from_base(mut r: PropertyLookupResult<'_>) -> PropertyLookupResult<'_> {
     r
 }
 
+fn implement_is_allowed(node: &syntax_nodes::Element) -> bool {
+    let mut candidate = node.parent();
+    while let Some(declaration) = candidate {
+        if declaration.kind() == SyntaxKind::Component {
+            return !matches!(
+                declaration.child_text(SyntaxKind::Identifier).as_deref(),
+                Some("global" | "interface")
+            );
+        }
+        candidate = declaration.parent();
+    }
+    true
+}
+
 fn disallow_non_member_content(
     node: &syntax_nodes::Element,
     declaration: &ElementType,
@@ -1677,15 +1691,25 @@ impl Element {
                     ElementType::Error
                 }
                 Ok(ElementType::Component(c)) if c.is_interface() => {
-                    let message = if is_component_root {
-                        "Components cannot inherit from interfaces".into()
+                    if is_component_root {
+                        diag.push_error(
+                            "Components cannot inherit from interfaces".into(),
+                            &base_node,
+                        );
+                    } else if implement_is_allowed(&node) {
+                        diag.push_error(
+                            format!(
+                                "Cannot create an instance of an interface; write 'implement {} <=> self;' to implement it",
+                                c.id
+                            ),
+                            &base_node,
+                        );
                     } else {
-                        format!(
-                            "Cannot create an instance of an interface; write 'implement {} <=> self;' to implement it",
-                            c.id
-                        )
-                    };
-                    diag.push_error(message, &base_node);
+                        debug_assert!(
+                            diag.has_errors(),
+                            "`disallow_non_member_content` should have caught the other cases"
+                        );
+                    }
                     ElementType::Error
                 }
                 Ok(ty) => {

--- a/internal/compiler/tests/syntax/basic/type_declaration.slint
+++ b/internal/compiler/tests/syntax/basic/type_declaration.slint
@@ -23,6 +23,8 @@ global MyType := {
     for x in mod : Text { }
 //  >                     <error{A global component cannot have sub elements}
 //           >  <^error{Builtin function must be called. Did you forgot the '()'?}
+    if bbb > 0 : Text { }
+//  >                   <error{A global component cannot have sub elements}
     aaa <=> bbb;
 
     property <int> eee <=> aaa;

--- a/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
@@ -12,6 +12,8 @@ export interface InvalidContent {
 //  >           <error{An interface cannot have sub elements}
     for x in 2: Text { }
 //  >                  <error{An interface cannot have sub elements}
+    if true: Text { }
+//  >               <error{An interface cannot have sub elements}
 
     animate i { duration: 100ms; }
 //  >                            <error{An interface cannot have animations}

--- a/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_declaration.slint
@@ -115,3 +115,9 @@ export component ComponentInstantiatesInterface {
     Other { }
 //  >    <error{Cannot create an instance of an interface; write 'implement Other <=> self;' to implement it}
 }
+
+// A global cannot implement an interface, so the hint has nothing to suggest there.
+global GlobalInstantiatesInterface {
+    Other { }
+//  >       <error{A global component cannot have sub elements}
+}

--- a/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
@@ -125,5 +125,13 @@ export interface DeclaredLater { }
 export interface InstantiatesInterface {
     Base { }
 //  >      <error{An interface cannot have sub elements}
-//  >   <^error{Cannot create an instance of an interface; write 'implement Base <=> self;' to implement it}
+}
+
+// The instantiation hint stays suppressed at any depth inside the interface.
+export interface NestedInstantiation {
+    Rectangle {
+//  >error{An interface cannot have sub elements}
+        Base { }
+    }
+//  <error{An interface cannot have sub elements}
 }

--- a/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
+++ b/internal/compiler/tests/syntax/interfaces/interface_inheritance.slint
@@ -127,6 +127,12 @@ export interface InstantiatesInterface {
 //  >      <error{An interface cannot have sub elements}
 }
 
+// A conditional sub element is a sub element, and reports as one.
+export interface ConditionalInstantiation {
+    if true: Base { }
+//  >               <error{An interface cannot have sub elements}
+}
+
 // The instantiation hint stays suppressed at any depth inside the interface.
 export interface NestedInstantiation {
     Rectangle {


### PR DESCRIPTION
Part of the experimental `interface` / `implement` work tracked in #1870.

## Reject a conditional sub elements in an interface or a global

`'if cond: SomeInterface { }'` in an interface or global was accepted by the compiler, where `SomeInterface { }` was rejected.

## Don't suggest `implement Foo <=> self;` where it is not supported

Writing an interface as a child element inside an interface or a global reported an error which suggested using `implement Foo <=> self;` instead. Now we only apply the suggestion in contexts where `implement` would actually be supported (i.e. in a Component).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>