### PR TITLE
Remove unused import. Palette imported twice and StyleMetrics is not used

### DIFF
--- a/internal/compiler/widgets/common/about-slint.slint
+++ b/internal/compiler/widgets/common/about-slint.slint
@@ -1,7 +1,7 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
-import { StyleMetrics, Palette, ScrollView, Palette } from "std-widgets-impl.slint";
+import { ScrollView, Palette } from "std-widgets-impl.slint";
 
 export component AboutSlint {
     preferred-height: 100%;


### PR DESCRIPTION
<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
