### PR TITLE
Visual Editor: Make UI tests deterministic

### DIFF
--- a/internal/editor-preview/Cargo.toml
+++ b/internal/editor-preview/Cargo.toml
@@ -18,6 +18,8 @@ version.workspace = true
 path = "lib.rs"
 
 [features]
+# Private source lifecycle hooks for the Visual Editor test observer.
+system-testing = []
 preview-engine = []
 preview-builtin = ["preview-engine"]
 preview-external = []

--- a/internal/editor-preview/editor_session.rs
+++ b/internal/editor-preview/editor_session.rs
@@ -115,6 +115,8 @@ impl EditorSession {
             }
             match std::fs::read(&path) {
                 Ok(contents) => {
+                    #[cfg(feature = "system-testing")]
+                    self.to_preview.observe_source(url, std::str::from_utf8(&contents).ok());
                     tracing::debug!("Sending file {} ({} bytes) to preview", url, contents.len());
                     self.to_preview.send(&LspToPreviewMessage::SetContents {
                         url: VersionedUrl::new(url.clone(), None),
@@ -122,6 +124,8 @@ impl EditorSession {
                     });
                 }
                 Err(err) => {
+                    #[cfg(feature = "system-testing")]
+                    self.to_preview.observe_source(url, None);
                     tracing::warn!("Failed to read file {}: {err}", path.display());
                     self.to_preview.send(&LspToPreviewMessage::ForgetFile { url: url.clone() });
                 }
@@ -192,6 +196,8 @@ impl EditorSession {
         }
 
         tracing::trace!("Loading document: {url} (version: {version:?})");
+        #[cfg(feature = "system-testing")]
+        self.to_preview.observe_source(&url, Some(&content));
 
         let Some(path) = crate::uri_to_file(&url) else { return Default::default() };
         // Normalize the URL
@@ -324,6 +330,8 @@ impl EditorSession {
                 Ok(content) => self.load_document(content, url, None).await,
                 // The file was likely deleted, log and move on
                 Err(err) => {
+                    #[cfg(feature = "system-testing")]
+                    self.to_preview.observe_source(&url, None);
                     tracing::debug!("Failed to read {} from disk: {err}", path.display());
                     Ok(Default::default())
                 }
@@ -363,6 +371,8 @@ impl EditorSession {
         url: lsp_types::Url,
     ) -> crate::Result<crate::VersionedDiagnostics> {
         tracing::debug!("Deleting document: {url}");
+        #[cfg(feature = "system-testing")]
+        self.to_preview.observe_source(&url, None);
         // The preview cares about resources and slint files, so forward everything
         self.to_preview.send(&LspToPreviewMessage::ForgetFile { url: url.clone() });
 

--- a/internal/editor-preview/lsp_to_previews.rs
+++ b/internal/editor-preview/lsp_to_previews.rs
@@ -38,6 +38,9 @@ pub trait RemoteTransport {
     fn accept_unpaired_connection(&self);
 }
 
+#[cfg(feature = "system-testing")]
+type SourceObserver = Rc<dyn Fn(&lsp_types::Url, Option<&str>)>;
+
 /// Fans LSP messages out to the active local preview and, if connected, to a
 /// remote viewer. The local target is itself swappable between `ChildProcess`
 /// and `EmbeddedWasm`, driven by
@@ -45,6 +48,8 @@ pub trait RemoteTransport {
 /// The remote viewer receives every wire-format message in parallel — it isn't
 /// a target on its own.
 pub struct LspToPreviews {
+    #[cfg(feature = "system-testing")]
+    source_observer: RefCell<Option<SourceObserver>>,
     locals: HashMap<PreviewTarget, Box<dyn LspToPreview>>,
     current_local: RefCell<PreviewTarget>,
     #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
@@ -66,6 +71,8 @@ impl LspToPreviews {
         // itself, which the remote transport keeps for the connection-state
         // back-channel without forming an `Rc` cycle.
         Ok(Rc::new_cyclic(|_weak| Self {
+            #[cfg(feature = "system-testing")]
+            source_observer: Default::default(),
             locals,
             current_local: RefCell::new(current_local),
             #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
@@ -78,11 +85,25 @@ impl LspToPreviews {
         let locals =
             std::iter::once((target, Box::new(lsp_to_preview) as Box<dyn LspToPreview>)).collect();
         Rc::new(Self {
+            #[cfg(feature = "system-testing")]
+            source_observer: Default::default(),
             locals,
             current_local: RefCell::new(target),
             #[cfg(all(not(target_arch = "wasm32"), feature = "preview-remote"))]
             remote: None,
         })
+    }
+
+    #[cfg(feature = "system-testing")]
+    pub fn set_source_observer(&self, observer: SourceObserver) {
+        self.source_observer.replace(Some(observer));
+    }
+
+    #[cfg(feature = "system-testing")]
+    pub(crate) fn observe_source(&self, url: &lsp_types::Url, content: Option<&str>) {
+        if let Some(observer) = self.source_observer.borrow().as_ref() {
+            observer(url, content);
+        }
     }
 
     /// Send to the local preview and to the remote viewer in parallel.

--- a/internal/editor-preview/settings_store.rs
+++ b/internal/editor-preview/settings_store.rs
@@ -31,7 +31,7 @@ pub fn save(tool_name: &str, name: &str, contents: &str) -> crate::Result<()> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn settings_path(tool_name: &str, name: &str) -> Option<PathBuf> {
-    if tool_name == "slint-editor"
+    if tool_name == "visual-editor"
         && let Some(config_dir) = std::env::var_os("SLINT_EDITOR_TEST_CONFIG_DIR")
     {
         return settings_path_from_config_dir(&PathBuf::from(config_dir).join(tool_name), name);

--- a/internal/editor-preview/settings_store.rs
+++ b/internal/editor-preview/settings_store.rs
@@ -31,6 +31,9 @@ pub fn save(tool_name: &str, name: &str, contents: &str) -> crate::Result<()> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn settings_path(tool_name: &str, name: &str) -> Option<PathBuf> {
+    if let Some(config_dir) = std::env::var_os("SLINT_EDITOR_TEST_CONFIG_DIR") {
+        return settings_path_from_config_dir(&PathBuf::from(config_dir), name);
+    }
     let application = if cfg!(target_os = "linux") { "slint" } else { tool_name };
     let project_dirs = directories::ProjectDirs::from("dev", "Slint", application)?;
     let mut config_dir = project_dirs.config_dir().to_owned();

--- a/internal/editor-preview/settings_store.rs
+++ b/internal/editor-preview/settings_store.rs
@@ -31,10 +31,10 @@ pub fn save(tool_name: &str, name: &str, contents: &str) -> crate::Result<()> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn settings_path(tool_name: &str, name: &str) -> Option<PathBuf> {
-    if tool_name == "slint-editor" {
-        if let Some(config_dir) = std::env::var_os("SLINT_EDITOR_TEST_CONFIG_DIR") {
-            return settings_path_from_config_dir(&PathBuf::from(config_dir).join(tool_name), name);
-        }
+    if tool_name == "slint-editor"
+        && let Some(config_dir) = std::env::var_os("SLINT_EDITOR_TEST_CONFIG_DIR")
+    {
+        return settings_path_from_config_dir(&PathBuf::from(config_dir).join(tool_name), name);
     }
     let application = if cfg!(target_os = "linux") { "slint" } else { tool_name };
     let project_dirs = directories::ProjectDirs::from("dev", "Slint", application)?;

--- a/internal/editor-preview/settings_store.rs
+++ b/internal/editor-preview/settings_store.rs
@@ -31,6 +31,7 @@ pub fn save(tool_name: &str, name: &str, contents: &str) -> crate::Result<()> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn settings_path(tool_name: &str, name: &str) -> Option<PathBuf> {
+    #[cfg(feature = "system-testing")]
     if tool_name == "visual-editor"
         && let Some(config_dir) = std::env::var_os("SLINT_EDITOR_TEST_CONFIG_DIR")
     {

--- a/internal/editor-preview/settings_store.rs
+++ b/internal/editor-preview/settings_store.rs
@@ -31,8 +31,10 @@ pub fn save(tool_name: &str, name: &str, contents: &str) -> crate::Result<()> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn settings_path(tool_name: &str, name: &str) -> Option<PathBuf> {
-    if let Some(config_dir) = std::env::var_os("SLINT_EDITOR_TEST_CONFIG_DIR") {
-        return settings_path_from_config_dir(&PathBuf::from(config_dir), name);
+    if tool_name == "slint-editor" {
+        if let Some(config_dir) = std::env::var_os("SLINT_EDITOR_TEST_CONFIG_DIR") {
+            return settings_path_from_config_dir(&PathBuf::from(config_dir).join(tool_name), name);
+        }
     }
     let application = if cfg!(target_os = "linux") { "slint" } else { tool_name };
     let project_dirs = directories::ProjectDirs::from("dev", "Slint", application)?;

--- a/internal/live-preview/protocol.rs
+++ b/internal/live-preview/protocol.rs
@@ -9,7 +9,6 @@ mod versioned_url;
 
 pub use lsp_to_preview::{
     LspToPreview, LspToPreviewMessage, PreviewComponent, PreviewConfig, RemoteConnectionState,
-    WorkspaceEditOutcome,
 };
 pub use pairing::PairingRejection;
 pub use preview_to_lsp::{PreviewTarget, PreviewToLsp, PreviewToLspMessage};

--- a/internal/live-preview/protocol.rs
+++ b/internal/live-preview/protocol.rs
@@ -9,6 +9,7 @@ mod versioned_url;
 
 pub use lsp_to_preview::{
     LspToPreview, LspToPreviewMessage, PreviewComponent, PreviewConfig, RemoteConnectionState,
+    WorkspaceEditOutcome,
 };
 pub use pairing::PairingRejection;
 pub use preview_to_lsp::{PreviewTarget, PreviewToLsp, PreviewToLspMessage};

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -7,6 +7,16 @@ use lsp_types::Url;
 
 use super::{PreviewTarget, VersionedUrl};
 
+/// The terminal result of applying a workspace edit in the local editor
+/// process. The result describes filesystem writes; it does not acknowledge
+/// preview installation, which follows through the normal reload path.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub enum WorkspaceEditOutcome {
+    Applied { files: u32 },
+    Rejected,
+    Failed { files: u32, written: u32 },
+}
+
 /// The Component to preview
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PreviewComponent {
@@ -51,6 +61,8 @@ pub enum LspToPreviewMessage {
         name: String,
         contents: String,
     },
+    /// Acknowledge the filesystem stage of a workspace edit.
+    WorkspaceEditResult { outcome: WorkspaceEditOutcome },
     ShowPreview(PreviewComponent),
     HighlightFromEditor {
         url: Option<Url>,

--- a/internal/live-preview/protocol/lsp_to_preview.rs
+++ b/internal/live-preview/protocol/lsp_to_preview.rs
@@ -7,16 +7,6 @@ use lsp_types::Url;
 
 use super::{PreviewTarget, VersionedUrl};
 
-/// The terminal result of applying a workspace edit in the local editor
-/// process. The result describes filesystem writes; it does not acknowledge
-/// preview installation, which follows through the normal reload path.
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-pub enum WorkspaceEditOutcome {
-    Applied { files: u32 },
-    Rejected,
-    Failed { files: u32, written: u32 },
-}
-
 /// The Component to preview
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PreviewComponent {
@@ -61,8 +51,6 @@ pub enum LspToPreviewMessage {
         name: String,
         contents: String,
     },
-    /// Acknowledge the filesystem stage of a workspace edit.
-    WorkspaceEditResult { outcome: WorkspaceEditOutcome },
     ShowPreview(PreviewComponent),
     HighlightFromEditor {
         url: Option<Url>,

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -1033,6 +1033,11 @@ impl Connection {
                                             );
                                         }
                                         LspToPreviewMessage::OpenProject { .. } => {}
+                                        LspToPreviewMessage::WorkspaceEditResult { .. } => {
+                                            tracing::warn!(
+                                                "Ignoring unexpected WorkspaceEditResult over WebSocket"
+                                            );
+                                        }
                                         // Pairing is settled before the session starts, so
                                         // these can only be a confused or malicious peer.
                                         LspToPreviewMessage::PairingHello { .. }

--- a/internal/live-preview/remote/connection.rs
+++ b/internal/live-preview/remote/connection.rs
@@ -1033,11 +1033,6 @@ impl Connection {
                                             );
                                         }
                                         LspToPreviewMessage::OpenProject { .. } => {}
-                                        LspToPreviewMessage::WorkspaceEditResult { .. } => {
-                                            tracing::warn!(
-                                                "Ignoring unexpected WorkspaceEditResult over WebSocket"
-                                            );
-                                        }
                                         // Pairing is settled before the session starts, so
                                         // these can only be a confused or malicious peer.
                                         LspToPreviewMessage::PairingHello { .. }

--- a/tools/editor/Cargo.toml
+++ b/tools/editor/Cargo.toml
@@ -23,7 +23,7 @@ path = "main.rs"
 ## Discover preview targets on the local network.
 preview-remote = ["dep:mdns-sd"]
 ## Enable the out-of-process system-testing transport.
-system-testing = ["slint/system-testing"]
+system-testing = ["slint/system-testing", "i-slint-editor-preview/system-testing"]
 
 [dependencies]
 i-slint-backend-selector = { workspace = true }

--- a/tools/editor/build.rs
+++ b/tools/editor/build.rs
@@ -26,10 +26,15 @@ fn record_test_build() {
     let git = |args: &[&str]| {
         std::process::Command::new("git").args(args).output().ok().filter(|o| o.status.success())
     };
-    let revision = git(&["rev-parse", "HEAD"])
+    let mut revision = git(&["rev-parse", "HEAD"])
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
         .unwrap_or_else(|| "unknown".into());
-    for reference in ["HEAD", "refs/heads"] {
+    if git(&["status", "--porcelain", "--untracked-files=normal"])
+        .is_some_and(|output| !output.stdout.is_empty())
+    {
+        revision.push_str("-dirty");
+    }
+    for reference in ["HEAD", "refs/heads", "index"] {
         if let Some(output) = git(&["rev-parse", "--git-path", reference]) {
             println!("cargo:rerun-if-changed={}", String::from_utf8_lossy(&output.stdout).trim());
         }

--- a/tools/editor/build.rs
+++ b/tools/editor/build.rs
@@ -4,6 +4,7 @@
 use slint_build::CompilerConfiguration;
 
 fn main() {
+    record_test_build();
     // Safety: there are no other threads at this point
     unsafe {
         // Make the compiler handle ComponentContainer:
@@ -16,4 +17,27 @@ fn main() {
         CompilerConfiguration::new().with_debug_info(true),
     )
     .unwrap();
+}
+
+fn record_test_build() {
+    if std::env::var_os("CARGO_FEATURE_SYSTEM_TESTING").is_none() {
+        return;
+    }
+    let git = |args: &[&str]| {
+        std::process::Command::new("git").args(args).output().ok().filter(|o| o.status.success())
+    };
+    let revision = git(&["rev-parse", "HEAD"])
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
+        .unwrap_or_else(|| "unknown".into());
+    for reference in ["HEAD", "refs/heads"] {
+        if let Some(output) = git(&["rev-parse", "--git-path", reference]) {
+            println!("cargo:rerun-if-changed={}", String::from_utf8_lossy(&output.stdout).trim());
+        }
+    }
+    let mut features: Vec<_> = std::env::vars()
+        .filter_map(|(name, _)| name.strip_prefix("CARGO_FEATURE_").map(str::to_owned))
+        .collect();
+    features.sort();
+    println!("cargo:rustc-env=SLINT_EDITOR_BUILD_REVISION={revision}");
+    println!("cargo:rustc-env=SLINT_EDITOR_BUILD_FEATURES={}", features.join(","));
 }

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -507,6 +507,9 @@ fn handle_workspace_edit(
                                 label.unwrap_or("(unnamed)"),
                                 path.display()
                             );
+                        } else {
+                            #[cfg(feature = "system-testing")]
+                            crate::preview::test_sync::record_write();
                         }
                     }
                     None => {

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -589,7 +589,7 @@ fn canonical_preview_component(
 
 fn handle_workspace_edit(
     document_cache: &editor_preview::DocumentCache,
-    to_preview: &impl editor_preview::LspToPreview,
+    to_preview: &editor_preview::LspToPreviews,
     label: Option<&str>,
     edit: &lsp_types::WorkspaceEdit,
 ) {

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -498,6 +498,8 @@ fn handle_workspace_edit(
 ) {
     match editor_preview::editing::text_edit::apply_workspace_edit(document_cache, edit) {
         Ok(edited_texts) => {
+            #[cfg(feature = "system-testing")]
+            let operation = crate::preview::test_sync::record_accepted_edit();
             for editor_preview::editing::text_edit::EditedText { url, contents } in edited_texts {
                 match editor_preview::uri_to_file(&url) {
                     Some(path) => {
@@ -517,6 +519,8 @@ fn handle_workspace_edit(
                     }
                 }
             }
+            #[cfg(feature = "system-testing")]
+            crate::preview::test_sync::record_edit_completed(operation, "completed");
         }
         Err(err) => {
             tracing::error!(

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -26,6 +26,7 @@ use slint::ComponentHandle;
 #[cfg(target_os = "linux")]
 mod flatpak;
 mod preview;
+mod source_write;
 #[cfg(target_os = "macos")]
 mod sparkle;
 mod startup;
@@ -155,20 +156,29 @@ async fn handle_local_message(
 ) {
     if let (Some(id), PreviewToLspMessage::SendWorkspaceEdit { label, edit }) = (edit_id, &message)
     {
-        #[cfg(feature = "system-testing")]
         let urls: Vec<_> = editor_preview::editing::text_edit::EditIterator::new(edit)
             .map(|(document, _)| document.uri)
             .collect();
         let outcome = handle_workspace_edit(&session.document_cache, label.as_deref(), edit);
         #[cfg(feature = "system-testing")]
+        let acknowledgment_urls = urls.clone();
+        #[cfg(feature = "system-testing")]
         let work = preview::test_sync::Work::capture("edit acknowledgment");
         if let Err(error) = slint::invoke_from_event_loop(move || {
             #[cfg(feature = "system-testing")]
-            work.run(|| preview::test_sync::acknowledge(&urls, id, outcome));
+            work.run(|| preview::test_sync::acknowledge(&acknowledgment_urls, id, outcome));
             #[cfg(not(feature = "system-testing"))]
             preview::workspace_edit_result(id, outcome);
         }) {
             tracing::error!("Failed to queue edit acknowledgment: {error}");
+        }
+        if matches!(outcome, preview::WorkspaceEditOutcome::Failed { may_have_changed: true }) {
+            for url in &urls {
+                if let Err(error) = session.reload_document(url.clone()).await {
+                    tracing::error!("Failed to reload source after a write failure: {error}");
+                }
+            }
+            session.send_files_to_preview(&urls, |_| true);
         }
     } else {
         handle_preview_message(message, session, project_root).await;
@@ -639,44 +649,7 @@ fn handle_workspace_edit(
             );
             preview::WorkspaceEditOutcome::Rejected
         }
-        Ok(edited_texts) => {
-            let files = u32::try_from(edited_texts.len()).unwrap_or(u32::MAX);
-            #[cfg(feature = "system-testing")]
-            crate::preview::test_sync::accepted_edit();
-            let mut written = 0u32;
-            for editor_preview::editing::text_edit::EditedText { url, contents } in edited_texts {
-                match editor_preview::uri_to_file(&url) {
-                    Some(path) => {
-                        if let Err(err) = std::fs::write(&path, &contents) {
-                            #[cfg(feature = "system-testing")]
-                            crate::preview::test_sync::effect("failed");
-                            tracing::error!(
-                                "Failed to apply workspace edit '{}' to {}: {err}",
-                                label.unwrap_or("(unnamed)"),
-                                path.display()
-                            );
-                        } else {
-                            written += 1;
-                            #[cfg(feature = "system-testing")]
-                            {
-                                crate::preview::test_sync::written(&url);
-                                crate::preview::test_sync::expect_watch(&url);
-                            }
-                        }
-                    }
-                    None => {
-                        tracing::warn!("Cannot apply workspace edit to non-file URL: {url}");
-                    }
-                }
-            }
-            if written == files {
-                preview::WorkspaceEditOutcome::Applied
-            } else {
-                #[cfg(feature = "system-testing")]
-                crate::preview::test_sync::effect("failed");
-                preview::WorkspaceEditOutcome::Failed
-            }
-        }
+        Ok(edited_texts) => persist_workspace_edit(edited_texts, label),
         Err(err) => {
             #[cfg(feature = "system-testing")]
             crate::preview::test_sync::effect("rejected");
@@ -689,9 +662,99 @@ fn handle_workspace_edit(
     }
 }
 
+fn persist_workspace_edit(
+    edited_texts: Vec<editor_preview::editing::text_edit::EditedText>,
+    label: Option<&str>,
+) -> preview::WorkspaceEditOutcome {
+    let files = u32::try_from(edited_texts.len()).unwrap_or(u32::MAX);
+    #[cfg(feature = "system-testing")]
+    crate::preview::test_sync::accepted_edit();
+    let mut written = 0u32;
+    let mut may_have_changed = false;
+    for editor_preview::editing::text_edit::EditedText { url, contents } in edited_texts {
+        match editor_preview::uri_to_file(&url) {
+            Some(path) => {
+                let result = source_write::write_source(
+                    &path,
+                    contents.as_bytes(),
+                    #[cfg(any(test, feature = "system-testing"))]
+                    {
+                        #[cfg(feature = "system-testing")]
+                        {
+                            crate::preview::test_sync::take_write_fault(&url)
+                        }
+                        #[cfg(not(feature = "system-testing"))]
+                        {
+                            None
+                        }
+                    },
+                );
+                let mutated = result.as_ref().err().is_none_or(|error| error.may_have_changed);
+                may_have_changed |= mutated;
+                #[cfg(feature = "system-testing")]
+                if mutated {
+                    crate::preview::test_sync::mutated(&url);
+                }
+                if let Err(failure) = result {
+                    let err = failure.error;
+                    #[cfg(feature = "system-testing")]
+                    crate::preview::test_sync::effect("failed");
+                    tracing::error!(
+                        "Failed to apply workspace edit '{}' to {}: {err}",
+                        label.unwrap_or("(unnamed)"),
+                        path.display()
+                    );
+                } else {
+                    written += 1;
+                    #[cfg(feature = "system-testing")]
+                    {
+                        crate::preview::test_sync::written(&url);
+                        crate::preview::test_sync::expect_watch(&url);
+                    }
+                }
+            }
+            None => {
+                tracing::warn!("Cannot apply workspace edit to non-file URL: {url}");
+            }
+        }
+    }
+    if written == files {
+        preview::WorkspaceEditOutcome::Applied
+    } else {
+        #[cfg(feature = "system-testing")]
+        crate::preview::test_sync::effect("failed");
+        preview::WorkspaceEditOutcome::Failed { may_have_changed }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workspace_failure_keeps_earlier_file_mutation() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = directory.path().join("First.slint");
+        let blocked = directory.path().join("Blocked.slint");
+        std::fs::write(&first, "original").unwrap();
+        std::fs::create_dir(&blocked).unwrap();
+        let edit = |path: &Path| editor_preview::editing::text_edit::EditedText {
+            url: Url::from_file_path(path).unwrap(),
+            contents: "updated".into(),
+        };
+        let outcome = persist_workspace_edit(vec![edit(&blocked)], None);
+        assert!(matches!(
+            outcome,
+            preview::WorkspaceEditOutcome::Failed { may_have_changed: false }
+        ));
+        let outcome = persist_workspace_edit(vec![edit(&first), edit(&blocked)], None);
+        assert!(matches!(
+            outcome,
+            preview::WorkspaceEditOutcome::Failed { may_have_changed: true }
+        ));
+        assert_eq!(std::fs::read_to_string(first).unwrap(), "updated");
+        assert!(blocked.is_dir());
+    }
 
     #[test]
     fn initial_source_repair_is_watched_before_preview_is_published() {

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -18,7 +18,7 @@ use i_slint_editor_preview::{LspToPreviews, Result, document_cache::OpenImportCa
 use i_slint_live_preview::file_watcher::{FileWatcher, WatchEvent};
 use i_slint_live_preview::protocol::{
     LspToPreviewMessage, PreviewComponent, PreviewTarget, PreviewToLspMessage, SourceFileVersion,
-    VersionedUrl,
+    VersionedUrl, WorkspaceEditOutcome,
 };
 use lsp_types::{MessageType, Url};
 use slint::ComponentHandle;
@@ -57,6 +57,8 @@ fn main() -> Result<()> {
     #[cfg(target_os = "windows")]
     let _updater = windows::connect(&editor_ui);
 
+    #[cfg(feature = "system-testing")]
+    preview::test_sync::initialize();
     let settings = startup::load_settings();
     if let Some(file) = cli.file {
         let project = Project::from_file(file, cli.component)?;
@@ -103,7 +105,17 @@ struct EditorLspToPreview;
 impl editor_preview::LspToPreview for EditorLspToPreview {
     fn send(&self, message: &LspToPreviewMessage) {
         let message = message.clone();
+        #[cfg(feature = "system-testing")]
+        let work = preview::test_sync::Work::capture("UI message");
+        #[cfg(feature = "system-testing")]
+        let input = preview::test_sync::source_delivery(&message);
         if let Err(err) = slint::invoke_from_event_loop(move || {
+            #[cfg(feature = "system-testing")]
+            work.run(|| {
+                preview::test_sync::install_source(input);
+                preview::lsp_to_preview(message);
+            });
+            #[cfg(not(feature = "system-testing"))]
             preview::lsp_to_preview(message);
         }) {
             tracing::error!("Failed to queue message onto the event loop: {err}");
@@ -117,13 +129,23 @@ impl editor_preview::LspToPreview for EditorLspToPreview {
     }
 }
 
+struct PreviewMessage {
+    message: PreviewToLspMessage,
+    #[cfg(feature = "system-testing")]
+    work: preview::test_sync::Work,
+}
+
 struct EmbeddedPreviewToLsp {
-    sender: crossbeam_channel::Sender<PreviewToLspMessage>,
+    sender: crossbeam_channel::Sender<PreviewMessage>,
 }
 
 impl editor_preview::PreviewToLsp for EmbeddedPreviewToLsp {
     fn send(&self, message: &PreviewToLspMessage) -> editor_preview::Result<()> {
-        self.sender.send(message.clone())?;
+        self.sender.send(PreviewMessage {
+            message: message.clone(),
+            #[cfg(feature = "system-testing")]
+            work: preview::test_sync::Work::capture("LSP message"),
+        })?;
         Ok(())
     }
 }
@@ -166,10 +188,7 @@ fn start_editor_session(
     start_lsp_thread(from_preview, project);
 }
 
-fn start_lsp_thread(
-    from_preview: crossbeam_channel::Receiver<PreviewToLspMessage>,
-    project: Project,
-) {
+fn start_lsp_thread(from_preview: crossbeam_channel::Receiver<PreviewMessage>, project: Project) {
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_io()
@@ -185,10 +204,10 @@ fn start_lsp_thread(
 }
 
 fn bridge_crossbeam_to_tokio(
-    from_preview: crossbeam_channel::Receiver<PreviewToLspMessage>,
-) -> tokio::sync::mpsc::UnboundedReceiver<PreviewToLspMessage> {
+    from_preview: crossbeam_channel::Receiver<PreviewMessage>,
+) -> tokio::sync::mpsc::UnboundedReceiver<PreviewMessage> {
     let (from_preview_tx, from_preview_rx) =
-        tokio::sync::mpsc::unbounded_channel::<PreviewToLspMessage>();
+        tokio::sync::mpsc::unbounded_channel::<PreviewMessage>();
     std::thread::spawn(move || {
         while let Ok(msg) = from_preview.recv() {
             if from_preview_tx.send(msg).is_err() {
@@ -201,7 +220,7 @@ fn bridge_crossbeam_to_tokio(
 }
 
 async fn lsp_main(
-    from_preview: crossbeam_channel::Receiver<PreviewToLspMessage>,
+    from_preview: crossbeam_channel::Receiver<PreviewMessage>,
     project: Project,
 ) -> Result<()> {
     use editor_preview::document_cache::CompilerConfiguration;
@@ -219,6 +238,8 @@ async fn lsp_main(
 
     // Wrap to_preview in Rc for sharing with the import callback and the session
     let to_preview = LspToPreviews::with_one(EditorLspToPreview);
+    #[cfg(feature = "system-testing")]
+    to_preview.set_source_observer(Rc::new(preview::test_sync::observed_read));
 
     let open_import_callback = {
         let to_preview = Rc::clone(&to_preview);
@@ -228,6 +249,11 @@ async fn lsp_main(
                 tracing::trace!("Importing file: {}", path);
                 let contents = std::fs::read(&path);
                 if let Ok(url) = Url::from_file_path(&path) {
+                    #[cfg(feature = "system-testing")]
+                    preview::test_sync::observed_read(
+                        &url,
+                        contents.as_ref().ok().and_then(|c| std::str::from_utf8(c).ok()),
+                    );
                     if let Ok(contents) = &contents {
                         to_preview.send(&LspToPreviewMessage::SetContents {
                             url: VersionedUrl::new(url, None),
@@ -276,6 +302,10 @@ async fn lsp_main(
 
     const RECOMPILE_DELAY: Duration = Duration::from_millis(50);
     let mut recompile_deadline = None;
+    #[cfg(feature = "system-testing")]
+    let mut pending_work = Vec::new();
+    #[cfg(feature = "system-testing")]
+    let mut held_events: Vec<(u64, WatchEvent)> = Vec::new();
     loop {
         if session.pending_recompile.is_empty() {
             recompile_deadline = None;
@@ -284,16 +314,38 @@ async fn lsp_main(
             recompile_deadline.get_or_insert_with(|| tokio::time::Instant::now() + RECOMPILE_DELAY);
         }
         tokio::select! {
+            _ = source_gate_changed() => {},
             watcher_event = file_watcher_rx.recv() => {
                 match watcher_event {
-                    Some(event) => trigger_editor_file_watcher(&mut session, event).await?,
+                    Some(event) => {
+                        #[cfg(feature = "system-testing")]
+                        {
+                            if let Ok(url) = Url::from_file_path(&event.path) {
+                                if let Some(gate) = preview::test_sync::hold_source(&url) {
+                                    held_events.push((gate, event));
+                                    continue;
+                                }
+                                let work = preview::test_sync::observed_write(&url);
+                                work.during(trigger_editor_file_watcher(&mut session, event)).await?;
+                                pending_work.push(work);
+                            }
+                        }
+                        #[cfg(not(feature = "system-testing"))]
+                        trigger_editor_file_watcher(&mut session, event).await?;
+                    },
                     None => break Err("File watcher channel closed".into()),
                 }
             }
             msg = from_preview_rx.recv() => {
                 match msg {
                     Some(msg) => {
-                        handle_preview_message(msg, &mut session, &project_root).await;
+                        #[cfg(feature = "system-testing")]
+                        {
+                            msg.work.during(handle_preview_message(msg.message, &mut session, &project_root)).await;
+                            pending_work.push(msg.work);
+                        }
+                        #[cfg(not(feature = "system-testing"))]
+                        handle_preview_message(msg.message, &mut session, &project_root).await;
                     }
                     None => {
                         tracing::debug!("Preview->LSP channel closed, exiting");
@@ -311,11 +363,38 @@ async fn lsp_main(
                 tracing::debug!("LSP recompiling");
                 let pending_recompile = std::mem::take(&mut session.pending_recompile);
 
+                #[cfg(feature = "system-testing")]
+                let work = preview::test_sync::Work::combine(std::mem::take(&mut pending_work));
                 for url in pending_recompile {
-                    if let Err(err) = session.reload_document(url).await {
+                    #[cfg(feature = "system-testing")]
+                    let result = work.during(session.reload_document(url)).await;
+                    #[cfg(not(feature = "system-testing"))]
+                    let result = session.reload_document(url).await;
+                    if let Err(err) = result {
                         tracing::error!("Failed document reload: {err}");
                     }
                 }
+            }
+        }
+
+        #[cfg(feature = "system-testing")]
+        {
+            let mut still_held = Vec::new();
+            for (gate, event) in held_events.drain(..) {
+                if preview::test_sync::gate_released(gate) {
+                    let work = Url::from_file_path(&event.path)
+                        .ok()
+                        .map(|url| preview::test_sync::observed_write(&url))
+                        .unwrap_or_default();
+                    work.during(trigger_editor_file_watcher(&mut session, event)).await?;
+                    pending_work.push(work);
+                } else {
+                    still_held.push((gate, event));
+                }
+            }
+            held_events = still_held;
+            if session.pending_recompile.is_empty() {
+                pending_work.clear();
             }
         }
 
@@ -326,6 +405,13 @@ async fn lsp_main(
             &mut watch_paths_revision,
         )?;
     }
+}
+
+async fn source_gate_changed() {
+    #[cfg(feature = "system-testing")]
+    preview::test_sync::gate_changed().await;
+    #[cfg(not(feature = "system-testing"))]
+    std::future::pending::<()>().await;
 }
 
 async fn trigger_editor_file_watcher(
@@ -408,7 +494,12 @@ async fn handle_preview_message(
             if let Err(error) =
                 i_slint_editor_preview::settings_store::save(TOOL_NAME, name, contents)
             {
+                #[cfg(feature = "system-testing")]
+                preview::test_sync::effect("failed");
                 tracing::warn!("Failed to save preview user settings: {error}");
+            } else {
+                #[cfg(feature = "system-testing")]
+                preview::test_sync::effect("completed");
             }
         }
         SendShowMessage { message } => {
@@ -442,7 +533,12 @@ async fn handle_preview_message(
             tracing::debug!("Ignoring message from preview: {msg:?}");
         }
         SendWorkspaceEdit { label, edit } => {
-            handle_workspace_edit(&session.document_cache, label.as_deref(), edit);
+            handle_workspace_edit(
+                &session.document_cache,
+                session.to_preview.as_ref(),
+                label.as_deref(),
+                edit,
+            );
         }
     }
 }
@@ -493,25 +589,45 @@ fn canonical_preview_component(
 
 fn handle_workspace_edit(
     document_cache: &editor_preview::DocumentCache,
+    to_preview: &impl editor_preview::LspToPreview,
     label: Option<&str>,
     edit: &lsp_types::WorkspaceEdit,
 ) {
     match editor_preview::editing::text_edit::apply_workspace_edit(document_cache, edit) {
-        Ok(edited_texts) => {
+        Ok(edited_texts) if edited_texts.is_empty() => {
             #[cfg(feature = "system-testing")]
-            let operation = crate::preview::test_sync::record_accepted_edit();
+            crate::preview::test_sync::effect("rejected");
+            to_preview.send(&LspToPreviewMessage::WorkspaceEditResult {
+                outcome: WorkspaceEditOutcome::Rejected,
+            });
+            tracing::warn!(
+                "Workspace edit '{}' did not address any loaded document",
+                label.unwrap_or("(unnamed)")
+            );
+        }
+        Ok(edited_texts) => {
+            let files = u32::try_from(edited_texts.len()).unwrap_or(u32::MAX);
+            #[cfg(feature = "system-testing")]
+            crate::preview::test_sync::accepted_edit();
+            let mut written = 0u32;
             for editor_preview::editing::text_edit::EditedText { url, contents } in edited_texts {
                 match editor_preview::uri_to_file(&url) {
                     Some(path) => {
                         if let Err(err) = std::fs::write(&path, &contents) {
+                            #[cfg(feature = "system-testing")]
+                            crate::preview::test_sync::effect("failed");
                             tracing::error!(
                                 "Failed to apply workspace edit '{}' to {}: {err}",
                                 label.unwrap_or("(unnamed)"),
                                 path.display()
                             );
                         } else {
+                            written += 1;
                             #[cfg(feature = "system-testing")]
-                            crate::preview::test_sync::record_write();
+                            {
+                                crate::preview::test_sync::written(&url);
+                                crate::preview::test_sync::expect_watch(&url);
+                            }
                         }
                     }
                     None => {
@@ -519,10 +635,21 @@ fn handle_workspace_edit(
                     }
                 }
             }
-            #[cfg(feature = "system-testing")]
-            crate::preview::test_sync::record_edit_completed(operation, "completed");
+            let outcome = if written == files {
+                WorkspaceEditOutcome::Applied { files }
+            } else {
+                #[cfg(feature = "system-testing")]
+                crate::preview::test_sync::effect("failed");
+                WorkspaceEditOutcome::Failed { files, written }
+            };
+            to_preview.send(&LspToPreviewMessage::WorkspaceEditResult { outcome });
         }
         Err(err) => {
+            #[cfg(feature = "system-testing")]
+            crate::preview::test_sync::effect("rejected");
+            to_preview.send(&LspToPreviewMessage::WorkspaceEditResult {
+                outcome: WorkspaceEditOutcome::Rejected,
+            });
             tracing::error!(
                 "Failed to compute workspace edit '{}': {err}",
                 label.unwrap_or("(unnamed)")

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -18,7 +18,7 @@ use i_slint_editor_preview::{LspToPreviews, Result, document_cache::OpenImportCa
 use i_slint_live_preview::file_watcher::{FileWatcher, WatchEvent};
 use i_slint_live_preview::protocol::{
     LspToPreviewMessage, PreviewComponent, PreviewTarget, PreviewToLspMessage, SourceFileVersion,
-    VersionedUrl, WorkspaceEditOutcome,
+    VersionedUrl,
 };
 use lsp_types::{MessageType, Url};
 use slint::ComponentHandle;
@@ -129,10 +129,46 @@ impl editor_preview::LspToPreview for EditorLspToPreview {
     }
 }
 
-struct PreviewMessage {
+pub(crate) struct PreviewMessage {
+    edit_id: Option<u64>,
     message: PreviewToLspMessage,
     #[cfg(feature = "system-testing")]
     work: preview::test_sync::Work,
+}
+
+impl PreviewMessage {
+    pub(crate) fn edit(id: u64, label: String, edit: lsp_types::WorkspaceEdit) -> Self {
+        Self {
+            edit_id: Some(id),
+            message: PreviewToLspMessage::SendWorkspaceEdit { label: Some(label), edit },
+            #[cfg(feature = "system-testing")]
+            work: preview::test_sync::Work::capture("LSP edit"),
+        }
+    }
+}
+
+async fn handle_local_message(
+    message: PreviewToLspMessage,
+    edit_id: Option<u64>,
+    session: &mut editor_preview::EditorSession,
+    project_root: &std::path::Path,
+) {
+    if let (Some(id), PreviewToLspMessage::SendWorkspaceEdit { label, edit }) = (edit_id, &message)
+    {
+        let outcome = handle_workspace_edit(&session.document_cache, label.as_deref(), edit);
+        #[cfg(feature = "system-testing")]
+        let work = preview::test_sync::Work::capture("edit acknowledgment");
+        if let Err(error) = slint::invoke_from_event_loop(move || {
+            #[cfg(feature = "system-testing")]
+            work.run(|| preview::workspace_edit_result(id, outcome));
+            #[cfg(not(feature = "system-testing"))]
+            preview::workspace_edit_result(id, outcome);
+        }) {
+            tracing::error!("Failed to queue edit acknowledgment: {error}");
+        }
+    } else {
+        handle_preview_message(message, session, project_root).await;
+    }
 }
 
 struct EmbeddedPreviewToLsp {
@@ -142,6 +178,7 @@ struct EmbeddedPreviewToLsp {
 impl editor_preview::PreviewToLsp for EmbeddedPreviewToLsp {
     fn send(&self, message: &PreviewToLspMessage) -> editor_preview::Result<()> {
         self.sender.send(PreviewMessage {
+            edit_id: None,
             message: message.clone(),
             #[cfg(feature = "system-testing")]
             work: preview::test_sync::Work::capture("LSP message"),
@@ -181,6 +218,7 @@ fn start_editor_session(
     settings: preview::settings::VisualEditorSettings,
 ) {
     let (to_lsp, from_preview) = crossbeam_channel::unbounded();
+    preview::PREVIEW_STATE.with_borrow_mut(|state| state.edit_sender = Some(to_lsp.clone()));
     let to_lsp = Rc::new(EmbeddedPreviewToLsp { sender: to_lsp })
         as Rc<dyn editor_preview::PreviewToLsp + 'static>;
     preview::ui::initialize_editor(editor_ui, &to_lsp, "");
@@ -341,11 +379,11 @@ async fn lsp_main(
                     Some(msg) => {
                         #[cfg(feature = "system-testing")]
                         {
-                            msg.work.during(handle_preview_message(msg.message, &mut session, &project_root)).await;
+                            msg.work.during(handle_local_message(msg.message, msg.edit_id, &mut session, &project_root)).await;
                             pending_work.push(msg.work);
                         }
                         #[cfg(not(feature = "system-testing"))]
-                        handle_preview_message(msg.message, &mut session, &project_root).await;
+                        handle_local_message(msg.message, msg.edit_id, &mut session, &project_root).await;
                     }
                     None => {
                         tracing::debug!("Preview->LSP channel closed, exiting");
@@ -533,12 +571,7 @@ async fn handle_preview_message(
             tracing::debug!("Ignoring message from preview: {msg:?}");
         }
         SendWorkspaceEdit { label, edit } => {
-            handle_workspace_edit(
-                &session.document_cache,
-                session.to_preview.as_ref(),
-                label.as_deref(),
-                edit,
-            );
+            handle_workspace_edit(&session.document_cache, label.as_deref(), edit);
         }
     }
 }
@@ -589,21 +622,18 @@ fn canonical_preview_component(
 
 fn handle_workspace_edit(
     document_cache: &editor_preview::DocumentCache,
-    to_preview: &editor_preview::LspToPreviews,
     label: Option<&str>,
     edit: &lsp_types::WorkspaceEdit,
-) {
+) -> preview::WorkspaceEditOutcome {
     match editor_preview::editing::text_edit::apply_workspace_edit(document_cache, edit) {
         Ok(edited_texts) if edited_texts.is_empty() => {
             #[cfg(feature = "system-testing")]
             crate::preview::test_sync::effect("rejected");
-            to_preview.send(&LspToPreviewMessage::WorkspaceEditResult {
-                outcome: WorkspaceEditOutcome::Rejected,
-            });
             tracing::warn!(
                 "Workspace edit '{}' did not address any loaded document",
                 label.unwrap_or("(unnamed)")
             );
+            preview::WorkspaceEditOutcome::Rejected
         }
         Ok(edited_texts) => {
             let files = u32::try_from(edited_texts.len()).unwrap_or(u32::MAX);
@@ -635,25 +665,22 @@ fn handle_workspace_edit(
                     }
                 }
             }
-            let outcome = if written == files {
-                WorkspaceEditOutcome::Applied { files }
+            if written == files {
+                preview::WorkspaceEditOutcome::Applied
             } else {
                 #[cfg(feature = "system-testing")]
                 crate::preview::test_sync::effect("failed");
-                WorkspaceEditOutcome::Failed { files, written }
-            };
-            to_preview.send(&LspToPreviewMessage::WorkspaceEditResult { outcome });
+                preview::WorkspaceEditOutcome::Failed
+            }
         }
         Err(err) => {
             #[cfg(feature = "system-testing")]
             crate::preview::test_sync::effect("rejected");
-            to_preview.send(&LspToPreviewMessage::WorkspaceEditResult {
-                outcome: WorkspaceEditOutcome::Rejected,
-            });
             tracing::error!(
                 "Failed to compute workspace edit '{}': {err}",
                 label.unwrap_or("(unnamed)")
             );
+            preview::WorkspaceEditOutcome::Rejected
         }
     }
 }

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -547,11 +547,11 @@ async fn handle_preview_message(
                 i_slint_editor_preview::settings_store::save(TOOL_NAME, name, contents)
             {
                 #[cfg(feature = "system-testing")]
-                preview::test_sync::effect("failed");
+                preview::test_sync::effect(preview::test_sync::Outcome::Failed);
                 tracing::warn!("Failed to save preview user settings: {error}");
             } else {
                 #[cfg(feature = "system-testing")]
-                preview::test_sync::effect("completed");
+                preview::test_sync::effect(preview::test_sync::Outcome::Completed);
             }
         }
         SendShowMessage { message } => {
@@ -642,7 +642,7 @@ fn handle_workspace_edit(
     match editor_preview::editing::text_edit::apply_workspace_edit(document_cache, edit) {
         Ok(edited_texts) if edited_texts.is_empty() => {
             #[cfg(feature = "system-testing")]
-            crate::preview::test_sync::effect("rejected");
+            crate::preview::test_sync::effect(preview::test_sync::Outcome::Rejected);
             tracing::warn!(
                 "Workspace edit '{}' did not address any loaded document",
                 label.unwrap_or("(unnamed)")
@@ -652,7 +652,7 @@ fn handle_workspace_edit(
         Ok(edited_texts) => persist_workspace_edit(edited_texts, label),
         Err(err) => {
             #[cfg(feature = "system-testing")]
-            crate::preview::test_sync::effect("rejected");
+            crate::preview::test_sync::effect(preview::test_sync::Outcome::Rejected);
             tracing::error!(
                 "Failed to compute workspace edit '{}': {err}",
                 label.unwrap_or("(unnamed)")
@@ -698,7 +698,7 @@ fn persist_workspace_edit(
                 if let Err(failure) = result {
                     let err = failure.error;
                     #[cfg(feature = "system-testing")]
-                    crate::preview::test_sync::effect("failed");
+                    crate::preview::test_sync::effect(preview::test_sync::Outcome::Failed);
                     tracing::error!(
                         "Failed to apply workspace edit '{}' to {}: {err}",
                         label.unwrap_or("(unnamed)"),
@@ -722,7 +722,7 @@ fn persist_workspace_edit(
         preview::WorkspaceEditOutcome::Applied
     } else {
         #[cfg(feature = "system-testing")]
-        crate::preview::test_sync::effect("failed");
+        crate::preview::test_sync::effect(preview::test_sync::Outcome::Failed);
         preview::WorkspaceEditOutcome::Failed { may_have_changed }
     }
 }

--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -155,12 +155,16 @@ async fn handle_local_message(
 ) {
     if let (Some(id), PreviewToLspMessage::SendWorkspaceEdit { label, edit }) = (edit_id, &message)
     {
+        #[cfg(feature = "system-testing")]
+        let urls: Vec<_> = editor_preview::editing::text_edit::EditIterator::new(edit)
+            .map(|(document, _)| document.uri)
+            .collect();
         let outcome = handle_workspace_edit(&session.document_cache, label.as_deref(), edit);
         #[cfg(feature = "system-testing")]
         let work = preview::test_sync::Work::capture("edit acknowledgment");
         if let Err(error) = slint::invoke_from_event_loop(move || {
             #[cfg(feature = "system-testing")]
-            work.run(|| preview::workspace_edit_result(id, outcome));
+            work.run(|| preview::test_sync::acknowledge(&urls, id, outcome));
             #[cfg(not(feature = "system-testing"))]
             preview::workspace_edit_result(id, outcome);
         }) {

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -127,7 +127,15 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         }
         M::ForgetFile { url } => {
             #[cfg(feature = "system-testing")]
-            test_sync::record_observed(&url, None);
+            {
+                test_sync::record_observed(&url, None);
+                test_sync::record_processed_with_inputs(
+                    &url,
+                    None,
+                    "load_error",
+                    &std::collections::HashMap::new(),
+                );
+            }
             delete_document(&url);
         }
         M::SetConfiguration { config } => {
@@ -514,6 +522,10 @@ fn apply_live_preview_data() {
 fn set_contents(url: &VersionedUrl, content: String) {
     #[cfg(feature = "system-testing")]
     test_sync::record_observed(url.url(), Some(&content));
+    #[cfg(feature = "system-testing")]
+    if test_sync::should_hold_source(url.url(), &content) {
+        return;
+    }
     let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
         if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
             undo_redo::set_undo_redo_enabled(preview_state);
@@ -2239,10 +2251,11 @@ async fn reload_preview_impl(
     );
 
     #[cfg(feature = "system-testing")]
-    test_sync::record_processed(
+    let attempt = test_sync::record_processed_with_inputs(
         &component.url,
-        &source_for_sync,
+        Some(&source_for_sync),
         if compiled.is_some() { "compiled" } else { "compile_error" },
+        &source_file_versions.borrow(),
     );
 
     let lsp = PREVIEW_STATE.with_borrow_mut(|preview_state| {
@@ -2257,7 +2270,19 @@ async fn reload_preview_impl(
     let diags = convert_diagnostics(&diagnostics, &source_file_versions.borrow());
     lsp.notify_diagnostics(diags).unwrap();
 
-    update_preview_area(compiled, behavior, open_import_callback, source_file_versions, format)?;
+    update_preview_area(
+        compiled,
+        behavior,
+        open_import_callback,
+        source_file_versions,
+        format,
+        #[cfg(feature = "system-testing")]
+        Some(attempt),
+        #[cfg(feature = "system-testing")]
+        Some((component.url.clone(), source_for_sync.clone())),
+        #[cfg(not(feature = "system-testing"))]
+        None,
+    )?;
 
     if let Some(loaded_component_name) = loaded_component_name {
         let current_preview_loaded = PREVIEW_STATE.with_borrow_mut(|preview_state| {
@@ -2694,6 +2719,9 @@ fn update_preview_area(
     open_import_callback: Option<i_slint_editor_preview::document_cache::OpenImportCallback>,
     source_file_versions: Rc<RefCell<i_slint_editor_preview::document_cache::SourceFileVersionMap>>,
     format: i_slint_editor_preview::ByteFormat,
+    #[cfg(feature = "system-testing")] attempt: Option<u64>,
+    #[cfg(feature = "system-testing")] applied_source: Option<(lsp_types::Url, String)>,
+    #[cfg(not(feature = "system-testing"))] _attempt: Option<u64>,
 ) -> Result<(), PlatformError> {
     let editor_ui = PREVIEW_STATE.with_borrow_mut(move |preview_state| {
         preview_state.workspace_edit_sent = false;
@@ -2703,14 +2731,6 @@ fn update_preview_area(
         let shared_handle = preview_state.handle.clone();
         let shared_document_cache = preview_state.document_cache.clone();
         let shared_overrides = preview_state.debug_hook_overrides.clone();
-        #[cfg(feature = "system-testing")]
-        let applied_source = preview_state.current_component().and_then(|component| {
-            preview_state
-                .source_code
-                .get(&component.url)
-                .map(|entry| (component.url, entry.code.clone()))
-        });
-
         if let Some(compiled) = compiled {
             api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
             // Keep the inspector mounted until reselection, so edits retain keyboard focus.
@@ -2720,10 +2740,6 @@ fn update_preview_area(
                 &api,
                 compiled,
                 Box::new(move |instance| {
-                    #[cfg(feature = "system-testing")]
-                    if let Some((url, source)) = &applied_source {
-                        test_sync::record_applied(url, source);
-                    }
                     if let Some(rtl) = instance.definition().raw_type_loader() {
                         shared_document_cache.replace(Some(Rc::new(
                             i_slint_editor_preview::DocumentCache::new_from_raw_parts(
@@ -2753,6 +2769,10 @@ fn update_preview_area(
 
                     shared_handle.replace(Some(instance));
                     previewed_component_changed();
+                    #[cfg(feature = "system-testing")]
+                    if let Some((url, source)) = &applied_source {
+                        test_sync::record_applied_with_attempt(url, source, attempt);
+                    }
                 }),
                 behavior,
             );

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -2150,25 +2150,12 @@ async fn reload_timer_function() {
         let work = PREVIEW_STATE
             .with_borrow_mut(|s| test_sync::Work::combine(std::mem::take(&mut s.sync_reload_work)));
         #[cfg(feature = "system-testing")]
-        let result = work
-            .during(reload_preview_impl(preview_component, behavior, style, config, generation))
+        work.during(reload_preview_impl(preview_component, behavior, style, config, generation))
             .await;
         #[cfg(not(feature = "system-testing"))]
-        let result =
-            reload_preview_impl(preview_component, behavior, style, config, generation).await;
+        reload_preview_impl(preview_component, behavior, style, config, generation).await;
         #[cfg(feature = "system-testing")]
         completion_work.push(work);
-        match result {
-            Ok(()) => {}
-            Err(e) => {
-                tracing::debug!("Preview reload failed: {}", e);
-                PREVIEW_STATE.with_borrow_mut(|preview_state| {
-                    preview_state.loading_state = PreviewFutureState::Pending;
-                });
-                tracing::error!("{e}");
-                std::process::exit(3);
-            }
-        }
 
         match PREVIEW_STATE.with_borrow(|preview_state| preview_state.loading_state) {
             PreviewFutureState::Loading => {
@@ -2353,7 +2340,7 @@ async fn reload_preview_impl(
     style: String,
     config: PreviewConfig,
     generation: u64,
-) -> Result<(), PlatformError> {
+) {
     let compilation = PREVIEW_STATE.with_borrow_mut(|state| {
         state.compilation_sequence += 1;
         state.compilation_sequence
@@ -2474,41 +2461,23 @@ async fn reload_preview_impl(
     let diags = convert_diagnostics(&diagnostics, &source_file_versions.borrow());
     lsp.notify_diagnostics(diags).unwrap();
 
+    let install = move || {
+        finish_preview_installation(update_preview_area(
+            compiled,
+            behavior,
+            open_import_callback,
+            source_file_versions,
+            format,
+            generation,
+            installation,
+            #[cfg(feature = "system-testing")]
+            Some(attempt),
+        ));
+    };
     #[cfg(feature = "system-testing")]
-    {
-        let work = test_sync::Work::capture("preview installation");
-        test_sync::publish(&component.url, attempt, move || {
-            work.run(|| {
-                if !preview_generation_is_current(generation) {
-                    test_sync::processed(attempt, "superseded", Vec::new());
-                    return;
-                }
-                if let Err(error) = update_preview_area(
-                    compiled,
-                    behavior,
-                    open_import_callback,
-                    source_file_versions,
-                    format,
-                    generation,
-                    installation,
-                    Some(attempt),
-                ) {
-                    tracing::error!("Preview installation failed: {error}");
-                    test_sync::effect(test_sync::Outcome::Failed);
-                }
-            })
-        });
-    }
+    test_sync::publish(&component.url, attempt, install);
     #[cfg(not(feature = "system-testing"))]
-    update_preview_area(
-        compiled,
-        behavior,
-        open_import_callback,
-        source_file_versions,
-        format,
-        generation,
-        installation,
-    )?;
+    install();
 
     if let Some(loaded_component_name) = loaded_component_name {
         let current_preview_loaded = PREVIEW_STATE.with_borrow_mut(|preview_state| {
@@ -2527,7 +2496,14 @@ async fn reload_preview_impl(
     }
 
     finish_parsing();
-    Ok(())
+}
+
+fn finish_preview_installation(result: Result<(), PlatformError>) {
+    if let Err(error) = result {
+        PREVIEW_STATE.with_borrow_mut(|state| state.loading_state = PreviewFutureState::Pending);
+        tracing::error!("Preview installation failed: {error}");
+        std::process::exit(3);
+    }
 }
 
 /// This sets up the preview area to show the ComponentInstance

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -321,14 +321,28 @@ fn preview_generation_is_current(generation: u64) -> bool {
     PREVIEW_STATE.with_borrow(|state| state.preview_generation == generation)
 }
 
-fn retire_factory(_state: &mut PreviewState) {
+fn retire_factory(_state: &mut PreviewState, _transfer_to_reload: bool) {
     #[cfg(feature = "system-testing")]
     if let Some(lease) = _state.factory_lease.take() {
-        // The ComponentFactory may remain retained by a component container
-        // after the surface is removed. Emptying the lease here lets the
-        // operation settle even when that abandoned factory is never invoked.
-        lease.as_ref().borrow_mut().take();
+        // A container can retain a retired factory without invoking it again.
+        // Transfer its work to a replacement reload, or release it on unmount.
+        if let Some(work) = lease.as_ref().borrow_mut().take()
+            && _transfer_to_reload
+        {
+            _state.sync_reload_work.push(work);
+        }
     }
+}
+
+fn abandon_pending_installation(state: &mut PreviewState) {
+    if let Some(edit) = state.workspace_edit_installation.as_mut() {
+        edit.abandon();
+        if state.pending_workspace_edit.is_none() {
+            state.workspace_edit_installation = None;
+            state.workspace_edit_sent = false;
+        }
+    }
+    undo_redo::cancel_pending(state);
 }
 
 /// Invalidate deferred component creation when the preview surface changes
@@ -337,15 +351,10 @@ fn retire_factory(_state: &mut PreviewState) {
 pub(crate) fn invalidate_preview_generation() {
     PREVIEW_STATE.with_borrow_mut(|state| {
         state.preview_generation = state.preview_generation.wrapping_add(1);
-        retire_factory(state);
-        if let Some(edit) = state.workspace_edit_installation.as_mut() {
-            edit.abandon();
-            if state.pending_workspace_edit.is_none() {
-                state.workspace_edit_installation = None;
-                state.workspace_edit_sent = false;
-            }
-        }
-        undo_redo::cancel_pending(state);
+        retire_factory(state, false);
+        abandon_pending_installation(state);
+        #[cfg(feature = "system-testing")]
+        test_sync::unmounted(None);
     });
     inspector::restore_committed();
     inspector::invalidate();
@@ -1837,6 +1846,19 @@ pub(crate) enum WorkspaceEditOutcome {
     Failed { may_have_changed: bool },
 }
 
+fn finish_pending_installation(state: &mut PreviewState) -> bool {
+    let Some(edit) = state.workspace_edit_installation.as_ref() else { return false };
+    if edit.is_superseded() {
+        undo_redo::discard_pending(state, true);
+        undo_redo::cancel_pending(state);
+    } else if state.pending_workspace_edit.is_some() || !edit.is_finished() {
+        return false;
+    }
+    state.workspace_edit_installation = None;
+    state.workspace_edit_sent = false;
+    true
+}
+
 pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
     let matches = PREVIEW_STATE.with_borrow(|state| {
         state.pending_workspace_edit.as_ref().is_some_and(|edit| edit.id == id)
@@ -1846,34 +1868,25 @@ pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
     if !matches {
         return;
     }
-    let (needs_recovery, release_pending) = PREVIEW_STATE.with_borrow_mut(|state| {
-        match outcome {
-            WorkspaceEditOutcome::Applied => {
-                undo_redo::commit_pending(state);
-                // The filesystem acknowledgement and preview installation are
-                // independent. Release queued history only after both have
-                // reached their terminal state.
-                if state.workspace_edit_installation.as_ref().is_some_and(|edit| edit.is_finished())
-                {
-                    state.workspace_edit_installation = None;
-                    state.workspace_edit_sent = false;
-                    (false, true)
-                } else {
-                    (false, false)
-                }
+    let (needs_recovery, release_pending) = PREVIEW_STATE.with_borrow_mut(|state| match outcome {
+        WorkspaceEditOutcome::Applied => {
+            if let Some(edit) = state.workspace_edit_installation.as_mut() {
+                edit.acknowledge();
             }
-            WorkspaceEditOutcome::Rejected => {
-                undo_redo::discard_pending(state, false);
-                state.workspace_edit_installation = None;
-                state.workspace_edit_sent = false;
-                (true, true)
-            }
-            WorkspaceEditOutcome::Failed { may_have_changed } => {
-                undo_redo::discard_pending(state, may_have_changed);
-                state.workspace_edit_installation = None;
-                state.workspace_edit_sent = false;
-                (true, true)
-            }
+            undo_redo::commit_pending(state);
+            (false, finish_pending_installation(state))
+        }
+        WorkspaceEditOutcome::Rejected => {
+            undo_redo::discard_pending(state, false);
+            state.workspace_edit_installation = None;
+            state.workspace_edit_sent = false;
+            (true, true)
+        }
+        WorkspaceEditOutcome::Failed { may_have_changed } => {
+            undo_redo::discard_pending(state, may_have_changed);
+            state.workspace_edit_installation = None;
+            state.workspace_edit_sent = false;
+            (true, true)
         }
     });
     if needs_recovery {
@@ -2235,12 +2248,18 @@ pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior)
 
     PREVIEW_STATE.with_borrow_mut(|preview_state| {
         preview_state.preview_generation = preview_state.preview_generation.wrapping_add(1);
-        retire_factory(preview_state);
+        retire_factory(preview_state, true);
         match behavior {
             LoadBehavior::Reload => {}
             LoadBehavior::Load
             | LoadBehavior::LoadWithoutLiveData
             | LoadBehavior::BringWindowToFront => {
+                if preview_state.current_component().is_some_and(|current| {
+                    current.url != preview_component.url
+                        || current.component != preview_component.component
+                }) {
+                    abandon_pending_installation(preview_state);
+                }
                 preview_state.set_current_component(preview_component)
             }
         }
@@ -2586,16 +2605,19 @@ fn set_preview_factory(
     let paused = Rc::new(std::cell::Cell::new(false));
     #[cfg(feature = "system-testing")]
     let factory_paused = paused.clone();
-    let factory = slint::ComponentFactory::new(move |ctx: FactoryContext| {
+    let create_factory = move |ctx: FactoryContext| {
         #[cfg(feature = "system-testing")]
         if factory_paused.get() {
+            test_sync::unmounted(attempt);
             return None;
         }
         #[cfg(feature = "system-testing")]
         let work = factory_lease.as_ref().borrow_mut().take().unwrap_or_default();
-        #[cfg(feature = "system-testing")]
-        return work.run(|| {
+        let create = || {
             if !preview_generation_is_current(generation) {
+                #[cfg(feature = "system-testing")]
+                test_sync::unmounted(attempt);
+                #[cfg(feature = "system-testing")]
                 if let Some(attempt) = attempt {
                     test_sync::processed(attempt, "superseded", Vec::new());
                 }
@@ -2604,22 +2626,20 @@ fn set_preview_factory(
             let instance = compiled.create_embedded(ctx).unwrap();
             callback(instance.clone_strong());
             Some(instance)
-        });
+        };
+        #[cfg(feature = "system-testing")]
+        return work.run(create);
         #[cfg(not(feature = "system-testing"))]
-        if !preview_generation_is_current(generation) {
-            return None;
-        }
-        #[cfg(not(feature = "system-testing"))]
-        let instance = compiled.create_embedded(ctx).unwrap();
-
-        #[cfg(not(feature = "system-testing"))]
-        callback(instance.clone_strong());
-        #[cfg(not(feature = "system-testing"))]
-        Some(instance)
-    });
-
+        create()
+    };
     #[cfg(feature = "system-testing")]
-    let deferred_factory = factory.clone();
+    let create_factory = Rc::new(create_factory);
+    #[cfg(feature = "system-testing")]
+    let deferred_create = create_factory.clone();
+    #[cfg(feature = "system-testing")]
+    let factory = slint::ComponentFactory::new(move |ctx| create_factory(ctx));
+    #[cfg(not(feature = "system-testing"))]
+    let factory = slint::ComponentFactory::new(create_factory);
     api.set_preview_area(factory);
     #[cfg(feature = "system-testing")]
     if let Some(attempt) = attempt {
@@ -2633,8 +2653,9 @@ fn set_preview_factory(
             resume.set(false);
             if let Some(editor_ui) = weak_ui.upgrade() {
                 let api = editor_ui.global::<ui::Api>();
-                api.set_preview_area(Default::default());
-                api.set_preview_area(deferred_factory);
+                api.set_preview_area(slint::ComponentFactory::new(move |ctx| deferred_create(ctx)));
+                i_slint_core::window::WindowInner::from_pub(editor_ui.window())
+                    .ensure_tree_instantiated();
             }
         }));
     }
@@ -3025,81 +3046,78 @@ fn update_preview_area(
             api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
             // Keep the inspector mounted until reselection, so edits retain keyboard focus.
 
-            let _factory_lease = set_preview_factory(
-                editor_ui,
-                &api,
-                compiled,
-                Box::new(move |instance| {
-                    if !preview_generation_is_current(generation) {
+            let set_factory = || {
+                set_preview_factory(
+                    editor_ui,
+                    &api,
+                    compiled,
+                    Box::new(move |instance| {
+                        if !preview_generation_is_current(generation) {
+                            #[cfg(feature = "system-testing")]
+                            if let Some(attempt) = attempt {
+                                test_sync::processed(attempt, "superseded", Vec::new());
+                            }
+                            return;
+                        }
+                        if let Some(rtl) = instance.definition().raw_type_loader() {
+                            shared_document_cache.replace(Some(Rc::new(
+                                i_slint_editor_preview::DocumentCache::new_from_raw_parts(
+                                    rtl,
+                                    open_import_callback.clone(),
+                                    source_file_versions.clone(),
+                                    format,
+                                ),
+                            )));
+                        }
+
+                        // element_hash (and thus hook ids) change on every recompile, so drop stale overrides.
+                        (*shared_overrides).borrow_mut().clear();
+                        {
+                            let overrides = shared_overrides.clone();
+                            instance.set_debug_hook_callback(Some(Box::new(
+                                move |id: &str| -> Option<slint_interpreter::Value> {
+                                    let mut m = (*overrides).borrow_mut();
+                                    let p = m.entry(SmolStr::from(id)).or_insert_with(|| {
+                                        tracing::trace!("Inserting Property override: {id}");
+                                        Box::pin(i_slint_core::Property::new(None))
+                                    });
+                                    p.as_ref().get()
+                                },
+                            )));
+                        }
+
+                        PREVIEW_STATE
+                            .with_borrow_mut(|state| state.committed_inspector_overrides.clear());
+                        shared_handle.replace(Some(instance));
+                        previewed_component_changed();
+                        let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
+                            if let Some(edit) = state.workspace_edit_installation.as_mut() {
+                                edit.observe(&installation);
+                            }
+                            finish_pending_installation(state)
+                        });
+                        inspector::invalidate();
+                        element_selection::reselect_element();
+                        if release_pending {
+                            undo_redo::apply_pending();
+                        }
                         #[cfg(feature = "system-testing")]
                         if let Some(attempt) = attempt {
-                            test_sync::processed(attempt, "superseded", Vec::new());
+                            test_sync::applied(attempt);
                         }
-                        return;
-                    }
-                    if let Some(rtl) = instance.definition().raw_type_loader() {
-                        shared_document_cache.replace(Some(Rc::new(
-                            i_slint_editor_preview::DocumentCache::new_from_raw_parts(
-                                rtl,
-                                open_import_callback.clone(),
-                                source_file_versions.clone(),
-                                format,
-                            ),
-                        )));
-                    }
-
-                    // element_hash (and thus hook ids) change on every recompile, so drop stale overrides.
-                    (*shared_overrides).borrow_mut().clear();
-                    {
-                        let overrides = shared_overrides.clone();
-                        instance.set_debug_hook_callback(Some(Box::new(
-                            move |id: &str| -> Option<slint_interpreter::Value> {
-                                let mut m = (*overrides).borrow_mut();
-                                let p = m.entry(SmolStr::from(id)).or_insert_with(|| {
-                                    tracing::trace!("Inserting Property override: {id}");
-                                    Box::pin(i_slint_core::Property::new(None))
-                                });
-                                p.as_ref().get()
-                            },
-                        )));
-                    }
-
-                    PREVIEW_STATE
-                        .with_borrow_mut(|state| state.committed_inspector_overrides.clear());
-                    shared_handle.replace(Some(instance));
-                    previewed_component_changed();
-                    let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
-                        let matches = state
-                            .workspace_edit_installation
-                            .as_mut()
-                            .is_some_and(|edit| edit.observe(&installation));
-                        if matches && state.pending_workspace_edit.is_none() {
-                            state.workspace_edit_installation = None;
-                            state.workspace_edit_sent = false;
-                            true
-                        } else {
-                            false
-                        }
-                    });
-                    inspector::invalidate();
-                    element_selection::reselect_element();
-                    if release_pending {
-                        undo_redo::apply_pending();
-                    }
+                    }),
+                    behavior,
+                    generation,
                     #[cfg(feature = "system-testing")]
-                    if let Some(attempt) = attempt {
-                        test_sync::applied(attempt);
-                    }
-                }),
-                behavior,
-                generation,
-                #[cfg(feature = "system-testing")]
-                attempt,
-            );
+                    attempt,
+                )
+            };
             #[cfg(feature = "system-testing")]
             {
-                preview_state.factory_lease = Some(_factory_lease);
+                preview_state.factory_lease = Some(set_factory());
             }
+            #[cfg(not(feature = "system-testing"))]
+            set_factory();
         }
 
         editor_ui.clone_strong()

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -1775,12 +1775,12 @@ fn dispatch_workspace_edit(
 ) -> bool {
     if state.workspace_edit_sent {
         #[cfg(feature = "system-testing")]
-        test_sync::effect("rejected");
+        test_sync::effect(test_sync::Outcome::Rejected);
         return false;
     }
     let Some(sender) = state.edit_sender.as_ref() else {
         #[cfg(feature = "system-testing")]
-        test_sync::effect("rejected");
+        test_sync::effect(test_sync::Outcome::Rejected);
         return false;
     };
 
@@ -1796,7 +1796,7 @@ fn dispatch_workspace_edit(
         state.workspace_edit_installation = None;
         state.workspace_edit_sent = false;
         #[cfg(feature = "system-testing")]
-        test_sync::effect("failed");
+        test_sync::effect(test_sync::Outcome::Failed);
         return false;
     }
     true
@@ -1805,12 +1805,12 @@ fn dispatch_workspace_edit(
 fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit: bool) -> bool {
     let Some(document_cache) = document_cache() else {
         #[cfg(feature = "system-testing")]
-        test_sync::effect("rejected");
+        test_sync::effect(test_sync::Outcome::Rejected);
         return false;
     };
     let Ok(result) = text_edit::apply_workspace_edit(&document_cache, &edit) else {
         #[cfg(feature = "system-testing")]
-        test_sync::effect("rejected");
+        test_sync::effect(test_sync::Outcome::Rejected);
         return false;
     };
     let file_hashes = undo_redo::compute_file_hashes(&result);
@@ -1822,7 +1822,7 @@ fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit:
             CompilationResult::ChangeCompiles => {}
             CompilationResult::ChangeFails => {
                 #[cfg(feature = "system-testing")]
-                test_sync::effect("rejected");
+                test_sync::effect(test_sync::Outcome::Rejected);
                 return false;
             }
             CompilationResult::NoChange => return true,
@@ -2503,7 +2503,7 @@ async fn reload_preview_impl(
                     Some(attempt),
                 ) {
                     tracing::error!("Preview installation failed: {error}");
-                    test_sync::effect("failed");
+                    test_sync::effect(test_sync::Outcome::Failed);
                 }
             })
         });

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -24,7 +24,7 @@ use i_slint_editor_preview::{
 };
 use i_slint_live_preview::protocol::{
     LspToPreviewMessage, PreviewComponent, PreviewConfig, PreviewToLspMessage, SourceFileVersion,
-    VersionedUrl, WorkspaceEditOutcome,
+    VersionedUrl,
 };
 use lsp_types::Url;
 use slint::{LogicalPosition, LogicalSize, PlatformError, SharedString, ToSharedString};
@@ -133,9 +133,6 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         M::SetUserSettings { name, contents } => {
             set_user_settings(name, contents);
         }
-        M::WorkspaceEditResult { outcome } => {
-            workspace_edit_result(outcome);
-        }
         M::ShowPreview(preview_component) => {
             tracing::debug!(
                 "Preview: opening url={}, component={:?}",
@@ -243,6 +240,8 @@ pub struct PreviewState {
     selected: Option<element_selection::ElementSelection>,
     notify_editor_about_selection_after_update: bool,
     workspace_edit_sent: bool,
+    pub(crate) edit_sender: Option<crossbeam_channel::Sender<crate::PreviewMessage>>,
+    next_edit_id: u64,
     compilation_sequence: u64,
     workspace_edit_installation: Option<edit_installation::PendingInstallation>,
     known_components: Vec<ComponentInformation>,
@@ -258,6 +257,7 @@ pub struct PreviewState {
     #[cfg(feature = "system-testing")]
     sync_reload_work: Vec<test_sync::Work>,
     inspector_edit: Option<inspector::Edit>,
+    committed_inspector_overrides: inspector::SavedOverrides,
 
     source_code: SourceCodeCache,
     resources: HashSet<Url>,
@@ -321,9 +321,9 @@ fn preview_generation_is_current(generation: u64) -> bool {
     PREVIEW_STATE.with_borrow(|state| state.preview_generation == generation)
 }
 
-fn retire_factory(state: &mut PreviewState) {
+fn retire_factory(_state: &mut PreviewState) {
     #[cfg(feature = "system-testing")]
-    if let Some(lease) = state.factory_lease.take() {
+    if let Some(lease) = _state.factory_lease.take() {
         // The ComponentFactory may remain retained by a component container
         // after the surface is removed. Emptying the lease here lets the
         // operation settle even when that abandoned factory is never invoked.
@@ -335,12 +335,20 @@ fn retire_factory(state: &mut PreviewState) {
 /// mode. A stale factory may still be retained by the declarative UI, so it
 /// must fail its generation check if it is invoked after the mode switch.
 pub(crate) fn invalidate_preview_generation() {
-    #[cfg(feature = "system-testing")]
-    test_sync::request_reload();
     PREVIEW_STATE.with_borrow_mut(|state| {
         state.preview_generation = state.preview_generation.wrapping_add(1);
         retire_factory(state);
+        if let Some(edit) = state.workspace_edit_installation.as_mut() {
+            edit.abandon();
+            if state.pending_workspace_edit.is_none() {
+                state.workspace_edit_installation = None;
+                state.workspace_edit_sent = false;
+            }
+        }
+        undo_redo::cancel_pending(state);
     });
+    inspector::restore_committed();
+    inspector::invalidate();
 }
 
 fn invalidate_contents(url: &lsp_types::Url) {
@@ -1747,37 +1755,26 @@ fn dispatch_workspace_edit(
     label: String,
     edit: lsp_types::WorkspaceEdit,
     history: undo_redo::PendingEdit,
+    expected: std::collections::HashMap<Url, String>,
 ) -> bool {
     if state.workspace_edit_sent {
         #[cfg(feature = "system-testing")]
         test_sync::effect("rejected");
         return false;
     }
-    let Some(to_lsp) = state.to_lsp.borrow().as_ref().cloned() else {
+    let Some(sender) = state.edit_sender.as_ref() else {
         #[cfg(feature = "system-testing")]
         test_sync::effect("rejected");
         return false;
     };
 
-    let expected = state
-        .document_cache
-        .borrow()
-        .as_ref()
-        .and_then(|cache| text_edit::apply_workspace_edit(cache, &edit).ok());
-    let Some(expected) = expected else {
-        #[cfg(feature = "system-testing")]
-        test_sync::effect("rejected");
-        return false;
-    };
-    state.workspace_edit_installation = Some(edit_installation::PendingInstallation::new(
-        state.compilation_sequence,
-        expected.into_iter().map(|e| (e.url, e.contents)).collect(),
-    ));
-    state.pending_workspace_edit = Some(undo_redo::PendingWorkspaceEdit { history });
+    state.workspace_edit_installation =
+        Some(edit_installation::PendingInstallation::new(state.compilation_sequence, expected));
+    state.next_edit_id += 1;
+    let id = state.next_edit_id;
+    state.pending_workspace_edit = Some(undo_redo::PendingWorkspaceEdit { id, history });
     state.workspace_edit_sent = true;
-    if let Err(error) =
-        to_lsp.send(&PreviewToLspMessage::SendWorkspaceEdit { label: Some(label.clone()), edit })
-    {
+    if let Err(error) = sender.send(crate::PreviewMessage::edit(id, label.clone(), edit)) {
         tracing::error!("Failed to send workspace edit '{}': {error}", label);
         state.pending_workspace_edit.take();
         state.workspace_edit_installation = None;
@@ -1802,6 +1799,7 @@ fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit:
     };
     let file_hashes = undo_redo::compute_file_hashes(&result);
 
+    let expected = result.iter().map(|e| (e.url.clone(), e.contents.clone())).collect();
     if test_edit {
         let test_result = drop_location::edited_text_compiles(&document_cache, result);
         match test_result {
@@ -1821,27 +1819,29 @@ fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit:
     }));
 
     PREVIEW_STATE.with_borrow_mut(|preview_state| {
-        dispatch_workspace_edit(preview_state, label, edit, history)
+        dispatch_workspace_edit(preview_state, label, edit, history, expected)
     })
 }
 
-fn workspace_edit_result(outcome: WorkspaceEditOutcome) {
+#[derive(Clone, Copy)]
+pub(crate) enum WorkspaceEditOutcome {
+    Applied,
+    Rejected,
+    Failed,
+}
+
+pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
     let (needs_recovery, release_pending) = PREVIEW_STATE.with_borrow_mut(|state| {
-        if !state.workspace_edit_sent && state.pending_workspace_edit.is_none() {
-            // A delayed acknowledgement from a previous edit cannot release
-            // a newer edit's lease.
+        if state.pending_workspace_edit.as_ref().is_none_or(|edit| edit.id != id) {
             return (false, false);
         }
         match outcome {
-            WorkspaceEditOutcome::Applied { .. } => {
+            WorkspaceEditOutcome::Applied => {
                 undo_redo::commit_pending(state);
                 // The filesystem acknowledgement and preview installation are
                 // independent. Release queued history only after both have
                 // reached their terminal state.
-                if state
-                    .workspace_edit_installation
-                    .as_ref()
-                    .is_some_and(|edit| edit.is_installed())
+                if state.workspace_edit_installation.as_ref().is_some_and(|edit| edit.is_finished())
                 {
                     state.workspace_edit_installation = None;
                     state.workspace_edit_sent = false;
@@ -1856,8 +1856,8 @@ fn workspace_edit_result(outcome: WorkspaceEditOutcome) {
                 state.workspace_edit_sent = false;
                 (true, true)
             }
-            WorkspaceEditOutcome::Failed { written, .. } => {
-                undo_redo::discard_pending(state, written != 0);
+            WorkspaceEditOutcome::Failed => {
+                undo_redo::discard_pending(state, true);
                 state.workspace_edit_installation = None;
                 state.workspace_edit_sent = false;
                 (true, true)
@@ -1865,6 +1865,7 @@ fn workspace_edit_result(outcome: WorkspaceEditOutcome) {
         }
     });
     if needs_recovery {
+        inspector::restore_committed();
         inspector::invalidate();
     }
     if needs_recovery || release_pending {
@@ -2210,7 +2211,6 @@ async fn reload_timer_function() {
 pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior) {
     #[cfg(feature = "system-testing")]
     {
-        test_sync::request_reload();
         let work = test_sync::Work::capture("preview debounce");
         PREVIEW_STATE.with_borrow_mut(|s| s.sync_reload_work.push(work));
     }
@@ -2408,7 +2408,7 @@ async fn reload_preview_impl(
 
     let installation = edit_installation::CompilationSnapshot {
         id: compilation,
-        inputs: compilation_inputs.as_ref().borrow().clone(),
+        inputs: std::mem::take(&mut *compilation_inputs.as_ref().borrow_mut()),
     };
     let success = compiled.is_some();
     let loaded_component_name = compiled.as_ref().map(|c| c.name().to_string());
@@ -2457,10 +2457,6 @@ async fn reload_preview_impl(
         let work = test_sync::Work::capture("preview installation");
         test_sync::publish(&component.url, attempt, move || {
             work.run(|| {
-                if !test_sync::current_attempt(attempt) {
-                    test_sync::processed(attempt, "superseded", Vec::new());
-                    return;
-                }
                 if !preview_generation_is_current(generation) {
                     test_sync::processed(attempt, "superseded", Vec::new());
                     return;
@@ -2579,9 +2575,7 @@ fn set_preview_factory(
         let work = factory_lease.as_ref().borrow_mut().take().unwrap_or_default();
         #[cfg(feature = "system-testing")]
         return work.run(|| {
-            if !preview_generation_is_current(generation)
-                || !attempt.is_none_or(test_sync::current_attempt)
-            {
+            if !preview_generation_is_current(generation) {
                 if let Some(attempt) = attempt {
                     test_sync::processed(attempt, "superseded", Vec::new());
                 }
@@ -2992,15 +2986,13 @@ fn update_preview_area(
             api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
             // Keep the inspector mounted until reselection, so edits retain keyboard focus.
 
-            #[cfg(feature = "system-testing")]
-            let factory_lease = set_preview_factory(
+            let _factory_lease = set_preview_factory(
                 editor_ui,
                 &api,
                 compiled,
                 Box::new(move |instance| {
-                    if !preview_generation_is_current(generation)
-                        || !attempt.is_none_or(test_sync::current_attempt)
-                    {
+                    if !preview_generation_is_current(generation) {
+                        #[cfg(feature = "system-testing")]
                         if let Some(attempt) = attempt {
                             test_sync::processed(attempt, "superseded", Vec::new());
                         }
@@ -3033,6 +3025,8 @@ fn update_preview_area(
                         )));
                     }
 
+                    PREVIEW_STATE
+                        .with_borrow_mut(|state| state.committed_inspector_overrides.clear());
                     shared_handle.replace(Some(instance));
                     previewed_component_changed();
                     let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
@@ -3060,72 +3054,13 @@ fn update_preview_area(
                 }),
                 behavior,
                 generation,
+                #[cfg(feature = "system-testing")]
                 attempt,
             );
             #[cfg(feature = "system-testing")]
             {
-                preview_state.factory_lease = Some(factory_lease);
+                preview_state.factory_lease = Some(_factory_lease);
             }
-            #[cfg(not(feature = "system-testing"))]
-            set_preview_factory(
-                editor_ui,
-                &api,
-                compiled,
-                Box::new(move |instance| {
-                    if !preview_generation_is_current(generation) {
-                        return;
-                    }
-                    if let Some(rtl) = instance.definition().raw_type_loader() {
-                        shared_document_cache.replace(Some(Rc::new(
-                            i_slint_editor_preview::DocumentCache::new_from_raw_parts(
-                                rtl,
-                                open_import_callback.clone(),
-                                source_file_versions.clone(),
-                                format,
-                            ),
-                        )));
-                    }
-
-                    // element_hash (and thus hook ids) change on every recompile, so drop stale overrides.
-                    (*shared_overrides).borrow_mut().clear();
-                    {
-                        let overrides = shared_overrides.clone();
-                        instance.set_debug_hook_callback(Some(Box::new(
-                            move |id: &str| -> Option<slint_interpreter::Value> {
-                                let mut m = (*overrides).borrow_mut();
-                                let p = m.entry(SmolStr::from(id)).or_insert_with(|| {
-                                    tracing::trace!("Inserting Property override: {id}");
-                                    Box::pin(i_slint_core::Property::new(None))
-                                });
-                                p.as_ref().get()
-                            },
-                        )));
-                    }
-
-                    shared_handle.replace(Some(instance));
-                    previewed_component_changed();
-                    let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
-                        let matches = state
-                            .workspace_edit_installation
-                            .as_mut()
-                            .is_some_and(|edit| edit.observe(&installation));
-                        if matches && state.pending_workspace_edit.is_none() {
-                            state.workspace_edit_installation = None;
-                            state.workspace_edit_sent = false;
-                            true
-                        } else {
-                            false
-                        }
-                    });
-                    inspector::invalidate();
-                    element_selection::reselect_element();
-                    if release_pending {
-                        undo_redo::apply_pending();
-                    }
-                }),
-                behavior,
-                generation,
-            );
         }
 
         editor_ui.clone_strong()
@@ -3238,6 +3173,29 @@ mod tests {
             *state = PreviewState::default();
             state.to_lsp = RefCell::new(Some(Rc::new(CapturePreviewToLsp { messages })));
         });
+    }
+
+    #[test]
+    fn stale_acknowledgment_cannot_finish_another_edit() {
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            state.workspace_edit_sent = true;
+            state.pending_workspace_edit = Some(undo_redo::PendingWorkspaceEdit {
+                id: 42,
+                history: undo_redo::PendingEdit::New(None),
+            });
+        });
+        for outcome in [
+            WorkspaceEditOutcome::Applied,
+            WorkspaceEditOutcome::Rejected,
+            WorkspaceEditOutcome::Failed,
+        ] {
+            workspace_edit_result(41, outcome);
+            PREVIEW_STATE.with_borrow(|state| {
+                assert!(state.workspace_edit_sent);
+                assert_eq!(state.pending_workspace_edit.as_ref().unwrap().id, 42);
+            });
+        }
+        PREVIEW_STATE.with_borrow_mut(|state| *state = PreviewState::default());
     }
 
     #[test]

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -24,7 +24,7 @@ use i_slint_editor_preview::{
 };
 use i_slint_live_preview::protocol::{
     LspToPreviewMessage, PreviewComponent, PreviewConfig, PreviewToLspMessage, SourceFileVersion,
-    VersionedUrl,
+    VersionedUrl, WorkspaceEditOutcome,
 };
 use lsp_types::Url;
 use slint::{LogicalPosition, LogicalSize, PlatformError, SharedString, ToSharedString};
@@ -75,8 +75,6 @@ pub fn initialize(
         preview_state.settings = settings;
     });
 
-    #[cfg(feature = "system-testing")]
-    test_sync::initialize();
     let settings = PREVIEW_STATE.with_borrow(|preview_state| preview_state.settings.clone());
     editor_ui.set_elements_pane_height(
         settings.elements_pane_height.map_or(0.0, |height| height as f32),
@@ -126,16 +124,6 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
             }
         }
         M::ForgetFile { url } => {
-            #[cfg(feature = "system-testing")]
-            {
-                test_sync::record_observed(&url, None);
-                test_sync::record_processed_with_inputs(
-                    &url,
-                    None,
-                    "load_error",
-                    &std::collections::HashMap::new(),
-                );
-            }
             delete_document(&url);
         }
         M::SetConfiguration { config } => {
@@ -143,6 +131,9 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
         }
         M::SetUserSettings { name, contents } => {
             set_user_settings(name, contents);
+        }
+        M::WorkspaceEditResult { outcome } => {
+            workspace_edit_result(outcome);
         }
         M::ShowPreview(preview_component) => {
             tracing::debug!(
@@ -251,12 +242,21 @@ pub struct PreviewState {
     selected: Option<element_selection::ElementSelection>,
     notify_editor_about_selection_after_update: bool,
     workspace_edit_sent: bool,
+    /// The filesystem side of the current workspace edit has completed, but
+    /// its preview installation may still be pending.
+    workspace_edit_installed: bool,
     known_components: Vec<ComponentInformation>,
     preview_loading_delay_timer: Option<slint::Timer>,
     initial_live_data: preview_data::PreviewDataMap,
     current_live_data: preview_data::PreviewDataMap,
     undo_redo_stack: undo_redo::UndoRedoStack,
-    pending_history: std::collections::VecDeque<bool>,
+    pending_history: std::collections::VecDeque<undo_redo::PendingHistory>,
+    pending_workspace_edit: Option<undo_redo::PendingWorkspaceEdit>,
+    preview_generation: u64,
+    #[cfg(feature = "system-testing")]
+    factory_lease: Option<Rc<RefCell<Option<test_sync::Work>>>>,
+    #[cfg(feature = "system-testing")]
+    sync_reload_work: Vec<test_sync::Work>,
     inspector_edit: Option<inspector::Edit>,
 
     source_code: SourceCodeCache,
@@ -316,6 +316,32 @@ pub(in crate::preview) fn set_file_tree_controller(
     });
 }
 thread_local! {pub static PREVIEW_STATE: std::cell::RefCell<PreviewState> = Default::default();}
+
+fn preview_generation_is_current(generation: u64) -> bool {
+    PREVIEW_STATE.with_borrow(|state| state.preview_generation == generation)
+}
+
+fn retire_factory(state: &mut PreviewState) {
+    #[cfg(feature = "system-testing")]
+    if let Some(lease) = state.factory_lease.take() {
+        // The ComponentFactory may remain retained by a component container
+        // after the surface is removed. Emptying the lease here lets the
+        // operation settle even when that abandoned factory is never invoked.
+        lease.as_ref().borrow_mut().take();
+    }
+}
+
+/// Invalidate deferred component creation when the preview surface changes
+/// mode. A stale factory may still be retained by the declarative UI, so it
+/// must fail its generation check if it is invoked after the mode switch.
+pub(crate) fn invalidate_preview_generation() {
+    #[cfg(feature = "system-testing")]
+    test_sync::request_reload();
+    PREVIEW_STATE.with_borrow_mut(|state| {
+        state.preview_generation = state.preview_generation.wrapping_add(1);
+        retire_factory(state);
+    });
+}
 
 fn invalidate_contents(url: &lsp_types::Url) {
     let needs_reload = PREVIEW_STATE.with_borrow_mut(|preview_state| {
@@ -520,12 +546,6 @@ fn apply_live_preview_data() {
 }
 
 fn set_contents(url: &VersionedUrl, content: String) {
-    #[cfg(feature = "system-testing")]
-    test_sync::record_observed(url.url(), Some(&content));
-    #[cfg(feature = "system-testing")]
-    if test_sync::should_hold_source(url.url(), &content) {
-        return;
-    }
     let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
         if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
             undo_redo::set_undo_redo_enabled(preview_state);
@@ -1722,11 +1742,49 @@ enum CompilationResult {
     NoChange,
 }
 
+fn dispatch_workspace_edit(
+    state: &mut PreviewState,
+    label: String,
+    edit: lsp_types::WorkspaceEdit,
+    history: undo_redo::PendingEdit,
+) -> bool {
+    if state.workspace_edit_sent {
+        #[cfg(feature = "system-testing")]
+        test_sync::effect("rejected");
+        return false;
+    }
+    let Some(to_lsp) = state.to_lsp.borrow().as_ref().cloned() else {
+        #[cfg(feature = "system-testing")]
+        test_sync::effect("rejected");
+        return false;
+    };
+
+    state.pending_workspace_edit = Some(undo_redo::PendingWorkspaceEdit { history });
+    state.workspace_edit_sent = true;
+    state.workspace_edit_installed = false;
+    if let Err(error) = to_lsp.send(&PreviewToLspMessage::SendWorkspaceEdit {
+        label: Some(label.clone()),
+        edit,
+    }) {
+        tracing::error!("Failed to send workspace edit '{}': {error}", label);
+        state.pending_workspace_edit.take();
+        state.workspace_edit_sent = false;
+        #[cfg(feature = "system-testing")]
+        test_sync::effect("failed");
+        return false;
+    }
+    true
+}
+
 fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit: bool) -> bool {
     let Some(document_cache) = document_cache() else {
+        #[cfg(feature = "system-testing")]
+        test_sync::effect("rejected");
         return false;
     };
     let Ok(result) = text_edit::apply_workspace_edit(&document_cache, &edit) else {
+        #[cfg(feature = "system-testing")]
+        test_sync::effect("rejected");
         return false;
     };
     let file_hashes = undo_redo::compute_file_hashes(&result);
@@ -1735,28 +1793,66 @@ fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit:
         let test_result = drop_location::edited_text_compiles(&document_cache, result);
         match test_result {
             CompilationResult::ChangeCompiles => {}
-            CompilationResult::ChangeFails => return false,
+            CompilationResult::ChangeFails => {
+                #[cfg(feature = "system-testing")]
+                test_sync::effect("rejected");
+                return false;
+            }
             CompilationResult::NoChange => return true,
         }
     }
 
     let reverse_edit = text_edit::reversed_edit(&document_cache, &edit);
+    let history = undo_redo::PendingEdit::New(reverse_edit.map(|reverse_edit| {
+        undo_redo::EditItem { title: label.clone(), edit: reverse_edit, file_hashes }
+    }));
 
     PREVIEW_STATE.with_borrow_mut(|preview_state| {
-        if std::mem::replace(&mut preview_state.workspace_edit_sent, true) {
-            return false;
-        }
-        preview_state.undo_redo_stack.push(label.clone(), reverse_edit, file_hashes);
-        undo_redo::set_undo_redo_enabled(preview_state);
-        preview_state
-            .to_lsp
-            .borrow()
-            .as_ref()
-            .unwrap()
-            .send(&PreviewToLspMessage::SendWorkspaceEdit { label: Some(label), edit })
-            .unwrap();
-        true
+        dispatch_workspace_edit(preview_state, label, edit, history)
     })
+}
+
+fn workspace_edit_result(outcome: WorkspaceEditOutcome) {
+    let (needs_recovery, release_pending) = PREVIEW_STATE.with_borrow_mut(|state| {
+        if !state.workspace_edit_sent && state.pending_workspace_edit.is_none() {
+            // A delayed acknowledgement from a previous edit cannot release
+            // a newer edit's lease.
+            return (false, false);
+        }
+        match outcome {
+            WorkspaceEditOutcome::Applied { .. } => {
+                undo_redo::commit_pending(state);
+                // The filesystem acknowledgement and preview installation are
+                // independent. Release queued history only after both have
+                // reached their terminal state.
+                if state.workspace_edit_installed {
+                    state.workspace_edit_installed = false;
+                    state.workspace_edit_sent = false;
+                    (false, true)
+                } else {
+                    (false, false)
+                }
+            }
+            WorkspaceEditOutcome::Rejected => {
+                undo_redo::discard_pending(state, false);
+                state.workspace_edit_sent = false;
+                state.workspace_edit_installed = false;
+                (true, true)
+            }
+            WorkspaceEditOutcome::Failed { written, .. } => {
+                undo_redo::discard_pending(state, written != 0);
+                state.workspace_edit_sent = false;
+                state.workspace_edit_installed = false;
+                (true, true)
+            }
+        }
+    });
+    if needs_recovery {
+        inspector::invalidate();
+    }
+    if needs_recovery || release_pending {
+        undo_redo::apply_pending();
+    }
 }
 
 fn change_style() {
@@ -1990,21 +2086,24 @@ async fn reload_timer_function() {
     let (selected, notify_editor) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
         let notify_editor = preview_state.notify_editor_about_selection_after_update;
         preview_state.notify_editor_about_selection_after_update = false;
-        (preview_state.selected.take(), notify_editor)
+        (preview_state.selected.clone(), notify_editor)
     });
 
+    #[cfg(feature = "system-testing")]
+    let mut completion_work = Vec::new();
     loop {
-        let Some((preview_component, config, behavior)) =
+        let Some((preview_component, config, behavior, generation)) =
             PREVIEW_STATE.with_borrow_mut(|preview_state| {
                 let behavior = preview_state.current_load_behavior.take()?;
                 let preview_component = preview_state.current_component()?;
+                let generation = preview_state.preview_generation;
 
                 assert_eq!(preview_state.loading_state, PreviewFutureState::PreLoading);
 
                 preview_state.loading_state = PreviewFutureState::Loading;
                 preview_state.dependencies.clear();
 
-                Some((preview_component, preview_state.config.clone(), behavior))
+                Some((preview_component, preview_state.config.clone(), behavior, generation))
             })
         else {
             return;
@@ -2013,7 +2112,19 @@ async fn reload_timer_function() {
         // the ComboBox is updated to the resolved style once the build finishes.
         let style = config.style.clone();
 
-        match reload_preview_impl(preview_component, behavior, style, config).await {
+        #[cfg(feature = "system-testing")]
+        let work = PREVIEW_STATE
+            .with_borrow_mut(|s| test_sync::Work::combine(std::mem::take(&mut s.sync_reload_work)));
+        #[cfg(feature = "system-testing")]
+        let result = work
+            .during(reload_preview_impl(preview_component, behavior, style, config, generation))
+            .await;
+        #[cfg(not(feature = "system-testing"))]
+        let result =
+            reload_preview_impl(preview_component, behavior, style, config, generation).await;
+        #[cfg(feature = "system-testing")]
+        completion_work.push(work);
+        match result {
             Ok(()) => {}
             Err(e) => {
                 tracing::debug!("Preview reload failed: {}", e);
@@ -2042,38 +2153,50 @@ async fn reload_timer_function() {
         };
     }
 
-    if let Some(selection) = selected {
-        element_selection::restore_selection(selection.clone(), SelectionNotification::Never);
+    let restore = || {
+        if let Some(selection) = selected {
+            element_selection::restore_selection(selection.clone(), SelectionNotification::Never);
 
-        if notify_editor
-            && let Some(component_instance) = component_instance()
-            && let Some((element, debug_index)) = component_instance
-                .element_node_at_source_code_position(&selection.path, selection.offset.into())
-                .first()
-        {
-            let Some(element_node) = ElementRcNode::new(element.clone(), *debug_index) else {
-                return;
-            };
-            let format = PREVIEW_STATE.with_borrow(|ps| ps.format());
-            let (path, pos) = element_node.with_element_node(|node| {
-                let sf = &node.source_file;
-                (
-                    sf.path().to_owned(),
-                    util::text_size_to_lsp_position(sf, selection.offset, format),
+            if notify_editor
+                && let Some(component_instance) = component_instance()
+                && let Some((element, debug_index)) = component_instance
+                    .element_node_at_source_code_position(&selection.path, selection.offset.into())
+                    .first()
+            {
+                let Some(element_node) = ElementRcNode::new(element.clone(), *debug_index) else {
+                    return;
+                };
+                let format = PREVIEW_STATE.with_borrow(|ps| ps.format());
+                let (path, pos) = element_node.with_element_node(|node| {
+                    let sf = &node.source_file;
+                    (
+                        sf.path().to_owned(),
+                        util::text_size_to_lsp_position(sf, selection.offset, format),
+                    )
+                });
+                let lsp = PREVIEW_STATE.with_borrow(|ps| ps.to_lsp.borrow().clone().unwrap());
+                lsp.ask_editor_to_show_document(
+                    &path.to_string_lossy(),
+                    lsp_types::Range::new(pos, pos),
+                    false,
                 )
-            });
-            let lsp = PREVIEW_STATE.with_borrow(|ps| ps.to_lsp.borrow().clone().unwrap());
-            lsp.ask_editor_to_show_document(
-                &path.to_string_lossy(),
-                lsp_types::Range::new(pos, pos),
-                false,
-            )
-            .ok();
+                .ok();
+            }
         }
-    }
+    };
+    #[cfg(feature = "system-testing")]
+    test_sync::Work::combine(completion_work).run(restore);
+    #[cfg(not(feature = "system-testing"))]
+    restore();
 }
 
 pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior) {
+    #[cfg(feature = "system-testing")]
+    {
+        test_sync::request_reload();
+        let work = test_sync::Work::capture("preview debounce");
+        PREVIEW_STATE.with_borrow_mut(|s| s.sync_reload_work.push(work));
+    }
     tracing::debug!(
         "Preview: load url={}, component={:?}, behavior={:?}",
         preview_component.url,
@@ -2082,6 +2205,8 @@ pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior)
     );
 
     PREVIEW_STATE.with_borrow_mut(|preview_state| {
+        preview_state.preview_generation = preview_state.preview_generation.wrapping_add(1);
+        retire_factory(preview_state);
         match behavior {
             LoadBehavior::Reload => {}
             LoadBehavior::Load
@@ -2188,6 +2313,7 @@ async fn reload_preview_impl(
     behavior: LoadBehavior,
     style: String,
     config: PreviewConfig,
+    generation: u64,
 ) -> Result<(), PlatformError> {
     start_parsing();
 
@@ -2201,7 +2327,10 @@ async fn reload_preview_impl(
     }
 
     let path = component.url.to_file_path().unwrap_or(PathBuf::from(&component.url.to_string()));
-    let (version, source) = get_url_from_cache(&component.url).unwrap_or_else(|err| {
+    let input = get_url_from_cache(&component.url);
+    #[cfg(feature = "system-testing")]
+    let missing_input = input.is_err();
+    let (version, source) = input.unwrap_or_else(|err| {
         tracing::debug!("Preview: Failed to load source for url={}, error={}", component.url, err);
         Default::default()
     });
@@ -2213,7 +2342,14 @@ async fn reload_preview_impl(
     };
 
     #[cfg(feature = "system-testing")]
-    let source_for_sync = source.clone();
+    let attempt = test_sync::begin_attempt(&component.url, component.component.clone());
+    #[cfg(feature = "system-testing")]
+    test_sync::read_input(
+        attempt,
+        &component.url,
+        version,
+        (!missing_input).then_some(source.as_str()),
+    );
     let (diagnostics, compiled, open_import_callback, source_file_versions) = parse_source(
         config,
         path,
@@ -2227,7 +2363,16 @@ async fn reload_preview_impl(
                 let path = PathBuf::from(&path);
                 // Always return Some to stop the compiler from trying to load itself...
                 // All loading is done by the LSP for us!
-                Some(get_path_from_cache(&path))
+                let result = get_path_from_cache(&path);
+                #[cfg(feature = "system-testing")]
+                if let Ok(url) = Url::from_file_path(&path) {
+                    let (version, content) = match &result {
+                        Ok((v, c)) => (*v, Some(c.as_str())),
+                        Err(_) => (None, None),
+                    };
+                    test_sync::read_input(attempt, &url, version, content);
+                }
+                Some(result)
             })
         },
     )
@@ -2251,11 +2396,16 @@ async fn reload_preview_impl(
     );
 
     #[cfg(feature = "system-testing")]
-    let attempt = test_sync::record_processed_with_inputs(
-        &component.url,
-        Some(&source_for_sync),
-        if compiled.is_some() { "compiled" } else { "compile_error" },
-        &source_file_versions.borrow(),
+    test_sync::processed(
+        attempt,
+        if missing_input {
+            "load_error"
+        } else if compiled.is_some() {
+            "compiled"
+        } else {
+            "compile_error"
+        },
+        diagnostics.iter().map(ToString::to_string).collect(),
     );
 
     let lsp = PREVIEW_STATE.with_borrow_mut(|preview_state| {
@@ -2270,18 +2420,42 @@ async fn reload_preview_impl(
     let diags = convert_diagnostics(&diagnostics, &source_file_versions.borrow());
     lsp.notify_diagnostics(diags).unwrap();
 
+    #[cfg(feature = "system-testing")]
+    {
+        let work = test_sync::Work::capture("preview installation");
+        test_sync::publish(&component.url, attempt, move || {
+            work.run(|| {
+                if !test_sync::current_attempt(attempt) {
+                    test_sync::processed(attempt, "superseded", Vec::new());
+                    return;
+                }
+                if !preview_generation_is_current(generation) {
+                    test_sync::processed(attempt, "superseded", Vec::new());
+                    return;
+                }
+                if let Err(error) = update_preview_area(
+                    compiled,
+                    behavior,
+                    open_import_callback,
+                    source_file_versions,
+                    format,
+                    generation,
+                    Some(attempt),
+                ) {
+                    tracing::error!("Preview installation failed: {error}");
+                    test_sync::effect("failed");
+                }
+            })
+        });
+    }
+    #[cfg(not(feature = "system-testing"))]
     update_preview_area(
         compiled,
         behavior,
         open_import_callback,
         source_file_versions,
         format,
-        #[cfg(feature = "system-testing")]
-        Some(attempt),
-        #[cfg(feature = "system-testing")]
-        Some((component.url.clone(), source_for_sync.clone())),
-        #[cfg(not(feature = "system-testing"))]
-        None,
+        generation,
     )?;
 
     if let Some(loaded_component_name) = loaded_component_name {
@@ -2305,13 +2479,20 @@ async fn reload_preview_impl(
 }
 
 /// This sets up the preview area to show the ComponentInstance
+#[cfg(feature = "system-testing")]
+type FactoryLease = Rc<RefCell<Option<test_sync::Work>>>;
+#[cfg(not(feature = "system-testing"))]
+type FactoryLease = ();
+
 fn set_preview_factory(
     editor_ui: &ui::EditorUi,
     api: &ui::Api<'_>,
     compiled: ComponentDefinition,
     callback: Box<dyn Fn(ComponentInstance)>,
     behavior: LoadBehavior,
-) {
+    generation: u64,
+    #[cfg(feature = "system-testing")] attempt: Option<u64>,
+) -> FactoryLease {
     // Ensure that any popups are closed as they are related to the old factory
     i_slint_core::window::WindowInner::from_pub(editor_ui.window()).close_all_popups();
 
@@ -2355,16 +2536,46 @@ fn set_preview_factory(
             });
         })));
 
+    #[cfg(feature = "system-testing")]
+    let lease = Rc::new(RefCell::new(Some(test_sync::Work::capture("component factory"))));
+    #[cfg(feature = "system-testing")]
+    let factory_lease = lease.clone();
     let factory = slint::ComponentFactory::new(move |ctx: FactoryContext| {
+        #[cfg(feature = "system-testing")]
+        let work = factory_lease.as_ref().borrow_mut().take().unwrap_or_default();
+        #[cfg(feature = "system-testing")]
+        return work.run(|| {
+            if !preview_generation_is_current(generation)
+                || !attempt.is_none_or(test_sync::current_attempt)
+            {
+                if let Some(attempt) = attempt {
+                    test_sync::processed(attempt, "superseded", Vec::new());
+                }
+                return None;
+            }
+            let instance = compiled.create_embedded(ctx).unwrap();
+            callback(instance.clone_strong());
+            Some(instance)
+        });
+        #[cfg(not(feature = "system-testing"))]
+        if !preview_generation_is_current(generation) {
+            return None;
+        }
+        #[cfg(not(feature = "system-testing"))]
         let instance = compiled.create_embedded(ctx).unwrap();
 
+        #[cfg(not(feature = "system-testing"))]
         callback(instance.clone_strong());
-
+        #[cfg(not(feature = "system-testing"))]
         Some(instance)
     });
 
     api.set_preview_area(factory);
     api.set_resize_to_preferred_size(behavior != LoadBehavior::Reload);
+    #[cfg(feature = "system-testing")]
+    return lease;
+    #[cfg(not(feature = "system-testing"))]
+    ()
 }
 
 /// Push the remote connection's state to the Remote Preview pane, which
@@ -2719,12 +2930,23 @@ fn update_preview_area(
     open_import_callback: Option<i_slint_editor_preview::document_cache::OpenImportCallback>,
     source_file_versions: Rc<RefCell<i_slint_editor_preview::document_cache::SourceFileVersionMap>>,
     format: i_slint_editor_preview::ByteFormat,
+    generation: u64,
     #[cfg(feature = "system-testing")] attempt: Option<u64>,
-    #[cfg(feature = "system-testing")] applied_source: Option<(lsp_types::Url, String)>,
-    #[cfg(not(feature = "system-testing"))] _attempt: Option<u64>,
 ) -> Result<(), PlatformError> {
+    if !preview_generation_is_current(generation) {
+        #[cfg(feature = "system-testing")]
+        if let Some(attempt) = attempt {
+            test_sync::processed(attempt, "superseded", Vec::new());
+        }
+        return Ok(());
+    }
+    let failed = compiled.is_none();
     let editor_ui = PREVIEW_STATE.with_borrow_mut(move |preview_state| {
-        preview_state.workspace_edit_sent = false;
+        if failed {
+            undo_redo::discard_pending(preview_state, false);
+            preview_state.workspace_edit_sent = false;
+            preview_state.workspace_edit_installed = false;
+        }
 
         let editor_ui = preview_state.editor_ui.as_ref().unwrap();
         let api = preview_state.api.upgrade().unwrap();
@@ -2735,11 +2957,20 @@ fn update_preview_area(
             api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
             // Keep the inspector mounted until reselection, so edits retain keyboard focus.
 
-            set_preview_factory(
+            #[cfg(feature = "system-testing")]
+            let factory_lease = set_preview_factory(
                 editor_ui,
                 &api,
                 compiled,
                 Box::new(move |instance| {
+                    if !preview_generation_is_current(generation)
+                        || !attempt.is_none_or(test_sync::current_attempt)
+                    {
+                        if let Some(attempt) = attempt {
+                            test_sync::processed(attempt, "superseded", Vec::new());
+                        }
+                        return;
+                    }
                     if let Some(rtl) = instance.definition().raw_type_loader() {
                         shared_document_cache.replace(Some(Rc::new(
                             i_slint_editor_preview::DocumentCache::new_from_raw_parts(
@@ -2769,12 +3000,90 @@ fn update_preview_area(
 
                     shared_handle.replace(Some(instance));
                     previewed_component_changed();
+                    let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
+                        if state.pending_workspace_edit.is_some() {
+                            state.workspace_edit_installed = true;
+                            false
+                        } else {
+                            state.workspace_edit_installed = false;
+                            state.workspace_edit_sent = false;
+                            true
+                        }
+                    });
+                    inspector::invalidate();
+                    element_selection::reselect_element();
+                    if release_pending {
+                        undo_redo::apply_pending();
+                    }
                     #[cfg(feature = "system-testing")]
-                    if let Some((url, source)) = &applied_source {
-                        test_sync::record_applied_with_attempt(url, source, attempt);
+                    if let Some(attempt) = attempt {
+                        test_sync::applied(attempt);
                     }
                 }),
                 behavior,
+                generation,
+                attempt,
+            );
+            #[cfg(feature = "system-testing")]
+            {
+                preview_state.factory_lease = Some(factory_lease);
+            }
+            #[cfg(not(feature = "system-testing"))]
+            set_preview_factory(
+                editor_ui,
+                &api,
+                compiled,
+                Box::new(move |instance| {
+                    if !preview_generation_is_current(generation) {
+                        return;
+                    }
+                    if let Some(rtl) = instance.definition().raw_type_loader() {
+                        shared_document_cache.replace(Some(Rc::new(
+                            i_slint_editor_preview::DocumentCache::new_from_raw_parts(
+                                rtl,
+                                open_import_callback.clone(),
+                                source_file_versions.clone(),
+                                format,
+                            ),
+                        )));
+                    }
+
+                    // element_hash (and thus hook ids) change on every recompile, so drop stale overrides.
+                    (*shared_overrides).borrow_mut().clear();
+                    {
+                        let overrides = shared_overrides.clone();
+                        instance.set_debug_hook_callback(Some(Box::new(
+                            move |id: &str| -> Option<slint_interpreter::Value> {
+                                let mut m = (*overrides).borrow_mut();
+                                let p = m.entry(SmolStr::from(id)).or_insert_with(|| {
+                                    tracing::trace!("Inserting Property override: {id}");
+                                    Box::pin(i_slint_core::Property::new(None))
+                                });
+                                p.as_ref().get()
+                            },
+                        )));
+                    }
+
+                    shared_handle.replace(Some(instance));
+                    previewed_component_changed();
+                    let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
+                        if state.pending_workspace_edit.is_some() {
+                            state.workspace_edit_installed = true;
+                            false
+                        } else {
+                            state.workspace_edit_installed = false;
+                            state.workspace_edit_sent = false;
+                            true
+                        }
+                    });
+                    inspector::invalidate();
+                    element_selection::reselect_element();
+                    if release_pending {
+                        undo_redo::apply_pending();
+                    }
+                }),
+                behavior,
+                generation,
             );
         }
 
@@ -2794,9 +3103,11 @@ fn update_preview_area(
         Ok(())
     })?;
 
-    inspector::invalidate();
-    element_selection::reselect_element();
-    undo_redo::apply_pending();
+    if failed {
+        inspector::invalidate();
+        element_selection::reselect_element();
+        undo_redo::apply_pending();
+    }
     Ok(())
 }
 

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -2582,7 +2582,15 @@ fn set_preview_factory(
     let lease = Rc::new(RefCell::new(Some(test_sync::Work::capture("component factory"))));
     #[cfg(feature = "system-testing")]
     let factory_lease = lease.clone();
+    #[cfg(feature = "system-testing")]
+    let paused = Rc::new(std::cell::Cell::new(false));
+    #[cfg(feature = "system-testing")]
+    let factory_paused = paused.clone();
     let factory = slint::ComponentFactory::new(move |ctx: FactoryContext| {
+        #[cfg(feature = "system-testing")]
+        if factory_paused.get() {
+            return None;
+        }
         #[cfg(feature = "system-testing")]
         let work = factory_lease.as_ref().borrow_mut().take().unwrap_or_default();
         #[cfg(feature = "system-testing")]
@@ -2610,7 +2618,26 @@ fn set_preview_factory(
         Some(instance)
     });
 
+    #[cfg(feature = "system-testing")]
+    let deferred_factory = factory.clone();
     api.set_preview_area(factory);
+    #[cfg(feature = "system-testing")]
+    if let Some(attempt) = attempt {
+        let weak_ui = editor_ui.as_weak();
+        let resume = paused.clone();
+        paused.set(test_sync::hold_factory(attempt, move || {
+            if !preview_generation_is_current(generation) {
+                test_sync::processed(attempt, "superseded", Vec::new());
+                return;
+            }
+            resume.set(false);
+            if let Some(editor_ui) = weak_ui.upgrade() {
+                let api = editor_ui.global::<ui::Api>();
+                api.set_preview_area(Default::default());
+                api.set_preview_area(deferred_factory);
+            }
+        }));
+    }
     api.set_resize_to_preferred_size(behavior != LoadBehavior::Reload);
     #[cfg(feature = "system-testing")]
     return lease;

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -239,18 +239,16 @@ pub struct PreviewState {
     >,
     selected: Option<element_selection::ElementSelection>,
     notify_editor_about_selection_after_update: bool,
-    workspace_edit_sent: bool,
     pub(crate) edit_sender: Option<crossbeam_channel::Sender<crate::PreviewMessage>>,
     next_edit_id: u64,
     compilation_sequence: u64,
-    workspace_edit_installation: Option<edit_installation::PendingInstallation>,
+    pending_edit: Option<edit_installation::PendingWorkspaceEdit>,
     known_components: Vec<ComponentInformation>,
     preview_loading_delay_timer: Option<slint::Timer>,
     initial_live_data: preview_data::PreviewDataMap,
     current_live_data: preview_data::PreviewDataMap,
     undo_redo_stack: undo_redo::UndoRedoStack,
     pending_history: std::collections::VecDeque<undo_redo::PendingHistory>,
-    pending_workspace_edit: Option<undo_redo::PendingWorkspaceEdit>,
     preview_generation: u64,
     #[cfg(feature = "system-testing")]
     factory_lease: Option<Rc<RefCell<Option<test_sync::Work>>>>,
@@ -335,11 +333,10 @@ fn retire_factory(_state: &mut PreviewState, _transfer_to_reload: bool) {
 }
 
 fn abandon_pending_installation(state: &mut PreviewState) {
-    if let Some(edit) = state.workspace_edit_installation.as_mut() {
+    if let Some(edit) = state.pending_edit.as_mut() {
         edit.abandon();
-        if state.pending_workspace_edit.is_none() {
-            state.workspace_edit_installation = None;
-            state.workspace_edit_sent = false;
+        if edit.is_finished() {
+            state.pending_edit = None;
         }
     }
     undo_redo::cancel_pending(state);
@@ -564,11 +561,10 @@ fn apply_live_preview_data() {
 
 fn set_contents(url: &VersionedUrl, content: String) {
     let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
-        let own_pending_contents = preview_state.pending_workspace_edit.is_some()
-            && preview_state
-                .workspace_edit_installation
-                .as_ref()
-                .is_some_and(|edit| edit.expects(url.url(), &content));
+        let own_pending_contents = preview_state
+            .pending_edit
+            .as_ref()
+            .is_some_and(|edit| edit.expects(url.url(), &content));
         if !own_pending_contents
             && !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content)
         {
@@ -1773,7 +1769,7 @@ fn dispatch_workspace_edit(
     history: undo_redo::PendingEdit,
     expected: std::collections::HashMap<Url, String>,
 ) -> bool {
-    if state.workspace_edit_sent {
+    if state.pending_edit.is_some() {
         #[cfg(feature = "system-testing")]
         test_sync::effect(test_sync::Outcome::Rejected);
         return false;
@@ -1784,17 +1780,17 @@ fn dispatch_workspace_edit(
         return false;
     };
 
-    state.workspace_edit_installation =
-        Some(edit_installation::PendingInstallation::new(state.compilation_sequence, expected));
     state.next_edit_id += 1;
     let id = state.next_edit_id;
-    state.pending_workspace_edit = Some(undo_redo::PendingWorkspaceEdit { id, history });
-    state.workspace_edit_sent = true;
+    state.pending_edit = Some(edit_installation::PendingWorkspaceEdit::new(
+        id,
+        state.compilation_sequence,
+        expected,
+        history,
+    ));
     if let Err(error) = sender.send(crate::PreviewMessage::edit(id, label.clone(), edit)) {
         tracing::error!("Failed to send workspace edit '{}': {error}", label);
-        state.pending_workspace_edit.take();
-        state.workspace_edit_installation = None;
-        state.workspace_edit_sent = false;
+        state.pending_edit = None;
         #[cfg(feature = "system-testing")]
         test_sync::effect(test_sync::Outcome::Failed);
         return false;
@@ -1847,21 +1843,23 @@ pub(crate) enum WorkspaceEditOutcome {
 }
 
 fn finish_pending_installation(state: &mut PreviewState) -> bool {
-    let Some(edit) = state.workspace_edit_installation.as_ref() else { return false };
+    let Some(edit) = state.pending_edit.as_ref() else { return false };
     if edit.is_superseded() {
         undo_redo::discard_pending(state, true);
         undo_redo::cancel_pending(state);
-    } else if state.pending_workspace_edit.is_some() || !edit.is_finished() {
+    } else if !edit.is_finished() {
         return false;
     }
-    state.workspace_edit_installation = None;
-    state.workspace_edit_sent = false;
+    state.pending_edit = None;
     true
 }
 
 pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
     let matches = PREVIEW_STATE.with_borrow(|state| {
-        state.pending_workspace_edit.as_ref().is_some_and(|edit| edit.id == id)
+        state
+            .pending_edit
+            .as_ref()
+            .is_some_and(|edit| edit.id == id && edit.awaiting_acknowledgment())
     });
     #[cfg(feature = "system-testing")]
     test_sync::acknowledgment_received(id, matches);
@@ -1870,22 +1868,15 @@ pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
     }
     let (needs_recovery, release_pending) = PREVIEW_STATE.with_borrow_mut(|state| match outcome {
         WorkspaceEditOutcome::Applied => {
-            if let Some(edit) = state.workspace_edit_installation.as_mut() {
-                edit.acknowledge();
-            }
             undo_redo::commit_pending(state);
             (false, finish_pending_installation(state))
         }
         WorkspaceEditOutcome::Rejected => {
             undo_redo::discard_pending(state, false);
-            state.workspace_edit_installation = None;
-            state.workspace_edit_sent = false;
             (true, true)
         }
         WorkspaceEditOutcome::Failed { may_have_changed } => {
             undo_redo::discard_pending(state, may_have_changed);
-            state.workspace_edit_installation = None;
-            state.workspace_edit_sent = false;
             (true, true)
         }
     });
@@ -2904,7 +2895,7 @@ fn set_selected_element(
                     ));
                 }
             } else if !notify_editor_about_selection_after_update
-                && !preview_state.workspace_edit_sent
+                && preview_state.pending_edit.is_none()
             {
                 api.set_current_element(Default::default());
                 api.set_properties(Default::default());
@@ -3033,8 +3024,6 @@ fn update_preview_area(
     let editor_ui = PREVIEW_STATE.with_borrow_mut(move |preview_state| {
         if failed {
             undo_redo::discard_pending(preview_state, false);
-            preview_state.workspace_edit_sent = false;
-            preview_state.workspace_edit_installation = None;
         }
 
         let editor_ui = preview_state.editor_ui.as_ref().unwrap();
@@ -3091,7 +3080,7 @@ fn update_preview_area(
                         shared_handle.replace(Some(instance));
                         previewed_component_changed();
                         let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
-                            if let Some(edit) = state.workspace_edit_installation.as_mut() {
+                            if let Some(edit) = state.pending_edit.as_mut() {
                                 edit.observe(&installation);
                             }
                             finish_pending_installation(state)
@@ -3235,11 +3224,12 @@ mod tests {
     #[test]
     fn stale_acknowledgment_cannot_finish_another_edit() {
         PREVIEW_STATE.with_borrow_mut(|state| {
-            state.workspace_edit_sent = true;
-            state.pending_workspace_edit = Some(undo_redo::PendingWorkspaceEdit {
-                id: 42,
-                history: undo_redo::PendingEdit::New(None),
-            });
+            state.pending_edit = Some(edit_installation::PendingWorkspaceEdit::new(
+                42,
+                0,
+                Default::default(),
+                undo_redo::PendingEdit::New(None),
+            ));
         });
         for outcome in [
             WorkspaceEditOutcome::Applied,
@@ -3248,8 +3238,8 @@ mod tests {
         ] {
             workspace_edit_result(41, outcome);
             PREVIEW_STATE.with_borrow(|state| {
-                assert!(state.workspace_edit_sent);
-                assert_eq!(state.pending_workspace_edit.as_ref().unwrap().id, 42);
+                assert!(state.pending_edit.is_some());
+                assert_eq!(state.pending_edit.as_ref().unwrap().id, 42);
             });
         }
         PREVIEW_STATE.with_borrow_mut(|state| *state = PreviewState::default());

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -555,7 +555,14 @@ fn apply_live_preview_data() {
 
 fn set_contents(url: &VersionedUrl, content: String) {
     let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
-        if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
+        let own_pending_contents = preview_state.pending_workspace_edit.is_some()
+            && preview_state
+                .workspace_edit_installation
+                .as_ref()
+                .is_some_and(|edit| edit.expects(url.url(), &content));
+        if !own_pending_contents
+            && !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content)
+        {
             undo_redo::set_undo_redo_enabled(preview_state);
         }
         let old = preview_state.source_code.insert(
@@ -1831,10 +1838,15 @@ pub(crate) enum WorkspaceEditOutcome {
 }
 
 pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
+    let matches = PREVIEW_STATE.with_borrow(|state| {
+        state.pending_workspace_edit.as_ref().is_some_and(|edit| edit.id == id)
+    });
+    #[cfg(feature = "system-testing")]
+    test_sync::acknowledgment_received(id, matches);
+    if !matches {
+        return;
+    }
     let (needs_recovery, release_pending) = PREVIEW_STATE.with_borrow_mut(|state| {
-        if state.pending_workspace_edit.as_ref().is_none_or(|edit| edit.id != id) {
-            return (false, false);
-        }
         match outcome {
             WorkspaceEditOutcome::Applied => {
                 undo_redo::commit_pending(state);

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -1834,7 +1834,7 @@ fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit:
 pub(crate) enum WorkspaceEditOutcome {
     Applied,
     Rejected,
-    Failed,
+    Failed { may_have_changed: bool },
 }
 
 pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
@@ -1868,8 +1868,8 @@ pub(crate) fn workspace_edit_result(id: u64, outcome: WorkspaceEditOutcome) {
                 state.workspace_edit_sent = false;
                 (true, true)
             }
-            WorkspaceEditOutcome::Failed => {
-                undo_redo::discard_pending(state, true);
+            WorkspaceEditOutcome::Failed { may_have_changed } => {
+                undo_redo::discard_pending(state, may_have_changed);
                 state.workspace_edit_installation = None;
                 state.workspace_edit_sent = false;
                 (true, true)
@@ -3226,7 +3226,7 @@ mod tests {
         for outcome in [
             WorkspaceEditOutcome::Applied,
             WorkspaceEditOutcome::Rejected,
-            WorkspaceEditOutcome::Failed,
+            WorkspaceEditOutcome::Failed { may_have_changed: true },
         ] {
             workspace_edit_result(41, outcome);
             PREVIEW_STATE.with_borrow(|state| {

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -56,7 +56,7 @@ mod properties;
 pub mod remote;
 pub(crate) mod settings;
 #[cfg(feature = "system-testing")]
-mod test_sync;
+pub(crate) mod test_sync;
 pub mod ui;
 mod undo_redo;
 
@@ -120,11 +120,15 @@ pub fn lsp_to_preview(message: LspToPreviewMessage) {
     use LspToPreviewMessage as M;
     match message {
         M::InvalidateContents { url } => invalidate_contents(&url),
-        M::ForgetFile { url } => delete_document(&url),
         M::SetContents { url, contents } => {
             if let Ok(contents) = String::from_utf8(contents) {
                 set_contents(&url, contents);
             }
+        }
+        M::ForgetFile { url } => {
+            #[cfg(feature = "system-testing")]
+            test_sync::record_observed(&url, None);
+            delete_document(&url);
         }
         M::SetConfiguration { config } => {
             config_changed(config);
@@ -508,6 +512,8 @@ fn apply_live_preview_data() {
 }
 
 fn set_contents(url: &VersionedUrl, content: String) {
+    #[cfg(feature = "system-testing")]
+    test_sync::record_observed(url.url(), Some(&content));
     let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
         if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
             undo_redo::set_undo_redo_enabled(preview_state);
@@ -2062,6 +2068,7 @@ pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior)
         preview_component.component,
         behavior
     );
+
     PREVIEW_STATE.with_borrow_mut(|preview_state| {
         match behavior {
             LoadBehavior::Reload => {}
@@ -2193,6 +2200,8 @@ async fn reload_preview_impl(
         i_slint_editor_preview::ByteFormat::Utf16
     };
 
+    #[cfg(feature = "system-testing")]
+    let source_for_sync = source.clone();
     let (diagnostics, compiled, open_import_callback, source_file_versions) = parse_source(
         config,
         path,
@@ -2227,6 +2236,13 @@ async fn reload_preview_impl(
         loaded_component_name,
         success,
         diagnostics.len()
+    );
+
+    #[cfg(feature = "system-testing")]
+    test_sync::record_processed(
+        &component.url,
+        &source_for_sync,
+        if compiled.is_some() { "compiled" } else { "compile_error" },
     );
 
     let lsp = PREVIEW_STATE.with_borrow_mut(|preview_state| {
@@ -2687,6 +2703,13 @@ fn update_preview_area(
         let shared_handle = preview_state.handle.clone();
         let shared_document_cache = preview_state.document_cache.clone();
         let shared_overrides = preview_state.debug_hook_overrides.clone();
+        #[cfg(feature = "system-testing")]
+        let applied_source = preview_state.current_component().and_then(|component| {
+            preview_state
+                .source_code
+                .get(&component.url)
+                .map(|entry| (component.url, entry.code.clone()))
+        });
 
         if let Some(compiled) = compiled {
             api.set_focus_previewed_element(behavior == LoadBehavior::BringWindowToFront);
@@ -2697,6 +2720,10 @@ fn update_preview_area(
                 &api,
                 compiled,
                 Box::new(move |instance| {
+                    #[cfg(feature = "system-testing")]
+                    if let Some((url, source)) = &applied_source {
+                        test_sync::record_applied(url, source);
+                    }
                     if let Some(rtl) = instance.definition().raw_type_loader() {
                         shared_document_cache.replace(Some(Rc::new(
                             i_slint_editor_preview::DocumentCache::new_from_raw_parts(

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -41,6 +41,7 @@ use std::rc::Rc;
 use i_slint_editor_preview::wasm_prelude::*;
 
 mod drop_location;
+mod edit_installation;
 mod element_catalog;
 mod element_selection;
 pub mod eval;
@@ -242,9 +243,8 @@ pub struct PreviewState {
     selected: Option<element_selection::ElementSelection>,
     notify_editor_about_selection_after_update: bool,
     workspace_edit_sent: bool,
-    /// The filesystem side of the current workspace edit has completed, but
-    /// its preview installation may still be pending.
-    workspace_edit_installed: bool,
+    compilation_sequence: u64,
+    workspace_edit_installation: Option<edit_installation::PendingInstallation>,
     known_components: Vec<ComponentInformation>,
     preview_loading_delay_timer: Option<slint::Timer>,
     initial_live_data: preview_data::PreviewDataMap,
@@ -577,23 +577,23 @@ fn set_contents(url: &VersionedUrl, content: String) {
 }
 
 fn apply_project_to_file_tree(root: &Url) {
-    PREVIEW_STATE.with_borrow(|preview_state| {
-        let Some(editor_ui) = preview_state.editor_ui.as_ref() else { return };
-        let Some(controller) = preview_state.file_tree_controller.as_ref() else { return };
-        let api = editor_ui.global::<ui::Api>();
-        let project = editor_ui.global::<ui::Project>();
-        ui::file_tree::open_project(controller, root, &api, &project);
+    let handles = PREVIEW_STATE.with_borrow(|state| {
+        Some((state.editor_ui.as_ref()?.clone_strong(), state.file_tree_controller.clone()?))
     });
+    let Some((editor_ui, controller)) = handles else { return };
+    let api = editor_ui.global::<ui::Api>();
+    let project = editor_ui.global::<ui::Project>();
+    ui::file_tree::open_project(&controller, root, &api, &project);
 }
 
 fn apply_preview_to_file_tree(component: &PreviewComponent) {
-    PREVIEW_STATE.with_borrow(|preview_state| {
-        let Some(editor_ui) = preview_state.editor_ui.as_ref() else { return };
-        let Some(controller) = preview_state.file_tree_controller.as_ref() else { return };
-        let api = editor_ui.global::<ui::Api>();
-        let project = editor_ui.global::<ui::Project>();
-        ui::file_tree::open_preview(controller, component, &api, &project);
+    let handles = PREVIEW_STATE.with_borrow(|state| {
+        Some((state.editor_ui.as_ref()?.clone_strong(), state.file_tree_controller.clone()?))
     });
+    let Some((editor_ui, controller)) = handles else { return };
+    let api = editor_ui.global::<ui::Api>();
+    let project = editor_ui.global::<ui::Project>();
+    ui::file_tree::open_preview(&controller, component, &api, &project);
 }
 
 fn preview_component(path: &Path, component: Option<String>) -> Option<PreviewComponent> {
@@ -1759,15 +1759,28 @@ fn dispatch_workspace_edit(
         return false;
     };
 
+    let expected = state
+        .document_cache
+        .borrow()
+        .as_ref()
+        .and_then(|cache| text_edit::apply_workspace_edit(cache, &edit).ok());
+    let Some(expected) = expected else {
+        #[cfg(feature = "system-testing")]
+        test_sync::effect("rejected");
+        return false;
+    };
+    state.workspace_edit_installation = Some(edit_installation::PendingInstallation::new(
+        state.compilation_sequence,
+        expected.into_iter().map(|e| (e.url, e.contents)).collect(),
+    ));
     state.pending_workspace_edit = Some(undo_redo::PendingWorkspaceEdit { history });
     state.workspace_edit_sent = true;
-    state.workspace_edit_installed = false;
-    if let Err(error) = to_lsp.send(&PreviewToLspMessage::SendWorkspaceEdit {
-        label: Some(label.clone()),
-        edit,
-    }) {
+    if let Err(error) =
+        to_lsp.send(&PreviewToLspMessage::SendWorkspaceEdit { label: Some(label.clone()), edit })
+    {
         tracing::error!("Failed to send workspace edit '{}': {error}", label);
         state.pending_workspace_edit.take();
+        state.workspace_edit_installation = None;
         state.workspace_edit_sent = false;
         #[cfg(feature = "system-testing")]
         test_sync::effect("failed");
@@ -1825,8 +1838,12 @@ fn workspace_edit_result(outcome: WorkspaceEditOutcome) {
                 // The filesystem acknowledgement and preview installation are
                 // independent. Release queued history only after both have
                 // reached their terminal state.
-                if state.workspace_edit_installed {
-                    state.workspace_edit_installed = false;
+                if state
+                    .workspace_edit_installation
+                    .as_ref()
+                    .is_some_and(|edit| edit.is_installed())
+                {
+                    state.workspace_edit_installation = None;
                     state.workspace_edit_sent = false;
                     (false, true)
                 } else {
@@ -1835,14 +1852,14 @@ fn workspace_edit_result(outcome: WorkspaceEditOutcome) {
             }
             WorkspaceEditOutcome::Rejected => {
                 undo_redo::discard_pending(state, false);
+                state.workspace_edit_installation = None;
                 state.workspace_edit_sent = false;
-                state.workspace_edit_installed = false;
                 (true, true)
             }
             WorkspaceEditOutcome::Failed { written, .. } => {
                 undo_redo::discard_pending(state, written != 0);
+                state.workspace_edit_installation = None;
                 state.workspace_edit_sent = false;
-                state.workspace_edit_installed = false;
                 (true, true)
             }
         }
@@ -2092,8 +2109,8 @@ async fn reload_timer_function() {
     #[cfg(feature = "system-testing")]
     let mut completion_work = Vec::new();
     loop {
-        let Some((preview_component, config, behavior, generation)) =
-            PREVIEW_STATE.with_borrow_mut(|preview_state| {
+        let Some((preview_component, config, behavior, generation)) = PREVIEW_STATE
+            .with_borrow_mut(|preview_state| {
                 let behavior = preview_state.current_load_behavior.take()?;
                 let preview_component = preview_state.current_component()?;
                 let generation = preview_state.preview_generation;
@@ -2315,6 +2332,11 @@ async fn reload_preview_impl(
     config: PreviewConfig,
     generation: u64,
 ) -> Result<(), PlatformError> {
+    let compilation = PREVIEW_STATE.with_borrow_mut(|state| {
+        state.compilation_sequence += 1;
+        state.compilation_sequence
+    });
+    let compilation_inputs = Rc::new(RefCell::new(std::collections::HashMap::new()));
     start_parsing();
 
     if let Some(component_instance) = component_instance() {
@@ -2350,6 +2372,8 @@ async fn reload_preview_impl(
         version,
         (!missing_input).then_some(source.as_str()),
     );
+    compilation_inputs.as_ref().borrow_mut().insert(component.url.clone(), source.clone());
+    let import_inputs = compilation_inputs.clone();
     let (diagnostics, compiled, open_import_callback, source_file_versions) = parse_source(
         config,
         path,
@@ -2359,11 +2383,15 @@ async fn reload_preview_impl(
         component.component.clone(),
         move |path| {
             let path = path.to_owned();
+            let import_inputs = import_inputs.clone();
             Box::pin(async move {
                 let path = PathBuf::from(&path);
                 // Always return Some to stop the compiler from trying to load itself...
                 // All loading is done by the LSP for us!
                 let result = get_path_from_cache(&path);
+                if let (Ok(url), Ok((_, content))) = (Url::from_file_path(&path), &result) {
+                    import_inputs.as_ref().borrow_mut().insert(url, content.clone());
+                }
                 #[cfg(feature = "system-testing")]
                 if let Ok(url) = Url::from_file_path(&path) {
                     let (version, content) = match &result {
@@ -2378,6 +2406,10 @@ async fn reload_preview_impl(
     )
     .await;
 
+    let installation = edit_installation::CompilationSnapshot {
+        id: compilation,
+        inputs: compilation_inputs.as_ref().borrow().clone(),
+    };
     let success = compiled.is_some();
     let loaded_component_name = compiled.as_ref().map(|c| c.name().to_string());
 
@@ -2440,6 +2472,7 @@ async fn reload_preview_impl(
                     source_file_versions,
                     format,
                     generation,
+                    installation,
                     Some(attempt),
                 ) {
                     tracing::error!("Preview installation failed: {error}");
@@ -2456,6 +2489,7 @@ async fn reload_preview_impl(
         source_file_versions,
         format,
         generation,
+        installation,
     )?;
 
     if let Some(loaded_component_name) = loaded_component_name {
@@ -2931,6 +2965,7 @@ fn update_preview_area(
     source_file_versions: Rc<RefCell<i_slint_editor_preview::document_cache::SourceFileVersionMap>>,
     format: i_slint_editor_preview::ByteFormat,
     generation: u64,
+    installation: edit_installation::CompilationSnapshot,
     #[cfg(feature = "system-testing")] attempt: Option<u64>,
 ) -> Result<(), PlatformError> {
     if !preview_generation_is_current(generation) {
@@ -2945,7 +2980,7 @@ fn update_preview_area(
         if failed {
             undo_redo::discard_pending(preview_state, false);
             preview_state.workspace_edit_sent = false;
-            preview_state.workspace_edit_installed = false;
+            preview_state.workspace_edit_installation = None;
         }
 
         let editor_ui = preview_state.editor_ui.as_ref().unwrap();
@@ -3001,13 +3036,16 @@ fn update_preview_area(
                     shared_handle.replace(Some(instance));
                     previewed_component_changed();
                     let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
-                        if state.pending_workspace_edit.is_some() {
-                            state.workspace_edit_installed = true;
-                            false
-                        } else {
-                            state.workspace_edit_installed = false;
+                        let matches = state
+                            .workspace_edit_installation
+                            .as_mut()
+                            .is_some_and(|edit| edit.observe(&installation));
+                        if matches && state.pending_workspace_edit.is_none() {
+                            state.workspace_edit_installation = None;
                             state.workspace_edit_sent = false;
                             true
+                        } else {
+                            false
                         }
                     });
                     inspector::invalidate();
@@ -3067,13 +3105,16 @@ fn update_preview_area(
                     shared_handle.replace(Some(instance));
                     previewed_component_changed();
                     let release_pending = PREVIEW_STATE.with_borrow_mut(|state| {
-                        if state.pending_workspace_edit.is_some() {
-                            state.workspace_edit_installed = true;
-                            false
-                        } else {
-                            state.workspace_edit_installed = false;
+                        let matches = state
+                            .workspace_edit_installation
+                            .as_mut()
+                            .is_some_and(|edit| edit.observe(&installation));
+                        if matches && state.pending_workspace_edit.is_none() {
+                            state.workspace_edit_installation = None;
                             state.workspace_edit_sent = false;
                             true
+                        } else {
+                            false
                         }
                     });
                     inspector::invalidate();

--- a/tools/editor/preview/edit_installation.rs
+++ b/tools/editor/preview/edit_installation.rs
@@ -15,17 +15,12 @@ enum Installation {
     Abandoned,
 }
 
-enum Acknowledgment {
-    Pending(super::undo_redo::PendingEdit),
-    Applied,
-}
-
 pub(super) struct PendingWorkspaceEdit {
     pub id: u64,
     after: u64,
     expected: HashMap<lsp_types::Url, String>,
     installation: Installation,
-    acknowledgment: Acknowledgment,
+    unacknowledged_history: Option<super::undo_redo::PendingEdit>,
 }
 
 impl PendingWorkspaceEdit {
@@ -40,7 +35,7 @@ impl PendingWorkspaceEdit {
             after,
             expected,
             installation: Installation::Waiting,
-            acknowledgment: Acknowledgment::Pending(history),
+            unacknowledged_history: Some(history),
         }
     }
 
@@ -50,14 +45,11 @@ impl PendingWorkspaceEdit {
     }
 
     pub fn awaiting_acknowledgment(&self) -> bool {
-        matches!(self.acknowledgment, Acknowledgment::Pending(_))
+        self.unacknowledged_history.is_some()
     }
 
     pub fn acknowledge(&mut self) -> Option<super::undo_redo::PendingEdit> {
-        match std::mem::replace(&mut self.acknowledgment, Acknowledgment::Applied) {
-            Acknowledgment::Pending(history) => Some(history),
-            Acknowledgment::Applied => None,
-        }
+        self.unacknowledged_history.take()
     }
 
     pub fn observe(&mut self, compilation: &CompilationSnapshot) -> bool {

--- a/tools/editor/preview/edit_installation.rs
+++ b/tools/editor/preview/edit_installation.rs
@@ -1,0 +1,88 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::collections::HashMap;
+
+/// The inputs actually supplied to one compilation, retained until installation.
+pub(super) struct CompilationSnapshot {
+    pub id: u64,
+    pub inputs: HashMap<lsp_types::Url, String>,
+}
+
+pub(super) struct PendingInstallation {
+    after: u64,
+    expected: HashMap<lsp_types::Url, String>,
+    installed: Option<u64>,
+}
+
+impl PendingInstallation {
+    pub fn new(after: u64, expected: HashMap<lsp_types::Url, String>) -> Self {
+        Self { after, expected, installed: None }
+    }
+
+    pub fn observe(&mut self, compilation: &CompilationSnapshot) -> bool {
+        let matches = compilation.id > self.after
+            && !self.expected.is_empty()
+            && self
+                .expected
+                .iter()
+                .all(|(url, contents)| compilation.inputs.get(url) == Some(contents));
+        // A later unrelated installation must not leave an earlier match valid.
+        self.installed = matches.then_some(compilation.id);
+        matches
+    }
+
+    pub fn is_installed(&self) -> bool {
+        self.installed.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs(entries: &[(&str, &str)]) -> HashMap<lsp_types::Url, String> {
+        entries
+            .iter()
+            .map(|(path, content)| (format!("file:///{path}").parse().unwrap(), (*content).into()))
+            .collect()
+    }
+
+    #[test]
+    fn compilation_started_before_edit_cannot_complete_it_even_with_identical_content() {
+        let expected = inputs(&[("Main.slint", "new")]);
+        let mut edit = PendingInstallation::new(7, expected.clone());
+        assert!(!edit.observe(&CompilationSnapshot { id: 7, inputs: expected.clone() }));
+        assert!(!edit.is_installed());
+        assert!(edit.observe(&CompilationSnapshot { id: 8, inputs: expected }));
+        assert!(edit.is_installed());
+    }
+
+    #[test]
+    fn every_edited_dependency_must_match_actual_compiler_inputs() {
+        let mut edit =
+            PendingInstallation::new(1, inputs(&[("Main.slint", "root"), ("Child.slint", "new")]));
+        for entries in
+            [vec![("Main.slint", "root")], vec![("Main.slint", "root"), ("Child.slint", "old")]]
+        {
+            assert!(!edit.observe(&CompilationSnapshot { id: 2, inputs: inputs(&entries) }));
+        }
+        assert!(edit.observe(&CompilationSnapshot {
+            id: 3,
+            inputs: inputs(&[("Main.slint", "root"), ("Child.slint", "new")])
+        }));
+    }
+
+    #[test]
+    fn unrelated_installation_before_acknowledgment_invalidates_previous_match() {
+        let mut edit = PendingInstallation::new(1, inputs(&[("Main.slint", "new")]));
+        assert!(
+            edit.observe(&CompilationSnapshot { id: 2, inputs: inputs(&[("Main.slint", "new")]) })
+        );
+        assert!(
+            !edit
+                .observe(&CompilationSnapshot { id: 3, inputs: inputs(&[("Other.slint", "new")]) })
+        );
+        assert!(!edit.is_installed());
+    }
+}

--- a/tools/editor/preview/edit_installation.rs
+++ b/tools/editor/preview/edit_installation.rs
@@ -12,30 +12,57 @@ pub(super) struct CompilationSnapshot {
 pub(super) struct PendingInstallation {
     after: u64,
     expected: HashMap<lsp_types::Url, String>,
-    installed: Option<u64>,
+    installed: Option<CompilationSnapshot>,
+    acknowledged: bool,
     abandoned: bool,
 }
 
 impl PendingInstallation {
     pub fn new(after: u64, expected: HashMap<lsp_types::Url, String>) -> Self {
-        Self { after, expected, installed: None, abandoned: false }
+        Self { after, expected, installed: None, acknowledged: false, abandoned: false }
     }
 
     pub fn expects(&self, url: &lsp_types::Url, content: &str) -> bool {
         self.expected.get(url).is_some_and(|expected| expected == content)
     }
 
+    pub fn acknowledge(&mut self) {
+        self.acknowledged = true;
+    }
+
     pub fn observe(&mut self, compilation: &CompilationSnapshot) -> bool {
-        let matches = !self.abandoned
-            && compilation.id > self.after
-            && !self.expected.is_empty()
-            && self
+        self.installed = Some(CompilationSnapshot {
+            id: compilation.id,
+            inputs: self
                 .expected
-                .iter()
-                .all(|(url, contents)| compilation.inputs.get(url) == Some(contents));
-        // A later unrelated installation must not leave an earlier match valid.
-        self.installed = matches.then_some(compilation.id);
-        matches
+                .keys()
+                .filter_map(|url| {
+                    compilation.inputs.get(url).map(|content| (url.clone(), content.clone()))
+                })
+                .collect(),
+        });
+        self.is_installed()
+    }
+
+    pub fn is_superseded(&self) -> bool {
+        let Some(installed) = &self.installed else { return false };
+        // Coalescing can skip the edited revision entirely. Only retire that edit
+        // after its write succeeded and the mounted inputs match current disk.
+        // An older compilation or a stale cache alone is not evidence of replacement.
+        self.acknowledged
+            && !self.abandoned
+            && installed.id > self.after
+            && !self.is_installed()
+            && !self.expected.is_empty()
+            && self.expected.keys().all(|url| {
+                installed.inputs.get(url).is_some_and(|content| {
+                    url.to_file_path()
+                        .ok()
+                        .and_then(|path| std::fs::read_to_string(path).ok())
+                        .as_ref()
+                        == Some(content)
+                })
+            })
     }
 
     pub fn abandon(&mut self) {
@@ -48,7 +75,15 @@ impl PendingInstallation {
     }
 
     pub fn is_installed(&self) -> bool {
-        self.installed.is_some()
+        !self.abandoned
+            && !self.expected.is_empty()
+            && self.installed.as_ref().is_some_and(|installed| {
+                installed.id > self.after
+                    && self
+                        .expected
+                        .iter()
+                        .all(|(url, content)| installed.inputs.get(url) == Some(content))
+            })
     }
 }
 
@@ -61,6 +96,30 @@ mod tests {
             .iter()
             .map(|(path, content)| (format!("file:///{path}").parse().unwrap(), (*content).into()))
             .collect()
+    }
+
+    #[test]
+    fn supersession_requires_successful_write_and_current_installed_source() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("Main.slint");
+        let url = lsp_types::Url::from_file_path(&path).unwrap();
+        let mut edit = PendingInstallation::new(1, HashMap::from([(url.clone(), "edit".into())]));
+        let snapshot = |id| CompilationSnapshot {
+            id,
+            inputs: HashMap::from([(url.clone(), "external".into())]),
+        };
+        std::fs::write(&path, "external").unwrap();
+        edit.observe(&snapshot(2));
+        assert!(!edit.is_superseded());
+        edit.acknowledge();
+        assert!(edit.is_superseded());
+        edit.observe(&snapshot(1));
+        assert!(!edit.is_superseded());
+        edit.observe(&snapshot(2));
+        std::fs::write(&path, "edit").unwrap();
+        assert!(!edit.is_superseded());
+        std::fs::remove_file(&path).unwrap();
+        assert!(!edit.is_superseded());
     }
 
     #[test]

--- a/tools/editor/preview/edit_installation.rs
+++ b/tools/editor/preview/edit_installation.rs
@@ -21,6 +21,10 @@ impl PendingInstallation {
         Self { after, expected, installed: None, abandoned: false }
     }
 
+    pub fn expects(&self, url: &lsp_types::Url, content: &str) -> bool {
+        self.expected.get(url).is_some_and(|expected| expected == content)
+    }
+
     pub fn observe(&mut self, compilation: &CompilationSnapshot) -> bool {
         let matches = !self.abandoned
             && compilation.id > self.after

--- a/tools/editor/preview/edit_installation.rs
+++ b/tools/editor/preview/edit_installation.rs
@@ -9,48 +9,79 @@ pub(super) struct CompilationSnapshot {
     pub inputs: HashMap<lsp_types::Url, String>,
 }
 
-pub(super) struct PendingInstallation {
-    after: u64,
-    expected: HashMap<lsp_types::Url, String>,
-    installed: Option<CompilationSnapshot>,
-    acknowledged: bool,
-    abandoned: bool,
+enum Installation {
+    Waiting,
+    Installed(CompilationSnapshot),
+    Abandoned,
 }
 
-impl PendingInstallation {
-    pub fn new(after: u64, expected: HashMap<lsp_types::Url, String>) -> Self {
-        Self { after, expected, installed: None, acknowledged: false, abandoned: false }
+enum Acknowledgment {
+    Pending(super::undo_redo::PendingEdit),
+    Applied,
+}
+
+pub(super) struct PendingWorkspaceEdit {
+    pub id: u64,
+    after: u64,
+    expected: HashMap<lsp_types::Url, String>,
+    installation: Installation,
+    acknowledgment: Acknowledgment,
+}
+
+impl PendingWorkspaceEdit {
+    pub fn new(
+        id: u64,
+        after: u64,
+        expected: HashMap<lsp_types::Url, String>,
+        history: super::undo_redo::PendingEdit,
+    ) -> Self {
+        Self {
+            id,
+            after,
+            expected,
+            installation: Installation::Waiting,
+            acknowledgment: Acknowledgment::Pending(history),
+        }
     }
 
     pub fn expects(&self, url: &lsp_types::Url, content: &str) -> bool {
-        self.expected.get(url).is_some_and(|expected| expected == content)
+        self.awaiting_acknowledgment()
+            && self.expected.get(url).is_some_and(|expected| expected == content)
     }
 
-    pub fn acknowledge(&mut self) {
-        self.acknowledged = true;
+    pub fn awaiting_acknowledgment(&self) -> bool {
+        matches!(self.acknowledgment, Acknowledgment::Pending(_))
+    }
+
+    pub fn acknowledge(&mut self) -> Option<super::undo_redo::PendingEdit> {
+        match std::mem::replace(&mut self.acknowledgment, Acknowledgment::Applied) {
+            Acknowledgment::Pending(history) => Some(history),
+            Acknowledgment::Applied => None,
+        }
     }
 
     pub fn observe(&mut self, compilation: &CompilationSnapshot) -> bool {
-        self.installed = Some(CompilationSnapshot {
-            id: compilation.id,
-            inputs: self
-                .expected
-                .keys()
-                .filter_map(|url| {
-                    compilation.inputs.get(url).map(|content| (url.clone(), content.clone()))
-                })
-                .collect(),
-        });
+        if !matches!(self.installation, Installation::Abandoned) {
+            self.installation = Installation::Installed(CompilationSnapshot {
+                id: compilation.id,
+                inputs: self
+                    .expected
+                    .keys()
+                    .filter_map(|url| {
+                        compilation.inputs.get(url).map(|content| (url.clone(), content.clone()))
+                    })
+                    .collect(),
+            });
+        }
         self.is_installed()
     }
 
     pub fn is_superseded(&self) -> bool {
-        let Some(installed) = &self.installed else { return false };
+        let Installation::Installed(installed) = &self.installation else { return false };
         // Coalescing can skip the edited revision entirely. Only retire that edit
         // after its write succeeded and the mounted inputs match current disk.
         // An older compilation or a stale cache alone is not evidence of replacement.
-        self.acknowledged
-            && !self.abandoned
+        !self.awaiting_acknowledgment()
             && installed.id > self.after
             && !self.is_installed()
             && !self.expected.is_empty()
@@ -66,30 +97,34 @@ impl PendingInstallation {
     }
 
     pub fn abandon(&mut self) {
-        self.abandoned = true;
-        self.installed = None;
+        self.installation = Installation::Abandoned;
     }
 
     pub fn is_finished(&self) -> bool {
-        self.abandoned || self.is_installed()
+        !self.awaiting_acknowledgment()
+            && (matches!(self.installation, Installation::Abandoned) || self.is_installed())
     }
 
     pub fn is_installed(&self) -> bool {
-        !self.abandoned
-            && !self.expected.is_empty()
-            && self.installed.as_ref().is_some_and(|installed| {
-                installed.id > self.after
-                    && self
-                        .expected
-                        .iter()
-                        .all(|(url, content)| installed.inputs.get(url) == Some(content))
-            })
+        let Installation::Installed(installed) = &self.installation else { return false };
+        !self.expected.is_empty()
+            && installed.id > self.after
+            && self.expected.iter().all(|(url, content)| installed.inputs.get(url) == Some(content))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pending(after: u64, expected: HashMap<lsp_types::Url, String>) -> PendingWorkspaceEdit {
+        PendingWorkspaceEdit::new(
+            1,
+            after,
+            expected,
+            super::super::undo_redo::PendingEdit::New(None),
+        )
+    }
 
     fn inputs(entries: &[(&str, &str)]) -> HashMap<lsp_types::Url, String> {
         entries
@@ -103,7 +138,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("Main.slint");
         let url = lsp_types::Url::from_file_path(&path).unwrap();
-        let mut edit = PendingInstallation::new(1, HashMap::from([(url.clone(), "edit".into())]));
+        let mut edit = pending(1, HashMap::from([(url.clone(), "edit".into())]));
         let snapshot = |id| CompilationSnapshot {
             id,
             inputs: HashMap::from([(url.clone(), "external".into())]),
@@ -111,7 +146,7 @@ mod tests {
         std::fs::write(&path, "external").unwrap();
         edit.observe(&snapshot(2));
         assert!(!edit.is_superseded());
-        edit.acknowledge();
+        assert!(edit.acknowledge().is_some());
         assert!(edit.is_superseded());
         edit.observe(&snapshot(1));
         assert!(!edit.is_superseded());
@@ -124,9 +159,12 @@ mod tests {
 
     #[test]
     fn abandoned_installation_is_terminal_without_claiming_application() {
-        let mut edit = PendingInstallation::new(1, inputs(&[("Main.slint", "new")]));
+        let mut edit = pending(1, inputs(&[("Main.slint", "new")]));
         edit.abandon();
+        assert!(!edit.is_finished());
+        assert!(edit.acknowledge().is_some());
         assert!(edit.is_finished());
+        assert!(edit.acknowledge().is_none());
         assert!(!edit.is_installed());
         assert!(
             !edit.observe(&CompilationSnapshot { id: 2, inputs: inputs(&[("Main.slint", "new")]) })
@@ -136,7 +174,7 @@ mod tests {
     #[test]
     fn compilation_started_before_edit_cannot_complete_it_even_with_identical_content() {
         let expected = inputs(&[("Main.slint", "new")]);
-        let mut edit = PendingInstallation::new(7, expected.clone());
+        let mut edit = pending(7, expected.clone());
         assert!(!edit.observe(&CompilationSnapshot { id: 7, inputs: expected.clone() }));
         assert!(!edit.is_installed());
         assert!(edit.observe(&CompilationSnapshot { id: 8, inputs: expected }));
@@ -145,8 +183,7 @@ mod tests {
 
     #[test]
     fn every_edited_dependency_must_match_actual_compiler_inputs() {
-        let mut edit =
-            PendingInstallation::new(1, inputs(&[("Main.slint", "root"), ("Child.slint", "new")]));
+        let mut edit = pending(1, inputs(&[("Main.slint", "root"), ("Child.slint", "new")]));
         for entries in
             [vec![("Main.slint", "root")], vec![("Main.slint", "root"), ("Child.slint", "old")]]
         {
@@ -160,7 +197,7 @@ mod tests {
 
     #[test]
     fn unrelated_installation_before_acknowledgment_invalidates_previous_match() {
-        let mut edit = PendingInstallation::new(1, inputs(&[("Main.slint", "new")]));
+        let mut edit = pending(1, inputs(&[("Main.slint", "new")]));
         assert!(
             edit.observe(&CompilationSnapshot { id: 2, inputs: inputs(&[("Main.slint", "new")]) })
         );

--- a/tools/editor/preview/edit_installation.rs
+++ b/tools/editor/preview/edit_installation.rs
@@ -13,15 +13,17 @@ pub(super) struct PendingInstallation {
     after: u64,
     expected: HashMap<lsp_types::Url, String>,
     installed: Option<u64>,
+    abandoned: bool,
 }
 
 impl PendingInstallation {
     pub fn new(after: u64, expected: HashMap<lsp_types::Url, String>) -> Self {
-        Self { after, expected, installed: None }
+        Self { after, expected, installed: None, abandoned: false }
     }
 
     pub fn observe(&mut self, compilation: &CompilationSnapshot) -> bool {
-        let matches = compilation.id > self.after
+        let matches = !self.abandoned
+            && compilation.id > self.after
             && !self.expected.is_empty()
             && self
                 .expected
@@ -30,6 +32,15 @@ impl PendingInstallation {
         // A later unrelated installation must not leave an earlier match valid.
         self.installed = matches.then_some(compilation.id);
         matches
+    }
+
+    pub fn abandon(&mut self) {
+        self.abandoned = true;
+        self.installed = None;
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.abandoned || self.is_installed()
     }
 
     pub fn is_installed(&self) -> bool {
@@ -46,6 +57,17 @@ mod tests {
             .iter()
             .map(|(path, content)| (format!("file:///{path}").parse().unwrap(), (*content).into()))
             .collect()
+    }
+
+    #[test]
+    fn abandoned_installation_is_terminal_without_claiming_application() {
+        let mut edit = PendingInstallation::new(1, inputs(&[("Main.slint", "new")]));
+        edit.abandon();
+        assert!(edit.is_finished());
+        assert!(!edit.is_installed());
+        assert!(
+            !edit.observe(&CompilationSnapshot { id: 2, inputs: inputs(&[("Main.slint", "new")]) })
+        );
     }
 
     #[test]

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -12,6 +12,8 @@ const CORNERS: [&str; 4] = [
 
 pub(super) struct Edit {
     key: String,
+    #[cfg(feature = "system-testing")]
+    work: test_sync::Work,
     overrides: Vec<(SmolStr, Option<slint_interpreter::Value>)>,
 }
 
@@ -58,6 +60,12 @@ fn validate<'a>(
 pub(super) fn cancel() {
     PREVIEW_STATE.with_borrow_mut(|state| {
         if let Some(edit) = state.inspector_edit.take() {
+            #[cfg(feature = "system-testing")]
+            test_sync::Work::combine(vec![
+                edit.work.clone(),
+                test_sync::Work::capture("gesture cancellation"),
+            ])
+            .run(|| test_sync::effect("canceled"));
             let overrides = state.debug_hook_overrides.borrow();
             for (id, previous) in edit.overrides {
                 if let Some(property) = overrides.get(&id) {
@@ -65,6 +73,11 @@ pub(super) fn cancel() {
                 }
             }
         }
+        // A committed edit has already consumed its gesture record. If its
+        // filesystem write later fails, no record remains to restore these
+        // temporary values, so discard all inspector overrides at the same
+        // terminal boundary as cancellation.
+        (*state.debug_hook_overrides).borrow_mut().clear();
     });
     if let Some(instance) = component_instance() {
         instance.window().request_redraw();
@@ -85,9 +98,12 @@ pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool
     }
     PREVIEW_STATE.with_borrow_mut(|state| {
         let mut overrides = (*state.debug_hook_overrides).borrow_mut();
-        let edit = state
-            .inspector_edit
-            .get_or_insert_with(|| Edit { key: key.to_string(), overrides: Vec::new() });
+        let edit = state.inspector_edit.get_or_insert_with(|| Edit {
+            key: key.to_string(),
+            overrides: Vec::new(),
+            #[cfg(feature = "system-testing")]
+            work: test_sync::Work::capture("inspector gesture"),
+        });
         for id in ids {
             let property = overrides
                 .entry(id.clone())
@@ -105,7 +121,23 @@ pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool
 }
 
 pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool {
-    let Some((node, url, version, names)) = validate(&key, &name, value) else { return false };
+    #[cfg(feature = "system-testing")]
+    {
+        let gesture = PREVIEW_STATE
+            .with_borrow(|s| s.inspector_edit.as_ref().map(|e| e.work.clone()).unwrap_or_default());
+        test_sync::Work::combine(vec![gesture, test_sync::Work::capture("inspector commit")])
+            .run(|| commit_impl(key, name, value))
+    }
+    #[cfg(not(feature = "system-testing"))]
+    commit_impl(key, name, value)
+}
+
+fn commit_impl(key: SharedString, name: SharedString, value: f32) -> bool {
+    let Some((node, url, version, names)) = validate(&key, &name, value) else {
+        #[cfg(feature = "system-testing")]
+        test_sync::effect("rejected");
+        return false;
+    };
     let unit = if name == "transform-rotation" { "deg" } else { "px" };
     let changes = names
         .iter()

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -10,11 +10,13 @@ const CORNERS: [&str; 4] = [
     "border-bottom-right-radius",
 ];
 
+pub(super) type SavedOverrides = Vec<(SmolStr, Option<slint_interpreter::Value>)>;
+
 pub(super) struct Edit {
     key: String,
     #[cfg(feature = "system-testing")]
     work: test_sync::Work,
-    overrides: Vec<(SmolStr, Option<slint_interpreter::Value>)>,
+    overrides: SavedOverrides,
 }
 
 fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
@@ -73,15 +75,21 @@ pub(super) fn cancel() {
                 }
             }
         }
-        // A committed edit has already consumed its gesture record. If its
-        // filesystem write later fails, no record remains to restore these
-        // temporary values, so discard all inspector overrides at the same
-        // terminal boundary as cancellation.
-        (*state.debug_hook_overrides).borrow_mut().clear();
     });
     if let Some(instance) = component_instance() {
         instance.window().request_redraw();
     }
+}
+
+pub(super) fn restore_committed() {
+    PREVIEW_STATE.with_borrow_mut(|state| {
+        let overrides = state.debug_hook_overrides.borrow();
+        for (id, previous) in state.committed_inspector_overrides.drain(..) {
+            if let Some(property) = overrides.get(&id) {
+                property.as_ref().set(previous);
+            }
+        }
+    });
 }
 
 pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool {
@@ -172,7 +180,9 @@ fn commit_impl(key: SharedString, name: SharedString, value: f32) -> bool {
     });
     if accepted {
         PREVIEW_STATE.with_borrow_mut(|state| {
-            state.inspector_edit.take();
+            if let Some(edit) = state.inspector_edit.take() {
+                state.committed_inspector_overrides = edit.overrides;
+            }
         });
     } else {
         cancel();
@@ -207,4 +217,36 @@ pub(super) fn invalidate() {
             api.set_inspector_generation(api.get_inspector_generation().wrapping_add(1));
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn committed_cleanup_preserves_unrelated_overrides() {
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            let mut overrides = (*state.debug_hook_overrides).borrow_mut();
+            for (id, value) in [("owned", 45.), ("unrelated", 12.)] {
+                overrides.insert(
+                    id.into(),
+                    Box::pin(i_slint_core::Property::new(Some(slint_interpreter::Value::Number(
+                        value,
+                    )))),
+                );
+            }
+            state.committed_inspector_overrides = vec![("owned".into(), None)];
+        });
+        restore_committed();
+        PREVIEW_STATE.with_borrow(|state| {
+            let overrides = state.debug_hook_overrides.borrow();
+            assert_eq!(overrides["owned"].as_ref().get(), None);
+            assert_eq!(
+                overrides["unrelated"].as_ref().get(),
+                Some(slint_interpreter::Value::Number(12.))
+            );
+            assert!(state.committed_inspector_overrides.is_empty());
+        });
+        PREVIEW_STATE.with_borrow_mut(|state| *state = super::super::PreviewState::default());
+    }
 }

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -67,7 +67,7 @@ pub(super) fn cancel() {
                 edit.work.clone(),
                 test_sync::Work::capture("gesture cancellation"),
             ])
-            .run(|| test_sync::effect("canceled"));
+            .run(|| test_sync::effect(test_sync::Outcome::Canceled));
             let overrides = state.debug_hook_overrides.borrow();
             for (id, previous) in edit.overrides {
                 if let Some(property) = overrides.get(&id) {
@@ -143,7 +143,7 @@ pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool 
 fn commit_impl(key: SharedString, name: SharedString, value: f32) -> bool {
     let Some((node, url, version, names)) = validate(&key, &name, value) else {
         #[cfg(feature = "system-testing")]
-        test_sync::effect("rejected");
+        test_sync::effect(test_sync::Outcome::Rejected);
         return false;
     };
     let unit = if name == "transform-rotation" { "deg" } else { "px" };

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -1,526 +1,823 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Opt-in synchronization for editor system tests.
-//!
-//! This observer is process shared because source writes happen on the LSP
-//! thread while requests are served on the preview UI thread. Events contain
-//! compact identities; source text is never retained in the event ring.
+//! Private lifecycle observation for system tests.
+//! Causal leases cross the UI/LSP queues and outlive deferred compilation and publication.
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
+use std::future::Future;
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 
-const PROTOCOL_VERSION: u32 = 2;
+use lsp_types::Url;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub(crate) const PROTOCOL_VERSION: u32 = 3;
 const MAX_EVENTS: usize = 512;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ContentIdentity {
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct Content {
     hash: u64,
-    len: u64,
+    len: usize,
 }
-
-fn content_identity(content: Option<&str>) -> Option<ContentIdentity> {
-    content.map(|content| {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        content.hash(&mut hasher);
-        ContentIdentity { hash: hasher.finish(), len: content.len() as u64 }
+fn identity(content: Option<&str>) -> Option<Content> {
+    content.map(|text| {
+        let mut hash = std::collections::hash_map::DefaultHasher::new();
+        text.hash(&mut hash);
+        Content { hash: hash.finish(), len: text.len() }
     })
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
-struct Event {
-    cursor: u64,
-    kind: &'static str,
-    url: String,
-    content_hash: Option<u64>,
-    content_len: Option<u64>,
-    outcome: Option<&'static str>,
-    operation: Option<u64>,
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct Input {
+    observation: u64,
+    version: Option<i32>,
+    content: Option<Content>,
+}
+#[derive(Clone, Debug, Serialize)]
+struct Attempt {
+    id: u64,
+    kind: String,
+    root: Url,
+    component: Option<String>,
+    epoch: u64,
+    started_cursor: u64,
+    inputs: BTreeMap<Url, Input>,
+    outcome: Option<String>,
+    diagnostics: Vec<String>,
+    processed_cursor: u64,
+}
+#[derive(Default, Serialize)]
+struct Operation {
+    sealed: bool,
+    pending: BTreeMap<u64, String>,
+    accepted_edits: u64,
+    writes: u64,
+    effects: Vec<String>,
+}
+impl Operation {
+    fn outcome(&self) -> &str {
+        if self.effects.iter().any(|s| s == "failed") {
+            "failed"
+        } else if self.accepted_edits > 0 || self.effects.iter().any(|s| s == "completed") {
+            "completed"
+        } else if self.effects.iter().any(|s| s == "rejected") {
+            "rejected"
+        } else if self.effects.iter().any(|s| s == "canceled") {
+            "canceled"
+        } else {
+            "noop"
+        }
+    }
+    fn settled(&self) -> bool {
+        self.sealed && self.pending.is_empty()
+    }
+}
+#[derive(Serialize)]
+struct Gate {
+    kind: String,
+    url: Url,
+    after: u64,
+    reached: Option<u64>,
     attempt: Option<u64>,
-    inputs: Vec<(String, Option<i32>)>,
+    released: bool,
 }
-
-#[derive(Clone, Debug)]
-struct Installed {
-    url: String,
-    content: Option<ContentIdentity>,
-    cursor: u64,
-    attempt: u64,
-}
-
 #[derive(Default)]
 struct Observer {
     session: String,
-    next_cursor: u64,
+    ui_thread: Option<std::thread::ThreadId>,
+    cursor: u64,
     discarded_through: u64,
-    next_attempt: u64,
-    next_operation: u64,
-    events: VecDeque<Event>,
-    installed: Option<Installed>,
+    serial: u64,
+    epoch: u64,
+    events: VecDeque<Value>,
+    inputs: BTreeMap<Url, Input>,
+    attempts: BTreeMap<u64, Attempt>,
+    installed: Option<(u64, u64)>,
+    operations: BTreeMap<u64, Operation>,
+    capturing: Option<u64>,
+    gates: BTreeMap<u64, Gate>,
+    replies: BTreeMap<u64, (Value, Value)>,
     writes: u64,
     accepted_edits: u64,
-    pending_operations: u64,
-    active_operation: Option<u64>,
-    gate_source: bool,
-    gate_publication: bool,
-    held_sources: Vec<(lsp_types::Url, String)>,
-    held_publications: Vec<(lsp_types::Url, String)>,
+}
+impl Observer {
+    fn id(&mut self) -> u64 {
+        self.serial += 1;
+        self.serial
+    }
+    fn event(&mut self, mut value: Value) -> u64 {
+        self.cursor += 1;
+        value["cursor"] = self.cursor.into();
+        self.events.push_back(value);
+        if self.events.len() > MAX_EVENTS {
+            self.discarded_through = self.events.pop_front().unwrap()["cursor"].as_u64().unwrap();
+        }
+        self.cursor
+    }
+}
+static STATE: OnceLock<Arc<Mutex<Observer>>> = OnceLock::new();
+static GATE_CHANGED: tokio::sync::Notify = tokio::sync::Notify::const_new();
+fn with_state<R>(f: impl FnOnce(&mut Observer) -> R) -> Option<R> {
+    STATE.get().map(|s| f(&mut s.lock().unwrap()))
+}
+thread_local! {
+    static CACHE_INPUTS: RefCell<BTreeMap<Url, Input>> = const { RefCell::new(BTreeMap::new()) };
+    static CONTEXT: RefCell<Option<Vec<u64>>> = const { RefCell::new(None) };
+    static PUBLICATIONS: RefCell<Vec<(u64, Work, Box<dyn FnOnce()>)>> = const { RefCell::new(Vec::new()) };
 }
 
-static OBSERVER: OnceLock<Arc<Mutex<Observer>>> = OnceLock::new();
-
-fn observer() -> Option<&'static Arc<Mutex<Observer>>> {
-    OBSERVER.get()
+#[derive(Default, Clone)]
+pub(crate) struct Work(Vec<Arc<Lease>>);
+struct Lease {
+    observer: Weak<Mutex<Observer>>,
+    operation: u64,
+    id: u64,
 }
-
-fn enabled_observer() -> Option<&'static Arc<Mutex<Observer>>> {
-    observer().filter(|_| cfg!(test) || std::env::var_os("SLINT_EDITOR_TEST_SYNC").is_some())
-}
-
-fn session_id() -> String {
-    format!(
-        "{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    )
-}
-
-fn push(
-    observer: &mut Observer,
-    kind: &'static str,
-    url: &lsp_types::Url,
-    content: Option<&str>,
-    outcome: Option<&'static str>,
-    operation: Option<u64>,
-    attempt: Option<u64>,
-) -> u64 {
-    observer.next_cursor += 1;
-    let cursor = observer.next_cursor;
-    observer.events.push_back(Event {
-        cursor,
-        kind,
-        url: url.to_string(),
-        content_hash: content_identity(content).map(|value| value.hash),
-        content_len: content_identity(content).map(|value| value.len),
-        outcome,
-        operation,
-        attempt,
-        inputs: Vec::new(),
-    });
-    while observer.events.len() > MAX_EVENTS {
-        if let Some(event) = observer.events.pop_front() {
-            observer.discarded_through = event.cursor;
+impl Drop for Lease {
+    fn drop(&mut self) {
+        if let Some(observer) = self.observer.upgrade()
+            && let Some(op) = observer.lock().unwrap().operations.get_mut(&self.operation)
+        {
+            op.pending.remove(&self.id);
         }
     }
-    cursor
 }
-
-fn with_observer(mut callback: impl FnMut(&mut Observer)) {
-    let Some(observer) = enabled_observer() else { return };
-    callback(&mut observer.lock().unwrap());
-}
-
-pub(crate) fn record_observed(url: &lsp_types::Url, content: Option<&str>) {
-    with_observer(|observer| {
-        if observer.session.is_empty() {
-            observer.session = session_id();
-        }
-        push(observer, "observed", url, content, None, None, None);
-    });
-}
-
-pub(crate) fn record_processed_with_inputs(
-    url: &lsp_types::Url,
-    content: Option<&str>,
-    outcome: &'static str,
-    inputs: &std::collections::HashMap<std::path::PathBuf, Option<i32>>,
-) -> u64 {
-    let mut result = 0;
-    with_observer(|observer| {
-        let attempt = {
-            observer.next_attempt += 1;
-            observer.next_attempt
-        };
-        result = push(observer, "processed", url, content, Some(outcome), None, Some(attempt));
-        if let Some(event) = observer.events.back_mut() {
-            event.inputs = inputs
-                .iter()
-                .map(|(path, version)| (path.display().to_string(), *version))
-                .collect();
-        }
-    });
-    result
-}
-
-pub(crate) fn record_applied_with_attempt(
-    url: &lsp_types::Url,
-    content: &str,
-    attempt: Option<u64>,
-) {
-    with_observer(|observer| {
-        if observer.gate_publication {
-            observer.held_publications.push((url.clone(), content.to_owned()));
-            push(observer, "gate", url, Some(content), Some("publication_reached"), None, None);
-            return;
-        }
-        record_applied_now(observer, url, content, attempt);
-    });
-}
-
-fn record_applied_now(
-    observer: &mut Observer,
-    url: &lsp_types::Url,
-    content: &str,
-    attempt: Option<u64>,
-) {
-    let attempt = attempt.unwrap_or_else(|| {
-        observer.next_attempt += 1;
-        observer.next_attempt
-    });
-    let cursor =
-        push(observer, "applied", url, Some(content), Some("compiled"), None, Some(attempt));
-    observer.installed = Some(Installed {
-        url: url.to_string(),
-        content: content_identity(Some(content)),
-        cursor,
-        attempt,
-    });
-}
-
-pub(crate) fn record_write() {
-    with_observer(|observer| {
-        observer.writes += 1;
-        push(
-            observer,
-            "write",
-            &lsp_types::Url::parse("about:workspace").unwrap(),
-            None,
-            Some("written"),
-            observer.active_operation,
-            None,
-        );
-    });
-}
-
-pub(crate) fn record_accepted_edit() -> u64 {
-    let mut operation = 0;
-    with_observer(|observer| {
-        operation = observer.active_operation.unwrap_or_else(|| {
-            observer.next_operation = observer.next_operation.saturating_add(1);
-            observer.pending_operations += 1;
-            observer.next_operation
-        });
-        observer.active_operation = Some(operation);
-        observer.accepted_edits += 1;
-        push(
-            observer,
-            "edit",
-            &lsp_types::Url::parse("about:workspace").unwrap(),
-            None,
-            Some("accepted"),
-            Some(operation),
-            None,
-        );
-    });
-    operation
-}
-
-pub(crate) fn record_edit_completed(operation: u64, outcome: &'static str) {
-    with_observer(|observer| {
-        observer.pending_operations = observer.pending_operations.saturating_sub(1);
-        if observer.active_operation == Some(operation) {
-            observer.active_operation = None;
-        }
-        push(
-            observer,
-            "action",
-            &lsp_types::Url::parse("about:action").unwrap(),
-            None,
-            Some(outcome),
-            Some(operation),
-            None,
-        );
-    });
-}
-
-pub(crate) fn should_hold_source(url: &lsp_types::Url, content: &str) -> bool {
-    let Some(observer) = enabled_observer() else { return false };
-    let mut observer = observer.lock().unwrap();
-    if !observer.gate_source {
-        return false;
+struct Scope(Option<Vec<u64>>);
+impl Drop for Scope {
+    fn drop(&mut self) {
+        CONTEXT.with_borrow_mut(|c| *c = self.0.take());
     }
-    observer.held_sources.push((url.clone(), content.to_owned()));
-    push(&mut observer, "gate", url, Some(content), Some("source_reached"), None, None);
-    true
 }
-
-fn pump() {
-    let Some(observer) = enabled_observer() else { return };
-    let (sources, publications) = {
-        let mut observer = observer.lock().unwrap();
-        if observer.gate_source || observer.gate_publication {
-            return;
-        }
-        (
-            std::mem::take(&mut observer.held_sources),
-            std::mem::take(&mut observer.held_publications),
-        )
-    };
-    for (url, content) in sources {
-        super::set_contents(&i_slint_live_preview::protocol::VersionedUrl::new(url, None), content);
-    }
-    if !publications.is_empty() {
-        with_observer(|observer| {
-            for (url, content) in &publications {
-                record_applied_now(observer, url, content, None);
+fn operations() -> Vec<u64> {
+    CONTEXT.with_borrow(|c| c.clone()).unwrap_or_else(|| {
+        with_state(|s| {
+            if s.ui_thread == Some(std::thread::current().id()) {
+                s.capturing.into_iter().collect()
+            } else {
+                Vec::new()
             }
+        })
+        .unwrap_or_default()
+    })
+}
+impl Work {
+    pub(crate) fn capture(stage: &str) -> Self {
+        STATE.get().map(|state| Self::capture_in(state, operations(), stage)).unwrap_or_default()
+    }
+    fn capture_in(observer: &Arc<Mutex<Observer>>, ids: Vec<u64>, stage: &str) -> Self {
+        let mut s = observer.lock().unwrap();
+        Self(
+            ids.into_iter()
+                .map(|operation| {
+                    let id = s.id();
+                    s.operations.get_mut(&operation).unwrap().pending.insert(id, stage.into());
+                    Arc::new(Lease { observer: Arc::downgrade(observer), operation, id })
+                })
+                .collect(),
+        )
+    }
+    pub(crate) fn combine(work: Vec<Self>) -> Self {
+        Self(work.into_iter().flat_map(|w| w.0).collect())
+    }
+    fn enter(&self) -> Scope {
+        let mut ids: Vec<_> = self.0.iter().map(|l| l.operation).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        Scope(CONTEXT.with_borrow_mut(|c| c.replace(ids)))
+    }
+    pub(crate) fn run<R>(&self, f: impl FnOnce() -> R) -> R {
+        let _scope = self.enter();
+        f()
+    }
+    pub(crate) async fn during<F: Future>(&self, future: F) -> F::Output {
+        let mut future = std::pin::pin!(future);
+        std::future::poll_fn(|cx| {
+            let _scope = self.enter();
+            future.as_mut().poll(cx)
+        })
+        .await
+    }
+}
+
+pub(crate) fn effect(outcome: &str) {
+    let ids = operations();
+    with_state(|s| {
+        for id in ids {
+            s.operations.get_mut(&id).unwrap().effects.push(outcome.into());
+            s.event(json!({"kind":"effect", "operation":id, "outcome":outcome}));
+        }
+    });
+}
+pub(crate) fn accepted_edit() {
+    let ids = operations();
+    with_state(|s| {
+        s.accepted_edits += 1;
+        for id in ids {
+            s.operations.get_mut(&id).unwrap().accepted_edits += 1;
+        }
+        s.event(json!({"kind":"accepted_edit"}));
+    });
+}
+pub(crate) fn written(url: &Url) {
+    let ids = operations();
+    with_state(|s| {
+        s.writes += 1;
+        for id in &ids {
+            s.operations.get_mut(id).unwrap().writes += 1;
+        }
+        s.event(json!({"kind":"write", "url":url, "operations":ids}));
+    });
+}
+
+pub(crate) fn request_reload() {
+    with_state(|s| s.epoch += 1);
+}
+pub(crate) fn begin_attempt(root: &Url, component: Option<String>) -> u64 {
+    with_state(|s| {
+        let id = s.id();
+        let started_cursor = s.event(json!({"kind":"attempt_started", "attempt":id, "url":root}));
+        s.attempts.insert(
+            id,
+            Attempt {
+                id,
+                kind: "compilation".into(),
+                root: root.clone(),
+                component,
+                epoch: s.epoch,
+                started_cursor,
+                inputs: BTreeMap::new(),
+                outcome: None,
+                diagnostics: Vec::new(),
+                processed_cursor: 0,
+            },
+        );
+        id
+    })
+    .unwrap_or(0)
+}
+pub(crate) fn observed_read(url: &Url, content: Option<&str>) {
+    with_state(|s| {
+        let content = identity(content);
+        let observation = s.event(json!({"kind":"observed", "url":url, "content":content}));
+        let input = Input { observation, version: None, content };
+        s.inputs.insert(url.clone(), input.clone());
+        if input.content.is_none() {
+            let id = s.id();
+            let processed_cursor =
+                s.event(json!({"kind":"processed", "attempt":id, "outcome":"load_error"}));
+            s.attempts.insert(
+                id,
+                Attempt {
+                    id,
+                    kind: "load".into(),
+                    root: url.clone(),
+                    component: None,
+                    epoch: s.epoch,
+                    started_cursor: observation,
+                    inputs: BTreeMap::from([(url.clone(), input)]),
+                    outcome: Some("load_error".into()),
+                    diagnostics: vec![format!("Unable to load {url}")],
+                    processed_cursor,
+                },
+            );
+        }
+    });
+}
+
+pub(crate) fn source_delivery(
+    message: &i_slint_live_preview::protocol::LspToPreviewMessage,
+) -> Option<(Url, Input)> {
+    use i_slint_live_preview::protocol::LspToPreviewMessage as M;
+    let (url, version, content) = match message {
+        M::SetContents { url, contents } => {
+            (url.url(), *url.version(), identity(std::str::from_utf8(contents).ok()))
+        }
+        M::ForgetFile { url } => (url, None, None),
+        _ => return None,
+    };
+    with_state(|s| {
+        s.inputs
+            .get(url)
+            .filter(|i| i.content == content)
+            .map(|i| (url.clone(), Input { version, ..i.clone() }))
+    })
+    .flatten()
+}
+
+pub(crate) fn install_source(input: Option<(Url, Input)>) {
+    if let Some((url, input)) = input {
+        CACHE_INPUTS.with_borrow_mut(|c| {
+            c.insert(url, input);
         });
     }
 }
 
-fn matching(
-    event: &Event,
-    url: &lsp_types::Url,
-    expected: Option<&str>,
-    outcome: Option<&str>,
-) -> bool {
-    event.url == url.as_str()
-        && event.content_hash == content_identity(expected).map(|value| value.hash)
-        && event.content_len == content_identity(expected).map(|value| value.len)
-        && outcome.is_none_or(|outcome| event.outcome == Some(outcome))
+pub(crate) fn read_input(attempt: u64, url: &Url, version: Option<i32>, content: Option<&str>) {
+    let content = identity(content);
+    let input = CACHE_INPUTS.with_borrow(|c| c.get(url).filter(|i| i.content == content).cloned());
+    with_state(|s| {
+        if let Some(a) = s.attempts.get_mut(&attempt) {
+            a.inputs
+                .insert(url.clone(), input.unwrap_or(Input { observation: 0, version, content }));
+        }
+    });
 }
 
-#[derive(serde::Deserialize)]
+pub(crate) fn processed(attempt: u64, outcome: &str, diagnostics: Vec<String>) {
+    with_state(|s| {
+        let cursor = s.event(json!({"kind":"processed", "attempt":attempt, "outcome":outcome}));
+        if let Some(a) = s.attempts.get_mut(&attempt) {
+            a.outcome = Some(outcome.into());
+            a.processed_cursor = cursor;
+            a.diagnostics = diagnostics;
+        }
+    });
+}
+pub(crate) fn current_attempt(attempt: u64) -> bool {
+    with_state(|s| s.attempts.get(&attempt).is_some_and(|a| a.epoch == s.epoch)).unwrap_or(true)
+}
+pub(crate) fn applied(attempt: u64) {
+    with_state(|s| {
+        let cursor = s.event(json!({"kind":"applied", "attempt":attempt}));
+        s.installed = Some((attempt, cursor));
+    });
+}
+
+fn claim_gate(kind: &str, url: &Url, attempt: Option<u64>) -> Option<u64> {
+    with_state(|s| {
+        let id = s.gates.iter().find_map(|(id, g)| {
+            (!g.released
+                && g.kind == kind
+                && &g.url == url
+                && (kind == "source"
+                    || (g.reached.is_none()
+                        && attempt
+                            .and_then(|id| s.attempts.get(&id))
+                            .is_some_and(|a| a.started_cursor > g.after))))
+            .then_some(*id)
+        })?;
+        if s.gates[&id].reached.is_none() {
+            let cursor =
+                s.event(json!({"kind":"gate_reached", "gate":id, "attempt":attempt, "url":url}));
+            let gate = s.gates.get_mut(&id).unwrap();
+            gate.reached = Some(cursor);
+            gate.attempt = attempt;
+        }
+        Some(id)
+    })
+    .flatten()
+}
+pub(crate) fn hold_source(url: &Url) -> Option<u64> {
+    claim_gate("source", url, None)
+}
+pub(crate) fn gate_released(id: u64) -> bool {
+    with_state(|s| s.gates.get(&id).is_none_or(|g| g.released)).unwrap_or(true)
+}
+pub(crate) async fn gate_changed() {
+    GATE_CHANGED.notified().await;
+}
+pub(crate) fn publish(url: &Url, attempt: u64, callback: impl FnOnce() + 'static) {
+    if let Some(gate) = claim_gate("publication", url, Some(attempt)) {
+        PUBLICATIONS.with_borrow_mut(|p| {
+            p.push((gate, Work::capture("publication gate"), Box::new(callback)))
+        });
+    } else {
+        callback();
+    }
+}
+fn pump_publications() {
+    let ready = PUBLICATIONS.with_borrow_mut(|p| {
+        let mut ready = Vec::new();
+        let mut held = Vec::new();
+        for item in p.drain(..) {
+            if gate_released(item.0) {
+                ready.push(item);
+            } else {
+                held.push(item);
+            }
+        }
+        *p = held;
+        ready
+    });
+    for (_, work, callback) in ready {
+        work.run(callback);
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Request {
     id: u64,
     protocol: u32,
     session: Option<String>,
-    mode: Mode,
+    mode: String,
+    #[serde(default)]
     after: u64,
-    operation: Option<u64>,
+    #[serde(default)]
+    sources: BTreeMap<Url, Option<String>>,
     outcome: Option<String>,
-    sources: BTreeMap<lsp_types::Url, Option<String>>,
-    gate: Option<String>,
-    release: bool,
-    gate_control: bool,
-    begin_action: bool,
+    operation: Option<u64>,
+    gate: Option<u64>,
+    kind: Option<String>,
+    url: Option<Url>,
 }
-
-#[derive(Clone, Copy, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum Mode {
-    Handshake,
-    Checkpoint,
-    Processed,
-    Applied,
-    Settled,
-    Gate,
-    Finish,
-}
-
-fn response(request: &Request) -> serde_json::Value {
-    let Some(observer) = observer() else {
-        return serde_json::json!({ "id": request.id, "error": "observer disabled" });
-    };
-    let mut observer = observer.lock().unwrap();
-    if request.protocol != PROTOCOL_VERSION && !matches!(request.mode, Mode::Handshake) {
-        return serde_json::json!({ "id": request.id, "error": "protocol mismatch" });
+fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
+    if r.protocol != PROTOCOL_VERSION {
+        return Err("protocol mismatch".into());
     }
-    if !matches!(request.mode, Mode::Handshake)
-        && request.session.as_deref() != Some(observer.session.as_str())
+    if r.mode != "handshake" && r.session.as_deref() != Some(&s.session) {
+        return Err("stale session".into());
+    }
+    if r.after > s.cursor {
+        return Err("future cursor".into());
+    }
+    if matches!(r.mode.as_str(), "observed" | "processed" | "events")
+        && r.after < s.discarded_through
     {
-        return serde_json::json!({ "id": request.id, "error": "stale session" });
+        return Err("event history overflow".into());
     }
-    if request.after > observer.next_cursor {
-        return serde_json::json!({ "id": request.id, "error": "future cursor" });
-    }
-    if request.after < observer.discarded_through {
-        return serde_json::json!({ "id": request.id, "error": "event history overflow" });
-    }
-    if observer.session.is_empty() {
-        observer.session = session_id();
-    }
-    if let Some(gate) = &request.gate {
-        match gate.as_str() {
-            "source" => observer.gate_source = !request.release,
-            "publication" => observer.gate_publication = !request.release,
-            _ => return serde_json::json!({ "id": request.id, "error": "unknown gate" }),
+    let mut ready = true;
+    let mut result = json!({});
+    match r.mode.as_str() {
+        "handshake" => {
+            result["build"] = json!({"revision": env!("SLINT_EDITOR_BUILD_REVISION"), "features": env!("SLINT_EDITOR_BUILD_FEATURES")});
         }
-    }
-    let cursor = observer.next_cursor;
-    if matches!(request.mode, Mode::Handshake) {
-        return serde_json::json!({ "id": request.id, "protocol": PROTOCOL_VERSION, "session": observer.session, "cursor": cursor, "writes": observer.writes, "ready": true });
-    }
-    if matches!(request.mode, Mode::Checkpoint) && request.begin_action {
-        observer.next_operation = observer.next_operation.saturating_add(1);
-        observer.pending_operations += 1;
-        observer.active_operation = Some(observer.next_operation);
-    }
-    if matches!(request.mode, Mode::Finish) {
-        let Some(operation) = request.operation else {
-            return serde_json::json!({ "id": request.id, "error": "missing operation" });
-        };
-        observer.pending_operations = observer.pending_operations.saturating_sub(1);
-        let outcome = match request.outcome.as_deref() {
-            Some("canceled") => Some("canceled"),
-            Some("rejected") => Some("rejected"),
-            Some("noop") => Some("noop"),
-            Some("completed") => Some("completed"),
-            _ => None,
-        };
-        push(
-            &mut observer,
-            "action",
-            &lsp_types::Url::parse("about:action").unwrap(),
-            None,
-            outcome,
-            Some(operation),
-            None,
-        );
-        return serde_json::json!({ "id": request.id, "protocol": PROTOCOL_VERSION, "session": observer.session, "cursor": observer.next_cursor, "writes": observer.writes, "accepted_edits": observer.accepted_edits, "ready": true, "operation": operation });
-    }
-    let source_matches = |kind: &str| {
-        request.sources.iter().all(|(url, expected)| {
-            observer.events.iter().any(|event| {
-                event.cursor > request.after
-                    && event.kind == kind
-                    && matching(event, url, expected.as_deref(), request.outcome.as_deref())
-            })
-        })
-    };
-    let current_matches = request.sources.iter().all(|(url, expected)| {
-        observer.installed.as_ref().is_some_and(|installed| {
-            installed.url == url.as_str()
-                && installed.content == content_identity(expected.as_deref())
-        })
-    });
-    let ready = match request.mode {
-        Mode::Checkpoint => true,
-        Mode::Processed => source_matches("processed"),
-        Mode::Applied => current_matches && (request.after == 0 || source_matches("applied")),
-        Mode::Settled => {
-            current_matches
-                && request.operation.is_some_and(|operation| {
-                    observer.pending_operations == 0
-                        && observer.events.iter().any(|event| {
-                            event.operation == Some(operation)
-                                && event.outcome == request.outcome.as_deref()
+        "checkpoint" => {}
+        "begin" => {
+            if s.capturing.is_some() {
+                return Err("an input action is already open".into());
+            }
+            let id = s.id();
+            s.operations.insert(id, Operation::default());
+            s.capturing = Some(id);
+            result["operation"] = id.into();
+        }
+        "seal" => {
+            let id = r.operation.ok_or("missing operation")?;
+            let op = s.operations.get_mut(&id).ok_or("unknown operation")?;
+            op.sealed = true;
+            if s.capturing == Some(id) {
+                s.capturing = None;
+            }
+        }
+        "settled" | "operation" => {
+            let id = r.operation.ok_or("missing operation")?;
+            let op = s.operations.get(&id).ok_or("unknown operation")?;
+            ready = r.mode == "operation" || op.settled();
+            result["settled"] = op.settled().into();
+            result["operation"] = id.into();
+            result["operation_state"] = json!(op);
+            result["outcome"] = op.outcome().into();
+            if op.settled() && r.outcome.as_deref().is_some_and(|o| o != op.outcome()) {
+                return Err(format!(
+                    "operation {id}: expected {:?}, got {}",
+                    r.outcome,
+                    op.outcome()
+                ));
+            }
+        }
+        "observed" => {
+            let found = s.events.iter().rev().find(|e| {
+                e["kind"] == "observed"
+                    && e["cursor"].as_u64().is_some_and(|c| c > r.after)
+                    && r.sources.iter().all(|(url, c)| {
+                        e["url"] == url.as_str() && e["content"] == json!(identity(c.as_deref()))
+                    })
+            });
+            ready = found.is_some();
+            result["observation"] = json!(found);
+        }
+        "processed" => {
+            let found = s.attempts.values().rev().find(|a| {
+                a.processed_cursor > r.after
+                    && a.outcome.is_some()
+                    && r.sources.iter().all(|(url, c)| {
+                        a.inputs.get(url).is_some_and(|i| {
+                            i.content == identity(c.as_deref())
+                                && (r.after == 0 || i.observation > r.after)
                         })
+                    })
+                    && r.outcome.as_deref().is_none_or(|o| a.outcome.as_deref() == Some(o))
+            });
+            ready = found.is_some();
+            result["attempt"] = json!(found);
+        }
+        "applied" => {
+            let found = s.installed.and_then(|(id, cursor)| {
+                (cursor > r.after || r.after == 0).then(|| s.attempts.get(&id)).flatten()
+            });
+            ready = found.is_some_and(|a| {
+                r.sources.iter().all(|(url, c)| {
+                    a.inputs.get(url).is_some_and(|i| {
+                        i.content == identity(c.as_deref())
+                            && (r.after == 0 || i.observation > r.after)
+                    })
                 })
+            });
+            ready &= super::PREVIEW_STATE.with_borrow(|p| {
+                !p.workspace_edit_sent
+                    && p.pending_workspace_edit.is_none()
+                    && p.pending_history.is_empty()
+                    && matches!(p.loading_state, super::PreviewFutureState::Pending)
+            });
+            result["attempt"] = json!(found);
         }
-        Mode::Gate if request.gate_control => true,
-        Mode::Gate => request.gate.as_deref().is_some_and(|gate| {
-            observer.events.iter().any(|event| {
-                event.kind == "gate"
-                    && event.outcome
-                        == Some(match gate {
-                            "source" => "source_reached",
-                            "publication" => "publication_reached",
-                            _ => "",
-                        })
-            })
-        }),
-        Mode::Handshake | Mode::Finish => true,
+        "gate_open" => {
+            let kind = r.kind.clone().ok_or("missing gate kind")?;
+            if kind != "source" && kind != "publication" {
+                return Err("unknown gate kind".into());
+            }
+            let url = r.url.clone().ok_or("missing gate URL")?;
+            if s.gates.values().any(|g| !g.released && g.kind == kind && g.url == url) {
+                return Err("overlapping gate".into());
+            }
+            let id = s.id();
+            s.gates.insert(
+                id,
+                Gate { kind, url, after: s.cursor, reached: None, attempt: None, released: false },
+            );
+            result["gate"] = id.into();
+        }
+        "gate_release" | "gate_wait" => {
+            let id = r.gate.ok_or("missing gate")?;
+            let g = s.gates.get_mut(&id).ok_or("unknown gate")?;
+            if r.mode == "gate_release" {
+                g.released = true;
+                GATE_CHANGED.notify_one();
+            } else {
+                ready = g.reached.is_some_and(|c| c > g.after && c > r.after);
+            }
+            result["gate"] = id.into();
+            result["gate_state"] = json!(g);
+        }
+        "events" => {}
+        _ => return Err("unknown mode".into()),
+    }
+    result["ready"] = ready.into();
+    Ok(result)
+}
+fn respond_in(s: &mut Observer, raw: Value) -> Value {
+    let id = raw.get("id").cloned().unwrap_or(Value::Null);
+    let Ok(request) = serde_json::from_value::<Request>(raw.clone()) else {
+        return json!({"id":id,"error":"malformed request"});
     };
-    serde_json::json!({
-        "id": request.id,
-        "protocol": PROTOCOL_VERSION,
-        "session": observer.session,
-        "cursor": cursor,
-        "writes": observer.writes,
-        "accepted_edits": observer.accepted_edits,
-        "ready": ready,
-        "events": observer.events.iter().filter(|event| event.cursor > request.after).take(32).collect::<Vec<_>>(),
-        "installed_attempt": observer.installed.as_ref().map(|installed| installed.attempt),
-        "installed_cursor": observer.installed.as_ref().map(|installed| installed.cursor),
-        "operation": observer.active_operation,
-    })
+    let immutable = matches!(
+        request.mode.as_str(),
+        "handshake" | "checkpoint" | "begin" | "seal" | "gate_open" | "gate_release"
+    );
+    if let Some((previous, result)) = s.replies.get(&request.id) {
+        return if previous == &raw {
+            result.clone()
+        } else {
+            json!({"id":id,"error":"request ID reused"})
+        };
+    }
+    let mut result = match answer(s, &request) {
+        Ok(v) => v,
+        Err(e) => json!({"error":e}),
+    };
+    result["id"] = id;
+    result["protocol"] = PROTOCOL_VERSION.into();
+    result["session"] = s.session.clone().into();
+    result["cursor"] = s.cursor.into();
+    result["writes"] = s.writes.into();
+    result["accepted_edits"] = s.accepted_edits.into();
+    result["installed"] = json!(s.installed.and_then(|(id, _)| s.attempts.get(&id)));
+    result["operations"] = json!(s.operations);
+    result["attempts"] = json!(s.attempts.values().rev().take(16).collect::<Vec<_>>());
+    result["events"] = json!(
+        s.events
+            .iter()
+            .filter(|e| e["cursor"].as_u64().unwrap() > request.after)
+            .collect::<Vec<_>>()
+    );
+    if immutable {
+        s.replies.insert(request.id, (raw, result.clone()));
+    }
+    result
 }
 
-pub(super) fn initialize() {
+fn respond(raw: Value) -> Value {
+    with_state(|s| respond_in(s, raw.clone()))
+        .unwrap_or_else(|| json!({"id":raw["id"],"error":"observer disabled"}))
+}
+
+pub(crate) fn initialize() {
     let Some(directory) = std::env::var_os("SLINT_EDITOR_TEST_SYNC") else { return };
-    let observer = Arc::new(Mutex::new(Observer { session: session_id(), ..Default::default() }));
-    let _ = OBSERVER.set(observer);
+    let session = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+    );
+    let _ = STATE.set(Arc::new(Mutex::new(Observer {
+        session,
+        ui_thread: Some(std::thread::current().id()),
+        ..Default::default()
+    })));
     let directory = std::path::PathBuf::from(directory);
-    thread_local! { static TIMER: slint::Timer = slint::Timer::default(); }
+    thread_local! {static TIMER:slint::Timer=slint::Timer::default();}
     TIMER.with(|timer| {
         timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(20), move || {
-            pump();
+            pump_publications();
             let Ok(bytes) = std::fs::read(directory.join("request.json")) else { return };
-            let Ok(request) = serde_json::from_slice::<Request>(&bytes) else {
-                let id = serde_json::from_slice::<serde_json::Value>(&bytes)
-                    .ok()
-                    .and_then(|value| value.get("id").and_then(serde_json::Value::as_u64))
-                    .unwrap_or_default();
-                let result = serde_json::json!({
-                    "id": id,
-                    "protocol": PROTOCOL_VERSION,
-                    "error": "malformed request"
-                });
-                let temporary = directory.join("response.tmp");
-                if std::fs::write(&temporary, result.to_string()).is_ok() {
-                    let _ = std::fs::rename(temporary, directory.join("response.json"));
-                }
-                return;
-            };
-            let result = response(&request);
+            let raw = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+            let response = respond(raw);
             let temporary = directory.join("response.tmp");
-            if std::fs::write(&temporary, result.to_string()).is_ok() {
+            if std::fs::write(&temporary, response.to_string()).is_ok() {
                 let _ = std::fs::rename(temporary, directory.join("response.json"));
             }
         })
     });
 }
 
+static WATCH_WORK: OnceLock<Mutex<BTreeMap<Url, Vec<Work>>>> = OnceLock::new();
+pub(crate) fn expect_watch(url: &Url) {
+    let work = Work::capture("filesystem observation");
+    if work.0.is_empty() {
+        return;
+    }
+    WATCH_WORK
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap()
+        .entry(url.clone())
+        .or_default()
+        .push(work);
+}
+pub(crate) fn observed_write(url: &Url) -> Work {
+    Work::combine(WATCH_WORK.get().and_then(|w| w.lock().unwrap().remove(url)).unwrap_or_default())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn request(id: u64, mode: &str) -> Value {
+        json!({"id":id,"protocol":PROTOCOL_VERSION,"session":"test","mode":mode})
+    }
+    fn observer() -> Observer {
+        Observer { session: "test".into(), ..Default::default() }
+    }
+
     #[test]
-    fn current_installation_and_shared_writes_are_authoritative() {
-        let observer =
-            Arc::new(Mutex::new(Observer { session: "test".into(), ..Default::default() }));
-        let _ = OBSERVER.set(observer);
-        let url = lsp_types::Url::parse("file:///tmp/Main.slint").unwrap();
-        record_applied_with_attempt(&url, "A", None);
-        record_applied_with_attempt(&url, "B", None);
-        let req = Request {
-            id: 1,
-            protocol: 2,
-            session: Some("test".into()),
-            mode: Mode::Applied,
-            after: 0,
-            operation: None,
-            outcome: None,
-            sources: [(url, Some("A".into()))].into(),
-            gate: None,
-            release: false,
-            gate_control: false,
-            begin_action: false,
-        };
-        assert!(!response(&req)["ready"].as_bool().unwrap());
-        let thread = std::thread::spawn(record_write);
-        thread.join().unwrap();
+    fn repeated_control_requests_are_idempotent() {
+        let mut state = observer();
+        let begin = request(1, "begin");
+        let first = respond_in(&mut state, begin.clone());
+        state.event(json!({"kind":"unrelated"}));
+        assert_eq!(first, respond_in(&mut state, begin));
+        assert_eq!(state.operations.len(), 1);
+        assert_eq!(respond_in(&mut state, request(1, "checkpoint"))["error"], "request ID reused");
+        let mut gate = request(2, "gate_open");
+        gate["kind"] = "publication".into();
+        gate["url"] = "file:///Main.slint".into();
+        let opened = respond_in(&mut state, gate.clone());
+        assert_eq!(opened, respond_in(&mut state, gate));
+        assert_eq!(state.gates.len(), 1);
+    }
+
+    #[test]
+    fn settlement_cannot_manufacture_a_canceled_result() {
+        let mut state = observer();
+        let id = respond_in(&mut state, request(1, "begin"))["operation"].clone();
+        let mut seal = request(2, "seal");
+        seal["operation"] = id.clone();
+        respond_in(&mut state, seal);
+        let mut wait = request(3, "settled");
+        wait["operation"] = id.clone();
+        wait["outcome"] = "canceled".into();
+        assert!(respond_in(&mut state, wait)["error"].as_str().unwrap().contains("got noop"));
+        assert!(state.operations[&id.as_u64().unwrap()].effects.is_empty());
+    }
+
+    #[test]
+    fn leases_survive_queue_transfers_and_release_only_after_last_owner() {
+        let state = Arc::new(Mutex::new(observer()));
+        state
+            .lock()
+            .unwrap()
+            .operations
+            .insert(7, Operation { sealed: true, ..Default::default() });
+        let work = Work::capture_in(&state, vec![7], "queued history");
+        let queued = work.clone();
+        drop(work);
+        assert!(!state.lock().unwrap().operations[&7].settled());
+        std::thread::spawn(move || {
+            queued.run(|| assert_eq!(operations(), vec![7]));
+            assert!(operations().is_empty());
+            drop(queued);
+        })
+        .join()
+        .unwrap();
+        assert!(state.lock().unwrap().operations[&7].settled());
+    }
+
+    #[test]
+    fn async_context_is_restored_between_polls() {
+        let state = Arc::new(Mutex::new(observer()));
+        state.lock().unwrap().operations.insert(7, Operation::default());
+        let work = Work::capture_in(&state, vec![7], "compile");
+        let mut polls = 0;
+        let future = std::future::poll_fn(|_| {
+            assert_eq!(operations(), vec![7]);
+            polls += 1;
+            if polls == 1 { std::task::Poll::Pending } else { std::task::Poll::Ready(()) }
+        });
+        let mut scoped = std::pin::pin!(work.during(future));
+        let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+        assert!(scoped.as_mut().poll(&mut cx).is_pending());
+        assert!(operations().is_empty());
+        assert!(scoped.as_mut().poll(&mut cx).is_ready());
+        assert!(operations().is_empty());
+    }
+
+    #[test]
+    fn history_overflow_does_not_prevent_checkpoint_or_gate_cleanup() {
+        let mut state = observer();
+        for _ in 0..MAX_EVENTS + 2 {
+            state.event(json!({"kind":"observed"}));
+        }
         assert_eq!(
-            response(&Request {
-                id: 2,
-                mode: Mode::Checkpoint,
-                protocol: 2,
-                session: Some("test".into()),
-                after: 0,
-                operation: None,
-                outcome: None,
-                sources: BTreeMap::new(),
-                gate: None,
-                release: false,
-                gate_control: false,
-                begin_action: false
-            })["writes"],
-            1
+            respond_in(&mut state, request(1, "processed"))["error"],
+            "event history overflow"
         );
+        assert_eq!(respond_in(&mut state, request(2, "checkpoint"))["ready"], true);
+        let mut open = request(3, "gate_open");
+        open["kind"] = "source".into();
+        open["url"] = "file:///Main.slint".into();
+        let gate = respond_in(&mut state, open)["gate"].clone();
+        let mut release = request(4, "gate_release");
+        release["gate"] = gate;
+        assert_eq!(respond_in(&mut state, release)["ready"], true);
+    }
+
+    fn attempt(
+        id: u64,
+        observation: u64,
+        processed_cursor: u64,
+        content: Option<&str>,
+        outcome: &str,
+    ) -> Attempt {
+        let root = Url::parse("file:///Main.slint").unwrap();
+        Attempt {
+            id,
+            kind: "compilation".into(),
+            root: root.clone(),
+            component: None,
+            epoch: 0,
+            started_cursor: observation,
+            inputs: BTreeMap::from([(
+                root,
+                Input { observation, version: Some(id as i32), content: identity(content) },
+            )]),
+            outcome: Some(outcome.into()),
+            diagnostics: vec!["diagnostic".into()],
+            processed_cursor,
+        }
+    }
+
+    #[test]
+    fn old_input_cannot_acknowledge_same_content_after_a_new_boundary() {
+        let mut state = observer();
+        state.cursor = 12;
+        state.attempts.insert(1, attempt(1, 1, 11, Some("A"), "compiled"));
+        let mut wait = request(1, "processed");
+        wait["after"] = 10.into();
+        wait["sources"] = json!({"file:///Main.slint":"A"});
+        assert_eq!(respond_in(&mut state, wait.clone())["ready"], false);
+        state.attempts.insert(2, attempt(2, 11, 12, Some("A"), "compiled"));
+        assert_eq!(respond_in(&mut state, wait)["attempt"]["id"], 2);
+    }
+
+    #[test]
+    fn missing_and_failed_inputs_are_separate_from_installed_success() {
+        let mut state = observer();
+        state.cursor = 6;
+        state.attempts.insert(1, attempt(1, 1, 2, Some("A"), "compiled"));
+        state.installed = Some((1, 3));
+        state.attempts.insert(2, attempt(2, 4, 5, None, "load_error"));
+        let mut wait = request(1, "processed");
+        wait["after"] = 3.into();
+        wait["sources"] = json!({"file:///Main.slint":null});
+        wait["outcome"] = "load_error".into();
+        let result = respond_in(&mut state, wait);
+        assert_eq!(result["attempt"]["id"], 2);
+        assert_eq!(result["installed"]["id"], 1);
+        assert_eq!(result["attempt"]["diagnostics"], json!(["diagnostic"]));
+    }
+
+    #[test]
+    fn protocol_and_session_are_validated_before_mutation() {
+        let mut state = observer();
+        let mut wrong = request(1, "begin");
+        wrong["protocol"] = 0.into();
+        assert_eq!(respond_in(&mut state, wrong)["error"], "protocol mismatch");
+        let mut stale = request(2, "begin");
+        stale["session"] = "previous".into();
+        assert_eq!(respond_in(&mut state, stale)["error"], "stale session");
+        assert!(state.operations.is_empty());
     }
 }

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -810,6 +810,7 @@ mod tests {
         assert_eq!(respond_in(&mut state, query)["error"], "unknown or expired operation");
     }
 
+    // cspell:ignore nocapture
     #[test]
     fn installation_errors_are_fatal_with_or_without_a_publication_gate() {
         const CHILD: &str = "SLINT_TEST_INSTALLATION_FAILURE";

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -617,8 +617,7 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
                     })
                 });
             ready &= super::PREVIEW_STATE.with_borrow(|p| {
-                !p.workspace_edit_sent
-                    && p.pending_workspace_edit.is_none()
+                p.pending_edit.is_none()
                     && p.pending_history.is_empty()
                     && matches!(p.loading_state, super::PreviewFutureState::Pending)
             });

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -1,40 +1,156 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR
+// LicenseRef-Slint-Software-3.0
 
-//! Opt-in synchronization for tests whose next action requires an installed source revision.
-//! The system-testing transport exposes accessibility, not the preview's document cache.
+//! Opt-in, revision-aware synchronization for editor system tests.
+//!
+//! The observer records lifecycle events at the preview boundaries. It never
+//! starts a reload in response to a test request.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
+
+const PROTOCOL_VERSION: u32 = 2;
+const MAX_EVENTS: usize = 512;
+
+#[derive(Clone, Debug, serde::Serialize)]
+struct Event {
+    cursor: u64,
+    kind: &'static str,
+    url: String,
+    content: Option<String>,
+    outcome: Option<&'static str>,
+}
+
+#[derive(Default)]
+struct State {
+    session: String,
+    next_cursor: u64,
+    events: VecDeque<Event>,
+    writes: u64,
+}
+
+thread_local! {
+    static STATE: std::cell::RefCell<State> = Default::default();
+}
 
 #[derive(serde::Deserialize)]
 struct Request {
     id: u64,
+    #[serde(default)]
+    mode: Mode,
+    #[serde(default)]
+    after: u64,
+    #[serde(default)]
+    outcome: Option<String>,
+    #[serde(default)]
     sources: BTreeMap<lsp_types::Url, String>,
 }
 
+#[derive(Clone, Copy, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Mode {
+    #[default]
+    Applied,
+    Checkpoint,
+    Processed,
+    Settled,
+}
+
+fn session_id() -> String {
+    format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    )
+}
+
+fn push(
+    kind: &'static str,
+    url: &lsp_types::Url,
+    content: Option<&str>,
+    outcome: Option<&'static str>,
+) {
+    STATE.with_borrow_mut(|state| {
+        state.next_cursor += 1;
+        if state.session.is_empty() {
+            state.session = session_id();
+        }
+        state.events.push_back(Event {
+            cursor: state.next_cursor,
+            kind,
+            url: url.to_string(),
+            content: content.map(str::to_owned),
+            outcome,
+        });
+        while state.events.len() > MAX_EVENTS {
+            state.events.pop_front();
+        }
+    });
+}
+
+pub(crate) fn record_observed(url: &lsp_types::Url, content: Option<&str>) {
+    push("observed", url, content, None);
+}
+
+pub(crate) fn record_processed(url: &lsp_types::Url, content: &str, outcome: &'static str) {
+    push("processed", url, Some(content), Some(outcome));
+}
+
+pub(crate) fn record_applied(url: &lsp_types::Url, content: &str) {
+    push("applied", url, Some(content), Some("compiled"));
+}
+
+pub(crate) fn record_write() {
+    STATE.with_borrow_mut(|state| state.writes += 1);
+}
+
 fn response(request: &Request) -> serde_json::Value {
-    super::PREVIEW_STATE.with_borrow(|state| {
-        let busy = state.workspace_edit_sent
-            || !state.pending_history.is_empty()
-            || !matches!(state.loading_state, super::PreviewFutureState::Pending);
-        let cache = super::document_cache_from(state);
-        let mismatches: Vec<_> = request
-            .sources
-            .iter()
-            .filter_map(|(url, expected)| {
-                let actual = cache
-                    .as_ref()
-                    .and_then(|cache| cache.get_document(url))
-                    .and_then(|document| document.node.as_ref())
-                    .and_then(|node| node.source_file.source());
-                (actual != Some(expected.as_str())).then_some(url)
+    STATE.with_borrow(|state| {
+        let session = state.session.clone();
+        let cursor = state.next_cursor;
+        if matches!(request.mode, Mode::Checkpoint) {
+            return serde_json::json!({
+                "id": request.id,
+                "protocol": PROTOCOL_VERSION,
+                "session": session,
+                "cursor": cursor,
+                "writes": state.writes,
+                "ready": true,
+            });
+        }
+
+        let matching = |kind: &str| {
+            request.sources.iter().all(|(url, expected)| {
+                state.events.iter().any(|event| {
+                    event.cursor > request.after
+                        && event.kind == kind
+                        && event.url == url.as_str()
+                        && event.content.as_deref() == Some(expected.as_str())
+                        && request.outcome.as_deref().is_none_or(|outcome| {
+                            event.outcome == Some(outcome)
+                        })
+                })
             })
-            .collect();
+        };
+        let ready = match request.mode {
+            Mode::Processed => matching("processed"),
+            Mode::Applied => matching("applied"),
+            Mode::Settled => matching("applied"),
+            Mode::Checkpoint => true,
+        };
         serde_json::json!({
             "id": request.id,
-            "ready": !busy && mismatches.is_empty(),
-            "busy": busy,
-            "mismatches": mismatches,
+            "protocol": PROTOCOL_VERSION,
+            "session": session,
+            "cursor": cursor,
+            "writes": state.writes,
+            "ready": ready,
+            "overflow": request.after != 0
+                && state.events.front().is_some_and(|event| request.after < event.cursor),
+            "events": state.events.iter().filter(|event| event.cursor > request.after).collect::<Vec<_>>(),
         })
     })
 }
@@ -42,19 +158,24 @@ fn response(request: &Request) -> serde_json::Value {
 pub(super) fn initialize() {
     let Some(directory) = std::env::var_os("SLINT_EDITOR_TEST_SYNC") else { return };
     let directory = std::path::PathBuf::from(directory);
+    STATE.with_borrow_mut(|state| state.session = session_id());
     thread_local! {
         static TIMER: slint::Timer = slint::Timer::default();
     }
     TIMER.with(|timer| {
-        timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(20), move || {
-            let Ok(bytes) = std::fs::read(directory.join("request.json")) else { return };
-            let Ok(request) = serde_json::from_slice::<Request>(&bytes) else { return };
-            let response = response(&request);
-            let temporary = directory.join("response.tmp");
-            if std::fs::write(&temporary, response.to_string()).is_ok() {
-                let _ = std::fs::rename(temporary, directory.join("response.json"));
-            }
-        });
+        timer.start(
+            slint::TimerMode::Repeated,
+            std::time::Duration::from_millis(20),
+            move || {
+                let Ok(bytes) = std::fs::read(directory.join("request.json")) else { return };
+                let Ok(request) = serde_json::from_slice::<Request>(&bytes) else { return };
+                let response = response(&request);
+                let temporary = directory.join("response.tmp");
+                if std::fs::write(&temporary, response.to_string()).is_ok() {
+                    let _ = std::fs::rename(temporary, directory.join("response.json"));
+                }
+            },
+        );
     });
 }
 
@@ -63,42 +184,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn waits_for_installed_source_and_pending_work() {
-        use super::super::{PREVIEW_STATE, PreviewFutureState, PreviewState};
-        use i_slint_editor_preview::test::{
-            compile_test_with_sources, main_test_file_name, recompile_test_with_sources,
+    fn lifecycle_events_are_revision_specific() {
+        let url = lsp_types::Url::parse("file:///tmp/Main.slint").unwrap();
+        STATE.with_borrow_mut(|state| *state = State::default());
+        record_observed(&url, Some("old"));
+        record_processed(&url, "old", "compile_error");
+        record_observed(&url, Some("new"));
+        record_processed(&url, "new", "compiled");
+        record_applied(&url, "new");
+        let request = Request {
+            id: 1,
+            mode: Mode::Processed,
+            after: 1,
+            outcome: Some("compiled".into()),
+            sources: [(url.clone(), "new".into())].into(),
         };
-        let url = lsp_types::Url::from_file_path(main_test_file_name()).unwrap();
-        let old = "export component Test inherits Window { width: 100px; }";
-        let new = "export component Test inherits Window { width: 200px; }";
-        let old_cache =
-            compile_test_with_sources("fluent", [(url.clone(), old.into())].into(), false);
-        let new_cache =
-            recompile_test_with_sources("fluent", [(url.clone(), new.into())].into(), false, false);
-        let request = Request { id: 42, sources: [(url, new.into())].into() };
-        PREVIEW_STATE.with_borrow_mut(|state| {
-            *state = PreviewState::default();
-            state.document_cache.replace(Some(std::rc::Rc::new(old_cache)));
-        });
-        assert_eq!(response(&request)["ready"], false);
-        PREVIEW_STATE.with_borrow_mut(|state| {
-            state.document_cache.replace(Some(std::rc::Rc::new(new_cache)));
-            state.loading_state = PreviewFutureState::Loading;
-        });
-        assert_eq!(response(&request)["ready"], false);
-        PREVIEW_STATE.with_borrow_mut(|state| {
-            state.loading_state = PreviewFutureState::Pending;
-            state.workspace_edit_sent = true;
-        });
-        assert_eq!(response(&request)["ready"], false);
-        PREVIEW_STATE.with_borrow_mut(|state| {
-            state.workspace_edit_sent = false;
-            state.pending_history.push_back(false);
-        });
-        assert_eq!(response(&request)["ready"], false);
-        PREVIEW_STATE.with_borrow_mut(|state| state.pending_history.clear());
         assert_eq!(response(&request)["ready"], true);
-        assert_eq!(response(&request)["id"], 42);
-        PREVIEW_STATE.with_borrow_mut(|state| *state = PreviewState::default());
+        let old_request = Request {
+            id: 2,
+            mode: Mode::Processed,
+            after: 0,
+            outcome: Some("compile_error".into()),
+            sources: [(url, "old".into())].into(),
+        };
+        assert_eq!(response(&old_request)["ready"], true);
     }
 }

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -811,6 +811,48 @@ mod tests {
     }
 
     #[test]
+    fn installation_errors_are_fatal_with_or_without_a_publication_gate() {
+        const CHILD: &str = "SLINT_TEST_INSTALLATION_FAILURE";
+        if let Ok(mode) = std::env::var(CHILD) {
+            i_slint_backend_testing::init_no_event_loop();
+            STATE.set(Arc::new(Mutex::new(observer()))).ok().unwrap();
+            let url: Url = "file:///Main.slint".parse().unwrap();
+            let mut open = request(1, "gate_open");
+            open["kind"] = "publication".into();
+            open["url"] = json!(url);
+            let gate = (mode == "deferred").then(|| respond(open)["gate"].clone());
+            let attempt = begin_attempt(&url, None);
+            publish(&url, attempt, || {
+                super::super::finish_preview_installation(Err(
+                    "injected installation failure".into()
+                ));
+            });
+            println!("publication held");
+            let mut release = request(2, "gate_release");
+            release["gate"] = gate.unwrap();
+            respond(release);
+            pump_publications();
+            panic!("installation failure did not terminate the editor");
+        }
+        for mode in ["immediate", "deferred"] {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "preview::test_sync::tests::installation_errors_are_fatal_with_or_without_a_publication_gate", "--nocapture"])
+                .env(CHILD, mode)
+                .output().unwrap();
+            assert_eq!(
+                output.status.code(),
+                Some(3),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout).contains("publication held"),
+                mode == "deferred"
+            );
+        }
+    }
+
+    #[test]
     fn older_requests_cannot_run_again() {
         let mut state = observer();
         respond_in(&mut state, request(1, "checkpoint"));

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -97,6 +97,7 @@ struct Observer {
     inputs: BTreeMap<Url, Input>,
     attempts: BTreeMap<u64, Attempt>,
     installed: Option<(u64, u64)>,
+    mounted: bool,
     operations: BTreeMap<u64, Operation>,
     capturing: Option<u64>,
     gates: BTreeMap<u64, Gate>,
@@ -381,10 +382,20 @@ pub(crate) fn processed(attempt: u64, outcome: &str, diagnostics: Vec<String>) {
         }
     });
 }
+pub(crate) fn unmounted(attempt: Option<u64>) {
+    with_state(|s| {
+        if s.mounted && attempt.is_none_or(|a| s.installed.is_none_or(|(id, _)| id <= a)) {
+            s.mounted = false;
+            s.event(json!({"kind":"unmounted"}));
+        }
+    });
+}
+
 pub(crate) fn applied(attempt: u64) {
     with_state(|s| {
         let cursor = s.event(json!({"kind":"applied", "attempt":attempt}));
         s.installed = Some((attempt, cursor));
+        s.mounted = true;
     });
 }
 
@@ -592,14 +603,15 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
             let found = s.installed.and_then(|(id, cursor)| {
                 (cursor > r.after || r.after == 0).then(|| s.attempts.get(&id)).flatten()
             });
-            ready = found.is_some_and(|a| {
-                r.sources.iter().all(|(url, c)| {
-                    a.inputs.get(url).is_some_and(|i| {
-                        i.content == identity(c.as_deref())
-                            && (r.after == 0 || i.observation > r.after)
+            ready = s.mounted
+                && found.is_some_and(|a| {
+                    r.sources.iter().all(|(url, c)| {
+                        a.inputs.get(url).is_some_and(|i| {
+                            i.content == identity(c.as_deref())
+                                && (r.after == 0 || i.observation > r.after)
+                        })
                     })
-                })
-            });
+                });
             ready &= super::PREVIEW_STATE.with_borrow(|p| {
                 !p.workspace_edit_sent
                     && p.pending_workspace_edit.is_none()
@@ -698,6 +710,7 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
     result["writes"] = s.writes.into();
     result["accepted_edits"] = s.accepted_edits.into();
     result["mutations"] = s.mutations.into();
+    result["mounted"] = json!(s.mounted);
     result["installed"] = json!(s.installed.and_then(|(id, _)| s.attempts.get(&id)));
     result["operations"] =
         json!(s.operations.iter().filter(|(_, op)| !op.settled()).collect::<BTreeMap<_, _>>());
@@ -933,6 +946,21 @@ mod tests {
         assert_eq!(respond_in(&mut state, wait.clone())["ready"], false);
         state.attempts.insert(2, attempt(2, 11, 12, Some("A"), "compiled"));
         assert_eq!(respond_in(&mut state, wait)["attempt"]["id"], 2);
+    }
+
+    #[test]
+    fn applied_requires_a_mounted_instance_but_retains_diagnostics() {
+        let mut state = observer();
+        state.cursor = 3;
+        state.attempts.insert(1, attempt(1, 1, 2, Some("A"), "compiled"));
+        state.installed = Some((1, 3));
+        let mut wait = request(1, "applied");
+        wait["sources"] = json!({"file:///Main.slint":"A"});
+        let result = respond_in(&mut state, wait.clone());
+        assert_eq!(result["ready"], false);
+        assert_eq!(result["installed"]["id"], 1);
+        state.mounted = true;
+        assert_eq!(respond_in(&mut state, wait)["ready"], true);
     }
 
     #[test]

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -163,19 +163,15 @@ pub(super) fn initialize() {
         static TIMER: slint::Timer = slint::Timer::default();
     }
     TIMER.with(|timer| {
-        timer.start(
-            slint::TimerMode::Repeated,
-            std::time::Duration::from_millis(20),
-            move || {
-                let Ok(bytes) = std::fs::read(directory.join("request.json")) else { return };
-                let Ok(request) = serde_json::from_slice::<Request>(&bytes) else { return };
-                let response = response(&request);
-                let temporary = directory.join("response.tmp");
-                if std::fs::write(&temporary, response.to_string()).is_ok() {
-                    let _ = std::fs::rename(temporary, directory.join("response.json"));
-                }
-            },
-        );
+        timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(20), move || {
+            let Ok(bytes) = std::fs::read(directory.join("request.json")) else { return };
+            let Ok(request) = serde_json::from_slice::<Request>(&bytes) else { return };
+            let response = response(&request);
+            let temporary = directory.join("response.tmp");
+            if std::fs::write(&temporary, response.to_string()).is_ok() {
+                let _ = std::fs::rename(temporary, directory.join("response.json"));
+            }
+        });
     });
 }
 

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -16,6 +16,7 @@ use serde_json::{Value, json};
 
 pub(crate) const PROTOCOL_VERSION: u32 = 3;
 const MAX_EVENTS: usize = 512;
+const MAX_COMPLETED: usize = 128;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct Content {
@@ -42,7 +43,6 @@ struct Attempt {
     kind: String,
     root: Url,
     component: Option<String>,
-    epoch: u64,
     started_cursor: u64,
     inputs: BTreeMap<Url, Input>,
     outcome: Option<String>,
@@ -91,7 +91,6 @@ struct Observer {
     cursor: u64,
     discarded_through: u64,
     serial: u64,
-    epoch: u64,
     events: VecDeque<Value>,
     inputs: BTreeMap<Url, Input>,
     attempts: BTreeMap<u64, Attempt>,
@@ -100,10 +99,42 @@ struct Observer {
     capturing: Option<u64>,
     gates: BTreeMap<u64, Gate>,
     replies: BTreeMap<u64, (Value, Value)>,
+    retired_request_through: u64,
     writes: u64,
     accepted_edits: u64,
 }
 impl Observer {
+    fn prune(&mut self) {
+        let settled: Vec<_> =
+            self.operations.iter().filter(|(_, op)| op.settled()).map(|(id, _)| *id).collect();
+        for id in settled.iter().take(settled.len().saturating_sub(MAX_COMPLETED)) {
+            self.operations.remove(id);
+        }
+        let released: Vec<_> =
+            self.gates.iter().filter(|(_, g)| g.released).map(|(id, _)| *id).collect();
+        for id in released.iter().take(released.len().saturating_sub(MAX_COMPLETED)) {
+            self.gates.remove(id);
+        }
+        let finished: Vec<_> = self
+            .attempts
+            .iter()
+            .filter(|(id, a)| {
+                a.outcome.is_some()
+                    && self.installed.is_none_or(|(installed, _)| installed != **id)
+                    && !self.gates.values().any(|g| !g.released && g.attempt == Some(**id))
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        for id in finished.iter().take(finished.len().saturating_sub(MAX_COMPLETED)) {
+            self.attempts.remove(id);
+        }
+        while self.replies.len() > MAX_COMPLETED {
+            if let Some((id, _)) = self.replies.pop_first() {
+                self.retired_request_through = self.retired_request_through.max(id);
+            }
+        }
+    }
+
     fn id(&mut self) -> u64 {
         self.serial += 1;
         self.serial
@@ -232,9 +263,6 @@ pub(crate) fn written(url: &Url) {
     });
 }
 
-pub(crate) fn request_reload() {
-    with_state(|s| s.epoch += 1);
-}
 pub(crate) fn begin_attempt(root: &Url, component: Option<String>) -> u64 {
     with_state(|s| {
         let id = s.id();
@@ -246,7 +274,6 @@ pub(crate) fn begin_attempt(root: &Url, component: Option<String>) -> u64 {
                 kind: "compilation".into(),
                 root: root.clone(),
                 component,
-                epoch: s.epoch,
                 started_cursor,
                 inputs: BTreeMap::new(),
                 outcome: None,
@@ -275,7 +302,6 @@ pub(crate) fn observed_read(url: &Url, content: Option<&str>) {
                     kind: "load".into(),
                     root: url.clone(),
                     component: None,
-                    epoch: s.epoch,
                     started_cursor: observation,
                     inputs: BTreeMap::from([(url.clone(), input)]),
                     outcome: Some("load_error".into()),
@@ -335,9 +361,6 @@ pub(crate) fn processed(attempt: u64, outcome: &str, diagnostics: Vec<String>) {
             a.diagnostics = diagnostics;
         }
     });
-}
-pub(crate) fn current_attempt(attempt: u64) -> bool {
-    with_state(|s| s.attempts.get(&attempt).is_some_and(|a| a.epoch == s.epoch)).unwrap_or(true)
 }
 pub(crate) fn applied(attempt: u64) {
     with_state(|s| {
@@ -457,7 +480,7 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
         }
         "seal" => {
             let id = r.operation.ok_or("missing operation")?;
-            let op = s.operations.get_mut(&id).ok_or("unknown operation")?;
+            let op = s.operations.get_mut(&id).ok_or("unknown or expired operation")?;
             op.sealed = true;
             if s.capturing == Some(id) {
                 s.capturing = None;
@@ -465,7 +488,7 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
         }
         "settled" | "operation" => {
             let id = r.operation.ok_or("missing operation")?;
-            let op = s.operations.get(&id).ok_or("unknown operation")?;
+            let op = s.operations.get(&id).ok_or("unknown or expired operation")?;
             ready = r.mode == "operation" || op.settled();
             result["settled"] = op.settled().into();
             result["operation"] = id.into();
@@ -543,7 +566,7 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
         }
         "gate_release" | "gate_wait" => {
             let id = r.gate.ok_or("missing gate")?;
-            let g = s.gates.get_mut(&id).ok_or("unknown gate")?;
+            let g = s.gates.get_mut(&id).ok_or("unknown or expired gate")?;
             if r.mode == "gate_release" {
                 g.released = true;
                 GATE_CHANGED.notify_one();
@@ -564,6 +587,9 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
     let Ok(request) = serde_json::from_value::<Request>(raw.clone()) else {
         return json!({"id":id,"error":"malformed request"});
     };
+    if request.id <= s.retired_request_through {
+        return json!({"id":id,"error":"request history expired"});
+    }
     let immutable = matches!(
         request.mode.as_str(),
         "handshake" | "checkpoint" | "begin" | "seal" | "gate_open" | "gate_release"
@@ -586,7 +612,8 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
     result["writes"] = s.writes.into();
     result["accepted_edits"] = s.accepted_edits.into();
     result["installed"] = json!(s.installed.and_then(|(id, _)| s.attempts.get(&id)));
-    result["operations"] = json!(s.operations);
+    result["operations"] =
+        json!(s.operations.iter().filter(|(_, op)| !op.settled()).collect::<BTreeMap<_, _>>());
     result["attempts"] = json!(s.attempts.values().rev().take(16).collect::<Vec<_>>());
     result["events"] = json!(
         s.events
@@ -597,6 +624,7 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
     if immutable {
         s.replies.insert(request.id, (raw, result.clone()));
     }
+    s.prune();
     result
 }
 
@@ -660,6 +688,35 @@ mod tests {
     }
     fn observer() -> Observer {
         Observer { session: "test".into(), ..Default::default() }
+    }
+
+    #[test]
+    fn completed_records_expire_without_discarding_pending_work() {
+        let mut state = observer();
+        state.operations.insert(1, Operation::default());
+        for id in 2..=(MAX_COMPLETED as u64 + 3) {
+            state.operations.insert(id, Operation { sealed: true, ..Default::default() });
+        }
+        state.prune();
+        assert!(state.operations.contains_key(&1));
+        assert!(!state.operations.contains_key(&2));
+        assert_eq!(state.operations.len(), MAX_COMPLETED + 1);
+        let mut query = request(1000, "operation");
+        query["operation"] = 2.into();
+        assert_eq!(respond_in(&mut state, query)["error"], "unknown or expired operation");
+    }
+
+    #[test]
+    fn expired_control_requests_cannot_run_again() {
+        let mut state = observer();
+        for id in 1..=(MAX_COMPLETED as u64 + 1) {
+            respond_in(&mut state, request(id, "checkpoint"));
+        }
+        assert_eq!(state.replies.len(), MAX_COMPLETED);
+        assert_eq!(
+            respond_in(&mut state, request(1, "checkpoint"))["error"],
+            "request history expired"
+        );
     }
 
     #[test]
@@ -767,7 +824,6 @@ mod tests {
             kind: "compilation".into(),
             root: root.clone(),
             component: None,
-            epoch: 0,
             started_cursor: observation,
             inputs: BTreeMap::from([(
                 root,

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -49,6 +49,16 @@ struct Attempt {
     diagnostics: Vec<String>,
     processed_cursor: u64,
 }
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Outcome {
+    #[default]
+    Noop,
+    Canceled,
+    Rejected,
+    Completed,
+    Failed,
+}
 #[derive(Default, Serialize)]
 struct Operation {
     sealed: bool,
@@ -56,22 +66,19 @@ struct Operation {
     accepted_edits: u64,
     writes: u64,
     mutations: u64,
-    effects: Vec<String>,
+    outcome: Outcome,
 }
 impl Operation {
     fn outcome(&self) -> &str {
-        if self.effects.iter().any(|s| s == "failed") {
-            "failed"
-        } else if self.accepted_edits > 0 || self.effects.iter().any(|s| s == "completed") {
-            "completed"
-        } else if self.effects.iter().any(|s| s == "rejected") {
-            "rejected"
-        } else if self.effects.iter().any(|s| s == "canceled") {
-            "canceled"
-        } else {
-            "noop"
+        match self.outcome {
+            Outcome::Noop => "noop",
+            Outcome::Canceled => "canceled",
+            Outcome::Rejected => "rejected",
+            Outcome::Completed => "completed",
+            Outcome::Failed => "failed",
         }
     }
+
     fn settled(&self) -> bool {
         self.sealed && self.pending.is_empty()
     }
@@ -102,8 +109,7 @@ struct Observer {
     capturing: Option<u64>,
     gates: BTreeMap<u64, Gate>,
     write_faults: BTreeMap<Url, crate::source_write::WriteFault>,
-    replies: BTreeMap<u64, (Value, Value)>,
-    retired_request_through: u64,
+    request: Option<(u64, Value, Option<Value>)>,
     writes: u64,
     mutations: u64,
     accepted_edits: u64,
@@ -132,11 +138,6 @@ impl Observer {
             .collect();
         for id in finished.iter().take(finished.len().saturating_sub(MAX_COMPLETED)) {
             self.attempts.remove(id);
-        }
-        while self.replies.len() > MAX_COMPLETED {
-            if let Some((id, _)) = self.replies.pop_first() {
-                self.retired_request_through = self.retired_request_through.max(id);
-            }
         }
     }
 
@@ -238,11 +239,12 @@ impl Work {
     }
 }
 
-pub(crate) fn effect(outcome: &str) {
+pub(crate) fn effect(outcome: Outcome) {
     let ids = operations();
     with_state(|s| {
         for id in ids {
-            s.operations.get_mut(&id).unwrap().effects.push(outcome.into());
+            let op = s.operations.get_mut(&id).unwrap();
+            op.outcome = op.outcome.max(outcome);
             s.event(json!({"kind":"effect", "operation":id, "outcome":outcome}));
         }
     });
@@ -252,7 +254,9 @@ pub(crate) fn accepted_edit() {
     with_state(|s| {
         s.accepted_edits += 1;
         for id in ids {
-            s.operations.get_mut(&id).unwrap().accepted_edits += 1;
+            let op = s.operations.get_mut(&id).unwrap();
+            op.accepted_edits += 1;
+            op.outcome = op.outcome.max(Outcome::Completed);
         }
         s.event(json!({"kind":"accepted_edit"}));
     });
@@ -678,9 +682,6 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
     let Ok(request) = serde_json::from_value::<Request>(raw.clone()) else {
         return json!({"id":id,"error":"malformed request"});
     };
-    if request.id <= s.retired_request_through {
-        return json!({"id":id,"error":"request history expired"});
-    }
     let immutable = matches!(
         request.mode.as_str(),
         "handshake"
@@ -692,12 +693,18 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
             | "write_fault"
             | "clear_write_fault"
     );
-    if let Some((previous, result)) = s.replies.get(&request.id) {
-        return if previous == &raw {
-            result.clone()
-        } else {
-            json!({"id":id,"error":"request ID reused"})
-        };
+    if let Some((previous_id, previous, response)) = &s.request {
+        if request.id < *previous_id {
+            return json!({"id":id,"error":"stale request ID"});
+        }
+        if request.id == *previous_id {
+            if previous != &raw {
+                return json!({"id":id,"error":"request ID reused"});
+            }
+            if let Some(response) = response {
+                return response.clone();
+            }
+        }
     }
     let mut result = match answer(s, &request) {
         Ok(v) => v,
@@ -721,9 +728,7 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
             .filter(|e| e["cursor"].as_u64().unwrap() > request.after)
             .collect::<Vec<_>>()
     );
-    if immutable {
-        s.replies.insert(request.id, (raw, result.clone()));
-    }
+    s.request = Some((request.id, raw, immutable.then(|| result.clone())));
     s.prune();
     result
 }
@@ -807,16 +812,25 @@ mod tests {
     }
 
     #[test]
-    fn expired_control_requests_cannot_run_again() {
+    fn older_requests_cannot_run_again() {
         let mut state = observer();
-        for id in 1..=(MAX_COMPLETED as u64 + 1) {
-            respond_in(&mut state, request(id, "checkpoint"));
-        }
-        assert_eq!(state.replies.len(), MAX_COMPLETED);
-        assert_eq!(
-            respond_in(&mut state, request(1, "checkpoint"))["error"],
-            "request history expired"
-        );
+        respond_in(&mut state, request(1, "checkpoint"));
+        respond_in(&mut state, request(2, "checkpoint"));
+        assert_eq!(respond_in(&mut state, request(1, "begin"))["error"], "stale request ID");
+        assert!(state.operations.is_empty());
+    }
+
+    #[test]
+    fn observational_requests_recheck_state_but_cannot_change_payload() {
+        let mut state = observer();
+        state.operations.insert(7, Operation::default());
+        let mut query = request(1, "settled");
+        query["operation"] = 7.into();
+        assert_eq!(respond_in(&mut state, query.clone())["ready"], false);
+        state.operations.get_mut(&7).unwrap().sealed = true;
+        assert_eq!(respond_in(&mut state, query.clone())["ready"], true);
+        query["operation"] = 8.into();
+        assert_eq!(respond_in(&mut state, query)["error"], "request ID reused");
     }
 
     #[test]
@@ -837,6 +851,24 @@ mod tests {
     }
 
     #[test]
+    fn accumulated_outcomes_preserve_precedence_in_both_orders() {
+        use Outcome::*;
+        let outcomes = [Noop, Canceled, Rejected, Completed, Failed];
+        for (index, outcome) in outcomes.iter().enumerate() {
+            let expected = ["noop", "canceled", "rejected", "completed", "failed"][index];
+            for previous in &outcomes[..=index] {
+                for pair in [[*previous, *outcome], [*outcome, *previous]] {
+                    let mut operation = Operation::default();
+                    for effect in pair {
+                        operation.outcome = operation.outcome.max(effect);
+                    }
+                    assert_eq!(operation.outcome(), expected);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn settlement_cannot_manufacture_a_canceled_result() {
         let mut state = observer();
         let id = respond_in(&mut state, request(1, "begin"))["operation"].clone();
@@ -847,7 +879,7 @@ mod tests {
         wait["operation"] = id.clone();
         wait["outcome"] = "canceled".into();
         assert!(respond_in(&mut state, wait)["error"].as_str().unwrap().contains("got noop"));
-        assert!(state.operations[&id.as_u64().unwrap()].effects.is_empty());
+        assert_eq!(state.operations[&id.as_u64().unwrap()].outcome(), "noop");
     }
 
     #[test]

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -423,6 +423,15 @@ pub(crate) fn acknowledgment_received(id: u64, accepted: bool) {
     });
 }
 
+pub(crate) fn hold_factory(attempt: u64, callback: impl FnOnce() + 'static) -> bool {
+    let root = with_state(|s| s.attempts.get(&attempt).map(|a| a.root.clone())).flatten();
+    let Some(gate) = root.and_then(|url| claim_gate("factory", &url, Some(attempt))) else {
+        return false;
+    };
+    PUBLICATIONS.with_borrow_mut(|p| p.push((gate, Work::default(), Box::new(callback))));
+    true
+}
+
 pub(crate) fn publish(url: &Url, attempt: u64, callback: impl FnOnce() + 'static) {
     if let Some(gate) = claim_gate("publication", url, Some(attempt)) {
         PUBLICATIONS.with_borrow_mut(|p| {
@@ -582,7 +591,7 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
         }
         "gate_open" => {
             let kind = r.kind.clone().ok_or("missing gate kind")?;
-            if kind != "source" && kind != "publication" && kind != "acknowledgment" {
+            if !matches!(kind.as_str(), "source" | "publication" | "acknowledgment" | "factory") {
                 return Err("unknown gate kind".into());
             }
             let url = r.url.clone().ok_or("missing gate URL")?;

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -14,7 +14,7 @@ use lsp_types::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-pub(crate) const PROTOCOL_VERSION: u32 = 3;
+pub(crate) const PROTOCOL_VERSION: u32 = 4;
 const MAX_EVENTS: usize = 512;
 const MAX_COMPLETED: usize = 128;
 
@@ -82,6 +82,7 @@ struct Gate {
     after: u64,
     reached: Option<u64>,
     attempt: Option<u64>,
+    edit: Option<u64>,
     released: bool,
 }
 #[derive(Default)]
@@ -377,9 +378,10 @@ fn claim_gate(kind: &str, url: &Url, attempt: Option<u64>) -> Option<u64> {
                 && &g.url == url
                 && (kind == "source"
                     || (g.reached.is_none()
-                        && attempt
-                            .and_then(|id| s.attempts.get(&id))
-                            .is_some_and(|a| a.started_cursor > g.after))))
+                        && (kind == "acknowledgment"
+                            || attempt
+                                .and_then(|id| s.attempts.get(&id))
+                                .is_some_and(|a| a.started_cursor > g.after)))))
             .then_some(*id)
         })?;
         if s.gates[&id].reached.is_none() {
@@ -402,6 +404,25 @@ pub(crate) fn gate_released(id: u64) -> bool {
 pub(crate) async fn gate_changed() {
     GATE_CHANGED.notified().await;
 }
+pub(crate) fn acknowledge(urls: &[Url], id: u64, outcome: super::WorkspaceEditOutcome) {
+    let gate = urls.iter().find_map(|url| claim_gate("acknowledgment", url, None));
+    let callback = move || super::workspace_edit_result(id, outcome);
+    if let Some(gate) = gate {
+        with_state(|s| s.gates.get_mut(&gate).unwrap().edit = Some(id));
+        PUBLICATIONS.with_borrow_mut(|p| {
+            p.push((gate, Work::capture("acknowledgment gate"), Box::new(callback)))
+        });
+    } else {
+        callback();
+    }
+}
+
+pub(crate) fn acknowledgment_received(id: u64, accepted: bool) {
+    with_state(|s| {
+        s.event(json!({"kind":"acknowledgment", "edit":id, "accepted":accepted}));
+    });
+}
+
 pub(crate) fn publish(url: &Url, attempt: u64, callback: impl FnOnce() + 'static) {
     if let Some(gate) = claim_gate("publication", url, Some(attempt)) {
         PUBLICATIONS.with_borrow_mut(|p| {
@@ -444,6 +465,7 @@ struct Request {
     outcome: Option<String>,
     operation: Option<u64>,
     gate: Option<u64>,
+    edit: Option<u64>,
     kind: Option<String>,
     url: Option<Url>,
 }
@@ -457,7 +479,7 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
     if r.after > s.cursor {
         return Err("future cursor".into());
     }
-    if matches!(r.mode.as_str(), "observed" | "processed" | "events")
+    if matches!(r.mode.as_str(), "observed" | "processed" | "events" | "acknowledgment")
         && r.after < s.discarded_through
     {
         return Err("event history overflow".into());
@@ -501,6 +523,16 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
                     op.outcome()
                 ));
             }
+        }
+        "acknowledgment" => {
+            let id = r.edit.ok_or("missing edit ID")?;
+            let found = s.events.iter().rev().find(|event| {
+                event["kind"] == "acknowledgment"
+                    && event["edit"] == id
+                    && event["cursor"].as_u64().is_some_and(|cursor| cursor > r.after)
+            });
+            ready = found.is_some();
+            result["acknowledgment"] = json!(found);
         }
         "observed" => {
             let found = s.events.iter().rev().find(|e| {
@@ -550,7 +582,7 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
         }
         "gate_open" => {
             let kind = r.kind.clone().ok_or("missing gate kind")?;
-            if kind != "source" && kind != "publication" {
+            if kind != "source" && kind != "publication" && kind != "acknowledgment" {
                 return Err("unknown gate kind".into());
             }
             let url = r.url.clone().ok_or("missing gate URL")?;
@@ -560,7 +592,15 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
             let id = s.id();
             s.gates.insert(
                 id,
-                Gate { kind, url, after: s.cursor, reached: None, attempt: None, released: false },
+                Gate {
+                    kind,
+                    url,
+                    after: s.cursor,
+                    reached: None,
+                    attempt: None,
+                    edit: None,
+                    released: false,
+                },
             );
             result["gate"] = id.into();
         }

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -55,6 +55,7 @@ struct Operation {
     pending: BTreeMap<u64, String>,
     accepted_edits: u64,
     writes: u64,
+    mutations: u64,
     effects: Vec<String>,
 }
 impl Operation {
@@ -99,9 +100,11 @@ struct Observer {
     operations: BTreeMap<u64, Operation>,
     capturing: Option<u64>,
     gates: BTreeMap<u64, Gate>,
+    write_faults: BTreeMap<Url, crate::source_write::WriteFault>,
     replies: BTreeMap<u64, (Value, Value)>,
     retired_request_through: u64,
     writes: u64,
+    mutations: u64,
     accepted_edits: u64,
 }
 impl Observer {
@@ -253,6 +256,21 @@ pub(crate) fn accepted_edit() {
         s.event(json!({"kind":"accepted_edit"}));
     });
 }
+pub(crate) fn take_write_fault(url: &Url) -> Option<crate::source_write::WriteFault> {
+    with_state(|s| s.write_faults.remove(url)).flatten()
+}
+
+pub(crate) fn mutated(url: &Url) {
+    let ids = operations();
+    with_state(|s| {
+        s.mutations += 1;
+        for id in &ids {
+            s.operations.get_mut(id).unwrap().mutations += 1;
+        }
+        s.event(json!({"kind":"mutation", "url":url, "operations":ids}));
+    });
+}
+
 pub(crate) fn written(url: &Url) {
     let ids = operations();
     with_state(|s| {
@@ -475,6 +493,7 @@ struct Request {
     operation: Option<u64>,
     gate: Option<u64>,
     edit: Option<u64>,
+    fault: Option<crate::source_write::WriteFault>,
     kind: Option<String>,
     url: Option<Url>,
 }
@@ -589,6 +608,17 @@ fn answer(s: &mut Observer, r: &Request) -> Result<Value, String> {
             });
             result["attempt"] = json!(found);
         }
+        "write_fault" => {
+            let url = r.url.clone().ok_or("missing fault URL")?;
+            let fault = r.fault.ok_or("missing write fault")?;
+            if s.write_faults.contains_key(&url) {
+                return Err("overlapping write fault".into());
+            }
+            s.write_faults.insert(url, fault);
+        }
+        "clear_write_fault" => {
+            s.write_faults.remove(&r.url.clone().ok_or("missing fault URL")?);
+        }
         "gate_open" => {
             let kind = r.kind.clone().ok_or("missing gate kind")?;
             if !matches!(kind.as_str(), "source" | "publication" | "acknowledgment" | "factory") {
@@ -641,7 +671,14 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
     }
     let immutable = matches!(
         request.mode.as_str(),
-        "handshake" | "checkpoint" | "begin" | "seal" | "gate_open" | "gate_release"
+        "handshake"
+            | "checkpoint"
+            | "begin"
+            | "seal"
+            | "gate_open"
+            | "gate_release"
+            | "write_fault"
+            | "clear_write_fault"
     );
     if let Some((previous, result)) = s.replies.get(&request.id) {
         return if previous == &raw {
@@ -660,6 +697,7 @@ fn respond_in(s: &mut Observer, raw: Value) -> Value {
     result["cursor"] = s.cursor.into();
     result["writes"] = s.writes.into();
     result["accepted_edits"] = s.accepted_edits.into();
+    result["mutations"] = s.mutations.into();
     result["installed"] = json!(s.installed.and_then(|(id, _)| s.attempts.get(&id)));
     result["operations"] =
         json!(s.operations.iter().filter(|(_, op)| !op.settled()).collect::<BTreeMap<_, _>>());

--- a/tools/editor/preview/test_sync.rs
+++ b/tools/editor/preview/test_sync.rs
@@ -1,59 +1,81 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR
-// LicenseRef-Slint-Software-3.0
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-//! Opt-in, revision-aware synchronization for editor system tests.
+//! Opt-in synchronization for editor system tests.
 //!
-//! The observer records lifecycle events at the preview boundaries. It never
-//! starts a reload in response to a test request.
+//! This observer is process shared because source writes happen on the LSP
+//! thread while requests are served on the preview UI thread. Events contain
+//! compact identities; source text is never retained in the event ring.
 
 use std::collections::{BTreeMap, VecDeque};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex, OnceLock};
 
 const PROTOCOL_VERSION: u32 = 2;
 const MAX_EVENTS: usize = 512;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ContentIdentity {
+    hash: u64,
+    len: u64,
+}
+
+fn content_identity(content: Option<&str>) -> Option<ContentIdentity> {
+    content.map(|content| {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        content.hash(&mut hasher);
+        ContentIdentity { hash: hasher.finish(), len: content.len() as u64 }
+    })
+}
 
 #[derive(Clone, Debug, serde::Serialize)]
 struct Event {
     cursor: u64,
     kind: &'static str,
     url: String,
-    content: Option<String>,
+    content_hash: Option<u64>,
+    content_len: Option<u64>,
     outcome: Option<&'static str>,
+    operation: Option<u64>,
+    attempt: Option<u64>,
+    inputs: Vec<(String, Option<i32>)>,
+}
+
+#[derive(Clone, Debug)]
+struct Installed {
+    url: String,
+    content: Option<ContentIdentity>,
+    cursor: u64,
+    attempt: u64,
 }
 
 #[derive(Default)]
-struct State {
+struct Observer {
     session: String,
     next_cursor: u64,
+    discarded_through: u64,
+    next_attempt: u64,
+    next_operation: u64,
     events: VecDeque<Event>,
+    installed: Option<Installed>,
     writes: u64,
+    accepted_edits: u64,
+    pending_operations: u64,
+    active_operation: Option<u64>,
+    gate_source: bool,
+    gate_publication: bool,
+    held_sources: Vec<(lsp_types::Url, String)>,
+    held_publications: Vec<(lsp_types::Url, String)>,
 }
 
-thread_local! {
-    static STATE: std::cell::RefCell<State> = Default::default();
+static OBSERVER: OnceLock<Arc<Mutex<Observer>>> = OnceLock::new();
+
+fn observer() -> Option<&'static Arc<Mutex<Observer>>> {
+    OBSERVER.get()
 }
 
-#[derive(serde::Deserialize)]
-struct Request {
-    id: u64,
-    #[serde(default)]
-    mode: Mode,
-    #[serde(default)]
-    after: u64,
-    #[serde(default)]
-    outcome: Option<String>,
-    #[serde(default)]
-    sources: BTreeMap<lsp_types::Url, String>,
-}
-
-#[derive(Clone, Copy, Default, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum Mode {
-    #[default]
-    Applied,
-    Checkpoint,
-    Processed,
-    Settled,
+fn enabled_observer() -> Option<&'static Arc<Mutex<Observer>>> {
+    observer().filter(|_| cfg!(test) || std::env::var_os("SLINT_EDITOR_TEST_SYNC").is_some())
 }
 
 fn session_id() -> String {
@@ -68,110 +90,389 @@ fn session_id() -> String {
 }
 
 fn push(
+    observer: &mut Observer,
     kind: &'static str,
     url: &lsp_types::Url,
     content: Option<&str>,
     outcome: Option<&'static str>,
-) {
-    STATE.with_borrow_mut(|state| {
-        state.next_cursor += 1;
-        if state.session.is_empty() {
-            state.session = session_id();
-        }
-        state.events.push_back(Event {
-            cursor: state.next_cursor,
-            kind,
-            url: url.to_string(),
-            content: content.map(str::to_owned),
-            outcome,
-        });
-        while state.events.len() > MAX_EVENTS {
-            state.events.pop_front();
-        }
+    operation: Option<u64>,
+    attempt: Option<u64>,
+) -> u64 {
+    observer.next_cursor += 1;
+    let cursor = observer.next_cursor;
+    observer.events.push_back(Event {
+        cursor,
+        kind,
+        url: url.to_string(),
+        content_hash: content_identity(content).map(|value| value.hash),
+        content_len: content_identity(content).map(|value| value.len),
+        outcome,
+        operation,
+        attempt,
+        inputs: Vec::new(),
     });
+    while observer.events.len() > MAX_EVENTS {
+        if let Some(event) = observer.events.pop_front() {
+            observer.discarded_through = event.cursor;
+        }
+    }
+    cursor
+}
+
+fn with_observer(mut callback: impl FnMut(&mut Observer)) {
+    let Some(observer) = enabled_observer() else { return };
+    callback(&mut observer.lock().unwrap());
 }
 
 pub(crate) fn record_observed(url: &lsp_types::Url, content: Option<&str>) {
-    push("observed", url, content, None);
+    with_observer(|observer| {
+        if observer.session.is_empty() {
+            observer.session = session_id();
+        }
+        push(observer, "observed", url, content, None, None, None);
+    });
 }
 
-pub(crate) fn record_processed(url: &lsp_types::Url, content: &str, outcome: &'static str) {
-    push("processed", url, Some(content), Some(outcome));
+pub(crate) fn record_processed_with_inputs(
+    url: &lsp_types::Url,
+    content: Option<&str>,
+    outcome: &'static str,
+    inputs: &std::collections::HashMap<std::path::PathBuf, Option<i32>>,
+) -> u64 {
+    let mut result = 0;
+    with_observer(|observer| {
+        let attempt = {
+            observer.next_attempt += 1;
+            observer.next_attempt
+        };
+        result = push(observer, "processed", url, content, Some(outcome), None, Some(attempt));
+        if let Some(event) = observer.events.back_mut() {
+            event.inputs = inputs
+                .iter()
+                .map(|(path, version)| (path.display().to_string(), *version))
+                .collect();
+        }
+    });
+    result
 }
 
-pub(crate) fn record_applied(url: &lsp_types::Url, content: &str) {
-    push("applied", url, Some(content), Some("compiled"));
+pub(crate) fn record_applied_with_attempt(
+    url: &lsp_types::Url,
+    content: &str,
+    attempt: Option<u64>,
+) {
+    with_observer(|observer| {
+        if observer.gate_publication {
+            observer.held_publications.push((url.clone(), content.to_owned()));
+            push(observer, "gate", url, Some(content), Some("publication_reached"), None, None);
+            return;
+        }
+        record_applied_now(observer, url, content, attempt);
+    });
+}
+
+fn record_applied_now(
+    observer: &mut Observer,
+    url: &lsp_types::Url,
+    content: &str,
+    attempt: Option<u64>,
+) {
+    let attempt = attempt.unwrap_or_else(|| {
+        observer.next_attempt += 1;
+        observer.next_attempt
+    });
+    let cursor =
+        push(observer, "applied", url, Some(content), Some("compiled"), None, Some(attempt));
+    observer.installed = Some(Installed {
+        url: url.to_string(),
+        content: content_identity(Some(content)),
+        cursor,
+        attempt,
+    });
 }
 
 pub(crate) fn record_write() {
-    STATE.with_borrow_mut(|state| state.writes += 1);
+    with_observer(|observer| {
+        observer.writes += 1;
+        push(
+            observer,
+            "write",
+            &lsp_types::Url::parse("about:workspace").unwrap(),
+            None,
+            Some("written"),
+            observer.active_operation,
+            None,
+        );
+    });
+}
+
+pub(crate) fn record_accepted_edit() -> u64 {
+    let mut operation = 0;
+    with_observer(|observer| {
+        operation = observer.active_operation.unwrap_or_else(|| {
+            observer.next_operation = observer.next_operation.saturating_add(1);
+            observer.pending_operations += 1;
+            observer.next_operation
+        });
+        observer.active_operation = Some(operation);
+        observer.accepted_edits += 1;
+        push(
+            observer,
+            "edit",
+            &lsp_types::Url::parse("about:workspace").unwrap(),
+            None,
+            Some("accepted"),
+            Some(operation),
+            None,
+        );
+    });
+    operation
+}
+
+pub(crate) fn record_edit_completed(operation: u64, outcome: &'static str) {
+    with_observer(|observer| {
+        observer.pending_operations = observer.pending_operations.saturating_sub(1);
+        if observer.active_operation == Some(operation) {
+            observer.active_operation = None;
+        }
+        push(
+            observer,
+            "action",
+            &lsp_types::Url::parse("about:action").unwrap(),
+            None,
+            Some(outcome),
+            Some(operation),
+            None,
+        );
+    });
+}
+
+pub(crate) fn should_hold_source(url: &lsp_types::Url, content: &str) -> bool {
+    let Some(observer) = enabled_observer() else { return false };
+    let mut observer = observer.lock().unwrap();
+    if !observer.gate_source {
+        return false;
+    }
+    observer.held_sources.push((url.clone(), content.to_owned()));
+    push(&mut observer, "gate", url, Some(content), Some("source_reached"), None, None);
+    true
+}
+
+fn pump() {
+    let Some(observer) = enabled_observer() else { return };
+    let (sources, publications) = {
+        let mut observer = observer.lock().unwrap();
+        if observer.gate_source || observer.gate_publication {
+            return;
+        }
+        (
+            std::mem::take(&mut observer.held_sources),
+            std::mem::take(&mut observer.held_publications),
+        )
+    };
+    for (url, content) in sources {
+        super::set_contents(&i_slint_live_preview::protocol::VersionedUrl::new(url, None), content);
+    }
+    if !publications.is_empty() {
+        with_observer(|observer| {
+            for (url, content) in &publications {
+                record_applied_now(observer, url, content, None);
+            }
+        });
+    }
+}
+
+fn matching(
+    event: &Event,
+    url: &lsp_types::Url,
+    expected: Option<&str>,
+    outcome: Option<&str>,
+) -> bool {
+    event.url == url.as_str()
+        && event.content_hash == content_identity(expected).map(|value| value.hash)
+        && event.content_len == content_identity(expected).map(|value| value.len)
+        && outcome.is_none_or(|outcome| event.outcome == Some(outcome))
+}
+
+#[derive(serde::Deserialize)]
+struct Request {
+    id: u64,
+    protocol: u32,
+    session: Option<String>,
+    mode: Mode,
+    after: u64,
+    operation: Option<u64>,
+    outcome: Option<String>,
+    sources: BTreeMap<lsp_types::Url, Option<String>>,
+    gate: Option<String>,
+    release: bool,
+    gate_control: bool,
+    begin_action: bool,
+}
+
+#[derive(Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Mode {
+    Handshake,
+    Checkpoint,
+    Processed,
+    Applied,
+    Settled,
+    Gate,
+    Finish,
 }
 
 fn response(request: &Request) -> serde_json::Value {
-    STATE.with_borrow(|state| {
-        let session = state.session.clone();
-        let cursor = state.next_cursor;
-        if matches!(request.mode, Mode::Checkpoint) {
-            return serde_json::json!({
-                "id": request.id,
-                "protocol": PROTOCOL_VERSION,
-                "session": session,
-                "cursor": cursor,
-                "writes": state.writes,
-                "ready": true,
-            });
+    let Some(observer) = observer() else {
+        return serde_json::json!({ "id": request.id, "error": "observer disabled" });
+    };
+    let mut observer = observer.lock().unwrap();
+    if request.protocol != PROTOCOL_VERSION && !matches!(request.mode, Mode::Handshake) {
+        return serde_json::json!({ "id": request.id, "error": "protocol mismatch" });
+    }
+    if !matches!(request.mode, Mode::Handshake)
+        && request.session.as_deref() != Some(observer.session.as_str())
+    {
+        return serde_json::json!({ "id": request.id, "error": "stale session" });
+    }
+    if request.after > observer.next_cursor {
+        return serde_json::json!({ "id": request.id, "error": "future cursor" });
+    }
+    if request.after < observer.discarded_through {
+        return serde_json::json!({ "id": request.id, "error": "event history overflow" });
+    }
+    if observer.session.is_empty() {
+        observer.session = session_id();
+    }
+    if let Some(gate) = &request.gate {
+        match gate.as_str() {
+            "source" => observer.gate_source = !request.release,
+            "publication" => observer.gate_publication = !request.release,
+            _ => return serde_json::json!({ "id": request.id, "error": "unknown gate" }),
         }
-
-        let matching = |kind: &str| {
-            request.sources.iter().all(|(url, expected)| {
-                state.events.iter().any(|event| {
-                    event.cursor > request.after
-                        && event.kind == kind
-                        && event.url == url.as_str()
-                        && event.content.as_deref() == Some(expected.as_str())
-                        && request.outcome.as_deref().is_none_or(|outcome| {
-                            event.outcome == Some(outcome)
+    }
+    let cursor = observer.next_cursor;
+    if matches!(request.mode, Mode::Handshake) {
+        return serde_json::json!({ "id": request.id, "protocol": PROTOCOL_VERSION, "session": observer.session, "cursor": cursor, "writes": observer.writes, "ready": true });
+    }
+    if matches!(request.mode, Mode::Checkpoint) && request.begin_action {
+        observer.next_operation = observer.next_operation.saturating_add(1);
+        observer.pending_operations += 1;
+        observer.active_operation = Some(observer.next_operation);
+    }
+    if matches!(request.mode, Mode::Finish) {
+        let Some(operation) = request.operation else {
+            return serde_json::json!({ "id": request.id, "error": "missing operation" });
+        };
+        observer.pending_operations = observer.pending_operations.saturating_sub(1);
+        let outcome = match request.outcome.as_deref() {
+            Some("canceled") => Some("canceled"),
+            Some("rejected") => Some("rejected"),
+            Some("noop") => Some("noop"),
+            Some("completed") => Some("completed"),
+            _ => None,
+        };
+        push(
+            &mut observer,
+            "action",
+            &lsp_types::Url::parse("about:action").unwrap(),
+            None,
+            outcome,
+            Some(operation),
+            None,
+        );
+        return serde_json::json!({ "id": request.id, "protocol": PROTOCOL_VERSION, "session": observer.session, "cursor": observer.next_cursor, "writes": observer.writes, "accepted_edits": observer.accepted_edits, "ready": true, "operation": operation });
+    }
+    let source_matches = |kind: &str| {
+        request.sources.iter().all(|(url, expected)| {
+            observer.events.iter().any(|event| {
+                event.cursor > request.after
+                    && event.kind == kind
+                    && matching(event, url, expected.as_deref(), request.outcome.as_deref())
+            })
+        })
+    };
+    let current_matches = request.sources.iter().all(|(url, expected)| {
+        observer.installed.as_ref().is_some_and(|installed| {
+            installed.url == url.as_str()
+                && installed.content == content_identity(expected.as_deref())
+        })
+    });
+    let ready = match request.mode {
+        Mode::Checkpoint => true,
+        Mode::Processed => source_matches("processed"),
+        Mode::Applied => current_matches && (request.after == 0 || source_matches("applied")),
+        Mode::Settled => {
+            current_matches
+                && request.operation.is_some_and(|operation| {
+                    observer.pending_operations == 0
+                        && observer.events.iter().any(|event| {
+                            event.operation == Some(operation)
+                                && event.outcome == request.outcome.as_deref()
                         })
                 })
+        }
+        Mode::Gate if request.gate_control => true,
+        Mode::Gate => request.gate.as_deref().is_some_and(|gate| {
+            observer.events.iter().any(|event| {
+                event.kind == "gate"
+                    && event.outcome
+                        == Some(match gate {
+                            "source" => "source_reached",
+                            "publication" => "publication_reached",
+                            _ => "",
+                        })
             })
-        };
-        let ready = match request.mode {
-            Mode::Processed => matching("processed"),
-            Mode::Applied => matching("applied"),
-            Mode::Settled => matching("applied"),
-            Mode::Checkpoint => true,
-        };
-        serde_json::json!({
-            "id": request.id,
-            "protocol": PROTOCOL_VERSION,
-            "session": session,
-            "cursor": cursor,
-            "writes": state.writes,
-            "ready": ready,
-            "overflow": request.after != 0
-                && state.events.front().is_some_and(|event| request.after < event.cursor),
-            "events": state.events.iter().filter(|event| event.cursor > request.after).collect::<Vec<_>>(),
-        })
+        }),
+        Mode::Handshake | Mode::Finish => true,
+    };
+    serde_json::json!({
+        "id": request.id,
+        "protocol": PROTOCOL_VERSION,
+        "session": observer.session,
+        "cursor": cursor,
+        "writes": observer.writes,
+        "accepted_edits": observer.accepted_edits,
+        "ready": ready,
+        "events": observer.events.iter().filter(|event| event.cursor > request.after).take(32).collect::<Vec<_>>(),
+        "installed_attempt": observer.installed.as_ref().map(|installed| installed.attempt),
+        "installed_cursor": observer.installed.as_ref().map(|installed| installed.cursor),
+        "operation": observer.active_operation,
     })
 }
 
 pub(super) fn initialize() {
     let Some(directory) = std::env::var_os("SLINT_EDITOR_TEST_SYNC") else { return };
+    let observer = Arc::new(Mutex::new(Observer { session: session_id(), ..Default::default() }));
+    let _ = OBSERVER.set(observer);
     let directory = std::path::PathBuf::from(directory);
-    STATE.with_borrow_mut(|state| state.session = session_id());
-    thread_local! {
-        static TIMER: slint::Timer = slint::Timer::default();
-    }
+    thread_local! { static TIMER: slint::Timer = slint::Timer::default(); }
     TIMER.with(|timer| {
         timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(20), move || {
+            pump();
             let Ok(bytes) = std::fs::read(directory.join("request.json")) else { return };
-            let Ok(request) = serde_json::from_slice::<Request>(&bytes) else { return };
-            let response = response(&request);
+            let Ok(request) = serde_json::from_slice::<Request>(&bytes) else {
+                let id = serde_json::from_slice::<serde_json::Value>(&bytes)
+                    .ok()
+                    .and_then(|value| value.get("id").and_then(serde_json::Value::as_u64))
+                    .unwrap_or_default();
+                let result = serde_json::json!({
+                    "id": id,
+                    "protocol": PROTOCOL_VERSION,
+                    "error": "malformed request"
+                });
+                let temporary = directory.join("response.tmp");
+                if std::fs::write(&temporary, result.to_string()).is_ok() {
+                    let _ = std::fs::rename(temporary, directory.join("response.json"));
+                }
+                return;
+            };
+            let result = response(&request);
             let temporary = directory.join("response.tmp");
-            if std::fs::write(&temporary, response.to_string()).is_ok() {
+            if std::fs::write(&temporary, result.to_string()).is_ok() {
                 let _ = std::fs::rename(temporary, directory.join("response.json"));
             }
-        });
+        })
     });
 }
 
@@ -180,29 +481,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn lifecycle_events_are_revision_specific() {
+    fn current_installation_and_shared_writes_are_authoritative() {
+        let observer =
+            Arc::new(Mutex::new(Observer { session: "test".into(), ..Default::default() }));
+        let _ = OBSERVER.set(observer);
         let url = lsp_types::Url::parse("file:///tmp/Main.slint").unwrap();
-        STATE.with_borrow_mut(|state| *state = State::default());
-        record_observed(&url, Some("old"));
-        record_processed(&url, "old", "compile_error");
-        record_observed(&url, Some("new"));
-        record_processed(&url, "new", "compiled");
-        record_applied(&url, "new");
-        let request = Request {
+        record_applied_with_attempt(&url, "A", None);
+        record_applied_with_attempt(&url, "B", None);
+        let req = Request {
             id: 1,
-            mode: Mode::Processed,
-            after: 1,
-            outcome: Some("compiled".into()),
-            sources: [(url.clone(), "new".into())].into(),
-        };
-        assert_eq!(response(&request)["ready"], true);
-        let old_request = Request {
-            id: 2,
-            mode: Mode::Processed,
+            protocol: 2,
+            session: Some("test".into()),
+            mode: Mode::Applied,
             after: 0,
-            outcome: Some("compile_error".into()),
-            sources: [(url, "old".into())].into(),
+            operation: None,
+            outcome: None,
+            sources: [(url, Some("A".into()))].into(),
+            gate: None,
+            release: false,
+            gate_control: false,
+            begin_action: false,
         };
-        assert_eq!(response(&old_request)["ready"], true);
+        assert!(!response(&req)["ready"].as_bool().unwrap());
+        let thread = std::thread::spawn(record_write);
+        thread.join().unwrap();
+        assert_eq!(
+            response(&Request {
+                id: 2,
+                mode: Mode::Checkpoint,
+                protocol: 2,
+                session: Some("test".into()),
+                after: 0,
+                operation: None,
+                outcome: None,
+                sources: BTreeMap::new(),
+                gate: None,
+                release: false,
+                gate_control: false,
+                begin_action: false
+            })["writes"],
+            1
+        );
     }
 }

--- a/tools/editor/preview/ui/file_tree.rs
+++ b/tools/editor/preview/ui/file_tree.rs
@@ -102,6 +102,7 @@ impl FileTreeController {
             api.set_image_nine_slice_right(0);
             api.set_image_nine_slice_bottom(0);
             api.set_image_nine_slice_left(0);
+            crate::preview::invalidate_preview_generation();
             api.set_editor_surface_mode(EditorSurfaceMode::Image);
         }
     }
@@ -168,6 +169,7 @@ pub(in crate::preview) fn open_project(
     if let Some(file_tree) = controller.borrow().as_ref() {
         file_tree.publish(project);
     }
+    crate::preview::invalidate_preview_generation();
     api.set_editor_surface_mode(EditorSurfaceMode::Component);
     api.set_startup_wizard_visible(false);
 }
@@ -187,6 +189,7 @@ pub(in crate::preview) fn open_preview(
     if selected && let Some(file_tree) = controller.borrow().as_ref() {
         file_tree.publish(project);
     }
+    crate::preview::invalidate_preview_generation();
     api.set_editor_surface_mode(EditorSurfaceMode::Component);
     api.set_startup_wizard_visible(false);
 }

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -30,7 +30,7 @@ fn content_hash(content: &str) -> u64 {
 fn prepare_history_edit(
     document_cache: &i_slint_editor_preview::DocumentCache,
     item: &EditItem,
-) -> Option<(lsp_types::WorkspaceEdit, FileHashes)> {
+) -> Option<(lsp_types::WorkspaceEdit, FileHashes, Vec<text_edit::EditedText>)> {
     for (url, expected) in &item.file_hashes {
         let document = document_cache.get_document(url)?;
         let cached = document.node.as_ref()?.source_file.source()?;
@@ -41,7 +41,7 @@ fn prepare_history_edit(
     }
     let result = text_edit::apply_workspace_edit(document_cache, &item.edit).ok()?;
     let reverse = text_edit::reversed_edit(document_cache, &item.edit)?;
-    Some((reverse, compute_file_hashes(&result)))
+    Some((reverse, compute_file_hashes(&result), result))
 }
 
 #[derive(Default)]
@@ -55,23 +55,6 @@ impl UndoRedoStack {
     pub fn clear(&mut self) {
         self.undo_stack.clear();
         self.redo_stack.clear();
-    }
-
-    pub fn push(
-        &mut self,
-        title: String,
-        reverse_edit: Option<lsp_types::WorkspaceEdit>,
-        file_hashes: FileHashes,
-    ) {
-        match reverse_edit {
-            Some(edit) => {
-                self.undo_stack.push(EditItem { title, edit, file_hashes });
-                self.redo_stack.clear();
-            }
-            None => {
-                self.clear();
-            }
-        }
     }
 
     pub fn check_set_contents_valid(&mut self, url: &lsp_types::Url, content: &str) -> bool {
@@ -98,14 +81,14 @@ impl UndoRedoStack {
                     self.clear();
                 }
             }
-            PendingEdit::Undo { original: _, replacement } => {
+            PendingEdit::Undo { replacement } => {
                 if self.undo_stack.pop().is_some() {
                     self.redo_stack.push(replacement);
                 } else {
                     self.clear();
                 }
             }
-            PendingEdit::Redo { original: _, replacement } => {
+            PendingEdit::Redo { replacement } => {
                 if self.redo_stack.pop().is_some() {
                     self.undo_stack.push(replacement);
                 } else {
@@ -121,11 +104,12 @@ impl UndoRedoStack {
 /// write, so a rejected edit cannot strand an undo or redo entry.
 pub(super) enum PendingEdit {
     New(Option<EditItem>),
-    Undo { original: EditItem, replacement: EditItem },
-    Redo { original: EditItem, replacement: EditItem },
+    Undo { replacement: EditItem },
+    Redo { replacement: EditItem },
 }
 
 pub(super) struct PendingWorkspaceEdit {
+    pub(super) id: u64,
     pub(super) history: PendingEdit,
 }
 
@@ -155,7 +139,9 @@ pub fn setup(api: &ui::Api<'_>) {
             let Some(edit) = state.undo_redo_stack.undo_stack.last().cloned() else {
                 return;
             };
-            let Some((reverse, file_hashes)) = prepare_history_edit(&document_cache, &edit) else {
+            let Some((reverse, file_hashes, expected)) =
+                prepare_history_edit(&document_cache, &edit)
+            else {
                 #[cfg(feature = "system-testing")]
                 super::test_sync::effect("rejected");
                 state.undo_redo_stack.clear();
@@ -167,7 +153,8 @@ pub fn setup(api: &ui::Api<'_>) {
                 state,
                 format!("Undo \"{}\"", edit.title),
                 edit.edit.clone(),
-                PendingEdit::Undo { original: edit, replacement },
+                PendingEdit::Undo { replacement },
+                expected.into_iter().map(|e| (e.url, e.contents)).collect(),
             );
         })
     });
@@ -181,7 +168,9 @@ pub fn setup(api: &ui::Api<'_>) {
             let Some(edit) = state.undo_redo_stack.redo_stack.last().cloned() else {
                 return;
             };
-            let Some((reverse, file_hashes)) = prepare_history_edit(&document_cache, &edit) else {
+            let Some((reverse, file_hashes, expected)) =
+                prepare_history_edit(&document_cache, &edit)
+            else {
                 #[cfg(feature = "system-testing")]
                 super::test_sync::effect("rejected");
                 state.undo_redo_stack.clear();
@@ -193,7 +182,8 @@ pub fn setup(api: &ui::Api<'_>) {
                 state,
                 format!("Redo \"{}\"", edit.title),
                 edit.edit.clone(),
-                PendingEdit::Redo { original: edit, replacement },
+                PendingEdit::Redo { replacement },
+                expected.into_iter().map(|e| (e.url, e.contents)).collect(),
             );
         })
     });
@@ -214,6 +204,13 @@ pub(super) fn discard_pending(state: &mut super::PreviewState, partial_write: bo
         state.undo_redo_stack.clear();
     }
     set_undo_redo_enabled(state);
+}
+
+pub(super) fn cancel_pending(state: &mut super::PreviewState) {
+    for _history in state.pending_history.drain(..) {
+        #[cfg(feature = "system-testing")]
+        _history.work.run(|| super::test_sync::effect("canceled"));
+    }
 }
 
 pub(super) fn apply_pending() {

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -4,17 +4,15 @@
 use super::ui;
 use core::hash::{Hash as _, Hasher as _};
 use i_slint_editor_preview::editing::text_edit;
-use i_slint_live_preview::protocol::PreviewToLspMessage;
-
 use std::collections::HashMap;
 
 type FileHashes = HashMap<lsp_types::Url, u64>;
 
 #[derive(Clone)]
-struct EditItem {
-    title: String,
-    edit: lsp_types::WorkspaceEdit,
-    file_hashes: FileHashes,
+pub(super) struct EditItem {
+    pub(super) title: String,
+    pub(super) edit: lsp_types::WorkspaceEdit,
+    pub(super) file_hashes: FileHashes,
 }
 
 pub fn compute_file_hashes(
@@ -89,6 +87,61 @@ impl UndoRedoStack {
         }
         ok
     }
+
+    fn commit(&mut self, pending: PendingEdit) {
+        match pending {
+            PendingEdit::New(item) => {
+                if let Some(item) = item {
+                    self.undo_stack.push(item);
+                    self.redo_stack.clear();
+                } else {
+                    self.clear();
+                }
+            }
+            PendingEdit::Undo { original: _, replacement } => {
+                if self.undo_stack.pop().is_some() {
+                    self.redo_stack.push(replacement);
+                } else {
+                    self.clear();
+                }
+            }
+            PendingEdit::Redo { original: _, replacement } => {
+                if self.redo_stack.pop().is_some() {
+                    self.undo_stack.push(replacement);
+                } else {
+                    self.clear();
+                }
+            }
+        }
+    }
+}
+
+/// The history mutation associated with the one workspace edit currently in
+/// flight. The stacks stay unchanged until the editor confirms the filesystem
+/// write, so a rejected edit cannot strand an undo or redo entry.
+pub(super) enum PendingEdit {
+    New(Option<EditItem>),
+    Undo { original: EditItem, replacement: EditItem },
+    Redo { original: EditItem, replacement: EditItem },
+}
+
+pub(super) struct PendingWorkspaceEdit {
+    pub(super) history: PendingEdit,
+}
+
+pub(super) struct PendingHistory {
+    redo: bool,
+    #[cfg(feature = "system-testing")]
+    work: super::test_sync::Work,
+}
+impl PendingHistory {
+    fn new(redo: bool) -> Self {
+        Self {
+            redo,
+            #[cfg(feature = "system-testing")]
+            work: super::test_sync::Work::capture("queued history"),
+        }
+    }
 }
 
 pub fn setup(api: &ui::Api<'_>) {
@@ -96,70 +149,71 @@ pub fn setup(api: &ui::Api<'_>) {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
             if state.workspace_edit_sent {
-                state.pending_history.push_back(false);
+                state.pending_history.push_back(PendingHistory::new(false));
                 return;
             }
-            let Some(edit) = state.undo_redo_stack.undo_stack.pop() else {
+            let Some(edit) = state.undo_redo_stack.undo_stack.last().cloned() else {
                 return;
             };
             let Some((reverse, file_hashes)) = prepare_history_edit(&document_cache, &edit) else {
+                #[cfg(feature = "system-testing")]
+                super::test_sync::effect("rejected");
                 state.undo_redo_stack.clear();
                 set_undo_redo_enabled(state);
                 return;
             };
-            state.undo_redo_stack.redo_stack.push(EditItem {
-                title: edit.title.clone(),
-                edit: reverse,
-                file_hashes,
-            });
-            state
-                .to_lsp
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .send(&PreviewToLspMessage::SendWorkspaceEdit {
-                    label: Some(format!("Undo \"{}\"", edit.title)),
-                    edit: edit.edit,
-                })
-                .unwrap();
-            set_undo_redo_enabled(state);
-            state.workspace_edit_sent = true;
+            let replacement = EditItem { title: edit.title.clone(), edit: reverse, file_hashes };
+            super::dispatch_workspace_edit(
+                state,
+                format!("Undo \"{}\"", edit.title),
+                edit.edit.clone(),
+                PendingEdit::Undo { original: edit, replacement },
+            );
         })
     });
     api.on_redo(|| {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
             if state.workspace_edit_sent {
-                state.pending_history.push_back(true);
+                state.pending_history.push_back(PendingHistory::new(true));
                 return;
             }
-            let Some(edit) = state.undo_redo_stack.redo_stack.pop() else {
+            let Some(edit) = state.undo_redo_stack.redo_stack.last().cloned() else {
                 return;
             };
             let Some((reverse, file_hashes)) = prepare_history_edit(&document_cache, &edit) else {
+                #[cfg(feature = "system-testing")]
+                super::test_sync::effect("rejected");
                 state.undo_redo_stack.clear();
                 set_undo_redo_enabled(state);
                 return;
             };
-            state.undo_redo_stack.undo_stack.push(EditItem {
-                title: edit.title.clone(),
-                edit: reverse,
-                file_hashes,
-            });
-            state
-                .to_lsp
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .send(&PreviewToLspMessage::SendWorkspaceEdit {
-                    label: Some(format!("Redo \"{}\"", edit.title)),
-                    edit: edit.edit,
-                })
-                .unwrap();
-            set_undo_redo_enabled(state);
-            state.workspace_edit_sent = true;
+            let replacement = EditItem { title: edit.title.clone(), edit: reverse, file_hashes };
+            super::dispatch_workspace_edit(
+                state,
+                format!("Redo \"{}\"", edit.title),
+                edit.edit.clone(),
+                PendingEdit::Redo { original: edit, replacement },
+            );
         })
     });
+}
+
+pub(super) fn commit_pending(state: &mut super::PreviewState) {
+    if let Some(pending) = state.pending_workspace_edit.take() {
+        state.undo_redo_stack.commit(pending.history);
+    }
+    set_undo_redo_enabled(state);
+}
+
+pub(super) fn discard_pending(state: &mut super::PreviewState, partial_write: bool) {
+    state.pending_workspace_edit.take();
+    if partial_write {
+        // Some files reached disk and others did not. The source and the
+        // cached document can no longer identify a reversible history state.
+        state.undo_redo_stack.clear();
+    }
+    set_undo_redo_enabled(state);
 }
 
 pub(super) fn apply_pending() {
@@ -171,11 +225,17 @@ pub(super) fn apply_pending() {
             Some((state.api.upgrade()?, state.pending_history.pop_front()?))
         });
         let Some((api, redo)) = next else { return };
-        if redo {
-            api.invoke_redo();
-        } else {
-            api.invoke_undo();
-        }
+        let invoke = || {
+            if redo.redo {
+                api.invoke_redo();
+            } else {
+                api.invoke_undo();
+            }
+        };
+        #[cfg(feature = "system-testing")]
+        redo.work.run(invoke);
+        #[cfg(not(feature = "system-testing"))]
+        invoke();
     }
 }
 

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -108,11 +108,6 @@ pub(super) enum PendingEdit {
     Redo { replacement: EditItem },
 }
 
-pub(super) struct PendingWorkspaceEdit {
-    pub(super) id: u64,
-    pub(super) history: PendingEdit,
-}
-
 pub(super) struct PendingHistory {
     redo: bool,
     #[cfg(feature = "system-testing")]
@@ -132,7 +127,7 @@ pub fn setup(api: &ui::Api<'_>) {
     api.on_undo(|| {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
-            if state.workspace_edit_sent {
+            if state.pending_edit.is_some() {
                 state.pending_history.push_back(PendingHistory::new(false));
                 return;
             }
@@ -161,7 +156,7 @@ pub fn setup(api: &ui::Api<'_>) {
     api.on_redo(|| {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
-            if state.workspace_edit_sent {
+            if state.pending_edit.is_some() {
                 state.pending_history.push_back(PendingHistory::new(true));
                 return;
             }
@@ -190,14 +185,14 @@ pub fn setup(api: &ui::Api<'_>) {
 }
 
 pub(super) fn commit_pending(state: &mut super::PreviewState) {
-    if let Some(pending) = state.pending_workspace_edit.take() {
-        state.undo_redo_stack.commit(pending.history);
+    if let Some(history) = state.pending_edit.as_mut().and_then(|edit| edit.acknowledge()) {
+        state.undo_redo_stack.commit(history);
     }
     set_undo_redo_enabled(state);
 }
 
 pub(super) fn discard_pending(state: &mut super::PreviewState, may_have_changed: bool) {
-    state.pending_workspace_edit.take();
+    state.pending_edit.take();
     if may_have_changed {
         // A failed write may leave partial source, so the cached document
         // can no longer identify a reversible history state.
@@ -216,7 +211,7 @@ pub(super) fn cancel_pending(state: &mut super::PreviewState) {
 pub(super) fn apply_pending() {
     loop {
         let next = super::PREVIEW_STATE.with_borrow_mut(|state| {
-            if state.workspace_edit_sent {
+            if state.pending_edit.is_some() {
                 return None;
             }
             Some((state.api.upgrade()?, state.pending_history.pop_front()?))

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -196,11 +196,11 @@ pub(super) fn commit_pending(state: &mut super::PreviewState) {
     set_undo_redo_enabled(state);
 }
 
-pub(super) fn discard_pending(state: &mut super::PreviewState, partial_write: bool) {
+pub(super) fn discard_pending(state: &mut super::PreviewState, may_have_changed: bool) {
     state.pending_workspace_edit.take();
-    if partial_write {
-        // Some files reached disk and others did not. The source and the
-        // cached document can no longer identify a reversible history state.
+    if may_have_changed {
+        // A failed write may leave partial source, so the cached document
+        // can no longer identify a reversible history state.
         state.undo_redo_stack.clear();
     }
     set_undo_redo_enabled(state);

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -143,7 +143,7 @@ pub fn setup(api: &ui::Api<'_>) {
                 prepare_history_edit(&document_cache, &edit)
             else {
                 #[cfg(feature = "system-testing")]
-                super::test_sync::effect("rejected");
+                super::test_sync::effect(super::test_sync::Outcome::Rejected);
                 state.undo_redo_stack.clear();
                 set_undo_redo_enabled(state);
                 return;
@@ -172,7 +172,7 @@ pub fn setup(api: &ui::Api<'_>) {
                 prepare_history_edit(&document_cache, &edit)
             else {
                 #[cfg(feature = "system-testing")]
-                super::test_sync::effect("rejected");
+                super::test_sync::effect(super::test_sync::Outcome::Rejected);
                 state.undo_redo_stack.clear();
                 set_undo_redo_enabled(state);
                 return;
@@ -209,7 +209,7 @@ pub(super) fn discard_pending(state: &mut super::PreviewState, may_have_changed:
 pub(super) fn cancel_pending(state: &mut super::PreviewState) {
     for _history in state.pending_history.drain(..) {
         #[cfg(feature = "system-testing")]
-        _history.work.run(|| super::test_sync::effect("canceled"));
+        _history.work.run(|| super::test_sync::effect(super::test_sync::Outcome::Canceled));
     }
 }
 

--- a/tools/editor/source_write.rs
+++ b/tools/editor/source_write.rs
@@ -1,0 +1,105 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+use std::io::{self, Write};
+use std::path::Path;
+
+#[derive(Debug)]
+pub(crate) struct WriteFailure {
+    pub error: io::Error,
+    pub may_have_changed: bool,
+}
+
+#[cfg(any(test, feature = "system-testing"))]
+#[derive(Clone, Copy, Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WriteFault {
+    BeforeOpen,
+    AfterTruncate,
+    AfterBytes(usize),
+}
+
+pub(crate) fn write_source(
+    path: &Path,
+    contents: &[u8],
+    #[cfg(any(test, feature = "system-testing"))] fault: Option<WriteFault>,
+) -> Result<(), WriteFailure> {
+    let mut may_have_changed = false;
+    let result = (|| {
+        #[cfg(any(test, feature = "system-testing"))]
+        if matches!(fault, Some(WriteFault::BeforeOpen)) {
+            return Err(io::Error::other("injected failure before opening source"));
+        }
+        let mut file = match std::fs::OpenOptions::new().write(true).open(path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                // Creation can affect the filesystem even if it reports an error.
+                may_have_changed = true;
+                std::fs::OpenOptions::new().write(true).create_new(true).open(path)?
+            }
+            Err(error) => return Err(error),
+        };
+        // A failed truncation may already have changed the file.
+        may_have_changed = true;
+        file.set_len(0)?;
+        #[cfg(any(test, feature = "system-testing"))]
+        match fault {
+            Some(WriteFault::AfterTruncate) => {
+                return Err(io::Error::other("injected failure after truncating source"));
+            }
+            Some(WriteFault::AfterBytes(count)) => {
+                file.write_all(&contents[..count.min(contents.len())])?;
+                return Err(io::Error::other("injected failure after partial source write"));
+            }
+            _ => {}
+        }
+        file.write_all(contents)
+    })();
+    result.map_err(|error| WriteFailure { error, may_have_changed })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failures_preserve_mutation_evidence() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.slint");
+        for (fault, expected, mutated) in [
+            (WriteFault::BeforeOpen, &b"original"[..], false),
+            (WriteFault::AfterTruncate, &b""[..], true),
+            (WriteFault::AfterBytes(3), &b"rep"[..], true),
+        ] {
+            std::fs::write(&path, b"original").unwrap();
+            let failure = write_source(&path, b"replacement", Some(fault)).unwrap_err();
+            assert_eq!(failure.may_have_changed, mutated);
+            assert_eq!(std::fs::read(&path).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn failed_open_does_not_claim_mutation() {
+        let directory = tempfile::tempdir().unwrap();
+        let failure = write_source(directory.path(), b"replacement", None).unwrap_err();
+        assert!(!failure.may_have_changed);
+    }
+
+    #[test]
+    fn failed_creation_is_conservatively_a_possible_mutation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("missing/source.slint");
+        let failure = write_source(&path, b"replacement", None).unwrap_err();
+        assert!(failure.may_have_changed);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn successful_write_truncates_and_can_create() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("source.slint");
+        write_source(&path, b"original", None).unwrap();
+        write_source(&path, b"new", None).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
+    }
+}

--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -102,7 +102,9 @@ existing causal lease ends on installation or retirement; releasing a retired
 factory cannot install it. The `acknowledgment` gate holds the real local edit
 response and exposes its edit ID. Only a matching response and an installation
 containing that edit's input revisions can complete a pending edit. Installation
-abandonment cancels queued history and allows an acknowledged edit to settle.
+abandonment cancels queued history and allows an acknowledged edit to settle. Ordinary source supersession is terminal only after a later instance is installed and, after the write acknowledgment, its edited-file inputs match current disk. This also covers watcher coalescing that skips the written revision. The disk comparison runs at edit completion, like history validation; test waits do not trigger a reload. Supersession cancels queued history and discards history based on the replaced source.
+
+The observer keeps the last successful attempt for diagnostics separately from whether an instance is mounted. Image-mode switches and factory callbacks that return no component clear mounted state. Applied waits require a mounted instance, including while an external reload is held at the factory gate.
 
 To prove that pointer-down owns work, leave the action context before checking
 its pending state. An unsealed action is pending even without a gesture token.
@@ -158,7 +160,7 @@ across files; earlier successful writes remain when a later file fails.
 | F14 | partial | Lookups without waits and deadline-aware polling exist. These do not make every multi-probe UI read an atomic snapshot. |
 | F15 | fixed | First-window acquisition uses a bounded condition wait; lifecycle requests also check process exit. |
 | F16 | fixed | Session, cursor, actual attempt inputs, installed identity, edit IDs, and causal leases distinguish the milestones. |
-| F17 | fixed | Each worker uses a copied binary with checksum, build revision, features, and required protocol handshake. Shell live preview is disabled. |
+| F17 | fixed | Each worker uses a copied binary with a streamed checksum cached for that immutable path, build revision, features, and required protocol handshake. Shell live preview is disabled. |
 | F18 | partial | Handles are reacquired at migrated replacement boundaries. Direct multi-property reads still require a test-controlled stable boundary. |
 | F19 | fixed | Every process gets a private settings directory and pinned defaults. |
 | F20 | fixed | Initial broken-source recovery acknowledges the startup failure before repair. |

--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -65,7 +65,7 @@ write and use the revision-specific API:
 checkpoint = current_editor_sync.get().checkpoint()
 source.write_bytes(broken)
 current_editor_sync.get().wait_for_processed(
-    source, broken, after=checkpoint["cursor"], outcome="compile_error"
+    source, broken, after=checkpoint, outcome="compile_error"
 )
 ```
 
@@ -82,48 +82,113 @@ starts a reload. The editor process uses `SLINT_EDITOR_TEST_CONFIG_DIR` for a
 private settings store and records a copied binary, source revision, build
 features, and handshake in the test artifacts.
 
-Source and publication gates are available for tests that deliberately overlap
-an edit with another operation:
+Protocol version 4 also provides scoped scheduling gates. Use the context manager
+so a failed assertion releases the gate:
 
 ```python
-sync.set_gate("source")
-source.write_bytes(expected)
-sync.wait_for_gate("source", after=checkpoint.cursor)
-sync.release_gate("source")
+sync = current_editor_sync.get()
+with sync.gate("publication", source) as gate:
+    with sync.action() as edit:
+        perform_input()
+    gate.wait_for_reached()
+    # Inspect the held stage without treating it as a completed edit.
+edit.wait_for_settled(outcome="completed")
 ```
 
-Always release a gate in a `finally` block in a test that can fail while it is
-held. Gates are test-only and disabled unless the observer is opted in.
+The `source` gate holds normal external-source processing. The `publication`
+gate holds a compiled preview before factory assignment. The `factory` gate
+holds creation after assignment, before invoking the component factory. Its
+existing causal lease ends on installation or retirement; releasing a retired
+factory cannot install it. The `acknowledgment` gate holds the real local edit
+response and exposes its edit ID. Only a matching response and an installation
+containing that edit's input revisions can complete a pending edit. Installation
+abandonment cancels queued history and allows an acknowledged edit to settle.
+
+To prove that pointer-down owns work, leave the action context before checking
+its pending state. An unsealed action is pending even without a gesture token.
+After cancellation, await the canceled action and assert zero writes. Dispatch
+a late release in a separate action and check it independently:
+
+```python
+with sync.action() as gesture:
+    pointer_down()
+# The operation is now sealed; its pending work must contain the gesture.
+cancel_gesture()
+gesture.wait_for_settled(outcome="canceled")
+gesture.assert_no_source_writes()
+with sync.action() as release:
+    pointer_up()
+release.assert_no_source_writes()
+snapshot.assert_unchanged_now()
+```
+
+Operations record accepted edits, completed writes, and possible file mutations
+separately. Failure opening an existing file has no mutation; attempted creation or
+truncation is conservatively a possible mutation even if the final bytes match.
+`assert_no_source_writes()` rejects any of these counters, including a completed
+write later undone. A successful edit followed by undo therefore records two
+writes even when disk content returns to the baseline.
+
+The private `write_fault` request accepts `before_open`, `after_truncate`, or
+`{"after_bytes": 5}` with a source URL. It is consumed by that file's next write.
+Always send `clear_write_fault` in `finally` to remove an unconsumed fault.
+Truncation and partial-write faults modify the real fixture file. Failure before
+mutation preserves history; possible mutation invalidates history and rereads
+source through the editor session. This is failure recovery, not a reload
+triggered by a synchronization wait. Workspace writes are not transactional
+across files; earlier successful writes remain when a later file fails.
 
 ### Audit disposition
 
 | Finding | Disposition | Current state |
 | --- | --- | --- |
-| F01 | fixed | Broken-source test waits for its exact compile error. |
-| F02 | fixed | Repair waits for the broken phase before writing the repair. |
-| F03 | defer | Root recovery remains explicitly skipped pending watcher repair. |
-| F04 | fixed | Missing imports record a missing observation and load-error attempt before restoration. |
-| F05 | partial | External revision is processed before gesture release; terminal no-write proof remains local. |
-| F06 | partial | Undo/release uses revision and write counters; full queued-history gate remains. |
-| F07 | partial | Publication gate control is exposed; rotation-specific migration remains. |
-| F08 | partial | Newest revision waits on processing and application; older-attempt scheduling gate remains. |
-| F09 | fixed | Source snapshot uses a synchronous mutation boundary instead of a timer. |
-| F10 | defer | Existing-element rendering callers need applied-generation migration. |
-| F11 | defer | Negative-observation callers require per-action terminal outcomes. |
-| F12 | defer | Redo overlap needs an external-observation gate. |
-| F13 | defer | Palette publication overlap needs a preview gate. |
-| F14 | defer | Nested UI probes still need a shared deadline and nonblocking variants. |
-| F15 | defer | First-window startup should use a bounded readiness condition. |
-| F16 | fixed | Revision-specific observer protocol covers observed, processed, and applied events. |
-| F17 | fixed | A copied executable is hashed and recorded before launch, with revision and feature metadata. |
-| F18 | partial | Sync waits are generation-aware; remaining UI callers still need migration. |
-| F19 | fixed | Each editor process has a private settings directory. |
-| F20 | fixed | Initial broken-source recovery acknowledges the startup compile error before repair. |
-| F21 | partial | Exact applied waits replace byte-change probes where migrated; remaining canvas callers need migration. |
+| F01 | fixed | Broken-source tests acknowledge the exact failed revision before checking the retained preview. |
+| F02 | fixed | Repair follows acknowledgment of the broken phase. |
+| F03 | deferred | Deleted-root recovery remains skipped; no watcher repair is included. |
+| F04 | fixed | Missing imports have an observed missing input and terminal failure before restoration. |
+| F05 | fixed | Source changes cancel the active gesture; cancellation and late release have terminal no-write checks. |
+| F06 | fixed | Undo during dragging and queued undo during pending publication have separate controlled tests. |
+| F07 | fixed | Rotation release holds publication and inspects the retained oriented canvas frame before installation. No claim is made about every intermediate rendered frame. |
+| F08 | fixed | Burst writes remain a coalescing test; separate publication and factory gates prove obsolete attempts cannot replace a newer instance. |
+| F09 | fixed | Snapshot helper tests use a controlled polling callback instead of a thread timer. |
+| F10 | fixed | Inspector rendering consumers await applied source before checking the element. |
+| F11 | partial | Cancellation and rejection tests use terminal operation counters. Remaining navigation and held-gesture `assert_unchanged_now()` calls are point-in-time disk assertions, not settlement guarantees. |
+| F12 | fixed | Redo has distinct held-source and already-applied external-edit variants. |
+| F13 | fixed | Image switching covers held publication; lifecycle tests additionally cover an assigned factory with acknowledgment before and after abandonment. |
+| F14 | partial | Lookups without waits and deadline-aware polling exist. These do not make every multi-probe UI read an atomic snapshot. |
+| F15 | fixed | First-window acquisition uses a bounded condition wait; lifecycle requests also check process exit. |
+| F16 | fixed | Session, cursor, actual attempt inputs, installed identity, edit IDs, and causal leases distinguish the milestones. |
+| F17 | fixed | Each worker uses a copied binary with checksum, build revision, features, and required protocol handshake. Shell live preview is disabled. |
+| F18 | partial | Handles are reacquired at migrated replacement boundaries. Direct multi-property reads still require a test-controlled stable boundary. |
+| F19 | fixed | Every process gets a private settings directory and pinned defaults. |
+| F20 | fixed | Initial broken-source recovery acknowledges the startup failure before repair. |
+| F21 | fixed | Palette edits use operation completion before capturing source; overlap variants deliberately retain their gates. |
 
-The remaining deferred cases require controlled source and preview publication
-gates. They must not be “fixed” by increasing a timeout or adding a silence
-window.
+Disk-only `wait_for_exact()` and held-gesture `assert_unchanged_now()` checks are
+intentional where that is the test contract. Neither proves future inactivity.
+The observer covers work caused by the specified operation, not unrelated
+future filesystem events. A coalesced revision that the editor never reads has
+no invented attempt. History and event retention are bounded; an expired cursor
+fails explicitly. Fault injection exercises controlled stages, not every
+platform-specific filesystem error or crash durability.
+
+### Validate lifecycle changes
+
+Run helper tests before application tests:
+
+```sh
+uv run pytest tests/test_editor_sync.py tests/test_source_snapshot.py
+uv run ruff check tests
+uv run ruff format --check tests
+uv run ty check tests
+```
+
+Run the affected lifecycle, transform, and history tests with `-n 1` and `-n 4`
+against the same preserved binary using `SLINT_EDITOR_BINARY`. Run the complete
+headless suite with `-n 3`. Keep replay pauses at zero. Failure artifacts include
+source differences, screenshots, observer state, and `trace.jsonl` beside the
+binary metadata. These scenarios require actual reached gates; repeated timing
+runs alone are not evidence of the intended ordering.
 
 ## Watch the Tests on a Desktop
 

--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -82,6 +82,15 @@ starts a reload. The editor process uses `SLINT_EDITOR_TEST_CONFIG_DIR` for a
 private settings store and records a copied binary, source revision, build
 features, and handshake in the test artifacts.
 
+The transport has one current request.
+Repeated control requests return the same response; observational requests recheck the current state.
+Older IDs and changed payloads reusing an ID fail explicitly.
+Only the current control response is cached; lifecycle event retention remains bounded separately.
+
+Resolve controls before opening an action, and check completed UI state after sealing and settlement.
+Keep intermediate probes inside held gestures when they assert transient behavior.
+Lifecycle tests share setup through a context manager so failures still capture screenshots and observer traces.
+
 Protocol version 4 also provides scoped scheduling gates. Use the context manager
 so a failed assertion releases the gate:
 
@@ -104,6 +113,11 @@ response and exposes its edit ID. Only a matching response and an installation
 containing that edit's input revisions can complete a pending edit. Installation
 abandonment cancels queued history and allows an acknowledged edit to settle. Ordinary source supersession is terminal only after a later instance is installed and, after the write acknowledgment, its edited-file inputs match current disk. This also covers watcher coalescing that skips the written revision. The disk comparison runs at edit completion, like history validation; test waits do not trigger a reload. Supersession cancels queued history and discards history based on the replaced source.
 
+One pending-edit record owns the edit ID, expected inputs, unacknowledged history, and installation stage.
+Acknowledgment consumes the pending history exactly once; the record remains until installation completes or is abandoned.
+Production and testing invoke the same installation operation.
+A publication gate only defers execution; installation errors use the production exit policy in either path.
+
 The observer keeps the last successful attempt for diagnostics separately from whether an instance is mounted. Image-mode switches and factory callbacks that return no component clear mounted state. Applied waits require a mounted instance, including while an external reload is held at the factory gate.
 
 To prove that pointer-down owns work, leave the action context before checking
@@ -125,7 +139,9 @@ snapshot.assert_unchanged_now()
 ```
 
 Operations record accepted edits, completed writes, and possible file mutations
-separately. Failure opening an existing file has no mutation; attempted creation or
+separately.
+A compact outcome accumulator preserves failure, completion, rejection, cancellation, and no-op precedence.
+Individual effects remain in the diagnostic event history. Failure opening an existing file has no mutation; attempted creation or
 truncation is conservatively a possible mutation even if the final bytes match.
 `assert_no_source_writes()` rejects any of these counters, including a completed
 write later undone. A successful edit followed by undo therefore records two
@@ -149,12 +165,12 @@ across files; earlier successful writes remain when a later file fails.
 | F03 | deferred | Deleted-root recovery remains skipped; no watcher repair is included. |
 | F04 | fixed | Missing imports have an observed missing input and terminal failure before restoration. |
 | F05 | fixed | Source changes cancel the active gesture; cancellation and late release have terminal no-write checks. |
-| F06 | fixed | Undo during dragging and queued undo during pending publication have separate controlled tests. |
+| F06 | fixed | Undo during dragging and queued undo during pending publication have separate controlled tests; sealed gestures cover pointer-down and movement. |
 | F07 | fixed | Rotation release holds publication and inspects the retained oriented canvas frame before installation. No claim is made about every intermediate rendered frame. |
 | F08 | fixed | Burst writes remain a coalescing test; separate publication and factory gates prove obsolete attempts cannot replace a newer instance. |
 | F09 | fixed | Snapshot helper tests use a controlled polling callback instead of a thread timer. |
 | F10 | fixed | Inspector rendering consumers await applied source before checking the element. |
-| F11 | partial | Cancellation and rejection tests use terminal operation counters. Remaining navigation and held-gesture `assert_unchanged_now()` calls are point-in-time disk assertions, not settlement guarantees. |
+| F11 | partial | Cancellation and rejection tests use terminal operation counters with input-scoped actions. Remaining navigation and held-gesture `assert_unchanged_now()` calls are point-in-time disk assertions, not settlement guarantees. |
 | F12 | fixed | Redo has distinct held-source and already-applied external-edit variants. |
 | F13 | fixed | Image switching covers held publication; lifecycle tests additionally cover an assigned factory with acknowledgment before and after abandonment. |
 | F14 | partial | Lookups without waits and deadline-aware polling exist. These do not make every multi-probe UI read an atomic snapshot. |

--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -47,18 +47,68 @@ The tests use the headless Skia backend by default, so editor windows do not app
 
 ## Wait for Edits
 
-Use `snapshot.wait_for_applied(expected, relative_path)` before an action that depends on an edit's completed preview and history update.
-It checks exact project source, then waits for matching source in the installed preview with no compilation, workspace edit, or history request pending.
-For external file writes, use `editor_sync.wait_for_source(path, expected)` to wait for the installed source directly.
+The test-only observer reports four different milestones. `observed` means the
+normal source path read a revision (or observed a missing file), `processed`
+means that exact input finished with `compiled`, `compile_error`, or another
+terminal outcome, `applied` means a successful component instance was installed,
+and `settled` covers the causal work for an action, including queued history.
+Do not use an installed-source wait to prove that a failed source was processed.
 
-`launch_editor` creates a private synchronization directory for each editor process.
-The `system-testing` build answers requests on its UI thread through `SLINT_EDITOR_TEST_SYNC`.
-Request IDs prevent an earlier response from satisfying a later wait; source comparisons prevent an older compilation from satisfying it.
-Timeout failures include the pending-work flag and documents that haven't reached the preview.
+Use `snapshot.wait_for_applied(expected, relative_path)` before an action that
+depends on an edit's completed preview and history update. For an external
+write whose failure or success phase matters, capture a checkpoint before the
+write and use the revision-specific API:
 
-Keep `wait_for_exact` for disk-only assertions and tests that deliberately send input while compilation is pending.
-Keyboard helpers dispatch immediately; put completion waits at the call sites that need them.
-Don't use completion waits for invalid source or transient drag previews, which must not become installed document revisions.
+```python
+checkpoint = current_editor_sync.get().checkpoint()
+source.write_bytes(broken)
+current_editor_sync.get().wait_for_processed(
+    source, broken, after=checkpoint["cursor"], outcome="compile_error"
+)
+```
+
+`EditorSync.action()` captures the causal boundary without delaying input.
+Use its write counter for canceled and rejected operations. Keyboard and
+pointer helpers dispatch immediately; completion waits belong at call sites
+that need them. Keep `wait_for_exact` for disk-only assertions and tests that
+deliberately send input while compilation is pending.
+
+The protocol has a session identity, version, monotonic event cursor, and a
+bounded event history. A stale cursor or history overflow fails the wait with a
+diagnostic instead of silently accepting an old event. The request path never
+starts a reload. The editor process uses `SLINT_EDITOR_TEST_CONFIG_DIR` for a
+private settings store and records the binary hash in its temporary sync
+directory.
+
+### Audit disposition
+
+| Finding | Disposition | Current state |
+| --- | --- | --- |
+| F01 | fixed | Broken-source test waits for its exact compile error. |
+| F02 | fixed | Repair waits for the broken phase before writing the repair. |
+| F03 | defer | Root recovery remains explicitly skipped pending watcher repair. |
+| F04 | defer | Import recovery still needs missing-input lifecycle coverage. |
+| F05 | partial | External revision is processed before gesture release; terminal no-write proof remains local. |
+| F06 | partial | Undo/release uses revision and write counters; full queued-history gate remains. |
+| F07 | defer | Rotation publication gate is not yet exposed. |
+| F08 | partial | Newest revision waits on processing and application; older-attempt scheduling gate remains. |
+| F09 | fixed | Source snapshot uses an explicit thread handshake instead of a timer. |
+| F10 | defer | Existing-element rendering callers need applied-generation migration. |
+| F11 | defer | Negative-observation callers require per-action terminal outcomes. |
+| F12 | defer | Redo overlap needs an external-observation gate. |
+| F13 | defer | Palette publication overlap needs a preview gate. |
+| F14 | defer | Nested UI probes still need a shared deadline and nonblocking variants. |
+| F15 | defer | First-window startup should use a bounded readiness condition. |
+| F16 | fixed | Revision-specific observer protocol covers observed, processed, and applied events. |
+| F17 | partial | Binary identity is recorded; CI artifact pinning remains external to the fixture. |
+| F18 | defer | Reload-sensitive handles still need generation-aware reacquisition. |
+| F19 | fixed | Each editor process has a private settings directory. |
+| F20 | defer | Initial failure occurs before the test checkpoint and needs startup lifecycle access. |
+| F21 | partial | Exact applied waits replace byte-change probes where migrated; remaining canvas callers need migration. |
+
+The remaining deferred cases require controlled source and preview publication
+gates. They must not be “fixed” by increasing a timeout or adding a silence
+window.
 
 ## Watch the Tests on a Desktop
 

--- a/tools/editor/ui-tests/README.md
+++ b/tools/editor/ui-tests/README.md
@@ -52,6 +52,8 @@ normal source path read a revision (or observed a missing file), `processed`
 means that exact input finished with `compiled`, `compile_error`, or another
 terminal outcome, `applied` means a successful component instance was installed,
 and `settled` covers the causal work for an action, including queued history.
+These waits are scoped to the checkpoint or operation supplied by the test;
+they do not infer completion from a quiet event loop.
 Do not use an installed-source wait to prove that a failed source was processed.
 
 Use `snapshot.wait_for_applied(expected, relative_path)` before an action that
@@ -77,8 +79,21 @@ The protocol has a session identity, version, monotonic event cursor, and a
 bounded event history. A stale cursor or history overflow fails the wait with a
 diagnostic instead of silently accepting an old event. The request path never
 starts a reload. The editor process uses `SLINT_EDITOR_TEST_CONFIG_DIR` for a
-private settings store and records the binary hash in its temporary sync
-directory.
+private settings store and records a copied binary, source revision, build
+features, and handshake in the test artifacts.
+
+Source and publication gates are available for tests that deliberately overlap
+an edit with another operation:
+
+```python
+sync.set_gate("source")
+source.write_bytes(expected)
+sync.wait_for_gate("source", after=checkpoint.cursor)
+sync.release_gate("source")
+```
+
+Always release a gate in a `finally` block in a test that can fail while it is
+held. Gates are test-only and disabled unless the observer is opted in.
 
 ### Audit disposition
 
@@ -87,12 +102,12 @@ directory.
 | F01 | fixed | Broken-source test waits for its exact compile error. |
 | F02 | fixed | Repair waits for the broken phase before writing the repair. |
 | F03 | defer | Root recovery remains explicitly skipped pending watcher repair. |
-| F04 | defer | Import recovery still needs missing-input lifecycle coverage. |
+| F04 | fixed | Missing imports record a missing observation and load-error attempt before restoration. |
 | F05 | partial | External revision is processed before gesture release; terminal no-write proof remains local. |
 | F06 | partial | Undo/release uses revision and write counters; full queued-history gate remains. |
-| F07 | defer | Rotation publication gate is not yet exposed. |
+| F07 | partial | Publication gate control is exposed; rotation-specific migration remains. |
 | F08 | partial | Newest revision waits on processing and application; older-attempt scheduling gate remains. |
-| F09 | fixed | Source snapshot uses an explicit thread handshake instead of a timer. |
+| F09 | fixed | Source snapshot uses a synchronous mutation boundary instead of a timer. |
 | F10 | defer | Existing-element rendering callers need applied-generation migration. |
 | F11 | defer | Negative-observation callers require per-action terminal outcomes. |
 | F12 | defer | Redo overlap needs an external-observation gate. |
@@ -100,10 +115,10 @@ directory.
 | F14 | defer | Nested UI probes still need a shared deadline and nonblocking variants. |
 | F15 | defer | First-window startup should use a bounded readiness condition. |
 | F16 | fixed | Revision-specific observer protocol covers observed, processed, and applied events. |
-| F17 | partial | Binary identity is recorded; CI artifact pinning remains external to the fixture. |
-| F18 | defer | Reload-sensitive handles still need generation-aware reacquisition. |
+| F17 | fixed | A copied executable is hashed and recorded before launch, with revision and feature metadata. |
+| F18 | partial | Sync waits are generation-aware; remaining UI callers still need migration. |
 | F19 | fixed | Each editor process has a private settings directory. |
-| F20 | defer | Initial failure occurs before the test checkpoint and needs startup lifecycle access. |
+| F20 | fixed | Initial broken-source recovery acknowledges the startup compile error before repair. |
 | F21 | partial | Exact applied waits replace byte-change probes where migrated; remaining canvas callers need migration. |
 
 The remaining deferred cases require controlled source and preview publication

--- a/tools/editor/ui-tests/tests/canvas_interactions.py
+++ b/tools/editor/ui-tests/tests/canvas_interactions.py
@@ -4,9 +4,15 @@
 import math
 
 import slint_testing
+from editor_sync import current_editor_sync
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
-from ui_driver import elements_with_label, wait_until, window_element_with_label
+from ui_driver import (
+    elements_with_label,
+    find_window_element_with_label,
+    wait_until,
+    window_element_with_label,
+)
 
 Frame = tuple[float, float, float, float]
 
@@ -233,32 +239,33 @@ def cancel_pointer_interaction(
             lambda: (
                 value
                 if (
-                    value := float(
-                        window_element_with_label(
-                            window, readout_label, slint_testing.AccessibleRole.Text
-                        ).accessible_value
+                    field := find_window_element_with_label(
+                        window, readout_label, slint_testing.AccessibleRole.Text
                     )
                 )
-                != initial_readout
+                is not None
+                and (value := float(field.accessible_value)) != initial_readout
                 else None
             )
         )
     snapshot.assert_unchanged_now()
 
-    window.dispatch_event(slint_testing.PointerExitedEvent())
-    window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-    if kind == "Text":
-        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
-    wait_until(
-        lambda: (
-            True
-            if same_state(selection_frame(window, frame_kind), initial_frame)
-            else None
+    with current_editor_sync.get().action() as cancellation:
+        window.dispatch_event(slint_testing.PointerExitedEvent())
+        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+        if kind == "Text":
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Shift))
+        wait_until(
+            lambda: (
+                True
+                if same_state(selection_frame(window, frame_kind), initial_frame)
+                else None
+            )
         )
-    )
-    assert not elements_with_label(window.root_element, "Rotation angle")
-    assert not elements_with_label(window.root_element, "Radius value")
-    snapshot.assert_unchanged()
+        assert not elements_with_label(window.root_element, "Rotation angle")
+        assert not elements_with_label(window.root_element, "Radius value")
+    cancellation.assert_no_source_writes()
+    snapshot.assert_unchanged_now()
 
 
 def live_modifier_resize(
@@ -327,13 +334,12 @@ def manual_radius_drag(
         lambda: (
             value
             if (
-                value := float(
-                    window_element_with_label(
-                        window, "Radius value", slint_testing.AccessibleRole.Text
-                    ).accessible_value
+                field := find_window_element_with_label(
+                    window, "Radius value", slint_testing.AccessibleRole.Text
                 )
             )
-            != initial_value
+            is not None
+            and (value := float(field.accessible_value)) != initial_value
             else None
         )
     )

--- a/tools/editor/ui-tests/tests/conftest.py
+++ b/tools/editor/ui-tests/tests/conftest.py
@@ -36,6 +36,8 @@ def editor_environment() -> dict[str, str]:
             ),
             "SLINT_EMIT_DEBUG_INFO": "1",
             "SLINT_ENABLE_EXPERIMENTAL_FEATURES": "1",
+            "SLINT_SCALE_FACTOR": "1",
+            "SLINT_STYLE": "fluent",
         }
     )
     return environment

--- a/tools/editor/ui-tests/tests/conftest.py
+++ b/tools/editor/ui-tests/tests/conftest.py
@@ -18,15 +18,18 @@ FIXTURE_PROJECT = UI_TEST_ROOT / "fixtures" / "editor-project"
 DEFAULT_EDITOR_BINARY = REPOSITORY_ROOT / "target" / "debug" / "slint-editor"
 
 
-@pytest.fixture
-def editor_binary() -> Path:
+@pytest.fixture(scope="session")
+def editor_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
     binary = Path(os.environ.get("SLINT_EDITOR_BINARY", DEFAULT_EDITOR_BINARY))
     assert binary.is_file(), f"Editor binary not found at {binary}"
-    return binary
+    pinned = tmp_path_factory.mktemp("editor-binary") / binary.name
+    shutil.copy2(binary, pinned)
+    pinned.chmod(0o755)
+    return pinned
 
 
 @pytest.fixture
-def editor_environment() -> dict[str, str]:
+def editor_environment(tmp_path: Path) -> dict[str, str]:
     environment = os.environ.copy()
     environment.pop("SLINT_SCALE_FACTOR", None)
     environment.update(
@@ -38,6 +41,7 @@ def editor_environment() -> dict[str, str]:
             "SLINT_ENABLE_EXPERIMENTAL_FEATURES": "1",
             "SLINT_SCALE_FACTOR": "1",
             "SLINT_STYLE": "fluent",
+            "SLINT_EDITOR_TEST_CONFIG_DIR": str(tmp_path / "editor-settings"),
         }
     )
     return environment

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -1,12 +1,39 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+"""Revision-specific synchronization for headless editor tests."""
+
 import json
 import time
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+PROTOCOL_VERSION = 2
+
+
+@dataclass(frozen=True)
+class SyncCheckpoint:
+    session: str
+    cursor: int
+    writes: int
+    accepted_edits: int
+    operation: int | None = None
+
+    def __getitem__(self, key: str):
+        return getattr(self, key)
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    session: str
+    cursor: int
+    writes: int
+    accepted_edits: int
+    events: tuple[dict, ...]
+    operation: int | None = None
 
 
 @dataclass
@@ -14,33 +41,97 @@ class EditorSync:
     directory: Path
     request_id: int = 0
     session: str | None = None
+    process: Any = None
+
+    def _write_request(self, request: dict) -> None:
+        temporary = self.directory / "request.tmp"
+        temporary.write_text(json.dumps(request))
+        temporary.replace(self.directory / "request.json")
+
+    def _decode(self, response: object, expected_id: int) -> SyncResult:
+        if not isinstance(response, dict):
+            raise TypeError(f"malformed editor sync response: {response!r}")
+        if response.get("id") != expected_id:
+            raise AssertionError(f"stale editor sync response: {response!r}")
+        if response.get("error"):
+            raise AssertionError(f"editor sync error: {response['error']}")
+        if response.get("protocol") != PROTOCOL_VERSION:
+            raise AssertionError(f"unsupported editor sync protocol: {response!r}")
+        session = response.get("session")
+        if not isinstance(session, str) or not session:
+            raise AssertionError(f"editor sync response has no session: {response!r}")
+        if self.session is None:
+            self.session = session
+        elif self.session != session:
+            raise AssertionError(
+                f"editor sync session changed: {self.session!r} -> {session!r}"
+            )
+        cursor = response.get("cursor")
+        writes = response.get("writes")
+        accepted_edits = response.get("accepted_edits", 0)
+        if not all(
+            isinstance(value, int) and value >= 0
+            for value in (cursor, writes, accepted_edits)
+        ):
+            raise TypeError(f"invalid editor sync counters: {response!r}")
+        if (
+            not isinstance(cursor, int)
+            or not isinstance(writes, int)
+            or not isinstance(accepted_edits, int)
+        ):
+            raise TypeError(f"invalid editor sync counters: {response!r}")
+        operation = response.get("operation")
+        if operation is not None and (not isinstance(operation, int) or operation < 1):
+            raise AssertionError(f"invalid editor sync operation: {response!r}")
+        return SyncResult(
+            session,
+            cursor,
+            writes,
+            accepted_edits,
+            tuple(response.get("events", ())),
+            operation,
+        )
 
     def _request(
         self,
         *,
         mode: str,
-        sources: dict[Path, bytes] | None = None,
+        sources: dict[Path, bytes | None] | None = None,
         after: int = 0,
         outcome: str | None = None,
+        operation: int | None = None,
+        begin_action: bool = False,
+        gate: str | None = None,
+        release: bool = False,
+        gate_control: bool = False,
         timeout: float = 15,
-    ) -> dict:
+        handshake: bool = False,
+    ) -> SyncResult:
+        if not handshake and self.session is None:
+            self._request(mode="handshake", timeout=timeout, handshake=True)
         self.request_id += 1
         request = {
             "id": self.request_id,
+            "protocol": PROTOCOL_VERSION,
+            "session": None if handshake else self.session,
             "mode": mode,
             "after": after,
+            "operation": operation,
+            "outcome": outcome,
             "sources": {
-                path.resolve().as_uri(): content.decode("utf-8")
+                path.resolve().as_uri(): (
+                    None if content is None else content.decode("utf-8")
+                )
                 for path, content in (sources or {}).items()
             },
+            "gate": gate,
+            "release": release,
+            "gate_control": gate_control,
+            "begin_action": begin_action,
         }
-        if outcome is not None:
-            request["outcome"] = outcome
-        temporary = self.directory / "request.tmp"
-        temporary.write_text(json.dumps(request))
-        temporary.replace(self.directory / "request.json")
+        self._write_request(request)
         deadline = time.monotonic() + timeout
-        last_response = None
+        last_response: object = None
         try:
             while True:
                 try:
@@ -49,47 +140,55 @@ class EditorSync:
                     )
                 except FileNotFoundError:
                     pass
-                if last_response is not None and last_response.get("id") == self.request_id:
-                    if "protocol" in last_response and last_response["protocol"] != 2:
-                        raise AssertionError(
-                            f"unsupported editor sync protocol: {last_response!r}"
-                        )
-                    response_session = last_response.get("session")
-                    if response_session is not None:
-                        if self.session is None:
-                            self.session = response_session
-                        elif self.session != response_session:
-                            raise AssertionError(
-                                "editor sync session changed while waiting: "
-                                f"{self.session!r} -> {response_session!r}"
-                            )
-                    if last_response.get("overflow"):
-                        raise AssertionError(
-                            f"editor sync event history overflowed after cursor {after}: {last_response!r}"
-                        )
+                if (
+                    isinstance(last_response, dict)
+                    and last_response.get("id") == self.request_id
+                ):
                     if last_response.get("ready"):
-                        return last_response
+                        return self._decode(last_response, self.request_id)
+                    if last_response.get("error"):
+                        self._decode(last_response, self.request_id)
+                if self.process is not None and self.process.poll() is not None:
+                    raise AssertionError(
+                        f"editor exited while waiting for {mode}: {last_response!r}"
+                    )
                 if time.monotonic() >= deadline:
                     raise AssertionError(
-                        f"Editor synchronization did not reach {mode} within {timeout}s: "
-                        f"{last_response!r}. Build with system-testing enabled."
+                        f"editor sync did not reach {mode} within {timeout}s: {last_response!r}"
                     )
                 time.sleep(0.02)
         finally:
             (self.directory / "request.json").unlink(missing_ok=True)
 
-    def checkpoint(self, timeout: float = 15) -> dict:
-        return self._request(mode="checkpoint", timeout=timeout)
+    def checkpoint(self, timeout: float = 15) -> SyncCheckpoint:
+        result = self._request(mode="checkpoint", timeout=timeout)
+        return SyncCheckpoint(
+            result.session,
+            result.cursor,
+            result.writes,
+            result.accepted_edits,
+            result.operation,
+        )
+
+    def begin_action(self, timeout: float = 15) -> SyncCheckpoint:
+        result = self._request(mode="checkpoint", timeout=timeout, begin_action=True)
+        return SyncCheckpoint(
+            result.session,
+            result.cursor,
+            result.writes,
+            result.accepted_edits,
+            result.operation,
+        )
 
     def wait_for_processed(
         self,
         path: Path,
-        expected: bytes,
+        expected: bytes | None,
         *,
         after: int = 0,
         outcome: str | None = None,
         timeout: float = 15,
-    ) -> dict:
+    ) -> SyncResult:
         return self._request(
             mode="processed",
             sources={path: expected},
@@ -101,50 +200,84 @@ class EditorSync:
     def wait_for_source(
         self,
         path: Path,
-        expected: bytes,
+        expected: bytes | None,
         timeout: float = 15,
         *,
         after: int = 0,
-    ) -> None:
-        self._request(
+    ) -> SyncResult:
+        return self._request(
             mode="applied", sources={path: expected}, after=after, timeout=timeout
+        )
+
+    wait_for_applied = wait_for_source
+
+    def set_gate(self, gate: str, timeout: float = 15) -> SyncResult:
+        """Enable a named scheduling gate without waiting for the held stage."""
+        if gate not in {"source", "publication"}:
+            raise ValueError(f"unknown editor sync gate: {gate}")
+        return self._request(mode="gate", gate=gate, gate_control=True, timeout=timeout)
+
+    def wait_for_gate(
+        self, gate: str, *, after: int = 0, timeout: float = 15
+    ) -> SyncResult:
+        """Wait until the named gate has observed the requested operation."""
+        return self._request(mode="gate", gate=gate, after=after, timeout=timeout)
+
+    def release_gate(self, gate: str, timeout: float = 15) -> SyncResult:
+        """Release a scheduling gate; the normal event loop drains held work."""
+        return self._request(
+            mode="gate", gate=gate, release=True, gate_control=True, timeout=timeout
         )
 
     @contextmanager
     def action(self, timeout: float = 15):
-        checkpoint = self.checkpoint(timeout)
-        yield EditorAction(self, checkpoint, timeout)
+        yield EditorAction(self, self.begin_action(timeout), timeout)
 
 
 @dataclass
 class EditorAction:
     sync: EditorSync
-    checkpoint: dict
+    checkpoint: SyncCheckpoint
     timeout: float
+    finished: bool = False
 
-    @property
-    def writes_before(self) -> int:
-        return int(self.checkpoint.get("writes", 0))
-
-    def wait_for_settled(self, path: Path, expected: bytes) -> dict:
-        return self.sync._request(
-            mode="settled",
-            sources={path: expected},
-            after=int(self.checkpoint["cursor"]),
+    def complete(self, outcome: str) -> SyncResult:
+        result = self.sync._request(
+            mode="finish",
+            after=self.checkpoint.cursor,
+            outcome=outcome,
+            operation=self.checkpoint.operation,
             timeout=self.timeout,
         )
+        self.finished = True
+        return result
 
-    def assert_no_source_writes(self, timeout: float = 0.2) -> None:
-        current = self.sync.checkpoint(timeout)
-        assert int(current.get("writes", 0)) == self.writes_before, (
-            f"action wrote source files: before={self.writes_before}, "
-            f"after={current.get('writes')}"
+    def wait_for_settled(
+        self, *, outcome: str, timeout: float | None = None
+    ) -> SyncResult:
+        if self.checkpoint.operation is None:
+            raise AssertionError("action checkpoint has no operation")
+        if not self.finished:
+            self.complete(outcome)
+        return self.sync._request(
+            mode="settled",
+            after=self.checkpoint.cursor,
+            outcome=outcome,
+            operation=self.checkpoint.operation,
+            timeout=self.timeout if timeout is None else timeout,
         )
+
+    def assert_no_source_writes(self) -> None:
+        current = self.sync.checkpoint(self.timeout)
+        if current.writes != self.checkpoint.writes:
+            raise AssertionError(
+                f"action wrote source files: before={self.checkpoint.writes}, after={current.writes}"
+            )
 
 
 current_editor_sync: ContextVar[EditorSync] = ContextVar("current_editor_sync")
 
 
-def wait_for_source(path: Path, expected: bytes, timeout: float = 15) -> None:
-    """Wait for the requested source in the installed preview and completed history work."""
+def wait_for_source(path: Path, expected: bytes | None, timeout: float = 15) -> None:
+    """Wait for the requested source revision in the installed preview."""
     current_editor_sync.get().wait_for_source(path, expected, timeout)

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -13,6 +13,7 @@ from pathlib import Path
 class EditorSync:
     directory: Path
     request_id: int = 0
+    session: str | None = None
 
     def _request(
         self,
@@ -53,6 +54,15 @@ class EditorSync:
                         raise AssertionError(
                             f"unsupported editor sync protocol: {last_response!r}"
                         )
+                    response_session = last_response.get("session")
+                    if response_session is not None:
+                        if self.session is None:
+                            self.session = response_session
+                        elif self.session != response_session:
+                            raise AssertionError(
+                                "editor sync session changed while waiting: "
+                                f"{self.session!r} -> {response_session!r}"
+                            )
                     if last_response.get("overflow"):
                         raise AssertionError(
                             f"editor sync event history overflowed after cursor {after}: {last_response!r}"

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -89,6 +89,7 @@ class EditorSync:
         operation: int | None = None,
         gate: int | None = None,
         edit: int | None = None,
+        fault: str | dict[str, int] | None = None,
         kind: str | None = None,
         url: Path | None = None,
     ) -> SyncResult:
@@ -114,6 +115,7 @@ class EditorSync:
             "operation": operation,
             "gate": gate,
             "edit": edit,
+            "fault": fault,
             "kind": kind,
             "url": None if url is None else url.resolve().as_uri(),
         }
@@ -255,6 +257,7 @@ class EditorAction:
         result = self.wait_for_settled()
         state = result.data["operation_state"]
         assert state["writes"] == 0, f"action wrote source: {state!r}"
+        assert state["mutations"] == 0, f"action may have changed source: {state!r}"
         assert state["accepted_edits"] == 0, f"action accepted an edit: {state!r}"
 
 

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -1,17 +1,22 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-"""Revision-specific synchronization for headless editor tests."""
+"""Private lifecycle waits for the real editor."""
 
 import json
 import time
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
-PROTOCOL_VERSION = 2
+PROTOCOL_VERSION = 3
+
+
+class Process(Protocol):
+    def poll(self) -> int | None: ...
 
 
 @dataclass(frozen=True)
@@ -22,18 +27,25 @@ class SyncCheckpoint:
     accepted_edits: int
     operation: int | None = None
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key: str) -> Any:
         return getattr(self, key)
 
 
 @dataclass(frozen=True)
 class SyncResult:
-    session: str
-    cursor: int
-    writes: int
-    accepted_edits: int
-    events: tuple[dict, ...]
-    operation: int | None = None
+    data: dict[str, Any]
+
+    @property
+    def cursor(self) -> int:
+        return self.data["cursor"]
+
+    @property
+    def operation(self) -> int | None:
+        return self.data.get("operation")
+
+    @property
+    def outcome(self) -> str | None:
+        return self.data.get("outcome")
 
 
 @dataclass
@@ -41,157 +53,130 @@ class EditorSync:
     directory: Path
     request_id: int = 0
     session: str | None = None
-    process: Any = None
+    process: Process | None = None
 
-    def _write_request(self, request: dict) -> None:
-        temporary = self.directory / "request.tmp"
-        temporary.write_text(json.dumps(request))
-        temporary.replace(self.directory / "request.json")
-
-    def _decode(self, response: object, expected_id: int) -> SyncResult:
+    def _decode(self, response: object) -> dict[str, Any]:
         if not isinstance(response, dict):
             raise TypeError(f"malformed editor sync response: {response!r}")
-        if response.get("id") != expected_id:
-            raise AssertionError(f"stale editor sync response: {response!r}")
         if response.get("error"):
-            raise AssertionError(f"editor sync error: {response['error']}")
+            raise AssertionError(f"editor sync error: {response!r}")
         if response.get("protocol") != PROTOCOL_VERSION:
             raise AssertionError(f"unsupported editor sync protocol: {response!r}")
         session = response.get("session")
         if not isinstance(session, str) or not session:
-            raise AssertionError(f"editor sync response has no session: {response!r}")
-        if self.session is None:
-            self.session = session
-        elif self.session != session:
-            raise AssertionError(
-                f"editor sync session changed: {self.session!r} -> {session!r}"
-            )
-        cursor = response.get("cursor")
-        writes = response.get("writes")
-        accepted_edits = response.get("accepted_edits", 0)
-        if not all(
-            isinstance(value, int) and value >= 0
-            for value in (cursor, writes, accepted_edits)
-        ):
-            raise TypeError(f"invalid editor sync counters: {response!r}")
-        if (
-            not isinstance(cursor, int)
-            or not isinstance(writes, int)
-            or not isinstance(accepted_edits, int)
-        ):
-            raise TypeError(f"invalid editor sync counters: {response!r}")
-        operation = response.get("operation")
-        if operation is not None and (not isinstance(operation, int) or operation < 1):
-            raise AssertionError(f"invalid editor sync operation: {response!r}")
-        return SyncResult(
-            session,
-            cursor,
-            writes,
-            accepted_edits,
-            tuple(response.get("events", ())),
-            operation,
-        )
+            raise AssertionError(f"missing editor session: {response!r}")
+        if self.session is not None and self.session != session:
+            raise AssertionError(f"stale editor session: {response!r}")
+        for name in ("id", "cursor", "writes", "accepted_edits"):
+            if type(response.get(name)) is not int or response[name] < 0:
+                raise AssertionError(f"invalid {name}: {response!r}")
+        if type(response.get("ready")) is not bool:
+            raise AssertionError(f"invalid ready state: {response!r}")
+        if not isinstance(response.get("events"), list):
+            raise TypeError(f"invalid event history: {response!r}")
+        self.session = session
+        return response
 
     def _request(
         self,
         *,
         mode: str,
+        timeout: float = 15,
+        deadline: float | None = None,
+        after: SyncCheckpoint | int = 0,
         sources: dict[Path, bytes | None] | None = None,
-        after: int = 0,
         outcome: str | None = None,
         operation: int | None = None,
-        begin_action: bool = False,
-        gate: str | None = None,
-        release: bool = False,
-        gate_control: bool = False,
-        timeout: float = 15,
-        handshake: bool = False,
+        gate: int | None = None,
+        kind: str | None = None,
+        url: Path | None = None,
     ) -> SyncResult:
-        if not handshake and self.session is None:
-            self._request(mode="handshake", timeout=timeout, handshake=True)
+        deadline = time.monotonic() + timeout if deadline is None else deadline
+        if self.session is None and mode != "handshake":
+            self._request(mode="handshake", deadline=deadline)
+        if isinstance(after, SyncCheckpoint):
+            if after.session != self.session:
+                raise AssertionError("checkpoint belongs to another editor session")
+            after = after.cursor
         self.request_id += 1
         request = {
             "id": self.request_id,
             "protocol": PROTOCOL_VERSION,
-            "session": None if handshake else self.session,
+            "session": self.session,
             "mode": mode,
             "after": after,
-            "operation": operation,
-            "outcome": outcome,
             "sources": {
-                path.resolve().as_uri(): (
-                    None if content is None else content.decode("utf-8")
-                )
-                for path, content in (sources or {}).items()
+                p.resolve().as_uri(): None if c is None else c.decode("utf-8")
+                for p, c in (sources or {}).items()
             },
+            "outcome": outcome,
+            "operation": operation,
             "gate": gate,
-            "release": release,
-            "gate_control": gate_control,
-            "begin_action": begin_action,
+            "kind": kind,
+            "url": None if url is None else url.resolve().as_uri(),
         }
-        self._write_request(request)
-        deadline = time.monotonic() + timeout
-        last_response: object = None
+        temporary = self.directory / "request.tmp"
+        temporary.write_text(json.dumps(request))
+        temporary.replace(self.directory / "request.json")
+        last: object = None
+        trace = self.directory / "trace.jsonl"
+        with trace.open("a") as log:
+            log.write(json.dumps({"request": request}) + "\n")
         try:
             while True:
-                try:
-                    last_response = json.loads(
-                        (self.directory / "response.json").read_text()
-                    )
-                except FileNotFoundError:
-                    pass
-                if (
-                    isinstance(last_response, dict)
-                    and last_response.get("id") == self.request_id
-                ):
-                    if last_response.get("ready"):
-                        return self._decode(last_response, self.request_id)
-                    if last_response.get("error"):
-                        self._decode(last_response, self.request_id)
                 if self.process is not None and self.process.poll() is not None:
-                    raise AssertionError(
-                        f"editor exited while waiting for {mode}: {last_response!r}"
-                    )
+                    raise AssertionError(f"editor exited during {mode}: {last!r}")
+                try:
+                    raw = json.loads((self.directory / "response.json").read_text())
+                except FileNotFoundError:
+                    raw = None
+                if raw is not None:
+                    if not isinstance(raw, dict) or type(raw.get("id")) is not int:
+                        raise AssertionError(f"malformed response: {raw!r}")
+                    if raw["id"] == self.request_id:
+                        response = self._decode(raw)
+                        if response != last:
+                            with trace.open("a") as log:
+                                log.write(json.dumps({"response": response}) + "\n")
+                        last = response
+                        if response["ready"]:
+                            return SyncResult(response)
                 if time.monotonic() >= deadline:
-                    raise AssertionError(
-                        f"editor sync did not reach {mode} within {timeout}s: {last_response!r}"
-                    )
-                time.sleep(0.02)
+                    raise AssertionError(f"editor sync did not reach {mode}: {last!r}")
+                time.sleep(min(0.02, max(0, deadline - time.monotonic())))
         finally:
             (self.directory / "request.json").unlink(missing_ok=True)
 
     def checkpoint(self, timeout: float = 15) -> SyncCheckpoint:
-        result = self._request(mode="checkpoint", timeout=timeout)
+        r = self._request(mode="checkpoint", timeout=timeout).data
         return SyncCheckpoint(
-            result.session,
-            result.cursor,
-            result.writes,
-            result.accepted_edits,
-            result.operation,
+            r["session"], r["cursor"], r["writes"], r["accepted_edits"]
         )
 
-    def begin_action(self, timeout: float = 15) -> SyncCheckpoint:
-        result = self._request(mode="checkpoint", timeout=timeout, begin_action=True)
-        return SyncCheckpoint(
-            result.session,
-            result.cursor,
-            result.writes,
-            result.accepted_edits,
-            result.operation,
+    def wait_for_observed(
+        self,
+        path: Path,
+        content: bytes | None,
+        *,
+        after: SyncCheckpoint | int,
+        timeout: float = 15,
+    ) -> SyncResult:
+        return self._request(
+            mode="observed", sources={path: content}, after=after, timeout=timeout
         )
 
     def wait_for_processed(
         self,
         path: Path,
-        expected: bytes | None,
+        content: bytes | None,
         *,
-        after: int = 0,
+        after: SyncCheckpoint | int = 0,
         outcome: str | None = None,
         timeout: float = 15,
     ) -> SyncResult:
         return self._request(
             mode="processed",
-            sources={path: expected},
+            sources={path: content},
             after=after,
             outcome=outcome,
             timeout=timeout,
@@ -203,81 +188,97 @@ class EditorSync:
         expected: bytes | None,
         timeout: float = 15,
         *,
-        after: int = 0,
+        after: SyncCheckpoint | int = 0,
+        deadline: float | None = None,
     ) -> SyncResult:
         return self._request(
-            mode="applied", sources={path: expected}, after=after, timeout=timeout
+            mode="applied",
+            sources={path: expected},
+            after=after,
+            timeout=timeout,
+            deadline=deadline,
         )
 
     wait_for_applied = wait_for_source
 
-    def set_gate(self, gate: str, timeout: float = 15) -> SyncResult:
-        """Enable a named scheduling gate without waiting for the held stage."""
-        if gate not in {"source", "publication"}:
-            raise ValueError(f"unknown editor sync gate: {gate}")
-        return self._request(mode="gate", gate=gate, gate_control=True, timeout=timeout)
-
-    def wait_for_gate(
-        self, gate: str, *, after: int = 0, timeout: float = 15
-    ) -> SyncResult:
-        """Wait until the named gate has observed the requested operation."""
-        return self._request(mode="gate", gate=gate, after=after, timeout=timeout)
-
-    def release_gate(self, gate: str, timeout: float = 15) -> SyncResult:
-        """Release a scheduling gate; the normal event loop drains held work."""
-        return self._request(
-            mode="gate", gate=gate, release=True, gate_control=True, timeout=timeout
-        )
+    @contextmanager
+    def action(self, timeout: float = 15) -> Iterator["EditorAction"]:
+        r = self._request(mode="begin", timeout=timeout).data
+        action = EditorAction(self, r["operation"], timeout)
+        try:
+            yield action
+        finally:
+            action.seal()
 
     @contextmanager
-    def action(self, timeout: float = 15):
-        yield EditorAction(self, self.begin_action(timeout), timeout)
+    def gate(
+        self, kind: str, path: Path, timeout: float = 15
+    ) -> Iterator["EditorGate"]:
+        r = self._request(mode="gate_open", kind=kind, url=path, timeout=timeout).data
+        gate = EditorGate(self, r["gate"], timeout)
+        try:
+            yield gate
+        finally:
+            if self.process is None or self.process.poll() is None:
+                gate.release()
 
 
 @dataclass
 class EditorAction:
     sync: EditorSync
-    checkpoint: SyncCheckpoint
+    operation: int
     timeout: float
-    finished: bool = False
+    sealed: bool = False
 
-    def complete(self, outcome: str) -> SyncResult:
-        result = self.sync._request(
-            mode="finish",
-            after=self.checkpoint.cursor,
-            outcome=outcome,
-            operation=self.checkpoint.operation,
-            timeout=self.timeout,
-        )
-        self.finished = True
-        return result
+    def seal(self) -> None:
+        if not self.sealed:
+            self.sync._request(
+                mode="seal", operation=self.operation, timeout=self.timeout
+            )
+            self.sealed = True
 
     def wait_for_settled(
-        self, *, outcome: str, timeout: float | None = None
+        self, *, outcome: str | None = None, timeout: float | None = None
     ) -> SyncResult:
-        if self.checkpoint.operation is None:
-            raise AssertionError("action checkpoint has no operation")
-        if not self.finished:
-            self.complete(outcome)
+        if not self.sealed:
+            raise AssertionError("close the input action before waiting for completion")
         return self.sync._request(
             mode="settled",
-            after=self.checkpoint.cursor,
+            operation=self.operation,
             outcome=outcome,
-            operation=self.checkpoint.operation,
             timeout=self.timeout if timeout is None else timeout,
         )
 
     def assert_no_source_writes(self) -> None:
-        current = self.sync.checkpoint(self.timeout)
-        if current.writes != self.checkpoint.writes:
-            raise AssertionError(
-                f"action wrote source files: before={self.checkpoint.writes}, after={current.writes}"
-            )
+        result = self.wait_for_settled()
+        state = result.data["operation_state"]
+        assert state["writes"] == 0, f"action wrote source: {state!r}"
+        assert state["accepted_edits"] == 0, f"action accepted an edit: {state!r}"
+
+
+@dataclass
+class EditorGate:
+    sync: EditorSync
+    id: int
+    timeout: float
+
+    def wait_for_reached(self) -> SyncResult:
+        return self.sync._request(mode="gate_wait", gate=self.id, timeout=self.timeout)
+
+    def release(self) -> None:
+        self.sync._request(mode="gate_release", gate=self.id, timeout=self.timeout)
 
 
 current_editor_sync: ContextVar[EditorSync] = ContextVar("current_editor_sync")
 
 
-def wait_for_source(path: Path, expected: bytes | None, timeout: float = 15) -> None:
-    """Wait for the requested source revision in the installed preview."""
-    current_editor_sync.get().wait_for_source(path, expected, timeout)
+def wait_for_source(
+    path: Path,
+    expected: bytes | None,
+    timeout: float = 15,
+    *,
+    deadline: float | None = None,
+) -> None:
+    current_editor_sync.get().wait_for_source(
+        path, expected, timeout, deadline=deadline
+    )

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-PROTOCOL_VERSION = 3
+PROTOCOL_VERSION = 4
 
 
 class Process(Protocol):
@@ -88,6 +88,7 @@ class EditorSync:
         outcome: str | None = None,
         operation: int | None = None,
         gate: int | None = None,
+        edit: int | None = None,
         kind: str | None = None,
         url: Path | None = None,
     ) -> SyncResult:
@@ -112,6 +113,7 @@ class EditorSync:
             "outcome": outcome,
             "operation": operation,
             "gate": gate,
+            "edit": edit,
             "kind": kind,
             "url": None if url is None else url.resolve().as_uri(),
         }

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -3,6 +3,7 @@
 
 import json
 import time
+from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,12 +14,27 @@ class EditorSync:
     directory: Path
     request_id: int = 0
 
-    def wait_for_source(self, path: Path, expected: bytes, timeout: float = 15) -> None:
+    def _request(
+        self,
+        *,
+        mode: str,
+        sources: dict[Path, bytes] | None = None,
+        after: int = 0,
+        outcome: str | None = None,
+        timeout: float = 15,
+    ) -> dict:
         self.request_id += 1
         request = {
             "id": self.request_id,
-            "sources": {path.resolve().as_uri(): expected.decode("utf-8")},
+            "mode": mode,
+            "after": after,
+            "sources": {
+                path.resolve().as_uri(): content.decode("utf-8")
+                for path, content in (sources or {}).items()
+            },
         }
+        if outcome is not None:
+            request["outcome"] = outcome
         temporary = self.directory / "request.tmp"
         temporary.write_text(json.dumps(request))
         temporary.replace(self.directory / "request.json")
@@ -32,20 +48,88 @@ class EditorSync:
                     )
                 except FileNotFoundError:
                     pass
-                if (
-                    last_response is not None
-                    and last_response["id"] == self.request_id
-                    and last_response["ready"]
-                ):
-                    return
+                if last_response is not None and last_response.get("id") == self.request_id:
+                    if "protocol" in last_response and last_response["protocol"] != 2:
+                        raise AssertionError(
+                            f"unsupported editor sync protocol: {last_response!r}"
+                        )
+                    if last_response.get("overflow"):
+                        raise AssertionError(
+                            f"editor sync event history overflowed after cursor {after}: {last_response!r}"
+                        )
+                    if last_response.get("ready"):
+                        return last_response
                 if time.monotonic() >= deadline:
                     raise AssertionError(
-                        f"Preview did not apply {path} within {timeout}s: "
+                        f"Editor synchronization did not reach {mode} within {timeout}s: "
                         f"{last_response!r}. Build with system-testing enabled."
                     )
                 time.sleep(0.02)
         finally:
             (self.directory / "request.json").unlink(missing_ok=True)
+
+    def checkpoint(self, timeout: float = 15) -> dict:
+        return self._request(mode="checkpoint", timeout=timeout)
+
+    def wait_for_processed(
+        self,
+        path: Path,
+        expected: bytes,
+        *,
+        after: int = 0,
+        outcome: str | None = None,
+        timeout: float = 15,
+    ) -> dict:
+        return self._request(
+            mode="processed",
+            sources={path: expected},
+            after=after,
+            outcome=outcome,
+            timeout=timeout,
+        )
+
+    def wait_for_source(
+        self,
+        path: Path,
+        expected: bytes,
+        timeout: float = 15,
+        *,
+        after: int = 0,
+    ) -> None:
+        self._request(
+            mode="applied", sources={path: expected}, after=after, timeout=timeout
+        )
+
+    @contextmanager
+    def action(self, timeout: float = 15):
+        checkpoint = self.checkpoint(timeout)
+        yield EditorAction(self, checkpoint, timeout)
+
+
+@dataclass
+class EditorAction:
+    sync: EditorSync
+    checkpoint: dict
+    timeout: float
+
+    @property
+    def writes_before(self) -> int:
+        return int(self.checkpoint.get("writes", 0))
+
+    def wait_for_settled(self, path: Path, expected: bytes) -> dict:
+        return self.sync._request(
+            mode="settled",
+            sources={path: expected},
+            after=int(self.checkpoint["cursor"]),
+            timeout=self.timeout,
+        )
+
+    def assert_no_source_writes(self, timeout: float = 0.2) -> None:
+        current = self.sync.checkpoint(timeout)
+        assert int(current.get("writes", 0)) == self.writes_before, (
+            f"action wrote source files: before={self.writes_before}, "
+            f"after={current.get('writes')}"
+        )
 
 
 current_editor_sync: ContextVar[EditorSync] = ContextVar("current_editor_sync")

--- a/tools/editor/ui-tests/tests/editor_sync.py
+++ b/tools/editor/ui-tests/tests/editor_sync.py
@@ -23,29 +23,11 @@ class Process(Protocol):
 class SyncCheckpoint:
     session: str
     cursor: int
-    writes: int
-    accepted_edits: int
-    operation: int | None = None
-
-    def __getitem__(self, key: str) -> Any:
-        return getattr(self, key)
 
 
 @dataclass(frozen=True)
 class SyncResult:
     data: dict[str, Any]
-
-    @property
-    def cursor(self) -> int:
-        return self.data["cursor"]
-
-    @property
-    def operation(self) -> int | None:
-        return self.data.get("operation")
-
-    @property
-    def outcome(self) -> str | None:
-        return self.data.get("outcome")
 
 
 @dataclass
@@ -153,9 +135,7 @@ class EditorSync:
 
     def checkpoint(self, timeout: float = 15) -> SyncCheckpoint:
         r = self._request(mode="checkpoint", timeout=timeout).data
-        return SyncCheckpoint(
-            r["session"], r["cursor"], r["writes"], r["accepted_edits"]
-        )
+        return SyncCheckpoint(r["session"], r["cursor"])
 
     def wait_for_observed(
         self,
@@ -186,7 +166,7 @@ class EditorSync:
             timeout=timeout,
         )
 
-    def wait_for_source(
+    def wait_for_applied(
         self,
         path: Path,
         expected: bytes | None,
@@ -202,8 +182,6 @@ class EditorSync:
             timeout=timeout,
             deadline=deadline,
         )
-
-    wait_for_applied = wait_for_source
 
     @contextmanager
     def action(self, timeout: float = 15) -> Iterator["EditorAction"]:
@@ -275,15 +253,3 @@ class EditorGate:
 
 
 current_editor_sync: ContextVar[EditorSync] = ContextVar("current_editor_sync")
-
-
-def wait_for_source(
-    path: Path,
-    expected: bytes | None,
-    timeout: float = 15,
-    *,
-    deadline: float | None = None,
-) -> None:
-    current_editor_sync.get().wait_for_source(
-        path, expected, timeout, deadline=deadline
-    )

--- a/tools/editor/ui-tests/tests/inspector_interactions.py
+++ b/tools/editor/ui-tests/tests/inspector_interactions.py
@@ -1,8 +1,15 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+import time
+
 import slint_testing
-from ui_driver import elements_with_label, wait_until, window_element_with_label
+from ui_driver import (
+    elements_with_label,
+    find_window_element_with_label,
+    wait_until,
+    window_element_with_label,
+)
 
 FIELDS = {
     "x": "Position X",
@@ -18,9 +25,15 @@ def inspector_field(
     window: slint_testing.Window,
     label: str,
     role: slint_testing.AccessibleRole | None = None,
+    *,
+    timeout: float = 5,
 ) -> slint_testing.Element:
+    deadline = time.monotonic() + timeout
     pane = window_element_with_label(
-        window, "Inspector and outline", slint_testing.AccessibleRole.Complementary
+        window,
+        "Inspector and outline",
+        slint_testing.AccessibleRole.Complementary,
+        timeout=max(0, deadline - time.monotonic()),
     )
     position = slint_testing.LogicalPosition(
         x=pane.absolute_position.x + pane.size.width / 2,
@@ -34,7 +47,9 @@ def inspector_field(
         fields = elements_with_label(pane, label, role)
         if len(fields) == 1:
             return fields[0]
-    return window_element_with_label(window, label, role)
+    return window_element_with_label(
+        window, label, role, timeout=max(0, deadline - time.monotonic())
+    )
 
 
 def edit_field(
@@ -53,11 +68,15 @@ def wait_for_field(
     role: slint_testing.AccessibleRole | None = None,
     timeout: float = 5,
 ) -> None:
+    deadline = time.monotonic() + timeout
+    inspector_field(window, label, role, timeout=timeout)
     wait_until(
         lambda: (
             field
-            if (field := inspector_field(window, label, role)).accessible_value == value
+            if (field := find_window_element_with_label(window, label, role))
+            is not None
+            and field.accessible_value == value
             else None
         ),
-        timeout=timeout,
+        deadline=deadline,
     )

--- a/tools/editor/ui-tests/tests/source_snapshot.py
+++ b/tools/editor/ui-tests/tests/source_snapshot.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from difflib import unified_diff
 from pathlib import Path
@@ -49,13 +50,20 @@ class SourceSnapshot:
         assert current == self.sources, exact_source_mismatch(current, self.sources)
 
     def assert_unchanged(
-        self, quiescence: float = 0.25, poll_interval: float = 0.02
+        self,
+        quiescence: float = 0.25,
+        poll_interval: float = 0.02,
+        after_first_observation: Callable[[], None] | None = None,
     ) -> None:
         deadline = time.monotonic() + quiescence
+        first_observation = True
         while True:
             self.assert_unchanged_now()
             if time.monotonic() >= deadline:
                 return
+            if first_observation and after_first_observation is not None:
+                first_observation = False
+                after_first_observation()
             time.sleep(poll_interval)
 
     def wait_for_exact(

--- a/tools/editor/ui-tests/tests/source_snapshot.py
+++ b/tools/editor/ui-tests/tests/source_snapshot.py
@@ -77,13 +77,15 @@ class SourceSnapshot:
         timeout: float = 15,
     ) -> None:
         """Check exact project source, then wait for this revision in the preview."""
-        from editor_sync import wait_for_source
+        from editor_sync import current_editor_sync
 
         deadline = time.monotonic() + timeout
         self.wait_for_exact(
             expected, relative_path, timeout=max(0, deadline - time.monotonic())
         )
-        wait_for_source(self.project / relative_path, expected, deadline=deadline)
+        current_editor_sync.get().wait_for_applied(
+            self.project / relative_path, expected, deadline=deadline
+        )
         expected_sources = self.sources | {Path(relative_path): expected}
         current = slint_sources(self.project)
         assert current == expected_sources, exact_source_mismatch(

--- a/tools/editor/ui-tests/tests/source_snapshot.py
+++ b/tools/editor/ui-tests/tests/source_snapshot.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from difflib import unified_diff
 from pathlib import Path
@@ -49,23 +48,6 @@ class SourceSnapshot:
         current = slint_sources(self.project)
         assert current == self.sources, exact_source_mismatch(current, self.sources)
 
-    def assert_unchanged(
-        self,
-        quiescence: float = 0.25,
-        poll_interval: float = 0.02,
-        after_first_observation: Callable[[], None] | None = None,
-    ) -> None:
-        deadline = time.monotonic() + quiescence
-        first_observation = True
-        while True:
-            self.assert_unchanged_now()
-            if time.monotonic() >= deadline:
-                return
-            if first_observation and after_first_observation is not None:
-                first_observation = False
-                after_first_observation()
-            time.sleep(poll_interval)
-
     def wait_for_exact(
         self,
         expected: bytes,
@@ -97,8 +79,11 @@ class SourceSnapshot:
         """Check exact project source, then wait for this revision in the preview."""
         from editor_sync import wait_for_source
 
-        self.wait_for_exact(expected, relative_path, timeout=timeout)
-        wait_for_source(self.project / relative_path, expected, timeout=timeout)
+        deadline = time.monotonic() + timeout
+        self.wait_for_exact(
+            expected, relative_path, timeout=max(0, deadline - time.monotonic())
+        )
+        wait_for_source(self.project / relative_path, expected, deadline=deadline)
         expected_sources = self.sources | {Path(relative_path): expected}
         current = slint_sources(self.project)
         assert current == expected_sources, exact_source_mismatch(

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -208,19 +208,19 @@ def test_palette_preview_follows_rejected_pointer(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        with current_editor_sync.get().action() as input_action:
-            artboard = window_element_with_label(
-                window, "Artboard", slint_testing.AccessibleRole.Region
-            )
-            first_rejected_position = slint_testing.LogicalPosition(
-                x=artboard.absolute_position.x - 60,
-                y=artboard.absolute_position.y + 180,
-            )
-            second_rejected_position = slint_testing.LogicalPosition(
-                x=artboard.absolute_position.x - 100,
-                y=artboard.absolute_position.y + 280,
-            )
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
+        first_rejected_position = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x - 60,
+            y=artboard.absolute_position.y + 180,
+        )
+        second_rejected_position = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x - 100,
+            y=artboard.absolute_position.y + 280,
+        )
 
+        with current_editor_sync.get().action() as input_action:
             begin_palette_drag(window, "Rectangle", first_rejected_position)
             preview = window_element_with_label(
                 window,
@@ -266,59 +266,59 @@ def test_unselected_element_shows_hover_outline_without_side_effects(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
         with current_editor_sync.get().action() as input_action:
-            artboard = window_element_with_label(
-                window, "Artboard", slint_testing.AccessibleRole.Region
-            )
             hover = hover_fixture_element(window, kind)
-            expected = {
-                "Rectangle": (40, 40, 180, 120),
-                "Text": (180, 56, 180, 48),
-                "Image": (230, 132, 128, 96),
-            }[kind]
-            x, y, width, height = expected
-            assert hover.absolute_position.x == pytest.approx(
-                artboard.absolute_position.x + x
-            )
-            assert hover.absolute_position.y == pytest.approx(
-                artboard.absolute_position.y + y
-            )
-            assert hover.size.width == pytest.approx(width)
-            assert hover.size.height == pytest.approx(height)
-            assert not elements_with_label(window.root_element, f"Selected {kind}")
         input_action.assert_no_source_writes()
+        expected = {
+            "Rectangle": (40, 40, 180, 120),
+            "Text": (180, 56, 180, 48),
+            "Image": (230, 132, 128, 96),
+        }[kind]
+        x, y, width, height = expected
+        assert hover.absolute_position.x == pytest.approx(
+            artboard.absolute_position.x + x
+        )
+        assert hover.absolute_position.y == pytest.approx(
+            artboard.absolute_position.y + y
+        )
+        assert hover.size.width == pytest.approx(width)
+        assert hover.size.height == pytest.approx(height)
+        assert not elements_with_label(window.root_element, f"Selected {kind}")
         snapshot.assert_unchanged_now()
 
+        blank = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x + artboard.size.width - 12,
+            y=artboard.absolute_position.y + artboard.size.height - 12,
+        )
         with current_editor_sync.get().action() as input_action:
-            blank = slint_testing.LogicalPosition(
-                x=artboard.absolute_position.x + artboard.size.width - 12,
-                y=artboard.absolute_position.y + artboard.size.height - 12,
-            )
             window.dispatch_event(slint_testing.PointerMoveEvent(blank))
-            wait_until(
-                lambda: (
-                    True
-                    if not elements_with_label(window.root_element, f"Hovered {kind}")
-                    else None
-                )
-            )
         input_action.assert_no_source_writes()
+        wait_until(
+            lambda: (
+                True
+                if not elements_with_label(window.root_element, f"Hovered {kind}")
+                else None
+            )
+        )
         snapshot.assert_unchanged_now()
 
+        outside = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x - 12,
+            y=artboard.absolute_position.y - 12,
+        )
         with current_editor_sync.get().action() as input_action:
-            outside = slint_testing.LogicalPosition(
-                x=artboard.absolute_position.x - 12,
-                y=artboard.absolute_position.y - 12,
-            )
             window.dispatch_event(slint_testing.PointerMoveEvent(outside))
-            wait_until(
-                lambda: (
-                    True
-                    if not elements_with_label(window.root_element, f"Hovered {kind}")
-                    else None
-                )
-            )
         input_action.assert_no_source_writes()
+        wait_until(
+            lambda: (
+                True
+                if not elements_with_label(window.root_element, f"Hovered {kind}")
+                else None
+            )
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -331,29 +331,27 @@ def test_overlapping_elements_update_hover_outline_to_topmost_item(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
+        artboard = window_element_with_label(
+            window, "Artboard", slint_testing.AccessibleRole.Region
+        )
+        rectangle_only = center(fixture_element(window, "Rectangle"))
+        overlapping = slint_testing.LogicalPosition(
+            x=artboard.absolute_position.x + 200,
+            y=artboard.absolute_position.y + 80,
+        )
         with current_editor_sync.get().action() as input_action:
-            artboard = window_element_with_label(
-                window, "Artboard", slint_testing.AccessibleRole.Region
-            )
-            rectangle_only = center(fixture_element(window, "Rectangle"))
-            overlapping = slint_testing.LogicalPosition(
-                x=artboard.absolute_position.x + 200,
-                y=artboard.absolute_position.y + 80,
-            )
             window.dispatch_event(slint_testing.PointerMoveEvent(rectangle_only))
             window_element_with_label(window, "Hovered Rectangle")
             window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
-            wait_until(
-                lambda: (
-                    True
-                    if elements_with_label(window.root_element, "Hovered Text")
-                    and not elements_with_label(
-                        window.root_element, "Hovered Rectangle"
-                    )
-                    else None
-                )
-            )
         input_action.assert_no_source_writes()
+        wait_until(
+            lambda: (
+                True
+                if elements_with_label(window.root_element, "Hovered Text")
+                and not elements_with_label(window.root_element, "Hovered Rectangle")
+                else None
+            )
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -435,8 +433,8 @@ def test_selected_element_does_not_get_a_duplicate_hover_outline(
             window.dispatch_event(
                 slint_testing.PointerMoveEvent(center(fixture_element(window, "Text")))
             )
-            assert not elements_with_label(window.root_element, "Hovered Text")
         input_action.assert_no_source_writes()
+        assert not elements_with_label(window.root_element, "Hovered Text")
         snapshot.assert_unchanged_now()
 
 
@@ -464,11 +462,11 @@ def test_unselected_element_click_selects_without_editing_source(
             window.dispatch_event(
                 slint_testing.PointerReleaseEvent(below_threshold, button)
             )
-            window_element_with_label(
-                window, f"Selected {kind}", slint_testing.AccessibleRole.Region
-            )
-            assert not elements_with_label(window.root_element, f"Hovered {kind}")
         input_action.assert_no_source_writes()
+        window_element_with_label(
+            window, f"Selected {kind}", slint_testing.AccessibleRole.Region
+        )
+        assert not elements_with_label(window.root_element, f"Hovered {kind}")
         snapshot.assert_unchanged_now()
 
 
@@ -1587,46 +1585,44 @@ def test_repeated_rectangles_show_radius_handles_only_on_primary_instance(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        with current_editor_sync.get().action() as input_action:
-            instances = wait_until(
-                lambda: (
-                    elements
-                    if len(
-                        elements := window.find_elements_by_id("Main::root-rectangle")
-                    )
-                    == 3
-                    else None
-                )
+        instances = wait_until(
+            lambda: (
+                elements
+                if len(elements := window.find_elements_by_id("Main::root-rectangle"))
+                == 3
+                else None
             )
-            target = center(instances[1])
-            button = slint_testing.PointerEventButton.Left
+        )
+        target = center(instances[1])
+        button = slint_testing.PointerEventButton.Left
+        with current_editor_sync.get().action() as input_action:
             window.dispatch_event(slint_testing.PointerMoveEvent(target))
             window.dispatch_event(slint_testing.PointerPressEvent(target, button))
             window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-            wait_until(
-                lambda: (
-                    selected
-                    if len(
-                        selected := elements_with_label(
-                            window.root_element,
-                            "Selected Rectangle",
-                            slint_testing.AccessibleRole.Region,
-                        )
-                    )
-                    == 3
-                    else None
-                )
-            )
-
-            for corner in CORNERS:
-                handles = elements_with_label(
-                    window.root_element,
-                    f"Rectangle radius {corner}",
-                    slint_testing.AccessibleRole.Button,
-                )
-                assert len(handles) == 1
-                assert position_distance(center(handles[0]), target) < 100
         input_action.assert_no_source_writes()
+        wait_until(
+            lambda: (
+                selected
+                if len(
+                    selected := elements_with_label(
+                        window.root_element,
+                        "Selected Rectangle",
+                        slint_testing.AccessibleRole.Region,
+                    )
+                )
+                == 3
+                else None
+            )
+        )
+
+        for corner in CORNERS:
+            handles = elements_with_label(
+                window.root_element,
+                f"Rectangle radius {corner}",
+                slint_testing.AccessibleRole.Button,
+            )
+            assert len(handles) == 1
+            assert position_distance(center(handles[0]), target) < 100
         snapshot.assert_unchanged_now()
 
 
@@ -1782,8 +1778,8 @@ def test_disabled_manipulation_does_not_edit_source(
     source_file.write_bytes(baseline)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
+        snapshot = SourceSnapshot.capture(fixture_project)
         with current_editor_sync.get().action() as input_action:
-            snapshot = SourceSnapshot.capture(fixture_project)
             select_outline_row(window, element_id)
             window_element_with_label(window, "Selected Rectangle")
             handle = window_element_with_label(window, "Rectangle resize bottom-right")

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -22,7 +22,7 @@ from canvas_interactions import (
     same_state,
     selection_frame,
 )
-from editor_sync import current_editor_sync, wait_for_source
+from editor_sync import current_editor_sync
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
@@ -566,12 +566,12 @@ def test_repeated_palette_drop_preserves_component_kind(
             reload_label = f"Reload probe {step}"
             reloaded = expected.replace(b"Reload probe", reload_label.encode(), 1)
             source_file.write_bytes(reloaded)
-            wait_for_source(source_file, reloaded)
+            current_editor_sync.get().wait_for_applied(source_file, reloaded)
             window_element_with_label(
                 window, reload_label, slint_testing.AccessibleRole.Text
             )
             source_file.write_bytes(expected)
-            wait_for_source(source_file, expected)
+            current_editor_sync.get().wait_for_applied(source_file, expected)
             window_element_with_label(
                 window, "Reload probe", slint_testing.AccessibleRole.Text
             )

--- a/tools/editor/ui-tests/tests/test_canvas.py
+++ b/tools/editor/ui-tests/tests/test_canvas.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import math
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
@@ -21,12 +22,13 @@ from canvas_interactions import (
     same_state,
     selection_frame,
 )
-from editor_sync import wait_for_source
+from editor_sync import current_editor_sync, wait_for_source
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
     elements_with_label,
     file_row,
+    find_window_element_with_label,
     first_window,
     launch_editor,
     select_fixture_element,
@@ -82,14 +84,6 @@ RUST_FIX_REQUIRED = pytest.mark.skip(
 def replace_once(source: bytes, old: bytes, new: bytes) -> bytes:
     assert source.count(old) == 1
     return source.replace(old, new, 1)
-
-
-def wait_for_source_change(source_file: Path, baseline: bytes) -> bytes:
-    def changed_source() -> bytes | None:
-        source = source_file.read_bytes()
-        return source if source != baseline else None
-
-    return wait_until(changed_source)
 
 
 def begin_palette_drag(
@@ -214,47 +208,51 @@ def test_palette_preview_follows_rejected_pointer(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        artboard = window_element_with_label(
-            window, "Artboard", slint_testing.AccessibleRole.Region
-        )
-        first_rejected_position = slint_testing.LogicalPosition(
-            x=artboard.absolute_position.x - 60,
-            y=artboard.absolute_position.y + 180,
-        )
-        second_rejected_position = slint_testing.LogicalPosition(
-            x=artboard.absolute_position.x - 100,
-            y=artboard.absolute_position.y + 280,
-        )
-
-        begin_palette_drag(window, "Rectangle", first_rejected_position)
-        preview = window_element_with_label(
-            window,
-            "Rectangle drag preview",
-            slint_testing.AccessibleRole.Region,
-        )
-        expected_width, expected_height = PALETTE_DROP_SIZES["Rectangle"]
-        assert preview.size.width == pytest.approx(expected_width)
-        assert preview.size.height == pytest.approx(expected_height)
-        assert preview.absolute_position.x == pytest.approx(
-            first_rejected_position.x - expected_width / 2
-        )
-        assert preview.absolute_position.y == pytest.approx(
-            first_rejected_position.y - expected_height / 2
-        )
-
-        window.dispatch_event(slint_testing.PointerMoveEvent(second_rejected_position))
-        wait_until(
-            lambda: (
-                preview
-                if preview.absolute_position.x
-                == pytest.approx(second_rejected_position.x - expected_width / 2)
-                and preview.absolute_position.y
-                == pytest.approx(second_rejected_position.y - expected_height / 2)
-                else None
+        with current_editor_sync.get().action() as input_action:
+            artboard = window_element_with_label(
+                window, "Artboard", slint_testing.AccessibleRole.Region
             )
-        )
-        finish_palette_drag(window, second_rejected_position)
-        snapshot.assert_unchanged()
+            first_rejected_position = slint_testing.LogicalPosition(
+                x=artboard.absolute_position.x - 60,
+                y=artboard.absolute_position.y + 180,
+            )
+            second_rejected_position = slint_testing.LogicalPosition(
+                x=artboard.absolute_position.x - 100,
+                y=artboard.absolute_position.y + 280,
+            )
+
+            begin_palette_drag(window, "Rectangle", first_rejected_position)
+            preview = window_element_with_label(
+                window,
+                "Rectangle drag preview",
+                slint_testing.AccessibleRole.Region,
+            )
+            expected_width, expected_height = PALETTE_DROP_SIZES["Rectangle"]
+            assert preview.size.width == pytest.approx(expected_width)
+            assert preview.size.height == pytest.approx(expected_height)
+            assert preview.absolute_position.x == pytest.approx(
+                first_rejected_position.x - expected_width / 2
+            )
+            assert preview.absolute_position.y == pytest.approx(
+                first_rejected_position.y - expected_height / 2
+            )
+
+            window.dispatch_event(
+                slint_testing.PointerMoveEvent(second_rejected_position)
+            )
+            wait_until(
+                lambda: (
+                    preview
+                    if preview.absolute_position.x
+                    == pytest.approx(second_rejected_position.x - expected_width / 2)
+                    and preview.absolute_position.y
+                    == pytest.approx(second_rejected_position.y - expected_height / 2)
+                    else None
+                )
+            )
+            finish_palette_drag(window, second_rejected_position)
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize("kind", MOVE_KINDS)
@@ -268,54 +266,60 @@ def test_unselected_element_shows_hover_outline_without_side_effects(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        artboard = window_element_with_label(
-            window, "Artboard", slint_testing.AccessibleRole.Region
-        )
-        hover = hover_fixture_element(window, kind)
-        expected = {
-            "Rectangle": (40, 40, 180, 120),
-            "Text": (180, 56, 180, 48),
-            "Image": (230, 132, 128, 96),
-        }[kind]
-        x, y, width, height = expected
-        assert hover.absolute_position.x == pytest.approx(
-            artboard.absolute_position.x + x
-        )
-        assert hover.absolute_position.y == pytest.approx(
-            artboard.absolute_position.y + y
-        )
-        assert hover.size.width == pytest.approx(width)
-        assert hover.size.height == pytest.approx(height)
-        assert not elements_with_label(window.root_element, f"Selected {kind}")
-        snapshot.assert_unchanged()
-
-        blank = slint_testing.LogicalPosition(
-            x=artboard.absolute_position.x + artboard.size.width - 12,
-            y=artboard.absolute_position.y + artboard.size.height - 12,
-        )
-        window.dispatch_event(slint_testing.PointerMoveEvent(blank))
-        wait_until(
-            lambda: (
-                True
-                if not elements_with_label(window.root_element, f"Hovered {kind}")
-                else None
+        with current_editor_sync.get().action() as input_action:
+            artboard = window_element_with_label(
+                window, "Artboard", slint_testing.AccessibleRole.Region
             )
-        )
-        snapshot.assert_unchanged()
-
-        outside = slint_testing.LogicalPosition(
-            x=artboard.absolute_position.x - 12,
-            y=artboard.absolute_position.y - 12,
-        )
-        window.dispatch_event(slint_testing.PointerMoveEvent(outside))
-        wait_until(
-            lambda: (
-                True
-                if not elements_with_label(window.root_element, f"Hovered {kind}")
-                else None
+            hover = hover_fixture_element(window, kind)
+            expected = {
+                "Rectangle": (40, 40, 180, 120),
+                "Text": (180, 56, 180, 48),
+                "Image": (230, 132, 128, 96),
+            }[kind]
+            x, y, width, height = expected
+            assert hover.absolute_position.x == pytest.approx(
+                artboard.absolute_position.x + x
             )
-        )
-        snapshot.assert_unchanged()
+            assert hover.absolute_position.y == pytest.approx(
+                artboard.absolute_position.y + y
+            )
+            assert hover.size.width == pytest.approx(width)
+            assert hover.size.height == pytest.approx(height)
+            assert not elements_with_label(window.root_element, f"Selected {kind}")
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
+
+        with current_editor_sync.get().action() as input_action:
+            blank = slint_testing.LogicalPosition(
+                x=artboard.absolute_position.x + artboard.size.width - 12,
+                y=artboard.absolute_position.y + artboard.size.height - 12,
+            )
+            window.dispatch_event(slint_testing.PointerMoveEvent(blank))
+            wait_until(
+                lambda: (
+                    True
+                    if not elements_with_label(window.root_element, f"Hovered {kind}")
+                    else None
+                )
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
+
+        with current_editor_sync.get().action() as input_action:
+            outside = slint_testing.LogicalPosition(
+                x=artboard.absolute_position.x - 12,
+                y=artboard.absolute_position.y - 12,
+            )
+            window.dispatch_event(slint_testing.PointerMoveEvent(outside))
+            wait_until(
+                lambda: (
+                    True
+                    if not elements_with_label(window.root_element, f"Hovered {kind}")
+                    else None
+                )
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_overlapping_elements_update_hover_outline_to_topmost_item(
@@ -327,26 +331,30 @@ def test_overlapping_elements_update_hover_outline_to_topmost_item(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        artboard = window_element_with_label(
-            window, "Artboard", slint_testing.AccessibleRole.Region
-        )
-        rectangle_only = center(fixture_element(window, "Rectangle"))
-        overlapping = slint_testing.LogicalPosition(
-            x=artboard.absolute_position.x + 200,
-            y=artboard.absolute_position.y + 80,
-        )
-        window.dispatch_event(slint_testing.PointerMoveEvent(rectangle_only))
-        window_element_with_label(window, "Hovered Rectangle")
-        window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
-        wait_until(
-            lambda: (
-                True
-                if elements_with_label(window.root_element, "Hovered Text")
-                and not elements_with_label(window.root_element, "Hovered Rectangle")
-                else None
+        with current_editor_sync.get().action() as input_action:
+            artboard = window_element_with_label(
+                window, "Artboard", slint_testing.AccessibleRole.Region
             )
-        )
-        snapshot.assert_unchanged()
+            rectangle_only = center(fixture_element(window, "Rectangle"))
+            overlapping = slint_testing.LogicalPosition(
+                x=artboard.absolute_position.x + 200,
+                y=artboard.absolute_position.y + 80,
+            )
+            window.dispatch_event(slint_testing.PointerMoveEvent(rectangle_only))
+            window_element_with_label(window, "Hovered Rectangle")
+            window.dispatch_event(slint_testing.PointerMoveEvent(overlapping))
+            wait_until(
+                lambda: (
+                    True
+                    if elements_with_label(window.root_element, "Hovered Text")
+                    and not elements_with_label(
+                        window.root_element, "Hovered Rectangle"
+                    )
+                    else None
+                )
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_overlapping_hover_does_not_intercept_selected_element_drag(
@@ -422,12 +430,14 @@ def test_selected_element_does_not_get_a_duplicate_hover_outline(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        select_fixture_element(window, "Text")
-        window.dispatch_event(
-            slint_testing.PointerMoveEvent(center(fixture_element(window, "Text")))
-        )
-        assert not elements_with_label(window.root_element, "Hovered Text")
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            select_fixture_element(window, "Text")
+            window.dispatch_event(
+                slint_testing.PointerMoveEvent(center(fixture_element(window, "Text")))
+            )
+            assert not elements_with_label(window.root_element, "Hovered Text")
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize("kind", MOVE_KINDS)
@@ -441,23 +451,25 @@ def test_unselected_element_click_selects_without_editing_source(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        hover = hover_fixture_element(window, kind)
-        target = center(hover)
-        button = slint_testing.PointerEventButton.Left
-        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
-        below_threshold = slint_testing.LogicalPosition(
-            x=target.x + 1,
-            y=target.y + 1,
-        )
-        window.dispatch_event(slint_testing.PointerMoveEvent(below_threshold))
-        window.dispatch_event(
-            slint_testing.PointerReleaseEvent(below_threshold, button)
-        )
-        window_element_with_label(
-            window, f"Selected {kind}", slint_testing.AccessibleRole.Region
-        )
-        assert not elements_with_label(window.root_element, f"Hovered {kind}")
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            hover = hover_fixture_element(window, kind)
+            target = center(hover)
+            button = slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+            below_threshold = slint_testing.LogicalPosition(
+                x=target.x + 1,
+                y=target.y + 1,
+            )
+            window.dispatch_event(slint_testing.PointerMoveEvent(below_threshold))
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(below_threshold, button)
+            )
+            window_element_with_label(
+                window, f"Selected {kind}", slint_testing.AccessibleRole.Region
+            )
+            assert not elements_with_label(window.root_element, f"Hovered {kind}")
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize("kind", ["Text", "Image"])
@@ -633,17 +645,20 @@ def test_component_palette_drag_over_rotated_element_does_not_crash(
                 else None
             )
         )
-        begin_palette_drag(window, "Rectangle", target)
-        finish_palette_drag(window, target)
-
-        updated = wait_for_source_change(source_file, baseline)
+        with current_editor_sync.get().action() as drop:
+            begin_palette_drag(window, "Rectangle", target)
+            finish_palette_drag(window, target)
+        drop.wait_for_settled(outcome="completed")
+        updated = source_file.read_bytes()
         assert updated.count(b"Rectangle {") == baseline.count(b"Rectangle {") + 1
 
 
+@pytest.mark.parametrize("hold_publication", [False, True])
 def test_image_asset_mode_destroys_canvas_without_replaying_palette_drop(
     editor_binary: Path,
     editor_environment: dict[str, str],
     fixture_project: Path,
+    hold_publication: bool,
 ) -> None:
     source_file = fixture_project / "PaletteDropCases.slint"
     asset_directory = fixture_project / "assets"
@@ -658,27 +673,39 @@ def test_image_asset_mode_destroys_canvas_without_replaying_palette_drop(
             x=artboard.absolute_position.x + 260,
             y=artboard.absolute_position.y + 220,
         )
-        begin_palette_drag(window, "Rectangle", target)
-        finish_palette_drag(window, target)
-        wait_for_source_change(source_file, baseline)
-        snapshot = SourceSnapshot.capture(fixture_project)
+        sync = current_editor_sync.get()
+        scope = (
+            sync.gate("publication", source_file) if hold_publication else nullcontext()
+        )
+        with scope as gate:
+            with sync.action() as drop:
+                begin_palette_drag(window, "Rectangle", target)
+                finish_palette_drag(window, target)
+            if gate is not None:
+                gate.wait_for_reached()
+            else:
+                drop.wait_for_settled(outcome="completed")
+            updated = source_file.read_bytes()
+            assert updated.count(b"Rectangle {") == baseline.count(b"Rectangle {") + 1
+            snapshot = SourceSnapshot.capture(fixture_project)
 
-        asset_directory_row = file_row(window, asset_directory)
-        asset_directory_row.single_click(slint_testing.PointerEventButton.Left)
-        image_row = file_row(window, image_file)
-        image_row.single_click(slint_testing.PointerEventButton.Left)
-        preview_tab = window_element_with_label(
-            window, "Preview", slint_testing.AccessibleRole.Button
-        )
-        assert preview_tab.accessible_checked
-        assert not elements_with_label(
-            window.root_element, "Artboard", slint_testing.AccessibleRole.Region
-        )
-        assert (
-            not window.root_element.query_descendants()
-            .match_type_name("EditorCanvas")
-            .find_all()
-        )
+            asset_directory_row = file_row(window, asset_directory)
+            asset_directory_row.single_click(slint_testing.PointerEventButton.Left)
+            image_row = file_row(window, image_file)
+            image_row.single_click(slint_testing.PointerEventButton.Left)
+            preview_tab = window_element_with_label(
+                window, "Preview", slint_testing.AccessibleRole.Button
+            )
+            assert preview_tab.accessible_checked
+            assert not elements_with_label(
+                window.root_element, "Artboard", slint_testing.AccessibleRole.Region
+            )
+            assert (
+                not window.root_element.query_descendants()
+                .match_type_name("EditorCanvas")
+                .find_all()
+            )
+        drop.wait_for_settled(outcome="completed")
 
         component_row = file_row(window, source_file)
         component_row.single_click(slint_testing.PointerEventButton.Left)
@@ -693,7 +720,7 @@ def test_image_asset_mode_destroys_canvas_without_replaying_palette_drop(
             )
             == 1
         )
-        snapshot.assert_unchanged()
+        snapshot.assert_unchanged_now()
 
 
 def rotated_resize_values(
@@ -845,12 +872,13 @@ def wait_for_radius_tooltip(window: slint_testing.Window, radius: float) -> None
     wait_until(
         lambda: (
             True
-            if float(
-                window_element_with_label(
+            if (
+                field := find_window_element_with_label(
                     window, "Radius value", slint_testing.AccessibleRole.Text
-                ).accessible_value
+                )
             )
-            == radius
+            is not None
+            and float(field.accessible_value) == radius
             else None
         )
     )
@@ -1559,43 +1587,47 @@ def test_repeated_rectangles_show_radius_handles_only_on_primary_instance(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        instances = wait_until(
-            lambda: (
-                elements
-                if len(elements := window.find_elements_by_id("Main::root-rectangle"))
-                == 3
-                else None
-            )
-        )
-        target = center(instances[1])
-        button = slint_testing.PointerEventButton.Left
-        window.dispatch_event(slint_testing.PointerMoveEvent(target))
-        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
-        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-        wait_until(
-            lambda: (
-                selected
-                if len(
-                    selected := elements_with_label(
-                        window.root_element,
-                        "Selected Rectangle",
-                        slint_testing.AccessibleRole.Region,
+        with current_editor_sync.get().action() as input_action:
+            instances = wait_until(
+                lambda: (
+                    elements
+                    if len(
+                        elements := window.find_elements_by_id("Main::root-rectangle")
                     )
+                    == 3
+                    else None
                 )
-                == 3
-                else None
             )
-        )
+            target = center(instances[1])
+            button = slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerMoveEvent(target))
+            window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+            window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+            wait_until(
+                lambda: (
+                    selected
+                    if len(
+                        selected := elements_with_label(
+                            window.root_element,
+                            "Selected Rectangle",
+                            slint_testing.AccessibleRole.Region,
+                        )
+                    )
+                    == 3
+                    else None
+                )
+            )
 
-        for corner in CORNERS:
-            handles = elements_with_label(
-                window.root_element,
-                f"Rectangle radius {corner}",
-                slint_testing.AccessibleRole.Button,
-            )
-            assert len(handles) == 1
-            assert position_distance(center(handles[0]), target) < 100
-        snapshot.assert_unchanged()
+            for corner in CORNERS:
+                handles = elements_with_label(
+                    window.root_element,
+                    f"Rectangle radius {corner}",
+                    slint_testing.AccessibleRole.Button,
+                )
+                assert len(handles) == 1
+                assert position_distance(center(handles[0]), target) < 100
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @RUST_FIX_REQUIRED
@@ -1703,35 +1735,39 @@ def test_handle_click_below_drag_threshold_does_not_edit_source(
     source_file.write_bytes(baseline)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        select_fixture_element(window, "Rectangle")
-        snapshot = SourceSnapshot.capture(fixture_project)
-        handle = (
-            radius_handle(window, "top-left")
-            if label == "Rectangle radius top-left"
-            else window_element_with_label(window, label)
-        )
-        before = selection_frame(window, "Rectangle")
-        start = center(handle)
-        radius_position_before = start if label == "Rectangle radius top-left" else None
-        end = slint_testing.LogicalPosition(x=start.x + 1, y=start.y + 1)
-        button = slint_testing.PointerEventButton.Left
-        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
-        window.dispatch_event(slint_testing.PointerMoveEvent(end))
-        assert same_state(selection_frame(window, "Rectangle"), before)
-        if radius_position_before is not None:
-            assert (
-                position_distance(
-                    center(
-                        window_element_with_label(
-                            window, label, slint_testing.AccessibleRole.Button
-                        )
-                    ),
-                    radius_position_before,
-                )
-                < 1.5
+        with current_editor_sync.get().action() as input_action:
+            select_fixture_element(window, "Rectangle")
+            snapshot = SourceSnapshot.capture(fixture_project)
+            handle = (
+                radius_handle(window, "top-left")
+                if label == "Rectangle radius top-left"
+                else window_element_with_label(window, label)
             )
-        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
-        snapshot.assert_unchanged()
+            before = selection_frame(window, "Rectangle")
+            start = center(handle)
+            radius_position_before = (
+                start if label == "Rectangle radius top-left" else None
+            )
+            end = slint_testing.LogicalPosition(x=start.x + 1, y=start.y + 1)
+            button = slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+            window.dispatch_event(slint_testing.PointerMoveEvent(end))
+            assert same_state(selection_frame(window, "Rectangle"), before)
+            if radius_position_before is not None:
+                assert (
+                    position_distance(
+                        center(
+                            window_element_with_label(
+                                window, label, slint_testing.AccessibleRole.Button
+                            )
+                        ),
+                        radius_position_before,
+                    )
+                    < 1.5
+                )
+            window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize("element_id", DISABLED_IDS)
@@ -1746,14 +1782,16 @@ def test_disabled_manipulation_does_not_edit_source(
     source_file.write_bytes(baseline)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        snapshot = SourceSnapshot.capture(fixture_project)
-        select_outline_row(window, element_id)
-        window_element_with_label(window, "Selected Rectangle")
-        handle = window_element_with_label(window, "Rectangle resize bottom-right")
-        assert not handle.accessible_enabled
-        target = center(handle)
-        window.drag_and_drop(
-            target,
-            slint_testing.LogicalPosition(x=target.x + 20, y=target.y + 16),
-        )
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            snapshot = SourceSnapshot.capture(fixture_project)
+            select_outline_row(window, element_id)
+            window_element_with_label(window, "Selected Rectangle")
+            handle = window_element_with_label(window, "Rectangle resize bottom-right")
+            assert not handle.accessible_enabled
+            target = center(handle)
+            window.drag_and_drop(
+                target,
+                slint_testing.LogicalPosition(x=target.x + 20, y=target.y + 16),
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -237,3 +237,39 @@ def test_same_content_and_return_to_original_have_new_observations(
         sync.wait_for_processed(source, baseline, after=checkpoint, outcome="compiled")
         sync.wait_for_applied(source, baseline, after=checkpoint)
         wait_for_field(window, "Rotation", "32")
+
+
+def test_unrelated_installation_cannot_release_pending_edit_history(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    older = baseline.replace(b"32deg", b"45deg")
+    edited = baseline.replace(b"32deg", b"62deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        with sync.gate("publication", source) as publication:
+            source.write_bytes(older)
+            publication.wait_for_reached()
+            with sync.gate("source", source) as processing:
+                with sync.action() as edit:
+                    edit_field(window, "Rotation", "62")
+                processing.wait_for_reached()
+                assert source.read_bytes() == edited
+                publication.release()
+                wait_for_field(window, "Rotation", "45")
+                window_element_with_label(window, "Rotation knob").single_click(
+                    slint_testing.PointerEventButton.Left
+                )
+                with sync.action() as undo:
+                    shortcut(window)
+                state = operation_state(undo)
+                assert "queued history" in state["operation_state"]["pending"].values()
+                assert state["operation_state"]["writes"] == 0
+        edit.wait_for_settled(outcome="completed")
+        undo.wait_for_settled(outcome="completed")
+        sync.wait_for_applied(source, baseline)
+        assert source.read_bytes() == baseline

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -14,15 +14,16 @@ from test_inspector_transform import (
     shortcut,
     wait_for_field,
 )
-from ui_driver import first_window, launch_editor, window_element_with_label
+from ui_driver import file_row, first_window, launch_editor, window_element_with_label
 
 
 def operation_state(action):
     return action.sync._request(mode="operation", operation=action.operation).data
 
 
+@pytest.mark.parametrize("stage", ["publication", "factory"])
 def test_publication_gate_holds_the_instance_and_supersedes_old_attempt(
-    editor_binary, editor_environment, fixture_project
+    editor_binary, editor_environment, fixture_project, stage
 ):
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
@@ -34,7 +35,7 @@ def test_publication_gate_holds_the_instance_and_supersedes_old_attempt(
         sync = current_editor_sync.get()
         sync.wait_for_applied(source, baseline)
         checkpoint = sync.checkpoint()
-        with sync.gate("publication", source) as gate:
+        with sync.gate(stage, source) as gate:
             source.write_bytes(older)
             held = gate.wait_for_reached().data["gate_state"]["attempt"]
             sync.wait_for_processed(source, older, after=checkpoint, outcome="compiled")
@@ -399,3 +400,67 @@ def test_obsolete_acknowledgment_cannot_finish_newer_edit(
             assert result.data["operation_state"]["writes"] == 1
         obsolete.wait_for_settled(outcome="completed")
         sync.wait_for_applied(source, baseline)
+
+
+@pytest.mark.parametrize("acknowledged", [False, True])
+def test_retired_assigned_factory_resolves_edit_and_queued_history(
+    editor_binary, editor_environment, fixture_project, acknowledged
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    edited = baseline.replace(b"32deg", b"62deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        with sync.action() as seed:
+            edit_field(window, "Rotation", "42")
+        seed.wait_for_settled(outcome="completed")
+        checkpoint = sync.checkpoint()
+        with (
+            sync.gate("acknowledgment", source) as acknowledgment,
+            sync.gate("factory", source) as factory,
+        ):
+            with sync.action() as edit:
+                edit_field(window, "Rotation", "62")
+            edit_id = acknowledgment.wait_for_reached().data["gate_state"]["edit"]
+            attempt = factory.wait_for_reached().data["gate_state"]["attempt"]
+            state = operation_state(edit)
+            assert not state["settled"]
+            assert "component factory" in state["operation_state"]["pending"].values()
+            window_element_with_label(window, "Rotation knob").single_click(
+                slint_testing.PointerEventButton.Left
+            )
+            with sync.action() as undo:
+                shortcut(window)
+            assert (
+                "queued history"
+                in operation_state(undo)["operation_state"]["pending"].values()
+            )
+            if acknowledged:
+                acknowledgment.release()
+                assert wait_for_acknowledgment(sync, edit_id, checkpoint)["accepted"]
+            file_row(window, fixture_project / "assets").single_click(
+                slint_testing.PointerEventButton.Left
+            )
+            file_row(window, fixture_project / "assets/checker.svg").single_click(
+                slint_testing.PointerEventButton.Left
+            )
+            undo.wait_for_settled(outcome="canceled")
+            undo.assert_no_source_writes()
+            if not acknowledged:
+                assert not operation_state(edit)["settled"]
+                acknowledgment.release()
+                assert wait_for_acknowledgment(sync, edit_id, checkpoint)["accepted"]
+            result = edit.wait_for_settled(outcome="completed")
+            assert result.data["operation_state"]["writes"] == 1
+            assert source.read_bytes() == edited
+            file_row(window, source).single_click(slint_testing.PointerEventButton.Left)
+            sync.wait_for_applied(source, edited, after=checkpoint)
+        retired = sync.wait_for_processed(
+            source, edited, after=checkpoint, outcome="superseded"
+        )
+        assert retired.data["attempt"]["id"] == attempt
+        sync.wait_for_applied(source, edited)
+        select_element(window, "Rectangle")
+        wait_for_field(window, "Rotation", "62")

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -19,14 +19,21 @@ from test_inspector_transform import (
 from ui_driver import file_row, first_window, launch_editor, window_element_with_label
 
 
+@pytest.fixture
+def rectangle_editor(editor_binary, editor_environment, fixture_project):
+    return open_rectangle(editor_binary, editor_environment, fixture_project)
+
+
 @contextmanager
-def selected_rectangle(binary, environment, source, baseline):
-    with launch_editor(binary, environment, source) as app:
+def open_rectangle(editor_binary, editor_environment, fixture_project):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    with launch_editor(editor_binary, editor_environment, source) as app:
         window = first_window(app)
         sync = current_editor_sync.get()
         sync.wait_for_applied(source, baseline)
         select_element(window, "Rectangle")
-        yield window, sync
+        yield window, sync, source, baseline
 
 
 def operation_state(action):
@@ -35,16 +42,11 @@ def operation_state(action):
 
 @pytest.mark.parametrize("stage", ["publication", "factory"])
 def test_publication_gate_holds_the_instance_and_supersedes_old_attempt(
-    editor_binary, editor_environment, fixture_project, stage
+    rectangle_editor, stage
 ):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    older = baseline.replace(b"32deg", b"45deg")
-    newest = baseline.replace(b"32deg", b"67deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+    with rectangle_editor as (window, sync, source, baseline):
+        older = baseline.replace(b"32deg", b"45deg")
+        newest = baseline.replace(b"32deg", b"67deg")
         checkpoint = sync.checkpoint()
         with sync.gate(stage, source) as gate:
             source.write_bytes(older)
@@ -62,16 +64,9 @@ def test_publication_gate_holds_the_instance_and_supersedes_old_attempt(
         wait_for_field(window, "Rotation", "67")
 
 
-def test_edit_and_queued_undo_remain_pending_until_publication(
-    editor_binary, editor_environment, fixture_project
-):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    edited = baseline.replace(b"32deg", b"62deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+def test_edit_and_queued_undo_remain_pending_until_publication(rectangle_editor):
+    with rectangle_editor as (window, sync, source, baseline):
+        edited = baseline.replace(b"32deg", b"62deg")
         with sync.gate("publication", source) as gate:
             with sync.action() as edit:
                 edit_field(window, "Rotation", "62")
@@ -98,16 +93,9 @@ def test_edit_and_queued_undo_remain_pending_until_publication(
         wait_for_field(window, "Rotation", "32")
 
 
-def test_source_gate_preserves_overlap_without_blocking_ui(
-    editor_binary, editor_environment, fixture_project
-):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    changed = baseline.replace(b"32deg", b"77deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+def test_source_gate_preserves_overlap_without_blocking_ui(rectangle_editor):
+    with rectangle_editor as (window, sync, source, baseline):
+        changed = baseline.replace(b"32deg", b"77deg")
         with sync.gate("source", source) as gate:
             source.write_bytes(changed)
             gate.wait_for_reached()
@@ -125,14 +113,9 @@ def test_source_gate_preserves_overlap_without_blocking_ui(
 @pytest.mark.parametrize("move", [False, True])
 @pytest.mark.parametrize("cancel", ["escape", "selection", "source"])
 def test_sealed_gesture_stays_pending_until_cancellation(
-    editor_binary, editor_environment, fixture_project, cancel, move
+    rectangle_editor, cancel, move
 ):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+    with rectangle_editor as (window, sync, source, baseline):
         knob = window_element_with_label(window, "Rotation knob")
         position = point(knob, 32)
         with sync.action() as gesture:
@@ -173,14 +156,9 @@ def test_sealed_gesture_stays_pending_until_cancellation(
 
 
 def test_write_then_undo_counts_both_writes_even_when_final_bytes_match(
-    editor_binary, editor_environment, fixture_project
+    rectangle_editor,
 ):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+    with rectangle_editor as (window, sync, source, baseline):
         with sync.action() as edit_and_undo:
             edit_field(window, "Rotation", "42")
             sync.wait_for_applied(source, baseline.replace(b"32deg", b"42deg"))
@@ -196,16 +174,9 @@ def test_write_then_undo_counts_both_writes_even_when_final_bytes_match(
             edit_and_undo.assert_no_source_writes()
 
 
-def test_same_content_and_return_to_original_have_new_observations(
-    editor_binary, editor_environment, fixture_project
-):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    changed = baseline.replace(b"32deg", b"42deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+def test_same_content_and_return_to_original_have_new_observations(rectangle_editor):
+    with rectangle_editor as (window, sync, source, baseline):
+        changed = baseline.replace(b"32deg", b"42deg")
         checkpoint = sync.checkpoint()
         with sync.gate("source", source) as gate:
             source.write_bytes(baseline)
@@ -222,17 +193,10 @@ def test_same_content_and_return_to_original_have_new_observations(
         wait_for_field(window, "Rotation", "32")
 
 
-def test_unrelated_installation_cannot_release_pending_edit_history(
-    editor_binary, editor_environment, fixture_project
-):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    older = baseline.replace(b"32deg", b"45deg")
-    edited = baseline.replace(b"32deg", b"62deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+def test_unrelated_installation_cannot_release_pending_edit_history(rectangle_editor):
+    with rectangle_editor as (window, sync, source, baseline):
+        older = baseline.replace(b"32deg", b"45deg")
+        edited = baseline.replace(b"32deg", b"62deg")
         with sync.gate("publication", source) as publication:
             source.write_bytes(older)
             publication.wait_for_reached()
@@ -264,16 +228,9 @@ def wait_for_acknowledgment(sync, edit_id, checkpoint):
 
 
 @pytest.mark.parametrize("first", ["acknowledgment", "publication"])
-def test_edit_waits_for_both_matching_milestones(
-    editor_binary, editor_environment, fixture_project, first
-):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    seeded = baseline.replace(b"32deg", b"42deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+def test_edit_waits_for_both_matching_milestones(rectangle_editor, first):
+    with rectangle_editor as (window, sync, source, baseline):
+        seeded = baseline.replace(b"32deg", b"42deg")
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -320,15 +277,8 @@ def test_edit_waits_for_both_matching_milestones(
         assert source.read_bytes() == seeded
 
 
-def test_obsolete_acknowledgment_cannot_finish_newer_edit(
-    editor_binary, editor_environment, fixture_project
-):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+def test_obsolete_acknowledgment_cannot_finish_newer_edit(rectangle_editor):
+    with rectangle_editor as (window, sync, source, baseline):
         with sync.gate("acknowledgment", source) as acknowledgment:
             with sync.action() as obsolete:
                 edit_field(window, "Rotation", "62")
@@ -372,15 +322,10 @@ def test_obsolete_acknowledgment_cannot_finish_newer_edit(
 
 @pytest.mark.parametrize("acknowledged", [False, True])
 def test_retired_assigned_factory_resolves_edit_and_queued_history(
-    editor_binary, editor_environment, fixture_project, acknowledged
+    rectangle_editor, acknowledged, fixture_project
 ):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    edited = baseline.replace(b"32deg", b"62deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+    with rectangle_editor as (window, sync, source, baseline):
+        edited = baseline.replace(b"32deg", b"62deg")
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -443,16 +388,11 @@ def test_retired_assigned_factory_resolves_edit_and_queued_history(
     ],
 )
 def test_write_failure_reports_mutation_and_reconciles_history(
-    editor_binary, editor_environment, fixture_project, fault, mutations, prefix
+    rectangle_editor, fault, mutations, prefix
 ):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    seeded = baseline.replace(b"32deg", b"42deg")
-    expected = seeded if prefix is None else seeded[:prefix]
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+    with rectangle_editor as (window, sync, source, baseline):
+        seeded = baseline.replace(b"32deg", b"42deg")
+        expected = seeded if prefix is None else seeded[:prefix]
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -498,16 +438,11 @@ def test_write_failure_reports_mutation_and_reconciles_history(
 @pytest.mark.parametrize("replacement", ["source", "component"])
 @pytest.mark.parametrize("stage", ["factory", "publication"])
 def test_newer_preview_resolves_pending_edit(
-    editor_binary, editor_environment, fixture_project, acknowledged, replacement, stage
+    rectangle_editor, acknowledged, replacement, stage, fixture_project
 ):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    edited = baseline.replace(b"32deg", b"62deg")
-    newer = baseline.replace(b"32deg", b"77deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+    with rectangle_editor as (window, sync, source, baseline):
+        edited = baseline.replace(b"32deg", b"62deg")
+        newer = baseline.replace(b"32deg", b"77deg")
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -596,15 +531,10 @@ def test_image_surface_clears_mounted_preview_but_keeps_last_success(
 
 @pytest.mark.parametrize("acknowledged", [False, True])
 def test_coalesced_edit_resolves_without_compiling_its_written_revision(
-    editor_binary, editor_environment, fixture_project, acknowledged
+    rectangle_editor, acknowledged
 ):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    newer = baseline.replace(b"32deg", b"77deg")
-    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
-        window,
-        sync,
-    ):
+    with rectangle_editor as (window, sync, source, baseline):
+        newer = baseline.replace(b"32deg", b"77deg")
         checkpoint = sync.checkpoint()
         with (
             sync.gate("source", source) as processing,

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -1,6 +1,8 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+from contextlib import contextmanager
+
 import pytest
 import slint_testing
 from editor_sync import current_editor_sync
@@ -17,6 +19,16 @@ from test_inspector_transform import (
 from ui_driver import file_row, first_window, launch_editor, window_element_with_label
 
 
+@contextmanager
+def selected_rectangle(binary, environment, source, baseline):
+    with launch_editor(binary, environment, source) as app:
+        window = first_window(app)
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        select_element(window, "Rectangle")
+        yield window, sync
+
+
 def operation_state(action):
     return action.sync._request(mode="operation", operation=action.operation).data
 
@@ -29,11 +41,10 @@ def test_publication_gate_holds_the_instance_and_supersedes_old_attempt(
     source = fixture_project / SOURCE
     older = baseline.replace(b"32deg", b"45deg")
     newest = baseline.replace(b"32deg", b"67deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         checkpoint = sync.checkpoint()
         with sync.gate(stage, source) as gate:
             source.write_bytes(older)
@@ -57,11 +68,10 @@ def test_edit_and_queued_undo_remain_pending_until_publication(
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
     edited = baseline.replace(b"32deg", b"62deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.gate("publication", source) as gate:
             with sync.action() as edit:
                 edit_field(window, "Rotation", "62")
@@ -94,11 +104,10 @@ def test_source_gate_preserves_overlap_without_blocking_ui(
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
     changed = baseline.replace(b"32deg", b"77deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.gate("source", source) as gate:
             source.write_bytes(changed)
             gate.wait_for_reached()
@@ -113,67 +122,29 @@ def test_source_gate_preserves_overlap_without_blocking_ui(
         wait_for_field(window, "Rotation", "77")
 
 
+@pytest.mark.parametrize("move", [False, True])
 @pytest.mark.parametrize("cancel", ["escape", "selection", "source"])
-def test_active_gesture_has_terminal_cancellation_and_release_cannot_write(
-    editor_binary, editor_environment, fixture_project, cancel
+def test_sealed_gesture_stays_pending_until_cancellation(
+    editor_binary, editor_environment, fixture_project, cancel, move
 ):
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         knob = window_element_with_label(window, "Rotation knob")
-        start, end = point(knob, 32), point(knob, 62)
-        with sync.action() as gesture:
-            window.dispatch_event(
-                slint_testing.PointerPressEvent(
-                    start, slint_testing.PointerEventButton.Left
-                )
-            )
-            window.dispatch_event(slint_testing.PointerMoveEvent(end))
-        assert not operation_state(gesture)["settled"]
-        assert source.read_bytes() == baseline
-        if cancel == "source":
-            baseline = baseline.replace(b"32deg", b"17deg")
-            source.write_bytes(baseline)
-            sync.wait_for_applied(source, baseline)
-        with sync.action() as release:
-            if cancel == "escape":
-                window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
-                window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
-            elif cancel == "selection":
-                select_element(window, "Text")
-            window.dispatch_event(
-                slint_testing.PointerReleaseEvent(
-                    end, slint_testing.PointerEventButton.Left
-                )
-            )
-        gesture.wait_for_settled(outcome="canceled")
-        gesture.assert_no_source_writes()
-        release.assert_no_source_writes()
-        assert source.read_bytes() == baseline
-
-
-@pytest.mark.parametrize("cancel", ["escape", "selection", "source"])
-def test_sealed_pointer_down_stays_pending_until_cancellation(
-    editor_binary, editor_environment, fixture_project, cancel
-):
-    baseline = prepare(fixture_project)
-    source = fixture_project / SOURCE
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
-        position = point(window_element_with_label(window, "Rotation knob"), 32)
+        position = point(knob, 32)
         with sync.action() as gesture:
             window.dispatch_event(
                 slint_testing.PointerPressEvent(
                     position, slint_testing.PointerEventButton.Left
                 )
             )
+            if move:
+                position = point(knob, 62)
+                window.dispatch_event(slint_testing.PointerMoveEvent(position))
+        assert source.read_bytes() == baseline
         state = operation_state(gesture)
         assert state["operation_state"]["sealed"]
         assert not state["settled"]
@@ -206,11 +177,10 @@ def test_write_then_undo_counts_both_writes_even_when_final_bytes_match(
 ):
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.action() as edit_and_undo:
             edit_field(window, "Rotation", "42")
             sync.wait_for_applied(source, baseline.replace(b"32deg", b"42deg"))
@@ -232,11 +202,10 @@ def test_same_content_and_return_to_original_have_new_observations(
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
     changed = baseline.replace(b"32deg", b"42deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         checkpoint = sync.checkpoint()
         with sync.gate("source", source) as gate:
             source.write_bytes(baseline)
@@ -260,11 +229,10 @@ def test_unrelated_installation_cannot_release_pending_edit_history(
     source = fixture_project / SOURCE
     older = baseline.replace(b"32deg", b"45deg")
     edited = baseline.replace(b"32deg", b"62deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
-        sync.wait_for_applied(source, baseline)
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.gate("publication", source) as publication:
             source.write_bytes(older)
             publication.wait_for_reached()
@@ -302,10 +270,10 @@ def test_edit_waits_for_both_matching_milestones(
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
     seeded = baseline.replace(b"32deg", b"42deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -357,10 +325,10 @@ def test_obsolete_acknowledgment_cannot_finish_newer_edit(
 ):
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.gate("acknowledgment", source) as acknowledgment:
             with sync.action() as obsolete:
                 edit_field(window, "Rotation", "62")
@@ -409,10 +377,10 @@ def test_retired_assigned_factory_resolves_edit_and_queued_history(
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
     edited = baseline.replace(b"32deg", b"62deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -481,10 +449,10 @@ def test_write_failure_reports_mutation_and_reconciles_history(
     source = fixture_project / SOURCE
     seeded = baseline.replace(b"32deg", b"42deg")
     expected = seeded if prefix is None else seeded[:prefix]
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -536,10 +504,10 @@ def test_newer_preview_resolves_pending_edit(
     source = fixture_project / SOURCE
     edited = baseline.replace(b"32deg", b"62deg")
     newer = baseline.replace(b"32deg", b"77deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         with sync.action() as seed:
             edit_field(window, "Rotation", "42")
         seed.wait_for_settled(outcome="completed")
@@ -633,10 +601,10 @@ def test_coalesced_edit_resolves_without_compiling_its_written_revision(
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
     newer = baseline.replace(b"32deg", b"77deg")
-    with launch_editor(editor_binary, editor_environment, source) as app:
-        window = first_window(app)
-        select_element(window, "Rectangle")
-        sync = current_editor_sync.get()
+    with selected_rectangle(editor_binary, editor_environment, source, baseline) as (
+        window,
+        sync,
+    ):
         checkpoint = sync.checkpoint()
         with (
             sync.gate("source", source) as processing,

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -464,3 +464,63 @@ def test_retired_assigned_factory_resolves_edit_and_queued_history(
         sync.wait_for_applied(source, edited)
         select_element(window, "Rectangle")
         wait_for_field(window, "Rotation", "62")
+
+
+@pytest.mark.parametrize(
+    "fault,mutations,prefix",
+    [
+        ("before_open", 0, None),
+        ("after_truncate", 1, 0),
+        ({"after_bytes": 5}, 1, 5),
+    ],
+)
+def test_write_failure_reports_mutation_and_reconciles_history(
+    editor_binary, editor_environment, fixture_project, fault, mutations, prefix
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    seeded = baseline.replace(b"32deg", b"42deg")
+    expected = seeded if prefix is None else seeded[:prefix]
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        with sync.action() as seed:
+            edit_field(window, "Rotation", "42")
+        seed.wait_for_settled(outcome="completed")
+        checkpoint = sync.checkpoint()
+        sync._request(mode="write_fault", url=source, fault=fault)
+        try:
+            with sync.action() as edit:
+                edit_field(window, "Rotation", "62")
+            result = edit.wait_for_settled(outcome="failed")
+        finally:
+            sync._request(mode="clear_write_fault", url=source)
+        state = result.data["operation_state"]
+        assert state["accepted_edits"] == 1
+        assert state["writes"] == 0
+        assert state["mutations"] == mutations
+        assert source.read_bytes() == expected
+        if mutations:
+            sync.wait_for_processed(
+                source, expected, after=checkpoint, outcome="compile_error"
+            )
+        window_element_with_label(window, "Rotation knob").single_click(
+            slint_testing.PointerEventButton.Left
+        )
+        with sync.action() as undo:
+            shortcut(window)
+        if mutations:
+            undo.wait_for_settled(outcome="noop")
+            undo.assert_no_source_writes()
+            assert source.read_bytes() == expected
+            source.write_bytes(seeded)
+            sync.wait_for_applied(source, seeded)
+        else:
+            undo.wait_for_settled(outcome="completed")
+            sync.wait_for_applied(source, baseline)
+        select_element(window, "Rectangle")
+        with sync.action() as next_edit:
+            edit_field(window, "Rotation", "77")
+        next_edit.wait_for_settled(outcome="completed")
+        sync.wait_for_applied(source, baseline.replace(b"32deg", b"77deg"))

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -1,0 +1,239 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import pytest
+import slint_testing
+from editor_sync import current_editor_sync
+from slint_testing import keys
+from test_inspector_transform import (
+    SOURCE,
+    edit_field,
+    point,
+    prepare,
+    select_element,
+    shortcut,
+    wait_for_field,
+)
+from ui_driver import first_window, launch_editor, window_element_with_label
+
+
+def operation_state(action):
+    return action.sync._request(mode="operation", operation=action.operation).data
+
+
+def test_publication_gate_holds_the_instance_and_supersedes_old_attempt(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    older = baseline.replace(b"32deg", b"45deg")
+    newest = baseline.replace(b"32deg", b"67deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        checkpoint = sync.checkpoint()
+        with sync.gate("publication", source) as gate:
+            source.write_bytes(older)
+            held = gate.wait_for_reached().data["gate_state"]["attempt"]
+            sync.wait_for_processed(source, older, after=checkpoint, outcome="compiled")
+            wait_for_field(window, "Rotation", "32")
+            source.write_bytes(newest)
+            sync.wait_for_applied(source, newest, after=checkpoint)
+            wait_for_field(window, "Rotation", "67")
+        result = sync.wait_for_processed(
+            source, older, after=checkpoint, outcome="superseded"
+        )
+        assert result.data["attempt"]["id"] == held
+        sync.wait_for_applied(source, newest)
+        wait_for_field(window, "Rotation", "67")
+
+
+def test_edit_and_queued_undo_remain_pending_until_publication(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    edited = baseline.replace(b"32deg", b"62deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        with sync.gate("publication", source) as gate:
+            with sync.action() as edit:
+                edit_field(window, "Rotation", "62")
+            gate.wait_for_reached()
+            assert source.read_bytes() == edited
+            state = operation_state(edit)
+            assert not state["settled"]
+            assert state["operation_state"]["writes"] == 1
+            # Document undo requires focus outside the numeric text field.
+            knob = window_element_with_label(window, "Rotation knob")
+            knob.single_click(slint_testing.PointerEventButton.Left)
+            with sync.action() as undo:
+                shortcut(window)
+            state = operation_state(undo)
+            assert not state["settled"]
+            assert "queued history" in state["operation_state"]["pending"].values()
+            assert state["operation_state"]["writes"] == 0
+            assert source.read_bytes() == edited
+        edit.wait_for_settled(outcome="completed")
+        result = undo.wait_for_settled(outcome="completed")
+        assert result.data["operation_state"]["accepted_edits"] == 1
+        assert result.data["operation_state"]["writes"] == 1
+        sync.wait_for_applied(source, baseline)
+        wait_for_field(window, "Rotation", "32")
+
+
+def test_source_gate_preserves_overlap_without_blocking_ui(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    changed = baseline.replace(b"32deg", b"77deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        with sync.gate("source", source) as gate:
+            source.write_bytes(changed)
+            gate.wait_for_reached()
+            wait_for_field(window, "Rotation", "32")
+            with sync.action() as noop:
+                pass
+            noop.wait_for_settled(outcome="noop")
+            noop.assert_no_source_writes()
+            with pytest.raises(AssertionError, match="expected.*canceled.*noop"):
+                noop.wait_for_settled(outcome="canceled")
+        sync.wait_for_applied(source, changed)
+        wait_for_field(window, "Rotation", "77")
+
+
+@pytest.mark.parametrize("cancel", ["escape", "selection", "source"])
+def test_active_gesture_has_terminal_cancellation_and_release_cannot_write(
+    editor_binary, editor_environment, fixture_project, cancel
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        knob = window_element_with_label(window, "Rotation knob")
+        start, end = point(knob, 32), point(knob, 62)
+        with sync.action() as gesture:
+            window.dispatch_event(
+                slint_testing.PointerPressEvent(
+                    start, slint_testing.PointerEventButton.Left
+                )
+            )
+            window.dispatch_event(slint_testing.PointerMoveEvent(end))
+        assert not operation_state(gesture)["settled"]
+        assert source.read_bytes() == baseline
+        if cancel == "source":
+            baseline = baseline.replace(b"32deg", b"17deg")
+            source.write_bytes(baseline)
+            sync.wait_for_applied(source, baseline)
+        with sync.action() as release:
+            if cancel == "escape":
+                window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+                window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+            elif cancel == "selection":
+                select_element(window, "Text")
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(
+                    end, slint_testing.PointerEventButton.Left
+                )
+            )
+        gesture.wait_for_settled(outcome="canceled")
+        gesture.assert_no_source_writes()
+        release.assert_no_source_writes()
+        assert source.read_bytes() == baseline
+
+
+def test_pointer_down_without_movement_is_canceled_by_escape(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        knob = window_element_with_label(window, "Rotation knob")
+        position = point(knob, 32)
+        with sync.action() as gesture:
+            window.dispatch_event(
+                slint_testing.PointerPressEvent(
+                    position, slint_testing.PointerEventButton.Left
+                )
+            )
+            state = operation_state(gesture)
+            assert not state["settled"]
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(
+                    position, slint_testing.PointerEventButton.Left
+                )
+            )
+        gesture.wait_for_settled(outcome="canceled")
+        gesture.assert_no_source_writes()
+        assert source.read_bytes() == baseline
+
+
+def test_write_then_undo_counts_both_writes_even_when_final_bytes_match(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        with sync.action() as edit_and_undo:
+            edit_field(window, "Rotation", "42")
+            sync.wait_for_applied(source, baseline.replace(b"32deg", b"42deg"))
+            window_element_with_label(window, "Rotation knob").single_click(
+                slint_testing.PointerEventButton.Left
+            )
+            shortcut(window)
+        result = edit_and_undo.wait_for_settled(outcome="completed")
+        assert source.read_bytes() == baseline
+        assert result.data["operation_state"]["writes"] == 2
+        assert result.data["operation_state"]["accepted_edits"] == 2
+        with pytest.raises(AssertionError, match="wrote source"):
+            edit_and_undo.assert_no_source_writes()
+
+
+def test_same_content_and_return_to_original_have_new_observations(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    changed = baseline.replace(b"32deg", b"42deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        checkpoint = sync.checkpoint()
+        with sync.gate("source", source) as gate:
+            source.write_bytes(baseline)
+            gate.wait_for_reached()
+        same = sync.wait_for_observed(source, baseline, after=checkpoint)
+        assert same.data["observation"]["cursor"] > checkpoint.cursor
+        checkpoint = sync.checkpoint()
+        source.write_bytes(changed)
+        sync.wait_for_applied(source, changed, after=checkpoint)
+        checkpoint = sync.checkpoint()
+        source.write_bytes(baseline)
+        sync.wait_for_processed(source, baseline, after=checkpoint, outcome="compiled")
+        sync.wait_for_applied(source, baseline, after=checkpoint)
+        wait_for_field(window, "Rotation", "32")

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -524,3 +524,167 @@ def test_write_failure_reports_mutation_and_reconciles_history(
             edit_field(window, "Rotation", "77")
         next_edit.wait_for_settled(outcome="completed")
         sync.wait_for_applied(source, baseline.replace(b"32deg", b"77deg"))
+
+
+@pytest.mark.parametrize("acknowledged", [False, True])
+@pytest.mark.parametrize("replacement", ["source", "component"])
+@pytest.mark.parametrize("stage", ["factory", "publication"])
+def test_newer_preview_resolves_pending_edit(
+    editor_binary, editor_environment, fixture_project, acknowledged, replacement, stage
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    edited = baseline.replace(b"32deg", b"62deg")
+    newer = baseline.replace(b"32deg", b"77deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        with sync.action() as seed:
+            edit_field(window, "Rotation", "42")
+        seed.wait_for_settled(outcome="completed")
+        checkpoint = sync.checkpoint()
+        with (
+            sync.gate("acknowledgment", source) as ack,
+            sync.gate(stage, source) as factory,
+        ):
+            with sync.action() as edit:
+                edit_field(window, "Rotation", "62")
+            edit_id = ack.wait_for_reached().data["gate_state"]["edit"]
+            factory.wait_for_reached()
+            window_element_with_label(window, "Rotation knob").single_click(
+                slint_testing.PointerEventButton.Left
+            )
+            with sync.action() as undo:
+                shortcut(window)
+            assert (
+                "queued history"
+                in operation_state(undo)["operation_state"]["pending"].values()
+            )
+            if acknowledged:
+                ack.release()
+                assert wait_for_acknowledgment(sync, edit_id, checkpoint)["accepted"]
+            if replacement == "source":
+                source.write_bytes(newer)
+                wait_for_field(window, "Rotation", "77")
+            else:
+                other = fixture_project / "Main.slint"
+                file_row(window, other).single_click(
+                    slint_testing.PointerEventButton.Left
+                )
+            if replacement == "source" and not acknowledged:
+                ack.release()
+            undo.wait_for_settled(outcome="canceled")
+            undo.assert_no_source_writes()
+            if not acknowledged:
+                ack.release()
+            factory.release()
+            edit.wait_for_settled(outcome="completed")
+            if replacement == "component":
+                sync.wait_for_applied(other, other.read_bytes())
+                file_row(window, source).single_click(
+                    slint_testing.PointerEventButton.Left
+                )
+                newer = edited
+            sync.wait_for_applied(source, newer)
+        select_element(window, "Rectangle")
+        with sync.action() as next_edit:
+            edit_field(window, "Rotation", "88")
+        next_edit.wait_for_settled(outcome="completed")
+        window_element_with_label(window, "Rotation knob").single_click(
+            slint_testing.PointerEventButton.Left
+        )
+        with sync.action() as next_undo:
+            shortcut(window)
+        result = next_undo.wait_for_settled(outcome="completed")
+        assert result.data["operation_state"]["writes"] == 1
+        sync.wait_for_applied(source, newer)
+
+
+def test_image_surface_clears_mounted_preview_but_keeps_last_success(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        before = sync._request(mode="checkpoint").data
+        assert before["mounted"]
+        file_row(window, fixture_project / "assets").single_click(
+            slint_testing.PointerEventButton.Left
+        )
+        file_row(window, fixture_project / "assets/checker.svg").single_click(
+            slint_testing.PointerEventButton.Left
+        )
+        after = sync._request(mode="checkpoint").data
+        assert not after["mounted"]
+        assert after["installed"]["id"] == before["installed"]["id"]
+        file_row(window, source).single_click(slint_testing.PointerEventButton.Left)
+        sync.wait_for_applied(source, baseline)
+        assert sync._request(mode="checkpoint").data["mounted"]
+
+
+@pytest.mark.parametrize("acknowledged", [False, True])
+def test_coalesced_edit_resolves_without_compiling_its_written_revision(
+    editor_binary, editor_environment, fixture_project, acknowledged
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    newer = baseline.replace(b"32deg", b"77deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        checkpoint = sync.checkpoint()
+        with (
+            sync.gate("source", source) as processing,
+            sync.gate("acknowledgment", source) as ack,
+        ):
+            with sync.action() as edit:
+                edit_field(window, "Rotation", "62")
+            processing.wait_for_reached()
+            edit_id = ack.wait_for_reached().data["gate_state"]["edit"]
+            if acknowledged:
+                ack.release()
+                assert wait_for_acknowledgment(sync, edit_id, checkpoint)["accepted"]
+            source.write_bytes(newer)
+            processing.release()
+            wait_for_field(window, "Rotation", "77")
+            ack.release()
+            edit.wait_for_settled(outcome="completed")
+        sync.wait_for_applied(source, newer)
+        with sync.action() as next_edit:
+            edit_field(window, "Rotation", "88")
+        next_edit.wait_for_settled(outcome="completed")
+        window_element_with_label(window, "Rotation knob").single_click(
+            slint_testing.PointerEventButton.Left
+        )
+        with sync.action() as undo:
+            shortcut(window)
+        result = undo.wait_for_settled(outcome="completed")
+        assert result.data["operation_state"]["writes"] == 1
+        sync.wait_for_applied(source, newer)
+
+
+def test_paused_factory_clears_mounted_identity(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    newer = baseline.replace(b"32deg", b"77deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        sync = current_editor_sync.get()
+        sync.wait_for_applied(source, baseline)
+        before = sync._request(mode="checkpoint").data
+        with sync.gate("factory", source) as factory:
+            source.write_bytes(newer)
+            factory.wait_for_reached()
+            window.grab_window_as_png()
+            held = sync._request(mode="checkpoint").data
+            assert not held["mounted"]
+            assert held["installed"]["id"] == before["installed"]["id"]
+        sync.wait_for_applied(source, newer)
+        assert sync._request(mode="checkpoint").data["mounted"]

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -286,3 +286,116 @@ def test_unrelated_installation_cannot_release_pending_edit_history(
         undo.wait_for_settled(outcome="completed")
         sync.wait_for_applied(source, baseline)
         assert source.read_bytes() == baseline
+
+
+def wait_for_acknowledgment(sync, edit_id, checkpoint):
+    return sync._request(
+        mode="acknowledgment", edit=edit_id, after=checkpoint.cursor
+    ).data["acknowledgment"]
+
+
+@pytest.mark.parametrize("first", ["acknowledgment", "publication"])
+def test_edit_waits_for_both_matching_milestones(
+    editor_binary, editor_environment, fixture_project, first
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    seeded = baseline.replace(b"32deg", b"42deg")
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        with sync.action() as seed:
+            edit_field(window, "Rotation", "42")
+        seed.wait_for_settled(outcome="completed")
+        sync.wait_for_applied(source, seeded)
+        checkpoint = sync.checkpoint()
+        with (
+            sync.gate("acknowledgment", source) as acknowledgment,
+            sync.gate("publication", source) as publication,
+        ):
+            with sync.action() as edit:
+                edit_field(window, "Rotation", "62")
+            edit_id = acknowledgment.wait_for_reached().data["gate_state"]["edit"]
+            publication.wait_for_reached()
+            window_element_with_label(window, "Rotation knob").single_click(
+                slint_testing.PointerEventButton.Left
+            )
+            with sync.action() as undo:
+                shortcut(window)
+            assert (
+                "queued history"
+                in operation_state(undo)["operation_state"]["pending"].values()
+            )
+            if first == "acknowledgment":
+                acknowledgment.release()
+                assert wait_for_acknowledgment(sync, edit_id, checkpoint)["accepted"]
+                remaining = "publication gate"
+            else:
+                publication.release()
+                wait_for_field(window, "Rotation", "62")
+                remaining = "acknowledgment gate"
+            assert (
+                remaining
+                in operation_state(edit)["operation_state"]["pending"].values()
+            )
+            assert (
+                "queued history"
+                in operation_state(undo)["operation_state"]["pending"].values()
+            )
+            assert operation_state(undo)["operation_state"]["writes"] == 0
+        edit.wait_for_settled(outcome="completed")
+        result = undo.wait_for_settled(outcome="completed")
+        assert result.data["operation_state"]["writes"] == 1
+        sync.wait_for_applied(source, seeded)
+        assert source.read_bytes() == seeded
+
+
+def test_obsolete_acknowledgment_cannot_finish_newer_edit(
+    editor_binary, editor_environment, fixture_project
+):
+    baseline = prepare(fixture_project)
+    source = fixture_project / SOURCE
+    with launch_editor(editor_binary, editor_environment, source) as app:
+        window = first_window(app)
+        select_element(window, "Rectangle")
+        sync = current_editor_sync.get()
+        with sync.gate("acknowledgment", source) as acknowledgment:
+            with sync.action() as obsolete:
+                edit_field(window, "Rotation", "62")
+            obsolete_id = acknowledgment.wait_for_reached().data["gate_state"]["edit"]
+            wait_for_field(window, "Rotation", "62")
+            checkpoint = sync.checkpoint()
+            broken = b"export component Broken inherits Window { invalid syntax }"
+            source.write_bytes(broken)
+            sync.wait_for_processed(
+                source, broken, after=checkpoint, outcome="compile_error"
+            )
+            source.write_bytes(baseline)
+            sync.wait_for_applied(source, baseline)
+            select_element(window, "Rectangle")
+            with sync.gate("publication", source) as publication:
+                with sync.action() as current:
+                    edit_field(window, "Rotation", "77")
+                publication.wait_for_reached()
+                window_element_with_label(window, "Rotation knob").single_click(
+                    slint_testing.PointerEventButton.Left
+                )
+                with sync.action() as undo:
+                    shortcut(window)
+                checkpoint = sync.checkpoint()
+                acknowledgment.release()
+                assert not wait_for_acknowledgment(sync, obsolete_id, checkpoint)[
+                    "accepted"
+                ]
+                assert not operation_state(current)["settled"]
+                assert (
+                    "queued history"
+                    in operation_state(undo)["operation_state"]["pending"].values()
+                )
+                assert operation_state(undo)["operation_state"]["writes"] == 0
+            current.wait_for_settled(outcome="completed")
+            result = undo.wait_for_settled(outcome="completed")
+            assert result.data["operation_state"]["writes"] == 1
+        obsolete.wait_for_settled(outcome="completed")
+        sync.wait_for_applied(source, baseline)

--- a/tools/editor/ui-tests/tests/test_editor_lifecycle.py
+++ b/tools/editor/ui-tests/tests/test_editor_lifecycle.py
@@ -155,8 +155,9 @@ def test_active_gesture_has_terminal_cancellation_and_release_cannot_write(
         assert source.read_bytes() == baseline
 
 
-def test_pointer_down_without_movement_is_canceled_by_escape(
-    editor_binary, editor_environment, fixture_project
+@pytest.mark.parametrize("cancel", ["escape", "selection", "source"])
+def test_sealed_pointer_down_stays_pending_until_cancellation(
+    editor_binary, editor_environment, fixture_project, cancel
 ):
     baseline = prepare(fixture_project)
     source = fixture_project / SOURCE
@@ -165,25 +166,37 @@ def test_pointer_down_without_movement_is_canceled_by_escape(
         select_element(window, "Rectangle")
         sync = current_editor_sync.get()
         sync.wait_for_applied(source, baseline)
-        knob = window_element_with_label(window, "Rotation knob")
-        position = point(knob, 32)
+        position = point(window_element_with_label(window, "Rotation knob"), 32)
         with sync.action() as gesture:
             window.dispatch_event(
                 slint_testing.PointerPressEvent(
                     position, slint_testing.PointerEventButton.Left
                 )
             )
-            state = operation_state(gesture)
-            assert not state["settled"]
-            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
-            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+        state = operation_state(gesture)
+        assert state["operation_state"]["sealed"]
+        assert not state["settled"]
+        assert "inspector gesture" in state["operation_state"]["pending"].values()
+        with sync.action() as cancellation:
+            if cancel == "escape":
+                window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+                window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+            elif cancel == "selection":
+                select_element(window, "Text")
+            else:
+                baseline = baseline.replace(b"32deg", b"17deg")
+                source.write_bytes(baseline)
+                sync.wait_for_applied(source, baseline)
+        gesture.wait_for_settled(outcome="canceled")
+        gesture.assert_no_source_writes()
+        cancellation.assert_no_source_writes()
+        with sync.action() as release:
             window.dispatch_event(
                 slint_testing.PointerReleaseEvent(
                     position, slint_testing.PointerEventButton.Left
                 )
             )
-        gesture.wait_for_settled(outcome="canceled")
-        gesture.assert_no_source_writes()
+        release.assert_no_source_writes()
         assert source.read_bytes() == baseline
 
 

--- a/tools/editor/ui-tests/tests/test_editor_sync.py
+++ b/tools/editor/ui-tests/tests/test_editor_sync.py
@@ -2,83 +2,129 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import json
+from types import SimpleNamespace
 
 import pytest
-from editor_sync import EditorSync
+from editor_sync import PROTOCOL_VERSION, EditorSync, SyncCheckpoint
 
 
-def test_wait_rejects_old_response_and_unfinished_edit(tmp_path, monkeypatch):
-    sync = EditorSync(tmp_path)
-    response = tmp_path / "response.json"
-    response.write_text(json.dumps({"id": 0, "ready": True}))
-    replies = iter(
-        [
-            {
-                "id": 1,
-                "protocol": 2,
-                "session": "s",
-                "cursor": 0,
-                "writes": 0,
-                "accepted_edits": 0,
-                "ready": True,
-            },
-            {
-                "id": 2,
-                "protocol": 2,
-                "session": "s",
-                "cursor": 1,
-                "writes": 0,
-                "accepted_edits": 0,
-                "ready": False,
-                "busy": True,
-            },
-            {
-                "id": 2,
-                "protocol": 2,
-                "session": "s",
-                "cursor": 1,
-                "writes": 0,
-                "accepted_edits": 0,
-                "ready": False,
-                "busy": False,
-            },
-            {
-                "id": 2,
-                "protocol": 2,
-                "session": "s",
-                "cursor": 2,
-                "writes": 0,
-                "accepted_edits": 0,
-                "ready": True,
-                "events": [],
-            },
-        ]
-    )
-    polls = []
+def reply(request_id=1, **changes):
+    return {
+        "id": request_id,
+        "protocol": PROTOCOL_VERSION,
+        "session": "s",
+        "cursor": 0,
+        "writes": 0,
+        "accepted_edits": 0,
+        "ready": True,
+        "events": [],
+    } | changes
 
-    def advance(_):
-        reply = next(replies)
-        polls.append(reply)
-        response.write_text(json.dumps(reply))
+
+@pytest.fixture
+def clock(monkeypatch):
+    clock = SimpleNamespace(now=0.0, steps=[])
+    monkeypatch.setattr("editor_sync.time.monotonic", lambda: clock.now)
+
+    def advance(seconds):
+        clock.now += seconds
+        if clock.steps:
+            clock.steps.pop(0)()
 
     monkeypatch.setattr("editor_sync.time.sleep", advance)
-    sync.wait_for_source(tmp_path / "Main.slint", b"new source")
-    assert len(polls) == 4
+    return clock
+
+
+def test_wait_rejects_old_response_and_waits_for_terminal_state(tmp_path, clock):
+    response = tmp_path / "response.json"
+    response.write_text(json.dumps(reply(0)))
+    replies = [
+        reply(1),
+        reply(2, ready=False, operations={"3": {"pending": ["publication"]}}),
+        reply(2, ready=True),
+    ]
+    clock.steps = [lambda r=r: response.write_text(json.dumps(r)) for r in replies]
+    EditorSync(tmp_path).wait_for_source(tmp_path / "Main.slint", b"new source")
+    assert not clock.steps
+    assert not (tmp_path / "request.json").exists()
+    assert "publication" in (tmp_path / "trace.jsonl").read_text()
+
+
+def test_one_deadline_includes_handshake(tmp_path, clock):
+    response = tmp_path / "response.json"
+    clock.steps = [lambda: response.write_text(json.dumps(reply()))]
+    with pytest.raises(AssertionError, match="did not reach applied"):
+        EditorSync(tmp_path).wait_for_source(
+            tmp_path / "Main.slint", b"source", timeout=0.04
+        )
+    assert clock.now == pytest.approx(0.04)
     assert not (tmp_path / "request.json").exists()
 
 
-def test_wait_timeout_reports_last_state_and_removes_request(tmp_path):
-    (tmp_path / "response.json").write_text(json.dumps({"id": 0, "ready": False}))
-    with pytest.raises(AssertionError, match="did not reach handshake"):
-        EditorSync(tmp_path).wait_for_source(
-            tmp_path / "Main.slint", b"source", timeout=0
+@pytest.mark.parametrize(
+    "response,match",
+    [
+        (reply(protocol=2), "protocol"),
+        (reply(session="old"), "stale"),
+        (reply(ready=False, writes=True), "writes"),
+        (reply(ready=False, events=None), "event history"),
+        (reply(error="event history overflow"), "overflow"),
+        (reply(error="request ID reused"), "reused"),
+        ({"ready": True}, "malformed"),
+    ],
+)
+def test_invalid_responses_fail_even_before_ready(tmp_path, clock, response, match):
+    (tmp_path / "response.json").write_text(json.dumps(response))
+    with pytest.raises((AssertionError, TypeError), match=match):
+        EditorSync(tmp_path, session="s").checkpoint()
+    assert clock.now == 0
+    assert not (tmp_path / "request.json").exists()
+
+
+def test_exit_fails_without_waiting(tmp_path, clock):
+    class ExitedProcess:
+        def poll(self) -> int:
+            return 3
+
+    with pytest.raises(AssertionError, match="editor exited"):
+        EditorSync(tmp_path, process=ExitedProcess()).checkpoint()
+    assert clock.now == 0
+
+
+def test_stale_checkpoint_is_rejected_before_request(tmp_path, clock):
+    sync = EditorSync(tmp_path, session="s")
+    with pytest.raises(AssertionError, match="another editor session"):
+        sync.wait_for_processed(
+            tmp_path / "Main.slint", None, after=SyncCheckpoint("old", 0, 0, 0)
         )
     assert not (tmp_path / "request.json").exists()
 
 
-def test_legacy_response_is_rejected(tmp_path):
-    (tmp_path / "response.json").write_text(json.dumps({"id": 1, "ready": True}))
-    with pytest.raises(AssertionError, match="protocol"):
-        EditorSync(tmp_path).wait_for_source(
-            tmp_path / "Main.slint", b"source", timeout=0
-        )
+def test_action_seals_without_inventing_an_outcome(tmp_path, monkeypatch):
+    sync = EditorSync(tmp_path, session="s")
+    requests = []
+
+    def request(**kwargs):
+        requests.append(kwargs)
+        return SimpleNamespace(data={"operation": 7})
+
+    monkeypatch.setattr(sync, "_request", request)
+    with pytest.raises(ValueError), sync.action():
+        raise ValueError("input failed")
+    assert [r["mode"] for r in requests] == ["begin", "seal"]
+    assert all("outcome" not in r for r in requests)
+
+
+def test_gate_released_when_test_fails(tmp_path, monkeypatch):
+    sync = EditorSync(tmp_path, session="s")
+    requests = []
+
+    def request(**kwargs):
+        requests.append(kwargs)
+        return SimpleNamespace(data={"gate": 8})
+
+    monkeypatch.setattr(sync, "_request", request)
+    with pytest.raises(ValueError), sync.gate("publication", tmp_path / "Main.slint"):
+        raise ValueError("assertion failed")
+    assert [r["mode"] for r in requests] == ["gate_open", "gate_release"]
+    assert requests[-1]["gate"] == 8

--- a/tools/editor/ui-tests/tests/test_editor_sync.py
+++ b/tools/editor/ui-tests/tests/test_editor_sync.py
@@ -50,7 +50,7 @@ def test_wait_rejects_old_response_and_waits_for_terminal_state(tmp_path, clock)
         reply(2, ready=True),
     ]
     clock.steps = [lambda r=r: response.write_text(json.dumps(r)) for r in replies]
-    EditorSync(tmp_path).wait_for_source(tmp_path / "Main.slint", b"new source")
+    EditorSync(tmp_path).wait_for_applied(tmp_path / "Main.slint", b"new source")
     assert not clock.steps
     assert not (tmp_path / "request.json").exists()
     assert "publication" in (tmp_path / "trace.jsonl").read_text()
@@ -60,7 +60,7 @@ def test_one_deadline_includes_handshake(tmp_path, clock):
     response = tmp_path / "response.json"
     clock.steps = [lambda: response.write_text(json.dumps(reply()))]
     with pytest.raises(AssertionError, match="did not reach applied"):
-        EditorSync(tmp_path).wait_for_source(
+        EditorSync(tmp_path).wait_for_applied(
             tmp_path / "Main.slint", b"source", timeout=0.04
         )
     assert clock.now == pytest.approx(0.04)
@@ -101,7 +101,7 @@ def test_stale_checkpoint_is_rejected_before_request(tmp_path, clock):
     sync = EditorSync(tmp_path, session="s")
     with pytest.raises(AssertionError, match="another editor session"):
         sync.wait_for_processed(
-            tmp_path / "Main.slint", None, after=SyncCheckpoint("old", 0, 0, 0)
+            tmp_path / "Main.slint", None, after=SyncCheckpoint("old", 0)
         )
     assert not (tmp_path / "request.json").exists()
 

--- a/tools/editor/ui-tests/tests/test_editor_sync.py
+++ b/tools/editor/ui-tests/tests/test_editor_sync.py
@@ -5,7 +5,13 @@ import json
 from types import SimpleNamespace
 
 import pytest
-from editor_sync import PROTOCOL_VERSION, EditorSync, SyncCheckpoint
+from editor_sync import (
+    PROTOCOL_VERSION,
+    EditorAction,
+    EditorSync,
+    SyncCheckpoint,
+    SyncResult,
+)
 
 
 def reply(request_id=1, **changes):
@@ -128,3 +134,22 @@ def test_gate_released_when_test_fails(tmp_path, monkeypatch):
         raise ValueError("assertion failed")
     assert [r["mode"] for r in requests] == ["gate_open", "gate_release"]
     assert requests[-1]["gate"] == 8
+
+
+@pytest.mark.parametrize(
+    "state,message",
+    [
+        ({"writes": 1, "mutations": 1, "accepted_edits": 1}, "wrote source"),
+        ({"writes": 0, "mutations": 1, "accepted_edits": 1}, "may have changed source"),
+        ({"writes": 0, "mutations": 0, "accepted_edits": 1}, "accepted an edit"),
+    ],
+)
+def test_no_write_assertion_rejects_each_mutation_evidence(
+    tmp_path, monkeypatch, state, message
+):
+    action = EditorAction(EditorSync(tmp_path), 1, 5, sealed=True)
+    monkeypatch.setattr(
+        action, "wait_for_settled", lambda: SyncResult({"operation_state": state})
+    )
+    with pytest.raises(AssertionError, match=message):
+        action.assert_no_source_writes()

--- a/tools/editor/ui-tests/tests/test_editor_sync.py
+++ b/tools/editor/ui-tests/tests/test_editor_sync.py
@@ -13,9 +13,45 @@ def test_wait_rejects_old_response_and_unfinished_edit(tmp_path, monkeypatch):
     response.write_text(json.dumps({"id": 0, "ready": True}))
     replies = iter(
         [
-            {"id": 1, "ready": False, "busy": True},
-            {"id": 1, "ready": False, "busy": False, "mismatches": ["old source"]},
-            {"id": 1, "ready": True},
+            {
+                "id": 1,
+                "protocol": 2,
+                "session": "s",
+                "cursor": 0,
+                "writes": 0,
+                "accepted_edits": 0,
+                "ready": True,
+            },
+            {
+                "id": 2,
+                "protocol": 2,
+                "session": "s",
+                "cursor": 1,
+                "writes": 0,
+                "accepted_edits": 0,
+                "ready": False,
+                "busy": True,
+            },
+            {
+                "id": 2,
+                "protocol": 2,
+                "session": "s",
+                "cursor": 1,
+                "writes": 0,
+                "accepted_edits": 0,
+                "ready": False,
+                "busy": False,
+            },
+            {
+                "id": 2,
+                "protocol": 2,
+                "session": "s",
+                "cursor": 2,
+                "writes": 0,
+                "accepted_edits": 0,
+                "ready": True,
+                "events": [],
+            },
         ]
     )
     polls = []
@@ -27,16 +63,22 @@ def test_wait_rejects_old_response_and_unfinished_edit(tmp_path, monkeypatch):
 
     monkeypatch.setattr("editor_sync.time.sleep", advance)
     sync.wait_for_source(tmp_path / "Main.slint", b"new source")
-    assert len(polls) == 3
+    assert len(polls) == 4
     assert not (tmp_path / "request.json").exists()
 
 
 def test_wait_timeout_reports_last_state_and_removes_request(tmp_path):
-    (tmp_path / "response.json").write_text(
-        json.dumps({"id": 1, "ready": False, "busy": True})
-    )
-    with pytest.raises(AssertionError, match="'busy': True"):
+    (tmp_path / "response.json").write_text(json.dumps({"id": 0, "ready": False}))
+    with pytest.raises(AssertionError, match="did not reach handshake"):
         EditorSync(tmp_path).wait_for_source(
             tmp_path / "Main.slint", b"source", timeout=0
         )
     assert not (tmp_path / "request.json").exists()
+
+
+def test_legacy_response_is_rejected(tmp_path):
+    (tmp_path / "response.json").write_text(json.dumps({"id": 1, "ready": True}))
+    with pytest.raises(AssertionError, match="protocol"):
+        EditorSync(tmp_path).wait_for_source(
+            tmp_path / "Main.slint", b"source", timeout=0
+        )

--- a/tools/editor/ui-tests/tests/test_inspector.py
+++ b/tools/editor/ui-tests/tests/test_inspector.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from editor_sync import current_editor_sync
 from inspector_interactions import FIELDS, edit_field, inspector_field, wait_for_field
 from source_snapshot import SourceSnapshot
 from ui_driver import (
@@ -106,7 +107,7 @@ def test_geometry_field_writes_exact_source(
         window = first_window(editor)
         select_element(window, "Rectangle")
         edit_field(window, label, value, slint_testing.AccessibleRole.TextInput)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(baseline, old, new), relative_path=INSPECTOR_SOURCE
         )
         wait_for_field(
@@ -156,7 +157,7 @@ def test_element_color_field_writes_exact_source(
         window = first_window(editor)
         select_element(window, kind)
         edit_field(window, label, value, slint_testing.AccessibleRole.TextInput)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(baseline, old, new), relative_path=INSPECTOR_SOURCE
         )
         assert_rendered_element(window, f"InspectorCases::inspect-{kind.lower()}")
@@ -228,7 +229,7 @@ def test_each_image_fit_value_writes_exact_source(
         window = first_window(editor)
         select_element(window, "Image")
         edit_field(window, "Image fit", fit, slint_testing.AccessibleRole.Combobox)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(
                 starting_source,
                 f"        image-fit: {initial};".encode(),
@@ -266,7 +267,7 @@ def test_each_horizontal_image_alignment_writes_exact_source(
             alignment,
             slint_testing.AccessibleRole.Combobox,
         )
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(
                 starting_source,
                 f"        horizontal-alignment: {initial};".encode(),
@@ -304,7 +305,7 @@ def test_each_vertical_image_alignment_writes_exact_source(
             alignment,
             slint_testing.AccessibleRole.Combobox,
         )
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(
                 starting_source,
                 f"        vertical-alignment: {initial};".encode(),
@@ -331,7 +332,7 @@ def test_image_source_writes_exact_source(
         edit_field(
             window, "Image source", value, slint_testing.AccessibleRole.TextInput
         )
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(
                 baseline,
                 b'        source: @image-url("assets/checker.svg");',
@@ -357,7 +358,7 @@ def test_font_family_writes_exact_source(
         edit_field(
             window, "Font family", "Fira Sans", slint_testing.AccessibleRole.TextInput
         )
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(
                 baseline,
                 b'        font-family: "Inter";',
@@ -392,7 +393,7 @@ def test_each_font_weight_writes_exact_source(
         window = first_window(editor)
         select_element(window, "Text")
         edit_field(window, "Font weight", weight, slint_testing.AccessibleRole.Combobox)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(
                 starting_source,
                 f"        font-weight: {initial};".encode(),
@@ -503,7 +504,7 @@ def test_numeric_and_expression_font_sizes_write_exact_source(
         window = first_window(editor)
         select_element(window, "Text")
         edit_field(window, "Font size", value, slint_testing.AccessibleRole.TextInput)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             replace_once(
                 baseline,
                 b"        font-size: 20px;",
@@ -570,14 +571,16 @@ def test_invalid_text_content_does_not_change_source(
 
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        select_element(window, "Text")
-        edit_field(
-            window,
-            "Text content",
-            "unknown_identifier",
-            slint_testing.AccessibleRole.TextInput,
-        )
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            select_element(window, "Text")
+            edit_field(
+                window,
+                "Text content",
+                "unknown_identifier",
+                slint_testing.AccessibleRole.TextInput,
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
         wait_for_field(
             window,
             "Text content",
@@ -686,7 +689,7 @@ def test_each_shadow_family_control_writes_exact_source(
                 slint_testing.AccessibleRole.TextInput,
             )
         edit_field(window, label, value)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             shadow_expected(starting_source, family, control, value),
             relative_path=INSPECTOR_SOURCE,
         )
@@ -731,7 +734,7 @@ def test_shadow_control_boundary_writes_exact_source(
                 slint_testing.AccessibleRole.TextInput,
             )
         edit_field(window, label, value)
-        snapshot.wait_for_exact(
+        snapshot.wait_for_applied(
             shadow_expected(starting_source, family, control, value),
             relative_path=INSPECTOR_SOURCE,
         )
@@ -782,12 +785,16 @@ def test_invalid_or_empty_inspector_edit_does_not_change_source(
 
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        select_element(window, kind)
-        role = slint_testing.AccessibleRole.Combobox if label == "Image fit" else None
-        field = inspector_field(window, label, role)
-        value_before = field.accessible_value
-        edit_field(window, label, value, role)
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            select_element(window, kind)
+            role = (
+                slint_testing.AccessibleRole.Combobox if label == "Image fit" else None
+            )
+            field = inspector_field(window, label, role)
+            value_before = field.accessible_value
+            edit_field(window, label, value, role)
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
         wait_for_field(window, label, value_before, role)
         window_element_with_label(
             window, f"Selected {kind}", slint_testing.AccessibleRole.Region
@@ -804,14 +811,16 @@ def test_invalid_rectangle_color_does_not_change_source(
 
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        select_element(window, "Rectangle")
-        edit_field(
-            window,
-            "Rectangle background",
-            "not-a-color",
-            slint_testing.AccessibleRole.TextInput,
-        )
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            select_element(window, "Rectangle")
+            edit_field(
+                window,
+                "Rectangle background",
+                "not-a-color",
+                slint_testing.AccessibleRole.TextInput,
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
         wait_for_field(
             window,
             "Rectangle background",

--- a/tools/editor/ui-tests/tests/test_inspector_transform.py
+++ b/tools/editor/ui-tests/tests/test_inspector_transform.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import math
-import time
 from pathlib import Path
 
 import pytest
 import slint_testing
+from canvas_interactions import oriented_selection_frame
 from editor_sync import current_editor_sync
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
@@ -123,8 +123,10 @@ def test_corner_edit_changes_only_one_property(
     ) as app:
         window = first_window(app)
         select_element(window, "Rectangle")
-        action(window, "Separate corners")
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as separate:
+            action(window, "Separate corners")
+        separate.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
         edit_field(window, LABELS[index], "30.5")
         snapshot.wait_for_applied(expected, relative_path=SOURCE)
         wait_for_field(window, LABELS[index], "30.5")
@@ -202,8 +204,10 @@ def test_invalid_transform_input_preserves_source(
     ) as app:
         window = first_window(app)
         select_element(window, "Rectangle")
-        edit_field(window, label, value)
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as edit:
+            edit_field(window, label, value)
+        edit.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def point(knob, angle):
@@ -228,27 +232,30 @@ def test_knob_crosses_zero_with_transient_preview(
         knob = window_element_with_label(window, "Rotation knob")
         assert knob.size.width == 32 and knob.size.height == 32
         start, end = point(knob, 350), point(knob, 10)
-        window.dispatch_event(
-            slint_testing.PointerPressEvent(
-                start, slint_testing.PointerEventButton.Left
+        with current_editor_sync.get().action() as gesture:
+            window.dispatch_event(
+                slint_testing.PointerPressEvent(
+                    start, slint_testing.PointerEventButton.Left
+                )
             )
-        )
-        wait_for_field(window, "Rotation", "350")
-        window.dispatch_event(slint_testing.PointerMoveEvent(end))
-        wait_for_field(window, "Rotation", "370")
-        snapshot.assert_unchanged()
-        if cancel == "escape":
-            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
-            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
-        if cancel == "pointer":
-            window.dispatch_event(slint_testing.PointerExitedEvent())
-        window.dispatch_event(
-            slint_testing.PointerReleaseEvent(
-                end, slint_testing.PointerEventButton.Left
+            wait_for_field(window, "Rotation", "350")
+            window.dispatch_event(slint_testing.PointerMoveEvent(end))
+            wait_for_field(window, "Rotation", "370")
+            snapshot.assert_unchanged_now()
+            if cancel == "escape":
+                window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+                window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+            if cancel == "pointer":
+                window.dispatch_event(slint_testing.PointerExitedEvent())
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(
+                    end, slint_testing.PointerEventButton.Left
+                )
             )
-        )
         if cancel != "release":
-            snapshot.assert_unchanged()
+            gesture.wait_for_settled(outcome="canceled")
+            gesture.assert_no_source_writes()
+            snapshot.assert_unchanged_now()
             wait_for_field(window, "Rotation", "350")
         else:
             snapshot.wait_for_applied(
@@ -329,20 +336,23 @@ def test_selection_change_cancels_knob_drag(
         select_element(window, "Rectangle")
         knob = window_element_with_label(window, "Rotation knob")
         start, end = point(knob, 32), point(knob, 62)
-        window.dispatch_event(
-            slint_testing.PointerPressEvent(
-                start, slint_testing.PointerEventButton.Left
+        with current_editor_sync.get().action() as gesture:
+            window.dispatch_event(
+                slint_testing.PointerPressEvent(
+                    start, slint_testing.PointerEventButton.Left
+                )
             )
-        )
-        window.dispatch_event(slint_testing.PointerMoveEvent(end))
-        wait_for_field(window, "Rotation", "62")
-        select_element(window, "Text")
-        window.dispatch_event(
-            slint_testing.PointerReleaseEvent(
-                end, slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerMoveEvent(end))
+            wait_for_field(window, "Rotation", "62")
+            select_element(window, "Text")
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(
+                    end, slint_testing.PointerEventButton.Left
+                )
             )
-        )
-        snapshot.assert_unchanged()
+        gesture.wait_for_settled(outcome="canceled")
+        gesture.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
         select_element(window, "Rectangle")
         wait_for_field(window, "Rotation", "32")
 
@@ -364,24 +374,27 @@ def test_corner_slider_previews_then_commits_once(
             x=pos.x + 6 + (size.width - 12) / 4, y=pos.y + 12
         )
         end = slint_testing.LogicalPosition(x=pos.x + size.width - 6, y=pos.y + 12)
-        window.dispatch_event(
-            slint_testing.PointerPressEvent(
-                start, slint_testing.PointerEventButton.Left
+        with current_editor_sync.get().action() as gesture:
+            window.dispatch_event(
+                slint_testing.PointerPressEvent(
+                    start, slint_testing.PointerEventButton.Left
+                )
             )
-        )
-        window.dispatch_event(slint_testing.PointerMoveEvent(end))
-        wait_for_field(window, "All corner radii", "48")
-        snapshot.assert_unchanged()
-        if cancel:
-            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
-            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
-        window.dispatch_event(
-            slint_testing.PointerReleaseEvent(
-                end, slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerMoveEvent(end))
+            wait_for_field(window, "All corner radii", "48")
+            snapshot.assert_unchanged_now()
+            if cancel:
+                window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+                window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(
+                    end, slint_testing.PointerEventButton.Left
+                )
             )
-        )
         if cancel:
-            snapshot.assert_unchanged()
+            gesture.wait_for_settled(outcome="canceled")
+            gesture.assert_no_source_writes()
+            snapshot.assert_unchanged_now()
             wait_for_field(window, "All corner radii", "12")
         else:
             expected = baseline
@@ -436,7 +449,7 @@ def test_knob_shift_drag_snaps_and_retains_keyboard_focus(
         window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Shift))
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
         wait_for_field(window, "Rotation", "45")
-        snapshot.assert_unchanged()
+        snapshot.assert_unchanged_now()
         window.dispatch_event(
             slint_testing.PointerReleaseEvent(
                 end, slint_testing.PointerEventButton.Left
@@ -479,21 +492,17 @@ def test_source_reload_cancels_knob_gesture(
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
         wait_for_field(window, "Rotation", "62")
         updated = baseline.replace(b"32deg", b"17.5deg")
-        checkpoint = current_editor_sync.get().checkpoint()
-        (fixture_project / SOURCE).write_bytes(updated)
-        current_editor_sync.get().wait_for_processed(
-            fixture_project / SOURCE,
-            updated,
-            after=int(checkpoint["cursor"]),
-            outcome="compiled",
-        )
-        wait_for_field(window, "Rotation", "17.5")
-        window.dispatch_event(
-            slint_testing.PointerReleaseEvent(
-                end, slint_testing.PointerEventButton.Left
+        sync = current_editor_sync.get()
+        with sync.action() as release:
+            (fixture_project / SOURCE).write_bytes(updated)
+            sync.wait_for_applied(fixture_project / SOURCE, updated)
+            wait_for_field(window, "Rotation", "17.5")
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(
+                    end, slint_testing.PointerEventButton.Left
+                )
             )
-        )
-        current_editor_sync.get().checkpoint(timeout=1)
+        release.assert_no_source_writes()
         assert (fixture_project / SOURCE).read_bytes() == updated
 
 
@@ -565,13 +574,15 @@ def test_undo_while_dragging_cancels_release(
                 )
             )
         if history:
+            result = action_scope.wait_for_settled(outcome="completed")
+            assert result.data["operation_state"]["writes"] == 1
             sync.wait_for_source(
                 fixture_project / SOURCE,
                 baseline,
-                after=int(action_scope.checkpoint["cursor"]),
             )
         else:
-            action_scope.assert_no_source_writes(timeout=1)
+            action_scope.wait_for_settled(outcome="canceled")
+            action_scope.assert_no_source_writes()
         wait_for_field(window, "Rotation", "32")
 
 
@@ -641,19 +652,21 @@ def test_rotation_release_keeps_preview_until_reload(
         )
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
         wait_for_field(window, "Rotation", "50")
-        snapshot.assert_unchanged()
-        window.dispatch_event(
-            slint_testing.PointerReleaseEvent(
-                end, slint_testing.PointerEventButton.Left
-            )
-        )
-        deadline = time.monotonic() + 0.5
-        while time.monotonic() < deadline:
-            assert (
-                window_element_with_label(
-                    window, "Rotation", slint_testing.AccessibleRole.TextInput
-                ).accessible_value
-                == "50"
-            )
-            time.sleep(0.01)
+        snapshot.assert_unchanged_now()
+        sync = current_editor_sync.get()
+        with sync.gate("publication", fixture_project / SOURCE) as gate:
+            with sync.action() as release:
+                window.dispatch_event(
+                    slint_testing.PointerReleaseEvent(
+                        end, slint_testing.PointerEventButton.Left
+                    )
+                )
+            gate.wait_for_reached()
+            state = sync._request(mode="operation", operation=release.operation).data
+            assert not state["settled"]
+            wait_for_field(window, "Rotation", "50")
+            frame = oriented_selection_frame(window, "Rectangle")
+            assert frame is not None and frame[-1] == pytest.approx(50, abs=1)
+            assert state["operation_state"]["writes"] == 1
+        release.wait_for_settled(outcome="completed")
         snapshot.wait_for_applied(baseline.replace(b"32deg", b"50deg"), SOURCE)

--- a/tools/editor/ui-tests/tests/test_inspector_transform.py
+++ b/tools/editor/ui-tests/tests/test_inspector_transform.py
@@ -576,7 +576,7 @@ def test_undo_while_dragging_cancels_release(
         if history:
             result = action_scope.wait_for_settled(outcome="completed")
             assert result.data["operation_state"]["writes"] == 1
-            sync.wait_for_source(
+            sync.wait_for_applied(
                 fixture_project / SOURCE,
                 baseline,
             )

--- a/tools/editor/ui-tests/tests/test_inspector_transform.py
+++ b/tools/editor/ui-tests/tests/test_inspector_transform.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from editor_sync import current_editor_sync
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from test_inspector import edit_field as edit_inspector_field
@@ -478,14 +479,21 @@ def test_source_reload_cancels_knob_gesture(
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
         wait_for_field(window, "Rotation", "62")
         updated = baseline.replace(b"32deg", b"17.5deg")
+        checkpoint = current_editor_sync.get().checkpoint()
         (fixture_project / SOURCE).write_bytes(updated)
+        current_editor_sync.get().wait_for_processed(
+            fixture_project / SOURCE,
+            updated,
+            after=int(checkpoint["cursor"]),
+            outcome="compiled",
+        )
         wait_for_field(window, "Rotation", "17.5")
         window.dispatch_event(
             slint_testing.PointerReleaseEvent(
                 end, slint_testing.PointerEventButton.Left
             )
         )
-        time.sleep(0.2)
+        current_editor_sync.get().checkpoint(timeout=1)
         assert (fixture_project / SOURCE).read_bytes() == updated
 
 
@@ -548,14 +556,22 @@ def test_undo_while_dragging_cancels_release(
         )
         window.dispatch_event(slint_testing.PointerMoveEvent(end))
         wait_for_field(window, "Rotation", "72" if history else "62")
-        shortcut(window)
-        window.dispatch_event(
-            slint_testing.PointerReleaseEvent(
-                end, slint_testing.PointerEventButton.Left
+        sync = current_editor_sync.get()
+        with sync.action() as action_scope:
+            shortcut(window)
+            window.dispatch_event(
+                slint_testing.PointerReleaseEvent(
+                    end, slint_testing.PointerEventButton.Left
+                )
             )
-        )
-        time.sleep(0.3)
-        snapshot.wait_for_applied(baseline, relative_path=SOURCE)
+        if history:
+            sync.wait_for_source(
+                fixture_project / SOURCE,
+                baseline,
+                after=int(action_scope.checkpoint["cursor"]),
+            )
+        else:
+            action_scope.assert_no_source_writes(timeout=1)
         wait_for_field(window, "Rotation", "32")
 
 

--- a/tools/editor/ui-tests/tests/test_navigation.py
+++ b/tools/editor/ui-tests/tests/test_navigation.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 import slint_testing
+from editor_sync import current_editor_sync
 from source_snapshot import SourceSnapshot
 from ui_driver import (
     PALETTE_KINDS,
@@ -26,14 +27,16 @@ def test_file_tree_opens_sibling_component(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        file_row(
-            window, fixture_project / "Sibling.slint"
-        ).invoke_accessible_default_action()
-        window_element_with_label(
-            window, "sibling-rectangle", slint_testing.AccessibleRole.ListItem
-        )
-        assert not elements_with_label(window.root_element, "root-text")
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            file_row(
+                window, fixture_project / "Sibling.slint"
+            ).invoke_accessible_default_action()
+            window_element_with_label(
+                window, "sibling-rectangle", slint_testing.AccessibleRole.ListItem
+            )
+            assert not elements_with_label(window.root_element, "root-text")
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_file_tree_folder_expand_and_collapse(
@@ -48,19 +51,21 @@ def test_file_tree_folder_expand_and_collapse(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        folder = file_row(window, assets)
-        assert not elements_with_label(window.root_element, str(image))
-        folder.invoke_accessible_default_action()
-        file_row(window, image)
-        file_row(window, assets).invoke_accessible_default_action()
-        wait_until(
-            lambda: (
-                True
-                if not elements_with_label(window.root_element, str(image))
-                else None
+        with current_editor_sync.get().action() as input_action:
+            folder = file_row(window, assets)
+            assert not elements_with_label(window.root_element, str(image))
+            folder.invoke_accessible_default_action()
+            file_row(window, image)
+            file_row(window, assets).invoke_accessible_default_action()
+            wait_until(
+                lambda: (
+                    True
+                    if not elements_with_label(window.root_element, str(image))
+                    else None
+                )
             )
-        )
-        snapshot.assert_unchanged()
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_file_tree_switches_image_and_component_surfaces(
@@ -74,41 +79,45 @@ def test_file_tree_switches_image_and_component_surfaces(
     image = assets / "checker.svg"
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        window_element_with_label(
-            window, "Editor canvas", slint_testing.AccessibleRole.Main
-        )
-        file_row(window, assets).invoke_accessible_default_action()
-        file_row(window, image).invoke_accessible_default_action()
-        image_editor = window_element_with_label(
-            window, "Image asset editor", slint_testing.AccessibleRole.Main
-        )
-        assert image_editor.accessible_description == "assets/checker.svg"
-        window_element_with_label(
-            window, "Preview", slint_testing.AccessibleRole.Button
-        )
-        file_fields = elements_with_label(
-            image_editor, "File", slint_testing.AccessibleRole.Text
-        )
-        assert file_fields
-        assert {
-            field.accessible_value for field in file_fields if field.accessible_value
-        } == {"assets/checker.svg"}
-        wait_until(
-            lambda: (
-                True
-                if not elements_with_label(window.root_element, "Editor canvas")
-                else None
+        with current_editor_sync.get().action() as input_action:
+            window_element_with_label(
+                window, "Editor canvas", slint_testing.AccessibleRole.Main
             )
-        )
-        for kind in PALETTE_KINDS:
-            assert not window_element_with_label(
-                window, kind, slint_testing.AccessibleRole.ListItem
-            ).accessible_enabled
-        file_row(window, source_file).invoke_accessible_default_action()
-        window_element_with_label(
-            window, "Editor canvas", slint_testing.AccessibleRole.Main
-        )
-        window_element_with_label(
-            window, "Fixture text", slint_testing.AccessibleRole.Text
-        )
-        snapshot.assert_unchanged()
+            file_row(window, assets).invoke_accessible_default_action()
+            file_row(window, image).invoke_accessible_default_action()
+            image_editor = window_element_with_label(
+                window, "Image asset editor", slint_testing.AccessibleRole.Main
+            )
+            assert image_editor.accessible_description == "assets/checker.svg"
+            window_element_with_label(
+                window, "Preview", slint_testing.AccessibleRole.Button
+            )
+            file_fields = elements_with_label(
+                image_editor, "File", slint_testing.AccessibleRole.Text
+            )
+            assert file_fields
+            assert {
+                field.accessible_value
+                for field in file_fields
+                if field.accessible_value
+            } == {"assets/checker.svg"}
+            wait_until(
+                lambda: (
+                    True
+                    if not elements_with_label(window.root_element, "Editor canvas")
+                    else None
+                )
+            )
+            for kind in PALETTE_KINDS:
+                assert not window_element_with_label(
+                    window, kind, slint_testing.AccessibleRole.ListItem
+                ).accessible_enabled
+            file_row(window, source_file).invoke_accessible_default_action()
+            window_element_with_label(
+                window, "Editor canvas", slint_testing.AccessibleRole.Main
+            )
+            window_element_with_label(
+                window, "Fixture text", slint_testing.AccessibleRole.Text
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/test_navigation.py
+++ b/tools/editor/ui-tests/tests/test_navigation.py
@@ -31,11 +31,11 @@ def test_file_tree_opens_sibling_component(
             file_row(
                 window, fixture_project / "Sibling.slint"
             ).invoke_accessible_default_action()
-            window_element_with_label(
-                window, "sibling-rectangle", slint_testing.AccessibleRole.ListItem
-            )
-            assert not elements_with_label(window.root_element, "root-text")
         input_action.assert_no_source_writes()
+        window_element_with_label(
+            window, "sibling-rectangle", slint_testing.AccessibleRole.ListItem
+        )
+        assert not elements_with_label(window.root_element, "root-text")
         snapshot.assert_unchanged_now()
 
 
@@ -51,20 +51,20 @@ def test_file_tree_folder_expand_and_collapse(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
+        folder = file_row(window, assets)
+        assert not elements_with_label(window.root_element, str(image))
         with current_editor_sync.get().action() as input_action:
-            folder = file_row(window, assets)
-            assert not elements_with_label(window.root_element, str(image))
             folder.invoke_accessible_default_action()
             file_row(window, image)
             file_row(window, assets).invoke_accessible_default_action()
-            wait_until(
-                lambda: (
-                    True
-                    if not elements_with_label(window.root_element, str(image))
-                    else None
-                )
-            )
         input_action.assert_no_source_writes()
+        wait_until(
+            lambda: (
+                True
+                if not elements_with_label(window.root_element, str(image))
+                else None
+            )
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -79,10 +79,10 @@ def test_file_tree_switches_image_and_component_surfaces(
     image = assets / "checker.svg"
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
+        window_element_with_label(
+            window, "Editor canvas", slint_testing.AccessibleRole.Main
+        )
         with current_editor_sync.get().action() as input_action:
-            window_element_with_label(
-                window, "Editor canvas", slint_testing.AccessibleRole.Main
-            )
             file_row(window, assets).invoke_accessible_default_action()
             file_row(window, image).invoke_accessible_default_action()
             image_editor = window_element_with_label(
@@ -116,8 +116,8 @@ def test_file_tree_switches_image_and_component_surfaces(
             window_element_with_label(
                 window, "Editor canvas", slint_testing.AccessibleRole.Main
             )
-            window_element_with_label(
-                window, "Fixture text", slint_testing.AccessibleRole.Text
-            )
         input_action.assert_no_source_writes()
+        window_element_with_label(
+            window, "Fixture text", slint_testing.AccessibleRole.Text
+        )
         snapshot.assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/test_outline.py
+++ b/tools/editor/ui-tests/tests/test_outline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import slint_testing
 from canvas_interactions import center
+from editor_sync import current_editor_sync
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
@@ -204,17 +205,19 @@ def test_outline_disclosure_collapses_and_expands_without_source_edit(
         editor_binary, editor_environment, fixture_project / "OutlineCases.slint"
     ) as editor:
         window = first_window(editor)
-        outline_row(window, "container").invoke_accessible_expand_action()
-        wait_until(
-            lambda: (
-                True
-                if not elements_with_label(window.root_element, "child-a")
-                else None
+        with current_editor_sync.get().action() as input_action:
+            outline_row(window, "container").invoke_accessible_expand_action()
+            wait_until(
+                lambda: (
+                    True
+                    if not elements_with_label(window.root_element, "child-a")
+                    else None
+                )
             )
-        )
-        outline_row(window, "container").invoke_accessible_expand_action()
-        outline_row(window, "child-a")
-        snapshot.assert_unchanged()
+            outline_row(window, "container").invoke_accessible_expand_action()
+            outline_row(window, "child-a")
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize(
@@ -240,22 +243,24 @@ def test_outline_keyboard_selection_synchronizes_editor(
         editor_binary, editor_environment, fixture_project / "OutlineCases.slint"
     ) as editor:
         window = first_window(editor)
-        initial_row = outline_row(window, initial)
-        row = outline_row(window, target)
-        initial_row.single_click(slint_testing.PointerEventButton.Left)
-        assert initial_row.accessible_item_selected
-        assert not row.accessible_item_selected
-        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Tab))
-        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Tab))
-        window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
-        window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
-        wait_until(lambda: row if row.accessible_item_selected else None)
-        window_element_with_label(
-            window,
-            selection,
-            slint_testing.AccessibleRole.Region,
-        )
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            initial_row = outline_row(window, initial)
+            row = outline_row(window, target)
+            initial_row.single_click(slint_testing.PointerEventButton.Left)
+            assert initial_row.accessible_item_selected
+            assert not row.accessible_item_selected
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Tab))
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Tab))
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
+            wait_until(lambda: row if row.accessible_item_selected else None)
+            window_element_with_label(
+                window,
+                selection,
+                slint_testing.AccessibleRole.Region,
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize(
@@ -293,8 +298,10 @@ def test_illegal_outline_drops_do_not_change_source(
     with launch_editor(
         editor_binary, editor_environment, fixture_project / "OutlineCases.slint"
     ) as editor:
-        drag_row(first_window(editor), source, target, location)
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            drag_row(first_window(editor), source, target, location)
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_escape_cancels_outline_drag_without_source_edit(
@@ -307,25 +314,29 @@ def test_escape_cancels_outline_drag_without_source_edit(
         editor_binary, editor_environment, fixture_project / "OutlineCases.slint"
     ) as editor:
         window = first_window(editor)
-        start = center(outline_row(window, "sibling-a"))
-        end = drop_position(window, "container", "onto")
-        button = slint_testing.PointerEventButton.Left
-        window.dispatch_event(slint_testing.PointerPressEvent(start, button))
-        window.dispatch_event(slint_testing.PointerMoveEvent(end))
-        window_element_with_label(
-            window, "Outline drag preview", slint_testing.AccessibleRole.Region
-        )
-        window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
-        window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
-        window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
-        wait_until(
-            lambda: (
-                True
-                if not elements_with_label(window.root_element, "Outline drag preview")
-                else None
+        with current_editor_sync.get().action() as input_action:
+            start = center(outline_row(window, "sibling-a"))
+            end = drop_position(window, "container", "onto")
+            button = slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerPressEvent(start, button))
+            window.dispatch_event(slint_testing.PointerMoveEvent(end))
+            window_element_with_label(
+                window, "Outline drag preview", slint_testing.AccessibleRole.Region
             )
-        )
-        snapshot.assert_unchanged()
+            window.dispatch_event(slint_testing.KeyPressedEvent(text=keys.Escape))
+            window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Escape))
+            window.dispatch_event(slint_testing.PointerReleaseEvent(end, button))
+            wait_until(
+                lambda: (
+                    True
+                    if not elements_with_label(
+                        window.root_element, "Outline drag preview"
+                    )
+                    else None
+                )
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_prohibited_layout_outline_drop_does_not_change_source(
@@ -337,5 +348,7 @@ def test_prohibited_layout_outline_drop_does_not_change_source(
     canvas_file = fixture_project / "CanvasCases.slint"
     with launch_editor(editor_binary, editor_environment, canvas_file) as editor:
         window = first_window(editor)
-        drag_row(window, "prohibited-layout", "<component-root>", "before")
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            drag_row(window, "prohibited-layout", "<component-root>", "before")
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/test_outline.py
+++ b/tools/editor/ui-tests/tests/test_outline.py
@@ -215,8 +215,8 @@ def test_outline_disclosure_collapses_and_expands_without_source_edit(
                 )
             )
             outline_row(window, "container").invoke_accessible_expand_action()
-            outline_row(window, "child-a")
         input_action.assert_no_source_writes()
+        outline_row(window, "child-a")
         snapshot.assert_unchanged_now()
 
 
@@ -243,9 +243,9 @@ def test_outline_keyboard_selection_synchronizes_editor(
         editor_binary, editor_environment, fixture_project / "OutlineCases.slint"
     ) as editor:
         window = first_window(editor)
+        initial_row = outline_row(window, initial)
+        row = outline_row(window, target)
         with current_editor_sync.get().action() as input_action:
-            initial_row = outline_row(window, initial)
-            row = outline_row(window, target)
             initial_row.single_click(slint_testing.PointerEventButton.Left)
             assert initial_row.accessible_item_selected
             assert not row.accessible_item_selected
@@ -253,13 +253,13 @@ def test_outline_keyboard_selection_synchronizes_editor(
             window.dispatch_event(slint_testing.KeyReleasedEvent(text=keys.Tab))
             window.dispatch_event(slint_testing.KeyPressedEvent(text=key))
             window.dispatch_event(slint_testing.KeyReleasedEvent(text=key))
-            wait_until(lambda: row if row.accessible_item_selected else None)
-            window_element_with_label(
-                window,
-                selection,
-                slint_testing.AccessibleRole.Region,
-            )
         input_action.assert_no_source_writes()
+        wait_until(lambda: row if row.accessible_item_selected else None)
+        window_element_with_label(
+            window,
+            selection,
+            slint_testing.AccessibleRole.Region,
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -314,10 +314,10 @@ def test_escape_cancels_outline_drag_without_source_edit(
         editor_binary, editor_environment, fixture_project / "OutlineCases.slint"
     ) as editor:
         window = first_window(editor)
+        start = center(outline_row(window, "sibling-a"))
+        end = drop_position(window, "container", "onto")
+        button = slint_testing.PointerEventButton.Left
         with current_editor_sync.get().action() as input_action:
-            start = center(outline_row(window, "sibling-a"))
-            end = drop_position(window, "container", "onto")
-            button = slint_testing.PointerEventButton.Left
             window.dispatch_event(slint_testing.PointerPressEvent(start, button))
             window.dispatch_event(slint_testing.PointerMoveEvent(end))
             window_element_with_label(

--- a/tools/editor/ui-tests/tests/test_palette.py
+++ b/tools/editor/ui-tests/tests/test_palette.py
@@ -6,11 +6,13 @@ from pathlib import Path
 import pytest
 import slint_testing
 from canvas_interactions import center
+from editor_sync import current_editor_sync
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
     PALETTE_KINDS,
     elements_with_label,
+    find_window_element_with_label,
     first_window,
     launch_editor,
     press_key,
@@ -33,10 +35,12 @@ def begin_palette_drag(
         lambda: (
             candidate
             if (
-                candidate := window_element_with_label(
+                candidate := find_window_element_with_label(
                     window, kind, slint_testing.AccessibleRole.ListItem
                 )
-            ).accessible_enabled
+            )
+            is not None
+            and candidate.accessible_enabled
             else None
         )
     )
@@ -93,7 +97,7 @@ def test_insert_palette_element_writes_exact_source(
         outline = window_element_with_label(
             window, "Current file outline", slint_testing.AccessibleRole.List
         )
-        inserted = wait_until(
+        wait_until(
             lambda: next(
                 (
                     row
@@ -101,11 +105,11 @@ def test_insert_palette_element_writes_exact_source(
                     .match_accessible_role(slint_testing.AccessibleRole.ListItem)
                     .find_all()
                     if row.accessible_label.strip() == kind
+                    and row.accessible_item_selected
                 ),
                 None,
             )
         )
-        wait_until(lambda: True if inserted.accessible_item_selected else None)
 
 
 @pytest.mark.parametrize("kind", PALETTE_KINDS)
@@ -119,17 +123,19 @@ def test_palette_drop_outside_canvas_does_not_edit_source(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        outside = center(
-            window_element_with_label(
-                window,
-                "Project and elements",
-                slint_testing.AccessibleRole.Navigation,
+        with current_editor_sync.get().action() as input_action:
+            outside = center(
+                window_element_with_label(
+                    window,
+                    "Project and elements",
+                    slint_testing.AccessibleRole.Navigation,
+                )
             )
-        )
-        begin_palette_drag(window, kind, outside)
+            begin_palette_drag(window, kind, outside)
+            snapshot.assert_unchanged_now()
+            release_palette_drag(window, outside)
+        input_action.assert_no_source_writes()
         snapshot.assert_unchanged_now()
-        release_palette_drag(window, outside)
-        snapshot.assert_unchanged()
 
 
 @pytest.mark.parametrize("kind", PALETTE_KINDS)
@@ -143,15 +149,17 @@ def test_escape_cancels_palette_drag_without_source_edit(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        target = canvas_drop_position(window)
-        begin_palette_drag(window, kind, target)
-        window_element_with_label(
-            window, f"{kind} drag preview", slint_testing.AccessibleRole.Region
-        )
-        press_key(window, keys.Escape)
-        release_palette_drag(window, target)
-        assert not elements_with_label(window.root_element, f"{kind} drag preview")
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            target = canvas_drop_position(window)
+            begin_palette_drag(window, kind, target)
+            window_element_with_label(
+                window, f"{kind} drag preview", slint_testing.AccessibleRole.Region
+            )
+            press_key(window, keys.Escape)
+            release_palette_drag(window, target)
+            assert not elements_with_label(window.root_element, f"{kind} drag preview")
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def library_rows(window: slint_testing.Window) -> list[slint_testing.Element]:
@@ -189,30 +197,32 @@ def test_library_search_filters_elements(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
-        expect_library(window, list(PALETTE_KINDS))
-        search = window_element_with_label(window, "Search elements")
-        for query, expected in [
-            ("  aG  ", ["Image"]),
-            ("T", ["Rectangle", "Text", "TouchArea"]),
-            ("  tOuCh  ", ["TouchArea"]),
-            ("AREA", ["TouchArea"]),
-            ("missing", []),
-        ]:
-            search.accessible_value = query
-            expect_library(window, expected)
+        with current_editor_sync.get().action() as input_action:
+            expect_library(window, list(PALETTE_KINDS))
+            search = window_element_with_label(window, "Search elements")
+            for query, expected in [
+                ("  aG  ", ["Image"]),
+                ("T", ["Rectangle", "Text", "TouchArea"]),
+                ("  tOuCh  ", ["TouchArea"]),
+                ("AREA", ["TouchArea"]),
+                ("missing", []),
+            ]:
+                search.accessible_value = query
+                expect_library(window, expected)
+                for label in ("Visual", "Input & interaction"):
+                    for header in elements_with_label(
+                        window.root_element, label, slint_testing.AccessibleRole.Button
+                    ):
+                        assert not header.accessible_enabled
+            window_element_with_label(window, "No Results")
             for label in ("Visual", "Input & interaction"):
-                for header in elements_with_label(
+                assert not elements_with_label(
                     window.root_element, label, slint_testing.AccessibleRole.Button
-                ):
-                    assert not header.accessible_enabled
-        window_element_with_label(window, "No Results")
-        for label in ("Visual", "Input & interaction"):
-            assert not elements_with_label(
-                window.root_element, label, slint_testing.AccessibleRole.Button
-            )
-        search.accessible_value = ""
-        expect_library(window, list(PALETTE_KINDS))
-        snapshot.assert_unchanged()
+                )
+            search.accessible_value = ""
+            expect_library(window, list(PALETTE_KINDS))
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_library_search_restores_independent_collapse_states(
@@ -225,33 +235,35 @@ def test_library_search_restores_independent_collapse_states(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
-        search = window_element_with_label(window, "Search elements")
-        for label, collapsed_labels in [
-            ("Visual", ["TouchArea"]),
-            ("Input & interaction", []),
-        ]:
+        with current_editor_sync.get().action() as input_action:
+            search = window_element_with_label(window, "Search elements")
+            for label, collapsed_labels in [
+                ("Visual", ["TouchArea"]),
+                ("Input & interaction", []),
+            ]:
+                window_element_with_label(
+                    window, label, slint_testing.AccessibleRole.Button
+                ).invoke_accessible_default_action()
+                expect_library(window, collapsed_labels)
+                search.accessible_value = "t"
+                expect_library(window, ["Rectangle", "Text", "TouchArea"])
+                search.accessible_value = "missing"
+                expect_library(window, [])
+                search.accessible_value = ""
+                expect_library(window, collapsed_labels)
             window_element_with_label(
-                window, label, slint_testing.AccessibleRole.Button
+                window, "Visual", slint_testing.AccessibleRole.Button
             ).invoke_accessible_default_action()
-            expect_library(window, collapsed_labels)
-            search.accessible_value = "t"
-            expect_library(window, ["Rectangle", "Text", "TouchArea"])
-            search.accessible_value = "missing"
-            expect_library(window, [])
+            expect_library(window, ["Image", "Rectangle", "Text"])
+            search.accessible_value = "touch"
+            expect_library(window, ["TouchArea"])
+            assert not elements_with_label(
+                window.root_element, "Visual", slint_testing.AccessibleRole.Button
+            )
             search.accessible_value = ""
-            expect_library(window, collapsed_labels)
-        window_element_with_label(
-            window, "Visual", slint_testing.AccessibleRole.Button
-        ).invoke_accessible_default_action()
-        expect_library(window, ["Image", "Rectangle", "Text"])
-        search.accessible_value = "touch"
-        expect_library(window, ["TouchArea"])
-        assert not elements_with_label(
-            window.root_element, "Visual", slint_testing.AccessibleRole.Button
-        )
-        search.accessible_value = ""
-        expect_library(window, ["Image", "Rectangle", "Text"])
-        snapshot.assert_unchanged()
+            expect_library(window, ["Image", "Rectangle", "Text"])
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_library_layout_stays_anchored_during_search_and_collapse(
@@ -300,18 +312,20 @@ def test_library_search_keyboard_does_not_delete_selection(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        select_fixture_element(window, "Rectangle")
-        search = window_element_with_label(window, "Search elements")
-        search.single_click(slint_testing.PointerEventButton.Left)
-        press_keys(window, "Text")
-        expect_library(window, ["Text"])
-        for _ in range(5):
-            press_key(window, keys.Backspace)
-        expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
-        window_element_with_label(
-            window, "Selected Rectangle", slint_testing.AccessibleRole.Region
-        )
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            select_fixture_element(window, "Rectangle")
+            search = window_element_with_label(window, "Search elements")
+            search.single_click(slint_testing.PointerEventButton.Left)
+            press_keys(window, "Text")
+            expect_library(window, ["Text"])
+            for _ in range(5):
+                press_key(window, keys.Backspace)
+            expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
+            window_element_with_label(
+                window, "Selected Rectangle", slint_testing.AccessibleRole.Region
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_toucharea_drag_preview(
@@ -324,20 +338,22 @@ def test_toucharea_drag_preview(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
-        target = canvas_drop_position(window)
-        begin_palette_drag(window, "TouchArea", target)
-        preview = window_element_with_label(
-            window, "TouchArea drag preview", slint_testing.AccessibleRole.Region
-        )
-        expected_width, expected_height = TOUCHAREA_PREVIEW_SIZE
-        assert preview.size.width == expected_width
-        assert preview.size.height == expected_height
-        assert preview.absolute_position.x == target.x - expected_width / 2
-        assert preview.absolute_position.y == target.y - expected_height / 2
+        with current_editor_sync.get().action() as input_action:
+            target = canvas_drop_position(window)
+            begin_palette_drag(window, "TouchArea", target)
+            preview = window_element_with_label(
+                window, "TouchArea drag preview", slint_testing.AccessibleRole.Region
+            )
+            expected_width, expected_height = TOUCHAREA_PREVIEW_SIZE
+            assert preview.size.width == expected_width
+            assert preview.size.height == expected_height
+            assert preview.absolute_position.x == target.x - expected_width / 2
+            assert preview.absolute_position.y == target.y - expected_height / 2
+            snapshot.assert_unchanged_now()
+            outside = slint_testing.LogicalPosition(x=10, y=10)
+            release_palette_drag(window, outside)
+        input_action.assert_no_source_writes()
         snapshot.assert_unchanged_now()
-        outside = slint_testing.LogicalPosition(x=10, y=10)
-        release_palette_drag(window, outside)
-        snapshot.assert_unchanged()
 
 
 @pytest.mark.parametrize(
@@ -364,15 +380,17 @@ def test_group_header_keyboard_activation(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
-        search = window_element_with_label(window, "Search elements")
-        search.single_click(slint_testing.PointerEventButton.Left)
-        for _ in range(tab_count):
-            press_key(window, keys.Tab)
-        press_key(window, activation_key)
-        expect_library(window, remaining)
-        window_element_with_label(
-            window, group_label, slint_testing.AccessibleRole.Button
-        )
-        press_key(window, activation_key)
-        expect_library(window, list(PALETTE_KINDS))
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            search = window_element_with_label(window, "Search elements")
+            search.single_click(slint_testing.PointerEventButton.Left)
+            for _ in range(tab_count):
+                press_key(window, keys.Tab)
+            press_key(window, activation_key)
+            expect_library(window, remaining)
+            window_element_with_label(
+                window, group_label, slint_testing.AccessibleRole.Button
+            )
+            press_key(window, activation_key)
+            expect_library(window, list(PALETTE_KINDS))
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/test_palette.py
+++ b/tools/editor/ui-tests/tests/test_palette.py
@@ -123,14 +123,14 @@ def test_palette_drop_outside_canvas_does_not_edit_source(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
-        with current_editor_sync.get().action() as input_action:
-            outside = center(
-                window_element_with_label(
-                    window,
-                    "Project and elements",
-                    slint_testing.AccessibleRole.Navigation,
-                )
+        outside = center(
+            window_element_with_label(
+                window,
+                "Project and elements",
+                slint_testing.AccessibleRole.Navigation,
             )
+        )
+        with current_editor_sync.get().action() as input_action:
             begin_palette_drag(window, kind, outside)
             snapshot.assert_unchanged_now()
             release_palette_drag(window, outside)
@@ -149,16 +149,16 @@ def test_escape_cancels_palette_drag_without_source_edit(
     snapshot = SourceSnapshot.capture(fixture_project)
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
+        target = canvas_drop_position(window)
         with current_editor_sync.get().action() as input_action:
-            target = canvas_drop_position(window)
             begin_palette_drag(window, kind, target)
             window_element_with_label(
                 window, f"{kind} drag preview", slint_testing.AccessibleRole.Region
             )
             press_key(window, keys.Escape)
             release_palette_drag(window, target)
-            assert not elements_with_label(window.root_element, f"{kind} drag preview")
         input_action.assert_no_source_writes()
+        assert not elements_with_label(window.root_element, f"{kind} drag preview")
         snapshot.assert_unchanged_now()
 
 
@@ -197,9 +197,9 @@ def test_library_search_filters_elements(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
+        expect_library(window, list(PALETTE_KINDS))
+        search = window_element_with_label(window, "Search elements")
         with current_editor_sync.get().action() as input_action:
-            expect_library(window, list(PALETTE_KINDS))
-            search = window_element_with_label(window, "Search elements")
             for query, expected in [
                 ("  aG  ", ["Image"]),
                 ("T", ["Rectangle", "Text", "TouchArea"]),
@@ -235,8 +235,8 @@ def test_library_search_restores_independent_collapse_states(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
+        search = window_element_with_label(window, "Search elements")
         with current_editor_sync.get().action() as input_action:
-            search = window_element_with_label(window, "Search elements")
             for label, collapsed_labels in [
                 ("Visual", ["TouchArea"]),
                 ("Input & interaction", []),
@@ -261,8 +261,8 @@ def test_library_search_restores_independent_collapse_states(
                 window.root_element, "Visual", slint_testing.AccessibleRole.Button
             )
             search.accessible_value = ""
-            expect_library(window, ["Image", "Rectangle", "Text"])
         input_action.assert_no_source_writes()
+        expect_library(window, ["Image", "Rectangle", "Text"])
         snapshot.assert_unchanged_now()
 
 
@@ -321,10 +321,10 @@ def test_library_search_keyboard_does_not_delete_selection(
             for _ in range(5):
                 press_key(window, keys.Backspace)
             expect_library(window, ["Image", "Rectangle", "Text", "TouchArea"])
-            window_element_with_label(
-                window, "Selected Rectangle", slint_testing.AccessibleRole.Region
-            )
         input_action.assert_no_source_writes()
+        window_element_with_label(
+            window, "Selected Rectangle", slint_testing.AccessibleRole.Region
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -338,8 +338,8 @@ def test_toucharea_drag_preview(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
+        target = canvas_drop_position(window)
         with current_editor_sync.get().action() as input_action:
-            target = canvas_drop_position(window)
             begin_palette_drag(window, "TouchArea", target)
             preview = window_element_with_label(
                 window, "TouchArea drag preview", slint_testing.AccessibleRole.Region
@@ -380,8 +380,8 @@ def test_group_header_keyboard_activation(
         editor_binary, editor_environment, fixture_project / "Palette.slint"
     ) as editor:
         window = first_window(editor)
+        search = window_element_with_label(window, "Search elements")
         with current_editor_sync.get().action() as input_action:
-            search = window_element_with_label(window, "Search elements")
             search.single_click(slint_testing.PointerEventButton.Left)
             for _ in range(tab_count):
                 press_key(window, keys.Tab)
@@ -391,6 +391,6 @@ def test_group_header_keyboard_activation(
                 window, group_label, slint_testing.AccessibleRole.Button
             )
             press_key(window, activation_key)
-            expect_library(window, list(PALETTE_KINDS))
         input_action.assert_no_source_writes()
+        expect_library(window, list(PALETTE_KINDS))
         snapshot.assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/test_panes.py
+++ b/tools/editor/ui-tests/tests/test_panes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import slint_testing
 from canvas_interactions import center
+from editor_sync import current_editor_sync
 from ui_driver import first_window, launch_editor, wait_until, window_element_with_label
 
 
@@ -61,8 +62,6 @@ def test_pane_sizes_persist_across_relaunch(
     fixture_project: Path,
     tmp_path: Path,
 ) -> None:
-    editor_environment["HOME"] = str(tmp_path / "home")
-    editor_environment["XDG_CONFIG_HOME"] = str(tmp_path / "config")
     source_file = fixture_project / "Main.slint"
 
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
@@ -72,8 +71,10 @@ def test_pane_sizes_persist_across_relaunch(
         initial_elements_y = elements_divider.absolute_position.y
         initial_outline_y = outline_divider.absolute_position.y
 
-        drag_vertically(window, elements_divider, 72)
-        drag_vertically(window, outline_divider, -64)
+        with current_editor_sync.get().action() as resize:
+            drag_vertically(window, elements_divider, 72)
+            drag_vertically(window, outline_divider, -64)
+        resize.wait_for_settled(outcome="completed")
 
         assert window_element_with_label(window, "FILES").accessible_label == "FILES"
         assert (
@@ -134,8 +135,6 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
     fixture_project: Path,
     tmp_path: Path,
 ) -> None:
-    editor_environment["HOME"] = str(tmp_path / "home")
-    editor_environment["XDG_CONFIG_HOME"] = str(tmp_path / "config")
     with launch_editor(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
@@ -208,8 +207,9 @@ def test_pane_dividers_are_accessible_and_no_results_is_visible(
         assert no_results.absolute_position.x + no_results.size.width <= (
             pane.absolute_position.x + pane.size.width - 14
         )
-        double_click(window, elements)
-
+        with current_editor_sync.get().action() as reset:
+            double_click(window, elements)
+        reset.wait_for_settled(outcome="completed")
         assert float(elements.accessible_value.split()[0]) == default_elements
         wait_for_pane_settings(tmp_path, {"elements_pane_height": None})
 

--- a/tools/editor/ui-tests/tests/test_reload.py
+++ b/tools/editor/ui-tests/tests/test_reload.py
@@ -1,12 +1,12 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import time
 from pathlib import Path
 
 import pytest
 import slint_testing
 from source_snapshot import SourceSnapshot
+from editor_sync import current_editor_sync
 from ui_driver import (
     elements_with_label,
     first_window,
@@ -75,20 +75,27 @@ def test_rapid_root_writes_show_newest_revision(
         )
         handle, size = window.handle, window.size
         original = source_file.read_bytes()
+        checkpoint = current_editor_sync.get().checkpoint()
         source_file.write_bytes(original.replace(b"Fixture text", b"Revision one"))
         source_file.write_bytes(original.replace(b"Fixture text", b"Revision two"))
         expected = original.replace(b"Fixture text", b"Newest revision")
         source_file.write_bytes(expected)
         snapshot.wait_for_exact(expected)
+        current_editor_sync.get().wait_for_processed(
+            source_file,
+            expected,
+            after=int(checkpoint["cursor"]),
+            outcome="compiled",
+        )
+        current_editor_sync.get().wait_for_source(
+            source_file, expected, after=int(checkpoint["cursor"])
+        )
         window_element_with_label(
             window, "Newest revision", slint_testing.AccessibleRole.Text, timeout=15
         )
-        deadline = time.monotonic() + 0.25
-        while time.monotonic() < deadline:
-            assert source_file.read_bytes() == expected
-            assert not elements_with_label(window.root_element, "Revision one")
-            assert not elements_with_label(window.root_element, "Revision two")
-            time.sleep(0.02)
+        assert source_file.read_bytes() == expected
+        assert not elements_with_label(window.root_element, "Revision one")
+        assert not elements_with_label(window.root_element, "Revision two")
         assert_editor_stable(editor, window, handle, size)
 
 

--- a/tools/editor/ui-tests/tests/test_reload.py
+++ b/tools/editor/ui-tests/tests/test_reload.py
@@ -87,10 +87,10 @@ def test_rapid_root_writes_show_newest_revision(
         sync.wait_for_processed(
             source_file,
             expected,
-            after=int(checkpoint["cursor"]),
+            after=checkpoint.cursor,
             outcome="compiled",
         )
-        sync.wait_for_source(source_file, expected, after=int(checkpoint["cursor"]))
+        sync.wait_for_applied(source_file, expected, after=checkpoint.cursor)
         window_element_with_label(
             window, "Newest revision", slint_testing.AccessibleRole.Text, timeout=15
         )

--- a/tools/editor/ui-tests/tests/test_reload.py
+++ b/tools/editor/ui-tests/tests/test_reload.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import pytest
 import slint_testing
-from source_snapshot import SourceSnapshot
 from editor_sync import current_editor_sync
+from source_snapshot import SourceSnapshot
 from ui_driver import (
     elements_with_label,
     first_window,
@@ -75,21 +75,23 @@ def test_rapid_root_writes_show_newest_revision(
         )
         handle, size = window.handle, window.size
         original = source_file.read_bytes()
-        checkpoint = current_editor_sync.get().checkpoint()
+        sync = current_editor_sync.get()
+        checkpoint = sync.checkpoint()
+        sync.set_gate("source")
         source_file.write_bytes(original.replace(b"Fixture text", b"Revision one"))
         source_file.write_bytes(original.replace(b"Fixture text", b"Revision two"))
         expected = original.replace(b"Fixture text", b"Newest revision")
         source_file.write_bytes(expected)
+        sync.wait_for_gate("source", after=checkpoint.cursor)
+        sync.release_gate("source")
         snapshot.wait_for_exact(expected)
-        current_editor_sync.get().wait_for_processed(
+        sync.wait_for_processed(
             source_file,
             expected,
             after=int(checkpoint["cursor"]),
             outcome="compiled",
         )
-        current_editor_sync.get().wait_for_source(
-            source_file, expected, after=int(checkpoint["cursor"])
-        )
+        sync.wait_for_source(source_file, expected, after=int(checkpoint["cursor"]))
         window_element_with_label(
             window, "Newest revision", slint_testing.AccessibleRole.Text, timeout=15
         )

--- a/tools/editor/ui-tests/tests/test_reload.py
+++ b/tools/editor/ui-tests/tests/test_reload.py
@@ -77,13 +77,12 @@ def test_rapid_root_writes_show_newest_revision(
         original = source_file.read_bytes()
         sync = current_editor_sync.get()
         checkpoint = sync.checkpoint()
-        sync.set_gate("source")
-        source_file.write_bytes(original.replace(b"Fixture text", b"Revision one"))
-        source_file.write_bytes(original.replace(b"Fixture text", b"Revision two"))
-        expected = original.replace(b"Fixture text", b"Newest revision")
-        source_file.write_bytes(expected)
-        sync.wait_for_gate("source", after=checkpoint.cursor)
-        sync.release_gate("source")
+        with sync.gate("source", source_file) as gate:
+            source_file.write_bytes(original.replace(b"Fixture text", b"Revision one"))
+            source_file.write_bytes(original.replace(b"Fixture text", b"Revision two"))
+            expected = original.replace(b"Fixture text", b"Newest revision")
+            source_file.write_bytes(expected)
+            gate.wait_for_reached()
         snapshot.wait_for_exact(expected)
         sync.wait_for_processed(
             source_file,

--- a/tools/editor/ui-tests/tests/test_selection.py
+++ b/tools/editor/ui-tests/tests/test_selection.py
@@ -50,19 +50,19 @@ def test_outline_selection_synchronizes_canvas_and_inspector(
         window = first_window(editor)
         with current_editor_sync.get().action() as input_action:
             select_fixture_element(window, "Rectangle")
-            assert (
-                window_element_with_label(
-                    window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
-                ).accessible_value
-                == "40"
-            )
-            assert (
-                window_element_with_label(
-                    window, FIELDS["width"], slint_testing.AccessibleRole.TextInput
-                ).accessible_value
-                == "180"
-            )
         input_action.assert_no_source_writes()
+        assert (
+            window_element_with_label(
+                window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
+            ).accessible_value
+            == "40"
+        )
+        assert (
+            window_element_with_label(
+                window, FIELDS["width"], slint_testing.AccessibleRole.TextInput
+            ).accessible_value
+            == "180"
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -76,39 +76,39 @@ def test_canvas_selection_synchronizes_outline_and_inspector(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        with current_editor_sync.get().action() as input_action:
-            text = wait_until(
-                lambda: (
-                    element
-                    if (
-                        element := next(
-                            iter(window.find_elements_by_id("Main::root-text")), None
-                        )
+        text = wait_until(
+            lambda: (
+                element
+                if (
+                    element := next(
+                        iter(window.find_elements_by_id("Main::root-text")), None
                     )
-                    else None
                 )
+                else None
             )
-            target = slint_testing.LogicalPosition(
-                x=text.absolute_position.x + text.size.width / 2,
-                y=text.absolute_position.y + text.size.height / 2,
-            )
-            button = slint_testing.PointerEventButton.Left
+        )
+        target = slint_testing.LogicalPosition(
+            x=text.absolute_position.x + text.size.width / 2,
+            y=text.absolute_position.y + text.size.height / 2,
+        )
+        button = slint_testing.PointerEventButton.Left
+        with current_editor_sync.get().action() as input_action:
             window.dispatch_event(slint_testing.PointerPressEvent(target, button))
             window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-            row = window_element_with_label(
-                window, "root-text", slint_testing.AccessibleRole.ListItem
-            )
-            wait_until(lambda: row if row.accessible_item_selected else None)
-            window_element_with_label(
-                window, "Selected Text", slint_testing.AccessibleRole.Region
-            )
-            assert (
-                window_element_with_label(
-                    window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
-                ).accessible_value
-                == "180"
-            )
         input_action.assert_no_source_writes()
+        row = window_element_with_label(
+            window, "root-text", slint_testing.AccessibleRole.ListItem
+        )
+        wait_until(lambda: row if row.accessible_item_selected else None)
+        window_element_with_label(
+            window, "Selected Text", slint_testing.AccessibleRole.Region
+        )
+        assert (
+            window_element_with_label(
+                window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
+            ).accessible_value
+            == "180"
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -134,41 +134,39 @@ def test_clear_canvas_selection_does_not_edit_source(
             button = slint_testing.PointerEventButton.Left
             window.dispatch_event(slint_testing.PointerPressEvent(target, button))
             window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-            wait_until(
-                lambda: (
-                    True
-                    if not elements_with_label(
-                        window.root_element, "Selected Rectangle"
-                    )
-                    else None
-                ),
-                timeout=15,
-            )
-            outline = window_element_with_label(
-                window, "Current file outline", slint_testing.AccessibleRole.List
-            )
-            wait_until(
-                lambda: (
-                    rows
-                    if (
-                        rows := outline.query_descendants()
-                        .match_accessible_role(slint_testing.AccessibleRole.ListItem)
-                        .find_all()
-                    )
-                    and rows[0].accessible_item_selected
-                    and (
-                        rectangle := find_window_element_with_label(
-                            window,
-                            "root-rectangle",
-                            slint_testing.AccessibleRole.ListItem,
-                        )
-                    )
-                    is not None
-                    and not rectangle.accessible_item_selected
-                    else None
-                )
-            )
         input_action.assert_no_source_writes()
+        wait_until(
+            lambda: (
+                True
+                if not elements_with_label(window.root_element, "Selected Rectangle")
+                else None
+            ),
+            timeout=15,
+        )
+        outline = window_element_with_label(
+            window, "Current file outline", slint_testing.AccessibleRole.List
+        )
+        wait_until(
+            lambda: (
+                rows
+                if (
+                    rows := outline.query_descendants()
+                    .match_accessible_role(slint_testing.AccessibleRole.ListItem)
+                    .find_all()
+                )
+                and rows[0].accessible_item_selected
+                and (
+                    rectangle := find_window_element_with_label(
+                        window,
+                        "root-rectangle",
+                        slint_testing.AccessibleRole.ListItem,
+                    )
+                )
+                is not None
+                and not rectangle.accessible_item_selected
+                else None
+            )
+        )
         snapshot.assert_unchanged_now()
 
 
@@ -186,10 +184,10 @@ def test_delete_without_element_selection_does_not_edit_source(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
+        window_element_with_label(
+            window, "Editor canvas", slint_testing.AccessibleRole.Main
+        )
         with current_editor_sync.get().action() as input_action:
-            window_element_with_label(
-                window, "Editor canvas", slint_testing.AccessibleRole.Main
-            )
             press_key(window, key)
         input_action.assert_no_source_writes()
         snapshot.assert_unchanged_now()
@@ -222,10 +220,10 @@ def test_focused_inspector_field_consumes_delete_key(
             window.dispatch_event(slint_testing.PointerPressEvent(target, button))
             window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
             press_key(window, key)
-            window_element_with_label(
-                window, "Selected Rectangle", slint_testing.AccessibleRole.Region
-            )
         input_action.assert_no_source_writes()
+        window_element_with_label(
+            window, "Selected Rectangle", slint_testing.AccessibleRole.Region
+        )
         snapshot.assert_unchanged_now()
 
 

--- a/tools/editor/ui-tests/tests/test_selection.py
+++ b/tools/editor/ui-tests/tests/test_selection.py
@@ -5,11 +5,13 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from editor_sync import current_editor_sync
 from inspector_interactions import FIELDS
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
     elements_with_label,
+    find_window_element_with_label,
     first_window,
     launch_editor,
     press_key,
@@ -46,20 +48,22 @@ def test_outline_selection_synchronizes_canvas_and_inspector(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        select_fixture_element(window, "Rectangle")
-        assert (
-            window_element_with_label(
-                window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
-            ).accessible_value
-            == "40"
-        )
-        assert (
-            window_element_with_label(
-                window, FIELDS["width"], slint_testing.AccessibleRole.TextInput
-            ).accessible_value
-            == "180"
-        )
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            select_fixture_element(window, "Rectangle")
+            assert (
+                window_element_with_label(
+                    window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
+                ).accessible_value
+                == "40"
+            )
+            assert (
+                window_element_with_label(
+                    window, FIELDS["width"], slint_testing.AccessibleRole.TextInput
+                ).accessible_value
+                == "180"
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_canvas_selection_synchronizes_outline_and_inspector(
@@ -72,38 +76,40 @@ def test_canvas_selection_synchronizes_outline_and_inspector(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        text = wait_until(
-            lambda: (
-                element
-                if (
-                    element := next(
-                        iter(window.find_elements_by_id("Main::root-text")), None
+        with current_editor_sync.get().action() as input_action:
+            text = wait_until(
+                lambda: (
+                    element
+                    if (
+                        element := next(
+                            iter(window.find_elements_by_id("Main::root-text")), None
+                        )
                     )
+                    else None
                 )
-                else None
             )
-        )
-        target = slint_testing.LogicalPosition(
-            x=text.absolute_position.x + text.size.width / 2,
-            y=text.absolute_position.y + text.size.height / 2,
-        )
-        button = slint_testing.PointerEventButton.Left
-        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
-        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-        row = window_element_with_label(
-            window, "root-text", slint_testing.AccessibleRole.ListItem
-        )
-        wait_until(lambda: row if row.accessible_item_selected else None)
-        window_element_with_label(
-            window, "Selected Text", slint_testing.AccessibleRole.Region
-        )
-        assert (
+            target = slint_testing.LogicalPosition(
+                x=text.absolute_position.x + text.size.width / 2,
+                y=text.absolute_position.y + text.size.height / 2,
+            )
+            button = slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+            window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+            row = window_element_with_label(
+                window, "root-text", slint_testing.AccessibleRole.ListItem
+            )
+            wait_until(lambda: row if row.accessible_item_selected else None)
             window_element_with_label(
-                window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
-            ).accessible_value
-            == "180"
-        )
-        snapshot.assert_unchanged()
+                window, "Selected Text", slint_testing.AccessibleRole.Region
+            )
+            assert (
+                window_element_with_label(
+                    window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
+                ).accessible_value
+                == "180"
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 def test_clear_canvas_selection_does_not_edit_source(
@@ -116,46 +122,54 @@ def test_clear_canvas_selection_does_not_edit_source(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        select_fixture_element(window, "Rectangle")
-        artboard = window_element_with_label(
-            window, "Artboard", slint_testing.AccessibleRole.Region
-        )
-        target = slint_testing.LogicalPosition(
-            x=artboard.absolute_position.x + artboard.size.width - 12,
-            y=artboard.absolute_position.y + artboard.size.height - 12,
-        )
-        button = slint_testing.PointerEventButton.Left
-        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
-        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-        wait_until(
-            lambda: (
-                True
-                if not elements_with_label(window.root_element, "Selected Rectangle")
-                else None
-            ),
-            timeout=15,
-        )
-        outline = window_element_with_label(
-            window, "Current file outline", slint_testing.AccessibleRole.List
-        )
-        wait_until(
-            lambda: (
-                rows
-                if (
-                    rows := outline.query_descendants()
-                    .match_accessible_role(slint_testing.AccessibleRole.ListItem)
-                    .find_all()
-                )
-                and rows[0].accessible_item_selected
-                and not window_element_with_label(
-                    window,
-                    "root-rectangle",
-                    slint_testing.AccessibleRole.ListItem,
-                ).accessible_item_selected
-                else None
+        with current_editor_sync.get().action() as input_action:
+            select_fixture_element(window, "Rectangle")
+            artboard = window_element_with_label(
+                window, "Artboard", slint_testing.AccessibleRole.Region
             )
-        )
-        snapshot.assert_unchanged()
+            target = slint_testing.LogicalPosition(
+                x=artboard.absolute_position.x + artboard.size.width - 12,
+                y=artboard.absolute_position.y + artboard.size.height - 12,
+            )
+            button = slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+            window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+            wait_until(
+                lambda: (
+                    True
+                    if not elements_with_label(
+                        window.root_element, "Selected Rectangle"
+                    )
+                    else None
+                ),
+                timeout=15,
+            )
+            outline = window_element_with_label(
+                window, "Current file outline", slint_testing.AccessibleRole.List
+            )
+            wait_until(
+                lambda: (
+                    rows
+                    if (
+                        rows := outline.query_descendants()
+                        .match_accessible_role(slint_testing.AccessibleRole.ListItem)
+                        .find_all()
+                    )
+                    and rows[0].accessible_item_selected
+                    and (
+                        rectangle := find_window_element_with_label(
+                            window,
+                            "root-rectangle",
+                            slint_testing.AccessibleRole.ListItem,
+                        )
+                    )
+                    is not None
+                    and not rectangle.accessible_item_selected
+                    else None
+                )
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize(
@@ -172,11 +186,13 @@ def test_delete_without_element_selection_does_not_edit_source(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        window_element_with_label(
-            window, "Editor canvas", slint_testing.AccessibleRole.Main
-        )
-        press_key(window, key)
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            window_element_with_label(
+                window, "Editor canvas", slint_testing.AccessibleRole.Main
+            )
+            press_key(window, key)
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize(
@@ -193,22 +209,24 @@ def test_focused_inspector_field_consumes_delete_key(
         editor_binary, editor_environment, fixture_project / "Main.slint"
     ) as editor:
         window = first_window(editor)
-        select_fixture_element(window, "Rectangle")
-        field = window_element_with_label(
-            window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
-        )
-        target = slint_testing.LogicalPosition(
-            x=field.absolute_position.x + field.size.width / 2,
-            y=field.absolute_position.y + field.size.height / 2,
-        )
-        button = slint_testing.PointerEventButton.Left
-        window.dispatch_event(slint_testing.PointerPressEvent(target, button))
-        window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
-        press_key(window, key)
-        window_element_with_label(
-            window, "Selected Rectangle", slint_testing.AccessibleRole.Region
-        )
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as input_action:
+            select_fixture_element(window, "Rectangle")
+            field = window_element_with_label(
+                window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
+            )
+            target = slint_testing.LogicalPosition(
+                x=field.absolute_position.x + field.size.width / 2,
+                y=field.absolute_position.y + field.size.height / 2,
+            )
+            button = slint_testing.PointerEventButton.Left
+            window.dispatch_event(slint_testing.PointerPressEvent(target, button))
+            window.dispatch_event(slint_testing.PointerReleaseEvent(target, button))
+            press_key(window, key)
+            window_element_with_label(
+                window, "Selected Rectangle", slint_testing.AccessibleRole.Region
+            )
+        input_action.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize(

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import slint_testing
+from editor_sync import current_editor_sync
 from inspector_interactions import FIELDS
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
@@ -49,9 +50,15 @@ def test_broken_source_preserves_last_valid_preview(
         )
         handle, size = window.handle, window.size
         broken = source_file.read_bytes() + b"\nthis is not valid Slint\n"
+        checkpoint = current_editor_sync.get().checkpoint()
         source_file.write_bytes(broken)
         snapshot.wait_for_exact(broken)
-        time.sleep(0.25)
+        current_editor_sync.get().wait_for_processed(
+            source_file,
+            broken,
+            after=int(checkpoint["cursor"]),
+            outcome="compile_error",
+        )
         window_element_with_label(
             window, "Fixture text", slint_testing.AccessibleRole.Text
         )
@@ -77,8 +84,15 @@ def test_repaired_source_recovers_preview(
         window_element_with_label(
             window, "Fixture text", slint_testing.AccessibleRole.Text
         )
+        checkpoint = current_editor_sync.get().checkpoint()
         source_file.write_bytes(baseline + b"\ninvalid source\n")
-        time.sleep(0.25)
+        broken = baseline + b"\ninvalid source\n"
+        current_editor_sync.get().wait_for_processed(
+            source_file,
+            broken,
+            after=int(checkpoint["cursor"]),
+            outcome="compile_error",
+        )
         repaired = baseline.replace(b"Fixture text", b"Recovered source", 1)
         source_file.write_bytes(repaired)
         snapshot.wait_for_exact(repaired)

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -267,12 +267,16 @@ def test_deleted_import_recovers_without_relaunch(
     imported_file = fixture_project / "components" / "Nested.slint"
     baseline = imported_file.read_bytes()
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
+        sync = current_editor_sync.get()
         window = first_window(editor)
         window_element_with_label(
             window, "Imported component", slint_testing.AccessibleRole.Text
         )
+        checkpoint = sync.checkpoint()
         imported_file.unlink()
-        time.sleep(0.25)
+        sync.wait_for_processed(
+            imported_file, None, after=checkpoint.cursor, outcome="load_error"
+        )
         window_element_with_label(
             window, "Imported component", slint_testing.AccessibleRole.Text
         )
@@ -303,6 +307,9 @@ def test_initial_broken_source_recovers_without_relaunch(
     )
     with launch_editor(editor_binary, editor_environment, source_file) as editor:
         window = first_window(editor)
+        sync = current_editor_sync.get()
+        initial_broken = source_file.read_bytes()
+        sync.wait_for_processed(source_file, initial_broken, outcome="compile_error")
         assert editor.process.poll() is None
         source_file.write_bytes(repaired)
         window_element_with_label(

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -1,17 +1,17 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import time
 from pathlib import Path
 
 import pytest
 import slint_testing
 from editor_sync import current_editor_sync
-from inspector_interactions import FIELDS
+from inspector_interactions import FIELDS, wait_for_field
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
 from ui_driver import (
     file_row,
+    find_window_element_with_label,
     first_window,
     launch_editor,
     press_key,
@@ -114,10 +114,17 @@ def test_imported_file_edit_targets_only_nested_source(
 
     with launch_editor(editor_binary, editor_environment, main_file) as editor:
         window = first_window(editor)
+        file_row(window, main_file)
         wait_until(
             lambda: (
                 current
-                if (current := file_row(window, main_file)).accessible_item_selected
+                if (
+                    current := find_window_element_with_label(
+                        window, str(main_file), slint_testing.AccessibleRole.ListItem
+                    )
+                )
+                is not None
+                and current.accessible_item_selected
                 else None
             ),
             timeout=15,
@@ -160,21 +167,17 @@ def test_stale_selection_commit_is_rejected(
         stage_field_text(window, FIELDS["x"], "99")
         snapshot.assert_unchanged_now()
         select_outline_row(window, "inspect-text")
-        wait_until(
-            lambda: (
-                field
-                if (
-                    field := window_element_with_label(
-                        window, FIELDS["x"], slint_testing.AccessibleRole.TextInput
-                    )
-                ).accessible_value
-                == "224"
-                else None
-            ),
+        wait_for_field(
+            window,
+            FIELDS["x"],
+            "224",
+            slint_testing.AccessibleRole.TextInput,
             timeout=15,
         )
-        press_key(window, keys.Return)
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as commit:
+            press_key(window, keys.Return)
+        commit.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.parametrize(
@@ -213,21 +216,13 @@ def test_stale_revision_commit_is_rejected(
         source_file.write_bytes(external)
         snapshot.wait_for_exact(external, relative_path="InspectorCases.slint")
         snapshot = SourceSnapshot.capture(fixture_project)
-        wait_until(
-            lambda: (
-                field
-                if (
-                    field := window_element_with_label(
-                        window, label, slint_testing.AccessibleRole.TextInput
-                    )
-                ).accessible_value
-                == updated
-                else None
-            ),
-            timeout=15,
+        wait_for_field(
+            window, label, updated, slint_testing.AccessibleRole.TextInput, timeout=15
         )
-        press_key(window, keys.Return)
-        snapshot.assert_unchanged()
+        with current_editor_sync.get().action() as commit:
+            press_key(window, keys.Return)
+        commit.assert_no_source_writes()
+        snapshot.assert_unchanged_now()
 
 
 @pytest.mark.skip(reason="Requires a Rust source-watcher recovery fix")
@@ -243,8 +238,11 @@ def test_deleted_root_file_recovers_without_relaunch(
         window_element_with_label(
             window, "Fixture text", slint_testing.AccessibleRole.Text
         )
+        checkpoint = current_editor_sync.get().checkpoint()
         source_file.unlink()
-        time.sleep(0.25)
+        current_editor_sync.get().wait_for_processed(
+            source_file, None, after=checkpoint, outcome="load_error"
+        )
         window_element_with_label(
             window, "Fixture text", slint_testing.AccessibleRole.Text
         )

--- a/tools/editor/ui-tests/tests/test_source_safety.py
+++ b/tools/editor/ui-tests/tests/test_source_safety.py
@@ -56,7 +56,7 @@ def test_broken_source_preserves_last_valid_preview(
         current_editor_sync.get().wait_for_processed(
             source_file,
             broken,
-            after=int(checkpoint["cursor"]),
+            after=checkpoint.cursor,
             outcome="compile_error",
         )
         window_element_with_label(
@@ -90,7 +90,7 @@ def test_repaired_source_recovers_preview(
         current_editor_sync.get().wait_for_processed(
             source_file,
             broken,
-            after=int(checkpoint["cursor"]),
+            after=checkpoint.cursor,
             outcome="compile_error",
         )
         repaired = baseline.replace(b"Fixture text", b"Recovered source", 1)

--- a/tools/editor/ui-tests/tests/test_source_snapshot.py
+++ b/tools/editor/ui-tests/tests/test_source_snapshot.py
@@ -18,7 +18,9 @@ def test_source_snapshot_accepts_exact_edit(fixture_project: Path) -> None:
     snapshot.wait_for_exact(expected, timeout=0.1)
 
 
-def test_source_snapshot_rejects_unexpected_edit(fixture_project: Path) -> None:
+def test_source_snapshot_rejects_unexpected_edit(
+    fixture_project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     snapshot = SourceSnapshot.capture(fixture_project)
     main_file = fixture_project / "Main.slint"
     original = main_file.read_bytes()
@@ -30,13 +32,30 @@ def test_source_snapshot_rejects_unexpected_edit(fixture_project: Path) -> None:
 
     main_file.write_bytes(original)
     delayed_snapshot = SourceSnapshot.capture(fixture_project)
-    delayed_write = threading.Timer(0.03, main_file.write_bytes, args=(changed,))
+    allow_write = threading.Event()
+
+    def write_after_handshake() -> None:
+        allow_write.wait(timeout=5)
+        main_file.write_bytes(changed)
+
+    delayed_write = threading.Thread(target=write_after_handshake)
     delayed_write.start()
+    original_sleep = __import__("source_snapshot").time.sleep
+    sleep_calls = 0
+
+    def release_after_first_observation(seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 1:
+            allow_write.set()
+        original_sleep(0)
+
+    monkeypatch.setattr("source_snapshot.time.sleep", release_after_first_observation)
     try:
         with pytest.raises(AssertionError):
             delayed_snapshot.assert_unchanged(quiescence=0.2)
     finally:
-        delayed_write.cancel()
+        allow_write.set()
         delayed_write.join()
 
     message = exact_source_mismatch(

--- a/tools/editor/ui-tests/tests/test_source_snapshot.py
+++ b/tools/editor/ui-tests/tests/test_source_snapshot.py
@@ -1,7 +1,6 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import threading
 from pathlib import Path
 
 import pytest
@@ -19,7 +18,7 @@ def test_source_snapshot_accepts_exact_edit(fixture_project: Path) -> None:
 
 
 def test_source_snapshot_rejects_unexpected_edit(
-    fixture_project: Path, monkeypatch: pytest.MonkeyPatch
+    fixture_project: Path,
 ) -> None:
     snapshot = SourceSnapshot.capture(fixture_project)
     main_file = fixture_project / "Main.slint"
@@ -32,31 +31,11 @@ def test_source_snapshot_rejects_unexpected_edit(
 
     main_file.write_bytes(original)
     delayed_snapshot = SourceSnapshot.capture(fixture_project)
-    allow_write = threading.Event()
-
-    def write_after_handshake() -> None:
-        allow_write.wait(timeout=5)
-        main_file.write_bytes(changed)
-
-    delayed_write = threading.Thread(target=write_after_handshake)
-    delayed_write.start()
-    original_sleep = __import__("source_snapshot").time.sleep
-    sleep_calls = 0
-
-    def release_after_first_observation(seconds: float) -> None:
-        nonlocal sleep_calls
-        sleep_calls += 1
-        if sleep_calls == 1:
-            allow_write.set()
-        original_sleep(0)
-
-    monkeypatch.setattr("source_snapshot.time.sleep", release_after_first_observation)
-    try:
-        with pytest.raises(AssertionError):
-            delayed_snapshot.assert_unchanged(quiescence=0.2)
-    finally:
-        allow_write.set()
-        delayed_write.join()
+    with pytest.raises(AssertionError):
+        delayed_snapshot.assert_unchanged(
+            quiescence=0.2,
+            after_first_observation=lambda: (main_file.write_bytes(changed), None)[1],
+        )
 
     message = exact_source_mismatch(
         {Path("Main.slint"): b"export component Main { width: 2px; }\n"},

--- a/tools/editor/ui-tests/tests/test_source_snapshot.py
+++ b/tools/editor/ui-tests/tests/test_source_snapshot.py
@@ -19,6 +19,7 @@ def test_source_snapshot_accepts_exact_edit(fixture_project: Path) -> None:
 
 def test_source_snapshot_rejects_unexpected_edit(
     fixture_project: Path,
+    monkeypatch,
 ) -> None:
     snapshot = SourceSnapshot.capture(fixture_project)
     main_file = fixture_project / "Main.slint"
@@ -27,15 +28,19 @@ def test_source_snapshot_rejects_unexpected_edit(
     main_file.write_bytes(changed)
 
     with pytest.raises(AssertionError):
-        snapshot.assert_unchanged(quiescence=0)
+        snapshot.assert_unchanged_now()
 
     main_file.write_bytes(original)
-    delayed_snapshot = SourceSnapshot.capture(fixture_project)
-    with pytest.raises(AssertionError):
-        delayed_snapshot.assert_unchanged(
-            quiescence=0.2,
-            after_first_observation=lambda: (main_file.write_bytes(changed), None)[1],
-        )
+    clock = [0.0]
+    monkeypatch.setattr("source_snapshot.time.monotonic", lambda: clock[0])
+
+    def observed_write(seconds):
+        clock[0] += seconds
+        main_file.write_bytes(changed)
+
+    monkeypatch.setattr("source_snapshot.time.sleep", observed_write)
+    snapshot.wait_for_exact(changed)
+    assert clock[0] == 0.02
 
     message = exact_source_mismatch(
         {Path("Main.slint"): b"export component Main { width: 2px; }\n"},
@@ -46,4 +51,4 @@ def test_source_snapshot_rejects_unexpected_edit(
 
 
 def test_source_snapshot_observes_unchanged_project(fixture_project: Path) -> None:
-    SourceSnapshot.capture(fixture_project).assert_unchanged(quiescence=0.01)
+    SourceSnapshot.capture(fixture_project).assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/test_undo_redo.py
+++ b/tools/editor/ui-tests/tests/test_undo_redo.py
@@ -3,6 +3,7 @@
 
 import math
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,7 @@ from canvas_interactions import (
     rotated_handle_center,
     rotation_delta,
 )
+from editor_sync import current_editor_sync
 from inspector_interactions import FIELDS, edit_field, wait_for_field
 from slint_testing import keys
 from source_snapshot import SourceSnapshot
@@ -246,12 +248,21 @@ def test_redo_after_external_edit_preserves_source(
             window, FIELDS["x"], "80", slint_testing.AccessibleRole.TextInput
         )
         select_fixture_element(window, "Rectangle")
-        source.write_bytes(external)
-        snapshot_after_external = SourceSnapshot.capture(fixture_project)
-        if wait_for_reload:
-            wait_for_field(
-                window, FIELDS["x"], "900", slint_testing.AccessibleRole.TextInput
-            )
-        shortcut(window, redo=True)
+        sync = current_editor_sync.get()
+        scope = nullcontext() if wait_for_reload else sync.gate("source", source)
+        with scope as gate:
+            source.write_bytes(external)
+            snapshot_after_external = SourceSnapshot.capture(fixture_project)
+            if gate is not None:
+                gate.wait_for_reached()
+            else:
+                sync.wait_for_applied(source, external)
+                wait_for_field(
+                    window, FIELDS["x"], "900", slint_testing.AccessibleRole.TextInput
+                )
+            with sync.action() as redo:
+                shortcut(window, redo=True)
+            redo.wait_for_settled(outcome="noop" if wait_for_reload else "rejected")
+            redo.assert_no_source_writes()
         snapshot.wait_for_applied(external, SOURCE)
-        snapshot_after_external.assert_unchanged()
+        snapshot_after_external.assert_unchanged_now()

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -5,7 +5,6 @@ import contextlib
 import hashlib
 import json
 import shutil
-import subprocess
 import time
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -32,8 +31,10 @@ def press_keys(window: slint_testing.Window, text: str) -> None:
 T = TypeVar("T")
 
 
-def wait_until(probe: Callable[[], T | None], timeout: float = 5) -> T:
-    deadline = time.monotonic() + timeout
+def wait_until(
+    probe: Callable[[], T | None], timeout: float = 5, *, deadline: float | None = None
+) -> T:
+    deadline = time.monotonic() + timeout if deadline is None else deadline
     while time.monotonic() < deadline:
         result = probe()
         if result is not None:
@@ -47,9 +48,7 @@ def wait_until(probe: Callable[[], T | None], timeout: float = 5) -> T:
 def first_window(
     application: slint_testing.Application,
 ) -> slint_testing.Window:
-    window = application.first_window
-    assert window is not None
-    return window
+    return wait_until(lambda: application.first_window, timeout=20)
 
 
 def elements_with_label(
@@ -63,6 +62,23 @@ def elements_with_label(
     return [
         element for element in query.find_all() if element.accessible_label == label
     ]
+
+
+def find_element_with_label(
+    root: slint_testing.Element,
+    label: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> slint_testing.Element | None:
+    matches = elements_with_label(root, label, role)
+    return matches[0] if len(matches) == 1 else None
+
+
+def find_window_element_with_label(
+    window: slint_testing.Window,
+    label: str,
+    role: slint_testing.AccessibleRole | None = None,
+) -> slint_testing.Element | None:
+    return find_element_with_label(window.root_element, label, role)
 
 
 def element_with_label(
@@ -109,7 +125,19 @@ def select_outline_row(
         window, row_label, slint_testing.AccessibleRole.ListItem
     )
     row.invoke_accessible_default_action()
-    return wait_until(lambda: row if row.accessible_item_selected else None)
+    return wait_until(
+        lambda: (
+            current
+            if (
+                current := find_window_element_with_label(
+                    window, row_label, slint_testing.AccessibleRole.ListItem
+                )
+            )
+            is not None
+            and current.accessible_item_selected
+            else None
+        )
+    )
 
 
 def select_fixture_element(window: slint_testing.Window, element_type: str) -> None:
@@ -132,30 +160,16 @@ def launch_editor(
         arguments.append(str(file))
     with TemporaryDirectory(prefix="slint-editor-sync-") as directory:
         run_directory = Path(directory)
-        pinned_binary = run_directory / "slint-editor"
-        shutil.copy2(binary, pinned_binary)
-        pinned_binary.chmod(0o755)
-        binary_hash = hashlib.sha256(pinned_binary.read_bytes()).hexdigest()
-        repository_root = Path(__file__).resolve().parents[4]
-        revision = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=repository_root,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
+        binary_hash = hashlib.sha256(binary.read_bytes()).hexdigest()
         (run_directory / "client-info.json").write_text(
             json.dumps(
                 {
-                    "binary": str(pinned_binary),
+                    "binary": str(binary),
                     "sha256": binary_hash,
-                    "revision": revision,
-                    "features": "system-testing,editor-ci",
-                    "protocol": 2,
+                    "protocol": 3,
                 }
             )
         )
-        arguments[0] = str(pinned_binary)
         sync = EditorSync(run_directory)
         token = current_editor_sync.set(sync)
         try:
@@ -166,16 +180,24 @@ def launch_editor(
                 env=environment
                 | {
                     "SLINT_EDITOR_TEST_SYNC": directory,
-                    "SLINT_EDITOR_TEST_CONFIG_DIR": str(Path(directory) / "config"),
+                    "SLINT_EDITOR_TEST_CONFIG_DIR": environment.get(
+                        "SLINT_EDITOR_TEST_CONFIG_DIR", str(Path(directory) / "config")
+                    ),
                 },
                 launch_timeout=20,
             ) as application:
                 sync.process = application.process
-                sync._request(mode="handshake", timeout=20, handshake=True)
-                info = json.loads((run_directory / "client-info.json").read_text())
-                info.update({"session": sync.session, "protocol": 2})
-                (run_directory / "client-info.json").write_text(json.dumps(info))
                 try:
+                    handshake = sync._request(mode="handshake", timeout=20)
+                    info = json.loads((run_directory / "client-info.json").read_text())
+                    info.update(
+                        {
+                            "session": sync.session,
+                            "protocol": 3,
+                            "build": handshake.data["build"],
+                        }
+                    )
+                    (run_directory / "client-info.json").write_text(json.dumps(info))
                     yield application
                     report = current_report.get()
                     if report is not None and report.completed_stages == 0:

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import contextlib
+import hashlib
+import json
 import time
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -132,9 +134,22 @@ def launch_editor(
         try:
             with slint_testing.Application(
                 arguments,
-                env=environment | {"SLINT_EDITOR_TEST_SYNC": directory},
+                env=environment
+                | {
+                    "SLINT_EDITOR_TEST_SYNC": directory,
+                    "SLINT_EDITOR_TEST_CONFIG_DIR": str(Path(directory) / "config"),
+                },
                 launch_timeout=20,
             ) as application:
+                (Path(directory) / "client-info.json").write_text(
+                    json.dumps(
+                        {
+                            "binary": str(binary),
+                            "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+                            "protocol": 2,
+                        }
+                    )
+                )
                 try:
                     yield application
                     report = current_report.get()

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -7,6 +7,7 @@ import json
 import shutil
 import time
 from collections.abc import Callable, Iterator
+from functools import cache
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TypeVar
@@ -149,6 +150,12 @@ def select_fixture_element(window: slint_testing.Window, element_type: str) -> N
     )
 
 
+@cache
+def binary_checksum(binary: Path) -> str:
+    with binary.open("rb") as file:
+        return hashlib.file_digest(file, "sha256").hexdigest()
+
+
 @contextlib.contextmanager
 def launch_editor(
     binary: Path,
@@ -160,7 +167,7 @@ def launch_editor(
         arguments.append(str(file))
     with TemporaryDirectory(prefix="slint-editor-sync-") as directory:
         run_directory = Path(directory)
-        binary_hash = hashlib.sha256(binary.read_bytes()).hexdigest()
+        binary_hash = binary_checksum(binary)
         (run_directory / "client-info.json").write_text(
             json.dumps(
                 {

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -12,7 +12,7 @@ from tempfile import TemporaryDirectory
 from typing import TypeVar
 
 import slint_testing
-from editor_sync import EditorSync, current_editor_sync
+from editor_sync import PROTOCOL_VERSION, EditorSync, current_editor_sync
 from ui_reporting import capture_failure, current_report, replay_stage
 
 PALETTE_KINDS = ("Image", "Rectangle", "Text", "TouchArea")
@@ -166,7 +166,7 @@ def launch_editor(
                 {
                     "binary": str(binary),
                     "sha256": binary_hash,
-                    "protocol": 3,
+                    "protocol": PROTOCOL_VERSION,
                 }
             )
         )
@@ -193,7 +193,7 @@ def launch_editor(
                     info.update(
                         {
                             "session": sync.session,
-                            "protocol": 3,
+                            "protocol": PROTOCOL_VERSION,
                             "build": handshake.data["build"],
                         }
                     )

--- a/tools/editor/ui-tests/tests/ui_driver.py
+++ b/tools/editor/ui-tests/tests/ui_driver.py
@@ -4,6 +4,8 @@
 import contextlib
 import hashlib
 import json
+import shutil
+import subprocess
 import time
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -129,9 +131,36 @@ def launch_editor(
     if file is not None:
         arguments.append(str(file))
     with TemporaryDirectory(prefix="slint-editor-sync-") as directory:
-        sync = EditorSync(Path(directory))
+        run_directory = Path(directory)
+        pinned_binary = run_directory / "slint-editor"
+        shutil.copy2(binary, pinned_binary)
+        pinned_binary.chmod(0o755)
+        binary_hash = hashlib.sha256(pinned_binary.read_bytes()).hexdigest()
+        repository_root = Path(__file__).resolve().parents[4]
+        revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repository_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (run_directory / "client-info.json").write_text(
+            json.dumps(
+                {
+                    "binary": str(pinned_binary),
+                    "sha256": binary_hash,
+                    "revision": revision,
+                    "features": "system-testing,editor-ci",
+                    "protocol": 2,
+                }
+            )
+        )
+        arguments[0] = str(pinned_binary)
+        sync = EditorSync(run_directory)
         token = current_editor_sync.set(sync)
         try:
+            environment = dict(environment)
+            environment.pop("SLINT_LIVE_PREVIEW", None)
             with slint_testing.Application(
                 arguments,
                 env=environment
@@ -141,15 +170,11 @@ def launch_editor(
                 },
                 launch_timeout=20,
             ) as application:
-                (Path(directory) / "client-info.json").write_text(
-                    json.dumps(
-                        {
-                            "binary": str(binary),
-                            "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
-                            "protocol": 2,
-                        }
-                    )
-                )
+                sync.process = application.process
+                sync._request(mode="handshake", timeout=20, handshake=True)
+                info = json.loads((run_directory / "client-info.json").read_text())
+                info.update({"session": sync.session, "protocol": 2})
+                (run_directory / "client-info.json").write_text(json.dumps(info))
                 try:
                     yield application
                     report = current_report.get()
@@ -158,6 +183,11 @@ def launch_editor(
                             pass
                 except Exception as error:
                     capture_failure(application, error)
+                    report = current_report.get()
+                    if report is not None:
+                        artifact_dir = report.artifacts / "editor-sync"
+                        shutil.copytree(run_directory, artifact_dir, dirs_exist_ok=True)
+                        error.add_note(f"Editor sync trace: {artifact_dir}")
                     raise
 
         finally:

--- a/tools/editor/ui/components/inspector/rotation-knob.slint
+++ b/tools/editor/ui/components/inspector/rotation-knob.slint
@@ -100,6 +100,7 @@ export component InspectorRotationKnob inherits FocusScope {
                 root.accumulated = root.value;
                 root.last-angle = root.pointer-angle();
                 root.shift-pressed = event.modifiers.shift;
+                if !root.preview(root.value) { root.cancel(); }
             } else if event.kind == PointerEventKind.move && root.dragging {
                 root.update(root.shift-pressed || event.modifiers.shift);
             } else if event.kind == PointerEventKind.up && root.dragging {


### PR DESCRIPTION
Visual Editor tests can observe saved source before the corresponding preview is installed, or continue before an asynchronous edit has finished.
This adds explicit lifecycle waits and controlled scheduling gates so recovery, property, cancellation, and overlapping-edit tests can verify those transitions directly.

- Add a private, opt-in `system-testing` observer with session, source, compilation, and edit identities; observed, processed, applied, and settled milestones; and causal work and filesystem mutation accounting.
- Associate workspace-edit acknowledgments and preview installation with the edit they complete, and reconcile pending history when installation fails, is superseded, or is abandoned.
- Migrate affected Python tests to identified completion conditions while preserving intentional overlap and persistence-only assertions.
- Isolate settings and synchronization state per test process, preserve immutable executable copies, and document the contracts and remaining audit limitations.

Validation:

- Rebuilt after rebasing onto current master and ran the complete headless UI suite with three workers: 301 passed, 47 existing skips.
- Before the rebase: 188 Rust tests and 19 Python helper tests passed; lifecycle tests passed with one worker (33 tests), and affected tests passed with four workers (77 passed, 3 existing skips).
- Clippy passed with and without `system-testing`; Rust formatting, Ruff, Python type checks, spelling, licence headers, and `git diff --check` passed. The pane-test conflict resolution also passed Ruff.

Validation ran on macOS. Windows and Linux execution remains for CI.
The UI-test README records retained point-in-time checks and deferred deleted-root recovery coverage.
