### PR TITLE
Visual Editor: Resize sidebar panes and remember their heights

### DIFF
--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -77,6 +77,29 @@ pub fn initialize(
 
     #[cfg(feature = "system-testing")]
     test_sync::initialize();
+    let settings = PREVIEW_STATE.with_borrow(|preview_state| preview_state.settings.clone());
+    editor_ui.set_elements_pane_height(
+        settings.elements_pane_height.map_or(0.0, |height| height as f32),
+    );
+    editor_ui
+        .set_outline_pane_height(settings.outline_pane_height.map_or(0.0, |height| height as f32));
+
+    let to_lsp_for_elements = to_lsp.clone();
+    editor_ui.on_elements_pane_resized(move |height| {
+        update_pane_height(PaneHeight::Elements, Some(height), &to_lsp_for_elements);
+    });
+    let to_lsp_for_outline = to_lsp.clone();
+    editor_ui.on_outline_pane_resized(move |height| {
+        update_pane_height(PaneHeight::Outline, Some(height), &to_lsp_for_outline);
+    });
+    let to_lsp_for_elements_reset = to_lsp.clone();
+    editor_ui.on_elements_pane_reset(move || {
+        update_pane_height(PaneHeight::Elements, None, &to_lsp_for_elements_reset);
+    });
+    let to_lsp_for_outline_reset = to_lsp.clone();
+    editor_ui.on_outline_pane_reset(move || {
+        update_pane_height(PaneHeight::Outline, None, &to_lsp_for_outline_reset);
+    });
 
     to_lsp
         .send_telemetry(&mut [(
@@ -332,9 +355,60 @@ pub fn set_user_settings(name: String, contents: String) {
         PREVIEW_STATE.with_borrow_mut(|preview_state| {
             if let Some(editor_ui) = preview_state.editor_ui.as_ref() {
                 apply_visible_recent_projects(editor_ui, &settings);
+                editor_ui.set_elements_pane_height(
+                    settings.elements_pane_height.map_or(0.0, |height| height as f32),
+                );
+                editor_ui.set_outline_pane_height(
+                    settings.outline_pane_height.map_or(0.0, |height| height as f32),
+                );
             }
             preview_state.settings = settings;
         });
+    }
+}
+
+#[derive(Copy, Clone)]
+enum PaneHeight {
+    Elements,
+    Outline,
+}
+
+fn update_pane_height(
+    pane: PaneHeight,
+    height: Option<f32>,
+    to_lsp: &Rc<dyn i_slint_editor_preview::PreviewToLsp>,
+) {
+    let value = height.map(|height| height.round() as i32).filter(|height| *height > 0);
+    let update = PREVIEW_STATE.with_borrow_mut(|preview_state| {
+        let target = match pane {
+            PaneHeight::Elements => &mut preview_state.settings.elements_pane_height,
+            PaneHeight::Outline => &mut preview_state.settings.outline_pane_height,
+        };
+        if *target == value {
+            if let Some(editor_ui) = preview_state.editor_ui.as_ref() {
+                let height = value.map_or(0.0, |height| height as f32);
+                match pane {
+                    PaneHeight::Elements => editor_ui.set_elements_pane_height(height),
+                    PaneHeight::Outline => editor_ui.set_outline_pane_height(height),
+                }
+            }
+            return None;
+        }
+        *target = value;
+        if let Some(editor_ui) = preview_state.editor_ui.as_ref() {
+            let height = value.map_or(0.0, |height| height as f32);
+            match pane {
+                PaneHeight::Elements => editor_ui.set_elements_pane_height(height),
+                PaneHeight::Outline => editor_ui.set_outline_pane_height(height),
+            }
+        }
+        Some(preview_state.settings.serialize())
+    });
+    let Some(contents) = update else { return };
+    if let Err(error) = to_lsp
+        .send(&PreviewToLspMessage::UpdateUserSettings { name: SETTINGS_FILE.into(), contents })
+    {
+        tracing::warn!("Failed to save visual editor pane settings: {error}");
     }
 }
 

--- a/tools/editor/preview/settings.rs
+++ b/tools/editor/preview/settings.rs
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    fn pane_heights_round_trip_and_nonpositive_values_are_unset() {
+    fn pane_heights_round_trip_and_non_positive_values_are_unset() {
         let settings = VisualEditorSettings {
             recent_projects: Vec::new(),
             elements_pane_height: Some(320),

--- a/tools/editor/preview/settings.rs
+++ b/tools/editor/preview/settings.rs
@@ -23,6 +23,8 @@ pub(crate) struct Project {
 #[serde(try_from = "VisualEditorSettingsSerde", into = "VisualEditorSettingsSerde")]
 pub(crate) struct VisualEditorSettings {
     recent_projects: Vec<Project>,
+    pub(crate) elements_pane_height: Option<i32>,
+    pub(crate) outline_pane_height: Option<i32>,
 }
 
 impl VisualEditorSettings {
@@ -119,6 +121,10 @@ struct VisualEditorSettingsSerde {
     version: u32,
     #[serde(default)]
     recent_projects: Vec<Project>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    elements_pane_height: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    outline_pane_height: Option<i32>,
 }
 
 impl TryFrom<VisualEditorSettingsSerde> for VisualEditorSettings {
@@ -134,15 +140,29 @@ impl TryFrom<VisualEditorSettingsSerde> for VisualEditorSettings {
         }
         let mut recent_projects = settings.recent_projects;
         recent_projects.truncate(MAX_RECENT_PROJECTS);
-        Ok(Self { recent_projects })
+        Ok(Self {
+            recent_projects,
+            elements_pane_height: positive_height(settings.elements_pane_height),
+            outline_pane_height: positive_height(settings.outline_pane_height),
+        })
     }
 }
 
 impl From<VisualEditorSettings> for VisualEditorSettingsSerde {
     fn from(value: VisualEditorSettings) -> Self {
-        let VisualEditorSettings { recent_projects } = value;
-        Self { version: VisualEditorSettings::CURRENT_VERSION, recent_projects }
+        let VisualEditorSettings { recent_projects, elements_pane_height, outline_pane_height } =
+            value;
+        Self {
+            version: VisualEditorSettings::CURRENT_VERSION,
+            recent_projects,
+            elements_pane_height: positive_height(elements_pane_height),
+            outline_pane_height: positive_height(outline_pane_height),
+        }
     }
+}
+
+fn positive_height(height: Option<i32>) -> Option<i32> {
+    height.filter(|height| *height > 0)
 }
 
 #[cfg(test)]
@@ -166,6 +186,8 @@ mod tests {
                 Url::parse("file:///project/main.slint").unwrap(),
                 "MainWindow",
             )],
+            elements_pane_height: None,
+            outline_pane_height: None,
         };
         let serialized = settings.serialize();
         let json: serde_json::Value = serde_json::from_str(&serialized).unwrap();
@@ -181,6 +203,31 @@ mod tests {
         assert!(
             VisualEditorSettings::deserialize(r#"{"version":2,"recent_projects":[]}"#).is_none()
         );
+    }
+
+    #[test]
+    fn pane_heights_round_trip_and_nonpositive_values_are_unset() {
+        let settings = VisualEditorSettings {
+            recent_projects: Vec::new(),
+            elements_pane_height: Some(320),
+            outline_pane_height: Some(240),
+        };
+        let json = settings.serialize();
+        assert_eq!(VisualEditorSettings::deserialize(&json), Some(settings));
+        let unset = VisualEditorSettings::deserialize(
+            r#"{"version":1,"recent_projects":[],"elements_pane_height":0,"outline_pane_height":-1}"#,
+        )
+        .unwrap();
+        assert_eq!(unset.elements_pane_height, None);
+        assert_eq!(unset.outline_pane_height, None);
+    }
+
+    #[test]
+    fn older_settings_default_pane_heights() {
+        let settings =
+            VisualEditorSettings::deserialize(r#"{"version":1,"recent_projects":[]}"#).unwrap();
+        assert_eq!(settings.elements_pane_height, None);
+        assert_eq!(settings.outline_pane_height, None);
     }
 
     #[test]
@@ -225,6 +272,8 @@ mod tests {
                     "Missing",
                 ),
             ],
+            elements_pane_height: None,
+            outline_pane_height: None,
         };
 
         let visible = settings.visible_recent_projects();

--- a/tools/editor/ui-tests/tests/test_panes.py
+++ b/tools/editor/ui-tests/tests/test_panes.py
@@ -49,28 +49,47 @@ def test_pane_sizes_persist_across_relaunch(
         drag_vertically(window, outline_divider, -64)
 
         assert window_element_with_label(window, "FILES").accessible_label == "FILES"
-        assert window_element_with_label(window, "ELEMENTS").accessible_label == "ELEMENTS"
-        assert window_element_with_label(window, "APPEARANCE").accessible_label == "APPEARANCE"
-        assert window_element_with_label(window, "OUTLINE").accessible_label == "OUTLINE"
+        assert (
+            window_element_with_label(window, "ELEMENTS").accessible_label == "ELEMENTS"
+        )
+        assert (
+            window_element_with_label(window, "APPEARANCE").accessible_label
+            == "APPEARANCE"
+        )
+        assert (
+            window_element_with_label(window, "OUTLINE").accessible_label == "OUTLINE"
+        )
         assert elements_divider.absolute_position.y > initial_elements_y
         assert outline_divider.absolute_position.y < initial_outline_y
 
         saved_elements_y = elements_divider.absolute_position.y
         saved_outline_y = outline_divider.absolute_position.y
 
-        window_element_with_label(window, "Collapse sidebars").invoke_accessible_default_action()
-        window_element_with_label(window, "Expand sidebars").invoke_accessible_default_action()
+        window_element_with_label(
+            window, "Collapse sidebars"
+        ).invoke_accessible_default_action()
+        window_element_with_label(
+            window, "Expand sidebars"
+        ).invoke_accessible_default_action()
         elements_divider = window_element_with_label(window, "Elements pane resize")
         outline_divider = window_element_with_label(window, "Outline pane resize")
-        assert elements_divider.absolute_position.y == pytest.approx(saved_elements_y, abs=1)
-        assert outline_divider.absolute_position.y == pytest.approx(saved_outline_y, abs=1)
+        assert elements_divider.absolute_position.y == pytest.approx(
+            saved_elements_y, abs=1
+        )
+        assert outline_divider.absolute_position.y == pytest.approx(
+            saved_outline_y, abs=1
+        )
 
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
         elements_divider = window_element_with_label(window, "Elements pane resize")
         outline_divider = window_element_with_label(window, "Outline pane resize")
-        assert elements_divider.absolute_position.y == pytest.approx(saved_elements_y, abs=1)
-        assert outline_divider.absolute_position.y == pytest.approx(saved_outline_y, abs=1)
+        assert elements_divider.absolute_position.y == pytest.approx(
+            saved_elements_y, abs=1
+        )
+        assert outline_divider.absolute_position.y == pytest.approx(
+            saved_outline_y, abs=1
+        )
 
 
 def test_pane_dividers_are_accessible_and_no_results_is_visible(
@@ -81,7 +100,9 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
 ) -> None:
     editor_environment["HOME"] = str(tmp_path / "home")
     editor_environment["XDG_CONFIG_HOME"] = str(tmp_path / "config")
-    with launch_editor(editor_binary, editor_environment, fixture_project / "Main.slint") as editor:
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Main.slint"
+    ) as editor:
         window = first_window(editor)
         elements = window_element_with_label(window, "Elements pane resize")
         outline = window_element_with_label(window, "Outline pane resize")
@@ -104,15 +125,27 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
 
         drag_vertically(window, elements, 1000)
         drag_vertically(window, outline, 1000)
-        assert float(elements.accessible_value.split()[0]) == elements.accessible_value_minimum
-        assert float(outline.accessible_value.split()[0]) == outline.accessible_value_minimum
+        assert (
+            float(elements.accessible_value.split()[0])
+            == elements.accessible_value_minimum
+        )
+        assert (
+            float(outline.accessible_value.split()[0])
+            == outline.accessible_value_minimum
+        )
 
         elements = window_element_with_label(window, "Elements pane resize")
         outline = window_element_with_label(window, "Outline pane resize")
         drag_vertically(window, elements, -1000)
         drag_vertically(window, outline, -1000)
-        assert float(elements.accessible_value.split()[0]) == elements.accessible_value_maximum
-        assert float(outline.accessible_value.split()[0]) == outline.accessible_value_maximum
+        assert (
+            float(elements.accessible_value.split()[0])
+            == elements.accessible_value_maximum
+        )
+        assert (
+            float(outline.accessible_value.split()[0])
+            == outline.accessible_value_maximum
+        )
 
         double_click(window, elements)
         assert float(elements.accessible_value.split()[0]) == default_elements
@@ -126,19 +159,37 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
         search.accessible_value = "missing"
         no_results = window_element_with_label(window, "No Results")
         assert no_results.size.height >= 24
-        assert no_results.absolute_position.y >= search.absolute_position.y + search.size.height
-        assert no_results.absolute_position.y + no_results.size.height <= window.size.height
+        assert (
+            no_results.absolute_position.y
+            >= search.absolute_position.y + search.size.height
+        )
+        assert (
+            no_results.absolute_position.y + no_results.size.height
+            <= window.size.height
+        )
         pane = window_element_with_label(window, "Project and elements")
         assert no_results.absolute_position.x + no_results.size.width <= (
             pane.absolute_position.x + pane.size.width - 14
         )
         double_click(window, elements)
 
-    with launch_editor(editor_binary, editor_environment, fixture_project / "Main.slint") as editor:
+    with launch_editor(
+        editor_binary, editor_environment, fixture_project / "Main.slint"
+    ) as editor:
         window = first_window(editor)
-        assert float(
-            window_element_with_label(window, "Elements pane resize").accessible_value.split()[0]
-        ) == default_elements
-        assert float(
-            window_element_with_label(window, "Outline pane resize").accessible_value.split()[0]
-        ) == default_outline
+        assert (
+            float(
+                window_element_with_label(
+                    window, "Elements pane resize"
+                ).accessible_value.split()[0]
+            )
+            == default_elements
+        )
+        assert (
+            float(
+                window_element_with_label(
+                    window, "Outline pane resize"
+                ).accessible_value.split()[0]
+            )
+            == default_outline
+        )

--- a/tools/editor/ui-tests/tests/test_panes.py
+++ b/tools/editor/ui-tests/tests/test_panes.py
@@ -1,0 +1,135 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+from pathlib import Path
+
+import pytest
+import slint_testing
+from canvas_interactions import center
+from ui_driver import first_window, launch_editor, window_element_with_label
+
+
+def drag_vertically(
+    window: slint_testing.Window, element: slint_testing.Element, delta: float
+) -> None:
+    start = center(element)
+    end = slint_testing.LogicalPosition(x=start.x, y=start.y + delta)
+    button = slint_testing.PointerEventButton.Left
+    window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+    window.dispatch_event(slint_testing.PointerMoveEvent(end))
+    window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+
+
+def double_click(window: slint_testing.Window, element: slint_testing.Element) -> None:
+    position = center(element)
+    button = slint_testing.PointerEventButton.Left
+    for _ in range(2):
+        window.dispatch_event(slint_testing.PointerPressEvent(position, button))
+        window.dispatch_event(slint_testing.PointerReleaseEvent(position, button))
+
+
+def test_pane_sizes_persist_across_relaunch(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    tmp_path: Path,
+) -> None:
+    editor_environment["HOME"] = str(tmp_path / "home")
+    source_file = fixture_project / "Main.slint"
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        elements_divider = window_element_with_label(window, "Elements pane resize")
+        outline_divider = window_element_with_label(window, "Outline pane resize")
+        initial_elements_y = elements_divider.absolute_position.y
+        initial_outline_y = outline_divider.absolute_position.y
+
+        drag_vertically(window, elements_divider, 72)
+        drag_vertically(window, outline_divider, -64)
+
+        assert window_element_with_label(window, "FILES").accessible_label == "FILES"
+        assert window_element_with_label(window, "ELEMENTS").accessible_label == "ELEMENTS"
+        assert window_element_with_label(window, "APPEARANCE").accessible_label == "APPEARANCE"
+        assert window_element_with_label(window, "OUTLINE").accessible_label == "OUTLINE"
+        assert elements_divider.absolute_position.y > initial_elements_y
+        assert outline_divider.absolute_position.y < initial_outline_y
+
+        saved_elements_y = elements_divider.absolute_position.y
+        saved_outline_y = outline_divider.absolute_position.y
+
+        window_element_with_label(window, "Collapse sidebars").invoke_accessible_default_action()
+        window_element_with_label(window, "Expand sidebars").invoke_accessible_default_action()
+        elements_divider = window_element_with_label(window, "Elements pane resize")
+        outline_divider = window_element_with_label(window, "Outline pane resize")
+        assert elements_divider.absolute_position.y == pytest.approx(saved_elements_y, abs=1)
+        assert outline_divider.absolute_position.y == pytest.approx(saved_outline_y, abs=1)
+
+    with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        window = first_window(editor)
+        elements_divider = window_element_with_label(window, "Elements pane resize")
+        outline_divider = window_element_with_label(window, "Outline pane resize")
+        assert elements_divider.absolute_position.y == pytest.approx(saved_elements_y, abs=1)
+        assert outline_divider.absolute_position.y == pytest.approx(saved_outline_y, abs=1)
+
+
+def test_pane_dividers_are_accessible_and_no_results_is_visible(
+    editor_binary: Path,
+    editor_environment: dict[str, str],
+    fixture_project: Path,
+    tmp_path: Path,
+) -> None:
+    editor_environment["HOME"] = str(tmp_path / "home")
+    with launch_editor(editor_binary, editor_environment, fixture_project / "Main.slint") as editor:
+        window = first_window(editor)
+        elements = window_element_with_label(window, "Elements pane resize")
+        outline = window_element_with_label(window, "Outline pane resize")
+
+        assert elements.accessible_value_minimum == 120
+        assert elements.accessible_value_step == 8
+        assert outline.accessible_value_minimum == 120
+        assert outline.accessible_value_step == 8
+
+        default_elements = float(elements.accessible_value.split()[0])
+        default_outline = float(outline.accessible_value.split()[0])
+        elements.invoke_accessible_increment_action()
+        assert float(elements.accessible_value.split()[0]) == default_elements + 8
+        elements.invoke_accessible_decrement_action()
+        assert float(elements.accessible_value.split()[0]) == default_elements
+        outline.invoke_accessible_decrement_action()
+        assert float(outline.accessible_value.split()[0]) == default_outline - 8
+        outline.invoke_accessible_increment_action()
+        assert float(outline.accessible_value.split()[0]) == default_outline
+
+        drag_vertically(window, elements, 1000)
+        drag_vertically(window, outline, 1000)
+        assert float(elements.accessible_value.split()[0]) == elements.accessible_value_minimum
+        assert float(outline.accessible_value.split()[0]) == outline.accessible_value_minimum
+
+        elements = window_element_with_label(window, "Elements pane resize")
+        outline = window_element_with_label(window, "Outline pane resize")
+        drag_vertically(window, elements, -1000)
+        drag_vertically(window, outline, -1000)
+        assert float(elements.accessible_value.split()[0]) == elements.accessible_value_maximum
+        assert float(outline.accessible_value.split()[0]) == outline.accessible_value_maximum
+
+        double_click(window, elements)
+        assert float(elements.accessible_value.split()[0]) == default_elements
+
+        double_click(window, outline)
+        assert float(outline.accessible_value.split()[0]) == default_outline
+
+        search = window_element_with_label(window, "Search elements")
+        search.accessible_value = "missing"
+        no_results = window_element_with_label(window, "No Results")
+        assert no_results.size.height >= 82
+        assert no_results.absolute_position.y >= search.absolute_position.y + search.size.height
+        assert no_results.absolute_position.y + no_results.size.height <= window.size.height
+
+    with launch_editor(editor_binary, editor_environment, fixture_project / "Main.slint") as editor:
+        window = first_window(editor)
+        assert float(
+            window_element_with_label(window, "Elements pane resize").accessible_value.split()[0]
+        ) == default_elements
+        assert float(
+            window_element_with_label(window, "Outline pane resize").accessible_value.split()[0]
+        ) == default_outline

--- a/tools/editor/ui-tests/tests/test_panes.py
+++ b/tools/editor/ui-tests/tests/test_panes.py
@@ -35,6 +35,7 @@ def test_pane_sizes_persist_across_relaunch(
     tmp_path: Path,
 ) -> None:
     editor_environment["HOME"] = str(tmp_path / "home")
+    editor_environment["XDG_CONFIG_HOME"] = str(tmp_path / "config")
     source_file = fixture_project / "Main.slint"
 
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
@@ -79,6 +80,7 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
     tmp_path: Path,
 ) -> None:
     editor_environment["HOME"] = str(tmp_path / "home")
+    editor_environment["XDG_CONFIG_HOME"] = str(tmp_path / "config")
     with launch_editor(editor_binary, editor_environment, fixture_project / "Main.slint") as editor:
         window = first_window(editor)
         elements = window_element_with_label(window, "Elements pane resize")
@@ -119,11 +121,18 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
         assert float(outline.accessible_value.split()[0]) == default_outline
 
         search = window_element_with_label(window, "Search elements")
+        elements.accessible_value = "120"
+        assert float(elements.accessible_value.split()[0]) == 120
         search.accessible_value = "missing"
         no_results = window_element_with_label(window, "No Results")
-        assert no_results.size.height >= 82
+        assert no_results.size.height >= 24
         assert no_results.absolute_position.y >= search.absolute_position.y + search.size.height
         assert no_results.absolute_position.y + no_results.size.height <= window.size.height
+        pane = window_element_with_label(window, "Project and elements")
+        assert no_results.absolute_position.x + no_results.size.width <= (
+            pane.absolute_position.x + pane.size.width - 14
+        )
+        double_click(window, elements)
 
     with launch_editor(editor_binary, editor_environment, fixture_project / "Main.slint") as editor:
         window = first_window(editor)

--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -151,9 +151,7 @@ export component HorizontalResizeDivider inherits FocusScope {
                 self.press-absolute-y = self.absolute-position.y + self.mouse-y;
                 root.drag-started();
             } else {
-                if self.mouse-y != 0px {
-                    root.drag-finished(self.absolute-position.y + self.mouse-y - self.press-absolute-y);
-                }
+                root.drag-finished(self.absolute-position.y + self.mouse-y - self.press-absolute-y);
                 root.clear-focus();
             }
         }

--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -62,6 +62,115 @@ export component EdgeDivider inherits Rectangle {
     background: StudioTheme.border;
 }
 
+export component HorizontalResizeDivider inherits FocusScope {
+    in property <string> resize-label;
+    in property <color> line-color: StudioTheme.border;
+    in property <length> value: 120px;
+    in property <length> value-minimum: 120px;
+    in property <length> value-maximum: 120px;
+    in property <length> value-step: 8px;
+    callback drag-started();
+    callback dragged(length);
+    callback drag-finished(length);
+    callback value-set(length);
+    callback reset-requested();
+
+    height: 6px;
+    accessible-role: AccessibleRole.slider;
+    accessible-label: root.resize-label;
+    accessible-description: "Lower pane height. Arrow keys adjust by 8 px; Home and End clamp; Ctrl+Home or double-click resets.";
+    accessible-value: "\{(root.value / 1px).round()} px";
+    accessible-value-minimum: root.value-minimum / 1px;
+    accessible-value-maximum: root.value-maximum / 1px;
+    accessible-value-step: root.value-step / 1px;
+    accessible-action-increment => {
+        root.value-set(min(root.value + root.value-step, root.value-maximum));
+    }
+    accessible-action-decrement => {
+        root.value-set(max(root.value - root.value-step, root.value-minimum));
+    }
+    key-pressed(event) => {
+        if event.modifiers.control && event.text == Key.Home {
+            root.reset-requested();
+            return accept;
+        }
+        if event.text == Key.UpArrow {
+            root.value-set(min(root.value + root.value-step, root.value-maximum));
+            return accept;
+        }
+        if event.text == Key.DownArrow {
+            root.value-set(max(root.value - root.value-step, root.value-minimum));
+            return accept;
+        }
+        if event.text == Key.Home {
+            root.value-set(root.value-minimum);
+            return accept;
+        }
+        if event.text == Key.End {
+            root.value-set(root.value-maximum);
+            return accept;
+        }
+        return reject;
+    }
+
+    accessible-action-set-value(value) => {
+        if value.is-float() {
+            root.value-set(value.to-float().clamp(
+                root.value-minimum / 1px,
+                root.value-maximum / 1px,
+            ) * 1px);
+        }
+    }
+
+    Rectangle {
+        width: parent.width;
+        height: parent.height;
+        border-width: root.has-focus ? 1px : 0px;
+        border-color: StudioTheme.accent-strong;
+        background: touch.has-hover || touch.pressed
+            ? StudioTheme.accent.with-alpha(0.12)
+            : transparent;
+    }
+
+    Rectangle {
+        y: (parent.height - self.height) / 2;
+        width: parent.width;
+        height: 1px;
+        background: root.line-color;
+    }
+
+    touch := TouchArea {
+        width: parent.width;
+        height: parent.height;
+        mouse-cursor: ns-resize;
+        private property <length> press-absolute-y;
+
+        changed pressed => {
+            if self.pressed {
+                root.focus();
+                self.press-absolute-y = self.absolute-position.y + self.mouse-y;
+                root.drag-started();
+            } else {
+                if self.mouse-y != 0px {
+                    root.drag-finished(self.absolute-position.y + self.mouse-y - self.press-absolute-y);
+                }
+                root.clear-focus();
+            }
+        }
+
+        moved => {
+            if self.pressed {
+                root.dragged(self.absolute-position.y + self.mouse-y - self.press-absolute-y);
+            }
+        }
+
+        double-clicked => {
+            root.reset-requested();
+        }
+
+    }
+}
+
 export component BodyLabel inherits Text {
     color: StudioTheme.text;
     font-size: 13px;
@@ -150,6 +259,10 @@ export component SidebarToggleButton inherits Rectangle {
     border-color: active ? StudioTheme.accent-strong : StudioTheme.border;
     background: active ? StudioTheme.accent.with-alpha(0.14) : touch.has-hover ? StudioTheme.panel-subtle : StudioTheme.panel-bg;
     animate background, border-color { duration: 120ms; }
+
+    accessible-action-default => {
+        root.clicked();
+    }
 
     Rectangle {
         x: (parent.width - self.width) / 2;

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -46,7 +46,7 @@ export component InspectorPane inherits Rectangle {
         : root.default-outline-height;
     private property <length> dragged-outline-height: 0px;
     property <length> outline-height: min(
-        root.dragged-outline-height > 0px ? root.dragged-outline-height : root.requested-outline-height,
+        max(120px, root.dragged-outline-height > 0px ? root.dragged-outline-height : root.requested-outline-height),
         max(120px, root.height - root.split-height - 120px),
     );
     property <length> inspector-height: root.height - root.split-height - root.outline-height;

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { Api, EditorSurfaceMode, ElementInformation, PropertyValueKind, SelectionRectangle } from "../api.slint";
-import { EdgeDivider, EditorMetrics, StudioTheme } from "common.slint";
+import { EdgeDivider, EditorMetrics, HorizontalResizeDivider, StudioTheme } from "common.slint";
 import { OutlinePane } from "outline-pane.slint";
 import { InspectorComboOption, InspectorTokens } from "inspector/tokens.slint";
 import { InspectorInfoIcon } from "inspector/info-icon.slint";
@@ -30,14 +30,31 @@ export component InspectorPane inherits Rectangle {
 
     callback element-selected();
     callback outline-drag-started();
+    callback outline-pane-resized(length);
+    callback outline-pane-reset();
 
     width: EditorMetrics.inspector-pane-width;
     background: InspectorTokens.panel-bg;
     accessible-role: AccessibleRole.complementary;
     accessible-label: "Inspector and outline";
     property <length> content-x: 1px;
-    property <length> split-height: 1px;
-    property <length> inspector-height: (root.height - root.split-height) / 2;
+    in property <length> outline-pane-height: 0px;
+    property <length> split-height: 6px;
+    property <length> default-outline-height: (root.height - root.split-height) / 2;
+    property <length> requested-outline-height: root.outline-pane-height > 0px
+        ? root.outline-pane-height
+        : root.default-outline-height;
+    private property <length> dragged-outline-height: 0px;
+    property <length> outline-height: min(
+        root.dragged-outline-height > 0px ? root.dragged-outline-height : root.requested-outline-height,
+        max(120px, root.height - root.split-height - 120px),
+    );
+    property <length> inspector-height: root.height - root.split-height - root.outline-height;
+    private property <length> drag-start-height;
+
+    changed outline-pane-height => {
+        root.dragged-outline-height = 0px;
+    }
     in-out property <length> inspector-scroll-y: 0px;
 
     property <[SelectionRectangle]> selection-rects: Api.selection.highlight-index >= 0
@@ -86,6 +103,10 @@ export component InspectorPane inherits Rectangle {
 
     function has-backend-rect() -> bool {
         return Api.selection.highlight-index >= 0 && root.selection-rects.length > Api.selection.highlight-index;
+    }
+
+    function clamp-outline-height(height: length) -> length {
+        return min(height, max(120px, root.height - root.split-height - 120px));
     }
 
     function is-rectangle-selection() -> bool {
@@ -670,7 +691,8 @@ export component InspectorPane inherits Rectangle {
                 }
 
                 if !root.image-mode && (root.is-root-selection() || root.is-rectangle-selection() || root.is-text-selection()): InspectorSection {
-                    title: "Appearance";
+                    title: "APPEARANCE";
+                    use-shared-title: true;
 
                     InspectorPropertyRow {
                         label: root.is-text-selection() ? "Color" : "Fill";
@@ -972,19 +994,44 @@ export component InspectorPane inherits Rectangle {
         }
     }
 
-    Rectangle {
+    HorizontalResizeDivider {
+        resize-label: "Outline pane resize";
+        value: root.outline-height;
+        value-maximum: max(120px, root.height - root.split-height - 120px);
         x: root.content-x;
         y: root.inspector-height;
         width: root.width - root.content-x;
         height: root.split-height;
-        background: InspectorTokens.divider;
+        drag-started => {
+            root.drag-start-height = root.outline-height;
+        }
+        dragged(delta) => {
+            root.dragged-outline-height = root.clamp-outline-height(
+                max(120px, root.drag-start-height - delta),
+            );
+        }
+        drag-finished(delta) => {
+            if delta != 0px {
+                root.outline-pane-resized(root.clamp-outline-height(
+                    max(120px, root.drag-start-height - delta),
+                ));
+            }
+        }
+        value-set(height) => {
+            let clamped-height = root.clamp-outline-height(max(120px, height));
+            root.dragged-outline-height = clamped-height;
+            root.outline-pane-resized(clamped-height);
+        }
+        reset-requested => {
+            root.outline-pane-reset();
+        }
     }
 
     OutlinePane {
         x: root.content-x;
         y: root.inspector-height + root.split-height;
         width: root.width - root.content-x;
-        height: root.height - self.y;
+        height: root.outline-height;
         element-selected => { root.element-selected(); }
         drag-started => { root.outline-drag-started(); }
     }

--- a/tools/editor/ui/components/inspector/section.slint
+++ b/tools/editor/ui/components/inspector/section.slint
@@ -3,9 +3,11 @@
 
 import { InspectorIconButton } from "icon-button.slint";
 import { InspectorTokens } from "tokens.slint";
+import { SectionTitle } from "../common.slint";
 
 export component InspectorSection inherits Rectangle {
     in property <string> title;
+    in property <bool> use-shared-title: false;
     in property <bool> show-appearance-icons: false;
     in property <bool> show-typography-icons: false;
 
@@ -21,7 +23,15 @@ export component InspectorSection inherits Rectangle {
         Rectangle {
             height: 16px;
 
-            Text {
+            if root.use-shared-title: SectionTitle {
+                x: InspectorTokens.side-padding;
+                width: parent.width - 2 * InspectorTokens.side-padding;
+                height: parent.height;
+                label: root.title;
+                vertical-alignment: center;
+            }
+
+            if !root.use-shared-title: Text {
                 x: InspectorTokens.side-padding;
                 text: root.title;
                 color: InspectorTokens.text;

--- a/tools/editor/ui/components/left-pane.slint
+++ b/tools/editor/ui/components/left-pane.slint
@@ -207,9 +207,11 @@ component ElementPaletteRows inherits VerticalLayout {
     spacing: 0px;
 
     ScrollView {
+        min-height: 0px;
         vertical-stretch: 1;
         content-width: self.width;
         content-height: max(palette.preferred-height, self.height);
+        horizontal-scrollbar-policy: ScrollBarPolicy.always-off;
 
         palette := VerticalLayout {
             width: parent.width;
@@ -222,7 +224,7 @@ component ElementPaletteRows inherits VerticalLayout {
             }
 
             Rectangle {
-                height: 82px;
+                min-height: 24px;
                 vertical-stretch: 1;
                 if Api.element-library.length > 0 && !Api.element-library-has-matches(Api.element-library, root.query): MutedLabel {
                     width: parent.width;
@@ -254,7 +256,7 @@ export component LeftPane inherits Rectangle {
     private property <length> drag-start-height;
 
     function clamp-elements-height(height: length) -> length {
-        return min(height, max(120px, root.height - 250px));
+        return height.clamp(120px, max(120px, root.height - 250px));
     }
 
     init => {
@@ -376,7 +378,6 @@ export component LeftPane inherits Rectangle {
 
             ElementPaletteRows {
                 vertical-stretch: 1;
-                width: parent.width;
                 query: root.element-query;
                 enabled: !root.image-mode;
                 drag-enabled: Api.known-components.length > 0;

--- a/tools/editor/ui/components/left-pane.slint
+++ b/tools/editor/ui/components/left-pane.slint
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import {
-    BodyLabel, ComponentPaletteRow, EdgeDivider, EditorMetrics, MutedLabel, SectionTitle,
+    BodyLabel, ComponentPaletteRow, EdgeDivider, EditorMetrics, HorizontalResizeDivider,
+    MutedLabel, SectionTitle,
     PrimerTextInput, SidebarToggleButton, StudioTheme,
 } from "common.slint";
 import { Api, EditorSurfaceMode, ElementLibraryGroup, ElementLibraryEntry } from "../api.slint";
 import { EditorTreeIcons } from "editor-tree-icons.slint";
 import { Project } from "../project.slint";
 import { FileTreeView } from "file-tree-view.slint";
+import { ScrollView } from "std-widgets.slint";
 
 component ElementsUnavailableNotice inherits Rectangle {
     height: 82px;
@@ -200,42 +202,76 @@ component ElementPaletteRows inherits VerticalLayout {
     vertical-stretch: 1;
     in property <bool> enabled: true;
     in property <bool> drag-enabled: true;
+    in property <string> query: "";
     callback drag-started();
-    private property <string> query: Api.element-library-normalize-query(search.text);
     spacing: 0px;
 
-    search := PrimerTextInput {
-        placeholder: "Search elements…";
-        accessible-name: "Search elements";
-        background: StudioTheme.panel-subtle;
-    }
-
-    for group in Api.element-library: ElementPaletteGroup {
-        group: group;
-        query: root.query;
-        enabled: root.enabled;
-        drag-enabled: root.drag-enabled;
-        drag-started => { root.drag-started(); }
-    }
-
-    Rectangle {
+    ScrollView {
         vertical-stretch: 1;
-        if Api.element-library.length > 0 && !Api.element-library-has-matches(Api.element-library, root.query): MutedLabel {
+        content-width: self.width;
+        content-height: max(palette.preferred-height, self.height);
+
+        palette := VerticalLayout {
             width: parent.width;
-            height: parent.height;
-            text: "No Results";
-            horizontal-alignment: center;
-            vertical-alignment: center;
+            for group in Api.element-library: ElementPaletteGroup {
+                group: group;
+                query: root.query;
+                enabled: root.enabled;
+                drag-enabled: root.drag-enabled;
+                drag-started => { root.drag-started(); }
+            }
+
+            Rectangle {
+                height: 82px;
+                vertical-stretch: 1;
+                if Api.element-library.length > 0 && !Api.element-library-has-matches(Api.element-library, root.query): MutedLabel {
+                    width: parent.width;
+                    height: parent.height;
+                    text: "No Results";
+                    horizontal-alignment: center;
+                    vertical-alignment: center;
+                }
+            }
         }
     }
 }
 
 export component LeftPane inherits Rectangle {
     in property <bool> can-collapse: false;
+    in property <length> elements-pane-height: 0px;
     callback drag-started();
     callback panes-collapsed();
+    callback elements-pane-resized(length);
+    callback elements-pane-reset();
 
     private property <bool> image-mode: Api.editor-surface-mode == EditorSurfaceMode.image;
+    private property <length> default-elements-height: root.image-mode ? 540px : 360px;
+    private property <length> requested-elements-height: root.elements-pane-height > 0px
+        ? root.elements-pane-height
+        : root.default-elements-height;
+    private property <string> element-query: Api.element-library-normalize-query(search.text);
+    private property <length> elements-height: 0px;
+    private property <length> drag-start-height;
+
+    function clamp-elements-height(height: length) -> length {
+        return min(height, max(120px, root.height - 250px));
+    }
+
+    init => {
+        root.elements-height = root.clamp-elements-height(root.requested-elements-height);
+    }
+
+    changed requested-elements-height => {
+        root.elements-height = root.clamp-elements-height(root.requested-elements-height);
+    }
+
+    changed image-mode => {
+        root.elements-height = root.clamp-elements-height(root.requested-elements-height);
+    }
+
+    changed height => {
+        root.elements-height = root.clamp-elements-height(root.requested-elements-height);
+    }
 
     width: EditorMetrics.left-pane-width;
     background: StudioTheme.panel-bg;
@@ -247,15 +283,20 @@ export component LeftPane inherits Rectangle {
     }
 
     VerticalLayout {
-        padding: 14px;
-        spacing: 12px;
+        height: 100%;
+        spacing: 0px;
 
         HorizontalLayout {
-            height: 34px;
+            height: 48px;
+            padding-top: 14px;
+            padding-left: 14px;
+            padding-right: 14px;
             spacing: 10px;
             cross-axis-alignment: center;
 
             if root.can-collapse: SidebarToggleButton {
+                accessible-role: AccessibleRole.button;
+                accessible-label: "Collapse sidebars";
                 clicked => {
                     root.panes-collapsed();
                 }
@@ -277,23 +318,66 @@ export component LeftPane inherits Rectangle {
             }
         }
 
-        SectionTitle { label: "FILES"; }
+        VerticalLayout {
+            padding: 14px;
+            padding-bottom: 0px;
+            SectionTitle { label: "FILES"; }
 
-        if Project.file-tree.length == 0: FilesUnavailableNotice { }
+            if Project.file-tree.length == 0: FilesUnavailableNotice { }
 
-        if Project.file-tree.length > 0: FileTreeView {
-            vertical-stretch: 1;
+            if Project.file-tree.length > 0: FileTreeView {
+                vertical-stretch: 1;
+            }
+        }
+
+        HorizontalResizeDivider {
+            resize-label: "Elements pane resize";
+            value: root.elements-height;
+            value-maximum: max(120px, root.height - 250px);
+            drag-started => {
+                root.drag-start-height = root.elements-height;
+            }
+            dragged(delta) => {
+                root.elements-height = root.clamp-elements-height(
+                    max(120px, root.drag-start-height - delta),
+                );
+            }
+            drag-finished(delta) => {
+                if delta != 0px {
+                    root.elements-pane-resized(root.clamp-elements-height(
+                        max(120px, root.drag-start-height - delta),
+                    ));
+                }
+            }
+            value-set(height) => {
+                let clamped-height = root.clamp-elements-height(max(120px, height));
+                root.elements-height = clamped-height;
+                root.elements-pane-resized(clamped-height);
+            }
+            reset-requested => {
+                root.elements-pane-reset();
+            }
         }
 
         VerticalLayout {
-            height: root.image-mode ? 540px : 360px;
+            height: root.elements-height;
             spacing: 8px;
+            padding: 14px;
 
             SectionTitle { label: "ELEMENTS"; }
+
+            search := PrimerTextInput {
+                placeholder: "Search elements…";
+                accessible-name: "Search elements";
+                background: StudioTheme.panel-subtle;
+            }
 
             if root.image-mode: ElementsUnavailableNotice { }
 
             ElementPaletteRows {
+                vertical-stretch: 1;
+                width: parent.width;
+                query: root.element-query;
                 enabled: !root.image-mode;
                 drag-enabled: Api.known-components.length > 0;
                 drag-started => { root.drag-started(); }

--- a/tools/editor/ui/components/outline-pane.slint
+++ b/tools/editor/ui/components/outline-pane.slint
@@ -27,7 +27,7 @@ export component OutlinePane inherits Rectangle {
             padding-left: 16px;
 
             SectionTitle {
-                label: "Outline";
+                label: "OUTLINE";
             }
         }
 

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -29,6 +29,12 @@ export component EditorUi inherits Window {
 
     property <bool> sidebars-collapsed: false;
     property <length> inspector-scroll-y: 0px;
+    in property <length> elements-pane-height: 0px;
+    in property <length> outline-pane-height: 0px;
+    callback elements-pane-resized(length);
+    callback outline-pane-resized(length);
+    callback elements-pane-reset();
+    callback outline-pane-reset();
 
     function open-startup-wizard() {
         Api.open-startup-wizard();
@@ -143,9 +149,16 @@ export component EditorUi inherits Window {
 
                         if !root.sidebars-collapsed: LeftPane {
                             can-collapse: true;
+                            elements-pane-height: root.elements-pane-height;
                             drag-started => { editor.focus(); }
                             panes-collapsed => {
                                 root.sidebars-collapsed = true;
+                            }
+                            elements-pane-resized(height) => {
+                                root.elements-pane-resized(height);
+                            }
+                            elements-pane-reset => {
+                                root.elements-pane-reset();
                             }
                         }
 
@@ -159,12 +172,19 @@ export component EditorUi inherits Window {
                         }
 
                         if Api.editor-surface-mode == EditorSurfaceMode.component && !root.sidebars-collapsed: InspectorPane {
+                            outline-pane-height: root.outline-pane-height;
                             phone-background: StudioTheme.phone-bg;
                             phone-background-label: StudioTheme.dark ? "#f7f8fb" : "#ffffff";
                             element-information: Api.current-element;
                             inspector-scroll-y <=> root.inspector-scroll-y;
                             element-selected => { editor.focus(); }
                             outline-drag-started => { editor.focus(); }
+                            outline-pane-resized(height) => {
+                                root.outline-pane-resized(height);
+                            }
+                            outline-pane-reset => {
+                                root.outline-pane-reset();
+                            }
                         }
                     }
                 }
@@ -202,6 +222,8 @@ export component EditorUi inherits Window {
 
                         SidebarToggleButton {
                             active: true;
+                            accessible-role: AccessibleRole.button;
+                            accessible-label: "Expand sidebars";
                             clicked => {
                                 root.sidebars-collapsed = false;
                             }


### PR DESCRIPTION
Dragging the Files/Elements or Inspector/Outline divider now resizes the lower pane and remembers its height across sidebar reopening and application restarts.
The four pane titles share the same uppercase styling.

Stacked on #13306, updated to `91d979faa195723b2f0b29733da8242776421b01`.

- Add keyboard and accessibility adjustments, and reset defaults with double-click or Ctrl+Home.
- Keep the Elements search field above the scrolling palette and show empty results at the minimum pane height.
- Preserve the full-width divider and section padding.
- Extend existing user settings without changing the settings version.

Validation: editor Rust tests, pane/palette/outline/inspector UI tests, editor Clippy with warnings denied, Rust formatting, Ruff, and rendered layout checks.
Window shrink/regrow behavior is source-reviewed; the UI regression harness does not expose a window-size setter.
