### PR TITLE
slint-sc-coverage: count a line that holds only a decision's operator

### DIFF
--- a/api/slint-sc/tests/cases/coverage/multiline.slint
+++ b/api/slint-sc/tests/cases/coverage/multiline.slint
@@ -1,0 +1,35 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Software-3.0
+
+// A decision written over several lines: both of its outcomes are points of
+// the line of its operator, whichever lines its operands are on.
+
+export component TestCase inherits Window {
+//#c                               ^-
+    in property <bool> a;
+    in property <bool> b;
+    out property <int> picked: a
+//#c                           ^+
+        ? 1
+//#c    ^++
+        : 2;
+    out property <bool> both: a
+//#c                          ^+
+        && b;
+//#c    ^++
+}
+
+/*
+```rust
+let mut x = TestCase::new(crate::harness::WINDOW_SIZE);
+x.set_a(true);
+for b in [false, true] {
+    x.set_b(b);
+    assert_eq!(x.get_picked(), 1);
+    assert_eq!(x.get_both(), b);
+}
+x.set_a(false);
+assert_eq!(x.get_picked(), 2);
+assert!(!x.get_both());
+```
+*/

--- a/tools/slint-sc-coverage/lib.rs
+++ b/tools/slint-sc-coverage/lib.rs
@@ -114,7 +114,13 @@ impl Entry {
 }
 
 impl LineCoverage {
+    /// The execution count of the line: the hits of its points, or the
+    /// evaluations of its decisions when it holds no point, as the line of an
+    /// operator of a decision written over several lines does.
     fn count(&self) -> u64 {
+        if self.points.is_empty() {
+            return self.branches.values().map(|(_, arms)| arms[0] + arms[1]).sum();
+        }
         self.points.values().sum()
     }
 
@@ -273,6 +279,10 @@ mod tests {
         // Inlined twice, the counts add up.
         report.add(&point(Kind::Binding, "len", 13, 50), 1);
         report.add(&point(Kind::Binding, "len", 13, 50), 2);
+        // The operator of a decision written over several lines is alone on
+        // its line, which the decision alone counts.
+        report.add(&point(Kind::Branch { outcome: true }, "?", 15, 9), 2);
+        report.add(&point(Kind::Branch { outcome: false }, "?", 15, 9), 1);
         report.add(&point(Kind::Handler, "clicked", 20, 5), 0);
         report.add(
             &Point { file: "/src/lib/b.slint".into(), ..point(Kind::Element, "Led", 2, 1) },
@@ -289,13 +299,16 @@ mod tests {
 SF:a.slint
 BRDA:13,0,0,4
 BRDA:13,0,1,0
-BRF:2
-BRH:1
+BRDA:15,0,0,2
+BRDA:15,0,1,1
+BRF:4
+BRH:3
 DA:7,3
 DA:13,7
+DA:15,3
 DA:20,0
-LF:3
-LH:2
+LF:4
+LH:3
 end_of_record
 TN:
 SF:lib/b.slint
@@ -313,7 +326,7 @@ end_of_record
         let case = Path::new("/src/a.slint");
         assert_eq!(report().listing(case), ["+ lib/b.slint:2:1 element Led"]);
         let lines = report().lines_of(case);
-        assert_eq!(lines.keys().copied().collect::<Vec<_>>(), [7, 13, 20]);
+        assert_eq!(lines.keys().copied().collect::<Vec<_>>(), [7, 13, 15, 20]);
         assert_eq!(
             lines[&13],
             [


### PR DESCRIPTION
A condition written over several lines leaves its operator alone on a line:

    out property <int> foo: condition
        ? 1
        : 2;

Both outcomes of the `?` are points of the second line, and that line holds nothing else. `LineCoverage::count` summed the points alone, so the lcov record called the line unexecuted and the line total missed it, while the branch records on the same line reported both outcomes taken.

Count the evaluations of the decisions of a line that holds no point, and add a case pinning where the outcomes of a decision written over several lines land.

<!--
- [ ] If the change modifies a visible behavior, it changes the documentation accordingly
- [ ] If possible, the change is auto-tested
- [ ] If the changes fixes or close an existing issue, the commit message reference the issue with `Fixes #xxx` or `Closes #xxx`
- [ ] If the change is noteworthy, the commit message should contain `ChangeLog: ...`
-->
