### PR TITLE
Publish the Android viewer on F-Droid: one APK per ABI, and a build recipe F-Droid can verify

### DIFF
--- a/.cspell/slint-project-words.txt
+++ b/.cspell/slint-project-words.txt
@@ -211,6 +211,8 @@ fabstyle
 Farbfeld
 Fcntl
 fdiagnostics
+fdroid
+fdroiddata
 FEFF
 FELGO
 fetchpriority
@@ -701,6 +703,7 @@ vecmodel
 vello
 veniam
 venv
+VercodeOperation
 verticalbox
 verticallayout
 VGWGPU

--- a/.github/workflows/android_reproducible.yaml
+++ b/.github/workflows/android_reproducible.yaml
@@ -4,10 +4,10 @@
 # cSpell: ignore sdkmanager diffoscope
 
 # The Android viewer build has to be reproducible so F-Droid can verify its
-# own rebuild against our signed APK. Build the arm64 APK twice, from
-# checkouts at different paths and depths, and require identical bytes.
-# Two Skia builds from source make this slow, so it runs with the full CI
-# only, not on pull requests.
+# own rebuild against our signed APK. Build the arm64 APK, build it again
+# with the F-Droid recipe inside the F-Droid build server image, and require
+# identical bytes. Two Skia builds from source make this slow, so it runs
+# with the full CI only, not on pull requests.
 name: Android reproducible build
 
 on:
@@ -16,46 +16,84 @@ on:
 
 jobs:
     build:
-        strategy:
-            matrix:
-                # The second checkout sits at another path and depth.
-                checkout: [., a/deeper/checkout/directory]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v7
             - uses: ./.github/actions/setup-android-viewer-build
-            - name: Clone into the build directory
-              if: matrix.checkout != '.'
-              run: git clone . ${{ matrix.checkout }}
             - name: Build the native library
               run: tools/viewer/android/build-native.sh arm64-v8a
-              working-directory: ${{ matrix.checkout }}
             - name: Build the APK
               run: gradle --no-daemon assembleRelease -Pslint.abi=arm64-v8a
-              working-directory: ${{ matrix.checkout }}/tools/viewer/android
+              working-directory: tools/viewer/android
             - uses: actions/upload-artifact@v7
               with:
-                  name: apk-${{ strategy.job-index }}
-                  path: ${{ matrix.checkout }}/tools/viewer/android/app/build/outputs/apk/release/app-*-release-unsigned.apk
+                  name: apk
+                  path: tools/viewer/android/app/build/outputs/apk/release/app-*-release-unsigned.apk
+
+    fdroid:
+        runs-on: ubuntu-latest
+        container:
+            image: registry.gitlab.com/fdroid/fdroidserver:buildserver-trixie
+        steps:
+            - uses: actions/checkout@v7
+            # Mirrors the `fdroid build` job of fdroiddata's .gitlab-ci.yml:
+            # fdroidserver from master, run as the vagrant user with sudo,
+            # JDK 21 as the default java. The recipe is this checkout's, pointed
+            # at this commit and without the release assets to compare against;
+            # the source is this checkout too, cloned where `fdroid build`
+            # expects it. Only the arm64 entry, the recipe's last, is built.
+            - name: fdroid build
+              # The image's default shell is sh.
+              shell: bash
+              run: |
+                  source /etc/profile.d/bsenv.sh
+                  apt-get update
+                  apt-get install -y sudo openjdk-21-jdk-headless
+                  update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java
+                  sdkmanager "platform-tools" "build-tools;31.0.0"
+                  mkdir -p $fdroidserver
+                  curl --silent https://gitlab.com/fdroid/fdroidserver/-/archive/master/fdroidserver-master.tar.gz \
+                      | tar -xz --directory=$fdroidserver --strip-components=1
+                  git -C $home_vagrant/gradlew-fdroid pull
+                  mkdir -p $home_vagrant/{logs,tmp,unsigned,build,metadata,.android,.gradle}
+                  git config --global --add safe.directory '*'
+                  sed -e "s|^    commit: .*|    commit: $(git rev-parse HEAD)|" -e '/^    binary: /d' \
+                      tools/viewer/android/fdroid/dev.slint.viewer.yml > $home_vagrant/metadata/dev.slint.viewer.yml
+                  git clone . $home_vagrant/build/dev.slint.viewer
+                  git -C $home_vagrant/build/dev.slint.viewer remote set-url origin https://github.com/slint-ui/slint.git
+                  chown -R vagrant $home_vagrant/{logs,tmp,unsigned,build,metadata,.android,.gradle}
+                  cd $home_vagrant
+                  sudo --preserve-env --user vagrant \
+                      env PATH=$fdroidserver:$PATH PYTHONPATH=$fdroidserver:$fdroidserver/examples \
+                      PYTHONUNBUFFERED=true HOME=$home_vagrant GRADLE_USER_HOME=$home_vagrant/.gradle \
+                      fdroid build --verbose --test --on-server --no-tarball \
+                      dev.slint.viewer:$(sed -n 's/^    versionCode: //p' tools/viewer/android/fdroid/dev.slint.viewer.yml | tail -1)
+            - uses: actions/upload-artifact@v7
+              with:
+                  name: apk-fdroid
+                  path: /home/vagrant/tmp/dev.slint.viewer_*.apk
+            - uses: actions/upload-artifact@v7
+              if: failure()
+              with:
+                  name: fdroid-build-logs
+                  path: /home/vagrant/logs/
 
     compare:
