### PR TITLE
accessibility: Fix a panic with when a text field sits inside another

### DIFF
--- a/internal/backends/winit/accesskit.rs
+++ b/internal/backends/winit/accesskit.rs
@@ -12,11 +12,11 @@ use accesskit::{
 use i_slint_core::SharedString;
 use i_slint_core::accessibility::{
     AccessibilityAction, AccessibleStringProperty, SupportedAccessibilityAction,
-    find_text_input_with_rc,
+    find_exposed_text_input, nearest_accessible_item,
 };
 use i_slint_core::api::Window;
 use i_slint_core::input::FocusReason;
-use i_slint_core::item_tree::{ItemTreeRc, ItemTreeRef, ItemTreeWeak, ParentItemTraversalMode};
+use i_slint_core::item_tree::{ItemTreeRc, ItemTreeRef, ItemTreeWeak};
 use i_slint_core::items::{ItemRc, WindowItem};
 use i_slint_core::lengths::{LogicalPoint, ScaleFactor};
 use i_slint_core::window::{PopupWindowLocation, WindowInner};
@@ -182,7 +182,7 @@ impl AccessKitAdapter {
                 }
                 let wrapper_item = self.nodes.item_rc_for_node_id(wrapper_parent)?;
                 let window_adapter = self.window_adapter_weak.upgrade()?;
-                let (inner_item_rc, text_input) = find_text_input_with_rc(&wrapper_item)?;
+                let (inner_item_rc, text_input) = find_exposed_text_input(&wrapper_item)?;
                 let state = self
                     .nodes
                     .text_state
@@ -319,18 +319,6 @@ impl AccessKitAdapter {
     }
 }
 
-fn accessible_parent_for_item_rc(mut item: ItemRc) -> ItemRc {
-    while !item.is_accessible() {
-        if let Some(parent) = item.parent_item(ParentItemTraversalMode::StopAtPopups) {
-            item = parent;
-        } else {
-            break;
-        }
-    }
-
-    item
-}
-
 const NODE_ID_INDEX_BITS: u32 = 16;
 const NODE_ID_INDEX_MASK: u64 = (1 << NODE_ID_INDEX_BITS) - 1; // 0xFFFF
 const NODE_ID_COMPONENT_BITS: u32 = 22;
