### PR TITLE
live-preview: follow-ups to the PreviewSession extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,6 +3687,7 @@ dependencies = [
  "notify",
  "postcard",
  "rand 0.9.5",
+ "scopeguard",
  "serde",
  "serde_json",
  "sha2",

--- a/internal/live-preview/Cargo.toml
+++ b/internal/live-preview/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.48.0", features = ["rt", "sync", "macros", "time"], optio
 futures-util = { version = "0.3.31", features = ["sink"], optional = true }
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"], optional = true }
 base64 = { version = "0.23", optional = true }
+scopeguard = { version = "1.1.0", default-features = false, optional = true }
 hostname = { version = "0.4.1", optional = true }
 anyhow = { version = "1.0.100", optional = true }
 # remote: only the viewer generates pairing secrets, so the random source
@@ -92,6 +93,7 @@ preview-session = [
   "dep:tokio",
   "dep:base64",
   "dep:anyhow",
+  "dep:scopeguard",
   "slint-interpreter/accessibility",
   "slint-interpreter/image-default-formats",
 ]

--- a/internal/live-preview/preview_sessions.rs
+++ b/internal/live-preview/preview_sessions.rs
@@ -68,14 +68,25 @@ enum PreviewSessionCommand {
     Reset(oneshot::Sender<()>),
 }
 
+/// The files and the compiler behind one preview, fed by an editor over any transport.
+///
+/// Lives on the thread that runs the preview: use [`PreviewSessionHandle`] to reach it from
+/// the thread that owns the transport.
 pub struct PreviewSession {
+    /// File contents pushed by the editor, keyed by the `Url` the editor sent. Using the URL
+    /// verbatim avoids platform-dependent path normalization (Windows backslashes,
+    /// percent-encoding) — equality is structural.
     file_cache: RefCell<HashMap<Url, CacheEntry>>,
+    /// Files the currently shown component depends on. `SetContents` for URLs outside this set
+    /// does not rebuild, so unrelated edits in the user's editor don't disturb the preview.
     dependencies: RefCell<HashSet<Url>>,
+    /// Taken for the duration of a compilation, which is how a second one is refused.
     compiler: RefCell<Option<slint_interpreter::Compiler>>,
     configuration: RefCell<Option<PreviewConfig>>,
     to_editor: Rc<dyn PreviewToLsp>,
 }
 
+/// Feeds messages to a [`PreviewSession`] from any thread.
 #[derive(Clone)]
 pub struct PreviewSessionHandle {
     command_sender: mpsc::UnboundedSender<PreviewSessionCommand>,
@@ -352,6 +363,7 @@ impl PreviewSession {
             .build_from_source(String::from_utf8_lossy(&file.contents).into_owned(), path)
             .await;
         self.restore_compiler(compiler);
+        // Set even on errors so edits to imported files still trigger a rebuild.
         *self.dependencies.borrow_mut() = compilation_result
             .watch_paths(InternalToken)
             .iter()
@@ -375,6 +387,8 @@ impl PreviewSession {
             .or_else(|| compilation_result.component_names().next())
             .and_then(|name| compilation_result.component(name))
         else {
+            // No compile errors but no component: skip the diagnostics so they don't clobber
+            // unrelated ones the editor holds for this URL.
             tracing::error!("Component not found");
             return PreviewCompilation::ComponentNotFound;
         };
@@ -436,6 +450,8 @@ impl PreviewSessionHandle {
     }
 }
 
+/// Whether the session can act on this URL. A preview only handles `file://` URLs; the editor
+/// can legitimately produce others (e.g. `vscode-remote://`), but they're ignored on this side.
 fn is_supported(url: &Url) -> bool {
     if url.scheme() != "file" {
         tracing::warn!("Ignoring message for unsupported URL scheme: {url}");
@@ -542,7 +558,8 @@ async fn show_component(
     Ok(())
 }
 
-fn register_font(window: &i_slint_core::api::Window, contents: Arc<[u8]>) {
+pub fn register_font(window: &i_slint_core::api::Window, contents: Arc<[u8]>) {
+    // Wrap the already-Arc-backed bytes in a Blob without copying.
     let blob = fontique::Blob::new(Arc::new(contents));
     WindowInner::from_pub(window)
         .context()

--- a/internal/live-preview/preview_sessions.rs
+++ b/internal/live-preview/preview_sessions.rs
@@ -359,10 +359,13 @@ impl PreviewSession {
             tracing::error!("Preview session is already compiling a component");
             return PreviewCompilation::Unavailable;
         };
+        // A dropped compilation must not take the compiler with it: a session without one
+        // refuses every build that follows.
+        let compiler = scopeguard::guard(compiler, |compiler| self.restore_compiler(compiler));
         let compilation_result = compiler
             .build_from_source(String::from_utf8_lossy(&file.contents).into_owned(), path)
             .await;
-        self.restore_compiler(compiler);
+        drop(compiler);
         // Set even on errors so edits to imported files still trigger a rebuild.
         *self.dependencies.borrow_mut() = compilation_result
             .watch_paths(InternalToken)

--- a/tools/viewer/remote.rs
+++ b/tools/viewer/remote.rs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::{net::SocketAddr, rc::Rc};
 
 use i_slint_core::SharedString;
-use i_slint_core::textlayout::sharedparley::fontique;
-use i_slint_core::window::WindowInner;
 use i_slint_live_preview::preview_sessions::{
-    PreviewCompilation, PreviewSession, PreviewSessionEvent,
+    PreviewCompilation, PreviewSession, PreviewSessionEvent, register_font,
 };
 use i_slint_live_preview::protocol::{PreviewComponent, PreviewToLspMessage, lsp_types};
 use i_slint_live_preview::remote::{Connection, ConnectionMessage, PairingPolicy};
@@ -265,13 +262,7 @@ async fn run_async(
                         tracing::debug!("Font {url} already registered, skipping");
                         continue;
                     }
-                    let blob = fontique::Blob::new(Arc::new(contents));
-                    WindowInner::from_pub(placeholder.window())
-                        .context()
-                        .font_context()
-                        .borrow_mut()
-                        .collection
-                        .register_fonts(blob, None);
+                    register_font(placeholder.window(), contents);
                     tracing::debug!("Registered font {url} ({len} bytes)");
                 }
             },


### PR DESCRIPTION
Follow-up to #13210, which extracted `PreviewSession` out of the remote connection and the viewer. Two things from reviewing it:

  - A compilation takes the compiler out of the session and puts it back when it
    finishes, which is how a second one is refused. If that future is dropped, the
    session never gets it back, and every later build returns `Unavailable` with
    nothing but a log line. The compiler is now returned however the compilation
    ends.

  - The move left the explanations behind: why the cache is keyed by the URL the
    editor sent, why an edit outside the dependencies is not a rebuild, which URL
    schemes a preview drops, why the dependencies are set even when the compilation
    failed, and why a missing component does not publish its diagnostics. They now
    sit with the code they explain. The viewer kept its own copy of the font
    registration, which would have meant a second copy of one of those comments, so
    it calls the one in the session instead.