-        needs: build
+        needs: [build, fdroid]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/download-artifact@v8
               with:
-                  name: apk-0
-                  path: first
+                  name: apk
+                  path: ours
             - uses: actions/download-artifact@v8
               with:
-                  name: apk-1
-                  path: second
-            - name: Compare the two APKs
+                  name: apk-fdroid
+                  path: fdroid
+            - name: Compare the APKs
               run: |
-                  if cmp first/app-*-release-unsigned.apk second/app-*-release-unsigned.apk; then
-                      echo "The two builds are byte-identical."
-                  else
-                      sudo apt-get install -y diffoscope-minimal
-                      diffoscope --text - --max-text-report-size 200000 first/app-*-release-unsigned.apk second/app-*-release-unsigned.apk || true
-                      exit 1
-                  fi
+                  ours=(ours/*.apk); theirs=(fdroid/*.apk)
+                  cmp "$ours" "$theirs" && exit 0
+                  sudo apt-get install -y diffoscope-minimal
+                  diffoscope --text - --max-text-report-size 200000 "$ours" "$theirs" || true
+                  exit 1

--- a/.github/workflows/android_reproducible.yaml
+++ b/.github/workflows/android_reproducible.yaml
@@ -62,12 +62,12 @@ jobs:
                   git clone . $home_vagrant/build/dev.slint.viewer
                   git -C $home_vagrant/build/dev.slint.viewer remote set-url origin https://github.com/slint-ui/slint.git
                   chown -R vagrant $home_vagrant/{logs,tmp,unsigned,build,metadata,.android,.gradle}
+                  code=$(sed -n 's/^    versionCode: //p' tools/viewer/android/fdroid/dev.slint.viewer.yml | tail -1)
                   cd $home_vagrant
                   sudo --preserve-env --user vagrant \
                       env PATH=$fdroidserver:$PATH PYTHONPATH=$fdroidserver:$fdroidserver/examples \
                       PYTHONUNBUFFERED=true HOME=$home_vagrant GRADLE_USER_HOME=$home_vagrant/.gradle \
-                      fdroid build --verbose --test --on-server --no-tarball \
-                      dev.slint.viewer:$(sed -n 's/^    versionCode: //p' tools/viewer/android/fdroid/dev.slint.viewer.yml | tail -1)
+                      fdroid build --verbose --test --on-server --no-tarball dev.slint.viewer:$code
             - uses: actions/upload-artifact@v7
               with:
                   name: apk-fdroid

--- a/.github/workflows/android_reproducible.yaml
+++ b/.github/workflows/android_reproducible.yaml
@@ -31,12 +31,12 @@ jobs:
               run: tools/viewer/android/build-native.sh arm64-v8a
               working-directory: ${{ matrix.checkout }}
             - name: Build the APK
-              run: gradle --no-daemon assembleRelease
+              run: gradle --no-daemon assembleRelease -Pslint.abi=arm64-v8a
               working-directory: ${{ matrix.checkout }}/tools/viewer/android
             - uses: actions/upload-artifact@v7
               with:
                   name: apk-${{ strategy.job-index }}
-                  path: ${{ matrix.checkout }}/tools/viewer/android/app/build/outputs/apk/release/app-release-unsigned.apk
+                  path: ${{ matrix.checkout }}/tools/viewer/android/app/build/outputs/apk/release/app-*-release-unsigned.apk
 
     compare:
         needs: build
@@ -52,10 +52,10 @@ jobs:
                   path: second
             - name: Compare the two APKs
               run: |
-                  if cmp first/app-release-unsigned.apk second/app-release-unsigned.apk; then
+                  if cmp first/app-*-release-unsigned.apk second/app-*-release-unsigned.apk; then
                       echo "The two builds are byte-identical."
                   else
                       sudo apt-get install -y diffoscope-minimal
-                      diffoscope --text - --max-text-report-size 200000 first/app-release-unsigned.apk second/app-release-unsigned.apk || true
+                      diffoscope --text - --max-text-report-size 200000 first/app-*-release-unsigned.apk second/app-*-release-unsigned.apk || true
                       exit 1
                   fi

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -479,8 +479,8 @@ jobs:
 
                 mkdir -p $output_path/demos/android
                 cp -a ../android/* $output_path/demos/android/
-                # slint-viewer APK/AAB are too big for the web server (APK is a release asset, AAB a CI artifact).
-                rm -f $output_path/demos/android/slint-viewer.apk \
+                # The slint-viewer APKs are release assets (too big for the web server), the AAB a CI artifact.
+                rm -f $output_path/demos/android/slint-viewer-*.apk \
                       $output_path/demos/android/slint-viewer.aab
 
                 # A directory listing so the published folder is browsable.
@@ -644,8 +644,8 @@ jobs:
                   mv slint-lsp-*.zip artifacts/
                   mv slint-compiler-*.tar.gz artifacts/
                   mv figma-plugin.zip artifacts/
-                  # slint-viewer APK ships as a release asset (too big for the web server).
-                  mv android-demos/slint-viewer.apk artifacts/
+                  # The slint-viewer APKs ship as release assets (too big for the web server).
+                  mv android-demos/slint-viewer-*.apk artifacts/
             - uses: actions/checkout@v7
               with:
                 path: "slint-src"
@@ -827,31 +827,14 @@ jobs:
             - name: Build home automation demo
               run: cargo apk build --manifest-path demos/Cargo.toml -p home-automation --target aarch64-linux-android --lib --release
 
-            # Play Store accepts only AABs for new submissions. Build the
-            # bundle, then derive the nightly slint-viewer APK from it so the
-            # viewer is only compiled once.
-            - name: Build slint-viewer AAB
+            # Play Store accepts only AABs for new submissions; the per-ABI
+            # APKs are for GitHub releases and F-Droid.
+            - name: Build slint-viewer AAB and per-ABI APKs
               env:
                   ANDROID_KEYSTORE_PATH: ${{ env.CARGO_APK_RELEASE_KEYSTORE }}
                   ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
                   ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
               run: tools/viewer/android/build-aab.sh
-            # A universal APK works on every ABI the bundle carries.
-            - name: Build slint-viewer APK from the AAB
-              env:
-                  ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-                  ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
-              run: |
-                  curl --fail -L -o bundletool.jar https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar
-                  java -jar bundletool.jar build-apks --mode=universal \
-                      --bundle=tools/viewer/android/app/build/outputs/bundle/release/slint-viewer.aab \
-                      --output=slint-viewer.apks \
-                      --ks="$CARGO_APK_RELEASE_KEYSTORE" \
-                      --ks-pass="pass:$ANDROID_KEYSTORE_PASSWORD" \
-                      --ks-key-alias="$ANDROID_KEYSTORE_ALIAS"
-                  mkdir -p target/release/apk
-                  unzip -p slint-viewer.apks universal.apk > target/release/apk/slint-viewer.apk
-
             # A full-nightly goes to internal testing; a release goes to
             # production as a draft that a human publishes, so an accidental
             # `release` run never reaches users.
@@ -871,6 +854,7 @@ jobs:
               run: |
                   mkdir -p android-demos
                   cp -a target/release/apk/*.apk android-demos/ || true
+                  cp -a tools/viewer/android/app/build/outputs/apk/release/slint-viewer-*.apk android-demos/ || true
                   cp -a tools/viewer/android/app/build/outputs/bundle/release/slint-viewer.aab android-demos/ || true
             - name: "upload APK artifact"
               if: always()

--- a/.github/workflows/nightly_snapshot.yaml
+++ b/.github/workflows/nightly_snapshot.yaml
@@ -480,7 +480,7 @@ jobs:
                 mkdir -p $output_path/demos/android
                 cp -a ../android/* $output_path/demos/android/
                 # The slint-viewer APKs are release assets (too big for the web server), the AAB a CI artifact.
-                rm -f $output_path/demos/android/slint-viewer-*.apk \
+                rm -f $output_path/demos/android/slint-viewer-* \
                       $output_path/demos/android/slint-viewer.aab
 
                 # A directory listing so the published folder is browsable.
@@ -644,8 +644,9 @@ jobs:
                   mv slint-lsp-*.zip artifacts/
                   mv slint-compiler-*.tar.gz artifacts/
                   mv figma-plugin.zip artifacts/
-                  # The slint-viewer APKs ship as release assets (too big for the web server).
-                  mv android-demos/slint-viewer-*.apk artifacts/
+                  # The slint-viewer APKs ship as release assets (too big for the web
+                  # server), with the version file F-Droid polls.
+                  mv android-demos/slint-viewer-* artifacts/
             - uses: actions/checkout@v7
               with:
                 path: "slint-src"
@@ -854,7 +855,7 @@ jobs:
               run: |
                   mkdir -p android-demos
                   cp -a target/release/apk/*.apk android-demos/ || true
-                  cp -a tools/viewer/android/app/build/outputs/apk/release/slint-viewer-*.apk android-demos/ || true
+                  cp -a tools/viewer/android/app/build/outputs/apk/release/slint-viewer-* android-demos/ || true
                   cp -a tools/viewer/android/app/build/outputs/bundle/release/slint-viewer.aab android-demos/ || true
             - name: "upload APK artifact"
               if: always()

--- a/cspell.json
+++ b/cspell.json
@@ -373,6 +373,7 @@
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     "REUSE.toml",
+    "tools/viewer/android/fdroid/dev.slint.viewer.yml",
     "**/Cargo.lock",
     "docs/common/src/utils/slint.tmLanguage.json",
     "ui-libraries/material/docs/vendor/**",

--- a/docs/internal/release.md
+++ b/docs/internal/release.md
@@ -147,6 +147,10 @@ In the mean time, the version in the master branch can be updated
 
 * Check that the build of https://docs.rs/crate/slint/latest and https://docs.rs/crate/slint-interpreter/latest succeeded
 
+* Check that F-Droid picked the release up and could reproduce it: the build shows up on
+  https://monitor.f-droid.org/builds and the version on https://f-droid.org/packages/dev.slint.viewer/.
+  See `tools/viewer/android/fdroid/README.md` for how it finds the release.
+
 * Check that the [`versions.json`](https://github.com/slint-ui/www-releases/blob/master/releases/versions.json) is accurate.
   (Version of the nightly build and no duplicated version)
   FIXME: the release scripts or version upgrade scripts might need fixes

--- a/docs/nightly-release-notes.md
+++ b/docs/nightly-release-notes.md
@@ -68,4 +68,5 @@ Alternatively, download the binary from "Assets" section below.
  - SlintPad: https://slint.dev/snapshots/{feature}/editor
  - Demos: links from https://github.com/slint-ui/slint/tree/master/examples
  - Android demo APKs: https://snapshots.slint.dev/{feature}/demos/android/
- - Slint Viewer for Android: download `slint-viewer.apk` from the "Assets" section below
+ - Slint Viewer for Android: download `slint-viewer-arm64-v8a.apk` (most phones), `slint-viewer-armeabi-v7a.apk`
+   or `slint-viewer-x86_64.apk` from the "Assets" section below

--- a/tools/viewer/android/app/build.gradle.kts
+++ b/tools/viewer/android/app/build.gradle.kts
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
-// cSpell: ignore getenv
+// cSpell: ignore getenv Pslint
+
+import com.android.build.api.variant.FilterConfiguration.FilterType.ABI
 
 plugins {
     id("com.android.application")
@@ -12,6 +14,16 @@ val slintVersion = System.getenv("SLINT_VERSION")
     ?: Regex("""(?m)^version = "([^"]+)"""")
         .find(file("../../../../Cargo.toml").readText())!!.groupValues[1]
 val (major, minor, patch) = slintVersion.substringBefore('-').split('.').map(String::toInt)
+val releaseVersionCode = major * 10000 + minor * 100 + patch
+
+// Each per-ABI APK needs a distinct versionCode: the release code times ten
+// plus this offset, so a device supporting several ABIs (arm64 also runs
+// armeabi-v7a) installs the highest, i.e. arm64.
+val abiVersionCodeOffset = mapOf("armeabi-v7a" to 1, "x86_64" to 2, "arm64-v8a" to 3)
+
+// -Pslint.abi=<abi> restricts the APKs to one ABI; F-Droid builds one ABI
+// per version code that way.
+val abis = (project.findProperty("slint.abi") as String?)?.let { listOf(it) } ?: abiVersionCodeOffset.keys.toList()
 
 // Mirror `[package.metadata.android]` in tools/viewer/Cargo.toml so the AAB
 // and the cargo-apk APK match.
@@ -24,12 +36,8 @@ android {
         applicationId = "dev.slint.viewer"
         minSdk = 26
         targetSdk = 36
-        versionCode = System.getenv("SLINT_BUILD_NUMBER")?.toIntOrNull()
-            ?: (major * 10000 + minor * 100 + patch)
+        versionCode = System.getenv("SLINT_BUILD_NUMBER")?.toIntOrNull() ?: releaseVersionCode
         versionName = slintVersion
-        ndk {
-            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
-        }
     }
 
     val keystorePath: String? = System.getenv("ANDROID_KEYSTORE_PATH")
@@ -56,6 +64,27 @@ android {
             vcsInfo {
                 include = false
             }
+        }
+    }
+
+    // One APK per ABI so a download carries only its architecture's native
+    // libraries (Skia dominates the size). `bundleRelease` ignores `splits`
+    // and keeps every ABI in the bundle.
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include(*abis.toTypedArray())
+        }
+    }
+}
+
+// The bundle has no ABI filter and keeps `defaultConfig`'s versionCode.
+androidComponents {
+    onVariants { variant ->
+        variant.outputs.forEach { output ->
+            val abi = output.filters.find { it.filterType == ABI }?.identifier ?: return@forEach
+            output.versionCode.set(releaseVersionCode * 10 + abiVersionCodeOffset.getValue(abi))
         }
     }
 }

