### PR TITLE
tests: run Qt widget tests offscreen

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,6 +5,9 @@
 set -eu
 unset CDPATH
 export RUSTFLAGS='-D warnings'
+# Qt widget tests open a real window unless told otherwise, which hangs
+# indefinitely on a machine with no display.
+export QT_QPA_PLATFORM=offscreen
 
 usage() {
   echo "Usage: $0 <all|rust|cpp|interpreter|python|nodejs> [<filter>] [<cargo test args>...]" >&2


### PR DESCRIPTION
The Qt-styled widget test binary opens a real window unless told otherwise, which hangs `tests/run_tests.sh` indefinitely on a machine with no display — observed as the suite sitting at identical output across multiple polls with no progress, only resolved by killing the stuck process and rerunning with `QT_QPA_PLATFORM=offscreen` set.

Sets `QT_QPA_PLATFORM=offscreen` alongside the existing `RUSTFLAGS` export at the top of the script, so it applies to every driver (`all`, `rust`, `cpp`, ...) without needing to remember it per invocation.

## Test plan
- [x] `sh -n tests/run_tests.sh` — syntax check
- [x] `QT_QPA_PLATFORM=offscreen` is Qt's own documented headless platform plugin; setting it is a no-op for non-Qt test binaries