### PR TITLE
Rebuild when bundled translations change

### DIFF
--- a/api/rs/build/lib.rs
+++ b/api/rs/build/lib.rs
@@ -299,6 +299,10 @@ impl CompilerConfiguration {
             to_absolute_path(path);
         }
 
+        if let Some(path) = config.translation_path_bundle.as_mut() {
+            to_absolute_path(path);
+        }
+
         Self { config }
     }
 }
@@ -528,6 +532,11 @@ pub fn compile_with_config(
             println!("cargo::metadata=SLINT_LIBRARY_MODULE={}", rust_module);
         }
     }
+    // Cargo scans a directory dependency recursively, so this also catches an added language.
+    if let Some(bundle_path) = &config.config.translation_path_bundle {
+        println!("cargo:rerun-if-changed={}", bundle_path.display());
+    }
+
     let paths_dependencies =
         compile_with_output_path(path, absolute_rust_output_file_path.clone(), config)?;
 
@@ -542,6 +551,7 @@ pub fn compile_with_config(
     println!("cargo:rerun-if-env-changed=SLINT_EMBED_RESOURCES");
     println!("cargo:rerun-if-env-changed=SLINT_EMIT_DEBUG_INFO");
     println!("cargo:rerun-if-env-changed=SLINT_LIVE_PREVIEW");
+    println!("cargo:rerun-if-env-changed=SLINT_BUNDLE_TRANSLATIONS");
 
     println!(
         "cargo:rustc-env=SLINT_INCLUDE_GENERATED={}",

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -319,6 +319,7 @@ pub async fn run_passes(
         match crate::translations::TranslationsBuilder::load_translations(
             path,
             type_loader.compiler_config.translation_domain.as_deref().unwrap_or(""),
+            &mut diag.all_loaded_files,
         ) {
             Ok(builder) => {
                 doc.translation_builder = Some(builder);

--- a/internal/compiler/translations.rs
+++ b/internal/compiler/translations.rs
@@ -45,7 +45,11 @@ pub struct TranslationsBuilder {
 }
 
 impl TranslationsBuilder {
-    pub fn load_translations(path: &Path, domain: &str) -> std::io::Result<Self> {
+    pub fn load_translations(
+        path: &Path,
+        domain: &str,
+        all_loaded_files: &mut std::collections::BTreeSet<std::path::PathBuf>,
+    ) -> std::io::Result<Self> {
         let mut languages = vec![("".into(), i_slint_common::DEFAULT_DECIMAL_SEPARATOR)];
         let mut catalogs = Vec::new();
         let mut plural_rules =
@@ -61,6 +65,7 @@ impl TranslationsBuilder {
         for l in entries {
             let path = l.path().join("LC_MESSAGES").join(format!("{domain}.po"));
             if path.exists() {
+                all_loaded_files.insert(path.clone());
                 let catalog = rspolib::pofile(path.as_path()).map_err(|e| {
                     std::io::Error::other(format!("Error parsing {}: {e}", path.display()))
                 })?;


### PR DESCRIPTION
Report the loaded `.po` files as compilation dependencies, so cargo and the depfile-based builds pick up an edited translation. The build script also watches the bundle root, so adding or removing a language triggers a rebuild.

Fixes: #13321
ChangeLog: Changing a bundled translation now triggers a rebuild
