### PR TITLE
Visual Editor: Use Slint blue for dark-mode focus accents

### DIFF
--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -16,8 +16,8 @@ export global StudioTheme {
     out property <color> muted: dark ? #b7b7b7 : #6e7781;
     out property <color> border: dark ? #494949 : #d0d7de;
     out property <color> soft-border: dark ? #3f3f3f : #eaeef2;
-    out property <color> accent: #0d99ff;
-    out property <color> accent-strong: #52aeff;
+    out property <color> accent: dark ? #2379f4 : #0d99ff;
+    out property <color> accent-strong: dark ? accent.mix(#ffffff, 0.75) : #52aeff;
     out property <color> canvas: dark ? #1f1f1f : #eef2f7;
     out property <color> phone-bg: dark ? #f7f8fb : #ffffff;
     out property <color> phone-text: #20252d;

--- a/tools/editor/ui/components/editor-tree-tokens.slint
+++ b/tools/editor/ui/components/editor-tree-tokens.slint
@@ -1,19 +1,20 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import { StudioTheme } from "common.slint";
 import { Palette } from "std-widgets.slint";
 
 export global EditorTreeTokens {
     property <ColorScheme> color-scheme: Palette.color-scheme;
 
     out property <color> row-bg-hover: color-scheme == ColorScheme.dark ? #383838 : #f5f5f5;
-    out property <color> row-bg-current: color-scheme == ColorScheme.dark ? #4a5878 : #e4f4ff;
-    out property <color> drop-target-bg: color-scheme == ColorScheme.dark ? #1f2d3d : #eaf5ff;
+    out property <color> row-bg-current: color-scheme == ColorScheme.dark ? StudioTheme.accent.with-alpha(0.22) : #e4f4ff;
+    out property <color> drop-target-bg: color-scheme == ColorScheme.dark ? StudioTheme.accent.with-alpha(0.14) : #eaf5ff;
     out property <color> text: color-scheme == ColorScheme.dark ? #e6edf3 : #1f2328;
     out property <color> muted-text: color-scheme == ColorScheme.dark ? #848d97 : #656d76;
-    out property <color> accent: color-scheme == ColorScheme.dark ? #2f81f7 : #0969da;
+    out property <color> accent: color-scheme == ColorScheme.dark ? StudioTheme.accent : #0969da;
     out property <color> guide: color-scheme == ColorScheme.dark ? #21262d : #d8dee4;
-    out property <color> directory-icon: color-scheme == ColorScheme.dark ? #848d97 : #0969da;
+    out property <color> directory-icon: color-scheme == ColorScheme.dark ? StudioTheme.accent : #d29922;
 
     out property <length> row-height: 32px;
     out property <length> row-font-size: 13px;

--- a/tools/editor/ui/components/editor-tree-view.slint
+++ b/tools/editor/ui/components/editor-tree-view.slint
@@ -5,7 +5,7 @@ import {
     DropLocation,
     OutlineTreeNode,
 } from "../api.slint";
-import { AppState } from "common.slint";
+import { AppState, StudioTheme } from "common.slint";
 import { ElementVisuals } from "element-presentation.slint";
 import { EditorTreeIcons } from "editor-tree-icons.slint";
 import { EditorTreeTokens } from "editor-tree-tokens.slint";
@@ -140,6 +140,15 @@ component EditorTreeRow {
                         : root.row-has-hover
                         ? EditorTreeTokens.row-bg-hover
                         : transparent;
+                }
+
+                if root.current && StudioTheme.dark: Rectangle {
+                    x: row-highlight.x;
+                    y: (parent.height - self.height) / 2;
+                    width: EditorTreeTokens.current-indicator-width;
+                    height: EditorTreeTokens.current-indicator-height;
+                    border-radius: self.width / 2;
+                    background: EditorTreeTokens.accent;
                 }
 
                 row-drag := DragArea {

--- a/tools/editor/ui/components/editor-tree-view.slint
+++ b/tools/editor/ui/components/editor-tree-view.slint
@@ -5,7 +5,7 @@ import {
     DropLocation,
     OutlineTreeNode,
 } from "../api.slint";
-import { AppState, StudioTheme } from "common.slint";
+import { AppState } from "common.slint";
 import { ElementVisuals } from "element-presentation.slint";
 import { EditorTreeIcons } from "editor-tree-icons.slint";
 import { EditorTreeTokens } from "editor-tree-tokens.slint";
@@ -140,15 +140,6 @@ component EditorTreeRow {
                         : root.row-has-hover
                         ? EditorTreeTokens.row-bg-hover
                         : transparent;
-                }
-
-                if root.current && StudioTheme.dark: Rectangle {
-                    x: row-highlight.x;
-                    y: (parent.height - self.height) / 2;
-                    width: EditorTreeTokens.current-indicator-width;
-                    height: EditorTreeTokens.current-indicator-height;
-                    border-radius: self.width / 2;
-                    background: EditorTreeTokens.accent;
                 }
 
                 row-drag := DragArea {

--- a/tools/editor/ui/components/file-tree-view.slint
+++ b/tools/editor/ui/components/file-tree-view.slint
@@ -16,7 +16,6 @@ component FileTreeRow inherits Rectangle {
     property <int> level-safe: max(1, node.indent-level + 1);
     property <int> gutter-segments: max(0, level-safe - 1);
     property <bool> row-has-hover: touch.has-hover;
-    property <color> folder-icon-color: #d29922;
     property <int> selected-guide-index: node.show-selected-guide ? root.level-safe - 2 : -1;
     property <color> selected-guide-color: Palette.color-scheme == ColorScheme.dark ? #474747 : #c4c4c4;
     property <color> guide-color: Palette.color-scheme == ColorScheme.dark ? #303030 : #e2e2e2;
@@ -107,7 +106,7 @@ component FileTreeRow inherits Rectangle {
                     ? root.node.is-expanded ? FileTreeIcons.directory-open : FileTreeIcons.directory
                     : root.node.kind == FileTreeNodeKind.image ? FileTreeIcons.image
                     : FileTreeIcons.file-code;
-                colorize: root.folder ? root.folder-icon-color : EditorTreeTokens.muted-text;
+                colorize: root.folder ? EditorTreeTokens.directory-icon : EditorTreeTokens.muted-text;
             }
 
             Text {

--- a/tools/editor/ui/components/inspector/corner-editor.slint
+++ b/tools/editor/ui/components/inspector/corner-editor.slint
@@ -21,15 +21,15 @@ component CornerMode inherits FocusScope {
     }
     Rectangle {
         border-radius: 4px;
-        background: root.selected ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg;
+        background: root.selected ? InspectorTokens.selected-control-bg : InspectorTokens.field-bg;
         border-width: root.has-focus ? 1px : 0px;
         border-color: InspectorTokens.accent;
         Rectangle {
             x: 7px; y: 5px; width: 14px; height: 14px;
             border-radius: 4px; border-width: 1px;
             border-color: root.selected ? InspectorTokens.text : InspectorTokens.muted;
-            if root.separate: Rectangle { x: 5px; y: -1px; width: 4px; height: 16px; background: root.selected ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg; }
-            if root.separate: Rectangle { x: -1px; y: 5px; width: 16px; height: 4px; background: root.selected ? InspectorTokens.field-bg-hover : InspectorTokens.field-bg; }
+            if root.separate: Rectangle { x: 5px; y: -1px; width: 4px; height: 16px; background: root.selected ? InspectorTokens.selected-control-bg : InspectorTokens.field-bg; }
+            if root.separate: Rectangle { x: -1px; y: 5px; width: 16px; height: 4px; background: root.selected ? InspectorTokens.selected-control-bg : InspectorTokens.field-bg; }
         }
     }
     TouchArea { clicked => { root.focus(); root.activated(); } }

--- a/tools/editor/ui/components/inspector/radius-slider.slint
+++ b/tools/editor/ui/components/inspector/radius-slider.slint
@@ -40,10 +40,11 @@ export component InspectorRadiusSlider inherits FocusScope {
         return reject;
     }
     Rectangle { x: 6px; y: 11px; width: parent.width - 12px; height: 2px; background: InspectorTokens.divider; }
+    Rectangle { x: 6px; y: 11px; width: (parent.width - 12px) * root.progress; height: 2px; background: InspectorTokens.slider-fill; }
     Rectangle {
         x: 1px + (parent.width - 12px) * root.progress;
         y: 7px; width: 10px; height: 10px; border-radius: 5px;
-        background: InspectorTokens.muted;
+        background: InspectorTokens.slider-thumb;
         border-width: root.has-focus ? 1px : 0px;
         border-color: InspectorTokens.accent;
     }

--- a/tools/editor/ui/components/inspector/tokens.slint
+++ b/tools/editor/ui/components/inspector/tokens.slint
@@ -11,7 +11,10 @@ export global InspectorTokens {
     out property <color> field-border: StudioTheme.dark ? #4b4b4b : #d9d9d9;
     out property <color> text: StudioTheme.dark ? #f4f4f4 : #1e1e1e;
     out property <color> muted: StudioTheme.dark ? #9a9a9a : #8c8c8c;
-    out property <color> accent: #0d99ff;
+    out property <color> accent: StudioTheme.accent;
+    out property <color> selected-control-bg: StudioTheme.dark ? accent : field-bg-hover;
+    out property <color> slider-fill: StudioTheme.dark ? accent : transparent;
+    out property <color> slider-thumb: StudioTheme.dark ? accent : muted;
     out property <length> label-width: 52px;
     out property <length> row-gap: 6px;
     out property <length> side-padding: 12px;


### PR DESCRIPTION
Use Slint blue (`#2379F4`) for folders, selected rows, and active inspector controls in dark mode.
The corner-mode button and radius slider share the accent, while a lighter tint distinguishes canvas handles and focus borders.
Keep neutral surfaces, file and element icons, and light-mode colors unchanged.

Validation:
- Compiled and launched the editor with winit and Skia; inspected light and dark renders before rebasing.
- Focused UI checks before rebasing: 7 passed, 2 existing skips.
- `cargo check -p slint-editor --features system-testing` passed after rebasing.
- `mise run ci:autofix:fix` passed with no tracked changes.

