### PR TITLE
skia: Fix vulkan texture layout on import

### DIFF
--- a/internal/renderers/skia/wgpu_29_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_29_surface/vulkan.rs
@@ -175,7 +175,7 @@ pub unsafe fn import_vulkan_texture(
             vk_image(&vulkan_texture.unwrap()) as _,
             alloc,
             skia_safe::gpu::vk::ImageTiling::OPTIMAL,
-            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            skia_safe::gpu::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
             vk_format,
             1,
             None,

--- a/internal/renderers/skia/wgpu_30_surface/vulkan.rs
+++ b/internal/renderers/skia/wgpu_30_surface/vulkan.rs
@@ -175,7 +175,7 @@ pub unsafe fn import_vulkan_texture(
             vk_image(&vulkan_texture.unwrap()) as _,
             alloc,
             skia_safe::gpu::vk::ImageTiling::OPTIMAL,
-            skia_safe::gpu::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            skia_safe::gpu::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
             vk_format,
             1,
             None,


### PR DESCRIPTION
When `import_wgpu_texture` is called, all textures are queued to be transitioned to `wgpu::TextureUses::RESOURCE` and submitted in `flush_and_submit` before any draw commands. When the draw commands are run, the texture is in `SHADER_READ_ONLY_OPTIMAL` which is the layout `import_vulkan_texture` should have.

This was found by running the slint-hosts-bevy example and seeing the validation errors.
