### PR TITLE
docs: say how a layout test case forces the solve

### DIFF
--- a/docs/development/layout-system.md
+++ b/docs/development/layout-system.md
@@ -405,3 +405,32 @@ cargo test --manifest-path tests/Cargo.toml -p test-driver-interpreter
 # Visual verification (for humans)
 cargo run --manifest-path examples/Cargo.toml -p gallery
 ```
+
+### Writing a layout test case
+
+Creating the component already computes layout *info*: the constraints of every element are pulled, even with no `test` property at all.
+What it does not do is *solve*, so no child is positioned or sized.
+A `test` that reads neither result exercises only half of the layout, and a case that panics once the solve runs still passes.
+
+Read what the half you are testing produces:
+
+```slint,ignore
+// Info: the intrinsic size the element reports.
+out property <bool> test: fl.preferred-height >= 0px;
+
+// Solve: a size the enclosing layout hands out.
+out property <bool> test: txt.width >= 0px;
+```
+
+The read has to reach a binding.
+`fl.width` on an element declared `width: 120px` is a constant and forces nothing, so the case passes however broken the layout is.
+
+An id inside a `for` is not in scope outside the loop.
+Give the enclosing layout an id and read its geometry instead.
+
+A `>= 0px` read forces the computation and checks nothing else.
+Assert the value you expect once the read reaches it.
+Where the value is not known, prefer `>= 0px` over `> 0px` for a nested layout.
+With no children it is 0 wide, and `> 0px` then fails for a reason that has nothing to do with what the test checks.
+
+See [testing.md](../testing.md#driver-tests) for the `test` property and the per-driver blocks.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,6 +48,10 @@ All the .slint files in the sub directories will be tested by the drivers with t
 language frontends.
 
 The `.slint` code contains a comment with some block of code which is extracted by the relevant driver.
+Only the interpreter driver evaluates the `test` property by itself.
+The rust, C++ and Node drivers run the `rust`, `cpp` or `js` block in that comment.
+A case without the block still compiles on those drivers, asserts nothing, and the suite reports success.
+Copy the block from a neighboring case.
 
 `tests/run_tests.sh <rust|cpp|interpreter|python|nodejs> [<filter>]` is the convenient entry
 point for all five drivers below and passes `--manifest-path tests/Cargo.toml` for you; the
@@ -77,6 +81,8 @@ export component Foo inherits Rectangle {
    in-out property <bool> test: 1 + 1 == 2;
 }
 ```
+
+For a layout case, see [Writing a layout test case](development/layout-system.md#writing-a-layout-test-case).
 
 ### Rust driver
 


### PR DESCRIPTION
Creating the component computes layout info but does not solve, so a `test`
that reads neither result exercises half of the layout: a case that panics
once the solve runs still passes.

Say which read forces which half, and that reading a size the element sets
explicitly forces nothing.