### PR TITLE
lsp: Fix complete and goto-definition with struct fields expression

### DIFF
--- a/internal/editor-preview/token_info.rs
+++ b/internal/editor-preview/token_info.rs
@@ -3,7 +3,7 @@
 
 use i_slint_compiler::diagnostics::{SourceLocation, Spanned};
 use i_slint_compiler::expression_tree::{Callable, Expression};
-use i_slint_compiler::langtype::{ElementType, EnumerationValue, Type};
+use i_slint_compiler::langtype::{ElementType, EnumerationValue, Struct, Type};
 use i_slint_compiler::lookup::{LookupObject, LookupResult, LookupResultCallable};
 use i_slint_compiler::namedreference::NamedReference;
 use i_slint_compiler::object_tree::ElementRc;
@@ -11,6 +11,7 @@ use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken, TextRange, s
 use i_slint_compiler::pathutils::clean_path;
 use smol_str::{SmolStr, ToSmolStr};
 use std::path::Path;
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub enum TokenInfo {
@@ -27,6 +28,10 @@ pub enum TokenInfo {
     /// This is like a NamedReference, but the element doesn't have an ElementRc because
     /// its enclosing component might not have been properly parsed
     IncompleteNamedReference(ElementType, SmolStr),
+    /// A field of a struct, and the struct it belongs to
+    StructField(Arc<Struct>, SmolStr),
+    /// The model data of a `for`, named by its declared identifier
+    ModelData(ElementRc),
 }
 
 /// Resolve a struct/enum declaration reference to its syntax node using the
@@ -82,6 +87,23 @@ impl TokenInfo {
             TokenInfo::LocalProperty(x) => Some(x.clone().into()),
             TokenInfo::LocalCallback(x) => Some(x.clone().into()),
             TokenInfo::LocalFunction(x) => Some(x.clone().into()),
+            TokenInfo::StructField(s, field) => {
+                let decl = node_for_decl(document_cache, s.node()?)?;
+                syntax_nodes::StructDeclaration::new(decl)?
+                    .ObjectType()
+                    .ObjectTypeMember()
+                    .find(|m| {
+                        m.child_token(SyntaxKind::Identifier).is_some_and(|t| {
+                            i_slint_compiler::parser::normalize_identifier(t.text()) == *field
+                        })
+                    })
+                    .map(|m| m.into())
+            }
+            TokenInfo::ModelData(elem) => {
+                let node = elem.borrow().debug.first()?.node.clone();
+                let repeated = node.parent()?.parent()?;
+                syntax_nodes::RepeatedElement::new(repeated)?.DeclaredIdentifier().map(|d| d.into())
+            }
             TokenInfo::IncompleteNamedReference(element_type, prop_name) => {
                 let mut element_type = element_type.clone();
                 while let ElementType::Component(com) = element_type {
@@ -93,6 +115,37 @@ impl TokenInfo {
                 None
             }
         }
+    }
+}
+
+/// Map what a name resolved to onto the thing the editor can show or jump to
+fn token_info_from_lookup_result(lr: LookupResult) -> Option<TokenInfo> {
+    match lr {
+        LookupResult::Expression { expression: Expression::ElementReference(e), .. } => {
+            Some(TokenInfo::ElementRc(e.upgrade()?))
+        }
+        LookupResult::Expression { expression: Expression::PropertyReference(nr), .. } => {
+            Some(TokenInfo::NamedReference(nr))
+        }
+        LookupResult::Expression { expression: Expression::EnumerationValue(v), .. } => {
+            Some(TokenInfo::EnumerationValue(v))
+        }
+        LookupResult::Expression {
+            expression: Expression::StructFieldAccess { base, name },
+            ..
+        } => match base.ty() {
+            Type::Struct(s) => Some(TokenInfo::StructField(s, name)),
+            _ => None,
+        },
+        LookupResult::Expression {
+            expression: Expression::RepeaterModelReference { element },
+            ..
+        } => Some(TokenInfo::ModelData(element.upgrade()?)),
+        LookupResult::Enumeration(e) => Some(TokenInfo::Type(Type::Enumeration(e))),
+        LookupResult::Callable(LookupResultCallable::Callable(
+            Callable::Callback(nr) | Callable::Function(nr),
+        )) => Some(TokenInfo::NamedReference(nr)),
+        _ => None,
     }
 }
 
@@ -147,28 +200,20 @@ pub fn token_info(document_cache: &crate::DocumentCache, token: SyntaxToken) -> 
                         }
                         Some(expr_it)
                     })?;
