### PR TITLE
tests: run the qt widget tests on the process main thread

### DIFF
--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -5698,6 +5698,7 @@ dependencies = [
  "i-slint-backend-testing",
  "i-slint-compiler",
  "i-slint-core",
+ "libtest-mimic",
  "rayon",
  "slint",
  "slint-interpreter",

--- a/tests/driver/rust/Cargo.toml
+++ b/tests/driver/rust/Cargo.toml
@@ -18,6 +18,13 @@ publish = false
 path = "main.rs"
 name = "test-driver-rust"
 
+# cSpell: ignore libtest
+# The qt widget tests need the main thread, so they use their own harness
+# (see write_main_thread_harness in build.rs).
+[[test]]
+name = "widgets-qt"
+harness = false
+
 [features]
 default = ["backend-qt"]
 
@@ -35,6 +42,9 @@ spin_on = { workspace = true }
 
 [target.'cfg(not(target_os = "wasm"))'.dependencies]
 i-slint-backend-qt = { workspace = true }
+
+[dev-dependencies]
+libtest-mimic = "0.8"
 
 [build-dependencies]
 i-slint-compiler = { workspace = true, features = ["default", "rust", "display-diagnostics", "bundle-translations"], optional = true }

--- a/tests/driver/rust/build.rs
+++ b/tests/driver/rust/build.rs
@@ -1,6 +1,8 @@
 // Copyright © SixtyFPS GmbH <info@slint.dev>
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0
 
+// cSpell: ignore libtest nextest
+
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
@@ -100,7 +102,7 @@ fn main() -> std::io::Result<()> {
     // Generate the per-case modules on all cores: with the build-time feature,
     // each case runs the Slint compiler (twice with deterministic-output),
     // which dominates the build script's runtime.
-    let module_lines = rayon::ThreadPoolBuilder::new()
+    let case_modules = rayon::ThreadPoolBuilder::new()
         .stack_size(512 * 1024)
         .build()
         .expect("failed to create thread pool")
@@ -108,15 +110,21 @@ fn main() -> std::io::Result<()> {
             testcases
                 .par_iter()
                 .map(|testcase| process_case(testcase, live_preview))
-                .collect::<std::io::Result<Vec<String>>>()
+                .collect::<std::io::Result<Vec<CaseModule>>>()
         })?;
 
     // Write the module declarations serially, in collection order, so the
     // including files don't depend on thread scheduling.
-    for (testcase, module_line) in testcases.iter().zip(module_lines) {
+    let mut main_thread_tests = Vec::new();
+    for (testcase, case_module) in testcases.iter().zip(case_modules) {
         let generated_file =
             generated_file_for_test(testcase, &mut generated_files, &mut generated_file)?;
-        writeln!(generated_file, "{module_line}")?;
+        writeln!(generated_file, "{}", case_module.module_line)?;
+        main_thread_tests.extend(case_module.main_thread_tests);
+    }
+
+    if let Some(file) = generated_files.get_mut(OsStr::new("widgets-qt")) {
+        write_main_thread_harness(file, &main_thread_tests)?;
     }
 
     generated_file.flush()?;
@@ -137,12 +145,98 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
+/// One test function of a case that must run on the process main thread,
+/// registered as a `libtest_mimic::Trial` by [`write_main_thread_harness`].
+struct MainThreadTest {
+    /// Module holding the function, without the `r#` prefix.
+    module: String,
+    function: String,
+    ignored: bool,
+}
+
+/// One processed case: the module declaration to write into the including file,
+/// and the case's main-thread tests.
+/// The list is empty for cases run under the regular libtest harness.
+struct CaseModule {
+    module_line: String,
+    main_thread_tests: Vec<MainThreadTest>,
+}
+
+/// Writes the `main` of the `widgets-qt` test target.
+///
+/// The qt style calls QStyle from the thread that runs the test.
+/// On macOS the style creates AppKit controls,
+/// and AppKit deadlocks on any thread but the process main thread.
+/// libtest runs every test on a worker thread,
+/// so the target sets `harness = false` and forks one subprocess per test through libtest-mimic.
+/// Each subprocess runs its single test on its own main thread,
+/// with its own thread-local testing platform.
+/// The `test-backends` crate uses the same pattern.
+fn write_main_thread_harness(
+    output: &mut dyn Write,
+    tests: &[MainThreadTest],
+) -> std::io::Result<()> {
+    writeln!(
+        output,
+        "
+type TestFn = fn() -> ::std::result::Result<(), ::std::boxed::Box<dyn ::std::error::Error>>;
+
+const TESTS: &[(&str, bool, TestFn)] = &["
+    )?;
+    for test in tests {
+        writeln!(
+            output,
+            "    (\"{module}::{function}\", {ignored}, r#{module}::{function} as TestFn),",
+            module = test.module,
+            function = test.function,
+            ignored = test.ignored,
+        )?;
+    }
+    writeln!(
+        output,
+        r#"];
+
+fn main() {{
+    let args = libtest_mimic::Arguments::from_args();
+    // `--exact <name>` marks the subprocess; cargo nextest uses it the same
+    // way. Run that one test right here, on this process's main thread.
+    // cargo forwards a filter to every test binary, so a name that matches
+    // no test here falls through and reports zero tests instead.
+    if args.exact && !args.list {{
+        if let Some(name) = args.filter.as_deref() {{
+            if let Some(test) = TESTS.iter().find(|(n, _, _)| *n == name) {{
+                return (test.2)().unwrap();
+            }}
+        }}
+    }}
+    let tests = TESTS
+        .iter()
+        .map(|&(name, ignored, _)| {{
+            libtest_mimic::Trial::test(name, move || {{
+                let status = ::std::process::Command::new(::std::env::current_exe()?)
+                    .args(["--exact", name])
+                    .status()?;
+                if status.success() {{
+                    Ok(())
+                }} else {{
+                    Err(format!("test failed in subprocess: {{status}}").into())
+                }}
+            }})
+            .with_ignored_flag(ignored)
+        }})
+        .collect();
+    libtest_mimic::run(&args, tests).exit();
+}}"#
+    )?;
+    Ok(())
+}
+
 /// Write the `{module_name}.rs` file for the test case into OUT_DIR and return
 /// the module declaration that includes it.
 fn process_case(
     testcase: &test_driver_lib::TestCase,
     live_preview: bool,
-) -> std::io::Result<String> {
+) -> std::io::Result<CaseModule> {
     println!("cargo:rerun-if-changed={}", testcase.absolute_path.display());
     let mut module_name = testcase.identifier();
     if module_name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
@@ -168,6 +262,10 @@ fn process_case(
         ""
     };
 
+    // The widgets-qt harness calls plain functions instead of `#[test]`
+    // functions; see write_main_thread_harness.
+    let main_thread = testcase.requested_style == Some("qt");
+
     let mut output = BufWriter::new(File::create(
         Path::new(&std::env::var_os("OUT_DIR").unwrap()).join(format!("{module_name}.rs")),
     )?);
@@ -175,52 +273,91 @@ fn process_case(
     output.write_all(b"#![deny(warnings)]\n#![deny(rust_2018_idioms)]\n#![deny(unsafe_code)]\n")?;
 
     #[cfg(not(feature = "build-time"))]
-    if !generate_macro(&source, &mut output, testcase)? {
+    if let Some(placeholder) = generate_macro(&source, &mut output, testcase, main_thread)? {
         output.flush()?;
-        return Ok(module_line);
+        let main_thread_tests = if main_thread {
+            vec![MainThreadTest {
+                module: module_name,
+                function: placeholder.to_string(),
+                ignored: true,
+            }]
+        } else {
+            Vec::new()
+        };
+        return Ok(CaseModule { module_line, main_thread_tests });
     }
     #[cfg(feature = "build-time")]
     generate_source(&source, &mut output, testcase)?;
 
+    let mut main_thread_tests = Vec::new();
     for (i, x) in test_driver_lib::extract_test_functions(&source)
         .filter(|x| x.language_id == "rust")
         .enumerate()
     {
+        let attributes = if main_thread {
+            main_thread_tests.push(MainThreadTest {
+                module: module_name.clone(),
+                function: format!("t_{i}"),
+                ignored: !ignored.is_empty(),
+            });
+            "pub".to_string()
+        } else {
+            format!("#[test] {ignored}")
+        };
         write!(
             output,
             r"
 #[rust_analyzer::skip]
-#[test] {} fn t_{}() -> ::std::result::Result<(), ::std::boxed::Box<dyn ::std::error::Error>> {{
+{} fn t_{}() -> ::std::result::Result<(), ::std::boxed::Box<dyn ::std::error::Error>> {{
     use i_slint_backend_testing as slint_testing;
     slint_testing::init_no_event_loop();
     slint_testing::configure_test_fonts();
     {}
     Ok(())
 }}",
-            ignored,
+            attributes,
             i,
             x.source.replace('\n', "\n    ")
         )?;
     }
 
     output.flush()?;
-    Ok(module_line)
+    Ok(CaseModule { module_line, main_thread_tests })
 }
 
+/// Generates the `slint!` macro invocation for the case,
+/// or a placeholder function when the case cannot run as a macro.
+/// Returns the placeholder's name, and `None` when it generates the macro.
 #[cfg(not(feature = "build-time"))]
 fn generate_macro(
     source: &str,
     output: &mut dyn Write,
     testcase: &test_driver_lib::TestCase,
-) -> Result<bool, std::io::Error> {
+    main_thread: bool,
+) -> Result<Option<&'static str>, std::io::Error> {
+    let write_placeholder = |output: &mut dyn Write,
+                             ignore_reason: &str,
+                             name: &str|
+     -> std::io::Result<()> {
+        if main_thread {
+            writeln!(
+                    output,
+                    "pub fn {name}() -> ::std::result::Result<(), ::std::boxed::Box<dyn ::std::error::Error>> {{ Ok(()) }}"
+                )
+        } else {
+            writeln!(output, "#[test] #[ignore = \"{ignore_reason}\"] fn {name}() {{}}")
+        }
+    };
     if source.contains("\\{") {
         // Unfortunately, \{ is not valid in a rust string so it cannot be used in a slint! macro
-        output.write_all(b"#[test] #[ignore = \"string template don't work in macros\"] fn ignored_because_string_template() {{}}")?;
-        return Ok(false);
+        let name = "ignored_because_string_template";
+        write_placeholder(output, "string template don't work in macros", name)?;
+        return Ok(Some(name));
     }
     if testcase.is_ignored("rust-macro") {
-        output.write_all(b"#[test] #[ignore = \"testcase ignored for the slint! macro\"] fn ignored_for_macro() {}")?;
-        return Ok(false);
+        let name = "ignored_for_macro";
+        write_placeholder(output, "testcase ignored for the slint! macro", name)?;
+        return Ok(Some(name));
     }
     // to silence all the warnings in .slint files that would be turned into errors
     output.write_all(b"#![allow(deprecated)]")?;
@@ -265,7 +402,7 @@ fn generate_macro(
     output.write_all(b"\"#]\n")?;
     output.write_all(source.as_bytes())?;
     output.write_all(b"}\n")?;
-    Ok(true)
+    Ok(None)
 }
 
 #[cfg(feature = "build-time")]


### PR DESCRIPTION
On macOS, `cargo test -p test-driver-rust --test widgets-qt` hangs forever with 0% CPU. The qt style calls QStyle from the thread running the test, and QMacStyle instantiates AppKit controls for hit testing. On current macOS, AppKit's control layout goes through SwiftUI and blocks until it can run on the process main thread. libtest runs every test on a worker thread while the main thread waits for results, so the first `NativeSlider` hit test deadlocks:

```
NativeSlider::input_event
→ QMacStyle::hitTestComplexControl
→ QMacStylePrivate::cocoaControl
→ -[NSSlider initWithFrame:]
→ SwiftUICore ViewGraphRootValueUpdater.updateGraph()
→ _MovableLockSyncMain → pthread_cond_wait   (waits for the main thread, forever)
```

`--test-threads=1` doesn't help: libtest still spawns a worker thread per test. CI never sees the hang because it filters these tests with `--skip=qt::`.

This complements #13370, which runs `tests/run_tests.sh` offscreen for machines without a display. With a display, the offscreen platform is not in effect for plain `cargo test`, and this change also lets the tests exercise the real macOS Qt style.

## Design

The `widgets-qt` target gets `harness = false` and a `build.rs`-generated harness, following the pattern of the `test-backends` crate: libtest-mimic forks one subprocess per test (marked with `--exact <name>`, the same convention cargo nextest uses), and each subprocess runs its single test on its own main thread with its own thread-local testing platform. Parallelism is preserved because every subprocess has its own main thread.

The libtest CLI surface stays compatible: `--skip=qt::` filters all tests out as before, `--list` prints the same names, and an `--exact` filter that names a test from another target reports zero matching tests instead of failing.

## Testing

Everything measured on macOS arm64 (macOS 26.6, Qt with QMacStyle):

- `widgets-qt`: 25/25 pass in ~7s, on both the macro and the `build-time` generation paths. Both previously hung on the first slider hit test.
- Full `test-driver-rust` suite: 35/35 test binaries, 855 passed, 0 failed. The suite could not complete on this machine before.
- `-- --skip=qt::` (the CI invocation), `-- --list`, and cross-target `-- --exact` selection verified against the built binary.

## Follow-up

`tests/backends`' own fork harness has the same latent panic on an unmatched `--exact` filter (`run_test`'s `unwrap_or_else(panic!)` in `tests/backends/tests/cases/harness.rs`); the same fallthrough fix would apply there. Left out to keep this change to one target.