--- a/tools/viewer/android/app/build.gradle.kts
+++ b/tools/viewer/android/app/build.gradle.kts
@@ -18,7 +18,8 @@ val releaseVersionCode = major * 10000 + minor * 100 + patch
 
 // Each per-ABI APK needs a distinct versionCode: the release code times ten
 // plus this offset, so a device supporting several ABIs (arm64 also runs
-// armeabi-v7a) installs the highest, i.e. arm64.
+// armeabi-v7a) installs the highest, i.e. arm64. The build entries of the
+// F-Droid recipe (fdroid/dev.slint.viewer.yml) follow this order.
 val abiVersionCodeOffset = mapOf("armeabi-v7a" to 1, "x86_64" to 2, "arm64-v8a" to 3)
 
 // -Pslint.abi=<abi> restricts the APKs to one ABI; F-Droid builds one ABI

--- a/tools/viewer/android/build-aab.sh
+++ b/tools/viewer/android/build-aab.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 #
 # Build the slint-viewer Android App Bundle for Play Store upload, plus one
-# APK per ABI for GitHub releases.
+# APK per ABI for GitHub releases and the version file F-Droid polls.
 #
 # SLINT_BUILD_NUMBER (the Play Store versionCode of the bundle) defaults to
 # the git commit count; override as an env var. The APKs derive their