@@ -412,7 +400,7 @@ impl NodeCollection {
                     .borrow()
                     .upgrade()
                     .map(|focus_item| {
-                        let parent = accessible_parent_for_item_rc(focus_item);
+                        let parent = nearest_accessible_item(focus_item);
                         self.focused_node_tracker
                             .as_ref()
                             .evaluate(|| {
@@ -440,7 +428,7 @@ impl NodeCollection {
     }
 
     fn find_node_id_by_item_rc(&mut self, mut item: ItemRc) -> NodeId {
-        item = accessible_parent_for_item_rc(item);
+        item = nearest_accessible_item(item);
 
         self.encode_item_node_id(&item)
     }
@@ -564,7 +552,7 @@ impl NodeCollection {
         if !wraps_text_input(wrapper_node.role()) {
             return;
         }
-        let Some((inner_item_rc, text_input)) = find_text_input_with_rc(item) else {
+        let Some((inner_item_rc, text_input)) = find_exposed_text_input(item) else {
             return;
         };
         let mut state =
@@ -646,7 +634,7 @@ impl NodeCollection {
                     return None;
                 };
 
-                let parent_item = accessible_parent_for_item_rc(popup.parent_item.upgrade()?);
+                let parent_item = nearest_accessible_item(popup.parent_item.upgrade()?);
                 let parent_node = self.encode_item_node_id(if parent_item.is_accessible() {
                     &parent_item
                 } else {

--- a/internal/core/accessibility.rs
+++ b/internal/core/accessibility.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     SharedString,
-    item_tree::ItemTreeVTable,
+    item_tree::{ItemTreeVTable, ParentItemTraversalMode},
     items::{ItemRc, TextInput},
 };
 use alloc::vec::Vec;
@@ -122,9 +122,31 @@ pub fn accessible_descendents(root_item: &ItemRc) -> impl Iterator<Item = ItemRc
     })
 }
 
+/// The item that stands for `item` in the accessibility tree: `item` itself when it is accessible,
+/// otherwise its closest accessible ancestor. The walk stops at a popup boundary.
+pub fn nearest_accessible_item(mut item: ItemRc) -> ItemRc {
+    while !item.is_accessible() {
+        let Some(parent) = item.parent_item(ParentItemTraversalMode::StopAtPopups) else { break };
+        item = parent;
+    }
+    item
+}
+
 /// Find the first built-in `TextInput` in `item` or its descendents.
 pub fn find_text_input(item: &ItemRc) -> Option<VRcMapped<ItemTreeVTable, TextInput>> {
     find_text_input_with_rc(item).map(|(_, input)| input)
+}
+
+/// The text input that `item` exposes in the accessibility tree.
+///
+/// This is the first input below `item`, and only when `item` is the accessible item nearest to
+/// it: an accessible item further up finds the same input, and exposing it from both would give
+/// its text runs two owners.
+pub fn find_exposed_text_input(
+    item: &ItemRc,
+) -> Option<(ItemRc, VRcMapped<ItemTreeVTable, TextInput>)> {
+    let found = find_text_input_with_rc(item)?;
+    (nearest_accessible_item(found.0.clone()) == *item).then_some(found)
 }
 
 /// Same as [`find_text_input`], but also returns the `TextInput`'s `ItemRc`.

--- a/internal/core/textlayout/sharedparley/accessibility.rs
+++ b/internal/core/textlayout/sharedparley/accessibility.rs
@@ -19,11 +19,19 @@ pub struct CachedTextInputAccessibilityState {
     /// Never reset while this state lives, so that a later emission can't reuse an index for a
     /// span an assistive technology may still remember.
     next_sub_index: u32,
+    /// The node the reused `NodeId`s were minted under. See [`Self::emit`].
+    #[cfg(debug_assertions)]
+    parent_id: Option<NodeId>,
 }
 
 impl Default for CachedTextInputAccessibilityState {
     fn default() -> Self {
-        Self { layout_access: Vec::new(), next_sub_index: 1 }
+        Self {
+            layout_access: Vec::new(),
+            next_sub_index: 1,
+            #[cfg(debug_assertions)]
+            parent_id: None,
+        }
     }
 }
 
@@ -45,6 +53,18 @@ impl CachedTextInputAccessibilityState {
         physical_offset: (f64, f64),
         encode_sub_node_id: impl Fn(NodeId, u32) -> NodeId,
     ) -> bool {
+        // `build_nodes` reuses the `NodeId`s it minted, and each of them encodes the node it was
+        // minted under. Emitting them below a second node hands accesskit the same child twice,
+        // which its consumer refuses.
+        #[cfg(debug_assertions)]
+        {
+            let previous = self.parent_id.replace(parent_id);
+            debug_assert!(
+                previous.is_none_or(|previous| previous == parent_id),
+                "the text runs of an input must be emitted below one node"
+            );
+        }
+
         let (visible_anchor, visible_cursor, cursor_affinity) = selection_offsets(text_input);
 
         // Before the layout, so it survives a renderer with none to lend. The displayed

--- a/internal/interpreter/tests.rs
+++ b/internal/interpreter/tests.rs
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-// cSpell: ignore dontcrash
+// cSpell: ignore descendents dontcrash
 
 #[allow(unused_imports)]
 use i_slint_core::api::ComponentHandle;
@@ -846,4 +846,57 @@ fn accent_color_reachable_from_global() {
     .unwrap();
     let after = instance.get_property("accent").unwrap();
     assert_ne!(before, after, "accent-background should follow the system accent color");
+}
+
+#[test]
+fn text_runs_belong_to_the_nearest_accessible_item() {
+    i_slint_backend_testing::init_no_event_loop();
+    use crate::{Compiler, ComponentHandle};
+    use i_slint_core::accessibility::{
+        AccessibleStringProperty, accessible_descendents, find_exposed_text_input,
+        find_text_input_with_rc,
+    };
+    use i_slint_core::items::ItemRc;
+    use i_slint_core::window::WindowInner;
+
+    // `nested` leaves its TextInput accessible, `hidden` doesn't.
+    let code = r#"
+        export component App inherits Window {
+            HorizontalLayout {
+                nested := Rectangle {
+                    accessible-role: text-input;
+                    accessible-label: "nested";
+                    TextInput { text: "one"; }
+                }
+                hidden := Rectangle {
+                    accessible-role: text-input;
+                    accessible-label: "hidden";
+                    TextInput { text: "two"; accessible-role: none; }
+                }
+            }
+        }
+    "#;
+    let mut compiler = Compiler::default();
+    compiler.set_style("fluent".into());
+    let result = spin_on::spin_on(compiler.build_from_source(code.into(), Default::default()));
+    assert!(!result.has_errors(), "{:?}", result.diagnostics().collect::<Vec<_>>());
+    let instance = result.component("App").unwrap().create().unwrap();
+    instance.show().unwrap();
+
+    let root = ItemRc::new_root(WindowInner::from_pub(instance.window()).component());
+    let labeled = |label: &str| {
+        accessible_descendents(&root)
+            .find(|item| {
+                item.accessible_string_property(AccessibleStringProperty::Label)
+                    .is_some_and(|found| found == label)
+            })
+            .unwrap_or_else(|| panic!("no accessible item labeled {label}"))
+    };
+
+    for (label, wrapper_exposes) in [("nested", false), ("hidden", true)] {
+        let wrapper = labeled(label);
+        let (input, _) = find_text_input_with_rc(&wrapper).expect("input below the wrapper");
+        assert_eq!(find_exposed_text_input(&wrapper).is_some(), wrapper_exposes, "{label}");
+        assert_eq!(find_exposed_text_input(&input).is_some(), !wrapper_exposes, "{label}");
+    }
 }

--- a/tools/editor/ui/components/inspector/text-field-base.slint
+++ b/tools/editor/ui/components/inspector/text-field-base.slint
@@ -73,6 +73,8 @@ export component InspectorTextFieldBase inherits Rectangle {
             @children
 
             input := TextInput {
+                // Disable TextInput's built-in accessibility support as the frame takes care of that.
+                accessible-role: none;
                 horizontal-stretch: 1;
                 text: root.value;
                 enabled: root.enabled;


### PR DESCRIPTION
Slint hands a screen reader a description of the window: every element, with its name, its value and its text.
If a user interface puts a text field inside an element that also acts as a text field, both of them described the same text. The screen reader library refuses a description that lists the same text under two elements, and stops the program — so an app built that way closed as soon as a screen reader was turned on. Slint now lets only the innermost of the two describe it.

The visual editor's property fields were built that way, which is how this turned up: opening a file with a screen reader running closed the editor. Their inner field now stays out of the description, so a screen reader announces one field with its name and its text, instead of two halves of the same field.

A check in debug builds now stops at the cause, and a test covers which of the two elements describes the text.

