### PR TITLE
Skia: Gate Apple and Windows ash dependency on Vulkan

### DIFF
--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -26,6 +26,7 @@ opengl = []
 # `vulkan-portability` is how wgpu compiles its Vulkan backend on Apple platforms (MoltenVK).
 # It feeds an apple-target-gated dependency of wgpu-core, so it's inert elsewhere.
 vulkan = [
+  "dep:ash",
   "skia-safe/vulkan",
   "wgpu-30",
   "wgpu-30/vulkan",
@@ -36,9 +37,9 @@ vulkan = [
 kms = ["softbuffer/kms"]
 # wgpu-{29,30} enables the wgpu surface module for internal use (e.g. linuxkms DRM rendering), as well as
 # the explicit graphics APIs: Direct3D 12 on Windows, Metal on Apple, Vulkan on apple and other unix
-wgpu-29 = ["i-slint-core/wgpu-29", "dep:wgpu-29", "dep:spin_on", "dep:ash", "dep:windows-core", "dep:wgpu-hal-29"]
+wgpu-29 = ["i-slint-core/wgpu-29", "dep:wgpu-29", "dep:spin_on", "dep:windows-core", "dep:wgpu-hal-29"]
 unstable-wgpu-29 = ["i-slint-core/unstable-wgpu-29", "wgpu-29"]
-wgpu-30 = ["i-slint-core/wgpu-30", "dep:wgpu-30", "dep:spin_on", "dep:ash", "dep:windows-core", "dep:wgpu-hal-30"]
+wgpu-30 = ["i-slint-core/wgpu-30", "dep:wgpu-30", "dep:spin_on", "dep:windows-core", "dep:wgpu-hal-30"]
 unstable-wgpu-30 = ["i-slint-core/unstable-wgpu-30", "wgpu-30"]
 default = ["softbuffer", "wgpu-30"]
 
@@ -61,11 +62,15 @@ skia-safe = { version = "0.153.3", features = ["gl"] }
 glow = { workspace = true }
 unicode-segmentation = { workspace = true }
 
-ash = { version = "^0.38.0", optional = true }
-
 wgpu-29 = { workspace = true, optional = true }
 wgpu-30 = { workspace = true, optional = true }
 spin_on = { version = "0.1", optional = true }
+
+[target.'cfg(all(target_family = "unix", not(target_vendor = "apple")))'.dependencies]
+ash = { version = "^0.38.0" }
+
+[target.'cfg(any(target_vendor = "apple", target_family = "windows"))'.dependencies]
+ash = { version = "^0.38.0", optional = true }
 
 [target.'cfg(any(not(target_vendor = "apple"), target_os = "macos"))'.dependencies]
 glutin = { workspace = true, default-features = false, features = ["egl", "wgl"] }


### PR DESCRIPTION
During work to speed up the visual editor CI Codex found Mac and Windows compiling a Vulkan only feature. 

# Skia: Avoid Vulkan bindings in Metal and Direct3D builds

Enable `ash` through the explicit `vulkan` feature on Apple and Windows targets.
Keep it available on other Unix targets, where the WGPU backend uses Vulkan by default.
Remove its unconditional activation from both WGPU version features.

The Visual Editor's macOS CI dependency graph no longer contains `ash`.
The existing timing report spent 11.25 seconds compiling it for the application build.
This is a compilation-unit duration, not a measured wall-time saving from this patch.
No CI configuration or test coverage is changed.

## Tradeoff

On non-Apple Unix targets, `ash` becomes unconditional, including configurations without WGPU.
This keeps the manifest-only patch small but adds the dependency to software-only Skia builds on those targets.
Review this tradeoff before merging.

## Validation

- Dependency graph: no `ash` in the existing macOS Visual Editor CI configuration.
- Dependency graph: no `ash` in default macOS or Windows Skia builds, including macOS WGPU 29.
- Dependency graph: `ash` remains present with explicit Vulkan on macOS and Windows.
- Dependency graph: `ash` remains present in Linux default and WGPU 29 builds.
- Native macOS `cargo check --locked -p i-slint-renderer-skia --features vulkan,wgpu-29` passed with warnings denied.
- The native check required a Skia source build because the Metal+Vulkan binary archive returned HTTP 404.
- Full editor lint, Rust tests, and UI tests were not rerun for this manifest-only patch.

This dependency-only change is separate from the CI scheduling change in #13319.
