### PR TITLE
Servo: fix compilation after dependency crate incompatible update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -845,9 +845,6 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v7
-            - name: Downgrade cc and ring crate to work around https://github.com/slint-ui/slint/issues/6875
-              run: |
-                  cargo update -p ring --precise 0.17.9
             - name: Fetch Yocto SDK
               run: |
                   # Fetch pre-built SDK built via populate_sdk for core-image-weston with setup from https://github.com/slint-ui/meta-slint/blob/main/.github/workflows/ci.yml

--- a/examples/servo/Cargo.toml
+++ b/examples/servo/Cargo.toml
@@ -49,6 +49,10 @@ thiserror = "2.0.17"
 surfman = { version = "0.13.0", features = ["chains"] }
 servo = "0.5.0"
 
+# Internal to servo 0.5, which doesn't build with the incompatible 0.8.3.
+# https://github.com/rust-ammonia/rust-content-security-policy/issues/81
+content-security-policy = "=0.8.2"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 surfman = { version = "0.13.0", features = ["chains", "sm-angle-default"] }
 servo = { version = "0.5.0", features = ["no-wgl"] }


### PR DESCRIPTION
Pin previous version of the crate.


Also take the opportunity to remove an old pin that should be fixed by now.
