### PR TITLE
winit: hide a macOS window until its first frame is submitted

### DIFF
--- a/internal/backends/winit/Cargo.toml
+++ b/internal/backends/winit/Cargo.toml
@@ -126,7 +126,7 @@ arboard = { version = "3.6", default-features = false, optional = true }
 # To disable macOS automatic shortcut translation
 objc2 = { workspace = true }
 # For GL rendering
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSColor", "NSView", "NSResponder", "objc2-core-foundation", "objc2-quartz-core"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSColor", "NSView", "NSWindow", "NSResponder", "objc2-core-foundation", "objc2-quartz-core"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "block2", "NSString", "NSNotification", "NSOperation", "NSRunLoop", "NSObjCRuntime", "NSUserDefaults"] }
 objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["CADisplayLink"] }
 block2 = "0.6.2"

--- a/internal/backends/winit/frame_throttle/apple_display_link.rs
+++ b/internal/backends/winit/frame_throttle/apple_display_link.rs
@@ -104,8 +104,6 @@ pub(super) fn try_create(
 ) -> Option<Box<dyn super::FrameThrottle>> {
     use objc2::runtime::AnyClass;
     use objc2::sel;
-    use objc2_app_kit::NSView;
-    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
     // -[NSView displayLinkWithTarget:selector:] is only available on macOS
     // 14.0+. The CADisplayLink class itself is reachable on older macOS via
@@ -116,10 +114,7 @@ pub(super) fn try_create(
 
     let mtm = MainThreadMarker::new().expect("frame throttle must be created on main thread");
 
-    let RawWindowHandle::AppKit(handle) = winit_window.window_handle().ok()?.as_raw() else {
-        return None;
-    };
-    let ns_view: &NSView = unsafe { handle.ns_view.cast().as_ref() };
+    let ns_view = crate::macos::ns_view(winit_window)?;
 
     let target = DisplayLinkTarget::new(mtm, window_adapter);
     let display_link = unsafe { ns_view.displayLinkWithTarget_selector(&target, sel!(tick:)) };

--- a/internal/backends/winit/lib.rs
+++ b/internal/backends/winit/lib.rs
@@ -37,6 +37,8 @@ pub(crate) mod event_loop;
 mod frame_throttle;
 #[cfg(target_os = "ios")]
 mod ios;
+#[cfg(target_os = "macos")]
+mod macos;
 
 /// Re-export of the winit crate.
 pub use winit;

--- a/internal/backends/winit/macos.rs
+++ b/internal/backends/winit/macos.rs
@@ -1,0 +1,51 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Keeps a freshly shown window invisible until its first frame is submitted.
+//!
+//! wgpu's Metal surface hands out no drawable while the hosting `NSWindow` reports itself
+//! as not visible (gfx-rs/wgpu#8309).
+//! A window that hasn't been ordered front yet counts as such.
+//! So the frame rendered before showing the window is dropped,
+//! and AppKit maps the window with an empty content layer.
+//! The title bar shows up alone until `occlusionState` catches up and a redraw lands.
+//! Ordering the window front with an alpha of zero hides that gap.
+//! The window server still reports such a window as visible, so the redraw goes through,
+//! and the alpha is restored once a frame is submitted.
+//!
+//! wgpu fixes this in <https://github.com/gfx-rs/wgpu/pull/10302>.
+//! Remove this module once every wgpu version Slint builds against contains that fix.
+
+use objc2::rc::Retained;
+use objc2_app_kit::{NSView, NSWindow};
+
+/// Makes a window fully transparent for as long as this value lives.
+/// Drop it when the first frame is submitted.
+pub(crate) struct RevealOnFirstFrame {
+    ns_window: Retained<NSWindow>,
+    alpha: f64,
+}
+
+impl RevealOnFirstFrame {
+    pub(crate) fn new(winit_window: &winit::window::Window) -> Option<Self> {
+        let ns_window = ns_view(winit_window)?.window()?;
+        let alpha = ns_window.alphaValue();
+        ns_window.setAlphaValue(0.0);
+        Some(Self { ns_window, alpha })
+    }
+}
+
+impl Drop for RevealOnFirstFrame {
+    fn drop(&mut self) {
+        self.ns_window.setAlphaValue(self.alpha);
+    }
+}
+
+pub(crate) fn ns_view(winit_window: &winit::window::Window) -> Option<&NSView> {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    let RawWindowHandle::AppKit(handle) = winit_window.window_handle().ok()?.as_raw() else {
+        return None;
+    };
+    Some(unsafe { handle.ns_view.cast().as_ref() })
+}

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -414,6 +414,10 @@ pub struct WinitWindowAdapter {
     #[cfg(target_arch = "wasm32")]
     virtual_keyboard_helper: RefCell<Option<super::wasm_input_helper::WasmInputHelper>>,
 
+    /// Set while a shown window waits for its first frame, see [`crate::macos::RevealOnFirstFrame`].
+    #[cfg(target_os = "macos")]
+    reveal_on_first_frame: RefCell<Option<crate::macos::RevealOnFirstFrame>>,
+
     #[cfg(any(enable_accesskit, muda))]
     event_loop_proxy: EventLoopProxy<SlintEvent>,
 
@@ -488,6 +492,8 @@ impl WinitWindowAdapter {
             renderer,
             #[cfg(target_arch = "wasm32")]
             virtual_keyboard_helper: Default::default(),
+            #[cfg(target_os = "macos")]
+            reveal_on_first_frame: Default::default(),
             #[cfg(any(enable_accesskit, muda))]
             event_loop_proxy: proxy,
             window_event_filter: Cell::new(None),
@@ -843,7 +849,13 @@ impl WinitWindowAdapter {
         }
 
         let renderer = self.renderer();
-        if matches!(renderer.render(self.window())?, DrawOutcome::Success) {
+        let outcome = renderer.render(self.window());
+        // A timeout or an error ends the wait as well, so that the window can't stay invisible.
+        #[cfg(target_os = "macos")]
+        if !matches!(outcome, Ok(DrawOutcome::Occluded | DrawOutcome::Skipped)) {
+            self.reveal_on_first_frame.take();
+        }
+        if matches!(outcome?, DrawOutcome::Success) {
             self.first_frame_presented.set(true);
         } else {
             // Frame was skipped (e.g. surface occluded). pending_redraw was already
@@ -1542,8 +1554,15 @@ impl WinitWindowAdapter {
                 });
                 self.update_accent_color();
             }
-            WinitWindowEvent::Occluded(x) => {
-                self.renderer.occluded(x);
+            WinitWindowEvent::Occluded(occluded) => {
+                self.renderer.occluded(occluded);
+
+                // wgpu hands out no drawable while the window isn't visible, see
+                // `macos::RevealOnFirstFrame`. Draw now instead of at the next display link tick.
+                #[cfg(target_os = "macos")]
+                if !occluded && self.pending_redraw.get() {
+                    self.draw()?;
+                }
 
                 // Same hack as in the Resized arm above, so that we handle Minimized changes
                 self.window_state_event();
@@ -1649,6 +1668,11 @@ impl WinitWindowAdapter {
             // rendering before the initial configure makes the compositor mis-size the window.
             if !self.first_frame_presented.get() && !self.shared_backend_data.is_wayland {
                 let _ = self.draw();
+                #[cfg(target_os = "macos")]
+                if !self.first_frame_presented.get() {
+                    *self.reveal_on_first_frame.borrow_mut() =
+                        crate::macos::RevealOnFirstFrame::new(&winit_window);
+                }
             }
 
             winit_window.set_visible(true);
@@ -1701,6 +1725,11 @@ impl WinitWindowAdapter {
             if let Some(existing_blinker) = self.cursor_blinker.borrow().upgrade() {
                 existing_blinker.stop();
             }*/
+
+            // After the window is ordered out, so that the reveal can't show it.
+            #[cfg(target_os = "macos")]
+            self.reveal_on_first_frame.take();
+
             Ok(())
         }
     }

--- a/internal/backends/winit/winitwindowadapter.rs
+++ b/internal/backends/winit/winitwindowadapter.rs
@@ -408,6 +408,9 @@ pub struct WinitWindowAdapter {
     /// Indicate whether we've ever received a resize event from winit after showing the window.
     pending_resize_event_after_show: Cell<bool>,
 
+    /// Whether the current winit window has presented a frame.
+    first_frame_presented: Cell<bool>,
+
     #[cfg(target_arch = "wasm32")]
     virtual_keyboard_helper: RefCell<Option<super::wasm_input_helper::WasmInputHelper>>,
 
@@ -481,6 +484,7 @@ impl WinitWindowAdapter {
             physical_size_before_scale_factor: Cell::new(None),
             has_explicit_size: Default::default(),
             pending_resize_event_after_show: Default::default(),
+            first_frame_presented: Default::default(),
             renderer,
             #[cfg(target_arch = "wasm32")]
             virtual_keyboard_helper: Default::default(),
@@ -603,6 +607,7 @@ impl WinitWindowAdapter {
 
         let winit_window =
             self.renderer.resume(active_event_loop, window_attributes, self.self_weak.clone())?;
+        self.first_frame_presented.set(false);
 
         // Push the host shell's color scheme and accent color to the SlintContext.
         // With `xdg_desktop_settings` the backend-wide portal watcher (spawned in
@@ -838,7 +843,9 @@ impl WinitWindowAdapter {
         }
 
         let renderer = self.renderer();
-        if !matches!(renderer.render(self.window())?, DrawOutcome::Success) {
+        if matches!(renderer.render(self.window())?, DrawOutcome::Success) {
+            self.first_frame_presented.set(true);
+        } else {
             // Frame was skipped (e.g. surface occluded). pending_redraw was already
             // cleared above, so re-arm it so we try again.
             self.request_redraw();
@@ -1640,9 +1647,7 @@ impl WinitWindowAdapter {
             // Pre-render the first frame before mapping the window to avoid a flash of
             // uninitialized VRAM on X11 (no background_pixmap). Skipped on Wayland, where
             // rendering before the initial configure makes the compositor mis-size the window.
-            if matches!(visibility, WindowVisibility::ShownFirstTime)
-                && !self.shared_backend_data.is_wayland
-            {
+            if !self.first_frame_presented.get() && !self.shared_backend_data.is_wayland {
                 let _ = self.draw();
             }
 


### PR DESCRIPTION
This is two commits.

**`winit: render the pre-show frame for any window that hasn't presented yet`** — permanent. The frame rendered before mapping a window (which avoids a flash of uninitialized VRAM on X11) was only rendered for a window shown right after its creation. A window created while the event loop runs and shown later, such as a dialog opened from a callback, mapped without it. The winit window now tracks whether it has presented a frame, and the pre-show frame is rendered whenever it hasn't.

**`winit: hide a macOS window until its first frame is submitted`** — a bridge. Since #12819 the Skia renderer reaches Metal through wgpu, whose Metal surface hands out no drawable while the hosting NSWindow reports itself as not visible (a workaround for gfx-rs/wgpu#8309). That includes a window that hasn't been ordered front yet, so the pre-show frame is dropped and AppKit maps the window with an empty content layer: the title bar appears alone and the content follows once the occlusion state catches up. The hand-written Metal surface that #12819 replaced called `nextDrawable` directly, without that check.

When the pre-show frame didn't land, the window is ordered front with an alpha of zero. The window server composites the whole window at that alpha, title bar included, so nothing of it shows, while the window still counts as visible for the occlusion state and wgpu hands out a drawable. The first frame is drawn as soon as winit reports the window as no longer occluded, and the alpha is restored once it is submitted, so the window appears complete in one step. A window whose pre-show frame succeeds, such as with the OpenGL femtovg renderer, is left alone.

wgpu fixes the underlying check in gfx-rs/wgpu#10302. Once Slint requires a wgpu release that contains it, the second commit can be reverted; the first stays.

Fixes #13302
