### PR TITLE
Visual Editor: add a solid-color picker with session-based undo

### DIFF
--- a/tools/editor/main.rs
+++ b/tools/editor/main.rs
@@ -442,7 +442,8 @@ async fn handle_preview_message(
             tracing::debug!("Ignoring message from preview: {msg:?}");
         }
         SendWorkspaceEdit { label, edit } => {
-            handle_workspace_edit(&session.document_cache, label.as_deref(), edit);
+            let applied = handle_workspace_edit(&session.document_cache, label.as_deref(), edit);
+            preview::workspace_edit_finished(edit.clone(), applied);
         }
     }
 }
@@ -495,13 +496,15 @@ fn handle_workspace_edit(
     document_cache: &editor_preview::DocumentCache,
     label: Option<&str>,
     edit: &lsp_types::WorkspaceEdit,
-) {
+) -> bool {
     match editor_preview::editing::text_edit::apply_workspace_edit(document_cache, edit) {
         Ok(edited_texts) => {
+            let mut applied = true;
             for editor_preview::editing::text_edit::EditedText { url, contents } in edited_texts {
                 match editor_preview::uri_to_file(&url) {
                     Some(path) => {
                         if let Err(err) = std::fs::write(&path, &contents) {
+                            applied = false;
                             tracing::error!(
                                 "Failed to apply workspace edit '{}' to {}: {err}",
                                 label.unwrap_or("(unnamed)"),
@@ -510,16 +513,19 @@ fn handle_workspace_edit(
                         }
                     }
                     None => {
+                        applied = false;
                         tracing::warn!("Cannot apply workspace edit to non-file URL: {url}");
                     }
                 }
             }
+            applied
         }
         Err(err) => {
             tracing::error!(
                 "Failed to compute workspace edit '{}': {err}",
                 label.unwrap_or("(unnamed)")
             );
+            false
         }
     }
 }

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -246,6 +246,7 @@ pub struct PreviewState {
     undo_redo_stack: undo_redo::UndoRedoStack,
     pending_history: std::collections::VecDeque<bool>,
     inspector_edit: Option<inspector::Edit>,
+    color_refresh: Option<inspector::ColorRefresh>,
 
     source_code: SourceCodeCache,
     resources: HashSet<Url>,
@@ -508,6 +509,7 @@ fn apply_live_preview_data() {
 }
 
 fn set_contents(url: &VersionedUrl, content: String) {
+    let own_color_edit = inspector::color_contents_changed(url.url(), &content);
     let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
         if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
             undo_redo::set_undo_redo_enabled(preview_state);
@@ -531,10 +533,18 @@ fn set_contents(url: &VersionedUrl, content: String) {
         (reload, invalidate)
     });
     if invalidate {
-        inspector::invalidate();
+        if own_color_edit {
+            inspector::refresh();
+        } else {
+            inspector::invalidate();
+        }
     }
     if let Some(current) = reload {
-        load_preview(current, LoadBehavior::Reload);
+        if own_color_edit {
+            schedule_preview(current, LoadBehavior::Reload);
+        } else {
+            load_preview(current, LoadBehavior::Reload);
+        }
     }
 }
 
@@ -2056,6 +2066,11 @@ async fn reload_timer_function() {
 }
 
 pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior) {
+    inspector::invalidate_color();
+    schedule_preview(preview_component, behavior);
+}
+
+fn schedule_preview(preview_component: PreviewComponent, behavior: LoadBehavior) {
     tracing::debug!(
         "Preview: load url={}, component={:?}, behavior={:?}",
         preview_component.url,
@@ -2271,8 +2286,9 @@ fn set_preview_factory(
     callback: Box<dyn Fn(ComponentInstance)>,
     behavior: LoadBehavior,
 ) {
-    // Ensure that any popups are closed as they are related to the old factory
-    i_slint_core::window::WindowInner::from_pub(editor_ui.window()).close_all_popups();
+    if !inspector::preserve_color_popup() {
+        i_slint_core::window::WindowInner::from_pub(editor_ui.window()).close_all_popups();
+    }
 
     let _ = i_slint_core::window::WindowInner::from_pub(editor_ui.window())
         .context()
@@ -2679,6 +2695,7 @@ fn update_preview_area(
     source_file_versions: Rc<RefCell<i_slint_editor_preview::document_cache::SourceFileVersionMap>>,
     format: i_slint_editor_preview::ByteFormat,
 ) -> Result<(), PlatformError> {
+    let compiled_successfully = compiled.is_some();
     let editor_ui = PREVIEW_STATE.with_borrow_mut(move |preview_state| {
         preview_state.workspace_edit_sent = false;
 
@@ -2747,7 +2764,11 @@ fn update_preview_area(
         Ok(())
     })?;
 
-    inspector::invalidate();
+    if compiled_successfully {
+        inspector::finish_refresh();
+    } else {
+        inspector::invalidate();
+    }
     element_selection::reselect_element();
     undo_redo::apply_pending();
     Ok(())

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -1714,6 +1714,11 @@ enum CompilationResult {
     NoChange,
 }
 
+pub(super) fn workspace_edit_finished(edit: lsp_types::WorkspaceEdit, applied: bool) {
+    let _ =
+        slint::invoke_from_event_loop(move || inspector::workspace_edit_finished(edit, applied));
+}
+
 fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit: bool) -> bool {
     let Some(document_cache) = document_cache() else {
         return false;

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -535,18 +535,10 @@ fn set_contents(url: &VersionedUrl, content: String) {
         (reload, invalidate)
     });
     if invalidate {
-        if own_color_edit {
-            inspector::refresh();
-        } else {
-            inspector::invalidate();
-        }
+        inspector::invalidate();
     }
     if let Some(current) = reload {
-        if own_color_edit {
-            schedule_preview(current, LoadBehavior::Reload);
-        } else {
-            load_preview(current, LoadBehavior::Reload);
-        }
+        load_preview(current, LoadBehavior::Reload);
     }
 }
 
@@ -2127,10 +2119,6 @@ async fn reload_timer_function() {
 
 pub fn load_preview(preview_component: PreviewComponent, behavior: LoadBehavior) {
     inspector::invalidate_color();
-    schedule_preview(preview_component, behavior);
-}
-
-fn schedule_preview(preview_component: PreviewComponent, behavior: LoadBehavior) {
     tracing::debug!(
         "Preview: load url={}, component={:?}, behavior={:?}",
         preview_component.url,

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -511,7 +511,9 @@ fn apply_live_preview_data() {
 fn set_contents(url: &VersionedUrl, content: String) {
     let own_color_edit = inspector::color_contents_changed(url.url(), &content);
     let (reload, invalidate) = PREVIEW_STATE.with_borrow_mut(|preview_state| {
-        if !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content) {
+        if !own_color_edit
+            && !preview_state.undo_redo_stack.check_set_contents_valid(url.url(), &content)
+        {
             undo_redo::set_undo_redo_enabled(preview_state);
         }
         let old = preview_state.source_code.insert(
@@ -1720,11 +1722,42 @@ pub(super) fn workspace_edit_finished(edit: lsp_types::WorkspaceEdit, applied: b
 }
 
 fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit: bool) -> bool {
+    submit_workspace_edit(label, edit, test_edit, None)
+}
+
+fn submit_workspace_edit(
+    label: String,
+    edit: lsp_types::WorkspaceEdit,
+    test_edit: bool,
+    color: Option<slint::Color>,
+) -> bool {
     let Some(document_cache) = document_cache() else {
         return false;
     };
     let Ok(result) = text_edit::apply_workspace_edit(&document_cache, &edit) else {
         return false;
+    };
+    let color_refresh = if let Some(color) = color {
+        let [expected] = result.as_slice() else { return false };
+        let unchanged = PREVIEW_STATE.with_borrow(|state| {
+            state
+                .source_code
+                .get(&expected.url)
+                .is_some_and(|source| source.code == expected.contents)
+        });
+        if unchanged {
+            inspector::cancel();
+            return true;
+        }
+        Some((
+            color,
+            text_edit::EditedText {
+                url: expected.url.clone(),
+                contents: expected.contents.clone(),
+            },
+        ))
+    } else {
+        None
     };
     let file_hashes = undo_redo::compute_file_hashes(&result);
 
@@ -1739,11 +1772,26 @@ fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit:
 
     let reverse_edit = text_edit::reversed_edit(&document_cache, &edit);
 
-    PREVIEW_STATE.with_borrow_mut(|preview_state| {
-        if std::mem::replace(&mut preview_state.workspace_edit_sent, true) {
+    let accepted = PREVIEW_STATE.with_borrow_mut(|preview_state| {
+        if undo_redo::edit_pending(preview_state) {
             return false;
         }
-        preview_state.undo_redo_stack.push(label.clone(), reverse_edit, file_hashes);
+        if let Some((color, expected)) = color_refresh {
+            let Some(reverse) = reverse_edit else { return false };
+            preview_state.color_refresh = Some(inspector::ColorRefresh {
+                expected,
+                submitted_edit: edit.clone(),
+                color,
+                undo: Some(undo_redo::EditItem {
+                    title: label.clone(),
+                    edit: reverse,
+                    file_hashes,
+                }),
+            });
+        } else {
+            preview_state.undo_redo_stack.push(label.clone(), reverse_edit, file_hashes);
+        }
+        preview_state.workspace_edit_sent = true;
         undo_redo::set_undo_redo_enabled(preview_state);
         preview_state
             .to_lsp
@@ -1753,7 +1801,14 @@ fn send_workspace_edit(label: String, edit: lsp_types::WorkspaceEdit, test_edit:
             .send(&PreviewToLspMessage::SendWorkspaceEdit { label: Some(label), edit })
             .unwrap();
         true
-    })
+    });
+    if accepted && color.is_some() {
+        let api = PREVIEW_STATE.with_borrow(|state| state.api.upgrade());
+        if let Some(api) = api {
+            api.set_inspector_color_refresh_pending(true);
+        }
+    }
+    accepted
 }
 
 fn change_style() {
@@ -2290,11 +2345,8 @@ fn set_preview_factory(
     compiled: ComponentDefinition,
     callback: Box<dyn Fn(ComponentInstance)>,
     behavior: LoadBehavior,
-    preserve_color_popup: bool,
 ) {
-    if !preserve_color_popup {
-        i_slint_core::window::WindowInner::from_pub(editor_ui.window()).close_all_popups();
-    }
+    i_slint_core::window::WindowInner::from_pub(editor_ui.window()).close_all_popups();
 
     let _ = i_slint_core::window::WindowInner::from_pub(editor_ui.window())
         .context()
@@ -2701,8 +2753,6 @@ fn update_preview_area(
     source_file_versions: Rc<RefCell<i_slint_editor_preview::document_cache::SourceFileVersionMap>>,
     format: i_slint_editor_preview::ByteFormat,
 ) -> Result<(), PlatformError> {
-    let compiled_successfully = compiled.is_some();
-    let preserve_color_popup = inspector::preserve_color_popup();
     let editor_ui = PREVIEW_STATE.with_borrow_mut(move |preview_state| {
         preview_state.workspace_edit_sent = false;
 
@@ -2752,7 +2802,6 @@ fn update_preview_area(
                     previewed_component_changed();
                 }),
                 behavior,
-                preserve_color_popup,
             );
         }
 
@@ -2772,11 +2821,7 @@ fn update_preview_area(
         Ok(())
     })?;
 
-    if compiled_successfully {
-        inspector::finish_refresh();
-    } else {
-        inspector::invalidate();
-    }
+    inspector::invalidate();
     element_selection::reselect_element();
     undo_redo::apply_pending();
     Ok(())

--- a/tools/editor/preview.rs
+++ b/tools/editor/preview.rs
@@ -2285,8 +2285,9 @@ fn set_preview_factory(
     compiled: ComponentDefinition,
     callback: Box<dyn Fn(ComponentInstance)>,
     behavior: LoadBehavior,
+    preserve_color_popup: bool,
 ) {
-    if !inspector::preserve_color_popup() {
+    if !preserve_color_popup {
         i_slint_core::window::WindowInner::from_pub(editor_ui.window()).close_all_popups();
     }
 
@@ -2696,6 +2697,7 @@ fn update_preview_area(
     format: i_slint_editor_preview::ByteFormat,
 ) -> Result<(), PlatformError> {
     let compiled_successfully = compiled.is_some();
+    let preserve_color_popup = inspector::preserve_color_popup();
     let editor_ui = PREVIEW_STATE.with_borrow_mut(move |preview_state| {
         preview_state.workspace_edit_sent = false;
 
@@ -2745,6 +2747,7 @@ fn update_preview_area(
                     previewed_component_changed();
                 }),
                 behavior,
+                preserve_color_popup,
             );
         }
 

--- a/tools/editor/preview/eval.rs
+++ b/tools/editor/preview/eval.rs
@@ -147,10 +147,10 @@ fn eval_expression(
         }
         Expression::Condition { true_expr, false_expr, condition } => {
             let condition = eval_expression(condition, local_context, None);
-            if condition.try_into().unwrap_or(true) {
-                eval_expression(true_expr, local_context, field_filter)
-            } else {
-                eval_expression(false_expr, local_context, field_filter)
+            match condition {
+                Value::Bool(true) => eval_expression(true_expr, local_context, field_filter),
+                Value::Bool(false) => eval_expression(false_expr, local_context, field_filter),
+                _ => Value::Void,
             }
         }
         Expression::Array { values, .. } => {
@@ -308,8 +308,7 @@ fn eval_expression(
 /// This has no access to any runtime information, so the evaluation is an approximation to the
 /// real value only.
 ///
-/// E.g. It will always evaluate the `true` branch of any condition and takes other shortcuts as well.
-/// It might also just fail to evaluate entirely, returning `None` in that case.
+/// Expressions that depend on unavailable runtime values can fail to evaluate and return `None`.
 ///
 /// The purpose of this function is to be able to show some not totally useless representation of
 /// property values in the UI.

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -106,13 +106,14 @@ fn target_with_root(
         if url != current_url || element.offset < 0 {
             return None;
         }
+        let no_selected_instance = -1;
         (
             ElementSelection {
                 path: url.to_file_path().ok()?,
                 offset: (element.offset as u32).into(),
                 instance_index: 0,
             },
-            -1,
+            no_selected_instance,
         )
     } else {
         return None;
@@ -135,7 +136,8 @@ fn target_with_root(
 fn color_target(key: &str, property_name: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
     let suffix = format!(":{property_name}");
     let base_key = key.strip_suffix(&suffix)?;
-    target_with_root(base_key, property_name == "background")
+    let allow_root_background = property_name == "background";
+    target_with_root(base_key, allow_root_background)
 }
 
 fn names(name: &str) -> Option<Vec<&str>> {

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -16,32 +16,27 @@ pub(super) struct Edit {
 }
 
 pub(super) struct ColorRefresh {
-    expected: text_edit::EditedText,
-    received: bool,
-    preserve_popup: bool,
-    write_completed: bool,
-    submitted_edit: lsp_types::WorkspaceEdit,
-    color: slint::Color,
-    previous_history: undo_redo::UndoRedoStack,
+    pub(super) expected: text_edit::EditedText,
+    pub(super) submitted_edit: lsp_types::WorkspaceEdit,
+    pub(super) color: slint::Color,
+    pub(super) undo: Option<undo_redo::EditItem>,
 }
 
 pub(super) fn color_contents_changed(url: &Url, content: &str) -> bool {
     PREVIEW_STATE.with_borrow_mut(|state| {
+        let changed = state.source_code.get(url).is_none_or(|source| source.code != content);
         let Some(refresh) = state.color_refresh.as_mut() else { return false };
-        if refresh.expected.url != *url || refresh.expected.contents != content {
+        if refresh.expected.url != *url {
             return false;
         }
-        refresh.received = true;
+        if refresh.expected.contents != content {
+            if changed {
+                refresh.undo = None;
+            }
+            return false;
+        }
         true
     })
-}
-
-pub(super) fn dismiss_color() {
-    PREVIEW_STATE.with_borrow_mut(|state| {
-        if let Some(refresh) = state.color_refresh.as_mut() {
-            refresh.preserve_popup = false;
-        }
-    });
 }
 
 fn clear_color_refresh() {
@@ -55,20 +50,10 @@ fn clear_color_refresh() {
 }
 
 pub(super) fn invalidate_color() {
-    dismiss_color();
     let api = PREVIEW_STATE.with_borrow(|state| state.api.upgrade());
     if let Some(api) = api {
         api.set_inspector_color_generation(api.get_inspector_color_generation().wrapping_add(1));
     }
-}
-
-pub(super) fn preserve_color_popup() -> bool {
-    PREVIEW_STATE.with_borrow(|state| {
-        state
-            .color_refresh
-            .as_ref()
-            .is_some_and(|refresh| refresh.received && refresh.preserve_popup)
-    })
 }
 
 pub(super) fn workspace_edit_finished(edit: lsp_types::WorkspaceEdit, applied: bool) {
@@ -78,60 +63,28 @@ pub(super) fn workspace_edit_finished(edit: lsp_types::WorkspaceEdit, applied: b
             return None;
         }
         let color = refresh.color;
-        refresh.write_completed = true;
-        let preserve_popup = refresh.preserve_popup;
         if !applied {
-            let mut previous = refresh.previous_history.clone();
-            for (url, source) in &state.source_code {
-                previous.check_set_contents_valid(url, &source.code);
-            }
-            state.undo_redo_stack = previous;
             state.workspace_edit_sent = false;
         } else {
+            if let Some(undo) = refresh.undo.take() {
+                state.undo_redo_stack.push_item(undo);
+            }
             state.inspector_edit.take();
         }
-        Some((state.api.upgrade(), color, preserve_popup))
+        Some((state.api.upgrade(), color))
     });
-    let Some((api, color, preserve_popup)) = result else { return };
+    let Some((api, color)) = result else { return };
     if applied {
         if let Some(api) = api {
             api.invoke_add_recent_color(color);
         }
-        if !preserve_popup {
-            clear_color_refresh();
-        }
     } else {
         cancel();
-        clear_color_refresh();
         invalidate_color();
-        PREVIEW_STATE.with_borrow(undo_redo::set_undo_redo_enabled);
-        undo_redo::apply_pending();
     }
-}
-
-pub(super) fn finish_refresh() {
-    let (pending, applied, write_completed) = PREVIEW_STATE.with_borrow(|state| {
-        let Some(refresh) = state.color_refresh.as_ref() else { return (false, false, false) };
-        let applied = refresh.received
-            && document_cache_from(state)
-                .and_then(|cache| {
-                    cache
-                        .get_document(&refresh.expected.url)
-                        .and_then(|document| document.node.as_ref())
-                        .map(|node| node.text() == refresh.expected.contents.as_str())
-                })
-                .unwrap_or(false);
-        (true, applied, refresh.write_completed)
-    });
-    if pending && applied {
-        refresh();
-        clear_color_refresh();
-    } else if pending && !write_completed {
-        refresh();
-    } else {
-        clear_color_refresh();
-        invalidate();
-    }
+    clear_color_refresh();
+    PREVIEW_STATE.with_borrow(undo_redo::set_undo_redo_enabled);
+    undo_redo::apply_pending();
 }
 
 fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
@@ -299,10 +252,6 @@ pub(super) fn commit_color(key: SharedString, name: SharedString, value: slint::
         return false;
     };
     let color = ui::color_to_string(value);
-    let Some(cache) = document_cache() else {
-        cancel();
-        return false;
-    };
     let edit = property_edit(
         node,
         url,
@@ -316,39 +265,8 @@ pub(super) fn commit_color(key: SharedString, name: SharedString, value: slint::
         cancel();
         return false;
     };
-    let expected = text_edit::apply_workspace_edit(&cache, &edit)
-        .ok()
-        .and_then(|mut documents| (documents.len() == 1).then(|| documents.remove(0)));
-    let Some(expected) = expected else {
-        cancel();
-        return false;
-    };
-    let changed = PREVIEW_STATE.with_borrow(|state| {
-        state.source_code.get(&expected.url).is_none_or(|source| source.code != expected.contents)
-    });
-    if !changed {
-        cancel();
-        return true;
-    }
-    let previous_history = PREVIEW_STATE.with_borrow(|state| state.undo_redo_stack.clone());
-    let accepted = send_workspace_edit("Editing color".into(), edit.clone(), true);
-    if accepted {
-        let api = PREVIEW_STATE.with_borrow_mut(|state| {
-            state.color_refresh = Some(ColorRefresh {
-                expected,
-                received: false,
-                preserve_popup: true,
-                write_completed: false,
-                submitted_edit: edit,
-                color: value,
-                previous_history,
-            });
-            state.api.upgrade()
-        });
-        if let Some(api) = api {
-            api.set_inspector_color_refresh_pending(true);
-        }
-    } else {
+    let accepted = submit_workspace_edit("Editing color".into(), edit, true, Some(value));
+    if !accepted {
         cancel();
     }
     accepted

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -18,6 +18,11 @@ pub(super) struct Edit {
 pub(super) struct ColorRefresh {
     expected: text_edit::EditedText,
     received: bool,
+    preserve_popup: bool,
+    write_completed: bool,
+    submitted_edit: lsp_types::WorkspaceEdit,
+    color: slint::Color,
+    previous_history: undo_redo::UndoRedoStack,
 }
 
 pub(super) fn color_contents_changed(url: &Url, content: &str) -> bool {
@@ -33,32 +38,80 @@ pub(super) fn color_contents_changed(url: &Url, content: &str) -> bool {
 
 pub(super) fn dismiss_color() {
     PREVIEW_STATE.with_borrow_mut(|state| {
-        state.color_refresh = None;
-        if let Some(api) = state.api.upgrade() {
-            api.set_inspector_color_refresh_pending(false);
+        if let Some(refresh) = state.color_refresh.as_mut() {
+            refresh.preserve_popup = false;
         }
     });
+}
+
+fn clear_color_refresh() {
+    let api = PREVIEW_STATE.with_borrow_mut(|state| {
+        state.color_refresh = None;
+        state.api.upgrade()
+    });
+    if let Some(api) = api {
+        api.set_inspector_color_refresh_pending(false);
+    }
 }
 
 pub(super) fn invalidate_color() {
     dismiss_color();
-    PREVIEW_STATE.with_borrow(|state| {
-        if let Some(api) = state.api.upgrade() {
-            api.set_inspector_color_generation(
-                api.get_inspector_color_generation().wrapping_add(1),
-            );
-        }
-    });
+    let api = PREVIEW_STATE.with_borrow(|state| state.api.upgrade());
+    if let Some(api) = api {
+        api.set_inspector_color_generation(api.get_inspector_color_generation().wrapping_add(1));
+    }
 }
 
 pub(super) fn preserve_color_popup() -> bool {
-    PREVIEW_STATE
-        .with_borrow(|state| state.color_refresh.as_ref().is_some_and(|refresh| refresh.received))
+    PREVIEW_STATE.with_borrow(|state| {
+        state
+            .color_refresh
+            .as_ref()
+            .is_some_and(|refresh| refresh.received && refresh.preserve_popup)
+    })
+}
+
+pub(super) fn workspace_edit_finished(edit: lsp_types::WorkspaceEdit, applied: bool) {
+    let result = PREVIEW_STATE.with_borrow_mut(|state| {
+        let refresh = state.color_refresh.as_mut()?;
+        if refresh.submitted_edit != edit {
+            return None;
+        }
+        let color = refresh.color;
+        refresh.write_completed = true;
+        let preserve_popup = refresh.preserve_popup;
+        if !applied {
+            let mut previous = refresh.previous_history.clone();
+            for (url, source) in &state.source_code {
+                previous.check_set_contents_valid(url, &source.code);
+            }
+            state.undo_redo_stack = previous;
+            state.workspace_edit_sent = false;
+        } else {
+            state.inspector_edit.take();
+        }
+        Some((state.api.upgrade(), color, preserve_popup))
+    });
+    let Some((api, color, preserve_popup)) = result else { return };
+    if applied {
+        if let Some(api) = api {
+            api.invoke_add_recent_color(color);
+        }
+        if !preserve_popup {
+            clear_color_refresh();
+        }
+    } else {
+        cancel();
+        clear_color_refresh();
+        invalidate_color();
+        PREVIEW_STATE.with_borrow(undo_redo::set_undo_redo_enabled);
+        undo_redo::apply_pending();
+    }
 }
 
 pub(super) fn finish_refresh() {
-    let (pending, applied) = PREVIEW_STATE.with_borrow(|state| {
-        let Some(refresh) = state.color_refresh.as_ref() else { return (false, false) };
+    let (pending, applied, write_completed) = PREVIEW_STATE.with_borrow(|state| {
+        let Some(refresh) = state.color_refresh.as_ref() else { return (false, false, false) };
         let applied = refresh.received
             && document_cache_from(state)
                 .and_then(|cache| {
@@ -68,20 +121,49 @@ pub(super) fn finish_refresh() {
                         .map(|node| node.text() == refresh.expected.contents.as_str())
                 })
                 .unwrap_or(false);
-        (true, applied)
+        (true, applied, refresh.write_completed)
     });
-    if pending {
+    if pending && applied {
         refresh();
-        if applied {
-            dismiss_color();
-        }
+        clear_color_refresh();
+    } else if pending && !write_completed {
+        refresh();
     } else {
+        clear_color_refresh();
         invalidate();
     }
 }
 
 fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
-    let selected = selected_element()?;
+    target_with_root(key, false)
+}
+
+fn target_with_root(
+    key: &str,
+    allow_root: bool,
+) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
+    let (selected, instance_index) = if let Some(selected) = selected_element() {
+        let index = selected.instance_index as i32;
+        (selected, index)
+    } else if allow_root {
+        let (element, current_url) = PREVIEW_STATE.with_borrow(|state| {
+            Some((state.api.upgrade()?.get_current_element(), state.current_component()?.url))
+        })?;
+        let url = Url::parse(&element.source_uri).ok()?;
+        if url != current_url || element.offset < 0 {
+            return None;
+        }
+        (
+            ElementSelection {
+                path: url.to_file_path().ok()?,
+                offset: (element.offset as u32).into(),
+                instance_index: 0,
+            },
+            -1,
+        )
+    } else {
+        return None;
+    };
     let node = selected.as_element_node()?;
     let (path, offset) = node.path_and_offset();
     let url = Url::from_file_path(path).ok()?;
@@ -92,7 +174,7 @@ fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
         "{url}:{}:{}:{}:{generation}",
         version.unwrap_or(i32::MIN),
         u32::from(offset),
-        selected.instance_index
+        instance_index
     );
     (key == expected).then_some((node, url, version))
 }
@@ -100,7 +182,7 @@ fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
 fn color_target(key: &str, property_name: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
     let suffix = format!(":{property_name}");
     let base_key = key.strip_suffix(&suffix)?;
-    target(base_key)
+    target_with_root(base_key, property_name == "background")
 }
 
 fn names(name: &str) -> Option<Vec<&str>> {
@@ -127,52 +209,61 @@ fn validate<'a>(
 }
 
 pub(super) fn cancel() {
-    PREVIEW_STATE.with_borrow_mut(|state| {
-        if let Some(edit) = state.inspector_edit.take() {
-            let overrides = state.debug_hook_overrides.borrow();
-            for (id, previous) in edit.overrides {
-                if let Some(property) = overrides.get(&id) {
-                    property.as_ref().set(previous);
-                }
+    let (edit, overrides) = PREVIEW_STATE
+        .with_borrow_mut(|state| (state.inspector_edit.take(), state.debug_hook_overrides.clone()));
+    if let Some(edit) = edit {
+        let overrides = (*overrides).borrow();
+        for (id, previous) in edit.overrides {
+            if let Some(property) = overrides.get(&id) {
+                property.as_ref().set(previous);
             }
         }
-    });
+    }
     if let Some(instance) = component_instance() {
         instance.window().request_redraw();
     }
 }
 
-pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool {
-    let Some((node, _, _, names)) = validate(&key, &name, value) else { return false };
+fn preview_value(
+    key: SharedString,
+    node: ElementRcNode,
+    names: &[&str],
+    value: slint_interpreter::Value,
+) -> bool {
     let hash = node.with_element_debug(|debug| debug.element_hash);
-    let ids: Vec<_> = names
-        .iter()
-        .map(|name| i_slint_compiler::passes::property_id(hash, &SmolStr::from(*name)))
-        .collect();
     if PREVIEW_STATE.with_borrow(|state| {
         state.inspector_edit.as_ref().is_some_and(|edit| edit.key != key.as_str())
     }) {
         cancel();
     }
-    PREVIEW_STATE.with_borrow_mut(|state| {
-        let mut overrides = (*state.debug_hook_overrides).borrow_mut();
-        let edit = state
-            .inspector_edit
-            .get_or_insert_with(|| Edit { key: key.to_string(), overrides: Vec::new() });
-        for id in ids {
-            let property = overrides
-                .entry(id.clone())
-                .or_insert_with(|| Box::pin(i_slint_core::Property::new(None)));
+    let overrides = PREVIEW_STATE.with_borrow(|state| state.debug_hook_overrides.clone());
+    let mut overrides = (*overrides).borrow_mut();
+    for name in names {
+        let id = i_slint_compiler::passes::property_id(hash, &SmolStr::from(*name));
+        let property = overrides
+            .entry(id.clone())
+            .or_insert_with(|| Box::pin(i_slint_core::Property::new(None)));
+        let previous = property.as_ref().get();
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            let edit = state
+                .inspector_edit
+                .get_or_insert_with(|| Edit { key: key.to_string(), overrides: Vec::new() });
             if !edit.overrides.iter().any(|(saved, _)| saved == &id) {
-                edit.overrides.push((id, property.as_ref().get()));
+                edit.overrides.push((id, previous));
             }
-            property.as_ref().set(Some(slint_interpreter::Value::Number(value as f64)));
-        }
-    });
+        });
+        property.as_ref().set(Some(value.clone()));
+    }
+    drop(overrides);
     if let Some(instance) = component_instance() {
         instance.window().request_redraw();
     }
     true
+}
+
+pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool {
+    let Some((node, _, _, names)) = validate(&key, &name, value) else { return false };
+    preview_value(key, node, &names, slint_interpreter::Value::Number(value as f64))
 }
 
 pub(super) fn preview_color(
@@ -185,38 +276,30 @@ pub(super) fn preview_color(
         cancel();
         return false;
     };
-    let hash = node.with_element_debug(|debug| debug.element_hash);
-    let id = i_slint_compiler::passes::property_id(hash, &SmolStr::from(name.as_str()));
-    if PREVIEW_STATE.with_borrow(|state| {
-        state.inspector_edit.as_ref().is_some_and(|edit| edit.key != key.as_str())
-    }) {
-        cancel();
-    }
-    // The interpreter represents both `color` and `brush` values as a Brush. The
-    // `From<Color>` conversion is the canonical representation for Color, while
-    // the explicit Brush form is used for a Brush-typed property.
     let value = if is_brush {
         slint_interpreter::Value::Brush(slint::Brush::SolidColor(value))
     } else {
         slint_interpreter::Value::from(value)
     };
-    PREVIEW_STATE.with_borrow_mut(|state| {
-        let mut overrides = (*state.debug_hook_overrides).borrow_mut();
-        let edit = state
-            .inspector_edit
-            .get_or_insert_with(|| Edit { key: key.to_string(), overrides: Vec::new() });
-        let property = overrides
-            .entry(id.clone())
-            .or_insert_with(|| Box::pin(i_slint_core::Property::new(None)));
-        if !edit.overrides.iter().any(|(saved, _)| saved == &id) {
-            edit.overrides.push((id, property.as_ref().get()));
-        }
-        property.as_ref().set(Some(value));
-    });
-    if let Some(instance) = component_instance() {
-        instance.window().request_redraw();
-    }
-    true
+    preview_value(key, node, &[name.as_str()], value)
+}
+
+fn property_edit(
+    node: ElementRcNode,
+    url: Url,
+    version: SourceFileVersion,
+    changes: Vec<i_slint_editor_preview::editing::PropertyChange>,
+) -> Option<lsp_types::WorkspaceEdit> {
+    let cache = document_cache()?;
+    let (_, offset) = node.path_and_offset();
+    properties::update_element_properties(
+        &cache,
+        i_slint_editor_preview::editing::VersionedPosition::new(
+            VersionedUrl::new(url, version),
+            offset,
+        ),
+        changes,
+    )
 }
 
 pub(super) fn commit_color(
@@ -229,28 +312,15 @@ pub(super) fn commit_color(
         cancel();
         return false;
     };
-    let color = if value.alpha() == 255 {
-        slint::format!("#{:02x}{:02x}{:02x}", value.red(), value.green(), value.blue())
-    } else {
-        slint::format!(
-            "#{:02x}{:02x}{:02x}{:02x}",
-            value.red(),
-            value.green(),
-            value.blue(),
-            value.alpha()
-        )
-    };
+    let color = ui::color_to_string(value);
     let Some(cache) = document_cache() else {
         cancel();
         return false;
     };
-    let (_, offset) = node.path_and_offset();
-    let edit = properties::update_element_properties(
-        &cache,
-        i_slint_editor_preview::editing::VersionedPosition::new(
-            VersionedUrl::new(url, version),
-            offset,
-        ),
+    let edit = property_edit(
+        node,
+        url,
+        version,
         vec![i_slint_editor_preview::editing::PropertyChange::new(
             name.as_str(),
             color.to_string(),
@@ -267,21 +337,31 @@ pub(super) fn commit_color(
         cancel();
         return false;
     };
-    let accepted = send_workspace_edit("Editing color".into(), edit, true);
+    let changed = PREVIEW_STATE.with_borrow(|state| {
+        state.source_code.get(&expected.url).is_none_or(|source| source.code != expected.contents)
+    });
+    if !changed {
+        cancel();
+        return true;
+    }
+    let previous_history = PREVIEW_STATE.with_borrow(|state| state.undo_redo_stack.clone());
+    let accepted = send_workspace_edit("Editing color".into(), edit.clone(), true);
     if accepted {
-        PREVIEW_STATE.with_borrow_mut(|state| {
-            state.inspector_edit.take();
-            let changed = state
-                .source_code
-                .get(&expected.url)
-                .is_none_or(|source| source.code != expected.contents);
-            if changed {
-                state.color_refresh = Some(ColorRefresh { expected, received: false });
-                if let Some(api) = state.api.upgrade() {
-                    api.set_inspector_color_refresh_pending(true);
-                }
-            }
+        let api = PREVIEW_STATE.with_borrow_mut(|state| {
+            state.color_refresh = Some(ColorRefresh {
+                expected,
+                received: false,
+                preserve_popup: true,
+                write_completed: false,
+                submitted_edit: edit,
+                color: value,
+                previous_history,
+            });
+            state.api.upgrade()
         });
+        if let Some(api) = api {
+            api.set_inspector_color_refresh_pending(true);
+        }
     } else {
         cancel();
     }
@@ -297,19 +377,7 @@ pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool 
             i_slint_editor_preview::editing::PropertyChange::new(name, format!("{value}{unit}"))
         })
         .collect::<Vec<_>>();
-    let Some(cache) = document_cache() else {
-        cancel();
-        return false;
-    };
-    let (_, offset) = node.path_and_offset();
-    let edit = properties::update_element_properties(
-        &cache,
-        i_slint_editor_preview::editing::VersionedPosition::new(
-            VersionedUrl::new(url, version),
-            offset,
-        ),
-        changes,
-    );
+    let edit = property_edit(node, url, version, changes);
     let accepted = edit.is_some_and(|edit| {
         send_workspace_edit(
             if name == "transform-rotation" {
@@ -359,9 +427,8 @@ pub(super) fn invalidate() {
 
 pub(super) fn refresh() {
     cancel();
-    PREVIEW_STATE.with_borrow(|state| {
-        if let Some(api) = state.api.upgrade() {
-            api.set_inspector_generation(api.get_inspector_generation().wrapping_add(1));
-        }
-    });
+    let api = PREVIEW_STATE.with_borrow(|state| state.api.upgrade());
+    if let Some(api) = api {
+        api.set_inspector_generation(api.get_inspector_generation().wrapping_add(1));
+    }
 }

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -32,6 +32,12 @@ fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
     (key == expected).then_some((node, url, version))
 }
 
+fn color_target(key: &str, property_name: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
+    let suffix = format!(":{property_name}");
+    let base_key = key.strip_suffix(&suffix)?;
+    target(base_key)
+}
+
 fn names(name: &str) -> Option<Vec<&str>> {
     match name {
         "all-corners" => Some(CORNERS.to_vec()),
@@ -102,6 +108,98 @@ pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool
         instance.window().request_redraw();
     }
     true
+}
+
+pub(super) fn preview_color(
+    key: SharedString,
+    name: SharedString,
+    value: slint::Color,
+    is_brush: bool,
+) -> bool {
+    let Some((node, _, _)) = color_target(&key, &name) else {
+        cancel();
+        return false;
+    };
+    let hash = node.with_element_debug(|debug| debug.element_hash);
+    let id = i_slint_compiler::passes::property_id(hash, &SmolStr::from(name.as_str()));
+    if PREVIEW_STATE.with_borrow(|state| {
+        state.inspector_edit.as_ref().is_some_and(|edit| edit.key != key.as_str())
+    }) {
+        cancel();
+    }
+    // The interpreter represents both `color` and `brush` values as a Brush. The
+    // `From<Color>` conversion is the canonical representation for Color, while
+    // the explicit Brush form is used for a Brush-typed property.
+    let value = if is_brush {
+        slint_interpreter::Value::Brush(slint::Brush::SolidColor(value))
+    } else {
+        slint_interpreter::Value::from(value)
+    };
+    PREVIEW_STATE.with_borrow_mut(|state| {
+        let mut overrides = (*state.debug_hook_overrides).borrow_mut();
+        let edit = state
+            .inspector_edit
+            .get_or_insert_with(|| Edit { key: key.to_string(), overrides: Vec::new() });
+        let property = overrides
+            .entry(id.clone())
+            .or_insert_with(|| Box::pin(i_slint_core::Property::new(None)));
+        if !edit.overrides.iter().any(|(saved, _)| saved == &id) {
+            edit.overrides.push((id, property.as_ref().get()));
+        }
+        property.as_ref().set(Some(value));
+    });
+    if let Some(instance) = component_instance() {
+        instance.window().request_redraw();
+    }
+    true
+}
+
+pub(super) fn commit_color(
+    key: SharedString,
+    name: SharedString,
+    value: slint::Color,
+    _is_brush: bool,
+) -> bool {
+    let Some((node, url, version)) = color_target(&key, &name) else {
+        cancel();
+        return false;
+    };
+    let color = if value.alpha() == 255 {
+        slint::format!("#{:02x}{:02x}{:02x}", value.red(), value.green(), value.blue())
+    } else {
+        slint::format!(
+            "#{:02x}{:02x}{:02x}{:02x}",
+            value.red(),
+            value.green(),
+            value.blue(),
+            value.alpha()
+        )
+    };
+    let Some(cache) = document_cache() else {
+        cancel();
+        return false;
+    };
+    let (_, offset) = node.path_and_offset();
+    let edit = properties::update_element_properties(
+        &cache,
+        i_slint_editor_preview::editing::VersionedPosition::new(
+            VersionedUrl::new(url, version),
+            offset,
+        ),
+        vec![i_slint_editor_preview::editing::PropertyChange::new(
+            name.as_str(),
+            color.to_string(),
+        )],
+    );
+    let accepted = edit.is_some_and(|edit| send_workspace_edit("Editing color".into(), edit, true));
+    if accepted {
+        PREVIEW_STATE.with_borrow_mut(|state| {
+            state.inspector_edit.take();
+        });
+    } else {
+        cancel();
+    }
+    accepted
 }
 
 pub(super) fn commit(key: SharedString, name: SharedString, value: f32) -> bool {

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -15,6 +15,71 @@ pub(super) struct Edit {
     overrides: Vec<(SmolStr, Option<slint_interpreter::Value>)>,
 }
 
+pub(super) struct ColorRefresh {
+    expected: text_edit::EditedText,
+    received: bool,
+}
+
+pub(super) fn color_contents_changed(url: &Url, content: &str) -> bool {
+    PREVIEW_STATE.with_borrow_mut(|state| {
+        let Some(refresh) = state.color_refresh.as_mut() else { return false };
+        if refresh.expected.url != *url || refresh.expected.contents != content {
+            return false;
+        }
+        refresh.received = true;
+        true
+    })
+}
+
+pub(super) fn dismiss_color() {
+    PREVIEW_STATE.with_borrow_mut(|state| {
+        state.color_refresh = None;
+        if let Some(api) = state.api.upgrade() {
+            api.set_inspector_color_refresh_pending(false);
+        }
+    });
+}
+
+pub(super) fn invalidate_color() {
+    dismiss_color();
+    PREVIEW_STATE.with_borrow(|state| {
+        if let Some(api) = state.api.upgrade() {
+            api.set_inspector_color_generation(
+                api.get_inspector_color_generation().wrapping_add(1),
+            );
+        }
+    });
+}
+
+pub(super) fn preserve_color_popup() -> bool {
+    PREVIEW_STATE
+        .with_borrow(|state| state.color_refresh.as_ref().is_some_and(|refresh| refresh.received))
+}
+
+pub(super) fn finish_refresh() {
+    let (pending, applied) = PREVIEW_STATE.with_borrow(|state| {
+        let Some(refresh) = state.color_refresh.as_ref() else { return (false, false) };
+        let applied = refresh.received
+            && document_cache_from(state)
+                .and_then(|cache| {
+                    cache
+                        .get_document(&refresh.expected.url)
+                        .and_then(|document| document.node.as_ref())
+                        .map(|node| node.text() == refresh.expected.contents.as_str())
+                })
+                .unwrap_or(false);
+        (true, applied)
+    });
+    if pending {
+        refresh();
+        if applied {
+            dismiss_color();
+        }
+    } else {
+        invalidate();
+    }
+}
+
 fn target(key: &str) -> Option<(ElementRcNode, Url, SourceFileVersion)> {
     let selected = selected_element()?;
     let node = selected.as_element_node()?;
@@ -191,10 +256,31 @@ pub(super) fn commit_color(
             color.to_string(),
         )],
     );
-    let accepted = edit.is_some_and(|edit| send_workspace_edit("Editing color".into(), edit, true));
+    let Some(edit) = edit else {
+        cancel();
+        return false;
+    };
+    let expected = text_edit::apply_workspace_edit(&cache, &edit)
+        .ok()
+        .and_then(|mut documents| (documents.len() == 1).then(|| documents.remove(0)));
+    let Some(expected) = expected else {
+        cancel();
+        return false;
+    };
+    let accepted = send_workspace_edit("Editing color".into(), edit, true);
     if accepted {
         PREVIEW_STATE.with_borrow_mut(|state| {
             state.inspector_edit.take();
+            let changed = state
+                .source_code
+                .get(&expected.url)
+                .is_none_or(|source| source.code != expected.contents);
+            if changed {
+                state.color_refresh = Some(ColorRefresh { expected, received: false });
+                if let Some(api) = state.api.upgrade() {
+                    api.set_inspector_color_refresh_pending(true);
+                }
+            }
         });
     } else {
         cancel();
@@ -267,6 +353,11 @@ pub(super) fn values(key: SharedString) -> slint::ModelRc<f32> {
 }
 
 pub(super) fn invalidate() {
+    invalidate_color();
+    refresh();
+}
+
+pub(super) fn refresh() {
     cancel();
     PREVIEW_STATE.with_borrow(|state| {
         if let Some(api) = state.api.upgrade() {

--- a/tools/editor/preview/inspector.rs
+++ b/tools/editor/preview/inspector.rs
@@ -266,21 +266,12 @@ pub(super) fn preview(key: SharedString, name: SharedString, value: f32) -> bool
     preview_value(key, node, &names, slint_interpreter::Value::Number(value as f64))
 }
 
-pub(super) fn preview_color(
-    key: SharedString,
-    name: SharedString,
-    value: slint::Color,
-    is_brush: bool,
-) -> bool {
+pub(super) fn preview_color(key: SharedString, name: SharedString, value: slint::Color) -> bool {
     let Some((node, _, _)) = color_target(&key, &name) else {
         cancel();
         return false;
     };
-    let value = if is_brush {
-        slint_interpreter::Value::Brush(slint::Brush::SolidColor(value))
-    } else {
-        slint_interpreter::Value::from(value)
-    };
+    let value = slint_interpreter::Value::from(value);
     preview_value(key, node, &[name.as_str()], value)
 }
 
@@ -302,12 +293,7 @@ fn property_edit(
     )
 }
 
-pub(super) fn commit_color(
-    key: SharedString,
-    name: SharedString,
-    value: slint::Color,
-    _is_brush: bool,
-) -> bool {
+pub(super) fn commit_color(key: SharedString, name: SharedString, value: slint::Color) -> bool {
     let Some((node, url, version)) = color_target(&key, &name) else {
         cancel();
         return false;

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -199,6 +199,7 @@ pub fn initialize_editor(
     api.on_inspector_preview(super::inspector::preview);
     api.on_inspector_commit(super::inspector::commit);
     api.on_inspector_cancel(super::inspector::cancel);
+    api.on_inspector_color_dismissed(super::inspector::dismiss_color);
     api.on_inspector_color_preview(super::inspector::preview_color);
     api.on_inspector_color_commit(super::inspector::commit_color);
     api.on_test_code_binding(super::test_code_binding);

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -62,6 +62,7 @@ fn fuzzy_filter_iter<Item: std::fmt::Debug>(
 }
 
 mod brushes;
+pub(super) use brushes::color_to_string;
 mod element_library;
 pub(super) mod file_tree;
 pub mod log_messages;
@@ -494,7 +495,7 @@ fn unit_model(units: &[expression_tree::WrittenUnit]) -> ModelRc<SharedString> {
 }
 
 fn is_equal_value(c: &PropertyValue, n: &PropertyValue) -> bool {
-    c.code == n.code
+    c.code == n.code && c.value_resolved == n.value_resolved && c.value_brush == n.value_brush
 }
 
 fn is_equal_property(c: &PropertyInformation, n: &PropertyInformation) -> bool {
@@ -1163,8 +1164,13 @@ fn current_property_value_data(
     api: &Api<'_>,
     property_name: SharedString,
 ) -> Option<PropertyValue> {
-    for group in api.get_properties().iter() {
-        for property in group.properties.iter() {
+    let groups = api.get_properties();
+    groups.model_tracker().track_row_count_changes();
+    for (group_index, group) in groups.iter().enumerate() {
+        groups.model_tracker().track_row_data_changes(group_index);
+        group.properties.model_tracker().track_row_count_changes();
+        for (property_index, property) in group.properties.iter().enumerate() {
+            group.properties.model_tracker().track_row_data_changes(property_index);
             if property.name == property_name {
                 return Some(property.value);
             }

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -200,7 +200,6 @@ pub fn initialize_editor(
     api.on_inspector_preview(super::inspector::preview);
     api.on_inspector_commit(super::inspector::commit);
     api.on_inspector_cancel(super::inspector::cancel);
-    api.on_inspector_color_dismissed(super::inspector::dismiss_color);
     api.on_inspector_color_preview(super::inspector::preview_color);
     api.on_inspector_color_commit(super::inspector::commit_color);
     api.on_test_code_binding(super::test_code_binding);

--- a/tools/editor/preview/ui.rs
+++ b/tools/editor/preview/ui.rs
@@ -199,6 +199,8 @@ pub fn initialize_editor(
     api.on_inspector_preview(super::inspector::preview);
     api.on_inspector_commit(super::inspector::commit);
     api.on_inspector_cancel(super::inspector::cancel);
+    api.on_inspector_color_preview(super::inspector::preview_color);
+    api.on_inspector_color_commit(super::inspector::commit_color);
     api.on_test_code_binding(super::test_code_binding);
     api.on_set_code_binding(super::set_code_binding);
     api.on_set_color_binding(super::set_color_binding);
@@ -619,12 +621,14 @@ fn map_value_and_type(
         color: slint::Color,
         kind: PropertyValueKind,
         code: SharedString,
+        value_resolved: bool,
     ) {
         let color_string = brushes::color_to_string(color);
         mapping.headers.push(mapping.name_prefix.clone());
         mapping.current_values.push(PropertyValue {
             value_kind: kind,
             kind,
+            value_resolved,
             display_string: color_string.clone(),
             brush_kind: BrushKind::Solid,
             value_brush: slint::Brush::SolidColor(color),
@@ -804,20 +808,26 @@ fn map_value_and_type(
                 get_value::<slint::Color>(value),
                 PropertyValueKind::Color,
                 get_code(value),
+                value.is_some(),
             );
         }
         Type::Brush => {
             let brush = get_value::<slint::Brush>(value);
             match brush {
-                slint::Brush::SolidColor(c) => {
-                    map_color(mapping, c, PropertyValueKind::Brush, get_code(value))
-                }
+                slint::Brush::SolidColor(c) => map_color(
+                    mapping,
+                    c,
+                    PropertyValueKind::Brush,
+                    get_code(value),
+                    value.is_some(),
+                ),
                 slint::Brush::LinearGradient(lg) => {
                     mapping.headers.push(mapping.name_prefix.clone());
                     mapping.current_values.push(PropertyValue {
                         display_string: SharedString::from("Linear Gradient"),
                         kind: PropertyValueKind::Brush,
                         value_kind: PropertyValueKind::Brush,
+                        value_resolved: value.is_some(),
                         brush_kind: BrushKind::Linear,
                         value_float: lg.angle(),
                         value_brush: slint::Brush::LinearGradient(lg.clone()),
@@ -838,6 +848,7 @@ fn map_value_and_type(
                         display_string: SharedString::from("Radial Gradient"),
                         kind: PropertyValueKind::Brush,
                         value_kind: PropertyValueKind::Brush,
+                        value_resolved: value.is_some(),
                         brush_kind: BrushKind::Radial,
                         value_brush: slint::Brush::RadialGradient(rg.clone()),
                         gradient_stops: Rc::new(VecModel::from(
@@ -857,6 +868,7 @@ fn map_value_and_type(
                         display_string: SharedString::from("Conic Gradient"),
                         kind: PropertyValueKind::Brush,
                         value_kind: PropertyValueKind::Brush,
+                        value_resolved: value.is_some(),
                         brush_kind: BrushKind::Conic,
                         value_brush: slint::Brush::ConicGradient(cg.clone()),
                         gradient_stops: Rc::new(VecModel::from(
@@ -876,6 +888,7 @@ fn map_value_and_type(
                         display_string: SharedString::from("Unknown Brush"),
                         kind: PropertyValueKind::Code,
                         value_kind: PropertyValueKind::Code,
+                        value_resolved: false,
                         value_string: SharedString::from("???"),
                         accessor_path: mapping.name_prefix.clone(),
                         code: get_code(value),

--- a/tools/editor/preview/ui/palette.rs
+++ b/tools/editor/preview/ui/palette.rs
@@ -184,7 +184,9 @@ pub fn evaluate_property(
             crate::preview::eval::fully_eval_expression_tree_expression(element, window_adapter)
         });
 
-    ui::map_value_and_type_to_property_value(ty, &value, "")
+    let mut property = ui::map_value_and_type_to_property_value(ty, &value, "");
+    property.value_resolved = value.is_some();
+    property
 }
 
 fn handle_type(

--- a/tools/editor/preview/ui/palette.rs
+++ b/tools/editor/preview/ui/palette.rs
@@ -177,8 +177,18 @@ pub fn evaluate_property(
     ty: &langtype::Type,
     window_adapter: Option<&Rc<dyn slint::platform::WindowAdapter>>,
 ) -> ui::PropertyValue {
+    let unfilled_rectangle = {
+        let element = element.borrow();
+        property_name == "background"
+            && default_value.is_none()
+            && matches!(&element.base_type, langtype::ElementType::Builtin(b) if b.name == "Rectangle")
+            && element.binding_cell_including_synthetic(property_name).is_none()
+    };
     let value = find_binding_expression(element, property_name)
         .or(default_value.clone())
+        .or_else(|| {
+            unfilled_rectangle.then(|| expression_tree::Expression::default_value_for_type(ty))
+        })
         .as_ref()
         .and_then(|element| {
             crate::preview::eval::fully_eval_expression_tree_expression(element, window_adapter)
@@ -186,6 +196,9 @@ pub fn evaluate_property(
 
     let mut property = ui::map_value_and_type_to_property_value(ty, &value, "");
     property.value_resolved = value.is_some();
+    if unfilled_rectangle {
+        property.code = Default::default();
+    }
     property
 }
 
@@ -388,7 +401,8 @@ export component Main { }
         compare(&result[3], "Test.color1", 0xff, 0x00, 0xff);
         compare(&result[4], "Test.color2", 0x22, 0xff, 0xff);
         compare(&result[5], "Test.color3", 0x33, 0xff, 0xff);
-        compare(&result[6], "Test.color5", 0x11, 0xff, 0xff);
+        assert_eq!(result[6].name, "Test.color5");
+        assert!(!result[6].value.value_resolved);
         compare(&result[7], "Test.color6", 0x77, 0x88, 0x99);
         assert_eq!(result[8].name, "Test.struct.x"); // not a color
         compare(&result[9], "Test.struct.y", 0x77, 0x88, 0x99);
@@ -470,7 +484,8 @@ export component Main { }
         );
         compare_brush(&result[4], "Test.brush2", &linear_gradient);
         compare_brush(&result[5], "Test.brush3", &radial_gradient);
-        compare_brush(&result[6], "Test.brush5", &solid_color);
+        assert_eq!(result[6].name, "Test.brush5");
+        assert!(!result[6].value.value_resolved);
         compare_brush(&result[7], "Test.brush6", &solid_color);
     }
 
@@ -547,9 +562,14 @@ export component Main { }
         compare(&result[4], "Test._1.color2", 0x22, 0x22, 0x22);
         compare(&result[5], "Test._1.color3", 0x33, 0x33, 0x33);
 
-        compare(&result[6], "Test.palette.color1", 0x11, 0xff, 0xff);
-        compare(&result[7], "Test.palette.color2", 0x22, 0xff, 0xff);
-        compare(&result[8], "Test.palette.color3", 0x33, 0xff, 0xff);
+        for (entry, name) in result[6..].iter().zip([
+            "Test.palette.color1",
+            "Test.palette.color2",
+            "Test.palette.color3",
+        ]) {
+            assert_eq!(entry.name, name);
+            assert!(!entry.value.value_resolved);
+        }
     }
 
     #[test]

--- a/tools/editor/preview/ui/property_view.rs
+++ b/tools/editor/preview/ui/property_view.rs
@@ -919,10 +919,8 @@ export component Test { in property <Foobar> test1; }"#,
         assert_eq!(result.kind, ui::PropertyValueKind::Color);
         assert!(matches!(result.value_brush, slint::Brush::SolidColor(_)));
         assert_eq!(result.value_string, "Foo.red");
-        assert_eq!(result.value_brush.color().red(), 0x00);
-        assert_eq!(result.value_brush.color().green(), 0x00);
-        assert_eq!(result.value_brush.color().blue(), 0xff);
-        assert_eq!(result.value_brush.color().alpha(), 0xff);
+        assert!(!result.value_resolved);
+        assert_eq!(result.value_brush.color(), slint::Color::default());
 
         let result = property_conversion_test(
             r#"struct Bar {
@@ -939,10 +937,8 @@ export component Test { in property <Foobar> test1; }"#,
         assert_eq!(result.kind, ui::PropertyValueKind::Color);
         assert!(matches!(result.value_brush, slint::Brush::SolidColor(_)));
         assert_eq!(result.value_string, "Foo.s.foo");
-        assert_eq!(result.value_brush.color().red(), 0x00);
-        assert_eq!(result.value_brush.color().green(), 0x00);
-        assert_eq!(result.value_brush.color().blue(), 0xff);
-        assert_eq!(result.value_brush.color().alpha(), 0xff);
+        assert!(!result.value_resolved);
+        assert_eq!(result.value_brush.color(), slint::Color::default());
 
         let result = property_conversion_test(
             r#"struct Bar {
@@ -962,10 +958,8 @@ export component Test { in property <Foobar> test1; }"#,
         assert_eq!(result.kind, ui::PropertyValueKind::Color);
         assert!(matches!(result.value_brush, slint::Brush::SolidColor(_)));
         assert_eq!(result.value_string, "Foo.s.baz.bar");
-        assert_eq!(result.value_brush.color().red(), 0x00);
-        assert_eq!(result.value_brush.color().green(), 0x00);
-        assert_eq!(result.value_brush.color().blue(), 0xff);
-        assert_eq!(result.value_brush.color().alpha(), 0xff);
+        assert!(!result.value_resolved);
+        assert_eq!(result.value_brush.color(), slint::Color::default());
     }
 
     #[test]

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -10,11 +10,10 @@ use std::collections::HashMap;
 
 type FileHashes = HashMap<lsp_types::Url, u64>;
 
-#[derive(Clone)]
-struct EditItem {
-    title: String,
-    edit: lsp_types::WorkspaceEdit,
-    file_hashes: FileHashes,
+pub(super) struct EditItem {
+    pub(super) title: String,
+    pub(super) edit: lsp_types::WorkspaceEdit,
+    pub(super) file_hashes: FileHashes,
 }
 
 pub fn compute_file_hashes(
@@ -46,7 +45,7 @@ fn prepare_history_edit(
     Some((reverse, compute_file_hashes(&result)))
 }
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct UndoRedoStack {
     undo_stack: Vec<EditItem>,
     redo_stack: Vec<EditItem>,
@@ -67,13 +66,17 @@ impl UndoRedoStack {
     ) {
         match reverse_edit {
             Some(edit) => {
-                self.undo_stack.push(EditItem { title, edit, file_hashes });
-                self.redo_stack.clear();
+                self.push_item(EditItem { title, edit, file_hashes });
             }
             None => {
                 self.clear();
             }
         }
+    }
+
+    pub(super) fn push_item(&mut self, item: EditItem) {
+        self.undo_stack.push(item);
+        self.redo_stack.clear();
     }
 
     pub fn check_set_contents_valid(&mut self, url: &lsp_types::Url, content: &str) -> bool {
@@ -95,7 +98,7 @@ pub fn setup(api: &ui::Api<'_>) {
     api.on_undo(|| {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
-            if state.workspace_edit_sent {
+            if edit_pending(state) {
                 state.pending_history.push_back(false);
                 return;
             }
@@ -129,7 +132,7 @@ pub fn setup(api: &ui::Api<'_>) {
     api.on_redo(|| {
         let Some(document_cache) = super::document_cache() else { return };
         super::PREVIEW_STATE.with_borrow_mut(|state| {
-            if state.workspace_edit_sent {
+            if edit_pending(state) {
                 state.pending_history.push_back(true);
                 return;
             }
@@ -162,10 +165,14 @@ pub fn setup(api: &ui::Api<'_>) {
     });
 }
 
+pub(super) fn edit_pending(state: &super::PreviewState) -> bool {
+    state.workspace_edit_sent || state.color_refresh.is_some()
+}
+
 pub(super) fn apply_pending() {
     loop {
         let next = super::PREVIEW_STATE.with_borrow_mut(|state| {
-            if state.workspace_edit_sent {
+            if edit_pending(state) {
                 return None;
             }
             Some((state.api.upgrade()?, state.pending_history.pop_front()?))

--- a/tools/editor/preview/undo_redo.rs
+++ b/tools/editor/preview/undo_redo.rs
@@ -46,7 +46,7 @@ fn prepare_history_edit(
     Some((reverse, compute_file_hashes(&result)))
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct UndoRedoStack {
     undo_stack: Vec<EditItem>,
     redo_stack: Vec<EditItem>,

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -706,8 +706,8 @@ export global Api {
     callback inspector-preview(key: string, name: string, value: float) -> bool;
     callback inspector-commit(key: string, name: string, value: float) -> bool;
     callback inspector-cancel();
-    callback inspector-color-preview(key: string, name: string, value: color, is-brush: bool) -> bool;
-    callback inspector-color-commit(key: string, name: string, value: color, is-brush: bool) -> bool;
+    callback inspector-color-preview(key: string, name: string, value: color) -> bool;
+    callback inspector-color-commit(key: string, name: string, value: color) -> bool;
 
     // ## Property Editor
     pure callback test-code-binding(element-url: string, element-version: int, element-offset: int, property-name: string, property-value: string) -> bool;

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -699,6 +699,9 @@ export global Api {
     callback reload-preview();
 
     in property <int> inspector-generation;
+    in property <int> inspector-color-generation;
+    in property <bool> inspector-color-refresh-pending;
+    callback inspector-color-dismissed();
     pure callback inspector-values(key: string) -> [float];
     callback inspector-preview(key: string, name: string, value: float) -> bool;
     callback inspector-commit(key: string, name: string, value: float) -> bool;

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -701,7 +701,6 @@ export global Api {
     in property <int> inspector-generation;
     in property <int> inspector-color-generation;
     in property <bool> inspector-color-refresh-pending;
-    callback inspector-color-dismissed();
     pure callback inspector-values(key: string) -> [float];
     callback inspector-preview(key: string, name: string, value: float) -> bool;
     callback inspector-commit(key: string, name: string, value: float) -> bool;

--- a/tools/editor/ui/api.slint
+++ b/tools/editor/ui/api.slint
@@ -230,6 +230,7 @@ export struct GradientStop {
 /// Data about the property value for use in "simple" mode
 export struct PropertyValue {
     display-string: string, // ALWAYS, its a string description of what is there
+    value-resolved: bool, // Whether value-brush/value-* came from a successful evaluation
     value-bool: bool, // boolean
     is-translatable: bool, // string
     kind: PropertyValueKind, // Defines what to display this as
@@ -702,6 +703,8 @@ export global Api {
     callback inspector-preview(key: string, name: string, value: float) -> bool;
     callback inspector-commit(key: string, name: string, value: float) -> bool;
     callback inspector-cancel();
+    callback inspector-color-preview(key: string, name: string, value: color, is-brush: bool) -> bool;
+    callback inspector-color-commit(key: string, name: string, value: color, is-brush: bool) -> bool;
 
     // ## Property Editor
     pure callback test-code-binding(element-url: string, element-version: int, element-offset: int, property-name: string, property-value: string) -> bool;

--- a/tools/editor/ui/components/common.slint
+++ b/tools/editor/ui/components/common.slint
@@ -42,6 +42,8 @@ export global EditorCursors {
 }
 
 export global EditorMetrics {
+    in-out property <length> window-width;
+    in-out property <length> window-height;
     out property <length> left-pane-width: 286px;
     out property <length> inspector-pane-width: 232px;
     out property <length> top-bar-height: 54px;

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Api, EditorSurfaceMode, ElementInformation, PropertyValueKind, SelectionRectangle } from "../api.slint";
+import { Api, BrushKind, EditorSurfaceMode, ElementInformation, PropertyValueKind, SelectionRectangle } from "../api.slint";
 import { EdgeDivider, EditorMetrics, HorizontalResizeDivider, StudioTheme } from "common.slint";
 import { OutlinePane } from "outline-pane.slint";
 import { InspectorComboOption, InspectorTokens } from "inspector/tokens.slint";
@@ -248,6 +248,14 @@ export component InspectorPane inherits Rectangle {
             return property.display-string;
         }
         return property.code;
+    }
+
+    function property-is-solid(property-name: string) -> bool {
+        let property = Api.current-property-value-data(property-name);
+        return property.code == ""
+            || property.kind == PropertyValueKind.color
+            || property.value-kind == PropertyValueKind.color
+            || property.brush-kind == BrushKind.solid;
     }
 
     function property-length-label(property-name: string, fallback: string) -> string {
@@ -701,6 +709,7 @@ export component InspectorPane inherits Rectangle {
                             accessible-name: "Root background";
                             value: root.phone-background-label;
                             swatch: root.phone-background;
+                            effective-color: root.phone-background;
                             commit-key: root.field-key("background");
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
@@ -712,6 +721,8 @@ export component InspectorPane inherits Rectangle {
                             accessible-name: "Rectangle background";
                             value: root.rectangle-background-code();
                             swatch: root.rectangle-background-swatch();
+                            effective-color: root.rectangle-background-swatch();
+                            unsupported: !root.property-is-solid("background");
                             commit-key: root.field-key("background");
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
@@ -723,6 +734,8 @@ export component InspectorPane inherits Rectangle {
                             accessible-name: "Text color";
                             value: root.text-color-code();
                             swatch: root.text-color-swatch();
+                            effective-color: root.text-color-swatch();
+                            unsupported: !root.property-is-solid("color");
                             commit-key: root.field-key("color");
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
@@ -797,6 +810,8 @@ export component InspectorPane inherits Rectangle {
                                     accessible-name: "Shadow color";
                                     value: root.shadow-color-code();
                                     swatch: root.shadow-color-swatch();
+                                    effective-color: root.shadow-color-swatch();
+                                    unsupported: !root.property-is-solid(root.current-shadow-prefix() + "color");
                                     commit-key: root.field-key(root.current-shadow-prefix() + "color");
                                     accepted(text) => {
                                         return root.commit-code(root.current-shadow-prefix() + "color", text);

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -711,6 +711,10 @@ export component InspectorPane inherits Rectangle {
                             unsupported: !background-value.value-resolved || background-value.brush-kind != BrushKind.solid;
                             effective-color: self.unsupported ? transparent : background-value.value-brush;
                             commit-key: root.field-key("background");
+                            preview-key: root.field-key("background");
+                            session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("background");
+                            property-name: "background";
+                            is-brush: true;
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("background", text);
@@ -724,6 +728,10 @@ export component InspectorPane inherits Rectangle {
                             effective-color: root.property-effective-color("background");
                             unsupported: !root.property-is-solid("background");
                             commit-key: root.field-key("background");
+                            preview-key: root.field-key("background");
+                            session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("background");
+                            property-name: "background";
+                            is-brush: true;
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("background", text);
@@ -737,6 +745,9 @@ export component InspectorPane inherits Rectangle {
                             effective-color: root.property-effective-color("color");
                             unsupported: !root.property-is-solid("color");
                             commit-key: root.field-key("color");
+                            preview-key: root.field-key("color");
+                            session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("color");
+                            property-name: "color";
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("color", text);
@@ -813,6 +824,10 @@ export component InspectorPane inherits Rectangle {
                                     effective-color: root.property-effective-color(root.current-shadow-prefix() + "color");
                                     unsupported: !root.property-is-solid(root.current-shadow-prefix() + "color");
                                     commit-key: root.field-key(root.current-shadow-prefix() + "color");
+                                    preview-key: root.field-key(root.current-shadow-prefix() + "color");
+                                    session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + (root.current-shadow-prefix() + "color");
+                                    property-name: root.current-shadow-prefix() + "color";
+                                    is-brush: true;
                                     accepted(text) => {
                                         return root.commit-code(root.current-shadow-prefix() + "color", text);
                                     }

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -714,7 +714,6 @@ export component InspectorPane inherits Rectangle {
                             preview-key: root.field-key("background");
                             session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("background");
                             property-name: "background";
-                            is-brush: true;
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("background", text);
@@ -731,7 +730,6 @@ export component InspectorPane inherits Rectangle {
                             preview-key: root.field-key("background");
                             session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("background");
                             property-name: "background";
-                            is-brush: true;
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
                                 return root.commit-code("background", text);
@@ -827,7 +825,6 @@ export component InspectorPane inherits Rectangle {
                                     preview-key: root.field-key(root.current-shadow-prefix() + "color");
                                     session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + (root.current-shadow-prefix() + "color");
                                     property-name: root.current-shadow-prefix() + "color";
-                                    is-brush: true;
                                     accepted(text) => {
                                         return root.commit-code(root.current-shadow-prefix() + "color", text);
                                     }

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -229,6 +229,10 @@ export component InspectorPane inherits Rectangle {
         return root.inspector-key + ":" + property-name;
     }
 
+    function color-session-key(property-name: string) -> string {
+        return root.selection-key + ":" + Api.inspector-color-generation + ":" + property-name;
+    }
+
     function property-brush(property-name: string) -> brush {
         let property = Api.current-property-value-data(property-name);
         return property.value-resolved ? property.value-brush : transparent;
@@ -712,7 +716,7 @@ export component InspectorPane inherits Rectangle {
                             effective-color: self.unsupported ? transparent : background-value.value-brush;
                             commit-key: root.field-key("background");
                             preview-key: root.field-key("background");
-                            session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("background");
+                            session-key: root.color-session-key("background");
                             property-name: "background";
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
@@ -728,7 +732,7 @@ export component InspectorPane inherits Rectangle {
                             unsupported: !root.property-is-solid("background");
                             commit-key: root.field-key("background");
                             preview-key: root.field-key("background");
-                            session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("background");
+                            session-key: root.color-session-key("background");
                             property-name: "background";
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
@@ -744,7 +748,7 @@ export component InspectorPane inherits Rectangle {
                             unsupported: !root.property-is-solid("color");
                             commit-key: root.field-key("color");
                             preview-key: root.field-key("color");
-                            session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + ("color");
+                            session-key: root.color-session-key("color");
                             property-name: "color";
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {
@@ -823,7 +827,7 @@ export component InspectorPane inherits Rectangle {
                                     unsupported: !root.property-is-solid(root.current-shadow-prefix() + "color");
                                     commit-key: root.field-key(root.current-shadow-prefix() + "color");
                                     preview-key: root.field-key(root.current-shadow-prefix() + "color");
-                                    session-key: root.selection-key + ":" + Api.inspector-color-generation + ":" + (root.current-shadow-prefix() + "color");
+                                    session-key: root.color-session-key(root.current-shadow-prefix() + "color");
                                     property-name: root.current-shadow-prefix() + "color";
                                     accepted(text) => {
                                         return root.commit-code(root.current-shadow-prefix() + "color", text);

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { Api, BrushKind, EditorSurfaceMode, ElementInformation, PropertyValueKind, SelectionRectangle } from "../api.slint";
+import { Api, BrushKind, EditorSurfaceMode, ElementInformation, PropertyValue, PropertyValueKind, SelectionRectangle } from "../api.slint";
 import { EdgeDivider, EditorMetrics, HorizontalResizeDivider, StudioTheme } from "common.slint";
 import { OutlinePane } from "outline-pane.slint";
 import { InspectorComboOption, InspectorTokens } from "inspector/tokens.slint";
@@ -24,8 +24,6 @@ import { ScrollView } from "std-widgets.slint";
 
 
 export component InspectorPane inherits Rectangle {
-    in property <color> phone-background;
-    in property <string> phone-background-label;
     in property <ElementInformation> element-information;
 
     callback element-selected();
@@ -706,10 +704,12 @@ export component InspectorPane inherits Rectangle {
                         label: root.is-text-selection() ? "Color" : "Fill";
 
                         if root.is-root-selection(): InspectorColorField {
+                            property <PropertyValue> background-value: Api.current-property-value-data("background");
                             accessible-name: "Root background";
-                            value: root.phone-background-label;
-                            swatch: root.phone-background;
-                            effective-color: root.phone-background;
+                            value: Api.current-property-value("background", "");
+                            swatch: background-value.value-resolved ? background-value.value-brush : transparent;
+                            unsupported: !background-value.value-resolved || background-value.brush-kind != BrushKind.solid;
+                            effective-color: self.unsupported ? transparent : background-value.value-brush;
                             commit-key: root.field-key("background");
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
                             accepted(text) => {

--- a/tools/editor/ui/components/inspector-pane.slint
+++ b/tools/editor/ui/components/inspector-pane.slint
@@ -229,9 +229,9 @@ export component InspectorPane inherits Rectangle {
         return root.inspector-key + ":" + property-name;
     }
 
-    function property-brush(property-name: string, fallback: brush) -> brush {
+    function property-brush(property-name: string) -> brush {
         let property = Api.current-property-value-data(property-name);
-        return property.code != "" ? property.value-brush : fallback;
+        return property.value-resolved ? property.value-brush : transparent;
     }
 
     function property-string(property-name: string, fallback: string) -> string {
@@ -250,10 +250,16 @@ export component InspectorPane inherits Rectangle {
 
     function property-is-solid(property-name: string) -> bool {
         let property = Api.current-property-value-data(property-name);
-        return property.code == ""
-            || property.kind == PropertyValueKind.color
-            || property.value-kind == PropertyValueKind.color
-            || property.brush-kind == BrushKind.solid;
+        return property.value-resolved
+            && (property.kind == PropertyValueKind.color
+                || property.value-kind == PropertyValueKind.color
+                || ((property.kind == PropertyValueKind.brush || property.value-kind == PropertyValueKind.brush)
+                    && property.brush-kind == BrushKind.solid));
+    }
+
+    function property-effective-color(property-name: string) -> color {
+        let property = Api.current-property-value-data(property-name);
+        return root.property-is-solid(property-name) ? property.value-brush : transparent;
     }
 
     function property-length-label(property-name: string, fallback: string) -> string {
@@ -320,17 +326,11 @@ export component InspectorPane inherits Rectangle {
     }
 
     function shadow-color-code() -> string {
-        let prefix = root.current-shadow-prefix();
-        let fallback = prefix == "inner-shadow-" ? "#00000030" : "#00000040";
-        return Api.current-property-value(prefix + "color", fallback);
+        return Api.current-property-value(root.current-shadow-prefix() + "color", "");
     }
 
-    function shadow-color-swatch() -> color {
-        let property = Api.current-property-value-data(root.current-shadow-prefix() + "color");
-        if property.code != "" {
-            return property.value-brush;
-        }
-        return root.current-shadow-prefix() == "inner-shadow-" ? #00000030 : #00000040;
+    function shadow-color-swatch() -> brush {
+        return root.property-brush(root.current-shadow-prefix() + "color");
     }
 
     function shadow-blur() -> float {
@@ -419,19 +419,19 @@ export component InspectorPane inherits Rectangle {
     }
 
     function rectangle-background-code() -> string {
-        return Api.current-property-value("background", StudioTheme.dark ? "#383838" : "#ffffff");
+        return Api.current-property-value("background", "");
     }
 
     function rectangle-background-swatch() -> brush {
-        return root.property-brush("background", StudioTheme.dark ? #383838 : #ffffff);
+        return root.property-brush("background");
     }
 
     function text-color-code() -> string {
-        return Api.current-property-value("color", StudioTheme.dark ? "#f4f4f4" : "#1f2328");
+        return Api.current-property-value("color", "");
     }
 
     function text-color-swatch() -> brush {
-        return root.property-brush("color", StudioTheme.dark ? #f4f4f4 : #1f2328);
+        return root.property-brush("color");
     }
 
     function text-content-code() -> string {
@@ -721,7 +721,7 @@ export component InspectorPane inherits Rectangle {
                             accessible-name: "Rectangle background";
                             value: root.rectangle-background-code();
                             swatch: root.rectangle-background-swatch();
-                            effective-color: root.rectangle-background-swatch();
+                            effective-color: root.property-effective-color("background");
                             unsupported: !root.property-is-solid("background");
                             commit-key: root.field-key("background");
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
@@ -734,7 +734,7 @@ export component InspectorPane inherits Rectangle {
                             accessible-name: "Text color";
                             value: root.text-color-code();
                             swatch: root.text-color-swatch();
-                            effective-color: root.text-color-swatch();
+                            effective-color: root.property-effective-color("color");
                             unsupported: !root.property-is-solid("color");
                             commit-key: root.field-key("color");
                             width: parent.width - 2 * InspectorTokens.side-padding - InspectorTokens.label-width - InspectorTokens.row-gap;
@@ -810,7 +810,7 @@ export component InspectorPane inherits Rectangle {
                                     accessible-name: "Shadow color";
                                     value: root.shadow-color-code();
                                     swatch: root.shadow-color-swatch();
-                                    effective-color: root.shadow-color-swatch();
+                                    effective-color: root.property-effective-color(root.current-shadow-prefix() + "color");
                                     unsupported: !root.property-is-solid(root.current-shadow-prefix() + "color");
                                     commit-key: root.field-key(root.current-shadow-prefix() + "color");
                                     accepted(text) => {

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -57,11 +57,14 @@ export component InspectorColorField inherits Rectangle {
             width: 24px;
             height: parent.height;
             mouse-cursor: pointer;
-            clicked => { root.picker-open = true; }
+            clicked => {
+                root.picker-open = true;
+                picker.show-picker();
+            }
         }
     }
 
-    InspectorSolidColorPicker {
+    picker := InspectorSolidColorPicker {
         value: Api.string-to-color(root.value);
         open: root.picker-open;
         accepted(color) => {

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -3,6 +3,8 @@
 
 import { InspectorTokens } from "tokens.slint";
 import { InspectorTextFieldBase } from "text-field-base.slint";
+import { InspectorSolidColorPicker } from "solid-color-picker.slint";
+import { Api } from "../../api.slint";
 
 export component InspectorColorField inherits Rectangle {
     in property <string> accessible-name: "";
@@ -11,6 +13,7 @@ export component InspectorColorField inherits Rectangle {
     in property <bool> wide: false;
     in property <string> commit-key: "";
     callback accepted(string) -> bool;
+    private property <bool> picker-open: false;
 
     width: wide ? InspectorTokens.wide-width : InspectorTokens.column-width;
     height: InspectorTokens.field-height;
@@ -49,5 +52,23 @@ export component InspectorColorField inherits Rectangle {
                 background: InspectorTokens.muted.with-alpha(0.35);
             }
         }
+
+        TouchArea {
+            width: 24px;
+            height: parent.height;
+            mouse-cursor: pointer;
+            clicked => { root.picker-open = true; }
+        }
+    }
+
+    InspectorSolidColorPicker {
+        value: Api.string-to-color(root.value);
+        open: root.picker-open;
+        accepted(color) => {
+            let accepted = root.accepted(Api.color-to-data(color).text);
+            if accepted { root.picker-open = false; }
+            return accepted;
+        }
+        closed => { root.picker-open = false; }
     }
 }

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -105,12 +105,8 @@ export component InspectorColorField inherits Rectangle {
         accepted(key, color) => {
             return Api.inspector-color-commit(key, root.property-name, color);
         }
-        detached(key) => {
-            return Api.inspector-color-commit(key, root.property-name, root.effective-color);
-        }
         closed => {
             root.picker-open = false;
-            Api.inspector-color-dismissed();
         }
     }
 }

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -14,6 +14,10 @@ export component InspectorColorField inherits Rectangle {
     in property <string> commit-key: "";
     in property <color> effective-color: swatch;
     in property <bool> unsupported: false;
+    in property <string> preview-key: "";
+    in property <string> session-key: "";
+    in property <string> property-name: "";
+    in property <bool> is-brush: false;
     callback accepted(string) -> bool;
     private property <bool> picker-open: false;
 
@@ -72,13 +76,20 @@ export component InspectorColorField inherits Rectangle {
         bound: root.value != "" && !Api.string-is-color(root.value);
         unsupported: root.unsupported;
         open: root.picker-open;
-        accepted(color) => {
-            let accepted = root.accepted(Api.color-to-data(color).text);
-            return accepted;
+        session-key: root.session-key;
+        target-key: root.preview-key;
+        preview(key, color) => {
+            return Api.inspector-color-preview(key, root.property-name, color, root.is-brush);
         }
-        detached => {
-            return root.accepted(Api.color-to-data(root.effective-color).text);
+        accepted(key, color) => {
+            return Api.inspector-color-commit(key, root.property-name, color, root.is-brush);
         }
-        closed => { root.picker-open = false; }
+        detached(key) => {
+            return Api.inspector-color-commit(key, root.property-name, root.effective-color, root.is-brush);
+        }
+        closed => {
+            root.picker-open = false;
+            Api.inspector-color-dismissed();
+        }
     }
 }

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -17,7 +17,6 @@ export component InspectorColorField inherits Rectangle {
     in property <string> preview-key: "";
     in property <string> session-key: "";
     in property <string> property-name: "";
-    in property <bool> is-brush: false;
     callback accepted(string) -> bool;
     private property <bool> picker-open: false;
 
@@ -101,13 +100,13 @@ export component InspectorColorField inherits Rectangle {
         session-key: root.session-key;
         target-key: root.preview-key;
         preview(key, color) => {
-            return Api.inspector-color-preview(key, root.property-name, color, root.is-brush);
+            return Api.inspector-color-preview(key, root.property-name, color);
         }
         accepted(key, color) => {
-            return Api.inspector-color-commit(key, root.property-name, color, root.is-brush);
+            return Api.inspector-color-commit(key, root.property-name, color);
         }
         detached(key) => {
-            return Api.inspector-color-commit(key, root.property-name, root.effective-color, root.is-brush);
+            return Api.inspector-color-commit(key, root.property-name, root.effective-color);
         }
         closed => {
             root.picker-open = false;

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -9,7 +9,7 @@ import { Api } from "../../api.slint";
 export component InspectorColorField inherits Rectangle {
     in property <string> accessible-name: "";
     in property <string> value;
-    in property <color> swatch;
+    in property <brush> swatch;
     in property <bool> wide: false;
     in property <string> commit-key: "";
     in property <color> effective-color: swatch;

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -12,6 +12,8 @@ export component InspectorColorField inherits Rectangle {
     in property <color> swatch;
     in property <bool> wide: false;
     in property <string> commit-key: "";
+    in property <color> effective-color: swatch;
+    in property <bool> unsupported: false;
     callback accepted(string) -> bool;
     private property <bool> picker-open: false;
 
@@ -65,12 +67,17 @@ export component InspectorColorField inherits Rectangle {
     }
 
     picker := InspectorSolidColorPicker {
-        value: Api.string-to-color(root.value);
+        value: root.effective-color;
+        expression: root.value;
+        bound: root.value != "" && !Api.string-is-color(root.value);
+        unsupported: root.unsupported;
         open: root.picker-open;
         accepted(color) => {
             let accepted = root.accepted(Api.color-to-data(color).text);
-            if accepted { root.picker-open = false; }
             return accepted;
+        }
+        detached => {
+            return root.accepted(Api.color-to-data(root.effective-color).text);
         }
         closed => { root.picker-open = false; }
     }

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -35,37 +35,56 @@ export component InspectorColorField inherits Rectangle {
             return root.accepted(text);
         }
 
-        Rectangle {
-            width: 11px;
-            height: 11px;
-            border-radius: 2.5px;
-            border-width: 1px;
-            border-color: InspectorTokens.muted;
-            background: root.swatch;
-
-            for row in 3: Rectangle {
-                x: 2.5px + row * 2.5px;
-                y: 2.5px;
-                width: 1px;
-                height: 6px;
-                background: InspectorTokens.muted.with-alpha(0.35);
-            }
-            for col in 3: Rectangle {
-                x: 2.5px;
-                y: 2.5px + col * 2.5px;
-                width: 6px;
-                height: 1px;
-                background: InspectorTokens.muted.with-alpha(0.35);
-            }
-        }
-
-        TouchArea {
+        swatch-focus := FocusScope {
             width: 24px;
+            key-pressed(event) => {
+                if event.text == Key.Return || event.text == " " {
+                    root.picker-open = true;
+                    return accept;
+                }
+                return reject;
+            }
             height: parent.height;
-            mouse-cursor: pointer;
-            clicked => {
-                root.picker-open = true;
-                picker.show-picker();
+            Rectangle {
+                x: 6px;
+                y: (parent.height - 11px) / 2;
+                width: 11px;
+                height: 11px;
+                border-radius: 2.5px;
+                border-width: 1px;
+                border-color: InspectorTokens.muted;
+                background: root.swatch;
+
+                for row in 3: Rectangle {
+                    x: 2.5px + row * 2.5px;
+                    y: 2.5px;
+                    width: 1px;
+                    height: 6px;
+                    background: InspectorTokens.muted.with-alpha(0.35);
+                }
+                for col in 3: Rectangle {
+                    x: 2.5px;
+                    y: 2.5px + col * 2.5px;
+                    width: 6px;
+                    height: 1px;
+                    background: InspectorTokens.muted.with-alpha(0.35);
+                }
+            }
+
+            TouchArea {
+                width: parent.width;
+                height: parent.height;
+                mouse-cursor: pointer;
+                accessible-role: AccessibleRole.button;
+                accessible-label: root.accessible-name + " color picker";
+                clicked => {
+                    root.picker-open = true;
+                    swatch-focus.focus();
+                }
+                accessible-action-default => {
+                    root.picker-open = true;
+                    swatch-focus.focus();
+                }
             }
         }
     }
@@ -76,6 +95,9 @@ export component InspectorColorField inherits Rectangle {
         bound: root.value != "" && !Api.string-is-color(root.value);
         unsupported: root.unsupported;
         open: root.picker-open;
+        anchor-position: swatch-focus.absolute-position;
+        anchor-width: swatch-focus.width;
+        restore-focus => { swatch-focus.focus(); }
         session-key: root.session-key;
         target-key: root.preview-key;
         preview(key, color) => {

--- a/tools/editor/ui/components/inspector/color-field.slint
+++ b/tools/editor/ui/components/inspector/color-field.slint
@@ -92,7 +92,7 @@ export component InspectorColorField inherits Rectangle {
     picker := InspectorSolidColorPicker {
         value: root.effective-color;
         expression: root.value;
-        bound: root.value != "" && !Api.string-is-color(root.value);
+        bound: root.value != "" && !Api.string-is-color(root.value) && !Api.is-css-color(root.value);
         unsupported: root.unsupported;
         open: root.picker-open;
         anchor-position: swatch-focus.absolute-position;

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -6,6 +6,51 @@ import { StudioTheme, EditorMetrics } from "../common.slint";
 import { InspectorTokens } from "tokens.slint";
 import { InspectorTextFieldBase } from "text-field-base.slint";
 
+component ColorSlider inherits Rectangle {
+    in property <float> position;
+    in property <bool> enabled;
+    in property <bool> dragging;
+    in property <color> thumb-shadow: transparent;
+    callback started();
+    callback moved(float);
+    callback finished();
+    callback canceled();
+
+    height: 16px;
+    Rectangle {
+        border-radius: 8px;
+        clip: true;
+        @children
+    }
+    TouchArea {
+        enabled: root.enabled;
+        pointer-event(event) => {
+            if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
+                root.started();
+                root.moved((self.mouse-x / max(1px, self.width)).clamp(0, 1));
+            } else if event.kind == PointerEventKind.move && root.dragging {
+                root.moved((self.mouse-x / max(1px, self.width)).clamp(0, 1));
+            } else if event.kind == PointerEventKind.up && root.dragging {
+                root.finished();
+            } else if event.kind == PointerEventKind.cancel {
+                root.canceled();
+            }
+        }
+    }
+    Rectangle {
+        x: root.position * parent.width - 7px;
+        y: 1px;
+        width: 14px;
+        height: 14px;
+        border-radius: 7px;
+        border-width: 2px;
+        border-color: white;
+        background: transparent;
+        drop-shadow-color: root.thumb-shadow;
+        drop-shadow-blur: 2px;
+    }
+}
+
 export component InspectorSolidColorPicker inherits Rectangle {
     in property <color> value;
     in property <string> expression: "";
@@ -127,16 +172,6 @@ export component InspectorSolidColorPicker inherits Rectangle {
     function update-saturation-brightness(x: length, y: length, width: length, height: length) {
         root.saturation = (x / max(1px, width)).clamp(0, 1);
         root.brightness = (1 - y / max(1px, height)).clamp(0, 1);
-        root.preview-color(root.color-at());
-    }
-
-    function update-hue(x: length, width: length) {
-        root.hue = 360 * (x / max(1px, width)).clamp(0, 1);
-        root.preview-color(root.color-at());
-    }
-
-    function update-alpha(x: length, width: length) {
-        root.alpha = (255 * (x / max(1px, width)).clamp(0, 1)).round();
         root.preview-color(root.color-at());
     }
 
@@ -358,88 +393,49 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         }
                     }
 
-                    if !root.unsupported: Rectangle {
-                        height: 16px;
+                    if !root.unsupported: ColorSlider {
+                        position: root.hue / 360;
+                        enabled: root.editable;
+                        dragging: root.dragging;
+                        started => { root.begin-gesture(); }
+                        moved(position) => {
+                            root.hue = 360 * position;
+                            root.preview-color(root.color-at());
+                        }
+                        finished => { root.finish-gesture(); }
+                        canceled => { root.cancel-gesture(); }
                         Rectangle {
-                            border-radius: 8px;
-                            clip: true;
                             background: @linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
-                        }
-                        TouchArea {
-                            enabled: root.editable;
-                            pointer-event(event) => {
-                                if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
-                                    root.begin-gesture();
-                                    root.update-hue(self.mouse-x, self.width);
-                                } else if event.kind == PointerEventKind.move && root.dragging {
-                                    root.update-hue(self.mouse-x, self.width);
-                                } else if event.kind == PointerEventKind.up && root.dragging {
-                                    root.finish-gesture();
-                                } else if event.kind == PointerEventKind.cancel {
-                                    root.cancel-gesture();
-                                }
-                            }
-                        }
-                        Rectangle {
-                            x: root.hue / 360 * parent.width - 7px;
-                            y: 1px;
-                            width: 14px;
-                            height: 14px;
-                            border-radius: 7px;
-                            border-width: 2px;
-                            border-color: white;
-                            background: transparent;
                         }
                     }
 
-                    if !root.unsupported: Rectangle {
-                        height: 16px;
+                    if !root.unsupported: ColorSlider {
+                        position: root.alpha / 255;
+                        enabled: root.editable;
+                        dragging: root.dragging;
+                        thumb-shadow: #00000070;
+                        started => { root.begin-gesture(); }
+                        moved(position) => {
+                            root.alpha = (255 * position).round();
+                            root.preview-color(root.color-at());
+                        }
+                        finished => { root.finish-gesture(); }
+                        canceled => { root.cancel-gesture(); }
                         Rectangle {
-                            border-radius: 8px;
-                            clip: true;
-                            Rectangle {
-                                for row in 2: Rectangle {
-                                    y: row * 8px;
-                                    width: 100%;
+                            for row in 2: Rectangle {
+                                y: row * 8px;
+                                width: 100%;
+                                height: 8px;
+                                for col in ceil(parent.width / 8px): Rectangle {
+                                    x: col * 8px;
+                                    width: 8px;
                                     height: 8px;
-                                    for col in ceil(parent.width / 8px): Rectangle {
-                                        x: col * 8px;
-                                        width: 8px;
-                                        height: 8px;
-                                        background: (row + col).mod(2) == 0 ? InspectorTokens.panel-bg : InspectorTokens.field-border;
-                                    }
-                                }
-                            }
-                            Rectangle {
-                                background: @linear-gradient(90deg, transparent, hsv(root.hue, root.saturation, root.brightness, 1));
-                            }
-                        }
-                        TouchArea {
-                            enabled: root.editable;
-                            pointer-event(event) => {
-                                if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
-                                    root.begin-gesture();
-                                    root.update-alpha(self.mouse-x, self.width);
-                                } else if event.kind == PointerEventKind.move && root.dragging {
-                                    root.update-alpha(self.mouse-x, self.width);
-                                } else if event.kind == PointerEventKind.up && root.dragging {
-                                    root.finish-gesture();
-                                } else if event.kind == PointerEventKind.cancel {
-                                    root.cancel-gesture();
+                                    background: (row + col).mod(2) == 0 ? InspectorTokens.panel-bg : InspectorTokens.field-border;
                                 }
                             }
                         }
                         Rectangle {
-                            x: root.alpha / 255 * parent.width - 7px;
-                            y: 1px;
-                            width: 14px;
-                            height: 14px;
-                            border-radius: 7px;
-                            border-width: 2px;
-                            border-color: white;
-                            background: transparent;
-                            drop-shadow-color: #00000070;
-                            drop-shadow-blur: 2px;
+                            background: @linear-gradient(90deg, transparent, hsv(root.hue, root.saturation, root.brightness, 1));
                         }
                     }
 

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -61,7 +61,6 @@ export component InspectorSolidColorPicker inherits Rectangle {
     in property <bool> open: false;
     callback accepted(string, color) -> bool;
     callback preview(string, color) -> bool;
-    callback detached(string) -> bool;
     callback closed();
     callback restore-focus();
     in property <Point> anchor-position;
@@ -74,9 +73,12 @@ export component InspectorSolidColorPicker inherits Rectangle {
     private property <int> alpha: 255;
     private property <bool> dragging: false;
     private property <bool> has-preview: false;
-    private property <string> gesture-key;
+    private property <string> active-target;
+    private property <bool> session-active: false;
+    private property <bool> detach-requested: false;
+    private property <color> gesture-color;
     private property <color> original-color: root.value;
-    private property <bool> editable: root.open && !Api.inspector-color-refresh-pending && !root.unsupported && !root.bound;
+    private property <bool> editable: root.open && !Api.inspector-color-refresh-pending && !root.unsupported && (!root.bound || root.detach-requested);
     private property <bool> popup-open: picker-popup.is-open;
 
     function color-at() -> color {
@@ -99,74 +101,36 @@ export component InspectorSolidColorPicker inherits Rectangle {
     function cancel-gesture() {
         if root.dragging {
             root.dragging = false;
-            if root.has-preview {
-                Api.inspector-cancel();
-                root.has-preview = false;
-            }
-            root.update-color(root.original-color);
+            root.preview-color(root.gesture-color);
         }
     }
 
-    function preview-color(c: color) {
-        if !root.editable {
-            return;
-        }
-        root.update-color(c);
-        if root.preview(root.gesture-key, c) {
-            root.has-preview = true;
-            return;
-        }
-        root.cancel-gesture();
-    }
-
-    function commit-color(key: string, c: color) -> bool {
-        if !root.editable {
+    function preview-color(c: color) -> bool {
+        if !root.session-active || !root.editable {
             return false;
         }
-        if c == root.original-color {
-            return true;
-        }
-        if root.accepted(key, c) {
+        if root.preview(root.active-target, c) {
+            root.has-preview = true;
             root.update-color(c);
-            root.original-color = c;
             return true;
         }
-        Api.inspector-cancel();
-        root.update-color(root.original-color);
+        root.close-picker(false, false);
         return false;
     }
 
     function commit-text(text: string) -> bool {
-        if !Api.string-is-color(text) || !root.editable {
-            return false;
-        }
-        return root.commit-color(root.target-key, Api.string-to-color(text));
+        return Api.string-is-color(text) && root.preview-color(Api.string-to-color(text));
     }
 
     function begin-gesture() {
         if root.editable {
-            root.gesture-key = root.target-key;
             root.dragging = true;
-            root.has-preview = false;
-            root.original-color = root.working-color;
+            root.gesture-color = root.working-color;
         }
     }
 
     function finish-gesture() {
-        if !root.dragging {
-            return;
-        }
-        let c = root.working-color;
         root.dragging = false;
-        if c == root.original-color {
-            if root.has-preview {
-                Api.inspector-cancel();
-                root.has-preview = false;
-            }
-            return;
-        }
-        root.commit-color(root.gesture-key, c);
-        root.has-preview = false;
     }
 
     function update-saturation-brightness(x: length, y: length, width: length, height: length) {
@@ -178,44 +142,48 @@ export component InspectorSolidColorPicker inherits Rectangle {
     function show-picker() {
         root.update-color(root.value);
         root.original-color = root.value;
+        root.active-target = root.target-key;
         root.dragging = false;
         root.has-preview = false;
+        root.detach-requested = false;
+        root.session-active = true;
         picker-popup.show();
     }
 
-    function close-picker(return-focus: bool) {
-        root.cancel-gesture();
+    function close-picker(accept: bool, return-focus: bool) {
+        if !root.session-active { return; }
+        root.session-active = false;
+        root.dragging = false;
+        let changed = root.working-color != root.original-color || root.detach-requested;
+        if !accept || !changed || !root.accepted(root.active-target, root.working-color) {
+            if root.has-preview { Api.inspector-cancel(); }
+            root.update-color(root.original-color);
+        }
+        root.has-preview = false;
         root.closed();
         picker-popup.close();
         if return-focus { root.restore-focus(); }
     }
 
     changed value => {
-        if !root.dragging && !Api.inspector-color-refresh-pending {
-            root.update-color(root.value);
-            root.original-color = root.value;
-        }
+        if !root.session-active { root.update-color(root.value); }
     }
 
     changed session-key => {
-        if root.open {
-            root.close-picker(false);
-        }
+        root.close-picker(false, false);
     }
 
     changed open => {
         if root.open {
             root.show-picker();
         } else {
-            root.cancel-gesture();
-            picker-popup.close();
+            root.close-picker(false, false);
         }
     }
 
     changed popup-open => {
         if !root.popup-open && root.open {
-            root.cancel-gesture();
-            root.closed();
+            root.close-picker(root.active-target == root.target-key, false);
         }
     }
 
@@ -240,13 +208,9 @@ export component InspectorSolidColorPicker inherits Rectangle {
             drop-shadow-offset-y: 7px;
 
             picker-focus := FocusScope {
-                key-pressed(event) => {
+                capture-key-pressed(event) => {
                     if event.text == Key.Escape {
-                        if root.dragging {
-                            root.cancel-gesture();
-                        } else {
-                            root.close-picker(true);
-                        }
+                        root.close-picker(false, true);
                         return accept;
                     }
                     return reject;
@@ -275,8 +239,8 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                 height: parent.height;
                                 accessible-role: AccessibleRole.button;
                                 accessible-label: "Close color picker";
-                                clicked => { root.close-picker(true); }
-                                accessible-action-default => { root.close-picker(true); }
+                                clicked => { root.close-picker(true, true); }
+                                accessible-action-default => { root.close-picker(true, true); }
                                 Text {
                                     text: "Close";
                                     width: parent.width;
@@ -308,7 +272,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         }
                     }
 
-                    if root.bound && !root.unsupported: HorizontalLayout {
+                    if root.bound && !root.detach-requested && !root.unsupported: HorizontalLayout {
                         height: 26px;
                         Text {
                             text: root.expression;
@@ -330,8 +294,8 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                 accessible-label: "Detach color binding";
                                 enabled: root.bound && !Api.inspector-color-refresh-pending;
                                 function detach-binding() {
-                                    if self.enabled && root.detached(root.target-key) {
-                                        root.original-color = root.working-color;
+                                    if self.enabled {
+                                        root.detach-requested = true;
                                     }
                                 }
                                 clicked => { self.detach-binding(); }
@@ -444,6 +408,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         spacing: 8px;
                         InspectorTextFieldBase {
                             accessible-name: "Hex color";
+                            live-edit: true;
                             enabled: root.editable;
                             value: Api.color-to-data(root.working-color).text;
                             commit-key: root.session-key;
@@ -455,6 +420,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             spacing: 2px;
                             InspectorTextFieldBase {
                                 accessible-name: "Opacity percentage";
+                                live-edit: true;
                                 enabled: root.editable;
                                 width: 58px;
                                 value: (root.alpha * 100 / 255).to-fixed(0);
@@ -464,7 +430,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                         return false;
                                     }
                                     root.alpha = (text.to-float().clamp(0, 100) * 255 / 100).round();
-                                    return root.commit-color(root.target-key, root.color-at());
+                                    return root.preview-color(root.color-at());
                                 }
                             }
                             Text {
@@ -506,12 +472,12 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                 accessible-label: "Recent color " + Api.color-to-data(recent).text;
                                 clicked => {
                                     if self.enabled {
-                                        root.commit-color(root.target-key, recent);
+                                        root.preview-color(recent);
                                     }
                                 }
                                 accessible-action-default => {
                                     if self.enabled {
-                                        root.commit-color(root.target-key, recent);
+                                        root.preview-color(recent);
                                     }
                                 }
                             }

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -20,7 +20,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
     private property <float> hue: root.working-color.to-hsv().hue;
     private property <float> saturation: root.working-color.to-hsv().saturation;
     private property <float> brightness: root.working-color.to-hsv().value;
-    private property <int> alpha: (root.working-color.alpha * 255).round();
+    private property <int> alpha: root.working-color.alpha;
     private property <bool> dragging: false;
     private property <bool> editing: false;
     private property <bool> is-detached: false;
@@ -35,7 +35,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
         root.hue = c.to-hsv().hue;
         root.saturation = c.to-hsv().saturation;
         root.brightness = c.to-hsv().value;
-        root.alpha = (c.alpha * 255).round();
+        root.alpha = c.alpha;
     }
 
     function commit-color(c: color) -> bool {

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -186,11 +186,12 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
     picker-popup := PopupWindow {
         x: -308px;
-        y: 0px;
+        y: root.height + 8px;
         width: 300px;
-        height: 408px;
+        height: picker-layout.preferred-height;
         close-policy: close-on-click-outside;
         forward-focus: picker-focus;
+
         Rectangle {
             background: InspectorTokens.panel-bg;
             border-width: 1px;
@@ -212,9 +213,11 @@ export component InspectorSolidColorPicker inherits Rectangle {
                     }
                     return reject;
                 }
-                VerticalLayout {
+
+                picker-layout := VerticalLayout {
                     padding: 12px;
-                    spacing: 9px;
+                    spacing: 12px;
+                    alignment: start;
 
                     HorizontalLayout {
                         height: 22px;
@@ -227,44 +230,87 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         }
                         Rectangle { horizontal-stretch: 1; }
                         Rectangle {
-                            width: 42px;
+                            width: 48px;
                             height: 22px;
-                            accessible-role: AccessibleRole.button;
-                            accessible-label: "Close color picker";
-                            Text {
-                                text: "Close";
-                                width: parent.width;
-                                color: InspectorTokens.muted;
-                                font-size: 11px;
-                                vertical-alignment: center;
-                                horizontal-alignment: right;
-                            }
                             TouchArea {
+                                width: parent.width;
+                                height: parent.height;
+                                accessible-role: AccessibleRole.button;
+                                accessible-label: "Close color picker";
                                 clicked => { root.close-picker(); }
+                                accessible-action-default => { root.close-picker(); }
+                                Text {
+                                    text: "Close";
+                                    width: parent.width;
+                                    height: parent.height;
+                                    color: InspectorTokens.muted;
+                                    font-size: 11px;
+                                    vertical-alignment: center;
+                                    horizontal-alignment: right;
+                                }
                             }
                         }
                     }
 
+                    Rectangle { height: 1px; background: InspectorTokens.divider; }
+
                     if root.unsupported: VerticalLayout {
                         spacing: 5px;
-                        Text { text: root.expression; color: InspectorTokens.text; font-size: 12px; overflow: elide; }
-                        Text { text: "This picker edits solid colors only."; color: InspectorTokens.muted; font-size: 11px; }
+                        Text {
+                            text: root.expression;
+                            color: InspectorTokens.text;
+                            font-size: 12px;
+                            overflow: elide;
+                        }
+                        Text {
+                            text: "This expression cannot be edited as a solid color.";
+                            color: InspectorTokens.muted;
+                            font-size: 11px;
+                            wrap: word-wrap;
+                        }
                     }
 
                     if root.bound && !root.unsupported: HorizontalLayout {
                         height: 26px;
-                        Text { text: root.expression; color: InspectorTokens.muted; font-size: 11px; horizontal-stretch: 1; vertical-alignment: center; overflow: elide; }
+                        Text {
+                            text: root.expression;
+                            color: InspectorTokens.muted;
+                            font-size: 11px;
+                            horizontal-stretch: 1;
+                            vertical-alignment: center;
+                            overflow: elide;
+                        }
                         Rectangle {
                             width: 58px;
                             height: 24px;
                             background: InspectorTokens.field-bg;
                             border-radius: InspectorTokens.field-radius;
-                            accessible-role: AccessibleRole.button;
-                            accessible-label: "Detach color binding";
-                            Text { text: "Detach"; width: parent.width; horizontal-alignment: center; vertical-alignment: center; color: InspectorTokens.text; font-size: 11px; }
                             TouchArea {
+                                width: parent.width;
+                                height: parent.height;
+                                accessible-role: AccessibleRole.button;
+                                accessible-label: "Detach color binding";
+                                enabled: root.bound && !root.is-detached && !Api.inspector-color-refresh-pending;
                                 clicked => {
-                                    if !Api.inspector-color-refresh-pending && root.detached(root.target-key) { root.is-detached = true; }
+                                    if self.enabled && root.detached(root.target-key) {
+                                        root.is-detached = true;
+                                        root.original-color = root.working-color;
+                                    }
+                                }
+                                accessible-action-default => {
+                                    if self.enabled && root.detached(root.target-key) {
+                                        root.is-detached = true;
+                                        root.original-color = root.working-color;
+                                    }
+                                }
+                                Text {
+                                    text: "Detach";
+                                    width: parent.width;
+                                    height: parent.height;
+                                    horizontal-alignment: center;
+                                    vertical-alignment: center;
+                                    color: root.is-detached ? InspectorTokens.text : InspectorTokens.muted;
+                                    font-size: 11px;
                                 }
                             }
                         }
@@ -272,20 +318,18 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
                     if !root.unsupported: Rectangle {
                         height: 170px;
-                        border-radius: 5px;
-                        clip: true;
-                        background: hsv(root.hue, 1, 1);
-
-                        Rectangle {
-                            background: @linear-gradient(90deg, white 0%, transparent 100%);
-                        }
-                        Rectangle {
-                            background: @linear-gradient(0deg, black 0%, transparent 100%);
-                        }
-                        Rectangle {
+                        sv := Rectangle {
                             border-radius: 5px;
-                            border-width: 1px;
-                            border-color: InspectorTokens.divider;
+                            clip: true;
+                            background: hsv(root.hue, 1, 1);
+
+                            Rectangle { background: @linear-gradient(90deg, white 0%, transparent 100%); }
+                            Rectangle { background: @linear-gradient(0deg, black 0%, transparent 100%); }
+                            Rectangle {
+                                border-radius: 5px;
+                                border-width: 1px;
+                                border-color: InspectorTokens.divider;
+                            }
                         }
                         TouchArea {
                             enabled: root.editable;
@@ -303,8 +347,8 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             }
                         }
                         Rectangle {
-                            x: root.saturation * (parent.width - 12px) - 6px;
-                            y: (1 - root.brightness) * (parent.height - 12px) - 6px;
+                            x: root.saturation * parent.width - 6px;
+                            y: (1 - root.brightness) * parent.height - 6px;
                             width: 12px;
                             height: 12px;
                             border-radius: 6px;
@@ -318,9 +362,11 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
                     if !root.unsupported: Rectangle {
                         height: 16px;
-                        border-radius: 8px;
-                        clip: true;
-                        background: @linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
+                        hue-track := Rectangle {
+                            border-radius: 8px;
+                            clip: true;
+                            background: @linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
+                        }
                         TouchArea {
                             enabled: root.editable;
                             pointer-event(event) => {
@@ -337,7 +383,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             }
                         }
                         Rectangle {
-                            x: root.hue / 360 * (parent.width - 12px);
+                            x: root.hue / 360 * parent.width - 7px;
                             y: 1px;
                             width: 14px;
                             height: 14px;
@@ -350,26 +396,24 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
                     if !root.unsupported: Rectangle {
                         height: 16px;
-                        border-radius: 8px;
-                        clip: true;
-                        background: @linear-gradient(90deg, transparent, hsv(root.hue, root.saturation, root.brightness, 1));
-                        Rectangle {
-                            width: 100%;
-                            height: 100%;
-                            background: #d7d7d7;
-                            for row in 4: Rectangle {
-                                x: 4px;
-                                y: row * 4px;
-                                width: 4px;
-                                height: 4px;
-                                background: #ffffff;
+                        alpha-track := Rectangle {
+                            border-radius: 8px;
+                            clip: true;
+                            Rectangle {
+                                for row in 2: Rectangle {
+                                    y: row * 8px;
+                                    width: 100%;
+                                    height: 8px;
+                                    for col in ceil(parent.width / 8px): Rectangle {
+                                        x: col * 8px;
+                                        width: 8px;
+                                        height: 8px;
+                                        background: (row + col).mod(2) == 0 ? InspectorTokens.panel-bg : InspectorTokens.field-border;
+                                    }
+                                }
                             }
-                            for col in 75: Rectangle {
-                                x: col * 8px;
-                                y: 0px;
-                                width: 4px;
-                                height: 4px;
-                                background: #ffffff;
+                            Rectangle {
+                                background: @linear-gradient(90deg, transparent, hsv(root.hue, root.saturation, root.brightness, 1));
                             }
                         }
                         TouchArea {
@@ -387,35 +431,72 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                 }
                             }
                         }
+                        Rectangle {
+                            x: root.alpha / 255 * parent.width - 7px;
+                            y: 1px;
+                            width: 14px;
+                            height: 14px;
+                            border-radius: 7px;
+                            border-width: 2px;
+                            border-color: white;
+                            background: transparent;
+                            drop-shadow-color: #00000070;
+                            drop-shadow-blur: 2px;
+                        }
                     }
 
                     if !root.unsupported: HorizontalLayout {
                         height: 26px;
                         spacing: 8px;
                         InspectorTextFieldBase {
+                            accessible-name: "Hex color";
                             enabled: root.editable;
                             value: Api.color-to-data(root.working-color).text;
                             commit-key: root.session-key;
                             horizontal-stretch: 1;
                             accepted(text) => { return root.commit-text(text); }
                         }
-                        InspectorTextFieldBase {
-                            enabled: root.editable;
-                            width: 70px;
-                            value: (root.alpha * 100 / 255).to-fixed(0);
-                            commit-key: root.session-key;
-                            accepted(text) => {
-                                if !text.is-float() || !root.editable { return false; }
-                                root.alpha = (text.to-float().clamp(0, 100) * 255 / 100).round();
-                                return root.commit-color(root.target-key, root.color-at());
+                        HorizontalLayout {
+                            width: 78px;
+                            spacing: 2px;
+                            InspectorTextFieldBase {
+                                accessible-name: "Opacity percentage";
+                                enabled: root.editable;
+                                width: 58px;
+                                value: (root.alpha * 100 / 255).to-fixed(0);
+                                commit-key: root.session-key;
+                                accepted(text) => {
+                                    if !text.is-float() || !root.editable {
+                                        return false;
+                                    }
+                                    root.alpha = (text.to-float().clamp(0, 100) * 255 / 100).round();
+                                    return root.commit-color(root.target-key, root.color-at());
+                                }
+                            }
+                            Text {
+                                text: "%";
+                                color: InspectorTokens.muted;
+                                font-size: 11px;
+                                vertical-alignment: center;
                             }
                         }
                     }
 
-                    if !root.unsupported: Text { text: "Recent colors"; color: InspectorTokens.muted; font-size: 11px; font-weight: 600; }
-                    if !root.unsupported: HorizontalLayout {
-                        height: 26px;
+                    if !root.unsupported: Text {
+                        text: "Recent colors";
+                        color: InspectorTokens.muted;
+                        font-size: 11px;
+                        font-weight: 600;
+                    }
+                    if !root.unsupported && Api.recent-colors.length == 0: Text {
+                        text: "No recent colors";
+                        color: InspectorTokens.muted;
+                        font-size: 11px;
+                    }
+                    if !root.unsupported && Api.recent-colors.length > 0: HorizontalLayout {
+                        height: 22px;
                         spacing: 6px;
+                        alignment: start;
                         for recent in Api.recent-colors: Rectangle {
                             width: 22px;
                             height: 22px;
@@ -423,7 +504,23 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             border-width: 1px;
                             border-color: InspectorTokens.divider;
                             background: recent;
-                            TouchArea { clicked => { root.commit-color(root.target-key, recent); } }
+                            TouchArea {
+                                width: parent.width;
+                                height: parent.height;
+                                enabled: root.editable;
+                                accessible-role: AccessibleRole.button;
+                                accessible-label: "Recent color " + Api.color-to-data(recent).text;
+                                clicked => {
+                                    if self.enabled {
+                                        root.commit-color(root.target-key, recent);
+                                    }
+                                }
+                                accessible-action-default => {
+                                    if self.enabled {
+                                        root.commit-color(root.target-key, recent);
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -30,9 +30,8 @@ export component InspectorSolidColorPicker inherits Rectangle {
     private property <bool> dragging: false;
     private property <bool> has-preview: false;
     private property <string> gesture-key;
-    private property <bool> is-detached: false;
     private property <color> original-color: root.value;
-    private property <bool> editable: root.open && !Api.inspector-color-refresh-pending && !root.unsupported && (!root.bound || root.is-detached);
+    private property <bool> editable: root.open && !Api.inspector-color-refresh-pending && !root.unsupported && !root.bound;
     private property <bool> popup-open: picker-popup.is-open;
 
     function color-at() -> color {
@@ -146,7 +145,6 @@ export component InspectorSolidColorPicker inherits Rectangle {
         root.original-color = root.value;
         root.dragging = false;
         root.has-preview = false;
-        root.is-detached = false;
         picker-popup.show();
     }
 
@@ -295,26 +293,21 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                 height: parent.height;
                                 accessible-role: AccessibleRole.button;
                                 accessible-label: "Detach color binding";
-                                enabled: root.bound && !root.is-detached && !Api.inspector-color-refresh-pending;
-                                clicked => {
+                                enabled: root.bound && !Api.inspector-color-refresh-pending;
+                                function detach-binding() {
                                     if self.enabled && root.detached(root.target-key) {
-                                        root.is-detached = true;
                                         root.original-color = root.working-color;
                                     }
                                 }
-                                accessible-action-default => {
-                                    if self.enabled && root.detached(root.target-key) {
-                                        root.is-detached = true;
-                                        root.original-color = root.working-color;
-                                    }
-                                }
+                                clicked => { self.detach-binding(); }
+                                accessible-action-default => { self.detach-binding(); }
                                 Text {
                                     text: "Detach";
                                     width: parent.width;
                                     height: parent.height;
                                     horizontal-alignment: center;
                                     vertical-alignment: center;
-                                    color: root.is-detached ? InspectorTokens.text : InspectorTokens.muted;
+                                    color: InspectorTokens.muted;
                                     font-size: 11px;
                                 }
                             }

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -52,16 +52,18 @@ export component InspectorSolidColorPicker inherits Rectangle {
     changed open => {
         if root.open {
             root.update-color(root.value);
+            picker-popup.show();
+        } else {
+            picker-popup.close();
         }
     }
 
-    PopupWindow {
+    picker-popup := PopupWindow {
         x: 0px;
         y: 0px;
         width: 300px;
         height: 408px;
         close-policy: close-on-click-outside;
-        visible: root.open;
         Rectangle {
             background: InspectorTokens.panel-bg;
             border-width: 1px;

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -63,17 +63,16 @@ export component InspectorSolidColorPicker inherits Rectangle {
         }
     }
 
-    function preview-color(c: color) -> bool {
+    function preview-color(c: color) {
         if !root.editable {
-            return false;
+            return;
         }
         root.update-color(c);
         if root.preview(root.gesture-key, c) {
             root.has-preview = true;
-            return true;
+            return;
         }
         root.cancel-gesture();
-        return false;
     }
 
     function commit-color(key: string, c: color) -> bool {
@@ -142,7 +141,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
         root.preview-color(root.color-at());
     }
 
-    public function show-picker() {
+    function show-picker() {
         root.update-color(root.value);
         root.original-color = root.value;
         root.dragging = false;
@@ -324,7 +323,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
                     if !root.unsupported: Rectangle {
                         height: 170px;
-                        sv := Rectangle {
+                        Rectangle {
                             border-radius: 5px;
                             clip: true;
                             background: hsv(root.hue, 1, 1);
@@ -368,7 +367,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
                     if !root.unsupported: Rectangle {
                         height: 16px;
-                        hue-track := Rectangle {
+                        Rectangle {
                             border-radius: 8px;
                             clip: true;
                             background: @linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
@@ -402,7 +401,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
                     if !root.unsupported: Rectangle {
                         height: 16px;
-                        alpha-track := Rectangle {
+                        Rectangle {
                             border-radius: 8px;
                             clip: true;
                             Rectangle {

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -9,11 +9,14 @@ import { InspectorTextFieldBase } from "text-field-base.slint";
 export component InspectorSolidColorPicker inherits Rectangle {
     in property <color> value;
     in property <string> expression: "";
+    in property <string> session-key: "";
+    in property <string> target-key: "";
     in property <bool> bound: false;
     in property <bool> unsupported: false;
     in property <bool> open: false;
-    callback accepted(color) -> bool;
-    callback detached() -> bool;
+    callback accepted(string, color) -> bool;
+    callback preview(string, color) -> bool;
+    callback detached(string) -> bool;
     callback closed();
 
     private property <color> working-color: root.value;
@@ -22,11 +25,14 @@ export component InspectorSolidColorPicker inherits Rectangle {
     private property <float> brightness: 0;
     private property <int> alpha: 255;
     private property <bool> dragging: false;
-    private property <bool> editing: false;
+    private property <bool> has-preview: false;
+    private property <string> gesture-key;
     private property <bool> is-detached: false;
     private property <color> original-color: root.value;
+    private property <bool> editable: root.open && !Api.inspector-color-refresh-pending && !root.unsupported && (!root.bound || root.is-detached);
+    private property <bool> popup-open: picker-popup.is-open;
 
-    function color-at(x: length, y: length) -> color {
+    function color-at() -> color {
         return hsv(root.hue, root.saturation, root.brightness, root.alpha / 255);
     }
 
@@ -43,50 +49,138 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
     init => { root.update-color(root.value); }
 
-    function commit-color(c: color) -> bool {
-        if (root.bound && !root.is-detached) || root.unsupported {
+    function cancel-gesture() {
+        if root.dragging {
+            root.dragging = false;
+            if root.has-preview {
+                Api.inspector-cancel();
+                root.has-preview = false;
+            }
+            root.update-color(root.original-color);
+        }
+    }
+
+    function preview-color(c: color) -> bool {
+        if !root.editable {
             return false;
         }
-        if root.accepted(c) {
-            root.working-color = c;
+        root.update-color(c);
+        if root.preview(root.gesture-key, c) {
+            root.has-preview = true;
+            return true;
+        }
+        root.cancel-gesture();
+        return false;
+    }
+
+    function commit-color(key: string, c: color) -> bool {
+        if !root.editable {
+            return false;
+        }
+        if c == root.original-color {
+            return true;
+        }
+        if root.accepted(key, c) {
+            root.update-color(c);
+            root.original-color = c;
             Api.add-recent-color(c);
             return true;
         }
+        Api.inspector-cancel();
         root.update-color(root.original-color);
         return false;
     }
 
     function commit-text(text: string) -> bool {
-        if !Api.string-is-color(text) {
+        if !Api.string-is-color(text) || !root.editable {
             return false;
         }
-        let c = Api.string-to-color(text);
-        if (root.bound && !root.is-detached) || root.unsupported {
-            return false;
+        return root.commit-color(root.target-key, Api.string-to-color(text));
+    }
+
+    function begin-gesture() {
+        if root.editable {
+            root.gesture-key = root.target-key;
+            root.dragging = true;
+            root.has-preview = false;
+            root.original-color = root.working-color;
         }
-        return root.commit-color(c);
+    }
+
+    function finish-gesture() {
+        if !root.dragging {
+            return;
+        }
+        let c = root.working-color;
+        root.dragging = false;
+        if c == root.original-color {
+            if root.has-preview {
+                Api.inspector-cancel();
+                root.has-preview = false;
+            }
+            return;
+        }
+        root.commit-color(root.gesture-key, c);
+        root.has-preview = false;
+    }
+
+    function update-saturation-brightness(x: length, y: length, width: length, height: length) {
+        root.saturation = (x / max(1px, width)).clamp(0, 1);
+        root.brightness = (1 - y / max(1px, height)).clamp(0, 1);
+        root.preview-color(root.color-at());
+    }
+
+    function update-hue(x: length, width: length) {
+        root.hue = 360 * (x / max(1px, width)).clamp(0, 1);
+        root.preview-color(root.color-at());
+    }
+
+    function update-alpha(x: length, width: length) {
+        root.alpha = (255 * (x / max(1px, width)).clamp(0, 1)).round();
+        root.preview-color(root.color-at());
     }
 
     public function show-picker() {
         root.update-color(root.value);
         root.original-color = root.value;
+        root.dragging = false;
+        root.has-preview = false;
         root.is-detached = false;
         picker-popup.show();
     }
 
     function close-picker() {
-        if root.dragging {
-            root.dragging = false;
-            root.update-color(root.original-color);
-        }
+        root.cancel-gesture();
         root.closed();
+        picker-popup.close();
+    }
+
+    changed value => {
+        if !root.dragging && !Api.inspector-color-refresh-pending {
+            root.update-color(root.value);
+            root.original-color = root.value;
+        }
+    }
+
+    changed session-key => {
+        if root.open {
+            root.close-picker();
+        }
     }
 
     changed open => {
         if root.open {
             root.show-picker();
         } else {
+            root.cancel-gesture();
             picker-popup.close();
+        }
+    }
+
+    changed popup-open => {
+        if !root.popup-open && root.open {
+            root.cancel-gesture();
+            root.closed();
         }
     }
 
@@ -110,8 +204,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                 key-pressed(event) => {
                     if event.text == Key.Escape {
                         if root.dragging {
-                            root.dragging = false;
-                            root.update-color(root.original-color);
+                            root.cancel-gesture();
                         } else {
                             root.close-picker();
                         }
@@ -171,7 +264,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             Text { text: "Detach"; width: parent.width; horizontal-alignment: center; vertical-alignment: center; color: InspectorTokens.text; font-size: 11px; }
                             TouchArea {
                                 clicked => {
-                                    if root.detached() { root.is-detached = true; }
+                                    if !Api.inspector-color-refresh-pending && root.detached(root.target-key) { root.is-detached = true; }
                                 }
                             }
                         }
@@ -195,23 +288,17 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             border-color: InspectorTokens.divider;
                         }
                         TouchArea {
-                            moved => {
-                                if self.pressed {
-                                    root.dragging = true;
-                                    root.saturation = (self.mouse-x / self.width).clamp(0, 1);
-                                    root.brightness = (1 - self.mouse-y / self.height).clamp(0, 1);
-                                    root.working-color = root.color-at(self.mouse-x, self.mouse-y);
-                                }
-                            }
-                            changed pressed => {
-                                if self.pressed {
-                                    root.dragging = true;
-                                    root.saturation = (self.mouse-x / self.width).clamp(0, 1);
-                                    root.brightness = (1 - self.mouse-y / self.height).clamp(0, 1);
-                                    root.working-color = root.color-at(self.mouse-x, self.mouse-y);
-                                } else if root.dragging {
-                                    root.commit-color(root.working-color);
-                                    root.dragging = false;
+                            enabled: root.editable;
+                            pointer-event(event) => {
+                                if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
+                                    root.begin-gesture();
+                                    root.update-saturation-brightness(self.mouse-x, self.mouse-y, self.width, self.height);
+                                } else if event.kind == PointerEventKind.move && root.dragging {
+                                    root.update-saturation-brightness(self.mouse-x, self.mouse-y, self.width, self.height);
+                                } else if event.kind == PointerEventKind.up && root.dragging {
+                                    root.finish-gesture();
+                                } else if event.kind == PointerEventKind.cancel {
+                                    root.cancel-gesture();
                                 }
                             }
                         }
@@ -235,20 +322,17 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         clip: true;
                         background: @linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
                         TouchArea {
-                            changed pressed => {
-                                if self.pressed {
-                                    root.dragging = true;
-                                    root.hue = 360 * (self.mouse-x / self.width).clamp(0, 1);
-                                    root.working-color = root.color-at(self.mouse-x, 0px);
-                                } else if root.dragging {
-                                    root.commit-color(root.working-color);
-                                    root.dragging = false;
-                                }
-                            }
-                            moved => {
-                                if self.pressed {
-                                    root.hue = 360 * (self.mouse-x / self.width).clamp(0, 1);
-                                    root.working-color = root.color-at(self.mouse-x, 0px);
+                            enabled: root.editable;
+                            pointer-event(event) => {
+                                if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
+                                    root.begin-gesture();
+                                    root.update-hue(self.mouse-x, self.width);
+                                } else if event.kind == PointerEventKind.move && root.dragging {
+                                    root.update-hue(self.mouse-x, self.width);
+                                } else if event.kind == PointerEventKind.up && root.dragging {
+                                    root.finish-gesture();
+                                } else if event.kind == PointerEventKind.cancel {
+                                    root.cancel-gesture();
                                 }
                             }
                         }
@@ -289,20 +373,17 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             }
                         }
                         TouchArea {
-                            changed pressed => {
-                                if self.pressed {
-                                    root.dragging = true;
-                                    root.alpha = (255 * (self.mouse-x / self.width).clamp(0, 1)).round();
-                                    root.working-color = root.color-at(self.mouse-x, 0px);
-                                } else if root.dragging {
-                                    root.commit-color(root.working-color);
-                                    root.dragging = false;
-                                }
-                            }
-                            moved => {
-                                if self.pressed {
-                                    root.alpha = (255 * (self.mouse-x / self.width).clamp(0, 1)).round();
-                                    root.working-color = root.color-at(self.mouse-x, 0px);
+                            enabled: root.editable;
+                            pointer-event(event) => {
+                                if event.kind == PointerEventKind.down && event.button == PointerEventButton.left {
+                                    root.begin-gesture();
+                                    root.update-alpha(self.mouse-x, self.width);
+                                } else if event.kind == PointerEventKind.move && root.dragging {
+                                    root.update-alpha(self.mouse-x, self.width);
+                                } else if event.kind == PointerEventKind.up && root.dragging {
+                                    root.finish-gesture();
+                                } else if event.kind == PointerEventKind.cancel {
+                                    root.cancel-gesture();
                                 }
                             }
                         }
@@ -312,20 +393,21 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         height: 26px;
                         spacing: 8px;
                         InspectorTextFieldBase {
+                            enabled: root.editable;
                             value: Api.color-to-data(root.working-color).text;
-                            commit-key: Api.color-to-data(root.working-color).text;
+                            commit-key: root.session-key;
                             horizontal-stretch: 1;
                             accepted(text) => { return root.commit-text(text); }
                         }
                         InspectorTextFieldBase {
+                            enabled: root.editable;
                             width: 70px;
                             value: (root.alpha * 100 / 255).to-fixed(0);
-                            commit-key: (root.alpha * 100 / 255).to-fixed(0);
+                            commit-key: root.session-key;
                             accepted(text) => {
-                                if !text.is-float() { return false; }
+                                if !text.is-float() || !root.editable { return false; }
                                 root.alpha = (text.to-float().clamp(0, 100) * 255 / 100).round();
-                                root.update-color(root.color-at(0px, 0px));
-                                return root.commit-color(root.working-color);
+                                return root.commit-color(root.target-key, root.color-at());
                             }
                         }
                     }
@@ -341,7 +423,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             border-width: 1px;
                             border-color: InspectorTokens.divider;
                             background: recent;
-                            TouchArea { clicked => { root.update-color(recent); root.commit-color(recent); } }
+                            TouchArea { clicked => { root.commit-color(root.target-key, recent); } }
                         }
                     }
                 }

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -49,10 +49,14 @@ export component InspectorSolidColorPicker inherits Rectangle {
         return true;
     }
 
+    public function show-picker() {
+        root.update-color(root.value);
+        picker-popup.show();
+    }
+
     changed open => {
         if root.open {
-            root.update-color(root.value);
-            picker-popup.show();
+            root.show-picker();
         } else {
             picker-popup.close();
         }
@@ -127,13 +131,14 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                 }
                             }
                             changed pressed => {
-                                root.dragging = self.pressed;
                                 if self.pressed {
+                                    root.dragging = true;
                                     root.saturation = (self.mouse-x / self.width).clamp(0, 1);
                                     root.brightness = (1 - self.mouse-y / self.height).clamp(0, 1);
                                     root.working-color = root.color-at(self.mouse-x, self.mouse-y);
                                 } else if root.dragging {
                                     root.commit-color(root.working-color);
+                                    root.dragging = false;
                                 }
                             }
                         }
@@ -159,10 +164,12 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         TouchArea {
                             changed pressed => {
                                 if self.pressed {
+                                    root.dragging = true;
                                     root.hue = 360 * (self.mouse-x / self.width).clamp(0, 1);
                                     root.working-color = root.color-at(self.mouse-x, 0px);
                                 } else if root.dragging {
                                     root.commit-color(root.working-color);
+                                    root.dragging = false;
                                 }
                             }
                             moved => {
@@ -192,10 +199,12 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         TouchArea {
                             changed pressed => {
                                 if self.pressed {
+                                    root.dragging = true;
                                     root.alpha = (255 * (self.mouse-x / self.width).clamp(0, 1)).round();
                                     root.working-color = root.color-at(self.mouse-x, 0px);
                                 } else if root.dragging {
                                     root.commit-color(root.working-color);
+                                    root.dragging = false;
                                 }
                             }
                             moved => {
@@ -210,7 +219,6 @@ export component InspectorSolidColorPicker inherits Rectangle {
                     HorizontalLayout {
                         height: 26px;
                         spacing: 8px;
-                        Text { text: "#"; color: InspectorTokens.muted; vertical-alignment: center; }
                         InspectorTextFieldBase {
                             value: Api.color-to-data(root.working-color).text;
                             commit-key: Api.color-to-data(root.working-color).text;

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -86,7 +86,6 @@ export component InspectorSolidColorPicker inherits Rectangle {
         if root.accepted(key, c) {
             root.update-color(c);
             root.original-color = c;
-            Api.add-recent-color(c);
             return true;
         }
         Api.inspector-cancel();

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -17,10 +17,10 @@ export component InspectorSolidColorPicker inherits Rectangle {
     callback closed();
 
     private property <color> working-color: root.value;
-    private property <float> hue: root.working-color.to-hsv().hue;
-    private property <float> saturation: root.working-color.to-hsv().saturation;
-    private property <float> brightness: root.working-color.to-hsv().value;
-    private property <int> alpha: root.working-color.alpha;
+    private property <float> hue: 0;
+    private property <float> saturation: 0;
+    private property <float> brightness: 0;
+    private property <int> alpha: 255;
     private property <bool> dragging: false;
     private property <bool> editing: false;
     private property <bool> is-detached: false;
@@ -31,12 +31,17 @@ export component InspectorSolidColorPicker inherits Rectangle {
     }
 
     function update-color(c: color) {
+        // RGB cannot retain the selected hue at zero saturation or brightness.
+        if c != hsv(root.hue, root.saturation, root.brightness, root.alpha / 255) {
+            root.hue = c.to-hsv().hue;
+            root.saturation = c.to-hsv().saturation;
+            root.brightness = c.to-hsv().value;
+        }
         root.working-color = c;
-        root.hue = c.to-hsv().hue;
-        root.saturation = c.to-hsv().saturation;
-        root.brightness = c.to-hsv().value;
         root.alpha = c.alpha;
     }
+
+    init => { root.update-color(root.value); }
 
     function commit-color(c: color) -> bool {
         if (root.bound && !root.is-detached) || root.unsupported {

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 import { Api } from "../../api.slint";
-import { StudioTheme } from "../common.slint";
+import { StudioTheme, EditorMetrics } from "../common.slint";
 import { InspectorTokens } from "tokens.slint";
 import { InspectorTextFieldBase } from "text-field-base.slint";
 
@@ -18,6 +18,9 @@ export component InspectorSolidColorPicker inherits Rectangle {
     callback preview(string, color) -> bool;
     callback detached(string) -> bool;
     callback closed();
+    callback restore-focus();
+    in property <Point> anchor-position;
+    in property <length> anchor-width;
 
     private property <color> working-color: root.value;
     private property <float> hue: 0;
@@ -149,10 +152,11 @@ export component InspectorSolidColorPicker inherits Rectangle {
         picker-popup.show();
     }
 
-    function close-picker() {
+    function close-picker(return-focus: bool) {
         root.cancel-gesture();
         root.closed();
         picker-popup.close();
+        if return-focus { root.restore-focus(); }
     }
 
     changed value => {
@@ -164,7 +168,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
 
     changed session-key => {
         if root.open {
-            root.close-picker();
+            root.close-picker(false);
         }
     }
 
@@ -185,8 +189,11 @@ export component InspectorSolidColorPicker inherits Rectangle {
     }
 
     picker-popup := PopupWindow {
-        x: -308px;
-        y: root.height + 8px;
+        x: (root.anchor-position.x >= self.width + 16px
+            ? root.anchor-position.x - self.width - 8px
+            : root.anchor-position.x + root.anchor-width + 8px)
+            .clamp(8px, max(8px, EditorMetrics.window-width - self.width - 8px)) - root.absolute-position.x;
+        y: root.anchor-position.y.clamp(8px, max(8px, EditorMetrics.window-height - self.height - 8px)) - root.absolute-position.y;
         width: 300px;
         height: picker-layout.preferred-height;
         close-policy: close-on-click-outside;
@@ -207,7 +214,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         if root.dragging {
                             root.cancel-gesture();
                         } else {
-                            root.close-picker();
+                            root.close-picker(true);
                         }
                         return accept;
                     }
@@ -237,8 +244,8 @@ export component InspectorSolidColorPicker inherits Rectangle {
                                 height: parent.height;
                                 accessible-role: AccessibleRole.button;
                                 accessible-label: "Close color picker";
-                                clicked => { root.close-picker(); }
-                                accessible-action-default => { root.close-picker(); }
+                                clicked => { root.close-picker(true); }
+                                accessible-action-default => { root.close-picker(true); }
                                 Text {
                                     text: "Close";
                                     width: parent.width;

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -8,8 +8,12 @@ import { InspectorTextFieldBase } from "text-field-base.slint";
 
 export component InspectorSolidColorPicker inherits Rectangle {
     in property <color> value;
+    in property <string> expression: "";
+    in property <bool> bound: false;
+    in property <bool> unsupported: false;
     in property <bool> open: false;
     callback accepted(color) -> bool;
+    callback detached() -> bool;
     callback closed();
 
     private property <color> working-color: root.value;
@@ -19,6 +23,8 @@ export component InspectorSolidColorPicker inherits Rectangle {
     private property <int> alpha: (root.working-color.alpha * 255).round();
     private property <bool> dragging: false;
     private property <bool> editing: false;
+    private property <bool> is-detached: false;
+    private property <color> original-color: root.value;
 
     function color-at(x: length, y: length) -> color {
         return hsv(root.hue, root.saturation, root.brightness, root.alpha / 255);
@@ -32,11 +38,17 @@ export component InspectorSolidColorPicker inherits Rectangle {
         root.alpha = (c.alpha * 255).round();
     }
 
-    function commit-color(c: color) {
+    function commit-color(c: color) -> bool {
+        if (root.bound && !root.is-detached) || root.unsupported {
+            return false;
+        }
         if root.accepted(c) {
             root.working-color = c;
             Api.add-recent-color(c);
+            return true;
         }
+        root.update-color(root.original-color);
+        return false;
     }
 
     function commit-text(text: string) -> bool {
@@ -44,14 +56,25 @@ export component InspectorSolidColorPicker inherits Rectangle {
             return false;
         }
         let c = Api.string-to-color(text);
-        root.update-color(c);
-        root.commit-color(c);
-        return true;
+        if (root.bound && !root.is-detached) || root.unsupported {
+            return false;
+        }
+        return root.commit-color(c);
     }
 
     public function show-picker() {
         root.update-color(root.value);
+        root.original-color = root.value;
+        root.is-detached = false;
         picker-popup.show();
+    }
+
+    function close-picker() {
+        if root.dragging {
+            root.dragging = false;
+            root.update-color(root.original-color);
+        }
+        root.closed();
     }
 
     changed open => {
@@ -63,11 +86,12 @@ export component InspectorSolidColorPicker inherits Rectangle {
     }
 
     picker-popup := PopupWindow {
-        x: 0px;
+        x: -308px;
         y: 0px;
         width: 300px;
         height: 408px;
         close-policy: close-on-click-outside;
+        forward-focus: picker-focus;
         Rectangle {
             background: InspectorTokens.panel-bg;
             border-width: 1px;
@@ -77,7 +101,19 @@ export component InspectorSolidColorPicker inherits Rectangle {
             drop-shadow-blur: 18px;
             drop-shadow-offset-y: 7px;
 
-            FocusScope {
+            picker-focus := FocusScope {
+                key-pressed(event) => {
+                    if event.text == Key.Escape {
+                        if root.dragging {
+                            root.dragging = false;
+                            root.update-color(root.original-color);
+                        } else {
+                            root.close-picker();
+                        }
+                        return accept;
+                    }
+                    return reject;
+                }
                 VerticalLayout {
                     padding: 12px;
                     spacing: 9px;
@@ -92,19 +128,51 @@ export component InspectorSolidColorPicker inherits Rectangle {
                             vertical-alignment: center;
                         }
                         Rectangle { horizontal-stretch: 1; }
-                        Text {
-                            text: "Close";
-                            color: InspectorTokens.muted;
-                            font-size: 11px;
-                            vertical-alignment: center;
-                        }
-                        TouchArea {
+                        Rectangle {
                             width: 42px;
-                            clicked => { root.closed(); }
+                            height: 22px;
+                            accessible-role: AccessibleRole.button;
+                            accessible-label: "Close color picker";
+                            Text {
+                                text: "Close";
+                                width: parent.width;
+                                color: InspectorTokens.muted;
+                                font-size: 11px;
+                                vertical-alignment: center;
+                                horizontal-alignment: right;
+                            }
+                            TouchArea {
+                                clicked => { root.close-picker(); }
+                            }
                         }
                     }
 
-                    Rectangle {
+                    if root.unsupported: VerticalLayout {
+                        spacing: 5px;
+                        Text { text: root.expression; color: InspectorTokens.text; font-size: 12px; overflow: elide; }
+                        Text { text: "This picker edits solid colors only."; color: InspectorTokens.muted; font-size: 11px; }
+                    }
+
+                    if root.bound && !root.unsupported: HorizontalLayout {
+                        height: 26px;
+                        Text { text: root.expression; color: InspectorTokens.muted; font-size: 11px; horizontal-stretch: 1; vertical-alignment: center; overflow: elide; }
+                        Rectangle {
+                            width: 58px;
+                            height: 24px;
+                            background: InspectorTokens.field-bg;
+                            border-radius: InspectorTokens.field-radius;
+                            accessible-role: AccessibleRole.button;
+                            accessible-label: "Detach color binding";
+                            Text { text: "Detach"; width: parent.width; horizontal-alignment: center; vertical-alignment: center; color: InspectorTokens.text; font-size: 11px; }
+                            TouchArea {
+                                clicked => {
+                                    if root.detached() { root.is-detached = true; }
+                                }
+                            }
+                        }
+                    }
+
+                    if !root.unsupported: Rectangle {
                         height: 170px;
                         border-radius: 5px;
                         clip: true;
@@ -156,7 +224,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         }
                     }
 
-                    Rectangle {
+                    if !root.unsupported: Rectangle {
                         height: 16px;
                         border-radius: 8px;
                         clip: true;
@@ -191,11 +259,30 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         }
                     }
 
-                    Rectangle {
+                    if !root.unsupported: Rectangle {
                         height: 16px;
                         border-radius: 8px;
                         clip: true;
-                        background: @linear-gradient(90deg, transparent, root.working-color);
+                        background: @linear-gradient(90deg, transparent, hsv(root.hue, root.saturation, root.brightness, 1));
+                        Rectangle {
+                            width: 100%;
+                            height: 100%;
+                            background: #d7d7d7;
+                            for row in 4: Rectangle {
+                                x: 4px;
+                                y: row * 4px;
+                                width: 4px;
+                                height: 4px;
+                                background: #ffffff;
+                            }
+                            for col in 75: Rectangle {
+                                x: col * 8px;
+                                y: 0px;
+                                width: 4px;
+                                height: 4px;
+                                background: #ffffff;
+                            }
+                        }
                         TouchArea {
                             changed pressed => {
                                 if self.pressed {
@@ -216,7 +303,7 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         }
                     }
 
-                    HorizontalLayout {
+                    if !root.unsupported: HorizontalLayout {
                         height: 26px;
                         spacing: 8px;
                         InspectorTextFieldBase {
@@ -227,20 +314,19 @@ export component InspectorSolidColorPicker inherits Rectangle {
                         }
                         InspectorTextFieldBase {
                             width: 70px;
-                            value: root.alpha.to-fixed(0);
-                            commit-key: root.alpha.to-fixed(0);
+                            value: (root.alpha * 100 / 255).to-fixed(0);
+                            commit-key: (root.alpha * 100 / 255).to-fixed(0);
                             accepted(text) => {
                                 if !text.is-float() { return false; }
-                                root.alpha = text.to-float().clamp(0, 255).round();
+                                root.alpha = (text.to-float().clamp(0, 100) * 255 / 100).round();
                                 root.update-color(root.color-at(0px, 0px));
-                                root.commit-color(root.working-color);
-                                return true;
+                                return root.commit-color(root.working-color);
                             }
                         }
                     }
 
-                    Text { text: "Recent colors"; color: InspectorTokens.muted; font-size: 11px; font-weight: 600; }
-                    HorizontalLayout {
+                    if !root.unsupported: Text { text: "Recent colors"; color: InspectorTokens.muted; font-size: 11px; font-weight: 600; }
+                    if !root.unsupported: HorizontalLayout {
                         height: 26px;
                         spacing: 6px;
                         for recent in Api.recent-colors: Rectangle {

--- a/tools/editor/ui/components/inspector/solid-color-picker.slint
+++ b/tools/editor/ui/components/inspector/solid-color-picker.slint
@@ -1,0 +1,250 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+import { Api } from "../../api.slint";
+import { StudioTheme } from "../common.slint";
+import { InspectorTokens } from "tokens.slint";
+import { InspectorTextFieldBase } from "text-field-base.slint";
+
+export component InspectorSolidColorPicker inherits Rectangle {
+    in property <color> value;
+    in property <bool> open: false;
+    callback accepted(color) -> bool;
+    callback closed();
+
+    private property <color> working-color: root.value;
+    private property <float> hue: root.working-color.to-hsv().hue;
+    private property <float> saturation: root.working-color.to-hsv().saturation;
+    private property <float> brightness: root.working-color.to-hsv().value;
+    private property <int> alpha: (root.working-color.alpha * 255).round();
+    private property <bool> dragging: false;
+    private property <bool> editing: false;
+
+    function color-at(x: length, y: length) -> color {
+        return hsv(root.hue, root.saturation, root.brightness, root.alpha / 255);
+    }
+
+    function update-color(c: color) {
+        root.working-color = c;
+        root.hue = c.to-hsv().hue;
+        root.saturation = c.to-hsv().saturation;
+        root.brightness = c.to-hsv().value;
+        root.alpha = (c.alpha * 255).round();
+    }
+
+    function commit-color(c: color) {
+        if root.accepted(c) {
+            root.working-color = c;
+            Api.add-recent-color(c);
+        }
+    }
+
+    function commit-text(text: string) -> bool {
+        if !Api.string-is-color(text) {
+            return false;
+        }
+        let c = Api.string-to-color(text);
+        root.update-color(c);
+        root.commit-color(c);
+        return true;
+    }
+
+    changed open => {
+        if root.open {
+            root.update-color(root.value);
+        }
+    }
+
+    PopupWindow {
+        x: 0px;
+        y: 0px;
+        width: 300px;
+        height: 408px;
+        close-policy: close-on-click-outside;
+        visible: root.open;
+        Rectangle {
+            background: InspectorTokens.panel-bg;
+            border-width: 1px;
+            border-color: InspectorTokens.divider;
+            border-radius: 8px;
+            drop-shadow-color: StudioTheme.dark ? #00000080 : #64748b35;
+            drop-shadow-blur: 18px;
+            drop-shadow-offset-y: 7px;
+
+            FocusScope {
+                VerticalLayout {
+                    padding: 12px;
+                    spacing: 9px;
+
+                    HorizontalLayout {
+                        height: 22px;
+                        Text {
+                            text: "Custom";
+                            color: InspectorTokens.text;
+                            font-size: 13px;
+                            font-weight: 700;
+                            vertical-alignment: center;
+                        }
+                        Rectangle { horizontal-stretch: 1; }
+                        Text {
+                            text: "Close";
+                            color: InspectorTokens.muted;
+                            font-size: 11px;
+                            vertical-alignment: center;
+                        }
+                        TouchArea {
+                            width: 42px;
+                            clicked => { root.closed(); }
+                        }
+                    }
+
+                    Rectangle {
+                        height: 170px;
+                        border-radius: 5px;
+                        clip: true;
+                        background: hsv(root.hue, 1, 1);
+
+                        Rectangle {
+                            background: @linear-gradient(90deg, white 0%, transparent 100%);
+                        }
+                        Rectangle {
+                            background: @linear-gradient(0deg, black 0%, transparent 100%);
+                        }
+                        Rectangle {
+                            border-radius: 5px;
+                            border-width: 1px;
+                            border-color: InspectorTokens.divider;
+                        }
+                        TouchArea {
+                            moved => {
+                                if self.pressed {
+                                    root.dragging = true;
+                                    root.saturation = (self.mouse-x / self.width).clamp(0, 1);
+                                    root.brightness = (1 - self.mouse-y / self.height).clamp(0, 1);
+                                    root.working-color = root.color-at(self.mouse-x, self.mouse-y);
+                                }
+                            }
+                            changed pressed => {
+                                root.dragging = self.pressed;
+                                if self.pressed {
+                                    root.saturation = (self.mouse-x / self.width).clamp(0, 1);
+                                    root.brightness = (1 - self.mouse-y / self.height).clamp(0, 1);
+                                    root.working-color = root.color-at(self.mouse-x, self.mouse-y);
+                                } else if root.dragging {
+                                    root.commit-color(root.working-color);
+                                }
+                            }
+                        }
+                        Rectangle {
+                            x: root.saturation * (parent.width - 12px) - 6px;
+                            y: (1 - root.brightness) * (parent.height - 12px) - 6px;
+                            width: 12px;
+                            height: 12px;
+                            border-radius: 6px;
+                            border-width: 2px;
+                            border-color: white;
+                            background: transparent;
+                            drop-shadow-color: #00000080;
+                            drop-shadow-blur: 3px;
+                        }
+                    }
+
+                    Rectangle {
+                        height: 16px;
+                        border-radius: 8px;
+                        clip: true;
+                        background: @linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
+                        TouchArea {
+                            changed pressed => {
+                                if self.pressed {
+                                    root.hue = 360 * (self.mouse-x / self.width).clamp(0, 1);
+                                    root.working-color = root.color-at(self.mouse-x, 0px);
+                                } else if root.dragging {
+                                    root.commit-color(root.working-color);
+                                }
+                            }
+                            moved => {
+                                if self.pressed {
+                                    root.hue = 360 * (self.mouse-x / self.width).clamp(0, 1);
+                                    root.working-color = root.color-at(self.mouse-x, 0px);
+                                }
+                            }
+                        }
+                        Rectangle {
+                            x: root.hue / 360 * (parent.width - 12px);
+                            y: 1px;
+                            width: 14px;
+                            height: 14px;
+                            border-radius: 7px;
+                            border-width: 2px;
+                            border-color: white;
+                            background: transparent;
+                        }
+                    }
+
+                    Rectangle {
+                        height: 16px;
+                        border-radius: 8px;
+                        clip: true;
+                        background: @linear-gradient(90deg, transparent, root.working-color);
+                        TouchArea {
+                            changed pressed => {
+                                if self.pressed {
+                                    root.alpha = (255 * (self.mouse-x / self.width).clamp(0, 1)).round();
+                                    root.working-color = root.color-at(self.mouse-x, 0px);
+                                } else if root.dragging {
+                                    root.commit-color(root.working-color);
+                                }
+                            }
+                            moved => {
+                                if self.pressed {
+                                    root.alpha = (255 * (self.mouse-x / self.width).clamp(0, 1)).round();
+                                    root.working-color = root.color-at(self.mouse-x, 0px);
+                                }
+                            }
+                        }
+                    }
+
+                    HorizontalLayout {
+                        height: 26px;
+                        spacing: 8px;
+                        Text { text: "#"; color: InspectorTokens.muted; vertical-alignment: center; }
+                        InspectorTextFieldBase {
+                            value: Api.color-to-data(root.working-color).text;
+                            commit-key: Api.color-to-data(root.working-color).text;
+                            horizontal-stretch: 1;
+                            accepted(text) => { return root.commit-text(text); }
+                        }
+                        InspectorTextFieldBase {
+                            width: 70px;
+                            value: root.alpha.to-fixed(0);
+                            commit-key: root.alpha.to-fixed(0);
+                            accepted(text) => {
+                                if !text.is-float() { return false; }
+                                root.alpha = text.to-float().clamp(0, 255).round();
+                                root.update-color(root.color-at(0px, 0px));
+                                root.commit-color(root.working-color);
+                                return true;
+                            }
+                        }
+                    }
+
+                    Text { text: "Recent colors"; color: InspectorTokens.muted; font-size: 11px; font-weight: 600; }
+                    HorizontalLayout {
+                        height: 26px;
+                        spacing: 6px;
+                        for recent in Api.recent-colors: Rectangle {
+                            width: 22px;
+                            height: 22px;
+                            border-radius: 3px;
+                            border-width: 1px;
+                            border-color: InspectorTokens.divider;
+                            background: recent;
+                            TouchArea { clicked => { root.update-color(recent); root.commit-color(recent); } }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/editor/ui/components/inspector/text-field-base.slint
+++ b/tools/editor/ui/components/inspector/text-field-base.slint
@@ -7,6 +7,7 @@ export component InspectorTextFieldBase inherits Rectangle {
     in property <string> accessible-name: "";
     in property <string> value;
     in property <bool> enabled: true;
+    in property <bool> live-edit: false;
     in property <length> field-padding-left: 8px;
     in property <length> field-padding-right: 7px;
     in property <length> content-spacing: 5px;
@@ -83,7 +84,10 @@ export component InspectorTextFieldBase inherits Rectangle {
                 selection-background-color: InspectorTokens.accent.with-alpha(0.28);
                 text-cursor-width: 1px;
 
-                edited => { root.edited = true; }
+                edited => {
+                    root.edited = true;
+                    if root.live-edit { root.accept-input(self.text); }
+                }
 
                 accepted => {
                     if !root.accept-input(self.text) {

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -58,7 +58,6 @@ export component EditorUi inherits Window {
         Api.inspector-cancel();
         Api.inspector-generation += 1;
         Api.inspector-color-generation += 1;
-        Api.inspector-color-dismissed();
         if redo {
             if Api.redo-enabled { Api.redo(); }
         } else {

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -50,6 +50,8 @@ export component EditorUi inherits Window {
     function apply-history(redo: bool) {
         Api.inspector-cancel();
         Api.inspector-generation += 1;
+        Api.inspector-color-generation += 1;
+        Api.inspector-color-dismissed();
         if redo {
             if Api.redo-enabled { Api.redo(); }
         } else {

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -173,8 +173,6 @@ export component EditorUi inherits Window {
 
                         if Api.editor-surface-mode == EditorSurfaceMode.component && !root.sidebars-collapsed: InspectorPane {
                             outline-pane-height: root.outline-pane-height;
-                            phone-background: StudioTheme.phone-bg;
-                            phone-background-label: StudioTheme.dark ? "#f7f8fb" : "#ffffff";
                             element-information: Api.current-element;
                             inspector-scroll-y <=> root.inspector-scroll-y;
                             element-selected => { editor.focus(); }

--- a/tools/editor/ui/main.slint
+++ b/tools/editor/ui/main.slint
@@ -27,6 +27,13 @@ export component EditorUi inherits Window {
     background: StudioTheme.app-bg;
     default-font-family: "Inter";
 
+    init => {
+        EditorMetrics.window-width = root.width;
+        EditorMetrics.window-height = root.height;
+    }
+    changed width => { EditorMetrics.window-width = root.width; }
+    changed height => { EditorMetrics.window-height = root.height; }
+
     property <bool> sidebars-collapsed: false;
     property <length> inspector-scroll-y: 0px;
     in property <length> elements-pane-height: 0px;


### PR DESCRIPTION
<img width="474" height="454" alt="Screenshot 2026-09-10 at 11 00 52" src="https://github.com/user-attachments/assets/4506509b-cb38-452c-a97a-9e9e72451f9d" />

This is a redesign of the live-preview colour picker.
- Intentionally has no real tests yet. They will come in a later PR.
- Only solid colours. Gradients come in a follow up PR.
- Cannot be dragged. That will also come in a later PR.
- Duplicates some Slint UI code from the live-prevew for the sake of simplicity and ease of redesign.