### PR TITLE
Visual Editor: Wait for saved pane settings before relaunch

### DIFF
--- a/tools/editor/ui-tests/tests/test_panes.py
+++ b/tools/editor/ui-tests/tests/test_panes.py
@@ -11,17 +11,29 @@ from ui_driver import first_window, launch_editor, wait_until, window_element_wi
 
 
 def wait_for_pane_settings(directory: Path, expected: dict[str, int | None]) -> None:
+    settings_path: Path | None = None
+    last_settings: dict | None = None
+
     def saved_heights() -> bool | None:
+        nonlocal settings_path, last_settings
         paths = list(directory.rglob("visual-editor-user-settings.json"))
         assert len(paths) <= 1, paths
         if not paths:
             return None
-        settings = json.loads(paths[0].read_text())
-        if all(settings.get(key) == value for key, value in expected.items()):
+        settings_path = paths[0]
+        last_settings = json.loads(settings_path.read_text())
+        if all(last_settings.get(key) == value for key, value in expected.items()):
             return True
         return None
 
-    wait_until(saved_heights)
+    try:
+        wait_until(saved_heights)
+    except AssertionError as error:
+        raise AssertionError(
+            f"Pane settings did not match {expected!r}; "
+            f"file: {settings_path or directory / '**/visual-editor-user-settings.json'}; "
+            f"last observed settings: {last_settings!r}"
+        ) from error
 
 
 def drag_vertically(

--- a/tools/editor/ui-tests/tests/test_panes.py
+++ b/tools/editor/ui-tests/tests/test_panes.py
@@ -1,12 +1,27 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import json
 from pathlib import Path
 
 import pytest
 import slint_testing
 from canvas_interactions import center
-from ui_driver import first_window, launch_editor, window_element_with_label
+from ui_driver import first_window, launch_editor, wait_until, window_element_with_label
+
+
+def wait_for_pane_settings(directory: Path, expected: dict[str, int | None]) -> None:
+    def saved_heights() -> bool | None:
+        paths = list(directory.rglob("visual-editor-user-settings.json"))
+        assert len(paths) <= 1, paths
+        if not paths:
+            return None
+        settings = json.loads(paths[0].read_text())
+        if all(settings.get(key) == value for key, value in expected.items()):
+            return True
+        return None
+
+    wait_until(saved_heights)
 
 
 def drag_vertically(
@@ -64,6 +79,8 @@ def test_pane_sizes_persist_across_relaunch(
 
         saved_elements_y = elements_divider.absolute_position.y
         saved_outline_y = outline_divider.absolute_position.y
+        saved_elements_height = int(elements_divider.accessible_value.split()[0])
+        saved_outline_height = int(outline_divider.accessible_value.split()[0])
 
         window_element_with_label(
             window, "Collapse sidebars"
@@ -78,6 +95,13 @@ def test_pane_sizes_persist_across_relaunch(
         )
         assert outline_divider.absolute_position.y == pytest.approx(
             saved_outline_y, abs=1
+        )
+        wait_for_pane_settings(
+            tmp_path,
+            {
+                "elements_pane_height": saved_elements_height,
+                "outline_pane_height": saved_outline_height,
+            },
         )
 
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
@@ -156,6 +180,7 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
         search = window_element_with_label(window, "Search elements")
         elements.accessible_value = "120"
         assert float(elements.accessible_value.split()[0]) == 120
+        wait_for_pane_settings(tmp_path, {"elements_pane_height": 120})
         search.accessible_value = "missing"
         no_results = window_element_with_label(window, "No Results")
         assert no_results.size.height >= 24
@@ -172,6 +197,9 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
             pane.absolute_position.x + pane.size.width - 14
         )
         double_click(window, elements)
+
+        assert float(elements.accessible_value.split()[0]) == default_elements
+        wait_for_pane_settings(tmp_path, {"elements_pane_height": None})
 
     with launch_editor(
         editor_binary, editor_environment, fixture_project / "Main.slint"


### PR DESCRIPTION
## Summary

Wait for pane settings to reach disk before terminating and relaunching the editor in the pane tests.
The preview queues settings updates for the host, while the testing context terminates the process on exit.
A successful UI reset therefore does not guarantee that the reset has been saved.

Keep the double-click reset and the relaunch assertions.
Assert the final UI reset, then use the existing condition-based wait to observe the saved reset.
First observe the saved 120-pixel height, so older default settings cannot satisfy the reset check.
Apply the same persistence boundary to the pane-size relaunch test.

Only `tools/editor/ui-tests/tests/test_panes.py` changes.
No production changes, fixed delays, test retries, skipped checks, or relaxed assertions.

## Validation

- Reproduced the original failure locally on repetition 3.
- Adding only the immediate UI-reset assertion still failed after relaunch on repetition 4, confirming the persistence race.
- Both fixed pane tests passed 20 consecutive local runs: 40 tests passed.
- Full UI suite with four workers: 253 passed, 47 skipped in 41.68 seconds.
- Ruff formatting, Ruff lint, and type checking passed.

Failure observed in https://github.com/slint-ui/slint/actions/runs/34365195901/job/102511984503.
