### PR TITLE
Skia: drop the ash dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,7 +3755,6 @@ dependencies = [
 name = "i-slint-renderer-skia"
 version = "1.18.0"
 dependencies = [
- "ash",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",

--- a/demos/Cargo.lock
+++ b/demos/Cargo.lock
@@ -2499,7 +2499,6 @@ dependencies = [
 name = "i-slint-renderer-skia"
 version = "1.18.0"
 dependencies = [
- "ash",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4821,7 +4821,6 @@ dependencies = [
 name = "i-slint-renderer-skia"
 version = "1.18.0"
 dependencies = [
- "ash",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",

--- a/internal/renderers/skia/Cargo.toml
+++ b/internal/renderers/skia/Cargo.toml
@@ -36,9 +36,9 @@ vulkan = [
 kms = ["softbuffer/kms"]
 # wgpu-{29,30} enables the wgpu surface module for internal use (e.g. linuxkms DRM rendering), as well as
 # the explicit graphics APIs: Direct3D 12 on Windows, Metal on Apple, Vulkan on apple and other unix
-wgpu-29 = ["i-slint-core/wgpu-29", "dep:wgpu-29", "dep:spin_on", "dep:ash", "dep:windows-core", "dep:wgpu-hal-29"]
+wgpu-29 = ["i-slint-core/wgpu-29", "dep:wgpu-29", "dep:spin_on", "dep:windows-core", "dep:wgpu-hal-29"]
 unstable-wgpu-29 = ["i-slint-core/unstable-wgpu-29", "wgpu-29"]
-wgpu-30 = ["i-slint-core/wgpu-30", "dep:wgpu-30", "dep:spin_on", "dep:ash", "dep:windows-core", "dep:wgpu-hal-30"]
+wgpu-30 = ["i-slint-core/wgpu-30", "dep:wgpu-30", "dep:spin_on", "dep:windows-core", "dep:wgpu-hal-30"]
 unstable-wgpu-30 = ["i-slint-core/unstable-wgpu-30", "wgpu-30"]
 default = ["softbuffer", "wgpu-30"]
 
@@ -60,8 +60,6 @@ clru = { workspace = true }
 skia-safe = { version = "0.153.3", features = ["gl"] }
 glow = { workspace = true }
 unicode-segmentation = { workspace = true }
-
-ash = { version = "^0.38.0", optional = true }
 
 wgpu-29 = { workspace = true, optional = true }
 wgpu-30 = { workspace = true, optional = true }

--- a/internal/renderers/skia/lib.rs
+++ b/internal/renderers/skia/lib.rs
@@ -45,6 +45,8 @@ pub mod software_surface;
 #[cfg(any(not(target_vendor = "apple"), target_os = "macos"))]
 pub mod opengl_surface;
 
+#[cfg(skia_wgpu_vulkan)]
+mod vulkan_handle;
 #[cfg(feature = "wgpu-29")]
 pub mod wgpu_29_surface;
 #[cfg(feature = "wgpu-30")]

--- a/internal/renderers/skia/vulkan_handle.rs
+++ b/internal/renderers/skia/vulkan_handle.rs
@@ -1,0 +1,30 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+// cSpell: ignore dispatchable
+//! Raw values of the Vulkan handles wgpu-hal hands out.
+//!
+//! wgpu-hal exposes its Vulkan objects as `ash::vk` handle types without re-exporting `ash`,
+//! and Skia's `vk` API takes the raw values.
+//! Every `ash::vk` handle is a `#[repr(transparent)]` wrapper mirroring the C type:
+//! a pointer for dispatchable handles (`VkInstance`, `VkQueue`, ...)
+//! and a `u64` for non-dispatchable ones (`VkImage`, ...).
+//! Reading the wrapper is what `ash::vk::Handle::as_raw` does, minus the dependency.
+
+/// Returns the raw value of a dispatchable handle.
+///
+/// # Safety
+/// `handle` must be one of `ash::vk`'s dispatchable handle types.
+pub unsafe fn dispatchable<H: Copy>(handle: H) -> u64 {
+    const { assert!(size_of::<H>() == size_of::<*mut u8>()) };
+    unsafe { core::mem::transmute_copy::<H, *mut u8>(&handle) as u64 }
+}
+
+/// Returns the raw value of a non-dispatchable handle.
+///
+/// # Safety
+/// `handle` must be one of `ash::vk`'s non-dispatchable handle types.
+pub unsafe fn non_dispatchable<H: Copy>(handle: H) -> u64 {
+    const { assert!(size_of::<H>() == size_of::<u64>()) };
+    unsafe { core::mem::transmute_copy::<H, u64>(&handle) }
+}

--- a/internal/renderers/skia/wgpu_29_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_29_surface/vulkan.rs
@@ -1,10 +1,28 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use ash::vk::Handle;
+use crate::vulkan_handle;
 use skia_safe::gpu::vk;
 
 use wgpu_29 as wgpu;
+
+// Raw values of the Vulkan handles behind wgpu-hal's objects, for Skia's `vk` API. The
+// parameter types pin which `ash::vk` handle each accessor returns; see `vulkan_handle`.
+fn vk_instance(device: &wgpu::hal::vulkan::Device) -> u64 {
+    unsafe { vulkan_handle::dispatchable(device.shared_instance().raw_instance().handle()) }
+}
+fn vk_physical_device(device: &wgpu::hal::vulkan::Device) -> u64 {
+    unsafe { vulkan_handle::dispatchable(device.raw_physical_device()) }
+}
+fn vk_device(device: &wgpu::hal::vulkan::Device) -> u64 {
+    unsafe { vulkan_handle::dispatchable(device.raw_device().handle()) }
+}
+fn vk_queue(queue: &wgpu::hal::vulkan::Queue) -> u64 {
+    unsafe { vulkan_handle::dispatchable(queue.as_raw()) }
+}
+fn vk_image(texture: &wgpu::hal::vulkan::Texture) -> u64 {
+    unsafe { vulkan_handle::non_dispatchable(texture.raw_handle()) }
+}
 
 fn vk_format_and_color_type(
     format: wgpu::TextureFormat,
@@ -77,7 +95,7 @@ pub unsafe fn make_vulkan_surface(
     // into Skia's internal BackendRenderTarget via wrap_vulkan_texture.
     unsafe {
         let vulkan_texture = texture.as_hal::<wgpu::wgc::api::Vulkan>()?;
-        let vk_image_raw = vulkan_texture.raw_handle().as_raw();
+        let vk_image_raw = vk_image(&vulkan_texture);
         let size = texture.size();
         let (vk_format, color_type) = vk_format_and_color_type(texture.format())?;
         wrap_vulkan_texture(
@@ -154,7 +172,7 @@ pub unsafe fn import_vulkan_texture(
         };
 
         let texture_info = &skia_safe::gpu::vk::ImageInfo::new(
-            vulkan_texture.unwrap().raw_handle().as_raw() as _,
+            vk_image(&vulkan_texture.unwrap()) as _,
             alloc,
             skia_safe::gpu::vk::ImageTiling::OPTIMAL,
             skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
@@ -195,18 +213,28 @@ pub unsafe fn make_vulkan_context(
         let vulkan_device = device.as_hal::<wgpu::wgc::api::Vulkan>()?;
         let vulkan_queue = queue.as_hal::<wgpu::wgc::api::Vulkan>()?;
 
-        let vulkan_queue_raw = vulkan_queue.as_raw();
+        let shared_instance = vulkan_device.shared_instance();
 
+        // Skia only asks about the instance and device handed to it below, or about the loader
+        // itself with a null instance. wgpu-hal has those handles in typed form, so use them
+        // rather than rebuilding them from the raw values Skia passes back.
         let get_proc = |of| {
             let result = match of {
-                skia_safe::gpu::vk::GetProcOf::Instance(instance, name) => vulkan_device
-                    .shared_instance()
-                    .entry()
-                    .get_instance_proc_addr(ash::vk::Instance::from_raw(instance as _), name),
-                skia_safe::gpu::vk::GetProcOf::Device(device, name) => vulkan_device
-                    .shared_instance()
-                    .raw_instance()
-                    .get_device_proc_addr(ash::vk::Device::from_raw(device as _), name),
+                skia_safe::gpu::vk::GetProcOf::Instance(instance, name) => {
+                    let instance_handle = if instance.is_null() {
+                        Default::default() // VK_NULL_HANDLE
+                    } else {
+                        let handle = shared_instance.raw_instance().handle();
+                        debug_assert_eq!(instance as u64, vk_instance(&vulkan_device));
+                        handle
+                    };
+                    shared_instance.entry().get_instance_proc_addr(instance_handle, name)
+                }
+                skia_safe::gpu::vk::GetProcOf::Device(device, name) => {
+                    let device_handle = vulkan_device.raw_device().handle();
+                    debug_assert_eq!(device as u64, vk_device(&vulkan_device));
+                    shared_instance.raw_instance().get_device_proc_addr(device_handle, name)
+                }
             };
 
             match result {
@@ -222,16 +250,16 @@ pub unsafe fn make_vulkan_context(
         // considers unsupported: without `VK_KHR_swapchain` in this list it refuses to wrap an
         // image that's in `PRESENT_SRC_KHR` layout, which is how wgpu hands out swapchain
         // images. Hand it what wgpu actually enabled, no more.
-        let instance_extensions = cstr_names(vulkan_device.shared_instance().extensions());
+        let instance_extensions = cstr_names(shared_instance.extensions());
         let device_extensions = cstr_names(vulkan_device.enabled_device_extensions());
 
         // WGPU 29 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the
         // physical device is chosen, causing it to ask for unsupported features/functions.
         let backend = vk::BackendContext::new_builder(
-            vulkan_device.shared_instance().raw_instance().handle().as_raw() as _,
-            vulkan_device.raw_physical_device().as_raw() as _,
-            vulkan_device.raw_device().handle().as_raw() as _,
-            (vulkan_queue_raw.as_raw() as _, vulkan_device.queue_family_index() as _),
+            vk_instance(&vulkan_device) as _,
+            vk_physical_device(&vulkan_device) as _,
+            vk_device(&vulkan_device) as _,
+            (vk_queue(&vulkan_queue) as _, vulkan_device.queue_family_index() as _),
             &get_proc,
             Some(vk::Version::new(1, 3, 0)),
         )

--- a/internal/renderers/skia/wgpu_30_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_30_surface/vulkan.rs
@@ -1,10 +1,28 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-use ash::vk::Handle;
+use crate::vulkan_handle;
 use skia_safe::gpu::vk;
 
 use wgpu_30 as wgpu;
+
+// Raw values of the Vulkan handles behind wgpu-hal's objects, for Skia's `vk` API. The
+// parameter types pin which `ash::vk` handle each accessor returns; see `vulkan_handle`.
+fn vk_instance(device: &wgpu::hal::vulkan::Device) -> u64 {
+    unsafe { vulkan_handle::dispatchable(device.shared_instance().raw_instance().handle()) }
+}
+fn vk_physical_device(device: &wgpu::hal::vulkan::Device) -> u64 {
+    unsafe { vulkan_handle::dispatchable(device.raw_physical_device()) }
+}
+fn vk_device(device: &wgpu::hal::vulkan::Device) -> u64 {
+    unsafe { vulkan_handle::dispatchable(device.raw_device().handle()) }
+}
+fn vk_queue(queue: &wgpu::hal::vulkan::Queue) -> u64 {
+    unsafe { vulkan_handle::dispatchable(queue.as_raw()) }
+}
+fn vk_image(texture: &wgpu::hal::vulkan::Texture) -> u64 {
+    unsafe { vulkan_handle::non_dispatchable(texture.raw_handle()) }
+}
 
 fn vk_format_and_color_type(
     format: wgpu::TextureFormat,
@@ -77,7 +95,7 @@ pub unsafe fn make_vulkan_surface(
     // into Skia's internal BackendRenderTarget via wrap_vulkan_texture.
     unsafe {
         let vulkan_texture = texture.as_hal::<wgpu::wgc::api::Vulkan>()?;
-        let vk_image_raw = vulkan_texture.raw_handle().as_raw();
+        let vk_image_raw = vk_image(&vulkan_texture);
         let size = texture.size();
         let (vk_format, color_type) = vk_format_and_color_type(texture.format())?;
         wrap_vulkan_texture(
@@ -154,7 +172,7 @@ pub unsafe fn import_vulkan_texture(
         };
 
         let texture_info = &skia_safe::gpu::vk::ImageInfo::new(
-            vulkan_texture.unwrap().raw_handle().as_raw() as _,
+            vk_image(&vulkan_texture.unwrap()) as _,
             alloc,
             skia_safe::gpu::vk::ImageTiling::OPTIMAL,
             skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
@@ -195,18 +213,28 @@ pub unsafe fn make_vulkan_context(
         let vulkan_device = device.as_hal::<wgpu::wgc::api::Vulkan>()?;
         let vulkan_queue = queue.as_hal::<wgpu::wgc::api::Vulkan>()?;
 
-        let vulkan_queue_raw = vulkan_queue.as_raw();
+        let shared_instance = vulkan_device.shared_instance();
 
+        // Skia only asks about the instance and device handed to it below, or about the loader
+        // itself with a null instance. wgpu-hal has those handles in typed form, so use them
+        // rather than rebuilding them from the raw values Skia passes back.
         let get_proc = |of| {
             let result = match of {
-                skia_safe::gpu::vk::GetProcOf::Instance(instance, name) => vulkan_device
-                    .shared_instance()
-                    .entry()
-                    .get_instance_proc_addr(ash::vk::Instance::from_raw(instance as _), name),
-                skia_safe::gpu::vk::GetProcOf::Device(device, name) => vulkan_device
-                    .shared_instance()
-                    .raw_instance()
-                    .get_device_proc_addr(ash::vk::Device::from_raw(device as _), name),
+                skia_safe::gpu::vk::GetProcOf::Instance(instance, name) => {
+                    let instance_handle = if instance.is_null() {
+                        Default::default() // VK_NULL_HANDLE
+                    } else {
+                        let handle = shared_instance.raw_instance().handle();
+                        debug_assert_eq!(instance as u64, vk_instance(&vulkan_device));
+                        handle
+                    };
+                    shared_instance.entry().get_instance_proc_addr(instance_handle, name)
+                }
+                skia_safe::gpu::vk::GetProcOf::Device(device, name) => {
+                    let device_handle = vulkan_device.raw_device().handle();
+                    debug_assert_eq!(device as u64, vk_device(&vulkan_device));
+                    shared_instance.raw_instance().get_device_proc_addr(device_handle, name)
+                }
             };
 
             match result {
@@ -222,16 +250,16 @@ pub unsafe fn make_vulkan_context(
         // considers unsupported: without `VK_KHR_swapchain` in this list it refuses to wrap an
         // image that's in `PRESENT_SRC_KHR` layout, which is how wgpu hands out swapchain
         // images. Hand it what wgpu actually enabled, no more.
-        let instance_extensions = cstr_names(vulkan_device.shared_instance().extensions());
+        let instance_extensions = cstr_names(shared_instance.extensions());
         let device_extensions = cstr_names(vulkan_device.enabled_device_extensions());
 
         // WGPU 29 is locked to vulkan 1.3 and skia assumes the highest vulkan API version of the
         // physical device is chosen, causing it to ask for unsupported features/functions.
         let backend = vk::BackendContext::new_builder(
-            vulkan_device.shared_instance().raw_instance().handle().as_raw() as _,
-            vulkan_device.raw_physical_device().as_raw() as _,
-            vulkan_device.raw_device().handle().as_raw() as _,
-            (vulkan_queue_raw.as_raw() as _, vulkan_device.queue_family_index() as _),
+            vk_instance(&vulkan_device) as _,
+            vk_physical_device(&vulkan_device) as _,
+            vk_device(&vulkan_device) as _,
+            (vk_queue(&vulkan_queue) as _, vulkan_device.queue_family_index() as _),
             &get_proc,
             Some(vk::Version::new(1, 3, 0)),
         )

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -2589,7 +2589,6 @@ dependencies = [
 name = "i-slint-renderer-skia"
 version = "1.18.0"
 dependencies = [
- "ash",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",


### PR DESCRIPTION
The renderer used `ash` for two things: the `Handle` trait, to turn the handles wgpu-hal exposes into the raw values Skia's `vk` API takes, and `from_raw`, to rebuild `vk::Instance` and `vk::Device` from the raw values Skia passes to its GetProc callback.

Skia only ever asks about the instance and device it was given, or about the loader with a null instance, so the typed handles wgpu-hal already holds can go straight back. The remaining direction, handle to raw value, reads the `#[repr(transparent)]` wrapper in `vulkan_handle`, behind safe accessors typed on wgpu-hal's objects.

The dependency was declared for every target while the code using it is only compiled where `skia_wgpu_vulkan` holds. Windows, Apple and wasm builds compiled `ash` for nothing; Linux and Android still get it through wgpu-hal's Vulkan backend.

Closes #13324

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->