### PR TITLE
interpreter: let a compilation result be sent to another thread

### DIFF
--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -20,6 +20,8 @@ pub struct CallbackIdx(usize);
 pub struct SubComponentIdx(usize);
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq)]
 pub struct GlobalIdx(usize);
+#[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq)]
+pub struct PublicComponentIdx(usize);
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SubComponentInstanceIdx(usize);
 #[derive(Debug, Clone, Copy, Into, From, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -761,7 +763,7 @@ impl TypeExport {
 
 #[derive(Debug, Clone)]
 pub struct CompilationUnit {
-    pub public_components: Vec<PublicComponent>,
+    pub public_components: TiVec<PublicComponentIdx, PublicComponent>,
     /// Storage for all sub-components
     pub sub_components: TiVec<SubComponentIdx, SubComponent>,
     /// The sub-components that are not item-tree root

--- a/internal/compiler/llr/item_tree.rs
+++ b/internal/compiler/llr/item_tree.rs
@@ -145,7 +145,7 @@ pub struct BindingExpression {
     pub use_count: Cell<usize>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GlobalComponent {
     pub name: SmolStr,
     pub properties: TiVec<PropertyIdx, Property>,
@@ -347,7 +347,7 @@ impl TwoWayBinding {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Property {
     pub name: SmolStr,
     pub ty: Type,
@@ -356,7 +356,7 @@ pub struct Property {
     pub use_count: Cell<usize>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Callback {
     pub name: SmolStr,
     pub ret_ty: Type,
@@ -375,7 +375,7 @@ pub struct Callback {
     pub needs_tracker: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Function {
     pub name: SmolStr,
     pub ret_ty: Type,
@@ -408,7 +408,7 @@ pub struct ListViewInfo {
     pub prop_height: MemberReference,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RepeatedElement {
     pub model: MutExpression,
     /// Within the sub_tree's root component. None for `if`
@@ -429,7 +429,7 @@ pub struct RepeatedElement {
     pub container_item_index: Option<ItemInstanceIdx>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ComponentContainerElement {
     /// The index of the `ComponentContainer` in the enclosing components `item_tree` array
     pub component_container_item_tree_index: u32,
@@ -439,6 +439,7 @@ pub struct ComponentContainerElement {
     pub component_placeholder_item_tree_index: u32,
 }
 
+#[derive(Clone)]
 pub struct Item {
     pub ty: Arc<NativeClass>,
     pub name: SmolStr,
@@ -456,7 +457,7 @@ impl std::fmt::Debug for Item {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TreeNode {
     pub sub_component_path: Vec<SubComponentInstanceIdx>,
     /// Either an index in the items, or the local dynamic index for repeater or component container
@@ -526,7 +527,7 @@ impl TreeNode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SubComponent {
     pub name: SmolStr,
     pub properties: TiVec<PropertyIdx, Property>,
@@ -634,14 +635,14 @@ pub struct SubComponent {
     pub debug_info: Option<super::debug_info::SubComponentDebugInfo>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PopupWindow {
     pub item_tree: ItemTree,
     pub position: MutExpression,
     pub is_tooltip: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PopupMenu {
     pub item_tree: ItemTree,
     pub sub_menu: MemberReference,
@@ -650,7 +651,7 @@ pub struct PopupMenu {
     pub entries: MemberReference,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Timer {
     pub interval: MutExpression,
     pub running: MutExpression,
@@ -684,7 +685,7 @@ impl SubComponent {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SubComponentInstance {
     pub ty: SubComponentIdx,
     pub name: SmolStr,
@@ -693,7 +694,7 @@ pub struct SubComponentInstance {
     pub repeater_offset: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ItemTree {
     pub root: SubComponentIdx,
     pub tree: TreeNode,
@@ -708,7 +709,7 @@ pub enum TopLevelComponentType {
     SystemTrayIcon,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PublicComponent {
     pub public_properties: PublicProperties,
     pub private_properties: PrivateProperties,
@@ -719,7 +720,7 @@ pub struct PublicComponent {
 
 /// One name the generated module exposes for a declared type (or a component alias):
 /// its own name, a renamed export, or a name kept only for backward compatibility.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TypeExport {
     /// The name users write.
     pub exported_name: SmolStr,
@@ -758,7 +759,7 @@ impl TypeExport {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompilationUnit {
     pub public_components: Vec<PublicComponent>,
     /// Storage for all sub-components

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1097,6 +1097,97 @@ async fn build_compilation_result(
     }
 }
 
+/// A [`CompilationResult`] that can be sent to another thread.
+///
+/// A `CompilationResult` is not `Send`: it shares its compilation unit between
+/// its components with an `Rc`. Convert one with
+/// [`CompilationResult::into_send()`], move it to the thread that will
+/// instantiate the components, and convert it back with `From`. That way a
+/// component can be compiled on a worker thread and instantiated on the thread
+/// running the event loop.
+///
+/// ```rust
+/// # i_slint_backend_testing::init_no_event_loop();
+/// let source = "export component App inherits Window { out property <int> v: 42; }".into();
+/// let sent = std::thread::spawn(move || {
+///     let compiler = slint_interpreter::Compiler::default();
+///     spin_on::spin_on(compiler.build_from_source(source, Default::default())).into_send()
+/// })
+/// .join()
+/// .unwrap();
+/// let result = slint_interpreter::CompilationResult::from(sent);
+/// let instance = result.component("App").unwrap().create().unwrap();
+/// # assert_eq!(instance.get_property("v").unwrap(), slint_interpreter::Value::Number(42.));
+/// ```
+pub struct CompilationResultSend {
+    /// `None` when the compilation produced no component.
+    compilation_unit: Option<i_slint_compiler::llr::CompilationUnit>,
+    /// The index of each component within the unit, by name.
+    components: HashMap<String, usize>,
+    diagnostics: Vec<Diagnostic>,
+    #[cfg(feature = "internal")]
+    watch_paths: Vec<PathBuf>,
+    #[cfg(feature = "internal")]
+    structs_and_enums: Vec<LangType>,
+}
+
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<CompilationResultSend>();
+};
+
+impl CompilationResultSend {
+    /// Returns true if the compilation failed.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics.iter().any(|d| d.level() == DiagnosticLevel::Error)
+    }
+
+    /// The diagnostics (errors and warnings) the compilation produced.
+    pub fn diagnostics(&self) -> impl Iterator<Item = Diagnostic> + '_ {
+        self.diagnostics.iter().cloned()
+    }
+
+    /// Print the diagnostics to stderr, in the same style as rustc errors.
+    #[cfg(feature = "display-diagnostics")]
+    pub fn print_diagnostics(&self) {
+        print_diagnostics(&self.diagnostics)
+    }
+}
+
+impl From<CompilationResultSend> for CompilationResult {
+    fn from(sent: CompilationResultSend) -> Self {
+        let CompilationResultSend {
+            compilation_unit,
+            components,
+            diagnostics,
+            #[cfg(feature = "internal")]
+            watch_paths,
+            #[cfg(feature = "internal")]
+            structs_and_enums,
+        } = sent;
+        let compilation_unit = compilation_unit.map(std::rc::Rc::new);
+        let components = components
+            .into_iter()
+            .filter_map(|(name, public_index)| {
+                let inner = std::rc::Rc::new(crate::component::ComponentDefinitionInner {
+                    compilation_unit: compilation_unit.clone()?,
+                    public_index,
+                    type_loaders: Default::default(),
+                });
+                Some((name, ComponentDefinition { inner }))
+            })
+            .collect();
+        Self {
+            components,
+            diagnostics,
+            #[cfg(feature = "internal")]
+            watch_paths,
+            #[cfg(feature = "internal")]
+            structs_and_enums,
+        }
+    }
+}
+
 /// The result of a compilation
 ///
 /// If [`Self::has_errors()`] is true, then the compilation failed.
@@ -1149,6 +1240,47 @@ impl CompilationResult {
     /// Returns an iterator over the compiled components.
     pub fn components(&self) -> impl Iterator<Item = ComponentDefinition> + '_ {
         self.components.values().cloned()
+    }
+
+    /// Consume the result so that it can be sent to another thread.
+    pub fn into_send(self) -> CompilationResultSend {
+        let Self {
+            components,
+            diagnostics,
+            #[cfg(feature = "internal")]
+            watch_paths,
+            #[cfg(feature = "internal")]
+            structs_and_enums,
+        } = self;
+
+        // Every definition of one result was built from the same unit.
+        let mut unit = None::<std::rc::Rc<i_slint_compiler::llr::CompilationUnit>>;
+        let components = components
+            .into_iter()
+            .map(|(name, definition)| {
+                let public_index = definition.inner.public_index;
+                match &unit {
+                    Some(u) => {
+                        debug_assert!(std::rc::Rc::ptr_eq(u, &definition.inner.compilation_unit))
+                    }
+                    None => unit = Some(definition.inner.compilation_unit.clone()),
+                }
+                (name, public_index)
+            })
+            .collect();
+        // The definitions are dropped by now, so the unit is only cloned when
+        // the caller kept one of them, or an instance, alive.
+        let compilation_unit = unit.map(std::rc::Rc::unwrap_or_clone);
+
+        CompilationResultSend {
+            compilation_unit,
+            components,
+            diagnostics,
+            #[cfg(feature = "internal")]
+            watch_paths,
+            #[cfg(feature = "internal")]
+            structs_and_enums,
+        }
     }
 
     /// Returns the names of the components that were compiled.

--- a/internal/interpreter/api.rs
+++ b/internal/interpreter/api.rs
@@ -1123,7 +1123,7 @@ pub struct CompilationResultSend {
     /// `None` when the compilation produced no component.
     compilation_unit: Option<i_slint_compiler::llr::CompilationUnit>,
     /// The index of each component within the unit, by name.
-    components: HashMap<String, usize>,
+    components: HashMap<String, i_slint_compiler::llr::PublicComponentIdx>,
     diagnostics: Vec<Diagnostic>,
     #[cfg(feature = "internal")]
     watch_paths: Vec<PathBuf>,

--- a/internal/interpreter/component.rs
+++ b/internal/interpreter/component.rs
@@ -11,7 +11,7 @@ use crate::public_api;
 use crate::{AnimationMode, Value};
 use i_slint_compiler::expression_tree::BuiltinFunction;
 use i_slint_compiler::langtype::Type as LangType;
-use i_slint_compiler::llr::{CompilationUnit, Expression, GlobalComponent};
+use i_slint_compiler::llr::{CompilationUnit, Expression, GlobalComponent, PublicComponentIdx};
 use i_slint_compiler::object_tree::PropertyVisibility;
 use i_slint_compiler::parser::normalize_identifier;
 use i_slint_core::item_tree::ItemTreeVTable;
@@ -39,7 +39,12 @@ pub struct TypeLoaders {
     /// resolve elements against the exact component the definition was
     /// built from — a name lookup could hit a same-named component from
     /// another document.
-    pub originals: std::rc::Rc<[std::rc::Rc<i_slint_compiler::object_tree::Component>]>,
+    pub originals: std::rc::Rc<
+        typed_index_collections::TiVec<
+            PublicComponentIdx,
+            std::rc::Rc<i_slint_compiler::object_tree::Component>,
+        >,
+    >,
 }
 
 /// Compiled component, one per exported public component in the
@@ -48,7 +53,7 @@ pub struct TypeLoaders {
 #[derive(Clone)]
 pub struct ComponentDefinitionInner {
     pub compilation_unit: Rc<CompilationUnit>,
-    pub public_index: usize,
+    pub public_index: PublicComponentIdx,
     /// `None` on both sides when the definition comes from a running
     /// instance without `TypeLoader` references.
     pub type_loaders: TypeLoaders,
@@ -305,7 +310,7 @@ impl ComponentInstanceInner {
 
     /// Definition this instance was created from.
     pub fn definition(&self) -> ComponentDefinitionInner {
-        let public_index = self.0.public_component_index.unwrap_or(0);
+        let public_index = self.0.public_component_index.unwrap_or(0.into());
         ComponentDefinitionInner {
             compilation_unit: self.0.root_sub_component.compilation_unit.clone(),
             public_index,
@@ -330,8 +335,9 @@ pub fn build_from_document(
     let unit = Rc::new(unit);
     // `lower_to_item_tree` builds `public_components` from `exported_roots()`
     // in iteration order, so the indices line up.
-    type_loaders.originals = document.exported_roots().collect();
-    (0..unit.public_components.len())
+    type_loaders.originals = std::rc::Rc::new(document.exported_roots().collect());
+    unit.public_components
+        .keys()
         .map(|public_index| ComponentDefinitionInner {
             compilation_unit: unit.clone(),
             public_index,

--- a/internal/interpreter/instance.rs
+++ b/internal/interpreter/instance.rs
@@ -8,8 +8,8 @@ use crate::erased::{ErasedItemRc, SubComponentCallback, SubComponentProperty};
 use crate::globals::GlobalStorage;
 use crate::item_registry::ItemRegistry;
 use i_slint_compiler::llr::{
-    self, CompilationUnit, ItemInstanceIdx, RepeatedElementIdx, SubComponentIdx,
-    SubComponentInstanceIdx,
+    self, CompilationUnit, ItemInstanceIdx, PublicComponentIdx, RepeatedElementIdx,
+    SubComponentIdx, SubComponentInstanceIdx,
 };
 use i_slint_core::item_tree::{ItemTreeNode, ItemTreeVTable};
 use i_slint_core::model::{Conditional, Repeater};
@@ -223,7 +223,7 @@ pub struct Instance {
     /// Index into `compilation_unit.public_components` for the public
     /// component this instance was built from. `None` for repeated /
     /// nested instances that don't correspond to a public component.
-    pub public_component_index: Option<usize>,
+    pub public_component_index: Option<PublicComponentIdx>,
     /// Lazily-created window adapter, used by `ImplicitLayoutInfo` and the
     /// public window/run helpers.
     pub window_adapter: OnceCell<WindowAdapterRc>,
@@ -636,7 +636,7 @@ impl Instance {
     /// up `property_init`, `two_way_bindings` and `init_code`.
     pub fn new(
         compilation_unit: Rc<CompilationUnit>,
-        public_component_index: usize,
+        public_component_index: PublicComponentIdx,
     ) -> VRc<ItemTreeVTable, Instance> {
         Self::new_with_window(compilation_unit, public_component_index, None, Default::default())
     }
@@ -646,7 +646,7 @@ impl Instance {
     /// the old instance so reloaded components keep the same window frame.
     pub fn new_with_window(
         compilation_unit: Rc<CompilationUnit>,
-        public_component_index: usize,
+        public_component_index: PublicComponentIdx,
         window_adapter: Option<i_slint_core::window::WindowAdapterRc>,
         type_loaders: crate::component::TypeLoaders,
     ) -> VRc<ItemTreeVTable, Instance> {
@@ -665,7 +665,7 @@ impl Instance {
     /// `parent_node` can walk back into the host tree.
     pub fn new_embedded(
         compilation_unit: Rc<CompilationUnit>,
-        public_component_index: usize,
+        public_component_index: PublicComponentIdx,
         type_loaders: crate::component::TypeLoaders,
         parent: vtable::VWeak<ItemTreeVTable>,
         parent_item_tree_index: u32,
@@ -681,7 +681,7 @@ impl Instance {
 
     fn new_with_options(
         compilation_unit: Rc<CompilationUnit>,
-        public_component_index: usize,
+        public_component_index: PublicComponentIdx,
         window_adapter: Option<i_slint_core::window::WindowAdapterRc>,
         type_loaders: crate::component::TypeLoaders,
         embedded_in: Option<(vtable::VWeak<ItemTreeVTable>, u32)>,
@@ -758,7 +758,7 @@ fn build_instance(
     item_tree: &llr::ItemTree,
     parent: Weak<SubComponentInstance>,
     globals: Rc<GlobalStorage>,
-    public_component_index: Option<usize>,
+    public_component_index: Option<PublicComponentIdx>,
     type_loaders: crate::component::TypeLoaders,
 ) -> VRc<ItemTreeVTable, Instance> {
     let parent_for_root = parent.clone();

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -847,3 +847,166 @@ fn accent_color_reachable_from_global() {
     let after = instance.get_property("accent").unwrap();
     assert_ne!(before, after, "accent-background should follow the system accent color");
 }
+
+/// The address of the compilation unit's sub component storage. It survives the
+/// unit being moved out of its `Rc`, and changes when the unit is copied.
+fn unit_storage(result: &crate::CompilationResult) -> usize {
+    result
+        .components
+        .values()
+        .next()
+        .expect("needs a component")
+        .inner
+        .compilation_unit
+        .sub_components
+        .raw
+        .as_ptr() as usize
+}
+
+/// The point of `into_send`: compile on a worker thread, instantiate on this one.
+#[test]
+fn compilation_result_moves_to_the_instantiating_thread() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{CompilationResult, Compiler, Value};
+
+    let code = r#"
+        export component App inherits Window {
+            in-out property <int> counter: 40;
+            out property <int> doubled: root.counter * 2;
+            public function bump() { root.counter += 1; }
+        }
+    "#;
+
+    // The compiler is not Send either, so the worker builds its own.
+    let (sent, storage_on_the_worker) = std::thread::spawn(move || {
+        let compiler = Compiler::default();
+        let result = poll_ready(compiler.build_from_source(code.into(), Default::default()));
+        let storage = unit_storage(&result);
+        (result.into_send(), storage)
+    })
+    .join()
+    .expect("compile worker panicked");
+    assert!(!sent.has_errors(), "{:?}", sent.diagnostics().collect::<Vec<_>>());
+
+    let result = CompilationResult::from(sent);
+    assert_eq!(
+        unit_storage(&result),
+        storage_on_the_worker,
+        "the unit was copied out of its Rc instead of moved"
+    );
+    let definition = result.component("App").unwrap();
+    let instance = definition.create().unwrap();
+    assert_eq!(instance.get_property("doubled").unwrap(), Value::Number(80.));
+
+    // Not just readable: the item tree built from the moved unit is live.
+    instance.invoke("bump", &[]).unwrap();
+    assert_eq!(instance.get_property("doubled").unwrap(), Value::Number(82.));
+
+    // The unit is shared, not copied per component, so it still feeds a second
+    // independent instance.
+    let other = definition.create().unwrap();
+    other.set_property("counter", Value::Number(1.)).unwrap();
+    assert_eq!(other.get_property("doubled").unwrap(), Value::Number(2.));
+    assert_eq!(instance.get_property("doubled").unwrap(), Value::Number(82.));
+}
+
+/// Every component of the result survives the round trip, resolved to the one
+/// it was compiled from rather than to a same-named component of another.
+#[test]
+fn every_component_survives_the_round_trip() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{CompilationResult, Compiler, Value};
+
+    let compiler = Compiler::default();
+    let result = poll_ready(
+        compiler.build_from_source(
+            r#"
+            export component First inherits Window { out property <int> v: 1; }
+            export component Second inherits Window { out property <int> v: 2; }
+            export component Third inherits Window { out property <int> v: 3; }
+        "#
+            .into(),
+            Default::default(),
+        ),
+    );
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let before: Vec<String> = {
+        let mut n: Vec<String> = result.component_names().map(String::from).collect();
+        n.sort();
+        n
+    };
+
+    let result = CompilationResult::from(result.into_send());
+    let mut after: Vec<String> = result.component_names().map(String::from).collect();
+    after.sort();
+    assert_eq!(before, after);
+    for (name, expected) in [("First", 1.), ("Second", 2.), ("Third", 3.)] {
+        let instance = result.component(name).unwrap().create().unwrap();
+        assert_eq!(instance.get_property("v").unwrap(), Value::Number(expected), "{name}");
+    }
+}
+
+/// A failed compilation carries its diagnostics across, and no component.
+#[test]
+fn a_failed_compilation_survives_the_round_trip() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{CompilationResult, Compiler};
+
+    let compiler = Compiler::default();
+    let result = poll_ready(
+        compiler
+            .build_from_source("export component App inherits { oops".into(), Default::default()),
+    );
+    assert!(result.has_errors());
+    let expected = result.diagnostics().count();
+
+    let sent = result.into_send();
+    assert!(sent.has_errors());
+    let result = CompilationResult::from(sent);
+    assert!(result.has_errors());
+    assert_eq!(result.diagnostics().count(), expected);
+    assert_eq!(result.components().count(), 0);
+}
+
+/// `into_send` takes the unit out of its `Rc` when nothing else holds it, and
+/// copies it when something does. Exercise the copy: keep a definition alive
+/// across the call, and check both it and the round-tripped result still work.
+#[test]
+fn a_definition_kept_alive_across_into_send_still_works() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{CompilationResult, Compiler, Value};
+
+    let compiler = Compiler::default();
+    let result = poll_ready(compiler.build_from_source(
+        "export component App inherits Window { in-out property <int> v: 7; }".into(),
+        Default::default(),
+    ));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+
+    let kept = result.component("App").unwrap();
+    let before = unit_storage(&result);
+    let round_tripped = CompilationResult::from(result.into_send());
+    assert_ne!(
+        unit_storage(&round_tripped),
+        before,
+        "the kept definition still holds the unit, so it had to be copied"
+    );
+
+    let from_kept = kept.create().unwrap();
+    let from_sent = round_tripped.component("App").unwrap().create().unwrap();
+    from_kept.set_property("v", Value::Number(1.)).unwrap();
+    from_sent.set_property("v", Value::Number(2.)).unwrap();
+    assert_eq!(from_kept.get_property("v").unwrap(), Value::Number(1.));
+    assert_eq!(from_sent.get_property("v").unwrap(), Value::Number(2.));
+}
+
+/// Poll a future that is expected to be immediately ready. The compiler is only
+/// asynchronous when an async file loader is set, which these tests don't use.
+fn poll_ready<F: std::future::Future>(future: F) -> F::Output {
+    let mut future = core::pin::pin!(future);
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+    match std::future::Future::poll(future.as_mut(), &mut cx) {
+        std::task::Poll::Ready(result) => result,
+        std::task::Poll::Pending => unreachable!("Compiler returned Pending"),
+    }
+}


### PR DESCRIPTION
- Make the LLR `Clone`
- Add API `CompilationResult::into_send(self)` to get something that can be send into another thread and converted back into a CompilationResult.