### PR TITLE
compiler: warn about an accessible text input inside another one

### DIFF
--- a/demos/usecases/ui/widgets/extended_line_edit.slint
+++ b/demos/usecases/ui/widgets/extended_line_edit.slint
@@ -67,6 +67,9 @@ component LineEditBase inherits Rectangle {
     }
 
     text-input := TextInput {
+        // Disable TextInput's built-in accessibility support as the widget takes care of that.
+        accessible-role: none;
+
         property <length> computed-x;
 
         x: min(0px, max(parent.width - self.width - self.text-cursor-width, self.computed-x));

--- a/docs/astro/src/content/docs/guide/development/best-practices.mdx
+++ b/docs/astro/src/content/docs/guide/development/best-practices.mdx
@@ -27,6 +27,24 @@ component CustomButton {
 }
 ```
 
+A component that takes the `text-input` role for a `TextInput` inside it describes that input's text itself.
+Set `accessible-role: none` on the inner `TextInput`, so that a screen reader is given the text once rather than under two elements.
+The compiler warns when both of them keep the role.
+
+```slint
+component CustomLineEdit {
+    in-out property <string> text <=> input.text;
+
+    accessible-role: text-input;
+    accessible-value <=> root.text;
+
+    input := TextInput {
+        // The component around it describes this input
+        accessible-role: none;
+    }
+}
+```
+
 ## Separate Code, UI, and Assets
 
 Many projects start out small, with just a few files. But before you know it, your team grows, files get added, and it becomes harder to see forest for the trees. We recommend starting with the following basic directory structure:

--- a/internal/compiler/passes.rs
+++ b/internal/compiler/passes.rs
@@ -6,6 +6,7 @@ mod binding_analysis;
 mod border_radius;
 mod check_drag_area;
 mod check_expressions;
+mod check_nested_text_inputs;
 mod check_public_api;
 mod clip;
 mod collect_custom_fonts;
@@ -213,6 +214,11 @@ pub async fn run_passes(
     });
     for root_component in doc.exported_roots() {
         lower_layout::check_window_layout(&root_component);
+    }
+    // After the loop above: needs the roles `lower_accessibility_properties` gives the
+    // built-in elements, in every component the walk reaches.
+    if type_loader.compiler_config.accessibility {
+        check_nested_text_inputs::check_nested_text_inputs(doc, diag);
     }
     // After the loop above: needs every component's `layoutinfo-h-with-constraint`
     // and the wrapper elements the `lower_property_to_element` passes inject.

--- a/internal/compiler/passes/check_nested_text_inputs.rs
+++ b/internal/compiler/passes/check_nested_text_inputs.rs
@@ -1,0 +1,141 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+//! Pass that warns about an accessible text input nested in another one.
+//!
+//! Both of them describe the text of the `TextInput` they contain,
+//! which hands an assistive technology the same text under two elements.
+
+use crate::diagnostics::{BuildDiagnostics, Spanned};
+use crate::expression_tree::Expression;
+use crate::langtype::ElementType;
+use crate::object_tree::{Component, Document, ElementRc};
+use by_address::ByAddress;
+use smol_str::SmolStr;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+/// The item above the one being visited that exposes a text input, and the role it does it with.
+type Enclosing = (ElementRc, SmolStr);
+
+/// What identifies the element a warning is about, to warn about it once.
+/// Inlining copies an element per use site, and the copies share one source location.
+#[derive(PartialEq, Eq, Hash)]
+enum Reported {
+    Source(PathBuf, usize),
+    /// An element the compiler synthesized, which has no source of its own.
+    Element(ByAddress<ElementRc>),
+}
+
+pub fn check_nested_text_inputs(doc: &Document, diag: &mut BuildDiagnostics) {
+    let mut check = Check { diag, reported: HashSet::new() };
+    for component in doc.exported_roots() {
+        check.visit_component(&component, None);
+    }
+}
+
+/// An accessible role whose item describes the text of the `TextInput` below it.
+fn exposes_text_input(role: &SmolStr) -> bool {
+    role == "text-input" || role == "spinbox"
+}
+
+/// The role the item ends up with, which is the one the most derived element sets: setting the
+/// role where a component is used writes it to the root element of that component.
+fn accessible_role(elem: &ElementRc) -> Option<SmolStr> {
+    let mut level = Some(elem.clone());
+    while let Some(e) = level {
+        let role = e.borrow().binding("accessible-role").map(|binding| {
+            match binding.value_expression() {
+                // `none` is a role of its own, and leaves nothing for the bases to say
+                Expression::EnumerationValue(value) if value.value != 0 => {
+                    Some(value.enumeration.values[value.value].clone())
+                }
+                _ => None,
+            }
+        });
+        if let Some(role) = role {
+            return role;
+        }
+        level = base_component(&e).map(|base| base.root_element.clone());
+    }
+    None
+}
+
+fn base_component(elem: &ElementRc) -> Option<Rc<Component>> {
+    match &elem.borrow().base_type {
+        ElementType::Component(base) => Some(base.clone()),
+        _ => None,
+    }
+}
+
+struct Check<'a> {
+    diag: &'a mut BuildDiagnostics,
+    reported: HashSet<Reported>,
+}
+
+impl Check<'_> {
+    fn visit_component(&mut self, component: &Rc<Component>, enclosing: Option<&Enclosing>) {
+        self.visit_item(&component.root_element, enclosing);
+        self.visit_popups(component);
+    }
+
+    /// A popup is a tree of its own:
+    /// its items nest under the popup, not under the element that declares it.
+    fn visit_popups(&mut self, component: &Component) {
+        let popups = component
+            .popup_windows
+            .borrow()
+            .iter()
+            .map(|p| p.component.clone())
+            .collect::<Vec<_>>();
+        for popup in &popups {
+            self.visit_component(popup, None);
+        }
+    }
+
+    /// Visits the item `elem` stands for, with `enclosing` the nearest item above it that exposes
+    /// a text input.
+    fn visit_item(&mut self, elem: &ElementRc, enclosing: Option<&Enclosing>) {
+        let role = accessible_role(elem).filter(exposes_text_input);
+        if role.is_some()
+            && let Some((enclosing, enclosing_role)) = enclosing
+            && self.reported.insert(reported(elem))
+        {
+            self.report(elem, enclosing, enclosing_role);
+        }
+        let here = role.map(|role| (elem.clone(), role));
+        let enclosing = here.as_ref().or(enclosing);
+
+        // An element instantiating a component is one item together with that component's root,
+        // so the item's children are the element's own plus those of every component it inherits.
+        let mut level = Some(elem.clone());
+        while let Some(e) = level {
+            let children = e.borrow().children.clone();
+            for child in &children {
+                self.visit_item(child, enclosing);
+            }
+            let Some(base) = base_component(&e) else { break };
+            self.visit_popups(&base);
+            level = Some(base.root_element.clone());
+        }
+    }
+
+    fn report(&mut self, elem: &ElementRc, enclosing: &ElementRc, enclosing_role: &SmolStr) {
+        self.diag.push_warning(
+            format!(
+                "This element and the '{enclosing_role}' around it expose the same text to a screen reader; set 'accessible-role: none' here"
+            ),
+            &*elem.borrow(),
+        );
+        self.diag.push_note("The enclosing element is declared here".into(), &*enclosing.borrow());
+    }
+}
+
+fn reported(elem: &ElementRc) -> Reported {
+    let location = elem.borrow().to_source_location();
+    match location.source_file {
+        Some(file) => Reported::Source(file.path().to_path_buf(), location.span.offset),
+        None => Reported::Element(ByAddress(elem.clone())),
+    }
+}

--- a/internal/compiler/tests/syntax/accessibility/nested_text_input.slint
+++ b/internal/compiler/tests/syntax/accessibility/nested_text_input.slint
@@ -1,0 +1,67 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
+
+component Wrapper inherits Rectangle {
+    accessible-role: text-input;
+    accessible-label: "wrapper";
+    @children
+}
+
+export component Test inherits Window {
+    // The input describes the text the Rectangle already describes
+    Rectangle {
+//  >        <note{The enclosing element is declared here}
+        accessible-role: text-input;
+        TextInput { }
+//      >        <warning{This element and the 'text-input' around it expose the same text to a screen reader; set 'accessible-role: none' here}
+    }
+
+    // Hiding the input, the way a widget does
+    Rectangle {
+        accessible-role: text-input;
+        TextInput { accessible-role: none; }
+    }
+
+    // A spin box describes the text of the input it contains
+    Rectangle {
+//  >        <note{The enclosing element is declared here}
+        accessible-role: spinbox;
+        TextInput { }
+//      >        <warning{This element and the 'spinbox' around it expose the same text to a screen reader; set 'accessible-role: none' here}
+    }
+
+    // The role reaches the input across a component boundary
+    Wrapper {
+//  >      <note{The enclosing element is declared here}
+        TextInput { }
+//      >        <warning{This element and the 'text-input' around it expose the same text to a screen reader; set 'accessible-role: none' here}
+    }
+
+    // The role of a component's root, hidden where the component is used
+    Rectangle {
+        accessible-role: text-input;
+        Wrapper { accessible-role: none; }
+    }
+
+    // An input that only exists while the condition holds
+    Rectangle {
+//  >        <note{The enclosing element is declared here}
+        accessible-role: text-input;
+        if true: TextInput { }
+//               >        <warning{This element and the 'text-input' around it expose the same text to a screen reader; set 'accessible-role: none' here}
+    }
+
+    // A popup is a tree of its own
+    Rectangle {
+        accessible-role: text-input;
+        popup := PopupWindow {
+            TextInput { }
+        }
+
+        TouchArea {
+            clicked => {
+                popup.show();
+            }
+        }
+    }
+}

--- a/internal/compiler/widgets/common/time-picker-base.slint
+++ b/internal/compiler/widgets/common/time-picker-base.slint
@@ -205,6 +205,8 @@ export component TimePickerInput {
     }
 
     text-input := TextInput {
+        // Disable TextInput's built-in accessibility support as the widget takes care of that.
+        accessible-role: none;
         vertical-alignment: center;
         horizontal-alignment: center;
         width: 100%;

--- a/tools/editor/ui/components/inspector/text-field-base.slint
+++ b/tools/editor/ui/components/inspector/text-field-base.slint
@@ -73,6 +73,9 @@ export component InspectorTextFieldBase inherits Rectangle {
             @children
 
             input := TextInput {
+                // Disable TextInput's built-in accessibility support as the component takes care of that.
+                accessible-role: none;
+
                 horizontal-stretch: 1;
                 text: root.value;
                 enabled: root.enabled;

--- a/ui-libraries/material/src/ui/components/time_picker.slint
+++ b/ui-libraries/material/src/ui/components/time_picker.slint
@@ -191,6 +191,8 @@ component TimePickerInput {
             padding: MaterialStyleMetrics.padding_8;
 
             text_input := TextInput {
+                // Disable TextInput's built-in accessibility support as the component takes care of that.
+                accessible_role: none;
                 vertical_alignment: center;
                 horizontal_alignment: center;
                 color: MaterialPalette.on_surface;


### PR DESCRIPTION
An element with a text input role describes the text of the TextInput below
it, and an accessible text input in between describes the same text again.
accesskit_consumer aborts the process over a child that two items claim, so a
UI built that way closes as soon as a screen reader attaches. Three places in
this repository were built that way, none of them noticed until a user ran
into it.

The check walks the tree the way the runtime does: a role set where a
component is used counts together with the elements inside that component, an
element and the root of the component it instantiates are one item, and a
popup starts a tree of its own. The role an element ends up with is the one
its most derived binding names, since setting the role where a component is
used writes it to the root element of that component, which is what makes
'accessible-role: none' the fix to point at in every case.

