### PR TITLE
lsp: test the formatter on match elements

### DIFF
--- a/tools/lsp/fmt/fmt.rs
+++ b/tools/lsp/fmt/fmt.rs
@@ -2711,6 +2711,56 @@ component A {
     }
 
     #[test]
+    fn match_element() {
+        assert_formatting(
+            r#"component A { match   value  {   0  :  Text {  }   1: Rectangle { background: red; }  } }
+"#,
+            r#"component A {
+    match value {
+        0: Text { }
+        1: Rectangle {
+            background: red;
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn match_wildcard_case() {
+        assert_formatting(
+            r#"component A { match ( value )  {  0: Text { }    *   :   Text { text: "other"; }  } }
+"#,
+            r#"component A {
+    match (value) {
+        0: Text { }
+        *: Text {
+            text: "other";
+        }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn match_empty_case() {
+        assert_formatting(
+            r#"component A { match value {  0:{}   1: Text { }   *:{  } } }
+"#,
+            r#"component A {
+    match value {
+        0: { }
+        1: Text { }
+        *: { }
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn array() {
         assert_formatting(
             r#"


### PR DESCRIPTION
Add tests for match element formatting. The format functions were added in #12021.

Cover the match element, the '*' wildcard case, and the empty case body.

Part of #1307.