### PR TITLE
Slider: Don't emit changed(...) when value is max or min value

### DIFF
--- a/internal/backends/qt/qt_widgets/slider.rs
+++ b/internal/backends/qt/qt_widgets/slider.rs
@@ -421,6 +421,9 @@ impl Item for NativeSlider {
 impl NativeSlider {
     fn set_value(self: Pin<&Self>, new_val: f32) {
         let new_val = new_val.max(self.minimum()).min(self.maximum());
+        if self.value() == new_val {
+            return;
+        }
         self.value.set(new_val);
         Self::FIELD_OFFSETS.changed().apply_pin(self).call(&(new_val,));
     }

--- a/internal/compiler/widgets/common/slider-base.slint
+++ b/internal/compiler/widgets/common/slider-base.slint
@@ -115,11 +115,12 @@ export component SliderBase {
     }
 
     public function set-value(value: float) {
-        if (root.value == value) {
+        let clamped = max(root.minimum, min(root.maximum, value));
+        if (root.value == clamped) {
             return;
         }
 
-        root.value = max(root.minimum, min(root.maximum, value));
+        root.value = clamped;
         root.changed(root.value);
     }
 

--- a/internal/compiler/widgets/qt/slider.slint
+++ b/internal/compiler/widgets/qt/slider.slint
@@ -27,11 +27,12 @@ export component Slider inherits NativeSlider {
     }
 
     function update-value(value: float) {
-        if (root.value == value) {
+        let clamped = max(root.minimum, min(root.maximum, value));
+        if (root.value == clamped) {
             return;
         }
 
-        root.value = max(root.minimum, min(root.maximum, value));
+        root.value = clamped;
         root.changed(root.value);
     }
 }

--- a/tests/cases/widgets/slider_basic.slint
+++ b/tests/cases/widgets/slider_basic.slint
@@ -228,6 +228,36 @@ assert_eq!(instance.get_value(), 10f32);
 instance.set_enabled(true);
 slint_testing::send_keyboard_char(&instance, Key::UpArrow.into(), true);
 assert_eq!(instance.get_value(), 11f32);
+
+// Clamping to a bound reports no change.
+// A step past the maximum used to compare unclamped, and re-emitted the bound.
+instance.set_vertical(false);
+instance.set_step(1.);
+edits.borrow_mut().clear();
+changes.borrow_mut().clear();
+
+instance.set_value(100.);
+slint_testing::send_keyboard_char(&instance, Key::RightArrow.into(), true);
+slint_testing::send_keyboard_char(&instance, Key::RightArrow.into(), true);
+assert_eq!(instance.get_value(), 100f32);
+assert!(changes.borrow().is_empty(), "{:?}", changes.borrow());
+
+instance.set_value(0.);
+slint_testing::send_keyboard_char(&instance, Key::LeftArrow.into(), true);
+slint_testing::send_keyboard_char(&instance, Key::LeftArrow.into(), true);
+assert_eq!(instance.get_value(), 0f32);
+assert!(changes.borrow().is_empty(), "{:?}", changes.borrow());
+
+// A step overshooting a bound still reaches it, and reports the clamped value
+instance.set_step(10.);
+instance.set_value(95.);
+slint_testing::send_keyboard_char(&instance, Key::RightArrow.into(), true);
+assert_eq!(instance.get_value(), 100f32);
+assert_eq!(changes.borrow().clone(), vec![100f32]);
+
+changes.borrow_mut().clear();
+slint_testing::send_keyboard_char(&instance, Key::RightArrow.into(), true);
+assert!(changes.borrow().is_empty(), "{:?}", changes.borrow());
 ```
 
 */


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
