### PR TITLE
docs: simplify visual editor agent instructions

### DIFF
--- a/tools/editor/ui/AGENTS.md
+++ b/tools/editor/ui/AGENTS.md
@@ -1,116 +1,37 @@
 # Visual Editor Agent Notes
 
-This directory contains the `.slint` sources for the visual editor UI.
+## Runtime
 
-## Default Runtime
-
-Use the real `slint-editor` app. Do not use `slint-viewer` for visual-editor
-work, because it bypasses the embedded editor/LSP plumbing.
-
-Run the app with Skia against the simple local fixture:
+Use the real `slint-editor` with winit and Skia to exercise the embedded editor/LSP plumbing.
+Do not substitute `slint-viewer`, a headless run, or the software renderer.
+From the repository root:
 
 ```sh
 SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 \
 SLINT_BACKEND=winit-skia \
-cargo run -p slint-editor \
-  -- tools/editor/ui/visual-editor/example/simple_preview.slint
+cargo run -p slint-editor -- examples/7guis/counter.slint
 ```
 
-Important:
+When launching, use `cargo run`; a preceding `cargo build` is unnecessary.
+Confirm that the editor window is visible; a running process alone is insufficient.
+Use MCP only when the user requests it.
+Do not modify core or backend code to enable MCP for editor UI work.
 
-- Run GUI launches outside the sandbox when needed so the macOS window is
-  actually visible.
-- Use Skia. Do not silently switch to the software renderer. If Skia needs a
-  first-time `skia-bindings` download, ask for network approval and keep using
-  Skia.
-- The backend and renderer are fixed to winit and Skia in
-  `tools/editor/Cargo.toml`, so no `--features` flags are needed.
-- `SLINT_ENABLE_EXPERIMENTAL_FEATURES=1` is required because the visual editor
-  uses internal/experimental types such as `component-factory`.
-- Use `tools/editor/ui/visual-editor/example/simple_preview.slint` when it exists.
-  In checkouts that do not have that fixture, use
-  `tools/editor/ui/visual-editor/example/Main.slint`.
+## macOS Development App
 
-## MCP
+For GUI control, reuse one development `.app` at a stable path with a stable `CFBundleIdentifier`.
+Update its executable from the current build instead of creating a new app identity for each PR or verification run.
+Keep this development app separate from the installed release app.
+Stable identity avoids presenting each build as a different app to computer-control permission systems.
 
-MCP is not the default launch path for this app. Do not change core/backend Rust
-code just to make MCP reachable while launching the visual editor.
+## Reloading
 
-Only use MCP if the user explicitly asks for it. Then launch with:
+The editor reloads changes to the opened document automatically.
+The editor shell under `tools/editor/ui/` is compiled into the executable and needs rebuilding unless Slint live preview is enabled.
 
-```sh
-SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 \
-SLINT_EMIT_DEBUG_INFO=1 \
-SLINT_MCP_PORT=9315 \
-SLINT_BACKEND=winit-skia \
-cargo run -p slint-editor \
-  --features slint/mcp \
-  -- tools/editor/ui/visual-editor/example/simple_preview.slint
-```
+## Pointer And Keyboard Handling
 
-If `http://127.0.0.1:9315/mcp` is not reachable, report that MCP is unavailable
-for the current run. When reporting MCP endpoints in chat, keep them in inline
-code or code blocks; do not emit bare local HTTP URLs, because some assistant
-hosts render those as web previews even though MCP is a JSON-RPC endpoint, not
-a browser UI. Do not switch to headless mode; this app is expected to run as a
-visible GUI.
-
-
-### Visual Editor UI Workflow
-
-For `.slint`-only changes under `tools/editor/ui/visual-editor`, NEVER run a separate `cargo build` unless Rust files changed or the user explicitly asks for a build.
-If the user asks to try the app, run the editor directly with `cargo run`; the incremental build from `cargo run` is enough.
-
-## Hot Reloading The Editor UI
-
-The editor automatically watches and reloads the opened target document
-(`tools/editor/ui/visual-editor/example/simple_preview.slint`). That is separate from the
-editor shell UI under `tools/editor/ui/`, which is compiled into the app via
-`slint::include_modules!()`.
-
-To hot-reload the editor shell UI, use Slint live preview. Compile this run in
-release mode so UI interaction stays responsive:
-
-```sh
-SLINT_ENABLE_EXPERIMENTAL_FEATURES=1 \
-SLINT_LIVE_PREVIEW=1 \
-SLINT_BACKEND=winit-skia \
-cargo run --release -p slint-editor \
-  --features slint/live-preview \
-  -- tools/editor/ui/visual-editor/example/Main.slint
-```
-
-With this live-preview run active, changes to `.slint` files under
-`tools/editor/ui/` should hot reload. Do not recompile Rust for `.slint`-only
-changes; recompile only after Rust, Cargo feature, build-script, or generated
-API changes. If live preview crashes with `accessing deleted parent` (issue
-#6426), report it and fall back to the default runtime above. Do not silently
-switch renderer or app entry point.
-
-## Architecture
-
-- Entry point: `tools/editor/main.rs` starts embedded LSP state, then creates
-  the `EditorUi` window with `preview::ui::create_ui(...)`.
-- UI creation: `tools/editor/preview/ui.rs` creates `EditorUi`, wires the editor
-  `Api` global, and registers callbacks.
-- Live preview surface: `EditorCanvas` embeds the compiled target component via
-  `ComponentContainer { component-factory: Api.preview-area; }`.
-- Component drag/drop should use real editor callbacks:
-  `Api.new-component-data`, `Api.can-drop`, and `Api.drop`.
-- Resize/move should follow the existing preview-view path:
-  `Api.selected-element-resize`, `Api.selected-element-can-move-to`, and
-  `Api.selected-element-move`.
-
-## Move, Resize, Rotate, And Key Handling
-
-- For screen-space interactions, compare parent/window-space pointer positions,
-  not raw local deltas.
-- Do not use `self.mouse-x - press-x` from a `TouchArea` inside a rotated
-  wrapper for move or resize.
-- For rotated resize, reconstruct the parent/window-space pointer position from
-  the rotated handle-local point, then convert that delta into local item axes
-  using the press-time rotation.
-- Commit final bounds through `Api.selected-element-resize` so the preview backend writes the source.
-- If a pointer interaction depends on keyboard state, focus the editor
-  `FocusScope` when the interaction starts. Use `Key.Shift` and `Key.ShiftR` in
-  `capture-key-pressed` / `capture-key-released` for live Shift state.
+- Compare pointer positions in parent or window coordinates for move and resize interactions.
+  For rotated resize, transform the handle-local pointer into that space, then convert its delta into item axes using the press-time rotation.
+- Focus the editor `FocusScope` when an interaction depends on keyboard state.
+  Track both `Key.Shift` and `Key.ShiftR` in `capture-key-pressed` and `capture-key-released` for live Shift state.


### PR DESCRIPTION
The Visual Editor UI instructions referenced deleted examples and obsolete callbacks, and repeated launch and troubleshooting guidance. Reduce them to the runtime, reload, and interaction constraints that remain useful.

Require one reusable macOS development `.app` with a stable path and `CFBundleIdentifier`, updated from each build, instead of a new app identity for each PR.

Validation: `git diff --check` passed and the replacement example path exists. Documentation only; no build or tests run. The instructions shrink from 116 to 37 lines.