-                    match lr? {
-                        LookupResult::Expression {
-                            expression: Expression::ElementReference(e),
-                            ..
-                        } => Some(TokenInfo::ElementRc(e.upgrade()?)),
-                        LookupResult::Expression {
-                            expression: Expression::PropertyReference(nr),
-                            ..
-                        } => Some(TokenInfo::NamedReference(nr)),
-                        LookupResult::Expression {
-                            expression: Expression::EnumerationValue(v),
-                            ..
-                        } => Some(TokenInfo::EnumerationValue(v)),
-                        LookupResult::Enumeration(e) => Some(TokenInfo::Type(Type::Enumeration(e))),
-                        LookupResult::Callable(LookupResultCallable::Callable(
-                            Callable::Callback(nr) | Callable::Function(nr),
-                        )) => Some(TokenInfo::NamedReference(nr)),
-                        _ => return None,
-                    }
+                    token_info_from_lookup_result(lr?)
                 }
                 _ => None,
             };
+        } else if let Some(n) = syntax_nodes::MemberAccess::new(node.clone()) {
+            // Member access on something that isn't a plain name, such as `foo[0].bar`
+            if token.kind() != SyntaxKind::Identifier {
+                return None;
+            }
+            let name = i_slint_compiler::parser::normalize_identifier(token.text());
+            let lr = crate::util::with_lookup_ctx(document_cache, node.clone(), None, |ctx| {
+                Expression::from_expression_node(n.Expression(), ctx).lookup(ctx, &name)
+            })?;
+            return token_info_from_lookup_result(lr?);
         } else if let Some(n) = syntax_nodes::ImportIdentifier::new(node.clone()) {
             let doc = document_cache.get_document_for_source_file(&node.source_file)?;
             let imp_name = i_slint_compiler::typeloader::ImportedName::from_node(n);

--- a/internal/editor-preview/util.rs
+++ b/internal/editor-preview/util.rs
@@ -180,6 +180,36 @@ struct ExpressionContextInfo {
     binding_expr: Option<(SyntaxNode, SyntaxNode)>,
 }
 
+/// Resolve the model expression of every `for` and `if` element in `scope`.
+///
+/// The compiler skips its passes on a document that has errors, which is what a document being
+/// edited usually looks like. Without this, the loop variable has no type.
+fn resolve_repeater_models(scope: &[object_tree::ElementRc], tr: &TypeRegister) {
+    let mut build_diagnostics = Default::default();
+    for (i, elem) in scope.iter().enumerate() {
+        object_tree::visit_repeater_model_expression(elem, |expr, _, property_type| {
+            let node = match expr.ignore_debug_hooks() {
+                Expression::Uncompiled(node) => syntax_nodes::Expression::from(node.clone()),
+                _ => return,
+            };
+            let ty = property_type();
+            let mut ctx = LookupCtx::empty_context(
+                tr,
+                &mut build_diagnostics,
+                i_slint_compiler::symbol_counters::SymbolCounters::shared(),
+            );
+            ctx.component_scope = &scope[..i];
+            ctx.property_type = ty.clone();
+            let new_expr = Expression::from_expression_node(node.clone(), &mut ctx)
+                .maybe_convert_to(ty, &node, ctx.diag, &ctx.symbol_counters);
+            match expr {
+                Expression::DebugHook { expression, .. } => **expression = new_expr,
+                _ => *expr = new_expr,
+            }
+        });
+    }
+}
+
 /// Run the function with the LookupCtx associated with the token
 pub fn with_lookup_ctx<R>(
     document_cache: &crate::DocumentCache,
@@ -253,6 +283,8 @@ pub fn with_lookup_ctx<R>(
             .iter()
             .find_map(|(p, t)| if p.as_str() == prop_name { Some(t.clone()) } else { None })
     }
+
+    resolve_repeater_models(&scope, tr);
 
     let mut build_diagnostics = Default::default();
     let mut lookup_context = LookupCtx::empty_context(

--- a/tools/lsp/language/completion.rs
+++ b/tools/lsp/language/completion.rs
@@ -298,6 +298,15 @@ pub(crate) fn completion_at(
                 resolve_expression_scope(ctx, document_cache, snippet_support)
             })?;
         }
+    } else if let Some(member_access) = syntax_nodes::MemberAccess::new(node.clone()) {
+        // Member access on something that isn't a plain name, such as `foo[0].` or `foo().`
+        let dot = member_access.child_token(SyntaxKind::Dot)?;
+        if offset >= dot.text_range().end() {
+            return with_lookup_ctx(document_cache, node, Some(offset), |ctx| {
+                let base = Expression::from_expression_node(member_access.Expression(), ctx);
+                completion_items_from_lookup(&base, ctx, snippet_support)
+            });
+        }
     } else if let Some(q) = syntax_nodes::QualifiedName::new(node.clone()) {
         match q.parent()?.kind() {
             SyntaxKind::Element => {
@@ -372,14 +381,7 @@ pub(crate) fn completion_at(
                         let str = i_slint_compiler::parser::normalize_identifier(t.text());
                         expr_it = expr_it.lookup(ctx, &str)?;
                     }
-                    has_dot.then(|| {
-                        let mut r = Vec::new();
-                        expr_it.for_each_entry(ctx, &mut |str, expr| -> Option<()> {
-                            r.push(completion_item_from_expression(str, expr, snippet_support));
-                            None
-                        });
-                        r
-                    })
+                    has_dot.then(|| completion_items_from_lookup(&expr_it, ctx, snippet_support))
                 })?;
             }
             _ => (),
