### PR TITLE
Normalize Windows verbatim paths in clean_path

### DIFF
--- a/internal/compiler/pathutils.rs
+++ b/internal/compiler/pathutils.rs
@@ -7,6 +7,7 @@
 //! This is not helped by us using URLs in place of paths *sometimes*.
 
 use smol_str::{SmolStr, SmolStrBuilder, format_smolstr};
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 /// Return `true` if `path` has a font file extension supported by Slint
@@ -166,6 +167,50 @@ enum PathComponent<'a> {
     File(&'a str),
 }
 
+fn starts_with_disk_root(path: &str) -> bool {
+    let b = path.as_bytes();
+    b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'\\' || b[2] == b'/')
+}
+
+/// `std::fs::canonicalize` returns `\\?\` verbatim paths,
+/// while `url::Url::from_file_path` drops that prefix and rewrites `\\?\UNC\` to `\\`.
+/// Without this rewrite a canonicalized path never compares equal to the same path from a URL.
+///
+/// `\\?\Volume{...}` has no plain spelling and `url::Url::from_file_path` rejects it,
+/// so it is left unchanged.
+fn plain_verbatim_path(path: &str) -> Cow<'_, str> {
+    if let Some(share) = path.strip_prefix(r"\\?\UNC\") {
+        Cow::Owned(format!(r"\\{share}"))
+    } else if let Some(disk) = path.strip_prefix(r"\\?\").filter(|p| starts_with_disk_root(p)) {
+        Cow::Borrowed(disk)
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+#[test]
+fn test_plain_verbatim_path() {
+    #[track_caller]
+    fn th(input: &str, expected: &str) {
+        assert_eq!(plain_verbatim_path(input), expected);
+    }
+
+    th(r"\\?\C:\Test\Foo.txt", r"C:\Test\Foo.txt");
+    th(r"\\?\C:\", r"C:\");
+    th(r"\\?\UNC\server\share\Foo.txt", r"\\server\share\Foo.txt");
+    // These have no plain spelling, so they stay as they are.
+    th(
+        r"\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\Test\Foo.txt",
+        r"\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\Test\Foo.txt",
+    );
+    th(r"\\.\C:\Test\Foo.txt", r"\\.\C:\Test\Foo.txt");
+    th(r"\\?\C:relative", r"\\?\C:relative");
+    // Untouched, because the verbatim prefix requires backslashes.
+    th("//?/C:/Test/Foo.txt", "//?/C:/Test/Foo.txt");
+    th(r"C:\Test\Foo.txt", r"C:\Test\Foo.txt");
+    th("/foo/bar", "/foo/bar");
+}
+
 /// Find which kind of path separator is used in the `str`
 fn find_path_separator(path: &str) -> char {
     for c in path.chars() {
@@ -193,11 +238,7 @@ fn components<'a>(
     let b = path.as_bytes();
 
     if offset == 0 {
-        if b.len() >= 3
-            && b[0].is_ascii_alphabetic()
-            && b[1] == b':'
-            && (b[2] == b'\\' || b[2] == b'/')
-        {
+        if starts_with_disk_root(path) {
             return Some((PC::Root(&path[0..3]), 3, b[2] as char));
         }
         if b.len() >= 2 && b[0] == b'\\' && b[1] == b'\\' {
@@ -325,6 +366,8 @@ impl<'a> Iterator for Components<'a> {
 fn clean_path_string(path: &str) -> SmolStr {
     use PathComponent as PC;
 
+    let path = plain_verbatim_path(path);
+    let path = path.as_ref();
     let separator = find_path_separator(path);
     let path = if separator == '\\' {
         path.replace('/', &format!("{separator}"))
@@ -400,9 +443,18 @@ fn test_clean_path_string() {
     th("ab/.././cb/././///./..", ".");
     th("ab/.././cb/.\\.\\\\\\\\./..", ".");
     th("ab\\..\\.\\cb\\././///./..", ".");
+    th(r"\\?\C:\ab\..\.\hello.txt", r"C:\hello.txt");
+    th(r"\\?\UNC\server\share\ab\..\hello.txt", r"\\server\share\hello.txt");
+    th(
+        r"\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\ab\..\hello.txt",
+        r"\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\hello.txt",
+    );
 }
 
 /// Return a clean up path without unnecessary `.` and `..` directories in it.
+///
+/// A Windows verbatim path is rewritten to its plain spelling,
+/// so that the result compares equal to the same path taken from a `Url`.
 ///
 /// This will *not* look at the file system, so symlinks will not get resolved.
 pub fn clean_path(path: &Path) -> PathBuf {

--- a/tools/editor/preview/settings.rs
+++ b/tools/editor/preview/settings.rs
@@ -76,12 +76,16 @@ impl VisualEditorSettings {
     }
 }
 
+fn canonical_path(path: &Path) -> std::io::Result<PathBuf> {
+    Ok(i_slint_compiler::pathutils::clean_path(&std::fs::canonicalize(path)?))
+}
+
 impl Project {
     pub(crate) fn from_file(
         path: impl AsRef<Path>,
         component: Option<String>,
     ) -> i_slint_editor_preview::Result<Self> {
-        let path = std::fs::canonicalize(path.as_ref())?;
+        let path = canonical_path(path.as_ref())?;
         let root = path
             .parent()
             .ok_or_else(|| format!("Failed to determine project root for {}", path.display()))?;
@@ -93,11 +97,11 @@ impl Project {
         path: &Path,
         component: Option<String>,
     ) -> i_slint_editor_preview::Result<Self> {
-        let root = std::fs::canonicalize(root)?;
+        let root = canonical_path(root)?;
         if !root.is_dir() {
             return Err(format!("{} is not a directory", root.display()).into());
         }
-        let path = std::fs::canonicalize(path)?;
+        let path = canonical_path(path)?;
         if !path.is_file()
             || !path
                 .extension()
@@ -282,6 +286,10 @@ mod tests {
         assert_eq!(visible[0].component, "Visible");
     }
 
+    fn url_spelling(path: &Path) -> PathBuf {
+        Url::from_file_path(std::fs::canonicalize(path).unwrap()).unwrap().to_file_path().unwrap()
+    }
+
     fn project_file() -> (tempfile::TempDir, PathBuf) {
         let directory = tempfile::tempdir().unwrap();
         fs::create_dir(directory.path().join("ui")).unwrap();
@@ -297,7 +305,7 @@ mod tests {
 
         let project = Project::from_file(&path, Some("MainWindow".into())).unwrap();
 
-        assert_eq!(project.root, std::fs::canonicalize(directory.path().join("ui")).unwrap());
+        assert_eq!(project.root, url_spelling(&directory.path().join("ui")));
         assert_eq!(project.preview.url, expected_url);
         assert_eq!(project.preview.component.as_deref(), Some("MainWindow"));
     }
@@ -309,7 +317,7 @@ mod tests {
 
         let project = Project::from_root(directory.path(), &path, None).unwrap();
 
-        assert_eq!(project.root, std::fs::canonicalize(directory.path()).unwrap());
+        assert_eq!(project.root, url_spelling(directory.path()));
         assert_eq!(project.preview.url, expected_url);
     }
 }


### PR DESCRIPTION
`std::fs::canonicalize` returns a `\\?\` verbatim path on Windows, while `Url::from_file_path` drops that prefix. A canonicalized path therefore never compares equal to the same path taken from a URL.

The editor held both spellings at once. `Project::from_root` stored the verbatim root, while the document paths come from `uri_to_file` and are plain, and `sync_file_watcher_if_needed` handed the file watcher both. One directory could then be registered twice, once under each spelling.

### The change

Rewrite verbatim paths to their plain spelling in `clean_path`, which every path entering the watch set already passes through. The rewrite mirrors `Url` exactly:

| Input | Output |
| --- | --- |
| `\\?\C:\project` | `C:\project` |
| `\\?\UNC\server\share` | `\\server\share` |
| `\\?\Volume{...}\project` | unchanged |

Volume-GUID paths have no plain spelling, and `Url::from_file_path` rejects them outright, so they never enter the URL world and stay as they are. I checked all three against the `url` crate rather than assuming.

`Project::from_root` kept the raw canonicalized root, so it normalizes too. That also makes the two diagnostics in the function print one spelling instead of two.

### Scope

This is a cleanup, not a bug fix. It claims no change to which events the file watcher reports: a probe directory takes the spelling of the watched path it derives from, so each spelling was already internally consistent, and the duplicate registration was the waste.

`initial_source_repair_is_watched_before_preview_is_published` failed on Windows for the same root cause, but 03e595fc5 (#13304) has since fixed that by comparing URLs instead of paths. I confirmed on Windows 11 that upstream passes the test without this change, so nothing here is needed to unbreak CI.

### Testing

Green on Windows 11: `slint-editor` (151), `slint-lsp` (336), `i-slint-compiler` (326 plus syntax tests), `i-slint-editor-preview` (84), `i-slint-live-preview` with `file-watcher` (16), `slint-interpreter` (60), `test-driver-interpreter` (883). `cargo fmt --all --check` clean, and clippy reports nothing on the changed code.

The full root workspace would not build locally: the prebuilt Skia needs a newer MSVC STL than the 14.39 toolset on this machine provides. The editor tests therefore ran with `renderer-software` swapped in, reverted before committing, and `cargo check -p slint-editor --all-targets` covers that the shipped Skia configuration compiles.