@@ -18,6 +18,7 @@
 #
 # Output: app/build/outputs/bundle/release/slint-viewer.aab
 #         app/build/outputs/apk/release/slint-viewer-<abi>.apk
+#         app/build/outputs/apk/release/slint-viewer-android-version.txt
 
 set -euo pipefail
 
@@ -42,7 +43,9 @@ gradle --no-daemon bundleRelease assembleRelease
 BUNDLE_DIR="$PROJECT_DIR/app/build/outputs/bundle/release"
 mv -f "$BUNDLE_DIR/app-release.aab" "$BUNDLE_DIR/slint-viewer.aab"
 
-# Name the per-ABI APKs after their ABI; AGP lists them in output-metadata.json.
+# Name the per-ABI APKs after their ABI, and write the release version code
+# (the per-ABI codes without their ABI digit) and name for F-Droid's update
+# check. AGP lists all of it in output-metadata.json.
 APK_DIR="$PROJECT_DIR/app/build/outputs/apk/release"
 python3 - "$APK_DIR" <<'EOF'
 import json, os, sys
@@ -51,6 +54,8 @@ outputs = json.load(open(os.path.join(apk_dir, "output-metadata.json")))["elemen
 for output in outputs:
     abi = next(f["value"] for f in output["filters"] if f["filterType"] == "ABI")
     os.replace(os.path.join(apk_dir, output["outputFile"]), os.path.join(apk_dir, f"slint-viewer-{abi}.apk"))
+with open(os.path.join(apk_dir, "slint-viewer-android-version.txt"), "w") as f:
+    f.write(f"versionCode={outputs[0]['versionCode'] // 10}\nversionName={outputs[0]['versionName']}\n")
 EOF
 
 ls "$BUNDLE_DIR/slint-viewer.aab" "$APK_DIR"/slint-viewer-*

--- a/tools/viewer/android/build-aab.sh
+++ b/tools/viewer/android/build-aab.sh
@@ -2,12 +2,14 @@
 # Copyright © SixtyFPS GmbH <info@slint.dev>
 # SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 #
-# Build the slint-viewer Android App Bundle for Play Store upload.
+# Build the slint-viewer Android App Bundle for Play Store upload, plus one
+# APK per ABI for GitHub releases.
 #
-# SLINT_BUILD_NUMBER (the Play Store versionCode) defaults to the git commit
-# count; override as an env var.
+# SLINT_BUILD_NUMBER (the Play Store versionCode of the bundle) defaults to
+# the git commit count; override as an env var. The APKs derive their
+# versionCode from the version, see app/build.gradle.kts.
 #
-# Signing (omit all three for an unsigned local bundle):
+# Signing (omit all three for unsigned outputs):
 #   ANDROID_KEYSTORE_PATH      upload keystore path
 #   ANDROID_KEYSTORE_PASSWORD  upload keystore password, also unlocks the key
 #   ANDROID_KEYSTORE_ALIAS     alias of the signing key in the keystore
@@ -15,6 +17,7 @@
 # Requires: what build-native.sh needs; gradle 8.11.1+ on PATH (AGP 8.10).
 #
 # Output: app/build/outputs/bundle/release/slint-viewer.aab
+#         app/build/outputs/apk/release/slint-viewer-<abi>.apk
 
 set -euo pipefail
 
@@ -33,10 +36,21 @@ export SLINT_BUILD_NUMBER
 "$PROJECT_DIR/build-native.sh"
 
 cd "$PROJECT_DIR"
-gradle --no-daemon bundleRelease
+gradle --no-daemon bundleRelease assembleRelease
 
 # Gradle names the bundle app-release.aab; rename it to the app.
 BUNDLE_DIR="$PROJECT_DIR/app/build/outputs/bundle/release"
 mv -f "$BUNDLE_DIR/app-release.aab" "$BUNDLE_DIR/slint-viewer.aab"
 
-echo "AAB built at: $BUNDLE_DIR/slint-viewer.aab"
+# Name the per-ABI APKs after their ABI; AGP lists them in output-metadata.json.
+APK_DIR="$PROJECT_DIR/app/build/outputs/apk/release"
+python3 - "$APK_DIR" <<'EOF'
+import json, os, sys
+apk_dir = sys.argv[1]
+outputs = json.load(open(os.path.join(apk_dir, "output-metadata.json")))["elements"]
+for output in outputs:
+    abi = next(f["value"] for f in output["filters"] if f["filterType"] == "ABI")
+    os.replace(os.path.join(apk_dir, output["outputFile"]), os.path.join(apk_dir, f"slint-viewer-{abi}.apk"))
+EOF
+
+ls "$BUNDLE_DIR/slint-viewer.aab" "$APK_DIR"/slint-viewer-*

--- a/tools/viewer/android/fdroid/README.md
+++ b/tools/viewer/android/fdroid/README.md
@@ -1,0 +1,20 @@
+# F-Droid
+
+`dev.slint.viewer.yml` is the F-Droid build recipe for the Slint Viewer.
+The copy that F-Droid uses lives in [fdroiddata](https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/dev.slint.viewer.yml);
+keep the two in sync and test changes here first.
+F-Droid's copy has no license header: its canonical format strips comments.
+
+F-Droid publishes our signed APK from GitHub releases rather than signing its own build,
+so its rebuild has to be byte-identical to ours; see the header of `../build-native.sh`.
+The `Android reproducible build` workflow runs this recipe in the F-Droid build server image
+and compares the result with our own build.
+
+The release run of the nightly workflow uploads `slint-viewer-<abi>.apk` per ABI to the GitHub release,
+along with `slint-viewer-android-version.txt` naming the release version code.
+F-Droid polls that file through the `releases/latest/download/` redirect, so it only sees a release once it's published,
+then copies the recipe's three build entries for the new version (`VercodeOperation` gives each its version code)
+and verifies each rebuild against the entry's `binary` URL.
+
+The `AllowedAPKSigningKeys` fingerprint is that of the release keystore the nightly workflow signs with.
+A different key means F-Droid rejects the APK, so treat the keystore as irreplaceable.

--- a/tools/viewer/android/fdroid/dev.slint.viewer.yml
+++ b/tools/viewer/android/fdroid/dev.slint.viewer.yml
@@ -1,0 +1,90 @@
+# Copyright © SixtyFPS GmbH <info@slint.dev>
+# SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+Categories:
+  - Development
+License: GPL-3.0-only
+AuthorName: SixtyFPS GmbH
+AuthorEmail: info@slint.dev
+WebSite: https://slint.dev
+SourceCode: https://github.com/slint-ui/slint
+IssueTracker: https://github.com/slint-ui/slint/issues
+Changelog: https://github.com/slint-ui/slint/blob/HEAD/CHANGELOG.md
+
+AutoName: Slint Viewer
+
+RepoType: git
+Repo: https://github.com/slint-ui/slint.git
+
+Builds:
+  - versionName: 1.18.0
+    versionCode: 118001
+    commit: v1.18.0
+    subdir: tools/viewer/android
+    sudo:
+      - apt-get update
+      - apt-get install -y clang libclang-dev python3 ninja-build make rustup
+    gradle:
+      - yes
+    output: app/build/outputs/apk/release/app-armeabi-v7a-release-unsigned.apk
+    binary: https://github.com/slint-ui/slint/releases/download/v%v/slint-viewer-armeabi-v7a.apk
+    prebuild:
+      - sdkmanager "platforms;android-36" "build-tools;36.0.0"
+      - cargo install --locked cargo-ndk@4.1.2 resvg@0.48.1
+    build:
+      - export PATH=$HOME/.cargo/bin:$PATH
+      - ./build-native.sh armeabi-v7a
+      - echo "slint.abi=armeabi-v7a" >> gradle.properties
+    ndk: r27
+
+  - versionName: 1.18.0
+    versionCode: 118002
+    commit: v1.18.0
+    subdir: tools/viewer/android
+    sudo:
+      - apt-get update
+      - apt-get install -y clang libclang-dev python3 ninja-build make rustup
+    gradle:
+      - yes
+    output: app/build/outputs/apk/release/app-x86_64-release-unsigned.apk
+    binary: https://github.com/slint-ui/slint/releases/download/v%v/slint-viewer-x86_64.apk
+    prebuild:
+      - sdkmanager "platforms;android-36" "build-tools;36.0.0"
+      - cargo install --locked cargo-ndk@4.1.2 resvg@0.48.1
+    build:
+      - export PATH=$HOME/.cargo/bin:$PATH
+      - ./build-native.sh x86_64
+      - echo "slint.abi=x86_64" >> gradle.properties
+    ndk: r27
+
+  - versionName: 1.18.0
+    versionCode: 118003
+    commit: v1.18.0
+    subdir: tools/viewer/android
+    sudo:
+      - apt-get update
+      - apt-get install -y clang libclang-dev python3 ninja-build make rustup
+    gradle:
+      - yes
+    output: app/build/outputs/apk/release/app-arm64-v8a-release-unsigned.apk
+    binary: https://github.com/slint-ui/slint/releases/download/v%v/slint-viewer-arm64-v8a.apk
+    prebuild:
+      - sdkmanager "platforms;android-36" "build-tools;36.0.0"
+      - cargo install --locked cargo-ndk@4.1.2 resvg@0.48.1
+    build:
+      - export PATH=$HOME/.cargo/bin:$PATH
+      - ./build-native.sh arm64-v8a
+      - echo "slint.abi=arm64-v8a" >> gradle.properties
+    ndk: r27
+
+AllowedAPKSigningKeys: eddd7a51dcb00057f082cc0946d9a748be037a34d1ead6643046602f0e5a67ca
+
+AutoUpdateMode: Version v%v
+UpdateCheckMode: HTTP
+UpdateCheckData: https://github.com/slint-ui/slint/releases/latest/download/slint-viewer-android-version.txt|versionCode=(\d+)|.|versionName=([\d.]+)
+VercodeOperation:
+  - 10 * %c + 1
+  - 10 * %c + 2
+  - 10 * %c + 3
+CurrentVersion: 1.18.0
+CurrentVersionCode: 118003


### PR DESCRIPTION
F-Droid doesn't take an APK blindly from the developer: it builds every app itself from source, following a short recipe the developer submits to F-Droid's fdroiddata repository. Our recipe checks out the release tag, installs the toolchain, runs build-native.sh and the gradle build, and F-Droid then compares its APK with the one on our GitHub release. 
If the two are identical byte for byte, F-Droid ships our signed APK; if not, it ships nothing. 

  - One APK per ABI. F-Droid asked for it so a phone only downloads its own architecture, about a third of the size. assembleRelease now produces slint-viewer-<versionCode>.apk for arm64-v8a, armeabi-v7a, and x86_64, each with its own version code (the release code times ten plus a digit per architecture). The release ships these three instead of the universal APK. The Play bundle is unchanged.
  - A version file with the release. F-Droid learns about new releases by reading a version number from a URL. The release now also uploads slint-viewer-android-version.txt, which F-Droid reads through GitHub's "latest release" redirect, so it only sees a release once it's published.
  - The recipe, and a CI check for it. The recipe lives in tools/viewer/android/fdroid/ so we can test it. The Android reproducible build workflow now runs it inside F-Droid's own build server image and fails unless the result matches our build. That replaces the earlier two-directory check. It's slow, so it runs in the full CI only.