@@ -837,12 +839,8 @@ fn resolve_expression_scope(
     document_cache: &editor_preview::DocumentCache,
     snippet_support: bool,
 ) -> Option<Vec<CompletionItem>> {
-    let mut r = Vec::new();
     let global = i_slint_compiler::lookup::global_lookup();
-    global.for_each_entry(lookup_context, &mut |str, expr| -> Option<()> {
-        r.push(completion_item_from_expression(str, expr, snippet_support));
-        None
-    });
+    let mut r = completion_items_from_lookup(&global, lookup_context, snippet_support);
     if snippet_support
         && let Some(token) = lookup_context.current_token.as_ref().and_then(|t| match t {
             i_slint_compiler::parser::NodeOrToken::Node(n) => n.first_token(),
@@ -876,6 +874,20 @@ fn resolve_expression_scope(
         );
     }
     Some(r)
+}
+
+/// The completion items for everything `obj` exposes
+fn completion_items_from_lookup(
+    obj: &impl LookupObject,
+    ctx: &LookupCtx,
+    snippet_support: bool,
+) -> Vec<CompletionItem> {
+    let mut r = Vec::new();
+    obj.for_each_entry(ctx, &mut |str, expr| -> Option<()> {
+        r.push(completion_item_from_expression(str, expr, snippet_support));
+        None
+    });
+    r
 }
 
 fn completion_item_from_expression(
@@ -1863,6 +1875,36 @@ mod tests {
         res.iter().find(|ci| ci.label == "xx").unwrap();
         res.iter().find(|ci| ci.label == "yy").unwrap();
         assert_eq!(res.len(), 2);
+    }
+
+    #[test]
+    fn struct_field_after_index() {
+        // The index makes the parser produce a MemberAccess instead of a QualifiedName (#13305)
+        let source = r#"
+            struct InnerData { inner: string }
+            struct Data { first: string, second: [InnerData] }
+            export component AppWindow {
+                property <Data> data;
+                Text { text: data.second[0].🔺; }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        assert_eq!(res.iter().map(|ci| ci.label.as_str()).collect::<Vec<_>>(), ["inner"]);
+    }
+
+    #[test]
+    fn struct_field_of_model_data() {
+        // The type of the loop variable comes from the model of the `for` (#13305)
+        let source = r#"
+            struct InnerData { inner: string }
+            struct Data { first: string, second: [InnerData] }
+            export component AppWindow {
+                property <Data> data;
+                for item in data.second: Text { text: item.🔺; }
+            }
+        "#;
+        let res = get_completions(source).unwrap();
+        assert_eq!(res.iter().map(|ci| ci.label.as_str()).collect::<Vec<_>>(), ["inner"]);
     }
 
     #[test]

--- a/tools/lsp/language/goto.rs
+++ b/tools/lsp/language/goto.rs
@@ -62,6 +62,38 @@ fn goto_node(
 use i_slint_compiler::parser::TextSize;
 
 #[test]
+fn test_goto_struct_field_and_model_data() {
+    // #13305
+    let source = r#"
+struct InnerData { inner: string }
+struct Data { first: string, second: [InnerData] }
+export component AppWindow {
+    in property <Data> data;
+    Text { text: data.first + data.second[0].inner; }
+    for item in data.second: Text { text: item.inner; }
+}"#;
+
+    let (mut dc, uri, _) = crate::language::test::loaded_document_cache(source.into());
+    let doc = dc.get_document(&uri).unwrap().node.clone().unwrap();
+    let mut target_line = |needle: &str, offset: u32| {
+        let offset = TextSize::new(source.find(needle).unwrap() as u32 + offset);
+        let token = crate::language::token_at_offset(&doc, offset).unwrap();
+        let def = goto_definition(&mut dc, token).unwrap();
+        let GotoDefinitionResponse::Link(link) = def else { panic!("not a single link {def:?}") };
+        let link = link.first().unwrap();
+        assert_eq!(link.target_uri, uri);
+        link.target_range.start.line
+    };
+
+    // The field declarations in the structs
+    assert_eq!(target_line("data.first", 5), 2);
+    assert_eq!(target_line("data.second[0].inner", 15), 1);
+    assert_eq!(target_line("item.inner", 5), 1);
+    // The declared identifier of the `for`
+    assert_eq!(target_line("item.inner", 0), 6);
+}
+
+#[test]
 fn test_goto_definition() {
     fn first_link(def: &GotoDefinitionResponse) -> &LocationLink {
         let GotoDefinitionResponse::Link(link) = def else { panic!("not a single link {def:?}") };

--- a/tools/lsp/language/hover.rs
+++ b/tools/lsp/language/hover.rs
@@ -6,12 +6,14 @@ use crate::editor_preview::{
     token_info::{TokenInfo, token_info},
 };
 use crate::util;
+use i_slint_compiler::expression_tree::Expression;
 use i_slint_compiler::langtype::ElementDocEntry;
 use i_slint_compiler::langtype::{BuiltinElement, ElementType, Type};
 use i_slint_compiler::object_tree::ElementRc;
 use i_slint_compiler::parser::{SyntaxKind, SyntaxNode, SyntaxToken};
 use itertools::Itertools as _;
 use lsp_types::{Hover, HoverContents, MarkupContent};
+use std::rc::Rc;
 
 pub fn get_tooltip(
     document_cache: &mut editor_preview::DocumentCache,
@@ -80,6 +82,14 @@ pub fn get_tooltip(
         // Todo: this can happen when there is some syntax error
         TokenInfo::LocalProperty(_) | TokenInfo::LocalCallback(_) | TokenInfo::LocalFunction(_) => {
             return None;
+        }
+        TokenInfo::StructField(s, field) => {
+            from_slint_code(&format!("{field}: {}", s.fields.get(&field)?), documentation)
+        }
+        TokenInfo::ModelData(elem) => {
+            let ty = Expression::RepeaterModelReference { element: Rc::downgrade(&elem) }.ty();
+            let name = elem.borrow().repeated.as_ref()?.model_data_id.clone();
+            from_slint_code(&format!("{name}: {ty}"), documentation)
         }
         TokenInfo::IncompleteNamedReference(el, name) => {
             from_property_in_type(&el, &name, documentation)?
@@ -354,6 +364,40 @@ mod tests {
     use super::*;
 
     use i_slint_compiler::parser::TextSize;
+
+    #[test]
+    fn test_tooltip_struct_field_and_model_data() {
+        // #13305
+        let source = r#"
+struct InnerData {
+    /// docs for inner
+    inner: string,
+}
+struct Data { first: string, second: [InnerData] }
+export component AppWindow {
+    in property <Data> data;
+    Text { text: data.first + data.second[0].inner; }
+    for item in data.second: Text { text: item.inner; }
+}"#;
+        let (mut dc, uri, _) = crate::language::test::loaded_document_cache(source.into());
+        let doc = dc.get_document(&uri).unwrap().node.clone().unwrap();
+        let mut tooltip = |needle: &str, offset: u32| {
+            let offset = TextSize::new(source.find(needle).unwrap() as u32 + offset);
+            let token = crate::language::token_at_offset(&doc, offset).unwrap();
+            match get_tooltip(&mut dc, token).unwrap().contents {
+                HoverContents::Markup(m) => m.value,
+                x => panic!("Found {x:?}"),
+            }
+        };
+
+        assert_eq!(tooltip("data.first", 5), "```slint\nfirst: string\n```");
+        assert_eq!(
+            tooltip("data.second[0].inner", 15),
+            "```slint\n/// docs for inner\ninner: string\n```"
+        );
+        assert_eq!(tooltip("item.inner", 0), "```slint\nitem: InnerData\n```");
+        assert_eq!(tooltip("item.inner", 5), "```slint\n/// docs for inner\ninner: string\n```");
+    }
 
     #[test]
     fn test_tooltip() {


### PR DESCRIPTION
Fixes: https://github.com/slint-ui/slint/issues/13305