### PR TITLE
Fix emit current-item-changed when using CTRL+Escape.

### DIFF
--- a/internal/compiler/widgets/common/listview.slint
+++ b/internal/compiler/widgets/common/listview.slint
@@ -121,6 +121,7 @@ component StandardListViewBase inherits ListView {
     protected function toggle-focus-item-selection() {
         if (root.current-item == root.focus-item) {
             root.current-item = -1;
+            root.current-item-changed(root.current-item);
         } else {
             root.select-focus-item();
         }

--- a/tests/cases/widgets/listview.slint
+++ b/tests/cases/widgets/listview.slint
@@ -85,14 +85,17 @@ slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key:
 assert_eq!(instance.get_current_item(), 2);
 
 // Control+Space deselects the currently focused item
+instance.set_callback_current_item(-2);
 slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
 assert_eq!(instance.get_current_item(), -1);
+assert_eq!(instance.get_callback_current_item(), -1);
 
 // Control+Space selects the currently focused item
 slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);
 slint_testing::send_keyboard_string_sequence(&instance, &SharedString::from(Key::Space));
 assert_eq!(instance.get_current_item(), 2);
+assert_eq!(instance.get_callback_current_item(), 2);
 
 // Control+UpArrow moves the focus up one item but not the selection
 slint_testing::send_keyboard_char(&instance, Key::Control.into(), true);


### PR DESCRIPTION
We can't use set-current-item before it returns if value < 0
=> We assign it and emit signal after that.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
